### PR TITLE
Fixes and improvements to benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Previous simulation platforms that have operated on similar datasets typically p
 
 *Note: The semantic sensor in MP3D houses currently requires the use of additional house 3D meshes with orders of magnitude more geometric complexity leading to reduced performance. We expect this to be addressed in future versions leading to speeds comparable to RGB + depth; stay tuned.
 
+To run the above benchmarks on your machine, see instructions in the [examples](#examples) section.
+
 ## Quick installation
 
 1. Clone the repo
@@ -195,6 +197,8 @@ Load a specific MP3D or Gibson house: `examples/example.py --scene path/to/mp3d/
 Load a specific SUNCG house: `examples/example.py --scene path/to/suncg/house_id/house.json`.
 
 Additional arguments to `example.py` are provided to change the sensor configuration, print statistics of the semantic annotations in a scene, compute action-space shortest path trajectories, and set other useful functionality. Refer to the `example.py` and `demo_runner.py` source files for an overview.
+
+To reproduce the benchmark table from above run `examples/benchmark.py --scene /path/to/mp3d/17DRP5sb8fy/17DRP5sb8fy.glb`.
 
 ## Common issues
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -12,7 +12,7 @@ import numpy as np
 import demo_runner as dr
 
 parser = argparse.ArgumentParser("Running benchmarks on simulator")
-parser.add_argument("--scene", type=str, default="test.glb")
+parser.add_argument("--scene", type=str, required=True)
 parser.add_argument(
     "--max_frames",
     type=int,
@@ -24,6 +24,7 @@ parser.add_argument("--seed", type=int, default=1)
 args = parser.parse_args()
 
 default_settings = dr.default_sim_settings.copy()
+default_settings["scene"] = args.scene
 default_settings["silent"] = True
 default_settings["seed"] = args.seed
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -12,7 +12,11 @@ import numpy as np
 import demo_runner as dr
 
 parser = argparse.ArgumentParser("Running benchmarks on simulator")
-parser.add_argument("--scene", type=str, required=True)
+parser.add_argument(
+    "--scene",
+    type=str,
+    default=dr.default_sim_settings["test_scene"],
+)
 parser.add_argument(
     "--max_frames",
     type=int,

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -20,6 +20,25 @@ parser.add_argument(
     help="Max number of frames simulated."
     "Default or larger value is suggested for accurate results.",
 )
+parser.add_argument(
+    "--resolution",
+    type=int,
+    nargs='+',
+    default=[128, 256, 512],
+    help="Resolution r for frame (r x r).",
+)
+parser.add_argument(
+    "--num_procs",
+    type=int,
+    nargs='+',
+    default=[1, 3, 5],
+    help="Number of concurrent processes.",
+)
+parser.add_argument(
+    "--benchmark_semantic_sensor",
+    action='store_true',
+    help="Whether to enable benchmarking of semantic sensor.",
+)
 parser.add_argument("--seed", type=int, default=1)
 args = parser.parse_args()
 
@@ -41,13 +60,19 @@ benchmark_items = {
     "rgb": {},
     "rgbd": {"depth_sensor": True},
     "depth_only": {"color_sensor": False, "depth_sensor": True},
-    "semantic_only": {"color_sensor": False, "semantic_sensor": True},
-    "rgbd_semantic": {"depth_sensor": True, "semantic_sensor": True},
 }
+if args.benchmark_semantic_sensor:
+    benchmark_items["semantic_only"] = {
+        "color_sensor": False,
+        "semantic_sensor": True,
+    }
+    benchmark_items["rgbd_semantic"] = {
+        "depth_sensor": True,
+        "semantic_sensor": True,
+    }
 
-#  resolutions = [128] # (debug)
-resolutions = [128, 256, 512]
-nprocs_tests = [1, 3, 5]
+resolutions = args.resolution
+nprocs_tests = args.num_procs
 
 performance_all = {}
 for nprocs in nprocs_tests:
@@ -78,12 +103,12 @@ for nproc, performance in performance_all.items():
     )
     title = "Resolution "
     for key, value in perf.items():
-        title += "%15s" % key
+        title += "\t%-10s" % key
     print(title)
     for idx in range(len(performance)):
         row = "%d x %d" % (resolutions[idx], resolutions[idx])
         for key, value in performance[idx].items():
-            row += "%15.1f" % value
+            row += "\t%-8.1f" % value
         print(row)
     print(
         " =============================================================================="

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -15,7 +15,7 @@ from PIL import Image
 import habitat_sim
 import habitat_sim.agent
 import habitat_sim.bindings as hsim
-from habitat_sim.utils import d3_40_colors_rgb
+import habitat_sim.utils as utils
 
 from settings import default_sim_settings, make_cfg
 import multiprocessing
@@ -44,7 +44,7 @@ class DemoRunner:
     def save_semantic_observation(self, obs, total_frames):
         semantic_obs = obs["semantic_sensor"]
         semantic_img = Image.new("P", (semantic_obs.shape[1], semantic_obs.shape[0]))
-        semantic_img.putpalette(d3_40_colors_rgb.flatten())
+        semantic_img.putpalette(utils.d3_40_colors_rgb.flatten())
         semantic_img.putdata((semantic_obs.flatten() % 40).astype(np.uint8))
         semantic_img.save("test.sem.%05d.png" % total_frames)
 
@@ -174,6 +174,13 @@ class DemoRunner:
 
     def init_common(self):
         self._cfg = make_cfg(self._sim_settings)
+        scene_file = self._sim_settings["scene"]
+
+        if not os.path.exists(scene_file) and scene_file == default_sim_settings["test_scene"]:
+            print("Test scenes not downloaded locally, downloading and extracting now...")
+            utils.download_and_unzip(default_sim_settings["test_scene_data_url"], ".")
+            print("Downloaded and extracted test scenes data.")
+
         self._sim = habitat_sim.Simulator(self._cfg)
 
         random.seed(self._sim_settings["seed"])

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -16,7 +16,11 @@ import habitat_sim
 import habitat_sim.agent
 import habitat_sim.bindings as hsim
 from habitat_sim.utils import d3_40_colors_rgb
+
 from settings import default_sim_settings, make_cfg
+import multiprocessing
+
+_barrier = None
 
 
 class DemoRunnerType(Enum):
@@ -180,16 +184,47 @@ class DemoRunner:
 
         return start_state
 
-    def benchmark(self, settings):
-        self.set_sim_settings(settings)
+    def _bench_target(self, _idx=0):
         self.init_common()
 
-        perf = self.do_time_steps()
+        best_perf = None
+        for _ in range(3):
+
+            if _barrier is not None:
+                _barrier.wait()
+                if _idx == 0:
+                    _barrier.reset()
+
+            perf = self.do_time_steps()
+            if best_perf is None or perf["fps"] > best_perf["fps"]:
+                best_perf = perf
 
         self._sim.close()
         del self._sim
 
-        return perf
+        return best_perf
+
+    @staticmethod
+    def _pool_init(b):
+        global _barrier
+        _barrier = b
+
+    def benchmark(self, settings):
+        self.set_sim_settings(settings)
+        nprocs = settings["num_processes"]
+
+        barrier = multiprocessing.Barrier(nprocs)
+        with multiprocessing.Pool(
+            nprocs, initializer=self._pool_init, initargs=(barrier,)
+        ) as pool:
+            perfs = pool.map(self._bench_target, range(nprocs))
+
+        res = {k: [] for k in perfs[0].keys()}
+        for p in perfs:
+            for k, v in p.items():
+                res[k] += [v]
+
+        return dict(fps=sum(res["fps"]), total_time=sum(res["total_time"]) / nprocs)
 
     def example(self):
         start_state = self.init_common()

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -196,6 +196,13 @@ class DemoRunner:
                     _barrier.reset()
 
             perf = self.do_time_steps()
+            # The variance introduced between runs is due to the worker threads
+            # being interrupted a different number of times by the kernel, not
+            # due to difference in the speed of the code itself.  The most
+            # accurate representation of the performance would be a run where
+            # the kernel never interrupted the workers, but this isn't
+            # feasible, so we just take the run with the least number of
+            # interrupts (the fastest) instead.
             if best_perf is None or perf["fps"] > best_perf["fps"]:
                 best_perf = perf
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -12,9 +12,9 @@ import numpy as np
 import demo_runner as dr
 
 parser = argparse.ArgumentParser()
+parser.add_argument("--scene", type=str, required=True)
 parser.add_argument("--width", type=int, default=640)
 parser.add_argument("--height", type=int, default=480)
-parser.add_argument("--scene", type=str, default="test.glb")
 parser.add_argument("--max_frames", type=int, default=1000)
 parser.add_argument("--save_png", action="store_true")
 parser.add_argument("--sensor_height", type=float, default=1.5)

--- a/examples/example.py
+++ b/examples/example.py
@@ -12,7 +12,11 @@ import numpy as np
 import demo_runner as dr
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--scene", type=str, required=True)
+parser.add_argument(
+    "--scene",
+    type=str,
+    default=dr.default_sim_settings["test_scene"]
+)
 parser.add_argument("--width", type=int, default=640)
 parser.add_argument("--height", type=int, default=480)
 parser.add_argument("--max_frames", type=int, default=1000)

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -25,6 +25,7 @@ default_sim_settings = {
     "compute_shortest_path": False,
     "compute_action_shortest_path": False,
     "test_scene": "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb",
+    "test_scene_data_url": "http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip",
     "goal_position": [5.047, 0.199, 11.145],
     "goal_headings": [[0, -0.980_785, 0, 0.195_090], [0.0, 1.0, 0.0, 0.0]],
 }

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -11,7 +11,6 @@ default_sim_settings = {
     "max_frames": 1000,
     "width": 640,
     "height": 480,
-    "scene": "test.glb",  # default scene: test.glb
     "default_agent": 0,
     "sensor_height": 1.5,
     "color_sensor": True,  # RGB sensor (default: ON)

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -24,8 +24,9 @@ default_sim_settings = {
     "print_semantic_mask_stats": False,
     "compute_shortest_path": False,
     "compute_action_shortest_path": False,
-    "goal_position": [-9.423, 0.072_447, -0.373],
-    "goal_headings": [[0.0, -0.471_395, 0.0, 0.881_922], [0.0, 1.0, 0.0, 0.0]],
+    "test_scene": "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb",
+    "goal_position": [5.047, 0.199, 11.145],
+    "goal_headings": [[0, -0.980_785, 0, 0.195_090], [0.0, 1.0, 0.0, 0.0]],
 }
 
 # build SimulatorConfiguration

--- a/habitat_sim/utils.py
+++ b/habitat_sim/utils.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from io import BytesIO
 import numpy as np
 import quaternion
+from urllib.request import urlopen
+from zipfile import ZipFile
 
 
 def quat_from_coeffs(coeffs: np.array) -> np.quaternion:
@@ -141,6 +144,12 @@ def quat_rotate_vector(q: np.quaternion, v: np.array) -> np.array:
     vq = np.quaternion(0, 0, 0, 0)
     vq.imag = v
     return (q * vq * q.inverse()).imag
+
+
+def download_and_unzip(file_url, local_directory):
+    response = urlopen(file_url)
+    zipfile = ZipFile(BytesIO(response.read()))
+    zipfile.extractall(path=local_directory)
 
 
 def colorize_ids(ids):


### PR DESCRIPTION
## Motivation and Context

The `benchmark.py` script assumed the presence of a `test.glb` file and had unexpected behavior when the file was not present.  Moreover, multi-process benchmarking was not incorporated, making it hard to reproduce the benchmark table out-of-the-box.  @danielgordon10 thanks for bringing up this issue.

This PR removes defaulting of the `--scene` argument from both `benchmark.py` and `example.py` and requires the user to specify the intended scene, avoiding confusing behavior and unexpected errors.  It also incorporates multi-process benchmarking implemented by @erikwijmans .

## How Has This Been Tested

Download the Matterport3D Habitat data and run `examples/benchmark.py --scene /path/to/mp3d/17DRP5sb8fy/17DRP5sb8fy.glb`. The benchmark script should output a table similar to the one below:
```
 ================ Performance (FPS) NPROC=1 ===================================
Resolution             rgb           rgbd     depth_only  semantic_only  rgbd_semantic
128 x 128         4288.3         2052.2         4266.9          540.3          429.1
256 x 256         3162.0         1704.4         3245.0          518.6          387.3
512 x 512         1611.6          803.4         1614.5          451.1          280.9
 ==============================================================================
 ================ Performance (FPS) NPROC=3 ===================================
Resolution             rgb           rgbd     depth_only  semantic_only  rgbd_semantic
128 x 128         8629.4         4258.8         8634.9          531.3          468.2
256 x 256         7483.4         3686.6         7462.1          522.5          456.1
512 x 512         4346.8         2228.6         4251.1          540.0          435.3
 ==============================================================================
 ================ Performance (FPS) NPROC=5 ===================================
Resolution             rgb           rgbd     depth_only  semantic_only  rgbd_semantic
128 x 128         8484.4         4178.5         8415.8          528.0          467.8
256 x 256         7444.6         3651.7         7423.0          522.4          455.7
512 x 512         7069.9         3503.1         7187.1          540.0          472.5
 ==============================================================================
```

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
