### PR TITLE
Reuse GPU-created depth buffer and unproject it during a read

### DIFF
--- a/src/esp/assets/FRLInstanceMeshData.cpp
+++ b/src/esp/assets/FRLInstanceMeshData.cpp
@@ -5,6 +5,7 @@
 #include "FRLInstanceMeshData.h"
 
 #include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/ArrayViewStl.h>
 #include <Magnum/GL/Texture.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/Image.h>

--- a/src/esp/assets/GenericInstanceMeshData.cpp
+++ b/src/esp/assets/GenericInstanceMeshData.cpp
@@ -5,6 +5,7 @@
 #include "GenericInstanceMeshData.h"
 
 #include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/ArrayViewStl.h>
 #include <Magnum/GL/Texture.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/Image.h>

--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/GL/BufferTextureFormat.h>
 #include <Magnum/ImageView.h>

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -25,10 +25,8 @@ GenericDrawable::GenericDrawable(
 void GenericDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                            Magnum::SceneGraph::Camera3D& camera) {
   GenericShader& shader = static_cast<GenericShader&>(shader_);
-  shader
-      .setTransformationProjectionMatrix(camera.projectionMatrix() *
-                                         transformationMatrix)
-      .setProjectionMatrix(transformationMatrix);
+  shader.setTransformationProjectionMatrix(camera.projectionMatrix() *
+                                           transformationMatrix);
 
   if (((shader.flags() & GenericShader::Flag::Textured) ||
        (shader.flags() & GenericShader::Flag::PrimitiveIDTextured)) &&

--- a/src/esp/gfx/GenericShader.h
+++ b/src/esp/gfx/GenericShader.h
@@ -54,10 +54,8 @@ class GenericShader : public Magnum::GL::AbstractShaderProgram {
   enum : uint8_t {
     //! color output
     ColorOutput = 0,
-    //! depth frame output
-    DepthOutput = 1,
     //! object id output
-    ObjectIdOutput = 2
+    ObjectIdOutput = 1
   };
 
   /**
@@ -72,15 +70,6 @@ class GenericShader : public Magnum::GL::AbstractShaderProgram {
   GenericShader& setTransformationProjectionMatrix(
       const Magnum::Matrix4& matrix) {
     setUniform(uniformLocation("transformationProjectionMatrix"), matrix);
-    return *this;
-  }
-
-  /**
-   * @brief Set projection matrix
-   * @return Reference to self (for method chaining)
-   */
-  GenericShader& setProjectionMatrix(const Magnum::Matrix4& matrix) {
-    setUniform(uniformLocation("projectionMatrix"), matrix);
     return *this;
   }
 

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -9,6 +9,7 @@
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Framebuffer.h>
+#include <Magnum/GL/PixelFormat.h>
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/GL/RenderbufferFormat.h>
 #include <Magnum/GL/Renderer.h>
@@ -26,7 +27,6 @@ struct Renderer::Impl {
   Impl(int width, int height)
       : framebufferSize_(width, height),
         colorBuffer_(),
-        depthBuffer_(),
         objectIdBuffer_(),
         depthRenderbuffer_(),
         framebuffer_({{}, framebufferSize_}) {
@@ -41,21 +41,18 @@ struct Renderer::Impl {
     framebufferSize_[1] = height;
     colorBuffer_.setStorage(GL::RenderbufferFormat::SRGB8Alpha8,
                             framebufferSize_);
-    depthBuffer_.setStorage(GL::RenderbufferFormat::R32F, framebufferSize_);
     objectIdBuffer_.setStorage(GL::RenderbufferFormat::R32UI, framebufferSize_);
-    depthRenderbuffer_.setStorage(GL::RenderbufferFormat::Depth24Stencil8,
+    depthRenderbuffer_.setStorage(GL::RenderbufferFormat::DepthComponent32F,
                                   framebufferSize_);
     framebuffer_ = GL::Framebuffer{{{}, framebufferSize_}};
     framebuffer_
         .attachRenderbuffer(GL::Framebuffer::ColorAttachment{0}, colorBuffer_)
-        .attachRenderbuffer(GL::Framebuffer::ColorAttachment{1}, depthBuffer_)
-        .attachRenderbuffer(GL::Framebuffer::ColorAttachment{2},
+        .attachRenderbuffer(GL::Framebuffer::ColorAttachment{1},
                             objectIdBuffer_)
         .attachRenderbuffer(GL::Framebuffer::BufferAttachment::Depth,
                             depthRenderbuffer_)
         .mapForDraw({{0, GL::Framebuffer::ColorAttachment{0}},
-                     {1, GL::Framebuffer::ColorAttachment{1}},
-                     {2, GL::Framebuffer::ColorAttachment{2}}});
+                     {1, GL::Framebuffer::ColorAttachment{1}}});
     CORRADE_INTERNAL_ASSERT(
         framebuffer_.checkStatus(GL::FramebufferTarget::Draw) ==
         GL::Framebuffer::Status::Complete);
@@ -64,8 +61,7 @@ struct Renderer::Impl {
   inline void renderEnter() {
     framebuffer_.clearDepth(1.0);
     framebuffer_.clearColor(0, Color4{});
-    framebuffer_.clearColor(1, Color4{});
-    framebuffer_.clearColor(2, Vector4ui{});
+    framebuffer_.clearColor(1, Vector4ui{});
     framebuffer_.bind();
   }
 
@@ -74,6 +70,52 @@ struct Renderer::Impl {
   void draw(RenderCamera& camera, MagnumDrawableGroup& drawables) {
     renderEnter();
     camera.getMagnumCamera().setViewport(framebufferSize_);
+
+    /* Inverted projection matrix to unproject the depth value and chop the
+       near plane off. We don't care about X/Y there and the corresponding
+       parts of the matrix are zero as well so take just the lower-right part
+       of it (denoted a, b, c, d).
+
+        x 0 0 0
+        0 y 0 0
+        0 0 a b
+        0 0 c d
+
+       Doing an inverse of just the bottom right block is enough as well -- see
+       https://en.wikipedia.org/wiki/Block_matrix#Block_diagonal_matrices for
+       a proof.
+
+       Taking a 2-component vector with the first component being Z and second
+       1, the final calculation of unprojected Z is then
+
+        | a b |   | z |   | az + b |
+        | c d | * | 1 | = | cz + d |
+
+    */
+    const Matrix4 projection = camera.getMagnumCamera().projectionMatrix();
+    depthUnprojection_ = Matrix2x2{Math::swizzle<'z', 'w'>(projection[2]),
+                                   Math::swizzle<'z', 'w'>(projection[3])}
+                             .inverted();
+
+    /* The Z value comes in range [0; 1], but we need it in the range [-1; 1].
+       Instead of doing z = x*2 - 1 for every pixel, we add that to this
+       matrix:
+
+        az + b
+        a(x*2 - 1) + b
+        2ax - a + b
+        (2a)x + (b - a)
+
+      and similarly for c/d. Which means -- from the second component we
+      subtract the first, and the first we multiply by 2. */
+    depthUnprojection_[1] -= depthUnprojection_[0];
+    depthUnprojection_[0] *= 2.0;
+
+    /* Finally, because the output has Z going forward, not backward, we need
+       to negate it. There's a perspective division happening, so we have to
+       negate just the first row. */
+    depthUnprojection_.setRow(0, -depthUnprojection_.row(0));
+
     camera.draw(drawables);
     renderExit();
   }
@@ -96,14 +138,38 @@ struct Renderer::Impl {
   }
 
   void readFrameDepth(float* ptr) {
-    framebuffer_.mapForRead(GL::Framebuffer::ColorAttachment{1});
     Image2D depthImage = framebuffer_.read(
-        Range2Di::fromSize({0, 0}, framebufferSize_), {PixelFormat::R32F});
-    std::memcpy(ptr, depthImage.data(), depthImage.data().size());
+        Range2Di::fromSize({0, 0}, framebufferSize_),
+        {GL::PixelFormat::DepthComponent, GL::PixelType::Float});
+
+    /* Unproject the Z */
+    Containers::ArrayView<const Float> data =
+        Containers::arrayCast<const Float>(depthImage.data());
+    for (std::size_t i = 0; i != data.size(); ++i) {
+      const Float z = data[i];
+
+      /* If a fragment has a depth of 1, it's due to a hole in the mesh. The
+         consumers expect 0 for things that are too far, so be nice to them.
+         We can afford using == for comparison as 1.0f has an exact
+         representation and the depth is cleared to exactly this value. */
+      if (z == 1.0f) {
+        ptr[i] = 0.0f;
+        continue;
+      }
+
+      /* The following is
+
+          (az + b) / (cz + d)
+
+         See the comment in draw() above for details. */
+      ptr[i] =
+          Math::fma(depthUnprojection_[0][0], z, depthUnprojection_[1][0]) /
+          Math::fma(depthUnprojection_[0][1], z, depthUnprojection_[1][1]);
+    }
   }
 
   void readFrameObjectId(uint32_t* ptr) {
-    framebuffer_.mapForRead(GL::Framebuffer::ColorAttachment{2});
+    framebuffer_.mapForRead(GL::Framebuffer::ColorAttachment{1});
     Image2D objectImage = framebuffer_.read(
         Range2Di::fromSize({0, 0}, framebufferSize_), {PixelFormat::R32UI});
     std::memcpy(ptr, objectImage.data(), objectImage.data().size());
@@ -111,10 +177,11 @@ struct Renderer::Impl {
 
   Magnum::Vector2i framebufferSize_;
   GL::Renderbuffer colorBuffer_;
-  GL::Renderbuffer depthBuffer_;
   GL::Renderbuffer objectIdBuffer_;
   GL::Renderbuffer depthRenderbuffer_;
   GL::Framebuffer framebuffer_;
+
+  Matrix2x2 depthUnprojection_;
 };
 
 Renderer::Renderer(int width, int height)

--- a/src/shaders/generic-default-gl410.frag
+++ b/src/shaders/generic-default-gl410.frag
@@ -1,5 +1,4 @@
 in mediump vec3 v_color;
-in highp float v_depth;
 
 
 #ifdef PER_VERTEX_IDS
@@ -23,8 +22,7 @@ uniform lowp vec4 colorUniform;
 #endif
 
 layout(location = 0) out mediump vec4 color;
-layout(location = 1) out highp float depth;
-layout(location = 2) out uint objectId;
+layout(location = 1) out uint objectId;
 
 void main () {
   mediump vec4 baseColor =
@@ -38,7 +36,6 @@ void main () {
     texture(textureData, interpolatedTextureCoordinates) *
     #endif
     baseColor;
-  depth = v_depth;
   objectId =
   #ifdef PER_VERTEX_IDS
     v_objectId;

--- a/src/shaders/generic-default-gl410.vert
+++ b/src/shaders/generic-default-gl410.vert
@@ -1,5 +1,4 @@
 uniform highp mat4 transformationProjectionMatrix;
-uniform highp mat4 projectionMatrix;
 
 layout(location = 0) in highp vec4 position;
 
@@ -13,7 +12,6 @@ layout(location = 1) in mediump vec3 color;
 #endif
 
 out mediump vec3 v_color;
-out highp float v_depth;
 
 #ifdef PER_VERTEX_IDS
 flat out uint v_objectId;
@@ -26,15 +24,10 @@ void main() {
   interpolatedTextureCoordinates = textureCoordinates;
   #endif
 
-  vec4 pointInCameraCoords = projectionMatrix * vec4(position.xyz, 1.0);
-  pointInCameraCoords /= pointInCameraCoords.w;
-
   #ifdef VERTEX_COLORED
   v_color = color;
   #endif
   #ifdef PER_VERTEX_IDS
   v_objectId = uint(position.w);
   #endif
-
-  v_depth = -pointInCameraCoords.z;
 }


### PR DESCRIPTION
## Motivation and Context

This is a first step towards the goal of integrating Magnum builtin shaders -- they don't have any such feature and thus it was a blocker that had to be removed first.

Apart from that this gives a nice little speedup in color-only rendering (0.2 ms) thanks to one clear less and one less render target being written to; while the additional operations for depth rendering aren't really slower in total.

![image](https://user-images.githubusercontent.com/344828/62976738-9551b600-be1d-11e9-8a17-be5efe671e1a.png)

## How Has This Been Tested

Pytest passes (it was a *pain* but yes it does!), CI passed the 1400 FPS milestone :tada: 