### PR TITLE
Update greedy follower heuristics

### DIFF
--- a/src/esp/nav/GreedyFollower.cpp
+++ b/src/esp/nav/GreedyFollower.cpp
@@ -82,7 +82,7 @@ nav::GreedyGeodesicFollowerImpl::calcStepAlong(
 
   const float alpha = gradDir.angularDistance(std::get<1>(state));
   VLOG(1) << alpha;
-  if (alpha <= turnAmount_ / 2.0 + 1e-3)
+  if (alpha <= turnAmount_ + 1e-3)
     return CODES::FORWARD;
 
   // There are some edge cases where the gradient doesn't line up with makes
@@ -93,7 +93,7 @@ nav::GreedyGeodesicFollowerImpl::calcStepAlong(
   const float newGeoDist = this->geoDist(
       cast<vec3f>(dummyNode_.absoluteTransformation().translation()),
       path.requestedEnd);
-  if ((path.geodesicDistance - newGeoDist) > 0.5 * forwardAmount_) {
+  if ((path.geodesicDistance - newGeoDist) > 0.95 * forwardAmount_) {
     return CODES::FORWARD;
   }
 


### PR DESCRIPTION
## Motivation and Context

The current heuristics of the greedy follower are set very conservatively such that it maximizes how often it is able to find a goal.  These have been set too conservatively and it commonly generates odd looking and not very short action-space paths.  This PR sets those significantly more aggressively such that the paths are significantly shorter (about 30% shorter on average).  This comes at the cost of how often it fails to find a path --  it fails to find a path about 6x more than it use to -- but it still finds a path 99.9% of the time (failed to find a path 600 times over 600k tests).

## How Has This Been Tested

With the unit test.

## Types of changes

-  New feature (non-breaking change which adds functionality)
