### PR TITLE
Properly handles objects that don't have a region and regions that don't have a level

### DIFF
--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -24,6 +24,8 @@ class SemanticCategory {
   virtual int index(const std::string& mapping = "") const = 0;
   //! Return name of SemanticCategory under given mapping
   virtual std::string name(const std::string& mapping = "") const = 0;
+
+  ESP_SMART_POINTERS(SemanticCategory);
 };
 
 // forward declarations
@@ -132,14 +134,18 @@ class SemanticLevel {
 class SemanticRegion {
  public:
   virtual std::string id() const {
-    return level_->id() + "_" + std::to_string(index_);
+    if (level_ != nullptr) {
+      return level_->id() + "_" + std::to_string(index_);
+    } else {
+      return "_" + std::to_string(index_);
+    }
   }
-  const SemanticLevel& level() const { return *level_; }
+  const SemanticLevel::ptr level() const { return level_; }
   const std::vector<std::shared_ptr<SemanticObject>>& objects() const {
     return objects_;
   }
   box3f aabb() const { return bbox_; }
-  const SemanticCategory& category() const { return *category_; }
+  const SemanticCategory::ptr category() const { return category_; }
 
  protected:
   int index_;
@@ -159,12 +165,16 @@ class SemanticRegion {
 class SemanticObject {
  public:
   virtual std::string id() const {
-    return region_->id() + "_" + std::to_string(index_);
+    if (region_ != nullptr) {
+      return region_->id() + "_" + std::to_string(index_);
+    } else {
+      return "_" + std::to_string(index_);
+    }
   }
-  const SemanticRegion& region() const { return *region_; }
+  const SemanticRegion::ptr region() const { return region_; }
   box3f aabb() const { return obb_.toAABB(); }
   geo::OBB obb() const { return obb_; }
-  const SemanticCategory& category() const { return *category_; }
+  const SemanticCategory::ptr category() const { return category_; }
 
  protected:
   int index_;

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -30,10 +30,10 @@ TEST(Mp3dTest, Load) {
     LOG(INFO) << "Level{id:" << level->id() << ",aabb:" << level->aabb() << "}";
     for (auto& region : level->regions()) {
       LOG(INFO) << "Region{id:" << region->id() << ",aabb:" << region->aabb()
-                << ",category:" << region->category().name() << "}";
+                << ",category:" << region->category()->name() << "}";
       for (auto& object : region->objects()) {
         LOG(INFO) << "Object{id:" << object->id() << ",obb:" << object->obb()
-                  << ",category:" << object->category().name() << "}";
+                  << ",category:" << object->category()->name() << "}";
       }
     }
   }

--- a/src/tests/SuncgTest.cpp
+++ b/src/tests/SuncgTest.cpp
@@ -20,10 +20,10 @@ TEST(SuncgTest, Load) {
     LOG(INFO) << "Level{id:" << level->id() << ",aabb:" << level->aabb() << "}";
     for (auto& region : level->regions()) {
       LOG(INFO) << "Region{id:" << region->id() << ",aabb:" << region->aabb()
-                << ",category:" << region->category().name() << "}";
+                << ",category:" << region->category()->name() << "}";
       for (auto& object : region->objects()) {
         LOG(INFO) << "Object{id:" << object->id() << ",obb:" << object->obb()
-                  << ",category:" << object->category().name() << "}";
+                  << ",category:" << object->category()->name() << "}";
       }
     }
   }


### PR DESCRIPTION
## Motivation and Context

Segfaults are no fun, see https://github.com/facebookresearch/habitat-api/issues/59 for full context.

I also changed the return types of things related to the semantic scene to be shared_ptr instead of references as nullptr becomes `None` on the python side, so now if you do `obj.region.id` for an object with no region, you get a nice, pythonic error message:

```
Traceback (most recent call last):
  File "repro.py", line 11, in <module>
    obj.region.id
AttributeError: 'NoneType' object has no attribute 'id'
```

## How Has This Been Tested

With the following code:

```
import habitat_sim


cfg = habitat_sim.SimulatorConfiguration()
cfg.agents = [habitat_sim.AgentConfiguration()]
cfg.scene.id = "./data/scene_datasets/mp3d/ur6pFq6Qu1A/ur6pFq6Qu1A.glb"
sim = habitat_sim.Simulator(cfg)

for obj in sim.semantic_scene.objects:
    obj.id


for region in sim.semantic_scene.regions:
    region.id
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)