### PR TITLE
Make installing magnum always the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Install the pre-commit hooks with `pip install pre-commit && pre-commit install`
 
 1. Install `ninja` (`sudo apt install ninja-build` on Linux, or `brew install ninja` on MacOS) for significantly faster incremental builds
 1. Install `ccache` (`sudo apt install ccache` on Linux, or `brew install ccache` on MacOS) for significantly faster clean re-builds and builds with slightly different settings
-1. You can skip reinstall magnum every time buy adding the argument of `--skip-reinstall-magnum` to either `build.sh` or `setup.py`
+1. You can skip reinstalling magnum every time buy adding the argument of `--skip-reinstall-magnum` to either `build.sh` or `setup.py`
 1. Arguments to `build.sh` and `setup.py` can be cached between subsequent invocations with the flag `--cache-args` on the _first_ invocation.
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Install the pre-commit hooks with `pip install pre-commit && pre-commit install`
 
 1. Install `ninja` (`sudo apt install ninja-build` on Linux, or `brew install ninja` on MacOS) for significantly faster incremental builds
 1. Install `ccache` (`sudo apt install ccache` on Linux, or `brew install ccache` on MacOS) for significantly faster clean re-builds and builds with slightly different settings
-1. You can skip reinstalling magnum every time buy adding the argument of `--skip-reinstall-magnum` to either `build.sh` or `setup.py`
+1. You can skip reinstalling magnum every time buy adding the argument of `--skip-install-magnum` to either `build.sh` or `setup.py`.  Note that you will still need to install magnum bindings once.
 1. Arguments to `build.sh` and `setup.py` can be cached between subsequent invocations with the flag `--cache-args` on the _first_ invocation.
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ To run the above benchmarks on your machine, see instructions in the [examples](
 
 1. Clone the repo
 1. Install numpy in your python env of choice (e.g., `pip install numpy` or `conda install numpy`)
+1. Install dependencies in your python env of choice (e.g., `pip install -r requirements.txt`)
 1. Install Habitat-Sim via `python setup.py install` in your python env of choice (note: python 3 is required)
 
     Use `python setup.py install --headless` for headless systems (i.e. without an attached display) or if you need multi-gpu support.
@@ -218,6 +219,8 @@ Install the pre-commit hooks with `pip install pre-commit && pre-commit install`
 
 1. Install `ninja` (`sudo apt install ninja-build` on Linux, or `brew install ninja` on MacOS) for significantly faster incremental builds
 1. Install `ccache` (`sudo apt install ccache` on Linux, or `brew install ccache` on MacOS) for significantly faster clean re-builds and builds with slightly different settings
+1. You can skip reinstall magnum every time buy adding the argument of `--skip-reinstall-magnum` to either `build.sh` or `setup.py`
+1. Arguments to `build.sh` and `setup.py` can be cached between subsequent invocations with the flag `--cache-args` on the _first_ invocation.
 
 ## Acknowledgments
 The Habitat project would not have been possible without the support and contributions of many individuals. We would like to thank Xinlei Chen, Georgia Gkioxari, Daniel Gordon, Leonidas Guibas, Saurabh Gupta, Or Litany, Marcus Rohrbach, Amanpreet Singh, Devendra Singh Chaplot, Yuandong Tian, and Yuxin Wu for many helpful conversations and guidance on the design and development of the Habitat platform.

--- a/setup.py
+++ b/setup.py
@@ -312,20 +312,6 @@ class CMakeBuild(build_ext):
 
 
 if __name__ == "__main__":
-    try:
-        import magnum
-
-        has_magnum = True
-    except ImportError:
-        has_magnum = False
-
-    if not has_magnum and is_pip():
-        raise RuntimeError(
-            "Must have magnum already installed when installing habitat_sim"
-            "via pip due to limitations of setup.py\n"
-            "You can install magnum via 'python setup.py install'"
-        )
-
     assert StrictVersion(
         "{}.{}".format(sys.version_info[0], sys.version_info[1])
     ) >= StrictVersion("3.6"), "Must use python3.6 or newer"
@@ -361,7 +347,7 @@ if __name__ == "__main__":
         _cmake_build_dir, "deps", "magnum-bindings", "src", "python"
     )
 
-    if not args.skip_reinstall_magnum or not has_magnum:
+    if not args.skip_reinstall_magnum and not is_pip():
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
         print("Assuming magnum bindings are already installed")

--- a/setup.py
+++ b/setup.py
@@ -350,5 +350,5 @@ if __name__ == "__main__":
     if not args.skip_install_magnum and not is_pip():
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
-        print("Assuming magnum bindings are already installed")
+         print("Assuming magnum bindings are already installed (or we're inside pip and ¯\\_(ツ)_/¯)")
         print(f"Run 'pip install {pymagnum_build_dir}' if this assumption is incorrect")

--- a/setup.py
+++ b/setup.py
@@ -351,6 +351,6 @@ if __name__ == "__main__":
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
         print(
-            "Assuming magnum bindings are already installed (or we're inside pip and -\_('-')_/-)"
+            "Assuming magnum bindings are already installed (or we're inside pip and ¯\\_('-')_/¯)"
         )
         print(f"Run 'pip install {pymagnum_build_dir}' if this assumption is incorrect")

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from distutils.version import StrictVersion
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
-ARG_CACHE_BLACKLIST = {"force_cmake", "cache_args"}
+ARG_CACHE_BLACKLIST = {"force_cmake", "cache_args", "inplace"}
 
 
 def build_parser():
@@ -71,6 +71,15 @@ Use "CMAKE_ARGS="..." pip install ." to set cmake args with pip""",
         action="store_true",
         help="""Caches the arguements sent to setup.py
         and reloads them on the next invocation.  This argument is not cached""",
+    )
+
+    parser.add_argument(
+        "--skip-reinstall-magnum",
+        dest="skip_reinstall_magnum",
+        action="store_true",
+        help="Don't reinstall magnum if you already have it.  "
+        "This is nice for incrementally building for development but "
+        "can cause install magnum bindings to fall out-of-sync",
     )
 
     return parser
@@ -352,7 +361,7 @@ if __name__ == "__main__":
         _cmake_build_dir, "deps", "magnum-bindings", "src", "python"
     )
 
-    if not has_magnum:
+    if not args.skip_reinstall_magnum or not has_magnum:
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
         print("Assuming magnum bindings are already installed")

--- a/setup.py
+++ b/setup.py
@@ -350,5 +350,7 @@ if __name__ == "__main__":
     if not args.skip_install_magnum and not is_pip():
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
-         print("Assuming magnum bindings are already installed (or we're inside pip and ¯\\_(ツ)_/¯)")
+        print(
+            "Assuming magnum bindings are already installed (or we're inside pip and -\_('-')_/-)"
+        )
         print(f"Run 'pip install {pymagnum_build_dir}' if this assumption is incorrect")

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,10 @@ Use "CMAKE_ARGS="..." pip install ." to set cmake args with pip""",
     )
 
     parser.add_argument(
-        "--skip-reinstall-magnum",
-        dest="skip_reinstall_magnum",
+        "--skip-install-magnum",
+        dest="skip_install_magnum",
         action="store_true",
-        help="Don't reinstall magnum if you already have it.  "
+        help="Don't install magnum.  "
         "This is nice for incrementally building for development but "
         "can cause install magnum bindings to fall out-of-sync",
     )
@@ -347,7 +347,7 @@ if __name__ == "__main__":
         _cmake_build_dir, "deps", "magnum-bindings", "src", "python"
     )
 
-    if not args.skip_reinstall_magnum and not is_pip():
+    if not args.skip_install_magnum and not is_pip():
         subprocess.check_call(shlex.split(f"pip install {pymagnum_build_dir}"))
     else:
         print("Assuming magnum bindings are already installed")


### PR DESCRIPTION
## Motivation and Context

The behavior of not installing magnum if you already have it is nice for development and incremental builds, but not nice for user.  This PR makes reinstalling magnum the default and adds a `--skip-reinstall-magnum` flag to the build to skip the reinstall.

## How Has This Been Tested

`build.sh` and `setup.py install` now both always install magnum by default.

## Types of changes

-  Bug fix (non-breaking change which fixes an issue)
