### PR TITLE
Properly propagate errors from the build shell scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Propagate failures properly
+set -e
+
 builder_args=()
 while [[ $# -gt 0 ]]
 do

--- a/build_js.sh
+++ b/build_js.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Propagate failures properly
+set -e
+
 git submodule update --init --recursive
 
 DATA_DIR="$(pwd)/data/"


### PR DESCRIPTION
## Motivation and Context

The CI happily continued running pytest even if the C++ build failed. That is *not* wanted.

## How Has This Been Tested

It no longer succeeds when it should fail, while it still succeeds when it should succeed.
