### PR TITLE
setup.py: Can't do inplace=1 because that breaks the install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,4 @@ markers =
     gfxtest: marks a test as needing to render
 
 [build_ext]
-inplace=1
 build_temp=build


### PR DESCRIPTION
## Motivation and Context

setup.py makes no sense and the install breaks if you set inplace to be the default for build_ext!

## How Has This Been Tested

In a fresh conda env with `python setup.py install`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
