### PR TITLE
Support no sensors

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -83,11 +83,14 @@ class Simulator:
 
     def reconfigure(self, config: Configuration):
         assert len(config.agents) > 0
-        assert len(config.agents[0].sensor_specifications) > 0
-        first_sensor_spec = config.agents[0].sensor_specifications[0]
+        if len(config.agents[0].sensor_specifications) > 0:
+            first_sensor_spec = config.agents[0].sensor_specifications[0]
 
-        config.sim_cfg.height = first_sensor_spec.resolution[0]
-        config.sim_cfg.width = first_sensor_spec.resolution[1]
+            config.sim_cfg.height = first_sensor_spec.resolution[0]
+            config.sim_cfg.width = first_sensor_spec.resolution[1]
+        else:
+            config.sim_cfg.height = -1
+            config.sim_cfg.width = -1
 
         if self.config == config:
             return

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -85,12 +85,12 @@ class Simulator:
         assert len(config.agents) > 0
         if len(config.agents[0].sensor_specifications) > 0:
             first_sensor_spec = config.agents[0].sensor_specifications[0]
+            config.sim_cfg.create_renderer = True
 
             config.sim_cfg.height = first_sensor_spec.resolution[0]
             config.sim_cfg.width = first_sensor_spec.resolution[1]
         else:
-            config.sim_cfg.height = -1
-            config.sim_cfg.width = -1
+            config.sim_cfg.create_renderer = False
 
         if self.config == config:
             return

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -646,6 +646,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_readwrite("height", &SimulatorConfiguration::height)
       .def_readwrite("compress_textures",
                      &SimulatorConfiguration::compressTextures)
+      .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
       .def("__eq__",
            [](const SimulatorConfiguration& self,
               const SimulatorConfiguration& other) -> bool {

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -75,7 +75,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   // LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
   sceneID_.push_back(activeSceneID_);
 
-  if (height != -1 || width != -1) {
+  if (cfg.createRenderer) {
     if (!context_) {
       context_ = std::make_unique<gfx::WindowlessContext>(config_.gpuDeviceId);
     }
@@ -171,7 +171,8 @@ bool operator==(const SimulatorConfiguration& a,
                 const SimulatorConfiguration& b) {
   return a.scene == b.scene && a.defaultAgentId == b.defaultAgentId &&
          a.defaultCameraUuid == b.defaultCameraUuid &&
-         a.compressTextures == b.compressTextures;
+         a.compressTextures == b.compressTextures &&
+         a.createRenderer == b.createRenderer;
 }
 
 bool operator!=(const SimulatorConfiguration& a,

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -29,8 +29,7 @@ using namespace Corrade;
 namespace esp {
 namespace gfx {
 
-Simulator::Simulator(const SimulatorConfiguration& cfg)
-    : context_(cfg.gpuDeviceId) {
+Simulator::Simulator(const SimulatorConfiguration& cfg) {
   // initalize members according to cfg
   reconfigure(cfg);
 }
@@ -52,11 +51,19 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   const int height = cfg.height;
   const int width = cfg.width;
 
-  // reinitalize members
-  if (renderer_) {
-    renderer_.reset();
+  // load scene
+  std::string sceneFilename = cfg.scene.id;
+  if (cfg.scene.filepaths.count("mesh")) {
+    sceneFilename = cfg.scene.filepaths.at("mesh");
   }
-  renderer_ = Renderer::create(width, height);
+
+  std::string houseFilename = io::changeExtension(sceneFilename, ".house");
+  if (cfg.scene.filepaths.count("house")) {
+    houseFilename = cfg.scene.filepaths.at("house");
+  }
+
+  const assets::AssetInfo sceneInfo =
+      assets::AssetInfo::fromPath(sceneFilename);
 
   // initalize scene graph
   // CAREFUL!
@@ -67,61 +74,59 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   activeSceneID_ = sceneManager_.initSceneGraph();
   // LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
   sceneID_.push_back(activeSceneID_);
-  auto& sceneGraph = sceneManager_.getSceneGraph(activeSceneID_);
 
-  // load scene
-  std::string sceneFilename = cfg.scene.id;
-  if (cfg.scene.filepaths.count("mesh")) {
-    sceneFilename = cfg.scene.filepaths.at("mesh");
-  }
-  auto& rootNode = sceneGraph.getRootNode();
-  auto& drawables = sceneGraph.getDrawables();
-  const assets::AssetInfo sceneInfo =
-      assets::AssetInfo::fromPath(sceneFilename);
-  resourceManager_.compressTextures(cfg.compressTextures);
-  if (!resourceManager_.loadScene(sceneInfo, &rootNode, &drawables)) {
-    LOG(ERROR) << "cannot load " << sceneFilename;
-    // Pass the error to the python through pybind11 allowing graceful exit
-    throw std::invalid_argument("Cannot load: " + sceneFilename);
-  }
-
-  // load semantic annotations if available
-  if (semanticScene_) {
-    semanticScene_.reset();
-  }
-  semanticScene_ = scene::SemanticScene::create();
-  std::string houseFilename = io::changeExtension(sceneFilename, ".house");
-  if (cfg.scene.filepaths.count("house")) {
-    houseFilename = cfg.scene.filepaths.at("house");
-  }
-  if (io::exists(houseFilename)) {
-    LOG(INFO) << "Loading house from " << houseFilename;
-    scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
-    // if semantic mesh exists, load it as well
-    // TODO: remove hardcoded filename change and use SceneConfiguration
-    const std::string semanticMeshFilename =
-        io::removeExtension(houseFilename) + "_semantic.ply";
-    if (io::exists(semanticMeshFilename)) {
-      LOG(INFO) << "Loading semantic mesh " << semanticMeshFilename;
-      activeSemanticSceneID_ = sceneManager_.initSceneGraph();
-      sceneID_.push_back(activeSemanticSceneID_);
-      auto& semanticSceneGraph =
-          sceneManager_.getSceneGraph(activeSemanticSceneID_);
-      auto& semanticRootNode = semanticSceneGraph.getRootNode();
-      auto& semanticDrawables = semanticSceneGraph.getDrawables();
-      const assets::AssetInfo semanticSceneInfo =
-          assets::AssetInfo::fromPath(semanticMeshFilename);
-      resourceManager_.loadScene(semanticSceneInfo, &semanticRootNode,
-                                 &semanticDrawables);
+  if (height != -1 || width != -1) {
+    if (!context_) {
+      context_ = std::make_unique<gfx::WindowlessContext>(config_.gpuDeviceId);
     }
-    LOG(INFO) << "Loaded.";
+
+    // reinitalize members
+    renderer_ = Renderer::create(width, height);
+
+    auto& sceneGraph = sceneManager_.getSceneGraph(activeSceneID_);
+
+    auto& rootNode = sceneGraph.getRootNode();
+    auto& drawables = sceneGraph.getDrawables();
+    resourceManager_.compressTextures(cfg.compressTextures);
+    if (!resourceManager_.loadScene(sceneInfo, &rootNode, &drawables)) {
+      LOG(ERROR) << "cannot load " << sceneFilename;
+      // Pass the error to the python through pybind11 allowing graceful exit
+      throw std::invalid_argument("Cannot load: " + sceneFilename);
+    }
+
+    if (io::exists(houseFilename)) {
+      LOG(INFO) << "Loading house from " << houseFilename;
+      // if semantic mesh exists, load it as well
+      // TODO: remove hardcoded filename change and use SceneConfiguration
+      const std::string semanticMeshFilename =
+          io::removeExtension(houseFilename) + "_semantic.ply";
+      if (io::exists(semanticMeshFilename)) {
+        LOG(INFO) << "Loading semantic mesh " << semanticMeshFilename;
+        activeSemanticSceneID_ = sceneManager_.initSceneGraph();
+        sceneID_.push_back(activeSemanticSceneID_);
+        auto& semanticSceneGraph =
+            sceneManager_.getSceneGraph(activeSemanticSceneID_);
+        auto& semanticRootNode = semanticSceneGraph.getRootNode();
+        auto& semanticDrawables = semanticSceneGraph.getDrawables();
+        const assets::AssetInfo semanticSceneInfo =
+            assets::AssetInfo::fromPath(semanticMeshFilename);
+        resourceManager_.loadScene(semanticSceneInfo, &semanticRootNode,
+                                   &semanticDrawables);
+      }
+      LOG(INFO) << "Loaded.";
+    }
+
+    // instance meshes and suncg houses contain their semantic annotations
+    if (sceneInfo.type == assets::AssetType::FRL_INSTANCE_MESH ||
+        sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
+        sceneInfo.type == assets::AssetType::INSTANCE_MESH) {
+      activeSemanticSceneID_ = activeSceneID_;
+    }
   }
 
-  // instance meshes and suncg houses contain their semantic annotations
-  if (sceneInfo.type == assets::AssetType::FRL_INSTANCE_MESH ||
-      sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
-      sceneInfo.type == assets::AssetType::INSTANCE_MESH) {
-    activeSemanticSceneID_ = activeSceneID_;
+  semanticScene_ = scene::SemanticScene::create();
+  if (io::exists(houseFilename)) {
+    scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
   }
 
   // also load SemanticScene for SUNCG house file

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -81,6 +81,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     }
 
     // reinitalize members
+    renderer_ = nullptr;
     renderer_ = Renderer::create(width, height);
 
     auto& sceneGraph = sceneManager_.getSceneGraph(activeSceneID_);
@@ -124,6 +125,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     }
   }
 
+  semanticScene_ = nullptr;
   semanticScene_ = scene::SemanticScene::create();
   if (io::exists(houseFilename)) {
     scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);

--- a/src/esp/gfx/Simulator.h
+++ b/src/esp/gfx/Simulator.h
@@ -32,6 +32,7 @@ struct SimulatorConfiguration {
   int gpuDeviceId = 0;
   std::string defaultCameraUuid = "rgba_camera";
   bool compressTextures = false;
+  bool createRenderer = true;
   int width = 256, height = 256;
 
   ESP_SMART_POINTERS(SimulatorConfiguration)

--- a/src/esp/gfx/Simulator.h
+++ b/src/esp/gfx/Simulator.h
@@ -61,7 +61,7 @@ class Simulator {
   void saveFrame(const std::string& filename);
 
  protected:
-  WindowlessContext context_;
+  std::unique_ptr<WindowlessContext> context_ = nullptr;
   std::shared_ptr<Renderer> renderer_ = nullptr;
   // CANNOT make the specification of resourceManager_ above the context_!
   // Because when deconstructing the resourceManager_, it needs

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -32,16 +32,17 @@ _test_scenes = [
 ]
 
 
-@pytest.mark.gfxtest
 @pytest.mark.parametrize("scene", _test_scenes)
-def test_semantic_scene(scene, sim, make_cfg_settings):
+def test_semantic_scene(scene, make_cfg_settings):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
 
     make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
     make_cfg_settings["semantic_sensor"] = False
     make_cfg_settings["scene"] = scene
-    sim.reconfigure(make_cfg(make_cfg_settings))
+    cfg = make_cfg(make_cfg_settings)
+    cfg.agents[0].sensor_specifications = []
+    sim = habitat_sim.Simulator(cfg)
 
     scene = sim.semantic_scene
     for obj in scene.objects:

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -98,6 +98,9 @@ def test_sensors(scene, has_sem, sensor_type, sim, make_cfg_settings):
     ) < 1.5e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
 
 
+# Tests to make sure that no sensors is supported and doesn't crash
+# Also tests to make sure we can have multiple instances
+# of the simulator with no sensors
 def test_smoke_no_sensors(make_cfg_settings):
     sims = []
     for scene in _test_scenes:

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -96,3 +96,19 @@ def test_sensors(scene, has_sem, sensor_type, sim, make_cfg_settings):
     assert np.linalg.norm(
         obs[sensor_type].astype(np.float) - gt.astype(np.float)
     ) < 1.5e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
+
+
+@pytest.mark.parametrize("scene", _test_scenes)
+def test_smoke_no_sensors(scene, make_cfg_settings):
+    if not osp.exists(scene):
+        pytest.skip("Skipping {}".format(scene))
+
+    make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
+    make_cfg_settings["semantic_sensor"] = False
+    make_cfg_settings["scene"] = scene
+    cfg = make_cfg(make_cfg_settings)
+    cfg.agents[0].sensor_specifications = []
+    sim = habitat_sim.Simulator(cfg)
+
+    sim.close()
+    del sim

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -98,17 +98,15 @@ def test_sensors(scene, has_sem, sensor_type, sim, make_cfg_settings):
     ) < 1.5e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
 
 
-@pytest.mark.parametrize("scene", _test_scenes)
-def test_smoke_no_sensors(scene, make_cfg_settings):
-    if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+def test_smoke_no_sensors(make_cfg_settings):
+    sims = []
+    for scene in _test_scenes:
+        if not osp.exists(scene):
+            continue
 
-    make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
-    make_cfg_settings["semantic_sensor"] = False
-    make_cfg_settings["scene"] = scene
-    cfg = make_cfg(make_cfg_settings)
-    cfg.agents[0].sensor_specifications = []
-    sim = habitat_sim.Simulator(cfg)
-
-    sim.close()
-    del sim
+        make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
+        make_cfg_settings["semantic_sensor"] = False
+        make_cfg_settings["scene"] = scene
+        cfg = make_cfg(make_cfg_settings)
+        cfg.agents[0].sensor_specifications = []
+        sims.append(habitat_sim.Simulator(cfg))


### PR DESCRIPTION
## Motivation and Context

Sometimes we don't need sensors (generating datasets for instance), so it is nice to not need to load-up the mesh and get a rendering context.  This PR allows the simulator to be configured without any sensors.

## How Has This Been Tested

I adapted the test for the semantic annotations to use its own instance of the simulator loaded up with no sensors -- this ensures that the semantic scene graph is also loaded.  This test would crash due to having two OpenGL contexts if the no-sensor thing didn't work :)
