### PR TITLE
Fix bindings cyclic type references and type annotations

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -50,18 +50,18 @@ class SixDOFPose(object):
         rotation (np.quaternion): unit quaternion rotation
     """
 
-    position: np.array = np.zeros(3)
+    position: np.ndarray = np.zeros(3)
     rotation: Union[np.quaternion, List] = np.quaternion(1, 0, 0, 0)
 
 
 @attr.s(auto_attribs=True, slots=True)
 class AgentState(object):
-    position: np.array = np.zeros(3)
+    position: np.ndarray = np.zeros(3)
     rotation: Union[np.quaternion, List] = np.quaternion(1, 0, 0, 0)
-    velocity: np.array = np.zeros(3)
-    angular_velocity: np.array = np.zeros(3)
-    force: np.array = np.zeros(3)
-    torque: np.array = np.zeros(3)
+    velocity: np.ndarray = np.zeros(3)
+    angular_velocity: np.ndarray = np.zeros(3)
+    force: np.ndarray = np.zeros(3)
+    torque: np.ndarray = np.zeros(3)
     sensor_states: Dict[str, SixDOFPose] = attr.Factory(dict)
 
 

--- a/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/habitat_sim/nav/greedy_geodesic_follower.py
@@ -91,7 +91,7 @@ class GreedyGeodesicFollower(object):
     def _turn_right(self, obj: hsim.SceneNode):
         self.agent.controls(obj, "turn_right", self.right_spec, True)
 
-    def next_action_along(self, goal_pos: np.array) -> Any:
+    def next_action_along(self, goal_pos: np.ndarray) -> Any:
         r"""Find the next action to greedily follow the geodesic shortest path from the agent's current position
         to get to the goal
 
@@ -111,7 +111,7 @@ class GreedyGeodesicFollower(object):
         else:
             return self.action_mapping[next_act]
 
-    def find_path(self, goal_pos: np.array) -> List[Any]:
+    def find_path(self, goal_pos: np.ndarray) -> List[Any]:
         r"""Finds the sequence actions that greedily follow the geodesic shortest path
         from the agent's current position to get to the goal.  This is roughly equivilent to just
         calling `next_action_along` until it returns `None`, but is faster

--- a/habitat_sim/utils.py
+++ b/habitat_sim/utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from io import BytesIO
+from typing import Tuple
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -13,7 +14,7 @@ import numpy as np
 import quaternion
 
 
-def quat_from_coeffs(coeffs: np.array) -> np.quaternion:
+def quat_from_coeffs(coeffs: np.ndarray) -> np.quaternion:
     r"""Creates a quaternion from the coeffs returned by the simulator backend
 
     Args:
@@ -29,7 +30,7 @@ def quat_from_coeffs(coeffs: np.array) -> np.quaternion:
     return quat
 
 
-def quat_to_coeffs(quat: np.quaternion) -> np.array:
+def quat_to_coeffs(quat: np.quaternion) -> np.ndarray:
     r"""Converts a quaternion into the coeffs format the backend expects
 
     Args:
@@ -56,7 +57,7 @@ def quat_from_magnum(quat: mn.Quaternion) -> np.quaternion:
     return a
 
 
-def quat_to_angle_axis(quat: np.quantile) -> (float, np.array):
+def quat_to_angle_axis(quat: np.quaternion) -> Tuple[float, np.ndarray]:
     r"""Converts a quaternion to angle axis format
 
     Args:
@@ -79,7 +80,7 @@ def quat_to_angle_axis(quat: np.quantile) -> (float, np.array):
     return (theta, w)
 
 
-def quat_from_angle_axis(theta: float, axis: np.array) -> np.quaternion:
+def quat_from_angle_axis(theta: float, axis: np.ndarray) -> np.quaternion:
     r"""Creates a quaternion from angle axis format
 
     Args:
@@ -94,7 +95,7 @@ def quat_from_angle_axis(theta: float, axis: np.array) -> np.quaternion:
     return quaternion.from_rotation_vector(theta * axis)
 
 
-def quat_from_two_vectors(v0: np.array, v1: np.array) -> np.quaternion:
+def quat_from_two_vectors(v0: np.ndarray, v1: np.ndarray) -> np.quaternion:
     r"""Creates a quaternion that rotates the frist vector onto the second vector
 
     v1 = (q * np.quaternion(0, *v0) * q.inverse()).imag
@@ -142,7 +143,7 @@ def angle_between_quats(q1: np.quaternion, q2: np.quaternion) -> float:
     return 2 * np.arctan2(np.linalg.norm(dq.imag), np.abs(dq.real))
 
 
-def quat_rotate_vector(q: np.quaternion, v: np.array) -> np.array:
+def quat_rotate_vector(q: np.quaternion, v: np.ndarray) -> np.ndarray:
     r"""Helper function to rotate a vector by a quaternion, simply does
     v = (q * np.quaternion(0, *v) * q.inverse()).imag
 

--- a/src/esp/bindings/OpaqueTypes.h
+++ b/src/esp/bindings/OpaqueTypes.h
@@ -15,10 +15,5 @@
 #include "esp/core/esp.h"
 #include "esp/nav/GreedyFollower.h"
 
-// Support for types with commas is implemented since
-// https://github.com/pybind/pybind11/commit/e88656ab45ae75df7dcb1fcdd2c89805b52e4665,
-// which is not in any released version yet. Use a typedef until then.
-typedef std::map<std::string, std::string> map_string_string;
-PYBIND11_MAKE_OPAQUE(map_string_string);
-typedef std::vector<esp::nav::GreedyGeodesicFollowerImpl::CODES> vector_codes;
-PYBIND11_MAKE_OPAQUE(vector_codes);
+PYBIND11_MAKE_OPAQUE(std::map<std::string, std::string>);
+PYBIND11_MAKE_OPAQUE(std::vector<esp::nav::GreedyGeodesicFollowerImpl::CODES>);

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -75,6 +75,18 @@ void initShortestPathBindings(py::module& m) {
           for slight differences in floor height)",
            "pt"_a, "max_y_delta"_a = 0.5);
 
+  // this enum is used by GreedyGeodesicFollowerImpl so it needs to be defined
+  // before it
+  py::enum_<GreedyGeodesicFollowerImpl::CODES>(m, "GreedyFollowerCodes")
+      .value("ERROR", GreedyGeodesicFollowerImpl::CODES::ERROR)
+      .value("STOP", GreedyGeodesicFollowerImpl::CODES::STOP)
+      .value("FORWARD", GreedyGeodesicFollowerImpl::CODES::FORWARD)
+      .value("LEFT", GreedyGeodesicFollowerImpl::CODES::LEFT)
+      .value("RIGHT", GreedyGeodesicFollowerImpl::CODES::RIGHT);
+
+  py::bind_vector<std::vector<GreedyGeodesicFollowerImpl::CODES>>(
+      m, "VectorGreedyCodes");
+
   py::class_<GreedyGeodesicFollowerImpl, GreedyGeodesicFollowerImpl::ptr>(
       m, "GreedyGeodesicFollowerImpl")
       .def(py::init(
@@ -90,14 +102,4 @@ void initShortestPathBindings(py::module& m) {
            py::overload_cast<const vec3f&, const vec4f&, const vec3f&>(
                &GreedyGeodesicFollowerImpl::findPath),
            py::return_value_policy::move);
-
-  py::enum_<GreedyGeodesicFollowerImpl::CODES>(m, "GreedyFollowerCodes")
-      .value("ERROR", GreedyGeodesicFollowerImpl::CODES::ERROR)
-      .value("STOP", GreedyGeodesicFollowerImpl::CODES::STOP)
-      .value("FORWARD", GreedyGeodesicFollowerImpl::CODES::FORWARD)
-      .value("LEFT", GreedyGeodesicFollowerImpl::CODES::LEFT)
-      .value("RIGHT", GreedyGeodesicFollowerImpl::CODES::RIGHT);
-
-  py::bind_vector<std::vector<GreedyGeodesicFollowerImpl::CODES>>(
-      m, "VectorGreedyCodes");
 }

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -118,6 +118,13 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("object", nodeGetter<RenderCamera>,
                              "Alias to node");
 
+  // Renderer::draw() and SceneGraph::setDefaultRenderCamera needs the Sensor
+  // definition
+  py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,
+             Magnum::SceneGraph::AbstractFeature3D,
+             Magnum::SceneGraph::PyFeatureHolder<Sensor>>
+      sensor(m, "Sensor");
+
   // ==== SceneGraph ====
   py::class_<scene::SceneGraph>(m, "SceneGraph")
       .def(py::init())
@@ -210,6 +217,14 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def("index", &SuncgRegionCategory::index, "mapping"_a = "")
       .def("name", &SuncgRegionCategory::name, "mapping"_a = "");
 
+  // These two are (cyclically) referenced by multiple classes below, define
+  // the classes first so pybind has the type definition available when binding
+  // functions
+  py::class_<SemanticObject, SemanticObject::ptr> semanticObject(
+      m, "SemanticObject");
+  py::class_<SemanticRegion, SemanticRegion::ptr> semanticRegion(
+      m, "SemanticRegion");
+
   // ==== SemanticLevel ====
   py::class_<SemanticLevel, SemanticLevel::ptr>(m, "SemanticLevel")
       .def_property_readonly("id", &SemanticLevel::id)
@@ -218,8 +233,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("objects", &SemanticLevel::objects);
 
   // ==== SemanticRegion ====
-  py::class_<SemanticRegion, SemanticRegion::ptr>(m, "SemanticRegion")
-      .def_property_readonly("id", &SemanticRegion::id)
+  semanticRegion.def_property_readonly("id", &SemanticRegion::id)
       .def_property_readonly("level", &SemanticRegion::level)
       .def_property_readonly("aabb", &SemanticRegion::aabb)
       .def_property_readonly("category", &SemanticRegion::category)
@@ -235,8 +249,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       .def_property_readonly("objects", &SuncgSemanticRegion::objects);
 
   // ==== SemanticObject ====
-  py::class_<SemanticObject, SemanticObject::ptr>(m, "SemanticObject")
-      .def_property_readonly("id", &SemanticObject::id)
+  semanticObject.def_property_readonly("id", &SemanticObject::id)
       .def_property_readonly("region", &SemanticObject::region)
       .def_property_readonly("aabb", &SemanticObject::aabb)
       .def_property_readonly("obb", &SemanticObject::obb)
@@ -254,11 +267,19 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   // ==== SemanticScene ====
   py::class_<SemanticScene, SemanticScene::ptr>(m, "SemanticScene")
       .def(py::init(&SemanticScene::create<>))
-      .def_static("load_mp3d_house", &SemanticScene::loadMp3dHouse, R"(
+      .def_static(
+          "load_mp3d_house",
+          [](const std::string& filename, SemanticScene& scene,
+             const vec4f& rotation) {
+            // numpy doesn't have a quaternion equivalent, use vec4 instead
+            return SemanticScene::loadMp3dHouse(
+                filename, scene, Eigen::Map<const quatf>(rotation.data()));
+          },
+          R"(
         Loads a SemanticScene from a Matterport3D House format file into passed
         :py:class:`SemanticScene`'.
       )",
-                  "file"_a, "scene"_a, "rotation"_a)
+          "file"_a, "scene"_a, "rotation"_a)
       .def_property_readonly("aabb", &SemanticScene::aabb)
       .def_property_readonly("categories", &SemanticScene::categories)
       .def_property_readonly("levels", &SemanticScene::levels)
@@ -360,9 +381,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   py::class_<Observation, Observation::ptr>(m, "Observation");
 
   // ==== Sensor ====
-  py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,
-             Magnum::SceneGraph::AbstractFeature3D,
-             Magnum::SceneGraph::PyFeatureHolder<Sensor>>(m, "Sensor")
+  sensor
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
                           const SensorSpec::ptr&>())
       .def("specification", &Sensor::specification)


### PR DESCRIPTION
## Motivation and Context

- The binding code was referencing types that weren't known yet to pybind (either described later or not at all), causing the exported functions to have C++ names in their signatures, making them unusable from Python.
- Various Python APIs had wrong type annotations. In particular, the `np.array()` is a function, the correct type is `np.ndarray`. Unfortunately that's all we can annotate for now; type, dimensionality and size needs to wait until https://github.com/numpy/numpy/issues/7370.

Discovered while running [m.css](https://mcss.mosra.cz) on the project to generate docs for the Python side.

## How Has This Been Tested

It builds? :sunglasses: 

This brings no functional change, so should be easy to review and merge.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
