### PR TITLE
Avoid using too new CMake features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,15 @@ jobs:
       - run:
           name: Install cmake
           no_output_timeout: 5m
+          # tinyply requires CMake 3.10, so stay at that version. Ubuntu 16.04
+          # has 3.5, so once tinyply is removed, we could go lower (well, if
+          # anybody actually needs that)
           command: |
               echo $(git ls-remote https://github.com/facebookresearch/habitat-api.git HEAD | awk '{ print $1}') > ./hapi_sha
               cat ./hapi_sha
-              wget https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.sh
+              wget https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh
               sudo mkdir /opt/cmake
-              sudo sh ./cmake-3.13.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+              sudo sh ./cmake-3.10.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
               sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
       - run:
           name: Install dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,10 @@ include_directories(${PROJECT_SOURCE_DIR})
 # compiler define for enabling ptex support
 if(BUILD_PTEX_SUPPORT)
   message("Building with ptex support")
-  add_compile_definitions(BUILD_PTEX_SUPPORT)
+  # This should be ideally add_compile_definitions() in the long term, but
+  # that's not available until CMake 3.12 and we don't want to cut off people
+  # on older versions.
+  add_definitions(-DBUILD_PTEX_SUPPORT)
 endif()
 
 # add subdirectories


### PR DESCRIPTION
## Motivation and Context

Fixes #137. Ideally this would be done via `configure_file()` together with other options, but as that's not that urgent, I'm throwing that on the pile in #42.

@mathfac (or somebody who's in charge of the CI) -- can we configure the CI to use some older CMake version (3.8, for example) so these issues get caught early enough? For Magnum itself I'm going as far as 3.1, but I don't think that level of compatibility is needed here. I'm on Arch and most of you are on macOS, which means we all probably have 3.15, but we shouldn't forget about LTS Linux distros.

## How Has This Been Tested

Things that worked before continue to work; things that temporarily didn't work are working again.
