### PR TITLE
Height and width were swapped in PinholeCamera.

### DIFF
--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -58,9 +58,8 @@ bool PinholeCamera::getObservation(gfx::Simulator& sim, Observation& obs) {
   // TODO: Get appropriate render with correct resolution
   std::shared_ptr<gfx::Renderer> renderer = sim.getRenderer();
   vec3i resolution = renderer->getSize();
-  if (resolution[0] != spec_->resolution[0] ||
-      resolution[1] != spec_->resolution[1]) {
-    renderer->setSize(spec_->resolution[0], spec_->resolution[1]);
+  if (resolution[0] != width_ || resolution[1] != height_) {
+    renderer->setSize(width_, height_);
   }
   if (spec_->sensorType == SensorType::SEMANTIC) {
     // TODO: check sim has semantic scene graph


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
This was causing frames from rgba_sensor to be stretched.

The bug was recently introduced by me in PR#141. Since know one yet uses this API, no one was affected by this bug.

Before:

![before](https://user-images.githubusercontent.com/35972327/63132177-0f488300-bf75-11e9-97ff-1513d8691b96.png)

After:

![after](https://user-images.githubusercontent.com/35972327/63132187-166f9100-bf75-11e9-9ae0-3ae5d77b2b00.png)

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
With this fix, frames pulled from the rgba_sensor are no longer stretched when specifying a width of 640 and height of 480. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
