### PR TITLE
Rework the __all__ property of Python modules, phase out the bindings module

### DIFF
--- a/habitat_sim/__init__.py
+++ b/habitat_sim/__init__.py
@@ -9,7 +9,45 @@ import builtins
 __version__ = "0.1.2"
 
 if not getattr(builtins, "__HSIM_SETUP__", False):
+    # TODO: all those import * should get removed, kept only for compatibility
+    #   with existing code
     from .nav import *
     from .agent import *
     from .simulator import *
-    from .bindings import *
+
+    # Bindings has a geo module, but we have our own. So take everything except
+    # that.
+    from .bindings import (
+        SceneNodeType,
+        GreedyFollowerCodes,
+        GreedyGeodesicFollowerImpl,
+        MultiGoalShortestPath,
+        PathFinder,
+        PinholeCamera,
+        SceneGraph,
+        SceneNode,
+        Sensor,
+        SensorSpec,
+        SensorType,
+        ShortestPath,
+        SimulatorConfiguration,
+    )
+
+    from . import agent, geo, gfx, logging, nav, scene, sensor, simulator, utils
+    from ._ext.habitat_sim_bindings import MapStringString
+
+    __all__ = [
+        "agent",
+        "nav",
+        "sensors",
+        "errors",
+        "geo",
+        "gfx",
+        "logging",
+        "nav",
+        "scene",
+        "sensor",
+        "simulator",
+        "utils",
+        "MapStringString",
+    ]

--- a/habitat_sim/agent/__init__.py
+++ b/habitat_sim/agent/__init__.py
@@ -6,3 +6,5 @@
 
 from .agent import *
 from .controls import *
+
+__all__ = agent.__all__ + controls.__all__

--- a/habitat_sim/agent/controls/__init__.py
+++ b/habitat_sim/agent/controls/__init__.py
@@ -8,6 +8,7 @@ from habitat_sim.agent.controls.controls import (
     ActuationSpec,
     ObjectControls,
     SceneNodeControl,
+    move_func_map,
     register_move_fn,
 )
 from habitat_sim.agent.controls.default_controls import *
@@ -16,6 +17,7 @@ from habitat_sim.agent.controls.pyrobot_noisy_controls import PyRobotNoisyActuat
 __all__ = [
     "ActuationSpec",
     "ObjectControls",
+    "move_func_map",
     "SceneNodeControl",
     "register_move_fn",
     "PyRobotNoisyActuationSpec",

--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# TODO: this whole thing needs to get removed, kept just for compatibility
+#   with existing code
+
 modules = [
     "SceneNodeType",
     "GreedyFollowerCodes",

--- a/habitat_sim/geo.py
+++ b/habitat_sim/geo.py
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from habitat_sim._ext.habitat_sim_bindings import OBB, BBox
+from habitat_sim._ext.habitat_sim_bindings.geo import (
+    BACK,
+    FRONT,
+    GRAVITY,
+    LEFT,
+    RIGHT,
+    UP,
+)
+
+__all__ = ["BBox", "OBB", "UP", "GRAVITY", "FRONT", "BACK", "LEFT", "RIGHT"]

--- a/habitat_sim/gfx.py
+++ b/habitat_sim/gfx.py
@@ -1,0 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from habitat_sim._ext.habitat_sim_bindings import Camera, Renderer
+from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
+from habitat_sim._ext.habitat_sim_bindings import SimulatorConfiguration
+
+__all__ = ["SimulatorBackend", "SimulatorConfiguration", "Camera", "Renderer"]

--- a/habitat_sim/nav/__init__.py
+++ b/habitat_sim/nav/__init__.py
@@ -1,1 +1,22 @@
+from habitat_sim._ext.habitat_sim_bindings import (
+    GreedyFollowerCodes,
+    GreedyGeodesicFollowerImpl,
+    HitRecord,
+    MultiGoalShortestPath,
+    PathFinder,
+    ShortestPath,
+    VectorGreedyCodes,
+)
+
 from .greedy_geodesic_follower import GreedyGeodesicFollower
+
+__all__ = [
+    "GreedyGeodesicFollower",
+    "GreedyGeodesicFollowerImpl",
+    "GreedyFollowerCodes",
+    "MultiGoalShortestPath",
+    "PathFinder",
+    "ShortestPath",
+    "HitRecord",
+    "VectorGreedyCodes",
+]

--- a/habitat_sim/scene.py
+++ b/habitat_sim/scene.py
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from habitat_sim._ext.habitat_sim_bindings import (
+    Mp3dObjectCategory,
+    Mp3dRegionCategory,
+    SceneConfiguration,
+    SceneGraph,
+    SceneNode,
+    SceneNodeType,
+    SemanticCategory,
+    SemanticLevel,
+    SemanticObject,
+    SemanticRegion,
+    SemanticScene,
+)
+
+__all__ = [
+    "Mp3dObjectCategory",
+    "Mp3dRegionCategory",
+    "SceneGraph",
+    "SceneNode",
+    "SceneNodeType",
+    "SemanticCategory",
+    "SemanticLevel",
+    "SemanticObject",
+    "SemanticRegion",
+    "SemanticScene",
+    "SceneConfiguration",
+]

--- a/habitat_sim/sensor.py
+++ b/habitat_sim/sensor.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from habitat_sim._ext.habitat_sim_bindings import (
+    Observation,
+    PinholeCamera,
+    Sensor,
+    SensorSpec,
+    SensorType,
+)
+
+__all__ = ["PinholeCamera", "Sensor", "SensorType", "SensorSpec", "Observation"]

--- a/habitat_sim/sensors/__init__.py
+++ b/habitat_sim/sensors/__init__.py
@@ -5,3 +5,5 @@
 # LICENSE file in the root directory of this source tree.
 
 from .sensor_suite import SensorSuite
+
+__all__ = ["SensorSuite"]


### PR DESCRIPTION
## Motivation and Context

In preparation for reworked docs (#71), reorganizing the `__all__` property of all modules to make more sense and be inspectable by doc generation tools. In particular:

- Avoiding extra deep hierarchies like `habitat_sim.agent.controls` but also not putting everything directly into `habitat_sim`.
- Taking stuff out of the `bindings` module and reorganizing it to other modules. The `bindings` module only grouped things coming from C++ until now and that semantically didn't have any value.
- Adding random things that were missing from `__all__`, being invisible to doc generators, IDE autocompletion etc.

What is *not* done:

- Getting rid of the old `bindings` module. It's kept there for backwards compatibility with existing code.
- Removing the `from foo import *` in the root `__init__.py` for the same reason.
- I don't see why the native module should be deep down in `_ext.bindings.habitat_sim_bindings`, I think having it as `_habitat_sim` *next* to the pure Python `habitat_sim` would be perfectly okay.
- The general structure and naming could be improved to be more clear, but I don't think that's something I should be doing -- you have a much better idea about the desired overall project structure than me.

## How Has This Been Tested

Docs generated with [m.css](https://mcss.mosra.cz) now reference all classes as expected, has a flattened class list and doesn't include the `bindings` module anymore. Sample is at https://tmp.mosra.cz/habitat-sim/