### PR TITLE
Exposes the subclasses used for {Mp3d, Suncg}SemanticScene

### DIFF
--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -405,7 +405,8 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("center", &OBB::center)
       .def_property_readonly("sizes", &OBB::sizes)
       .def_property_readonly("half_extents", &OBB::halfExtents)
-      .def_property_readonly("rotation", &OBB::rotation);
+      .def_property_readonly(
+          "rotation", [](const OBB& self) { return self.rotation().coeffs(); });
 
   // ==== SemanticCategory ====
   py::class_<SemanticCategory, SemanticCategory::ptr>(m, "SemanticCategory")

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -14,10 +14,12 @@ using namespace py::literals;
 #include "esp/gfx/Simulator.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/scene/AttachedObject.h"
+#include "esp/scene/Mp3dSemanticScene.h"
 #include "esp/scene/ObjectControls.h"
 #include "esp/scene/SceneGraph.h"
 #include "esp/scene/SceneNode.h"
 #include "esp/scene/SemanticScene.h"
+#include "esp/scene/SuncgSemanticScene.h"
 #include "esp/sensor/PinholeCamera.h"
 #include "esp/sensor/Sensor.h"
 
@@ -406,9 +408,33 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("rotation", &OBB::rotation);
 
   // ==== SemanticCategory ====
-  py::class_<SemanticCategory>(m, "SemanticCategory")
+  py::class_<SemanticCategory, SemanticCategory::ptr>(m, "SemanticCategory")
       .def("index", &SemanticCategory::index, "mapping"_a = "")
       .def("name", &SemanticCategory::name, "mapping"_a = "");
+
+  // === Mp3dObjectCategory ===
+  py::class_<Mp3dObjectCategory, SemanticCategory, Mp3dObjectCategory::ptr>(
+      m, "Mp3dObjectCategory")
+      .def("index", &Mp3dObjectCategory::index, "mapping"_a = "")
+      .def("name", &Mp3dObjectCategory::name, "mapping"_a = "");
+
+  // === Mp3dRegionCategory ===
+  py::class_<Mp3dRegionCategory, SemanticCategory, Mp3dRegionCategory::ptr>(
+      m, "Mp3dRegionCategory")
+      .def("index", &Mp3dRegionCategory::index, "mapping"_a = "")
+      .def("name", &Mp3dRegionCategory::name, "mapping"_a = "");
+
+  // === SuncgObjectCategory ===
+  py::class_<SuncgObjectCategory, SemanticCategory, SuncgObjectCategory::ptr>(
+      m, "SuncgObjectCategory")
+      .def("index", &SuncgObjectCategory::index, "mapping"_a = "")
+      .def("name", &SuncgObjectCategory::name, "mapping"_a = "");
+
+  // === SuncgRegionCategory ===
+  py::class_<SuncgRegionCategory, SemanticCategory, SuncgRegionCategory::ptr>(
+      m, "SuncgRegionCategory")
+      .def("index", &SuncgRegionCategory::index, "mapping"_a = "")
+      .def("name", &SuncgRegionCategory::name, "mapping"_a = "");
 
   // ==== SemanticLevel ====
   py::class_<SemanticLevel, SemanticLevel::ptr>(m, "SemanticLevel")
@@ -425,6 +451,15 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("category", &SemanticRegion::category)
       .def_property_readonly("objects", &SemanticRegion::objects);
 
+  // ==== SuncgSemanticRegion ====
+  py::class_<SuncgSemanticRegion, SemanticRegion, SuncgSemanticRegion::ptr>(
+      m, "SuncgSemanticRegion")
+      .def_property_readonly("id", &SuncgSemanticRegion::id)
+      .def_property_readonly("level", &SuncgSemanticRegion::level)
+      .def_property_readonly("aabb", &SuncgSemanticRegion::aabb)
+      .def_property_readonly("category", &SuncgSemanticRegion::category)
+      .def_property_readonly("objects", &SuncgSemanticRegion::objects);
+
   // ==== SemanticObject ====
   py::class_<SemanticObject, SemanticObject::ptr>(m, "SemanticObject")
       .def_property_readonly("id", &SemanticObject::id)
@@ -432,6 +467,15 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("aabb", &SemanticObject::aabb)
       .def_property_readonly("obb", &SemanticObject::obb)
       .def_property_readonly("category", &SemanticObject::category);
+
+  // ==== SuncgSemanticObject ====
+  py::class_<SuncgSemanticObject, SemanticObject, SuncgSemanticObject::ptr>(
+      m, "SuncgSemanticObject")
+      .def_property_readonly("id", &SuncgSemanticObject::id)
+      .def_property_readonly("region", &SuncgSemanticObject::region)
+      .def_property_readonly("aabb", &SuncgSemanticObject::aabb)
+      .def_property_readonly("obb", &SuncgSemanticObject::obb)
+      .def_property_readonly("category", &SuncgSemanticObject::category);
 
   // ==== SemanticScene ====
   py::class_<SemanticScene, SemanticScene::ptr>(m, "SemanticScene")

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include "esp/scene/Mp3dSemanticScene.h"
 #include "SemanticScene.h"
 
 #include <algorithm>
@@ -50,49 +51,35 @@ static const std::map<char, std::string> kRegionCategoryMap = {
     {'Z', "junk"}  // reflections of mirrors, points floating in space, etc.
 };
 
-struct Mp3dObjectCategory : public SemanticCategory {
-  int index(const std::string& mapping) const override {
-    if (mapping == "" || mapping == "mpcat40") {
-      return mpcat40Index_;
-    } else if (mapping == "raw") {
-      return categoryMappingIndex_;
-    } else {
-      LOG(ERROR) << "Unknown SemanticCategory mapping" << mapping;
-      return ID_UNDEFINED;
-    }
+int Mp3dObjectCategory::index(const std::string& mapping) const {
+  if (mapping == "" || mapping == "mpcat40") {
+    return mpcat40Index_;
+  } else if (mapping == "raw") {
+    return categoryMappingIndex_;
+  } else {
+    LOG(ERROR) << "Unknown SemanticCategory mapping" << mapping;
+    return ID_UNDEFINED;
   }
-  std::string name(const std::string& mapping) const override {
-    if (mapping == "" || mapping == "mpcat40") {
-      return mpcat40Name_;
-    } else if (mapping == "raw") {
-      return categoryMappingName_;
-    } else {
-      LOG(ERROR) << "Unknown SemanticCategory mapping" << mapping;
-      return "";
-    }
-  }
+}
 
- protected:
-  int index_ = ID_UNDEFINED;
-  int categoryMappingIndex_ = ID_UNDEFINED;
-  int mpcat40Index_ = ID_UNDEFINED;
-  std::string categoryMappingName_ = "";
-  std::string mpcat40Name_ = "";
-  friend SemanticScene;
-};
-
-struct Mp3dRegionCategory : public SemanticCategory {
-  Mp3dRegionCategory(const char labelCode) : labelCode_(labelCode) {}
-  int index(const std::string& mapping) const override {
-    return labelCode_ - 'a';
+std::string Mp3dObjectCategory::name(const std::string& mapping) const {
+  if (mapping == "" || mapping == "mpcat40") {
+    return mpcat40Name_;
+  } else if (mapping == "raw") {
+    return categoryMappingName_;
+  } else {
+    LOG(ERROR) << "Unknown SemanticCategory mapping" << mapping;
+    return "";
   }
-  std::string name(const std::string& mapping) const override {
-    return kRegionCategoryMap.at(labelCode_);
-  }
+}
 
- protected:
-  char labelCode_;
-};
+int Mp3dRegionCategory::index(const std::string& mapping) const {
+  return labelCode_ - 'a';
+}
+
+std::string Mp3dRegionCategory::name(const std::string& mapping) const {
+  return kRegionCategoryMap.at(labelCode_);
+}
 
 bool SemanticScene::loadMp3dHouse(
     const std::string& houseFilename,

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "esp/scene/Mp3dSemanticScene.h"
+#include "Mp3dSemanticScene.h"
 #include "SemanticScene.h"
 
 #include <algorithm>

--- a/src/esp/scene/Mp3dSemanticScene.h
+++ b/src/esp/scene/Mp3dSemanticScene.h
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 #pragma once
 
 #include "esp/scene/SemanticScene.h"

--- a/src/esp/scene/Mp3dSemanticScene.h
+++ b/src/esp/scene/Mp3dSemanticScene.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "esp/scene/SemanticScene.h"
+
+namespace esp {
+namespace scene {
+struct Mp3dObjectCategory : public SemanticCategory {
+  int index(const std::string& mapping) const override;
+
+  std::string name(const std::string& mapping) const override;
+
+ protected:
+  int index_ = ID_UNDEFINED;
+  int categoryMappingIndex_ = ID_UNDEFINED;
+  int mpcat40Index_ = ID_UNDEFINED;
+  std::string categoryMappingName_ = "";
+  std::string mpcat40Name_ = "";
+  friend SemanticScene;
+
+  ESP_SMART_POINTERS(Mp3dObjectCategory)
+};
+
+struct Mp3dRegionCategory : public SemanticCategory {
+  Mp3dRegionCategory(const char labelCode) : labelCode_(labelCode) {}
+
+  int index(const std::string& mapping) const override;
+
+  std::string name(const std::string& mapping) const override;
+
+ protected:
+  char labelCode_;
+
+  ESP_SMART_POINTERS(Mp3dRegionCategory)
+};
+}  // namespace scene
+}  // namespace esp

--- a/src/esp/scene/Mp3dSemanticScene.h
+++ b/src/esp/scene/Mp3dSemanticScene.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "esp/scene/SemanticScene.h"
+#include "SemanticScene.h"
 
 namespace esp {
 namespace scene {

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -111,12 +111,15 @@ class SemanticScene {
 class SemanticLevel {
  public:
   virtual std::string id() const { return std::to_string(index_); }
+
   const std::vector<std::shared_ptr<SemanticRegion>>& regions() const {
     return regions_;
   }
+
   const std::vector<std::shared_ptr<SemanticObject>>& objects() const {
     return objects_;
   }
+
   box3f aabb() const { return bbox_; }
 
  protected:
@@ -140,11 +143,15 @@ class SemanticRegion {
       return "_" + std::to_string(index_);
     }
   }
+
   const SemanticLevel::ptr level() const { return level_; }
+
   const std::vector<std::shared_ptr<SemanticObject>>& objects() const {
     return objects_;
   }
+
   box3f aabb() const { return bbox_; }
+
   const SemanticCategory::ptr category() const { return category_; }
 
  protected:
@@ -171,9 +178,13 @@ class SemanticObject {
       return "_" + std::to_string(index_);
     }
   }
+
   const SemanticRegion::ptr region() const { return region_; }
+
   box3f aabb() const { return obb_.toAABB(); }
+
   geo::OBB obb() const { return obb_; }
+
   const SemanticCategory::ptr category() const { return category_; }
 
  protected:

--- a/src/esp/scene/SuncgSemanticScene.cpp
+++ b/src/esp/scene/SuncgSemanticScene.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "esp/scene/SuncgSemanticScene.h"
+#include "SuncgSemanticScene.h"
 #include "SemanticScene.h"
 #include "SuncgObjectCategoryMap.h"
 

--- a/src/esp/scene/SuncgSemanticScene.h
+++ b/src/esp/scene/SuncgSemanticScene.h
@@ -1,3 +1,6 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/src/esp/scene/SuncgSemanticScene.h
+++ b/src/esp/scene/SuncgSemanticScene.h
@@ -1,0 +1,62 @@
+
+#pragma once
+
+#include "esp/scene/SemanticScene.h"
+
+namespace esp {
+namespace scene {
+
+class SuncgSemanticObject : public SemanticObject {
+ public:
+  std::string id() const override;
+
+ protected:
+  std::string nodeId_;
+  friend SemanticScene;
+  ESP_SMART_POINTERS(SuncgSemanticObject)
+};
+
+class SuncgSemanticRegion : public SemanticRegion {
+ public:
+  std::string id() const override;
+
+ protected:
+  std::string nodeId_;
+  std::vector<int> nodeIndicesInLevel_;
+  friend SemanticScene;
+  ESP_SMART_POINTERS(SuncgSemanticRegion)
+};
+
+struct SuncgObjectCategory : public SemanticCategory {
+  SuncgObjectCategory(const std::string& nodeId, const std::string& modelId)
+      : nodeId_(nodeId), modelId_(modelId) {}
+
+  int index(const std::string& mapping) const override;
+
+  std::string name(const std::string& mapping) const override;
+
+ protected:
+  std::string nodeId_;
+  std::string modelId_;
+  friend SemanticScene;
+
+  ESP_SMART_POINTERS(SuncgObjectCategory)
+};
+
+struct SuncgRegionCategory : public SemanticCategory {
+  SuncgRegionCategory(const std::string& nodeId,
+                      const std::vector<std::string> categories)
+      : nodeId_(nodeId), categories_(categories) {}
+
+  int index(const std::string& mapping) const override;
+
+  std::string name(const std::string& mapping) const override;
+
+ protected:
+  std::string nodeId_;
+  std::vector<std::string> categories_;
+
+  ESP_SMART_POINTERS(SuncgRegionCategory)
+};
+}  // namespace scene
+}  // namespace esp

--- a/src/esp/scene/SuncgSemanticScene.h
+++ b/src/esp/scene/SuncgSemanticScene.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "esp/scene/SemanticScene.h"
+#include "SemanticScene.h"
 
 namespace esp {
 namespace scene {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -32,6 +32,7 @@ def test_attach_detach():
     for _, v in agent.sensors.items():
         habitat_sim.errors.assert_obj_valid(v)
 
+    agent.detach()
     with pytest.raises(habitat_sim.errors.InvalidAttachedObject):
         habitat_sim.errors.assert_obj_valid(agent.body)
 

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import habitat_sim.bindings as hsim
+import habitat_sim
+import habitat_sim.utils
+import habitat_sim.errors
+import numpy as np
+import quaternion
+import pytest
+import os.path as osp
+from examples.settings import make_cfg
+
+_test_scenes = [
+    osp.abspath(
+        osp.join(
+            osp.dirname(__file__),
+            "../data/scene_datasets/mp3d/17DRP5sb8fy/17DRP5sb8fy.glb",
+        )
+    ),
+    osp.abspath(
+        osp.join(
+            osp.dirname(__file__),
+            "../data/scene_datasets/mp3d/ur6pFq6Qu1A/ur6pFq6Qu1A.glb",
+        )
+    ),
+]
+
+
+@pytest.mark.gfxtest
+@pytest.mark.parametrize("scene", _test_scenes)
+def test_semantic_scene(scene, sim, make_cfg_settings):
+    if not osp.exists(scene):
+        pytest.skip("Skipping {}".format(scene))
+
+    make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
+    make_cfg_settings["semantic_sensor"] = False
+    make_cfg_settings["scene"] = scene
+    sim.reconfigure(make_cfg(make_cfg_settings))
+
+    scene = sim.semantic_scene
+    for obj in scene.objects:
+        obj.aabb
+        obj.aabb.sizes
+        obj.aabb.center
+        obj.id
+        obj.obb.rotation
+        obj.category.name()
+        obj.category.index()
+
+    for region in scene.regions:
+        region.id
+        region.category.name()
+        region.category.index()
+
+    for level in scene.levels:
+        level.id


### PR DESCRIPTION
## Motivation and Context

PyBind11 requires explicit bindings whenever subclasses are used to implement an abstract base class or when a subclass is used to override virtual methods.  Those subclasses weren't bound, which results in memory corruptions.

Also binds a lambda for the OBB rotation as we can't convert an `Eigen::Quaternion` into python

https://github.com/facebookresearch/habitat-api/issues/59

## How Has This Been Tested

With the following re-production script:

```
import habitat_sim

cfg = habitat_sim.SimulatorConfiguration()
cfg.agents = [habitat_sim.AgentConfiguration()]
cfg.scene.id = "data/scene_datasets/mp3d/ur6pFq6Qu1A/ur6pFq6Qu1A.glb"
sim = habitat_sim.Simulator(cfg)

scene = sim.semantic_scene
for obj in scene.objects:
    obj.id
    obj.category.name()
    obj.category.index()

for region in scene.regions:
    region.id
    region.category.name()
    region.category.index()

for level in scene.levels:
    level.id

sim.close()
```

After landing #6, I will make another PR to add a this as a test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
