### PR TITLE
Use Phong shader for rendering scenes

### DIFF
--- a/src/esp/assets/GltfMeshData.cpp
+++ b/src/esp/assets/GltfMeshData.cpp
@@ -19,7 +19,8 @@ void GltfMeshData::uploadBuffersToGPU(bool forceReload) {
   renderingBuffer_.reset();
   renderingBuffer_ = std::make_unique<GltfMeshData::RenderingBuffer>();
   // position, normals, uv, colors are bound to corresponding attributes
-  renderingBuffer_->mesh = Magnum::MeshTools::compile(*meshData_);
+  renderingBuffer_->mesh = Magnum::MeshTools::compile(
+      *meshData_, Magnum::MeshTools::CompileFlag::GenerateSmoothNormals);
   buffersOnGPU_ = true;
 }
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -14,7 +14,7 @@
 #include <Magnum/Math/Range.h>
 #include <Magnum/Math/Tags.h>
 #include <Magnum/PixelFormat.h>
-#include <Magnum/Shaders/Flat.h>
+#include <Magnum/Shaders/Phong.h>
 #include <Magnum/Trade/AbstractImporter.h>
 #include <Magnum/Trade/ImageData.h>
 #include <Magnum/Trade/MeshObjectData3D.h>
@@ -657,27 +657,44 @@ Magnum::GL::AbstractShaderProgram* ResourceManager::getShaderProgram(
 
       case COLORED_SHADER: {
         shaderPrograms_[COLORED_SHADER] =
-            std::make_shared<Magnum::Shaders::Flat3D>(
-                Magnum::Shaders::Flat3D::Flag::ObjectId);
+            std::make_shared<Magnum::Shaders::Phong>(
+                Magnum::Shaders::Phong::Flag::ObjectId, 3 /*lights*/);
       } break;
 
       case VERTEX_COLORED_SHADER: {
         shaderPrograms_[VERTEX_COLORED_SHADER] =
-            std::make_shared<Magnum::Shaders::Flat3D>(
-                Magnum::Shaders::Flat3D::Flag::ObjectId |
-                Magnum::Shaders::Flat3D::Flag::VertexColor);
+            std::make_shared<Magnum::Shaders::Phong>(
+                Magnum::Shaders::Phong::Flag::ObjectId |
+                    Magnum::Shaders::Phong::Flag::VertexColor,
+                3 /*lights*/);
       } break;
 
       case TEXTURED_SHADER: {
         shaderPrograms_[TEXTURED_SHADER] =
-            std::make_shared<Magnum::Shaders::Flat3D>(
-                Magnum::Shaders::Flat3D::Flag::ObjectId |
-                Magnum::Shaders::Flat3D::Flag::Textured);
+            std::make_shared<Magnum::Shaders::Phong>(
+                Magnum::Shaders::Phong::Flag::ObjectId |
+                    Magnum::Shaders::Phong::Flag::DiffuseTexture,
+                3 /*lights*/);
       } break;
 
       default:
         return nullptr;
         break;
+    }
+
+    /* Default setup for Phong, shared by all models */
+    if (type == COLORED_SHADER || type == VERTEX_COLORED_SHADER ||
+        type == TEXTURED_SHADER) {
+      using namespace Magnum::Math::Literals;
+
+      static_cast<Magnum::Shaders::Phong&>(*shaderPrograms_[TEXTURED_SHADER])
+          .setLightPositions({Magnum::Vector3{10.0f, 10.0f, 10.0f} * 100.0f,
+                              Magnum::Vector3{-5.0f, -5.0f, 10.0f} * 100.0f,
+                              Magnum::Vector3{0.0f, 10.0f, -10.0f} * 100.0f})
+          .setLightColors({0xffffff_rgbf * 0.8f, 0xffcccc_rgbf * 0.8f,
+                           0xccccff_rgbf * 0.8f})
+          .setSpecularColor(0x11111100_rgbaf)
+          .setShininess(80.0f);
     }
   }
   return shaderPrograms_[type].get();
@@ -1088,7 +1105,7 @@ gfx::Drawable& ResourceManager::createDrawable(
                                                     texture};
   } else {  // all other shaders use GenericShader
     auto* shader =
-        static_cast<Magnum::Shaders::Flat3D*>(getShaderProgram(shaderType));
+        static_cast<Magnum::Shaders::Phong*>(getShaderProgram(shaderType));
     drawable = new gfx::GenericDrawable{node,    *shader,  mesh, group,
                                         texture, objectId, color};
   }

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -4,7 +4,7 @@
 
 #include "GenericDrawable.h"
 
-#include <Magnum/Shaders/Flat.h>
+#include <Magnum/Shaders/Phong.h>
 
 #include "esp/scene/SceneNode.h"
 
@@ -13,7 +13,7 @@ namespace gfx {
 
 GenericDrawable::GenericDrawable(
     scene::SceneNode& node,
-    Magnum::Shaders::Flat3D& shader,
+    Magnum::Shaders::Phong& shader,
     Magnum::GL::Mesh& mesh,
     Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */,
     Magnum::GL::Texture2D* texture /* = nullptr */,
@@ -26,20 +26,22 @@ GenericDrawable::GenericDrawable(
 
 void GenericDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                            Magnum::SceneGraph::Camera3D& camera) {
-  Magnum::Shaders::Flat3D& shader =
-      static_cast<Magnum::Shaders::Flat3D&>(shader_);
-  shader.setTransformationProjectionMatrix(camera.projectionMatrix() *
-                                           transformationMatrix);
+  Magnum::Shaders::Phong& shader =
+      static_cast<Magnum::Shaders::Phong&>(shader_);
+  shader.setTransformationMatrix(transformationMatrix)
+      .setProjectionMatrix(camera.projectionMatrix())
+      .setNormalMatrix(transformationMatrix.rotationScaling())
+      .setObjectId(node_.getId());
 
-  if ((shader.flags() & Magnum::Shaders::Flat3D::Flag::Textured) && texture_) {
-    shader.bindTexture(*texture_);
+  if ((shader.flags() & Magnum::Shaders::Phong::Flag::DiffuseTexture) &&
+      texture_) {
+    shader.bindDiffuseTexture(*texture_);
   }
 
-  if (!(shader.flags() & Magnum::Shaders::Flat3D::Flag::VertexColor)) {
-    shader.setColor(color_);
+  if (!(shader.flags() & Magnum::Shaders::Phong::Flag::VertexColor)) {
+    shader.setDiffuseColor(color_);
   }
 
-  shader.setObjectId(node_.getId());
   mesh_.draw(shader_);
 }
 

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -17,7 +17,7 @@ class GenericDrawable : public Drawable {
   //! Adds drawable to given group and uses provided texture, objectId, and
   //! color for textured, object id buffer and color shader output respectively
   explicit GenericDrawable(scene::SceneNode& node,
-                           Magnum::Shaders::Flat3D& shader,
+                           Magnum::Shaders::Phong& shader,
                            Magnum::GL::Mesh& mesh,
                            Magnum::SceneGraph::DrawableGroup3D* group = nullptr,
                            Magnum::GL::Texture2D* texture = nullptr,


### PR DESCRIPTION
## Motivation and Context

before:

![chair3-before](https://user-images.githubusercontent.com/344828/65282394-198e0c00-db35-11e9-9811-7bfc1c84479d.png)

after:

![chair3-after](https://user-images.githubusercontent.com/344828/65282399-1e52c000-db35-11e9-9203-4521054be093.png)

This PR depends on #151 (which depends on #150), and only changes use of Flat to Phong, together with adding a fine-tuned light setup. What you *don't* see here is a completely fresh set of tests for all shader combinations in Magnum itself, which makes adding new features (such as vertex color, object ID output, normal mapping, alpha masking, ...) much easier and less error prone. This will also enables many new features in the near future, such as instanced rendering for physics objects.

## How Has This Been Tested

Viewer looks prettier than before, but I think some ground truth data need to be updated for this to pass tests. @erikwijmans could you take care of that? :pray: 

Perf measurements -- there's *expected* slowdown compared to #150 and #151, as the shader is getting much more data and doing much more work now. However it's not *too* bad I would say -- it will get much worse with PBR: 

![image](https://user-images.githubusercontent.com/344828/62985775-09e61e00-be39-11e9-95b9-9cee978848af.png)