### PR TITLE
Get emscripten build compiling again.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -819,7 +819,7 @@ bool ResourceManager::loadGeneralMeshData(
         LOG(ERROR) << "Cannot load scene, exiting";
         return false;
       }
-      for (uint sceneDataID : sceneData->children3D()) {
+      for (unsigned int sceneDataID : sceneData->children3D()) {
         magnumData.emplace_back(sceneDataID);
       }
     } else if (importer->mesh3DCount() && meshes_[metaData.meshIndex.first]) {

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -2,35 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <chrono>
-#include <ctime>
-#include <functional>
-
-#include <Corrade/PluginManager/Manager.h>
-#include <Corrade/Utility/String.h>
-#include <Magnum/Math/Color.h>
-#include <Magnum/PixelFormat.h>
-#include <Magnum/Trade/ImageData.h>
-#include <Magnum/Trade/MeshObjectData3D.h>
-#include <Magnum/Trade/PhongMaterialData.h>
-#include <Magnum/Trade/SceneData.h>
-#include <Magnum/Trade/TextureData.h>
-
-#include "esp/geo/geo.h"
-#include "esp/gfx/GenericDrawable.h"
-#include "esp/gfx/PTexMeshDrawable.h"
-#include "esp/gfx/PTexMeshShader.h"
-#include "esp/io/io.h"
-#include "esp/io/json.h"
-#include "esp/scene/SceneConfiguration.h"
-#include "esp/scene/SceneGraph.h"
-
 #include "PhysicsManager.h"
-#include "esp/assets/FRLInstanceMeshData.h"
-#include "esp/assets/GenericInstanceMeshData.h"
-#include "esp/assets/GltfMeshData.h"
-#include "esp/assets/Mp3dInstanceMeshData.h"
-#include "esp/assets/PTexMeshData.h"
+#include "esp/assets/CollisionMeshData.h"
 #include "esp/assets/ResourceManager.h"
 
 namespace esp {


### PR DESCRIPTION
The PTexMeshShader relies on Texture::imageSize which is not
available with WebGL or GLES versions < 3.1.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Build and run.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
