### PR TITLE
Show both frame time and FPS in the benchmark

### DIFF
--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -146,7 +146,8 @@ class DemoRunner:
         end_time = time.time()
         perf = {}
         perf["total_time"] = end_time - start_time
-        perf["fps"] = total_frames / perf["total_time"]
+        perf["frame_time"] = perf["total_time"] / total_frames
+        perf["fps"] = 1.0 / perf["frame_time"]
 
         return perf
 
@@ -214,7 +215,7 @@ class DemoRunner:
             # the kernel never interrupted the workers, but this isn't
             # feasible, so we just take the run with the least number of
             # interrupts (the fastest) instead.
-            if best_perf is None or perf["fps"] > best_perf["fps"]:
+            if best_perf is None or perf["frame_time"] < best_perf["frame_time"]:
                 best_perf = perf
 
         self._sim.close()
@@ -242,7 +243,11 @@ class DemoRunner:
             for k, v in p.items():
                 res[k] += [v]
 
-        return dict(fps=sum(res["fps"]), total_time=sum(res["total_time"]) / nprocs)
+        return dict(
+            frame_time=sum(res["frame_time"]),
+            fps=sum(res["fps"]),
+            total_time=sum(res["total_time"]) / nprocs,
+        )
 
     def example(self):
         start_state = self.init_common()

--- a/examples/example.py
+++ b/examples/example.py
@@ -57,13 +57,13 @@ settings = make_settings()
 demo_runner = dr.DemoRunner(settings, dr.DemoRunnerType.EXAMPLE)
 perf = demo_runner.example()
 
-print(" ============ Performance ======================== ")
+print(" ========================= Performance ======================== ")
 print(
-    " %d x %d, total time: %0.3f sec."
+    " %d x %d, total time %0.2f s,"
     % (settings["width"], settings["height"], perf["total_time"]),
-    "FPS: %0.1f" % perf["fps"],
+    "frame time %0.3f ms (%0.1f FPS)" % (perf["frame_time"] * 1000.0, perf["fps"]),
 )
-print(" ================================================= ")
+print(" ============================================================== ")
 
 assert perf["fps"] > args.test_fps_regression, (
     "FPS is below regression threshold: %0.1f < %0.1f"


### PR DESCRIPTION
## Motivation and Context

FPS have inverse relation to the performance and thus are hard to reason about. Example output:

```
 ========================= Performance ======================== 
 640 x 480, total time 15.1 s, frame time 3.010 ms (332.3 FPS)
 ============================================================== 
```

The output is rearranged a bit to fit all the values better, the FPS output in the dict is kept as-is to preserve the FPS regression test behavior (but those would be ideal to have converted to frame time as well, at some point).

## How Has This Been Tested

It prints both frame time and FPS and their product seems to be 1 second :tada:
