### PR TITLE
CI setup that runs tests e2e testing using GPU machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,104 @@
+version: 2
+gpu: &gpu
+  machine:
+    image: ubuntu-1604:201903-01
+  resource_class: gpu.small
+  environment:
+    FPS_THRESHOLD: 900
+
+jobs:
+  build_install_test_ubuntu:
+    <<: *gpu
+    steps:
+      - checkout:
+          path: ./habitat-sim
+      - run:
+          name: Install cmake
+          no_output_timeout: 1h
+          command: |
+              wget https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.sh
+              sudo mkdir /opt/cmake
+              sudo sh ./cmake-3.13.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+              sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+      - run:
+          name: Install conda and dependencies
+          no_output_timeout: 1h
+          command: |
+              curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+              chmod +x ~/miniconda.sh
+              ~/miniconda.sh -b -p $HOME/miniconda
+              rm ~/miniconda.sh
+              $HOME/miniconda/bin/conda install -y numpy pyyaml scipy ipython mkl mkl-include
+              export PATH=$HOME/miniconda/bin:$PATH
+              conda create -y -n habitat python=3.6
+              . activate habitat
+              conda install -y -c conda-forge ninja numpy pyyaml scipy ipython mkl mkl-include pytest
+              sudo apt-get update || true
+              sudo apt-get install -y --no-install-recommends \
+                  build-essential \
+                  git \
+                  curl \
+                  vim \
+                  ca-certificates \
+                  libjpeg-dev \
+                  libglm-dev \
+                  libegl1-mesa-dev \
+                  xorg-dev \
+                  freeglut3-dev \
+                  pkg-config \
+                  wget \
+                  zip \
+                  unzip || true
+      - run:
+          name: Install cuda
+          no_output_timeout: 1h
+          command: |
+              wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.44-1_amd64.deb
+              sudo dpkg -i cuda-repo-ubuntu1604_8.0.44-1_amd64.deb
+              sudo apt-get update || true
+              sudo apt-get --yes --force-yes install cuda
+              nvidia-smi
+      - run:
+          name: Download test data
+          command: |
+              cd habitat-sim
+              wget http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip
+              unzip habitat-test-scenes.zip
+              rm habitat-test-scenes.zip
+      - run:
+          name: Build, install habitat-sim and run benchmark
+          no_output_timeout: 1h
+          command: |
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat; cd habitat-sim
+              python setup.py install --headless
+              python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
+      - run:
+          name: Run sim tests
+          command: |
+              cd habitat-sim
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat
+              export PYTHONPATH=$PYTHONPATH:$(pwd)
+              ./build.sh --headless
+              HEADLESS=True pip install -e .
+              pytest
+      - run:
+          name: Run api tests
+          command: |
+              git clone https://github.com/facebookresearch/habitat-api.git
+              export PYTHONPATH=$PYTHONPATH:$(pwd)/habitat-sim
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat; cd habitat-api
+              ln -s ../habitat-sim/data data
+              conda install -c  conda-forge opencv -y
+              conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch
+              pip install -r requirements.txt
+              python setup.py test
+
+
+workflows:
+  version: 2
+  build_and_install:
+    jobs:
+      - build_install_test_ubuntu

--- a/examples/example.py
+++ b/examples/example.py
@@ -31,6 +31,7 @@ parser.add_argument("--compute_shortest_path", action="store_true")
 parser.add_argument("--compute_action_shortest_path", action="store_true")
 parser.add_argument("--seed", type=int, default=1)
 parser.add_argument("--silent", action="store_true")
+parser.add_argument("--test_fps_regression", type=int, default=0)
 args = parser.parse_args()
 
 
@@ -67,3 +68,7 @@ print(
     "FPS: %0.1f" % perf["fps"],
 )
 print(" ================================================= ")
+
+assert perf["fps"] > args.test_fps_regression, \
+    "FPS is below regression threshold: %0.1f < %0.1f" % \
+    (perf["fps"], args.test_fps_regression)


### PR DESCRIPTION
## Motivation and Context
CI setup that runs tests using GPU machines:
- Builds and installs habitat-sim with ` python setup.py install` and `./build.sh --headless`
- Runs `pytest` tests on habitat-sim with testing data
- Added speed regression test with FPS threshold (900 FPS) , thanks @erikwijmans for advice how to do it in elegant way.
- Added run of habitat-api tests on master branch. That will guarantee that HSIM changes won't break HAPI
- Added pytorch installation and running habitat baseline test in prediction mode. That maybe too much of testing, but decided to keep it for now.

Have ideas how to speed  up and parallelize jobs. Will follow up in next PRs.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Tests time estimations:
```
Install conda and dependencies 02:56
Install cuda 04:32
Build, install habitat-sim and run benchmark 03:13
Run sim tests 03:08
Run api tests with pytorch 08:14
```

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
