### PR TITLE
Move actions in local coordinates

### DIFF
--- a/habitat_sim/agent/default_controls.py
+++ b/habitat_sim/agent/default_controls.py
@@ -27,7 +27,7 @@ _rotate_local_fns = [
 
 
 def _move_along(scene_node: hsim.SceneNode, distance: float, axis: int):
-    ax = scene_node.absolute_transformation()[axis].xyz
+    ax = scene_node.transformation[axis].xyz
     scene_node.translate_local(ax * distance)
 
 


### PR DESCRIPTION
## Motivation and Context

The move controllers should move the scene-node in its local coordinate system, not the global coordinate system as currently the move controllers don't make any sense when moving a sensor instead of the agents body.

## How Has This Been Tested

Via in interactive viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-  Bug fix (non-breaking change which fixes an issue)


