### PR TITLE
Better install with setup.py

### DIFF
--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -9,7 +9,6 @@ from habitat_sim.bindings.mode import use_dev_bindings
 
 if use_dev_bindings:
     from .dev_bindings import *
-
 else:
     from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
 

--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -5,8 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 from habitat_sim.bindings.modules import modules
+from habitat_sim.bindings.mode import use_dev_bindings
 
-try:
+if use_dev_bindings:
+    from .dev_bindings import *
+
+else:
     from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
 
     exec(
@@ -14,7 +18,5 @@ try:
             ", ".join(modules)
         )
     )
-except ImportError:
-    from .dev_bindings import *
 
 __all__ = ["SimulatorBackend"] + modules

--- a/habitat_sim/bindings/dev_bindings.py
+++ b/habitat_sim/bindings/dev_bindings.py
@@ -72,9 +72,8 @@ try:
     import habitat_sim_bindings
 except ImportError:
     msg = """
-Could not import habitat sim bindings
-Please follow the building instructions in the README
------------------------------------------------------------
+Failed to to import habitat sim bindings in developer mode
+----------------------------------------------------------
 
 """
 

--- a/habitat_sim/bindings/mode.py
+++ b/habitat_sim/bindings/mode.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+use_dev_bindings = True


### PR DESCRIPTION
## Motivation and Context

Issue #13 brought up that the current method of figuring out how to import the bindings leads to confusing error messages when things are installed with `setup.py.   The relevant error, that it couldn't import `habitat_sim._ext.habitat_sim_bindings`, is buried by the error message that it couldn't import the bindings in developer mode.  

This PR uses `setup.py` to modify the value of a variable such that the code knows where it should expect the bindings to be, and only looks in that location.

## How Has This Been Tested

Installed in a clean conda environment.  After deleting the `build` folder and doing `unset PYTHONPATH`, `python examples/example.py` works.   Doing

```
cd ..
python
>>> import habitat_sim
```
also works.  That `cd ..` is still key however.

In a different clean conda environment, I built with `build.sh`.  Doing 
```
python
>>> import habitat_sim
```

succeeds and `python examples/example.py` fails (this is what I would expect to happen).  `python examples/example.py` works if I add `/path/to/habitat-sim` to my `PYTHONPATH`.

