### PR TITLE
Example of creating a stereo agent

### DIFF
--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -29,6 +29,9 @@ def _render(sim, display, depth=False):
             stereo_pair = np.clip(stereo_pair, 0, 10)
             stereo_pair /= 10.0
 
+        if len(stereo_pair.shape) > 2:
+            stereo_pair = stereo_pair[..., 0:3][..., ::-1]
+
         if display:
             cv2.imshow("stereo_pair", stereo_pair)
             k = cv2.waitKey()
@@ -50,10 +53,10 @@ def main(display=True):
         "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"
     )
 
-    # First, lets create a stereo RGB agent
+    # First, let's create a stereo RGB agent
     left_rgb_sensor = habitat_sim.SensorSpec()
     # Give it the uuid of left_sensor, this will also be how we
-    # index the observations to retreive the rendering from this sensor
+    # index the observations to retrieve the rendering from this sensor
     left_rgb_sensor.uuid = "left_sensor"
     left_rgb_sensor.resolution = [512, 512]
     # The left RGB sensor will be 1.5 meters off the ground
@@ -69,7 +72,7 @@ def main(display=True):
     right_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
 
     agent_config = habitat_sim.AgentConfiguration()
-    # Now we simly set the agents list of sensor specs to be the two specs for our two sensors
+    # Now we simly set the agent's list of sensor specs to be the two specs for our two sensors
     agent_config.sensor_specifications = [left_rgb_sensor, right_rgb_sensor]
 
     sim = habitat_sim.Simulator(habitat_sim.Configuration(backend_cfg, [agent_config]))
@@ -78,12 +81,12 @@ def main(display=True):
     sim.close()
     del sim
 
-    # Now lets do the exact same thing but for a depth camera stereo pair!
+    # Now let's do the exact same thing but for a depth camera stereo pair!
     left_depth_sensor = habitat_sim.SensorSpec()
     left_depth_sensor.uuid = "left_sensor"
     left_depth_sensor.resolution = [512, 512]
     left_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.LEFT
-    # The only difference we need to do is set the sensor type to depth
+    # The only difference is that we set the sensor type to DEPTH
     left_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
 
     right_depth_sensor = habitat_sim.SensorSpec()
@@ -92,7 +95,7 @@ def main(display=True):
     right_depth_sensor.position = (
         1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
     )
-    # The only difference we need to do is set the sensor type to depth
+    # The only difference is that we set the sensor type to DEPTH
     right_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
 
     agent_config = habitat_sim.AgentConfiguration()

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -23,16 +23,13 @@ cv2 = None
 def _render(sim, display, depth=False):
     for _ in range(100):
         obs = sim.step("turn_right")
+        stereo_pair = np.concatenate([obs["left_sensor"], obs["right_sensor"]], axis=1)
+
+        if depth:
+            stereo_pair = np.clip(stereo_pair, 0, 10)
+            stereo_pair /= 10.0
 
         if display:
-            stereo_pair = np.concatenate(
-                [obs["left_sensor"], obs["right_sensor"]], axis=1
-            )
-
-            if depth:
-                stereo_pair = np.clip(stereo_pair, 0, 10)
-                stereo_pair /= 10.0
-
             cv2.imshow("stereo_pair", stereo_pair)
             k = cv2.waitKey()
             if k == ord("q"):

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -4,7 +4,7 @@
 
 r"""
 This is a demonstration of how to create an agent with
-two cameras in a stereo pair
+two cameras in a stereo pair.
 
 
 This can be done by giving the agent two sensors (be it RGB, depth, or semantic)
@@ -22,18 +22,25 @@ import habitat_sim
 cv2 = None
 
 
+# Helper function to render observations from the stereo agent
 def _render(sim, display, depth=False):
     for _ in range(100):
+        # Just spin in a circle
         obs = sim.step("turn_right")
+        # Put the two stereo observations next to eachother
         stereo_pair = np.concatenate([obs["left_sensor"], obs["right_sensor"]], axis=1)
 
+        # If it is a depth pair, manually normalize into [0, 1]
+        # so that images are always consistent
         if depth:
             stereo_pair = np.clip(stereo_pair, 0, 10)
             stereo_pair /= 10.0
 
+        # If in RGB/RGBA format, change first to RGB and change to BGR
         if len(stereo_pair.shape) > 2:
             stereo_pair = stereo_pair[..., 0:3][..., ::-1]
 
+        # display=False is used for the smoke test
         if display:
             cv2.imshow("stereo_pair", stereo_pair)
             k = cv2.waitKey()
@@ -43,6 +50,7 @@ def _render(sim, display, depth=False):
 
 def main(display=True):
     global cv2
+    # Only import cv2 if we are doing to display
     if display:
         import cv2 as _cv2
 

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -1,0 +1,94 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+This is a demonstration of how to create an agent with
+two RGB cameras in a stereo pair
+"""
+
+import random
+
+import numpy as np
+
+import habitat_sim
+
+cv2 = None
+
+
+def _render(sim, display, depth=False):
+    for _ in range(100):
+        obs = sim.step("turn_right")
+
+        if display:
+            stereo_pair = np.concatenate(
+                [obs["left_sensor"], obs["right_sensor"]], axis=1
+            )
+
+            if depth:
+                stereo_pair = np.clip(stereo_pair, 0, 10)
+                stereo_pair /= 10.0
+
+            cv2.imshow("stereo_pair", stereo_pair)
+            k = cv2.waitKey()
+            if k == ord("q"):
+                break
+
+
+def main(display=True):
+    global cv2
+    if display:
+        import cv2 as _cv2
+
+        cv2 = _cv2
+
+        cv2.namedWindow("stereo_pair")
+
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.scene.id = (
+        "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"
+    )
+
+    left_rgb_sensor = habitat_sim.SensorSpec()
+    left_rgb_sensor.uuid = "left_sensor"
+    left_rgb_sensor.resolution = [256, 256]
+    left_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.LEFT
+
+    right_rgb_sensor = habitat_sim.SensorSpec()
+    right_rgb_sensor.uuid = "right_sensor"
+    right_rgb_sensor.resolution = [256, 256]
+    right_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.RIGHT
+
+    agent_config = habitat_sim.AgentConfiguration()
+    agent_config.sensor_specifications = [left_rgb_sensor, right_rgb_sensor]
+
+    sim = habitat_sim.Simulator(habitat_sim.Configuration(backend_cfg, [agent_config]))
+
+    _render(sim, display)
+    sim.close()
+    del sim
+
+    left_depth_sensor = habitat_sim.SensorSpec()
+    left_depth_sensor.uuid = "left_sensor"
+    left_depth_sensor.resolution = [256, 256]
+    left_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.LEFT
+    left_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
+
+    right_depth_sensor = habitat_sim.SensorSpec()
+    right_depth_sensor.uuid = "right_sensor"
+    right_depth_sensor.resolution = [256, 256]
+    right_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.RIGHT
+    right_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
+
+    agent_config = habitat_sim.AgentConfiguration()
+    agent_config.sensor_specifications = [left_depth_sensor, right_depth_sensor]
+
+    sim = habitat_sim.Simulator(habitat_sim.Configuration(backend_cfg, [agent_config]))
+
+    _render(sim, display, depth=True)
+    sim.close()
+    del sim
+
+
+if __name__ == "__main__":
+    main(display=True)

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -7,8 +7,10 @@ This is a demonstration of how to create an agent with
 two cameras in a stereo pair
 
 
-This can be done by simple giving the agent two sensors (be it RGB, depth, or semantic)
-with different positions.  The cameras must have different uuid's
+This can be done by giving the agent two sensors (be it RGB, depth, or semantic)
+with different positions.
+
+Note that the cameras must have different uuid's
 """
 
 import random

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -58,7 +58,7 @@ def main(display=True):
     # Give it the uuid of left_sensor, this will also be how we
     # index the observations to retreive the rendering from this sensor
     left_rgb_sensor.uuid = "left_sensor"
-    left_rgb_sensor.resolution = [256, 256]
+    left_rgb_sensor.resolution = [512, 512]
     # The left RGB sensor will be 1.5 meters off the ground
     # and 0.25 meters to the left of the center of the agent
     left_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.LEFT
@@ -66,7 +66,7 @@ def main(display=True):
     # Same deal with the right sensor
     right_rgb_sensor = habitat_sim.SensorSpec()
     right_rgb_sensor.uuid = "right_sensor"
-    right_rgb_sensor.resolution = [256, 256]
+    right_rgb_sensor.resolution = [512, 512]
     # The right RGB sensor will be 1.5 meters off the ground
     # and 0.25 meters to the right of the center of the agent
     right_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
@@ -84,14 +84,14 @@ def main(display=True):
     # Now lets do the exact same thing but for a depth camera stereo pair!
     left_depth_sensor = habitat_sim.SensorSpec()
     left_depth_sensor.uuid = "left_sensor"
-    left_depth_sensor.resolution = [256, 256]
+    left_depth_sensor.resolution = [512, 512]
     left_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.LEFT
     # The only difference we need to do is set the sensor type to depth
     left_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
 
     right_depth_sensor = habitat_sim.SensorSpec()
     right_depth_sensor.uuid = "right_sensor"
-    right_depth_sensor.resolution = [256, 256]
+    right_depth_sensor.resolution = [512, 512]
     right_depth_sensor.position = (
         1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
     )

--- a/examples/stereo_agent.py
+++ b/examples/stereo_agent.py
@@ -4,7 +4,11 @@
 
 r"""
 This is a demonstration of how to create an agent with
-two RGB cameras in a stereo pair
+two cameras in a stereo pair
+
+
+This can be done by simple giving the agent two sensors (be it RGB, depth, or semantic)
+with different positions.  The cameras must have different uuid's
 """
 
 import random
@@ -49,17 +53,26 @@ def main(display=True):
         "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"
     )
 
+    # First, lets create a stereo RGB agent
     left_rgb_sensor = habitat_sim.SensorSpec()
+    # Give it the uuid of left_sensor, this will also be how we
+    # index the observations to retreive the rendering from this sensor
     left_rgb_sensor.uuid = "left_sensor"
     left_rgb_sensor.resolution = [256, 256]
-    left_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.LEFT
+    # The left RGB sensor will be 1.5 meters off the ground
+    # and 0.25 meters to the left of the center of the agent
+    left_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.LEFT
 
+    # Same deal with the right sensor
     right_rgb_sensor = habitat_sim.SensorSpec()
     right_rgb_sensor.uuid = "right_sensor"
     right_rgb_sensor.resolution = [256, 256]
-    right_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.RIGHT
+    # The right RGB sensor will be 1.5 meters off the ground
+    # and 0.25 meters to the right of the center of the agent
+    right_rgb_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
 
     agent_config = habitat_sim.AgentConfiguration()
+    # Now we simly set the agents list of sensor specs to be the two specs for our two sensors
     agent_config.sensor_specifications = [left_rgb_sensor, right_rgb_sensor]
 
     sim = habitat_sim.Simulator(habitat_sim.Configuration(backend_cfg, [agent_config]))
@@ -68,16 +81,21 @@ def main(display=True):
     sim.close()
     del sim
 
+    # Now lets do the exact same thing but for a depth camera stereo pair!
     left_depth_sensor = habitat_sim.SensorSpec()
     left_depth_sensor.uuid = "left_sensor"
     left_depth_sensor.resolution = [256, 256]
-    left_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.LEFT
+    left_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.LEFT
+    # The only difference we need to do is set the sensor type to depth
     left_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
 
     right_depth_sensor = habitat_sim.SensorSpec()
     right_depth_sensor.uuid = "right_sensor"
     right_depth_sensor.resolution = [256, 256]
-    right_depth_sensor.position = 1.5 * habitat_sim.geo.UP + 0.5 * habitat_sim.geo.RIGHT
+    right_depth_sensor.position = (
+        1.5 * habitat_sim.geo.UP + 0.25 * habitat_sim.geo.RIGHT
+    )
+    # The only difference we need to do is set the sensor type to depth
     right_depth_sensor.sensor_type = habitat_sim.SensorType.DEPTH
 
     agent_config = habitat_sim.AgentConfiguration()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,21 @@
+import multiprocessing
+import os.path as osp
+
+import pytest
+
+import examples.stereo_agent
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
+    reason="Requires the habitat-test-scenes",
+)
+def test_stereo_agent_example():
+    # This test needs to be done in its own process as there is a potentially for
+    # an OpenGL context clash otherwise
+    mp_ctx = multiprocessing.get_context("spawn")
+    proc = mp_ctx.Process(target=examples.stereo_agent.main, args=(False,))
+    proc.start()
+    proc.join()
+
+    assert proc.exitcode == 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,11 +11,12 @@ import examples.stereo_agent
     not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
     reason="Requires the habitat-test-scenes",
 )
-def test_stereo_agent_example():
+@pytest.mark.parametrize("example_module,args", [(examples.stereo_agent, (False,))])
+def test_stereo_agent_example(example_module, args):
     # This test needs to be done in its own process as there is a potentially for
     # an OpenGL context clash otherwise
     mp_ctx = multiprocessing.get_context("spawn")
-    proc = mp_ctx.Process(target=examples.stereo_agent.main, args=(False,))
+    proc = mp_ctx.Process(target=example_module.main, args=args)
     proc.start()
     proc.join()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,6 +6,7 @@ import pytest
 import examples.stereo_agent
 
 
+@pytest.mark.gfxtest
 @pytest.mark.skipif(
     not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
     reason="Requires the habitat-test-scenes",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,10 +1,9 @@
 import multiprocessing
 import os.path as osp
 
-import pytest
-
 import examples.new_actions
 import examples.stereo_agent
+import pytest
 
 
 @pytest.mark.gfxtest
@@ -17,7 +16,7 @@ import examples.stereo_agent
     "example_module,args",
     [(examples.stereo_agent, (False,)), (examples.new_actions, ())],
 )
-def test_stereo_agent_example(example_module, args):
+def test_example_modules(example_module, args):
     # This test needs to be done in its own process as there is a potentially for
     # an OpenGL context clash otherwise
     mp_ctx = multiprocessing.get_context("spawn")


### PR DESCRIPTION
## Motivation and Context

See #56 for context!

This one adds an example of creating an agent that uses a stereo RGB pair or a stereo depth pair.  The displaying to the user is done via cv2

## How Has This Been Tested

<img width="1136" alt="depth_example" src="https://user-images.githubusercontent.com/12722529/58681604-ee7f7280-8321-11e9-8002-c6ef44f4f675.png">

<img width="1136" alt="rgb_example" src="https://user-images.githubusercontent.com/12722529/58681605-f17a6300-8321-11e9-93bf-1092d81b1078.png">

Also via the new smoke test in pytest.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-  New feature (non-breaking change which adds functionality)

