### PR TITLE
Clean up the primitive ID textured shader, resolve the WebGL TODO

### DIFF
--- a/src/esp/assets/FRLInstanceMeshData.cpp
+++ b/src/esp/assets/FRLInstanceMeshData.cpp
@@ -26,6 +26,7 @@
 
 #include "esp/core/esp.h"
 #include "esp/geo/geo.h"
+#include "esp/gfx/PrimitiveIDTexturedShader.h"
 #include "esp/io/io.h"
 #include "esp/io/json.h"
 
@@ -263,9 +264,9 @@ void FRLInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
   renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
       .setCount(tri_ibo_->size())  // Set vertex/index count (numQuads * 6)
       .addVertexBuffer(renderingBuffer_->vbo, 0,
-                       Magnum::GL::Attribute<0, Magnum::Vector3>{})
+                       gfx::PrimitiveIDTexturedShader::Position{})
       .addVertexBuffer(renderingBuffer_->cbo, 0,
-                       Magnum::GL::Attribute<1, Magnum::Color3>{})
+                       gfx::PrimitiveIDTexturedShader::Color3{})
       .setIndexBuffer(renderingBuffer_->ibo, 0,
                       Magnum::GL::MeshIndexType::UnsignedInt);
 

--- a/src/esp/assets/FRLInstanceMeshData.cpp
+++ b/src/esp/assets/FRLInstanceMeshData.cpp
@@ -239,14 +239,6 @@ void FRLInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
 
   const size_t numQuads = cpu_vbo_.size() / 4;
 
-  cbo_float_ = new std::vector<float>(cpu_cbo_.size() * 3);
-  for (int iVert = 0; iVert < cpu_cbo_.size(); ++iVert) {
-    const uint32_t idx = 3 * iVert;
-    (*cbo_float_)[idx + 0] = cpu_cbo_[iVert][0] / 255.0f;
-    (*cbo_float_)[idx + 1] = cpu_cbo_[iVert][1] / 255.0f;
-    (*cbo_float_)[idx + 2] = cpu_cbo_[iVert][2] / 255.0f;
-  }
-
   /* Extract object IDs from the fourth component -- it's originally a float
      so we have to allocate instead of using a strided array view :( */
   Cr::Containers::Array<uint32_t> objectIds{numQuads * 2};
@@ -258,15 +250,16 @@ void FRLInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
 
   renderingBuffer_->vbo.setData(*cpu_vbo_3_,
                                 Magnum::GL::BufferUsage::StaticDraw);
-  renderingBuffer_->cbo.setData(*cbo_float_,
-                                Magnum::GL::BufferUsage::StaticDraw);
+  renderingBuffer_->cbo.setData(cpu_cbo_, Magnum::GL::BufferUsage::StaticDraw);
   renderingBuffer_->ibo.setData(*tri_ibo_, Magnum::GL::BufferUsage::StaticDraw);
   renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
       .setCount(tri_ibo_->size())  // Set vertex/index count (numQuads * 6)
       .addVertexBuffer(renderingBuffer_->vbo, 0,
                        gfx::PrimitiveIDTexturedShader::Position{})
-      .addVertexBuffer(renderingBuffer_->cbo, 0,
-                       gfx::PrimitiveIDTexturedShader::Color3{})
+      .addVertexBuffer(
+          renderingBuffer_->cbo, 0,
+          gfx::PrimitiveIDTexturedShader::Color3{
+              gfx::PrimitiveIDTexturedShader::Color3::DataType::UnsignedByte})
       .setIndexBuffer(renderingBuffer_->ibo, 0,
                       Magnum::GL::MeshIndexType::UnsignedInt);
 

--- a/src/esp/assets/FRLInstanceMeshData.h
+++ b/src/esp/assets/FRLInstanceMeshData.h
@@ -29,7 +29,6 @@ class FRLInstanceMeshData : public GenericInstanceMeshData {
     delete cpu_vbo_3_;
     delete tri_ibo_;
     delete cbo_float_;
-    delete obj_id_tex_data_;
   };
 
   void to_ply(const std::string& ply_file) const;
@@ -63,7 +62,6 @@ class FRLInstanceMeshData : public GenericInstanceMeshData {
   std::vector<vec3f>* cpu_vbo_3_ = nullptr;
   std::vector<uint32_t>* tri_ibo_ = nullptr;
   std::vector<float>* cbo_float_ = nullptr;
-  float* obj_id_tex_data_ = nullptr;
 
   vecXi id_to_label;
   vecXi id_to_node;

--- a/src/esp/assets/FRLInstanceMeshData.h
+++ b/src/esp/assets/FRLInstanceMeshData.h
@@ -28,7 +28,6 @@ class FRLInstanceMeshData : public GenericInstanceMeshData {
   virtual ~FRLInstanceMeshData() {
     delete cpu_vbo_3_;
     delete tri_ibo_;
-    delete cbo_float_;
   };
 
   void to_ply(const std::string& ply_file) const;
@@ -61,7 +60,6 @@ class FRLInstanceMeshData : public GenericInstanceMeshData {
 
   std::vector<vec3f>* cpu_vbo_3_ = nullptr;
   std::vector<uint32_t>* tri_ibo_ = nullptr;
-  std::vector<float>* cbo_float_ = nullptr;
 
   vecXi id_to_label;
   vecXi id_to_node;

--- a/src/esp/assets/GenericInstanceMeshData.cpp
+++ b/src/esp/assets/GenericInstanceMeshData.cpp
@@ -249,9 +249,9 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
   renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
       .setCount(cpu_ibo_.size() * 3)
       .addVertexBuffer(renderingBuffer_->vbo, 0,
-                       Magnum::GL::Attribute<0, Magnum::Vector3>{})
+                       gfx::PrimitiveIDTexturedShader::Position{})
       .addVertexBuffer(renderingBuffer_->cbo, 0,
-                       Magnum::GL::Attribute<1, Magnum::Color3>{})
+                       gfx::PrimitiveIDTexturedShader::Color3{})
       .setIndexBuffer(renderingBuffer_->ibo, 0,
                       Magnum::GL::MeshIndexType::UnsignedInt);
 

--- a/src/esp/assets/GenericInstanceMeshData.cpp
+++ b/src/esp/assets/GenericInstanceMeshData.cpp
@@ -27,8 +27,12 @@
 
 #include "esp/core/esp.h"
 #include "esp/geo/geo.h"
+#include "esp/gfx/PrimitiveIDTexturedShader.h"
 #include "esp/io/io.h"
 #include "esp/io/json.h"
+
+namespace Cr = Corrade;
+namespace Mn = Magnum;
 
 namespace esp {
 namespace assets {
@@ -42,33 +46,30 @@ void copyTo(std::shared_ptr<tinyply::PlyData> data, std::vector<T>& dst) {
 }
 }  // namespace
 
-/*
- * In modern OpenGL fragment sharder, we can access the ID of the current
- * primitive and thus can index an array.  We can make a 2D texture behave
- * like a 2D array with nearest sampling and edge clamping.
- */
-Magnum::GL::Texture2D createInstanceTexture(float* data, const int texSize) {
-  /*
-   * Create the image that wil be uploaded to the texture.  We
-   * can index the original data array
-   * with image[primId / texSize, primId % texSize]
-   * NB: The indices will have to mapped into [0, 1] in the GLSL code
-   */
-  Magnum::Image2D image(
-      Magnum::PixelFormat::R32F, {texSize, texSize},
-      Corrade::Containers::Array<char>(reinterpret_cast<char*>(data),
-                                       texSize * texSize * sizeof(data[0])));
+Mn::GL::Texture2D createInstanceTexture(
+    Cr::Containers::ArrayView<std::uint32_t> objectIds) {
+  const Mn::Vector2i textureSize{
+      gfx::PrimitiveIDTexturedShader::PrimitiveIDTextureWidth,
+      int(objectIds.size() +
+          gfx::PrimitiveIDTexturedShader::PrimitiveIDTextureWidth - 1) /
+          gfx::PrimitiveIDTexturedShader::PrimitiveIDTextureWidth};
+  Cr::Containers::Array<Mn::UnsignedShort> packedObjectIds{
+      Cr::Containers::NoInit, std::size_t(textureSize.product())};
+  for (std::size_t i = 0; i != objectIds.size(); ++i) {
+    ASSERT(objectIds[i] <= 65535);
+    packedObjectIds[i] = objectIds[i];
+  }
+  Mn::GL::Texture2D texture;
+  texture.setMinificationFilter(Mn::SamplerFilter::Nearest)
+      .setMagnificationFilter(Mn::SamplerFilter::Nearest)
+      .setWrapping(
+          {Mn::SamplerWrapping::ClampToEdge, Mn::SamplerWrapping::ClampToEdge})
+      .setStorage(1, Mn::GL::TextureFormat::R16UI, textureSize)
+      .setSubImage(0, {},
+                   Mn::ImageView2D{Mn::PixelFormat::R16UI, textureSize,
+                                   packedObjectIds});
 
-  Magnum::GL::Texture2D tex;
-
-  tex.setMinificationFilter(Magnum::SamplerFilter::Nearest)
-      .setMagnificationFilter(Magnum::SamplerFilter::Nearest)
-      .setWrapping({Magnum::SamplerWrapping::ClampToEdge,
-                    Magnum::SamplerWrapping::ClampToEdge})
-      .setStorage(1, Magnum::GL::TextureFormat::R32F, image.size())
-      .setSubImage(0, {}, image);
-
-  return tex;
+  return texture;
 }
 
 bool GenericInstanceMeshData::loadPLY(const std::string& plyFile) {
@@ -235,30 +236,18 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
     cbo_float_.emplace_back(c.cast<float>() / 255.0f);
   }
 
-  /*
-   * Textures in OpenGL must be square and must have a sizes that are powers of
-   * 2, so first compute the size of the smallest texture that can contain our
-   * array.  Then copy the object id's buffer into the texture data buffer as
-   * floats.
-   */
-  const int nPrims = cpu_ibo_.size();
-  const int texSize = std::pow(2, std::ceil(std::log2(std::sqrt(nPrims))));
-  // The image takes ownership over the obj_id_tex_data array, so there is no
-  // delete
-  float* obj_id_tex_data = new float[texSize * texSize]();
-  for (size_t i = 0; i < nPrims; ++i) {
-    obj_id_tex_data[i] = static_cast<float>(objectIds_[i]);
-  }
-
-  // Takes ownership of the data pointer
-  renderingBuffer_->tex = createInstanceTexture(obj_id_tex_data, texSize);
-
+  /* Pack primitive IDs into a texture. 1D texture won't be large enough so the
+     data have to be put into a 2D texture. For simplicity on both the C++ and
+     shader side the texture has a fixed width and height is dynamic, and
+     addressing is done as (gl_PrimitiveID % width, gl_PrimitiveID / width). */
+  ASSERT(objectIds_.size() == cpu_ibo_.size());
+  renderingBuffer_->tex = createInstanceTexture(objectIds_);
   renderingBuffer_->vbo.setData(cpu_vbo_, Magnum::GL::BufferUsage::StaticDraw);
   renderingBuffer_->cbo.setData(cbo_float_,
                                 Magnum::GL::BufferUsage::StaticDraw);
   renderingBuffer_->ibo.setData(cpu_ibo_, Magnum::GL::BufferUsage::StaticDraw);
   renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
-      .setCount(nPrims * 3)
+      .setCount(cpu_ibo_.size() * 3)
       .addVertexBuffer(renderingBuffer_->vbo, 0,
                        Magnum::GL::Attribute<0, Magnum::Vector3>{})
       .addVertexBuffer(renderingBuffer_->cbo, 0,

--- a/src/esp/assets/GenericInstanceMeshData.h
+++ b/src/esp/assets/GenericInstanceMeshData.h
@@ -18,12 +18,16 @@
 namespace esp {
 namespace assets {
 
-/*
- * In modern OpenGL fragment sharder, we can access the ID of the current
- * primitive and thus can index an array.  We can make a 2D texture behave
- * like a 2D array with nearest sampling and edge clamping.
- */
-Magnum::GL::Texture2D createInstanceTexture(float* data, const int texSize);
+/**
+@brief Pack primitive IDs into a texture
+
+1D texture won't be large enough so the data have to be put into a 2D texture.
+For simplicity on both the C++ and shader side the texture has a fixed width
+and height is dynamic, and addressing is done as
+`(gl_PrimitiveID % width, gl_PrimitiveID / width)`.
+*/
+Magnum::GL::Texture2D createInstanceTexture(
+    Corrade::Containers::ArrayView<uint32_t> objectIds);
 
 class GenericInstanceMeshData : public BaseMesh {
  public:

--- a/src/esp/gfx/PrimitiveIDTexturedShader.cpp
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.cpp
@@ -56,6 +56,8 @@ PrimitiveIDTexturedShader::PrimitiveIDTexturedShader() {
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(link());
 
+  transformationProjectionMatrixUniform_ =
+      uniformLocation("transformationProjectionMatrix");
   setUniform(uniformLocation("primTexture"), TextureLayer);
 }
 

--- a/src/esp/gfx/PrimitiveIDTexturedShader.cpp
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.cpp
@@ -5,6 +5,7 @@
 #include "PrimitiveIDTexturedShader.h"
 
 #include <Corrade/Containers/Reference.h>
+#include <Corrade/Utility/FormatStl.h>
 #include <Corrade/Utility/Resource.h>
 #include <Magnum/GL/Context.h>
 #include <Magnum/GL/Shader.h>
@@ -18,6 +19,8 @@
 static void importShaderResources() {
   CORRADE_RESOURCE_INITIALIZE(ShaderResources)
 }
+
+namespace Cr = Corrade;
 
 namespace esp {
 namespace gfx {
@@ -48,7 +51,10 @@ PrimitiveIDTexturedShader::PrimitiveIDTexturedShader() {
   Magnum::GL::Shader frag{glVersion, Magnum::GL::Shader::Type::Fragment};
 
   vert.addSource(rs.get("primitive-id-textured-gl410.vert"));
-  frag.addSource(rs.get("primitive-id-textured-gl410.frag"));
+  frag
+      .addSource(Corrade::Utility::formatString(
+          "#define PRIMITIVE_TEXTURE_WIDTH {}\n", PrimitiveIDTextureWidth))
+      .addSource(rs.get("primitive-id-textured-gl410.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Magnum::GL::Shader::compile({vert, frag}));
 
@@ -64,12 +70,6 @@ PrimitiveIDTexturedShader::PrimitiveIDTexturedShader() {
 PrimitiveIDTexturedShader& PrimitiveIDTexturedShader::bindTexture(
     Magnum::GL::Texture2D& texture) {
   texture.bind(TextureLayer);
-
-// TODO this is a hack and terrible! Properly set texSize for WebGL builds
-#ifndef MAGNUM_TARGET_WEBGL
-  setUniform(uniformLocation("texSize"), texture.imageSize(0).x());
-#endif
-
   return *this;
 }
 

--- a/src/esp/gfx/PrimitiveIDTexturedShader.h
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.h
@@ -48,13 +48,6 @@ class PrimitiveIDTexturedShader : public Magnum::GL::AbstractShaderProgram {
     return *this;
   }
 
-  /**
-   * @brief Bind a color texture
-   * @return Reference to self (for method chaining)
-   *
-   * Expects that the shader was created with @ref Flag::Textured enabled.
-   * @see @ref setColor()
-   */
   PrimitiveIDTexturedShader& bindTexture(Magnum::GL::Texture2D& texture);
 
  private:

--- a/src/esp/gfx/PrimitiveIDTexturedShader.h
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.h
@@ -12,6 +12,7 @@
 #include <Magnum/GL/AbstractShaderProgram.h>
 #include <Magnum/Math/Color.h>
 #include <Magnum/Math/Matrix4.h>
+#include <Magnum/Shaders/Generic.h>
 
 #include "esp/core/esp.h"
 
@@ -26,9 +27,9 @@ class PrimitiveIDTexturedShader : public Magnum::GL::AbstractShaderProgram {
   explicit PrimitiveIDTexturedShader();
 
   //! @brief vertex positions
-  typedef Magnum::GL::Attribute<0, Magnum::Vector4> Position;
+  typedef Magnum::Shaders::Generic3D::Position Position;
   //! @brief vertex colors
-  typedef Magnum::GL::Attribute<3, Magnum::Vector3> Color;
+  typedef Magnum::Shaders::Generic3D::Color3 Color3;
 
   enum : int {
     /**

--- a/src/esp/gfx/PrimitiveIDTexturedShader.h
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.h
@@ -44,7 +44,7 @@ class PrimitiveIDTexturedShader : public Magnum::GL::AbstractShaderProgram {
    */
   PrimitiveIDTexturedShader& setTransformationProjectionMatrix(
       const Magnum::Matrix4& matrix) {
-    setUniform(uniformLocation("transformationProjectionMatrix"), matrix);
+    setUniform(transformationProjectionMatrixUniform_, matrix);
     return *this;
   }
 
@@ -56,6 +56,9 @@ class PrimitiveIDTexturedShader : public Magnum::GL::AbstractShaderProgram {
    * @see @ref setColor()
    */
   PrimitiveIDTexturedShader& bindTexture(Magnum::GL::Texture2D& texture);
+
+ private:
+  int transformationProjectionMatrixUniform_;
 };
 
 }  // namespace gfx

--- a/src/esp/gfx/PrimitiveIDTexturedShader.h
+++ b/src/esp/gfx/PrimitiveIDTexturedShader.h
@@ -30,6 +30,19 @@ class PrimitiveIDTexturedShader : public Magnum::GL::AbstractShaderProgram {
   //! @brief vertex colors
   typedef Magnum::GL::Attribute<3, Magnum::Vector3> Color;
 
+  enum : int {
+    /**
+     * Hardcoded width of the primitive ID texture, since we wouldn't be able
+     * to fit it all into a 1D texture. Picking a power-of-two size as that
+     * nicely fits caches etc. Conservatively choosing 4K as 8K might not be
+     * supported on some platforms (mobile/WebGL, possibly). A 4096x4096
+     * texture fits 16M primitives, which should be enough. Smaller meshes will
+     * have the height much smaller while larger meshes are of course allowed
+     * to go beyond that -- e.g. 4096x6000 is not expected to be a problem.
+     */
+    PrimitiveIDTextureWidth = 4096
+  };
+
   //! Color attachment location per output type
   enum : uint8_t {
     //! color output

--- a/src/shaders/primitive-id-textured-gl410.frag
+++ b/src/shaders/primitive-id-textured-gl410.frag
@@ -1,16 +1,13 @@
 in mediump vec3 v_color;
 
-uniform highp sampler2D primTexture;
-uniform highp int texSize;
+uniform highp usampler2D primTexture;
 
 layout(location = 0) out mediump vec4 color;
 layout(location = 1) out uint objectId;
 
 void main () {
   color = vec4(v_color, 1.0);
-  objectId = uint(
-      texture(primTexture,
-              vec2((float(gl_PrimitiveID % texSize) + 0.5f) / float(texSize),
-                   (float(gl_PrimitiveID / texSize) + 0.5f) / float(texSize)))
-          .r + 0.5);
+  objectId = texelFetch(primTexture, ivec2(
+      gl_PrimitiveID % PRIMITIVE_TEXTURE_WIDTH,
+      gl_PrimitiveID / PRIMITIVE_TEXTURE_WIDTH), 0).r;
 }

--- a/src/shaders/primitive-id-textured-gl410.vert
+++ b/src/shaders/primitive-id-textured-gl410.vert
@@ -1,7 +1,9 @@
 uniform highp mat4 transformationProjectionMatrix;
 
+// IDs corresponding to Magnum's generic attribute definitions and
+// PrimitiveIDTexturedShader::{Position,Color3}
 layout(location = 0) in highp vec4 position;
-layout(location = 1) in mediump vec3 color;
+layout(location = 3) in mediump vec3 color;
 
 out mediump vec3 v_color;
 


### PR DESCRIPTION
## Motivation and Context

Follow-up to #151, doing a cleanup pass over the `PrimitiveIDTexturedShader`. There was a few outdated assumptions about how GPUs work, unnecessarily large used data types and inconsistent attribute definitions. In short:

- Using a rectangular 16-bit texture instead of a 32-bit power-of-two texture, saving more than half of the memory. The textures can be neither power-of-two nor square, those restrictions are useful only in order to save memory when having mipmapping (which is not the case here). Aassuming the object IDs never go over 65k, we can also save a half of the memory by using a smaller type.
- Using `texelFetch()` instead of `texture()` -- that way we sidestep all coordinate rounding, filtering etc., making the texel access faster, *and* we don't need to pass texture size to the shader. That nicely resolves the WebGL TODO as well.
- Using `usampler2D` instead of `sampler2D`, avoiding more rounding
- Defining vertex attributes consistently with Magnum's builtin shaders (so the mesh can be evenutally used with those as well) -- the original definition was matching neither the shader code nor the mesh setup, which made it useless
- Using packed 24bit data types for colors instead of expanding them to three-component floats

## How Has This Been Tested

Tests pass locally. Unfortunately the PLY files can't be tested on the CI, so the green tick doesn't mean it works everywhere -- if you can, please try it out locally with MP3D data as well. The `FRLInstanceMeshData` update is done with best intentions in mind but as far as I understood it's a dead code.

All in all, this update could have a significant effect on rendering performance of PLY files -- didn't measure, tho.