### PR TITLE
Fix WebGL glClear issue.

### DIFF
--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -62,7 +62,7 @@ struct Renderer::Impl {
   }
 
   inline void renderEnter() {
-    framebuffer_.clear(GL::FramebufferClear::Depth);
+    framebuffer_.clearDepth(1.0);
     framebuffer_.clearColor(0, Color4{});
     framebuffer_.clearColor(1, Color4{});
     framebuffer_.clearColor(2, Vector4ui{});

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -62,9 +62,9 @@ struct Renderer::Impl {
   }
 
   inline void renderEnter() {
-    framebuffer_.clear(GL::FramebufferClear::Color |
-                       GL::FramebufferClear::Depth);
-    framebuffer_.clearColor(1, Vector4{});
+    framebuffer_.clear(GL::FramebufferClear::Depth);
+    framebuffer_.clearColor(0, Color4{});
+    framebuffer_.clearColor(1, Color4{});
     framebuffer_.clearColor(2, Vector4ui{});
     framebuffer_.bind();
   }


### PR DESCRIPTION
Fixes the following GL_ERROR on WebGL:

glClear: can't be called on integer buffers

The problem is that glClear will clear all glDrawBuffers.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Before this change, the main color_attachement was not clearing.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Tested with work-in-progress embind patch.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
