### PR TITLE
Setup py improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ tests/17DRP5sb8fy
 data/
 habitat-test-scenes.zip
 habitat_sim/_ext
+
+.setuppy_args_cache.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,7 @@ addopts = --verbose -rsxX -q
 testpaths = tests
 markers =
     gfxtest: marks a test as needing to render
+
+[build_ext]
+inplace=1
+build_temp=build

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,10 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
 
-        if in_git():
+        # Init & update all submodules if not already (the user might be pinned
+        # on some particular commit or have working tree changes, don't destroy
+        # those)
+        if in_git() and not os.path.exists(".git/modules"):
             subprocess.check_call(
                 ["git", "submodule", "update", "--init", "--recursive"]
             )

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,14 @@
 Adapted from: http://www.benjack.io/2017/06/12/python-cpp-tests.html
 """
 
+import argparse
 import builtins
 import glob
 import json
 import os
 import os.path as osp
 import re
+import shlex
 import subprocess
 import sys
 from distutils.version import StrictVersion
@@ -21,32 +23,73 @@ from distutils.version import StrictVersion
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
-HEADLESS = False
-FORCE_CMAKE = False
-BUILD_TESTS = False
+ARG_CACHE_BLACKLIST = {"force_cmake", "cache_args"}
 
 
-filtered_args = []
+def build_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--headless",
+        dest="headless",
+        action="store_true",
+        help="""Build in headless mode.
+Use "HEADLESS=True pip install ." to build in headless mode with pip""",
+    )
+    parser.add_argument(
+        "--force-cmake",
+        "--cmake",
+        dest="force_cmake",
+        action="store_true",
+        help="Forces cmake to be rerun.  This argument is not cached",
+    )
+    parser.add_argument(
+        "--build-tests", dest="build_tests", action="store_true", help="Build tests"
+    )
+    parser.add_argument(
+        "--cmake-args",
+        type=str,
+        default="",
+        help="""Additional arguements to be passed to cmake.
+Note that you will need to do `--cmake-args="..."` as `--cmake-args "..."`
+will generally not be parsed correctly
+You may need to use --force-cmake to ensure cmake is rerun with new args.
+Use "CMAKE_ARGS="..." pip install ." to set cmake args with pip""",
+    )
+
+    parser.add_argument(
+        "--no-update-submodules",
+        dest="no_update_submodules",
+        action="store_true",
+        help="Don't update git submodules",
+    )
+
+    parser.add_argument(
+        "--cache-args",
+        dest="cache_args",
+        action="store_true",
+        help="""Caches the arguements sent to setup.py
+        and reloads them on the next invocation.  This argument is not cached""",
+    )
+
+    return parser
+
+
+parseable_args = []
+unparseable_args = []
 for i, arg in enumerate(sys.argv):
-    if arg == "--headless":
-        HEADLESS = True
-        continue
-
-    if arg == "--force-cmake" or arg == "--cmake":
-        FORCE_CMAKE = True
-        continue
-
-    if arg == "--build-tests":
-        BUILD_TESTS = True
-        continue
-
     if arg == "--":
-        filtered_args += sys.argv[i:]
+        unparseable_args = sys.argv[i:]
         break
 
-    filtered_args.append(arg)
+    parseable_args.append(arg)
 
-sys.argv = filtered_args
+
+parser = build_parser()
+args, filtered_args = parser.parse_known_args(args=parseable_args)
+
+sys.argv = filtered_args + unparseable_args
 
 
 def in_git():
@@ -77,6 +120,39 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
+    def finalize_options(self):
+        super().finalize_options()
+
+        cacheable_params = [
+            opt[0].replace("=", "").replace("-", "_") for opt in self.user_options
+        ]
+
+        args_cache_file = ".setuppy_args_cache.json"
+
+        if not args.cache_args and osp.exists(args_cache_file):
+            with open(args_cache_file, "r") as f:
+                cached_args = json.load(f)
+
+            for k, v in cached_args["args"].items():
+                setattr(args, k, v)
+
+            for k, v in cached_args["build_ext"].items():
+                setattr(self, k, v)
+
+        elif args.cache_args:
+            cache = dict(
+                args={
+                    k: v for k, v in vars(args).items() if k not in ARG_CACHE_BLACKLIST
+                },
+                build_ext={
+                    k: getattr(self, k)
+                    for k in cacheable_params
+                    if k not in ARG_CACHE_BLACKLIST
+                },
+            )
+            with open(args_cache_file, "w") as f:
+                json.dump(cache, f, indent=4, sort_keys=True)
+
     def run(self):
         try:
             subprocess.check_output(["cmake", "--version"])
@@ -95,7 +171,7 @@ class CMakeBuild(build_ext):
         # Init & update all submodules if not already (the user might be pinned
         # on some particular commit or have working tree changes, don't destroy
         # those)
-        if in_git() and not os.path.exists(".git/modules"):
+        if in_git() and not args.no_update_submodules:
             subprocess.check_call(
                 ["git", "submodule", "update", "--init", "--recursive"]
             )
@@ -105,6 +181,7 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE=" + sys.executable,
             "-DCMAKE_EXPORT_COMPILE_COMMANDS={}".format("OFF" if is_pip() else "ON"),
         ]
+        cmake_args += shlex.split(args.cmake_args)
 
         cfg = "Debug" if self.debug else "RelWithDebInfo"
         build_args = ["--config", cfg]
@@ -122,24 +199,25 @@ class CMakeBuild(build_ext):
         if not has_ninja() or self.parallel:
             build_args += ["-j{}".format(self.parallel) if self.parallel else "-j"]
 
-        cmake_args += ["-DBUILD_GUI_VIEWERS={}".format("ON" if not HEADLESS else "OFF")]
-        cmake_args += ["-DBUILD_TESTS={}".format("ON" if BUILD_TESTS else "OFF")]
+        cmake_args += [
+            "-DBUILD_GUI_VIEWERS={}".format("ON" if not args.headless else "OFF")
+        ]
+        cmake_args += ["-DBUILD_TESTS={}".format("ON" if args.build_tests else "OFF")]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get("CXXFLAGS", ""), self.distribution.get_version()
         )
 
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-
         if self.run_cmake(cmake_args):
             subprocess.check_call(
-                ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
+                shlex.split("cmake -H{} -B{}".format(ext.sourcedir, self.build_temp))
+                + cmake_args,
+                env=env,
             )
 
         subprocess.check_call(
-            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+            shlex.split("cmake --build {}".format(self.build_temp)) + build_args
         )
         print()  # Add an empty line for cleaner output
 
@@ -147,24 +225,18 @@ class CMakeBuild(build_ext):
         if is_pip():
             return
 
-        if not HEADLESS:
-            link_dst = osp.join(osp.dirname(self.build_temp), "viewer")
+        if not args.headless:
+            link_dst = osp.join(self.build_temp, "viewer")
             if not osp.islink(link_dst):
                 os.symlink(
                     osp.abspath(osp.join(self.build_temp, "utils/viewer/viewer")),
                     link_dst,
                 )
 
-        if not osp.islink(osp.join(osp.dirname(self.build_temp), "utils")):
-            os.symlink(
-                osp.abspath(osp.join(self.build_temp, "utils")),
-                osp.join(osp.dirname(self.build_temp), "utils"),
-            )
-
         self.create_compile_commands()
 
     def run_cmake(self, cmake_args):
-        if FORCE_CMAKE:
+        if args.force_cmake:
             return True
 
         cache_parser = re.compile(r"(?P<K>\w+?)(:\w+?|)=(?P<V>.*?)$")
@@ -178,7 +250,7 @@ class CMakeBuild(build_ext):
                 if arg[0:2] == "-G":
                     continue
 
-                k, v = arg.split("=")
+                k, v = arg.split("=", 1)
                 # Strip +D
                 k = k[2:]
                 for l in cache_contents:
@@ -226,7 +298,10 @@ if __name__ == "__main__":
     ) >= StrictVersion("3.6"), "Must use python3.6 or newer"
 
     if os.environ.get("HEADLESS", "").lower() == "true":
-        HEADLESS = True
+        args.headless = True
+
+    if os.environ.get("CMAKE_ARGS", None) is not None:
+        args.cmake_args = os.environ["CMAKE_ARGS"]
 
     requirements = ["attrs", "numba", "numpy", "numpy-quaternion", "pillow"]
 

--- a/setup.py
+++ b/setup.py
@@ -114,8 +114,13 @@ class CMakeBuild(build_ext):
 
         if has_ninja():
             cmake_args += ["-GNinja"]
-        else:
-            build_args += ["-j"]
+        # Make it possible to *reduce* the number of jobs. Ninja requires a
+        # number passed to -j (and builds on all cores by default), while make
+        # doesn't require a number (but builds sequentially by default), so we
+        # add the argument only when it's not ninja or the number of jobs is
+        # specified.
+        if not has_ninja() or self.parallel:
+            build_args += ["-j{}".format(self.parallel) if self.parallel else "-j"]
 
         cmake_args += ["-DBUILD_GUI_VIEWERS={}".format("ON" if not HEADLESS else "OFF")]
         cmake_args += ["-DBUILD_TESTS={}".format("ON" if BUILD_TESTS else "OFF")]

--- a/src/esp/gfx/Viewer.cpp
+++ b/src/esp/gfx/Viewer.cpp
@@ -39,9 +39,8 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("action-path",
                "Provides actions along the action space shortest path to a "
                "random goal")
-      .addSkippedPrefix("magnum")
-      .setHelp("engine-specific options")
-      .setHelp("Displays a 3D scene file provided on command line")
+      .addSkippedPrefix("magnum", "engine-specific options")
+      .setGlobalHelp("Displays a 3D scene file provided on command line")
       .parse(arguments.argc, arguments.argv);
 
   const auto viewportSize = GL::defaultFramebuffer.viewport().size();


### PR DESCRIPTION
## Motivation and Context

While #24 said that

> do we expect people to be multitasking while installing habitat-sim [...]?

I'm actually one of those crazy multitaskers :) 100% CPU wouldn't be a problem, but when running on all cores, *something* in the build demands 8 GB of RAM which I usually don't have, so my system comes to a grinding halt. (I still want to investigate what's responsible and if it's possible to tell `ninja` to not overschedule such jobs.)

While the default is still *all the cores*, it now allows to override the setting using the setuptools' builtin `--parallel` option. Together with redirecting it to use a pre-existing CMake build (which was set up manually for #35) dir my command-line looks like this:

```sh
python setup.py build_ext --build-temp=build --parallel 3
```

Apart from this, because I use some system deps, I'm not interested in `setup.py` implicitly pulling submodules that I am not interested in, so it runs `git submodule update` only the very first time.

## How Has This Been Tested

I'm now able to *both* have 163 tabs open in my browser *and* build Habitat :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / ~~dependency upgrade~~ buildsystem update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. -- maybe? please tell me where
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
