### PR TITLE
Gets rid of GLSL undefined uniform warning

### DIFF
--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -40,7 +40,8 @@ void GenericDrawable::draw(const Magnum::Matrix4& transformationMatrix,
     shader.setColor(color_);
   }
 
-  if (!(shader.flags() & GenericShader::Flag::PerVertexIds)) {
+  if (!(shader.flags() & GenericShader::Flag::PerVertexIds) &&
+      !(shader.flags() & GenericShader::Flag::PrimitiveIDTextured)) {
     shader.setObjectId(node_.getId());
   }
   mesh_.draw(shader_);


### PR DESCRIPTION
## Motivation and Context
On devfair, OpenGL optimizes out the dummy `objectId = uint(objectIdUniform);` when rendering with ID textured meshes, which then produces an annoying `GL::AbstractShaderProgram: location of uniform 'objectIdUniform' cannot be retrieved` warning.  This PR simply adds PrimitiveIDTextured meshes to the list of things to not set the `objectIdUniform` with.  This is fine in both the case where the line is and isn't optimized out.

## How Has This Been Tested
`pytest` passes both on linux box and my local MacOS laptop.

`pytest -s` has no annoying `GL::AbstractShaderProgram: location of uniform 'objectIdUniform' cannot be retrieved` warnings.
