### PR TITLE
Tests: fix a "variable referenced before assignment" error

### DIFF
--- a/tests/test_greedy_follower.py
+++ b/tests/test_greedy_follower.py
@@ -89,7 +89,7 @@ def test_greedy_follower(test_navmesh, scene_graph, pbar):
                 np.linalg.norm(end_state.position - goal_pos)
                 <= follower.forward_spec.amount
             ), "Didn't make it"
-        except:
+        except Exception as e:
             if test_all:
                 num_fails += 1
                 pbar.set_postfix(num_fails=num_fails)


### PR DESCRIPTION
## Motivation and Context

I Ctrl-C'd while running the `test_greedy_follower` test and instead of `KeyboardInterrupt` it ended up with a "variable referenced before assignment" error on the line with `raise e`. This fixes it simply by copying it from the similar code below.

## How Has This Been Tested

Everything compiles and runs, tests pass and do the expected thing during Ctrl-C.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
