### PR TITLE
Revamps controls

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -19,16 +19,6 @@ from .controls import ActuationSpec, ObjectControls
 __all__ = ["ActionSpec", "SixDOFPose", "AgentState", "AgentConfiguration", "Agent"]
 
 
-BodyActions = {
-    "move_right",
-    "move_left",
-    "move_forward",
-    "move_backward",
-    "turn_left",
-    "turn_right",
-}
-
-
 def _default_action_space():
     return dict(
         move_forward=ActionSpec("move_forward", ActuationSpec(amount=0.25)),
@@ -174,7 +164,7 @@ class Agent(object):
         ), f"No action {action_id} in action space"
         action = self.agent_config.action_space[action_id]
 
-        if action.name in BodyActions:
+        if self.controls.is_body_action(action.name):
             self.controls.action(
                 self.scene_node, action.name, action.actuation, apply_filter=True
             )

--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -27,7 +27,7 @@ def _default_action_space():
     )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True)
 class ActionSpec(object):
     r"""Defines how a specific action is implemented
 

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -44,8 +44,12 @@ def register_move_fn(
     controller: Optional[Type[SceneNodeControl]] = None,
     *,
     name: Optional[str] = None,
-    body_action: bool = False,
+    body_action: bool = None,
 ):
+    assert (
+        body_action is not None
+    ), "body_action must be explicitly set to True or False"
+
     def _wrapper(controller: Type[SceneNodeControl]):
         assert issubclass(
             controller, SceneNodeControl

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -23,12 +23,12 @@ def _camel_to_snake(name):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True)
 class ActuationSpec(object):
     amount: float
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True)
 class SceneNodeControl(abc.ABC):
     body_action: bool = False
 

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -25,9 +25,9 @@ def _camel_to_snake(name):
 
 @attr.s(auto_attribs=True)
 class ActuationSpec(object):
-    r"""Struct to hold paramters for the default actions
+    r"""Struct to hold parameters for the default actions
 
-    The default actions only have one paramters, the amount
+    The default actions only have one parameters, the amount
     they move the scene node by, however other actions may have any number of
     parameters and can define different structs to hold those parameters
 
@@ -56,7 +56,7 @@ class SceneNodeControl(abc.ABC):
 
         Args:
             scene_node (hsim.SceneNode): The scene node to control
-            actuation_spec (ActuationSpec): Struct holding any paramters of the control
+            actuation_spec (ActuationSpec): Struct holding any parameters of the control
         """
         pass
 
@@ -70,7 +70,7 @@ def register_move_fn(
     name: Optional[str] = None,
     body_action: bool = None,
 ):
-    r"""Registers a new control with habitat sim
+    r"""Registers a new control with Habitat-Sim
 
     See default_controls.py for an example of adding new actions
     (note that this can be done _outside_ the core habitat_sim codebase in exactly the same way)
@@ -81,9 +81,9 @@ def register_move_fn(
         name (Optional[str]): The name to register the control with
             If none, will register with the name of the controller converted to snake case
             i.e. a controller with class name MoveForward will be registered as move_forward
-        body_action (bool): Whether or not this action manipulates the agents body
+        body_action (bool): Whether or not this action manipulates the agent's body
             (thereby also moving the sensors) or manipulates just the sensors.
-            This is a non-optional keyword arguement and must be set (this is done for readability purpose)
+            This is a non-optional keyword arguement and must be set (this is done for readability)
     """
 
     assert (

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -8,10 +8,10 @@ import abc
 import re
 from typing import Dict, Optional, Type
 
-import attr
 import numpy as np
 import quaternion
 
+import attr
 import habitat_sim.bindings as hsim
 from habitat_sim import utils
 
@@ -25,15 +25,38 @@ def _camel_to_snake(name):
 
 @attr.s(auto_attribs=True)
 class ActuationSpec(object):
+    r"""Struct to hold paramters for the default actions
+
+    The default actions only have one paramters, the amount
+    they move the scene node by, however other actions may have any number of
+    parameters and can define different structs to hold those parameters
+
+    Args:
+        amount (float): The amount the control moves the scene node by
+    """
     amount: float
 
 
 @attr.s(auto_attribs=True)
 class SceneNodeControl(abc.ABC):
+    r"""Base class for all controls
+
+    Control classes are used to implement agent actions.  Any new control
+    must subclass this class.
+
+    See examples/new_actions.py for an example of adding new actions
+    """
+
     body_action: bool = False
 
     @abc.abstractmethod
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+        r"""Abstract method to be overridden to implement the control
+
+        Args:
+            scene_node (hsim.SceneNode): The scene node to control
+            actuation_spec (ActuationSpec): Struct holding any paramters of the control
+        """
         pass
 
 
@@ -46,6 +69,19 @@ def register_move_fn(
     name: Optional[str] = None,
     body_action: bool = None,
 ):
+    r"""Registers a new control with habitat sim
+
+    Args:
+        controller (Optional[Type[SceneNodeControl]]): The class of the controller to register
+            If none, will return a wrapper for use with decorator syntax
+        name (Optional[str]): The name to register the control with
+            If none, will register with the name of the controller converted to snake case
+            i.e. a controller with class name MoveForward will be registered as move_forward
+        body_action (bool): Whether or not this action manipulates the agents body
+            (thereby also moving the sensors) or manipulates just the sensors.
+            This is a non-optional keyword arguement and must be set (this is done for readability purpose)
+    """
+
     assert (
         body_action is not None
     ), "body_action must be explicitly set to True or False"

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -8,14 +8,14 @@ import abc
 import re
 from typing import Dict, Optional, Type
 
+import attr
 import numpy as np
 import quaternion
 
-import attr
 import habitat_sim.bindings as hsim
 from habitat_sim import utils
 
-__all__ = ["ActuationSpec", "Controller", "ObjectControls"]
+__all__ = ["ActuationSpec", "SceneNodeControl", "ObjectControls"]
 
 
 def _camel_to_snake(name):
@@ -29,7 +29,7 @@ class ActuationSpec(object):
 
 
 @attr.s(auto_attribs=True, slots=True)
-class Controller(abc.ABC):
+class SceneNodeControl(abc.ABC):
     body_action: bool = False
 
     @abc.abstractmethod
@@ -37,19 +37,19 @@ class Controller(abc.ABC):
         pass
 
 
-move_func_map: Dict[str, Controller] = dict()
+move_func_map: Dict[str, SceneNodeControl] = dict()
 
 
 def register_move_fn(
-    controller: Optional[Type[Controller]] = None,
+    controller: Optional[Type[SceneNodeControl]] = None,
     *,
     name: Optional[str] = None,
     body_action: bool = False,
 ):
-    def _wrapper(controller: Type[Controller]):
+    def _wrapper(controller: Type[SceneNodeControl]):
         assert issubclass(
-            controller, Controller
-        ), "All controls must inherit from habitat_sim.agent.Controller"
+            controller, SceneNodeControl
+        ), "All controls must inherit from habitat_sim.agent.SceneNodeControl"
 
         move_func_map[
             _camel_to_snake(controller.__name__) if name is None else name

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -44,7 +44,8 @@ class SceneNodeControl(abc.ABC):
     Control classes are used to implement agent actions.  Any new control
     must subclass this class.
 
-    See examples/new_actions.py for an example of adding new actions
+    See default_controls.py for an example of adding new actions
+    (note that this can be done _outside_ the core habitat_sim codebase in exactly the same way)
     """
 
     body_action: bool = False
@@ -70,6 +71,9 @@ def register_move_fn(
     body_action: bool = None,
 ):
     r"""Registers a new control with habitat sim
+
+    See default_controls.py for an example of adding new actions
+    (note that this can be done _outside_ the core habitat_sim codebase in exactly the same way)
 
     Args:
         controller (Optional[Type[SceneNodeControl]]): The class of the controller to register

--- a/habitat_sim/agent/controls.py
+++ b/habitat_sim/agent/controls.py
@@ -6,12 +6,12 @@
 
 import abc
 import re
-from typing import Dict, Optional
+from typing import Dict, Optional, Type
 
-import attr
 import numpy as np
 import quaternion
 
+import attr
 import habitat_sim.bindings as hsim
 from habitat_sim import utils
 
@@ -41,12 +41,16 @@ move_func_map: Dict[str, Controller] = dict()
 
 
 def register_move_fn(
-    controller: Optional[Controller] = None,
+    controller: Optional[Type[Controller]] = None,
     *,
     name: Optional[str] = None,
     body_action: bool = False,
 ):
-    def _wrapper(controller: Controller):
+    def _wrapper(controller: Type[Controller]):
+        assert issubclass(
+            controller, Controller
+        ), "All controls must inherit from habitat_sim.agent.Controller"
+
         move_func_map[
             _camel_to_snake(controller.__name__) if name is None else name
         ] = controller(body_action)

--- a/habitat_sim/agent/default_controls.py
+++ b/habitat_sim/agent/default_controls.py
@@ -56,25 +56,25 @@ class MoveLeft(SceneNodeControl):
         _move_along(scene_node, -actuation_spec.amount, _x_axis)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class MoveUp(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _y_axis)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class MoveDown(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _y_axis)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class LookLeft(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, actuation_spec.amount, _y_axis)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class LookRight(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, -actuation_spec.amount, _y_axis)
@@ -84,13 +84,13 @@ register_move_fn(LookLeft, name="turn_left", body_action=True)
 register_move_fn(LookRight, name="turn_right", body_action=True)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class LookUp(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, actuation_spec.amount, _x_axis)
 
 
-@register_move_fn
+@register_move_fn(body_action=False)
 class LookDown(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, -actuation_spec.amount, _x_axis)

--- a/habitat_sim/agent/default_controls.py
+++ b/habitat_sim/agent/default_controls.py
@@ -9,7 +9,7 @@ import numpy as np
 import habitat_sim.bindings as hsim
 from habitat_sim import utils
 
-from .controls import ActuationSpec, Controller, register_move_fn
+from .controls import ActuationSpec, SceneNodeControl, register_move_fn
 
 __all__ = []
 
@@ -33,49 +33,49 @@ def _rotate_local(scene_node: hsim.SceneNode, theta: float, axis: int):
 
 
 @register_move_fn(body_action=True)
-class MoveBackward(Controller):
+class MoveBackward(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _z_axis)
 
 
 @register_move_fn(body_action=True)
-class MoveForward(Controller):
+class MoveForward(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _z_axis)
 
 
 @register_move_fn(body_action=True)
-class MoveRight(Controller):
+class MoveRight(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _x_axis)
 
 
 @register_move_fn(body_action=True)
-class MoveLeft(Controller):
+class MoveLeft(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _x_axis)
 
 
 @register_move_fn
-class MoveUp(Controller):
+class MoveUp(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _y_axis)
 
 
 @register_move_fn
-class MoveDown(Controller):
+class MoveDown(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _y_axis)
 
 
 @register_move_fn
-class LookLeft(Controller):
+class LookLeft(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, actuation_spec.amount, _y_axis)
 
 
 @register_move_fn
-class LookRight(Controller):
+class LookRight(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, -actuation_spec.amount, _y_axis)
 
@@ -85,12 +85,12 @@ register_move_fn(LookRight, name="turn_right", body_action=True)
 
 
 @register_move_fn
-class LookUp(Controller):
+class LookUp(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, actuation_spec.amount, _x_axis)
 
 
 @register_move_fn
-class LookDown(Controller):
+class LookDown(SceneNodeControl):
     def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, -actuation_spec.amount, _x_axis)


### PR DESCRIPTION
## Motivation and Context

The current way the controls are defined is kinda confusing at the delineation between body action and not is not apparent at the definition of the control!

This PR aims to fix this by having the `register_move_fn` take an argument that determines control or not.  I also made the controls a class that implements a `__call__` function as that way `body_action` can be set on a per-instance basis.

Closes #52 #51 

## How Has This Been Tested

Via `pytest`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
