### PR TITLE
CI: adapt to be consistent with habitat-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,6 @@ jobs:
               . activate habitat; cd habitat-api
               python setup.py develop --all
               python setup.py test
-              python -u habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_train_test.yaml --run-type train
       - save_cache:
           key: habitat-api-{{ checksum "./hapi_sha" }}
           background: true


### PR DESCRIPTION
## Motivation and Context

Doing the same as here: https://github.com/facebookresearch/habitat-api/commit/dd75f18fb81e00810126a46c23c812e75230e86f#diff-1d37e48f9ceff6d8030570cd36286a61

## How Has This Been Tested

I expect the CI to not be red anymore.
