### PR TITLE
CMake: stop using file(GLOB)

### DIFF
--- a/src/esp/agent/CMakeLists.txt
+++ b/src/esp/agent/CMakeLists.txt
@@ -1,6 +1,7 @@
-file(GLOB_RECURSE agent_SOURCES "*.cpp")
-
-add_library(agent STATIC ${agent_SOURCES})
+add_library(agent STATIC
+  Agent.cpp
+  Agent.h
+)
 
 target_link_libraries(agent
   PUBLIC

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -1,7 +1,30 @@
-file(GLOB_RECURSE assets_SOURCES "*.cpp")
+set(assets_SOURCES
+  Asset.cpp
+  Asset.h
+  Attributes.cpp
+  Attributes.h
+  BaseMesh.cpp
+  BaseMesh.h
+  CollisionMeshData.h
+  FRLInstanceMeshData.cpp
+  FRLInstanceMeshData.h
+  GenericInstanceMeshData.cpp
+  GenericInstanceMeshData.h
+  GltfMeshData.cpp
+  GltfMeshData.h
+  MeshData.h
+  MeshMetaData.h
+  Mp3dInstanceMeshData.cpp
+  Mp3dInstanceMeshData.h
+  ResourceManager.cpp
+  ResourceManager.h
+)
 
-if(NOT BUILD_PTEX_SUPPORT)
-  list(REMOVE_ITEM assets_SOURCES ${CMAKE_CURRENT_LIST_DIR}/PTexMeshData.cpp)
+if(BUILD_PTEX_SUPPORT)
+  list(APPEND assets_SOURCES
+    PTexMeshData.cpp
+    PTexMeshData.h
+  )
 endif()
 
 find_package(Magnum
@@ -28,8 +51,6 @@ if(BUILD_ASSIMP_SUPPORT)
       AssimpImporter
   )
 endif()
-
-
 
 add_library(assets STATIC ${assets_SOURCES})
 

--- a/src/esp/bindings/CMakeLists.txt
+++ b/src/esp/bindings/CMakeLists.txt
@@ -1,6 +1,11 @@
 find_package(MagnumBindings REQUIRED Python)
 
-pybind11_add_module(habitat_sim_bindings bindings.cpp ShortestPathBindings.cpp geoBindings.cpp)
+pybind11_add_module(habitat_sim_bindings
+  bindings.cpp
+  geoBindings.cpp
+  OpaqueTypes.h
+  ShortestPathBindings.cpp
+)
 target_link_libraries(habitat_sim_bindings
   PRIVATE
     MagnumBindings::Python

--- a/src/esp/core/CMakeLists.txt
+++ b/src/esp/core/CMakeLists.txt
@@ -1,5 +1,3 @@
-file(GLOB_RECURSE core_SOURCES "*.cpp")
-
 if(NOT BUILD_GUI_VIEWERS AND CORRADE_TARGET_UNIX AND NOT CORRADE_TARGET_APPLE)
   set(ESP_BUILD_EGL_SUPPORT ON)
 endif()
@@ -19,10 +17,18 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 
-
 find_package(Corrade REQUIRED Utility)
 
-add_library(core STATIC ${core_SOURCES})
+add_library(core STATIC
+  Buffer.cpp
+  Buffer.h
+  Configuration.h
+  esp.cpp
+  esp.h
+  logging.h
+  random.h
+  spimpl.h
+)
 
 target_link_libraries(core
   PUBLIC

--- a/src/esp/geo/CMakeLists.txt
+++ b/src/esp/geo/CMakeLists.txt
@@ -1,6 +1,11 @@
-file(GLOB_RECURSE geo_SOURCES "*.cpp")
-
-add_library(geo STATIC ${geo_SOURCES})
+add_library(geo STATIC
+  CoordinateFrame.cpp
+  CoordinateFrame.h
+  geo.cpp
+  geo.h
+  OBB.cpp
+  OBB.h
+)
 
 target_link_libraries(geo
   PUBLIC

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -1,14 +1,40 @@
-file(GLOB_RECURSE gfx_SOURCES "*.cpp")
+set(gfx_SOURCES
+  Drawable.cpp
+  Drawable.h
+  GenericDrawable.cpp
+  GenericDrawable.h
+  magnum.h
+  PrimitiveIDTexturedDrawable.cpp
+  PrimitiveIDTexturedDrawable.h
+  PrimitiveIDTexturedShader.cpp
+  PrimitiveIDTexturedShader.h
+  RenderCamera.cpp
+  RenderCamera.h
+  Renderer.cpp
+  Renderer.h
+  Simulator.cpp
+  Simulator.h
+  WindowlessContext.cpp
+  WindowlessContext.h
+)
 
-# If not GUI build, remove Viewer source
+# If GUI build, add Viewer source
 # TODO(MS) Viewer really ought to be in separate module that is disabled
-if(NOT BUILD_GUI_VIEWERS)
-  list(REMOVE_ITEM gfx_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Viewer.cpp")
+if(BUILD_GUI_VIEWERS)
+  list(APPEND gfx_SOURCES
+    Viewer.cpp
+    Viewer.h
+  )
 endif()
 
-# If ptex support is disabled remove relevant source files
-if(NOT BUILD_PTEX_SUPPORT)
-  list(REMOVE_ITEM gfx_SOURCES "${CMAKE_CURRENT_LIST_DIR}/PTexMeshDrawable.cpp" "${CMAKE_CURRENT_LIST_DIR}/PTexMeshShader.cpp")
+# If ptex support is enabled add relevant source files
+if(BUILD_PTEX_SUPPORT)
+  list(APPEND gfx_SOURCES
+    PTexMeshDrawable.cpp
+    PTexMeshDrawable.h
+    PTexMeshShader.cpp
+    PTexMeshShader.h
+  )
 endif()
 
 if ((UNIX AND NOT APPLE) AND (NOT BUILD_GUI_VIEWERS))

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -1,6 +1,9 @@
-file(GLOB_RECURSE io_SOURCES "*.cpp")
-
-add_library(io STATIC ${io_SOURCES})
+add_library(io STATIC
+  io.cpp
+  io.h
+  json.cpp
+  json.h
+)
 
 target_link_libraries(io
   PUBLIC

--- a/src/esp/nav/CMakeLists.txt
+++ b/src/esp/nav/CMakeLists.txt
@@ -1,6 +1,9 @@
-file(GLOB_RECURSE nav_SOURCES "*.cpp")
-
-add_library(nav STATIC ${nav_SOURCES})
+add_library(nav STATIC
+  GreedyFollower.cpp
+  GreedyFollower.h
+  PathFinder.cpp
+  PathFinder.h
+)
 
 target_include_directories(nav
   PRIVATE

--- a/src/esp/physics/CMakeLists.txt
+++ b/src/esp/physics/CMakeLists.txt
@@ -1,5 +1,3 @@
-file(GLOB physics_SOURCES "*.cpp")
-
 find_package(MagnumPlugins
   REQUIRED
     StbImageImporter
@@ -7,7 +5,12 @@ find_package(MagnumPlugins
     TinyGltfImporter
 )
 
-add_library(physics STATIC ${physics_SOURCES})
+add_library(physics STATIC
+  PhysicsManager.cpp
+  PhysicsManager.h
+  RigidObject.cpp
+  RigidObject.h
+)
 
 if(WITH_BULLET)
   target_compile_definitions(physics PUBLIC PHYSICS_WITH_BULLET)

--- a/src/esp/physics/bullet/CMakeLists.txt
+++ b/src/esp/physics/bullet/CMakeLists.txt
@@ -1,8 +1,11 @@
-file(GLOB_RECURSE bulletphysics_SOURCES "*.cpp")
-
 find_package(MagnumIntegration REQUIRED Bullet)
 
-add_library(bulletphysics STATIC ${bulletphysics_SOURCES})
+add_library(bulletphysics STATIC
+  BulletPhysicsManager.cpp
+  BulletPhysicsManager.h
+  BulletRigidObject.cpp
+  BulletRigidObject.h
+)
 
 target_link_libraries(bulletphysics
   PUBLIC

--- a/src/esp/scene/CMakeLists.txt
+++ b/src/esp/scene/CMakeLists.txt
@@ -1,6 +1,21 @@
-file(GLOB_RECURSE scene_SOURCES "*.cpp")
-
-add_library(scene STATIC ${scene_SOURCES})
+add_library(scene STATIC
+  Mp3dSemanticScene.cpp
+  Mp3dSemanticScene.h
+  ObjectControls.cpp
+  ObjectControls.h
+  SceneConfiguration.cpp
+  SceneConfiguration.h
+  SceneGraph.cpp
+  SceneGraph.h
+  SceneManager.cpp
+  SceneManager.h
+  SceneNode.cpp
+  SceneNode.h
+  SemanticScene.h
+  SuncgObjectCategoryMap.h
+  SuncgSemanticScene.cpp
+  SuncgSemanticScene.h
+)
 
 target_link_libraries(scene
   PUBLIC

--- a/src/esp/sensor/CMakeLists.txt
+++ b/src/esp/sensor/CMakeLists.txt
@@ -1,6 +1,9 @@
-file(GLOB_RECURSE sensor_SOURCES "*.cpp")
-
-add_library(sensor STATIC ${sensor_SOURCES})
+add_library(sensor STATIC
+  PinholeCamera.cpp
+  PinholeCamera.h
+  Sensor.cpp
+  Sensor.h
+)
 
 target_link_libraries(sensor
   PUBLIC

--- a/src/esp/sim/CMakeLists.txt
+++ b/src/esp/sim/CMakeLists.txt
@@ -1,6 +1,7 @@
-file(GLOB_RECURSE sim_SOURCES "*.cpp")
-
-add_library(sim STATIC ${sim_SOURCES})
+add_library(sim STATIC
+  SimulatorWithAgents.cpp
+  SimulatorWithAgents.h
+)
 
 target_link_libraries(sim
   PUBLIC


### PR DESCRIPTION
## Motivation and Context

Part of #42. I tried to postpone this but finally lost patience when a branch switch *again* led to linker errors :sweat_smile: There are several reasons why this is bad (and why CMake guides discourage this practice):

 * Newly added files aren't detected unless CMake is explicitly run again (which is slow). Running just ninja won't pick them up, leading to linker errors or other strange issues. This makes switching branches and other tasks more painful than it should be and incremental builds aren't reliable.
 * Target-dependent compilation has to *remove* files from the list instead of adding them, which is less clear.
 * It's not possible to have untracked cpp files in the working copy (for example an unfinished work from another branch) because CMake would pick them up and try to compile them.

This commit also explicitly lists header files (even though it is not needed), because some IDEs (such as Qt Creator) otherwise won't display them in the project tree.

## How Has This Been Tested

It still builds. 