### PR TITLE
Fix a bunch of silly crashes.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -6,6 +6,7 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/PluginManager/Manager.h>
+#include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/String.h>
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/EigenIntegration/Integration.h>
@@ -49,6 +50,8 @@
 #include "esp/gfx/PTexMeshDrawable.h"
 #include "esp/gfx/PTexMeshShader.h"
 #endif
+
+namespace Cr = Corrade;
 
 namespace esp {
 namespace assets {
@@ -1099,10 +1102,12 @@ bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,
                                          scene::SceneNode* parent,
                                          DrawableGroup* drawables) {
   ASSERT(parent != nullptr);
-  const std::string& houseFile = houseInfo.filepath;
+  std::string houseFile = Cr::Utility::Directory::join(
+      Cr::Utility::Directory::current(), houseInfo.filepath);
   const auto& json = io::parseJsonFile(houseFile);
   const auto& levels = json["levels"].GetArray();
   std::vector<std::string> pathTokens = io::tokenize(houseFile, "/", 0, true);
+  ASSERT(pathTokens.size() >= 3);
   pathTokens.pop_back();  // house.json
   const std::string houseId = pathTokens.back();
   pathTokens.pop_back();  // <houseId>

--- a/src/esp/gfx/Viewer.cpp
+++ b/src/esp/gfx/Viewer.cpp
@@ -103,10 +103,10 @@ Viewer::Viewer(const Arguments& arguments)
   if (io::exists(navmeshFilename)) {
     LOG(INFO) << "Loading navmesh from " << navmeshFilename;
     pathfinder_->loadNavMesh(navmeshFilename);
-  }
 
-  const vec3f position = pathfinder_->getRandomNavigablePoint();
-  agentBodyNode_->setTranslation(Vector3(position));
+    const vec3f position = pathfinder_->getRandomNavigablePoint();
+    agentBodyNode_->setTranslation(Vector3(position));
+  }
 
   // connect controls to navmesh if loaded
   /*
@@ -339,10 +339,12 @@ void Viewer::keyPressEvent(KeyEvent& event) {
     case KeyEvent::Key::Down:
       controls_(*cameraNode_, "lookDown", lookSensitivity, false);
       break;
-    case KeyEvent::Key::Nine: {
-      const vec3f position = pathfinder_->getRandomNavigablePoint();
-      agentBodyNode_->setTranslation(Vector3(position));
-    } break;
+    case KeyEvent::Key::Nine:
+      if (pathfinder_->isLoaded()) {
+        const vec3f position = pathfinder_->getRandomNavigablePoint();
+        agentBodyNode_->setTranslation(Vector3(position));
+      }
+      break;
     case KeyEvent::Key::A:
       controls_(*agentBodyNode_, "moveLeft", moveSensitivity);
       LOG(INFO) << "Agent position "


### PR DESCRIPTION
## Motivation and Context

First commit fixes #157, accessing pathfinder only if it's loaded. Reproducible by doing the following:

```sh
cd path/to/mp3d/82sE5b5pLXE
path/to/viewer 82sE5b5pLXE_semantic.ply    # boom, there's no 82sE5b5pLXE_semantic.navmesh
```

Second commit fixes the following:

```sh
cd path/to/any/house
path/to/viewer house.json         # boom
path/to/viewer $(pwd)/house.json  # doesn't boom
```

## How Has This Been Tested

Doesn't crash as much as before -- however the pathfinder should be more robust I think, accessing it while it's not loaded should not segfault.