### PR TITLE
esp/gfx: update Viewer to not use deprecated Utility::Arguments APIs

### DIFF
--- a/src/esp/gfx/Viewer.cpp
+++ b/src/esp/gfx/Viewer.cpp
@@ -39,9 +39,8 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("action-path",
                "Provides actions along the action space shortest path to a "
                "random goal")
-      .addSkippedPrefix("magnum")
-      .setHelp("engine-specific options")
-      .setHelp("Displays a 3D scene file provided on command line")
+      .addSkippedPrefix("magnum", "engine-specific options")
+      .setGlobalHelp("Displays a 3D scene file provided on command line")
       .parse(arguments.argc, arguments.argv);
 
   const auto viewportSize = GL::defaultFramebuffer.viewport().size();


### PR DESCRIPTION
 ## Motivation and Context

The overloaded `setHelp()` function led to many accidents where option help was mistakenly set as global help (as seen here as well), the overload got renamed to `setGlobalHelp()` to avoid such mistakes. The code was updated to use the new API.

## How Has This Been Tested

No deprecation warnings are emitted during compilation anymore. No functional change, apart from correct label being printed in viewer's `--help`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
