### PR TITLE
Fix orientation of MP3D bounding boxes

### DIFF
--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -97,7 +97,8 @@ struct Mp3dRegionCategory : public SemanticCategory {
 bool SemanticScene::loadMp3dHouse(
     const std::string& houseFilename,
     SemanticScene& scene,
-    const quatf& worldRotation /* = quatf::Identity() */) {
+    const quatf& worldRotation /* = quatf::FromTwoVectors(-vec3f::UnitZ(),
+                                                       geo::ESP_GRAVITY) */ ) {
   if (!io::exists(houseFilename)) {
     LOG(ERROR) << "Could not load file " << houseFilename;
     return false;

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -79,9 +79,11 @@ class SemanticScene {
   }
 
   //! load SemanticScene from a Matterport3D House format filename
-  static bool loadMp3dHouse(const std::string& filename,
-                            SemanticScene& scene,
-                            const quatf& rotation = quatf::Identity());
+  static bool loadMp3dHouse(
+      const std::string& filename,
+      SemanticScene& scene,
+      const quatf& rotation = quatf::FromTwoVectors(-vec3f::UnitZ(),
+                                                    geo::ESP_GRAVITY));
 
   //! load SemanticScene from a SUNCG house format file
   static bool loadSuncgHouse(const std::string& filename,


### PR DESCRIPTION
## Motivation and Context

The MP3D bounding boxes need to be transformed to -Y down instead of -Z down to fit with the coordinate system that the agent/world is in.

## How Has This Been Tested

Compiles and we use this exact same transform (I literally copied that line) to rotate the MP3D meshes to -Y down, so it should work here too!
