### PR TITLE
GPU-based depth unprojection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,11 @@ jobs:
       - checkout:
           path: ./habitat-sim
       - run:
+          name: CPU info
+          no_output_timeout: 1m
+          command: |
+              cat /proc/cpuinfo
+      - run:
           name: Install cmake
           no_output_timeout: 5m
           # tinyply requires CMake 3.10, so stay at that version. Ubuntu 16.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat
               export PYTHONPATH=$PYTHONPATH:$(pwd)
-              GTEST_COLOR=yes ./build.sh --headless --run-tests
+              CORRADE_TEST_COLOR=ON GTEST_COLOR=yes ./build.sh --headless --run-tests
               pytest
       - run:
           name: Install api

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,9 @@ class CMakeBuild(build_ext):
             build_args += ["-j{}".format(self.parallel) if self.parallel else "-j"]
 
         cmake_args += [
-            "-DBUILD_GUI_VIEWERS={}".format("ON" if not args.headless else "OFF")
+            "-DBUILD_GUI_VIEWERS={}".format("ON" if not args.headless else "OFF"),
+            # So Magnum itself prefers EGL over GLX for windowless apps
+            "-DTARGET_HEADLESS={}".format("ON" if args.headless else "OFF"),
         ]
         # NOTE: BUILD_TEST is intentional as opposed to BUILD_TESTS which collides
         # with definition used by some of our dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TEST)
   message("Building TESTS")
   enable_testing()
   find_package(Corrade REQUIRED TestSuite)
+  find_package(Magnum REQUIRED OpenGLTester)
 endif()
 
 # include source dirs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 # ---[ Dependencies
 include(cmake/dependencies.cmake)
 
+# build tests
+if(BUILD_TEST)
+  message("Building TESTS")
+  enable_testing()
+  find_package(Corrade REQUIRED TestSuite)
+endif()
+
 # include source dirs
 include_directories(${PROJECT_SOURCE_DIR})
 
@@ -77,10 +84,7 @@ if(BUILD_GUI_VIEWERS)
   add_subdirectory(utils/viewer)
 endif()
 
-# build tests
 if(BUILD_TEST)
-  message("Building TESTS")
-  enable_testing()
   add_subdirectory(tests)
 endif()
 

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -10,7 +10,6 @@ if(NOT USE_SYSTEM_MAGNUM)
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.
   set(WITH_INTERCONNECT OFF CACHE BOOL "" FORCE)
-  set(WITH_TESTSUITE OFF CACHE BOOL "" FORCE)
   add_subdirectory("${DEPS_DIR}/corrade")
 endif()
 find_package(Corrade REQUIRED Utility)
@@ -118,8 +117,6 @@ if(NOT USE_SYSTEM_MAGNUM)
 
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.
-  set(WITH_INTERCONNECT OFF CACHE BOOL "" FORCE)
-  set(WITH_TESTSUITE OFF CACHE BOOL "" FORCE)
   set(WITH_DEBUGTOOLS OFF CACHE BOOL "" FORCE)
   set(WITH_PRIMITIVES OFF CACHE BOOL "" FORCE)
   set(WITH_TEXT OFF CACHE BOOL "" FORCE)

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -118,7 +118,6 @@ if(NOT USE_SYSTEM_MAGNUM)
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.
   set(WITH_DEBUGTOOLS OFF CACHE BOOL "" FORCE)
-  set(WITH_PRIMITIVES OFF CACHE BOOL "" FORCE)
   set(WITH_TEXT OFF CACHE BOOL "" FORCE)
   set(WITH_TEXTURETOOLS OFF CACHE BOOL "" FORCE)
 
@@ -140,6 +139,9 @@ if(NOT USE_SYSTEM_MAGNUM)
   # We only support WebGL2
   if(CORRADE_TARGET_EMSCRIPTEN)
     set(TARGET_GLES2 OFF CACHE BOOL "" FORCE)
+  endif()
+  if(BUILD_TEST)
+    set(WITH_OPENGLTESTER ON CACHE BOOL "" FORCE)
   endif()
 
   if(BUILD_GUI_VIEWERS)

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(gfx_SOURCES
+  DepthUnprojection.cpp
+  DepthUnprojection.h
   Drawable.cpp
   Drawable.h
   GenericDrawable.cpp
@@ -124,4 +126,8 @@ elseif(UNIX)
     find_package(Magnum REQUIRED WindowlessEglApplication)
     target_link_libraries(gfx PUBLIC Magnum::WindowlessEglApplication)
   endif()
+endif()
+
+if(BUILD_TEST)
+  add_subdirectory(test)
 endif()

--- a/src/esp/gfx/DepthUnprojection.cpp
+++ b/src/esp/gfx/DepthUnprojection.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "DepthUnprojection.h"
+
+#include <Corrade/Containers/ArrayView.h>
+#include <Magnum/Math/Functions.h>
+#include <Magnum/Math/Matrix4.h>
+
+namespace Cr = Corrade;
+namespace Mn = Magnum;
+
+namespace esp {
+namespace gfx {
+
+Mn::Matrix2x2 calculateDepthUnprojection(const Mn::Matrix4& projectionMatrix) {
+  /* Inverted projection matrix to unproject the depth value and chop the
+     near plane off. We don't care about X/Y there and the corresponding
+     parts of the matrix are zero as well so take just the lower-right part
+     of it (denoted a, b, c, d).
+
+      x 0 0 0
+      0 y 0 0
+      0 0 a b
+      0 0 c d
+
+     Doing an inverse of just the bottom right block is enough as well -- see
+     https://en.wikipedia.org/wiki/Block_matrix#Block_diagonal_matrices for
+     a proof.
+
+     Taking a 2-component vector with the first component being Z and second
+     1, the final calculation of unprojected Z is then
+
+      | a b |   | z |   | az + b |
+      | c d | * | 1 | = | cz + d |
+
+  */
+  auto unprojection =
+      Mn::Matrix2x2{Mn::Math::swizzle<'z', 'w'>(projectionMatrix[2]),
+                    Mn::Math::swizzle<'z', 'w'>(projectionMatrix[3])}
+          .inverted();
+
+  /* The Z value comes in range [0; 1], but we need it in the range [-1; 1].
+     Instead of doing z = x*2 - 1 for every pixel, we add that to this
+     matrix:
+
+      az + b
+      a(x*2 - 1) + b
+      2ax - a + b
+      (2a)x + (b - a)
+
+    and similarly for c/d. Which means -- from the second component we
+    subtract the first, and the first we multiply by 2. */
+  unprojection[1] -= unprojection[0];
+  unprojection[0] *= 2.0;
+
+  /* Finally, because the output has Z going forward, not backward, we need
+     to negate it. There's a perspective division happening, so we have to
+     negate just the first row. */
+  unprojection.setRow(0, -unprojection.row(0));
+
+  return unprojection;
+}
+
+void unprojectDepth(const Mn::Matrix2x2& unprojection,
+                    Cr::Containers::ArrayView<Mn::Float> depth) {
+  for (std::size_t i = 0; i != depth.size(); ++i) {
+    /* We can afford using == for comparison as 1.0f has an exact
+       representation and the depth is cleared to exactly this value. */
+    if (depth[i] == 1.0f) {
+      depth[i] = 0.0f;
+      continue;
+    }
+
+    /* The following is
+
+        (az + b) / (cz + d)
+
+       See the comment in draw() above for details. */
+    depth[i] = Mn::Math::fma(unprojection[0][0], depth[i], unprojection[1][0]) /
+               Mn::Math::fma(unprojection[0][1], depth[i], unprojection[1][1]);
+  }
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/DepthUnprojection.cpp
+++ b/src/esp/gfx/DepthUnprojection.cpp
@@ -14,56 +14,12 @@ namespace Mn = Magnum;
 namespace esp {
 namespace gfx {
 
-Mn::Matrix2x2 calculateDepthUnprojection(const Mn::Matrix4& projectionMatrix) {
-  /* Inverted projection matrix to unproject the depth value and chop the
-     near plane off. We don't care about X/Y there and the corresponding
-     parts of the matrix are zero as well so take just the lower-right part
-     of it (denoted a, b, c, d).
-
-      x 0 0 0
-      0 y 0 0
-      0 0 a b
-      0 0 c d
-
-     Doing an inverse of just the bottom right block is enough as well -- see
-     https://en.wikipedia.org/wiki/Block_matrix#Block_diagonal_matrices for
-     a proof.
-
-     Taking a 2-component vector with the first component being Z and second
-     1, the final calculation of unprojected Z is then
-
-      | a b |   | z |   | az + b |
-      | c d | * | 1 | = | cz + d |
-
-  */
-  auto unprojection =
-      Mn::Matrix2x2{Mn::Math::swizzle<'z', 'w'>(projectionMatrix[2]),
-                    Mn::Math::swizzle<'z', 'w'>(projectionMatrix[3])}
-          .inverted();
-
-  /* The Z value comes in range [0; 1], but we need it in the range [-1; 1].
-     Instead of doing z = x*2 - 1 for every pixel, we add that to this
-     matrix:
-
-      az + b
-      a(x*2 - 1) + b
-      2ax - a + b
-      (2a)x + (b - a)
-
-    and similarly for c/d. Which means -- from the second component we
-    subtract the first, and the first we multiply by 2. */
-  unprojection[1] -= unprojection[0];
-  unprojection[0] *= 2.0;
-
-  /* Finally, because the output has Z going forward, not backward, we need
-     to negate it. There's a perspective division happening, so we have to
-     negate just the first row. */
-  unprojection.setRow(0, -unprojection.row(0));
-
-  return unprojection;
+Mn::Vector2 calculateDepthUnprojection(const Mn::Matrix4& projectionMatrix) {
+  return Mn::Vector2{(projectionMatrix[2][2] - 1.0f), projectionMatrix[3][2]} *
+         0.5f;
 }
 
-void unprojectDepth(const Mn::Matrix2x2& unprojection,
+void unprojectDepth(const Mn::Vector2& unprojection,
                     Cr::Containers::ArrayView<Mn::Float> depth) {
   for (std::size_t i = 0; i != depth.size(); ++i) {
     /* We can afford using == for comparison as 1.0f has an exact
@@ -73,13 +29,7 @@ void unprojectDepth(const Mn::Matrix2x2& unprojection,
       continue;
     }
 
-    /* The following is
-
-        (az + b) / (cz + d)
-
-       See the comment in draw() above for details. */
-    depth[i] = Mn::Math::fma(unprojection[0][0], depth[i], unprojection[1][0]) /
-               Mn::Math::fma(unprojection[0][1], depth[i], unprojection[1][1]);
+    depth[i] = unprojection[1] / (depth[i] + unprojection[0]);
   }
 }
 

--- a/src/esp/gfx/DepthUnprojection.cpp
+++ b/src/esp/gfx/DepthUnprojection.cpp
@@ -97,6 +97,10 @@ Mn::Vector2 calculateDepthUnprojection(const Mn::Matrix4& projectionMatrix) {
          0.5f;
 }
 
+/* Clang doesn't have target_clones yet: https://reviews.llvm.org/D51650 */
+#if defined(CORRADE_TARGET_X86) && defined(__GNUC__) && __GNUC__ >= 6
+__attribute__((target_clones("default", "sse4.2", "avx2")))
+#endif
 void unprojectDepth(const Mn::Vector2& unprojection,
                     Cr::Containers::ArrayView<Mn::Float> depth) {
   for (Mn::Float& d : depth) {

--- a/src/esp/gfx/DepthUnprojection.cpp
+++ b/src/esp/gfx/DepthUnprojection.cpp
@@ -5,14 +5,92 @@
 #include "DepthUnprojection.h"
 
 #include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Containers/Reference.h>
+#include <Corrade/Utility/Resource.h>
+#include <Magnum/GL/Shader.h>
+#include <Magnum/GL/Texture.h>
+#include <Magnum/GL/Version.h>
 #include <Magnum/Math/Functions.h>
 #include <Magnum/Math/Matrix4.h>
 
 namespace Cr = Corrade;
 namespace Mn = Magnum;
 
+static void importShaderResources() {
+  CORRADE_RESOURCE_INITIALIZE(ShaderResources)
+}
+
 namespace esp {
 namespace gfx {
+
+namespace {
+enum { DepthTextureUnit = 1 };
+}
+
+DepthShader::DepthShader(Flags flags) : flags_{flags} {
+  if (!Corrade::Utility::Resource::hasGroup("default-shaders")) {
+    importShaderResources();
+  }
+
+  const Corrade::Utility::Resource rs{"default-shaders"};
+
+#ifdef MAGNUM_TARGET_WEBGL
+  Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
+#else
+  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+#endif
+
+  Mn::GL::Shader vert{glVersion, Mn::GL::Shader::Type::Vertex};
+  Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
+
+  if (flags & Flag::UnprojectExistingDepth) {
+    vert.addSource("#define UNPROJECT_EXISTING_DEPTH\n");
+    frag.addSource("#define UNPROJECT_EXISTING_DEPTH\n");
+  }
+
+  if (flags & Flag::NoFarPlanePatching)
+    frag.addSource("#define NO_FAR_PLANE_PATCHING\n");
+
+  vert.addSource(rs.get("depth.vert"));
+  frag.addSource(rs.get("depth.frag"));
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
+
+  attachShaders({vert, frag});
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+  if (flags & Flag::UnprojectExistingDepth) {
+    projectionMatrixOrDepthUnprojectionUniform_ =
+        uniformLocation("depthUnprojection");
+    setUniform(uniformLocation("depthTexture"), DepthTextureUnit);
+  } else {
+    transformationMatrixUniform_ = uniformLocation("transformationMatrix");
+    projectionMatrixOrDepthUnprojectionUniform_ =
+        uniformLocation("projectionMatrix");
+  }
+}
+
+DepthShader& DepthShader::setTransformationMatrix(const Mn::Matrix4& matrix) {
+  CORRADE_INTERNAL_ASSERT(!(flags_ & Flag::UnprojectExistingDepth));
+  setUniform(transformationMatrixUniform_, matrix);
+  return *this;
+}
+
+DepthShader& DepthShader::setProjectionMatrix(const Mn::Matrix4& matrix) {
+  if (flags_ & Flag::UnprojectExistingDepth) {
+    setUniform(projectionMatrixOrDepthUnprojectionUniform_,
+               calculateDepthUnprojection(matrix));
+  } else {
+    setUniform(projectionMatrixOrDepthUnprojectionUniform_, matrix);
+  }
+  return *this;
+}
+
+DepthShader& DepthShader::bindDepthTexture(Mn::GL::Texture2D& texture) {
+  texture.bind(DepthTextureUnit);
+  return *this;
+}
 
 Mn::Vector2 calculateDepthUnprojection(const Mn::Matrix4& projectionMatrix) {
   return Mn::Vector2{(projectionMatrix[2][2] - 1.0f), projectionMatrix[3][2]} *

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <Corrade/Containers/Containers.h>
+#include <Magnum/Magnum.h>
+
+namespace esp {
+namespace gfx {
+
+/** @brief Calculate depth unprojection coefficients */
+Magnum::Matrix2x2 calculateDepthUnprojection(
+    const Magnum::Matrix4& projectionMatrix);
+
+/**
+@brief Unproject depth values
+@param[in] unprojection Unprojection coefficients from
+    @ref calculateDepthUnprojection()
+@param[in,out] depth    Depth values in range @f$ [ 0 ; 1 ] @f$
+
+See @ref calculateDepthUnprojection() for the full algorithm explanation.
+Additionally to applying that calculation, if the input depth is at the far
+plane (of value @cpp 1.0f @ce), it's set to @cpp 0.0f @ce on output as
+consumers expect zeros for things that are too far.
+*/
+void unprojectDepth(const Magnum::Matrix2x2& unprojection,
+                    Corrade::Containers::ArrayView<Magnum::Float> depth);
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -121,7 +121,7 @@ struct Renderer::Impl {
   GL::Renderbuffer depthRenderbuffer_;
   GL::Framebuffer framebuffer_;
 
-  Matrix2x2 depthUnprojection_;
+  Vector2 depthUnprojection_;
 };
 
 Renderer::Renderer(int width, int height)

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -4,8 +4,6 @@
 
 #include "Renderer.h"
 
-#include "magnum.h"
-
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
@@ -18,6 +16,9 @@
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/Image.h>
 #include <Magnum/PixelFormat.h>
+
+#include "esp/gfx/DepthUnprojection.h"
+#include "esp/gfx/magnum.h"
 
 using namespace Magnum;
 
@@ -72,50 +73,8 @@ struct Renderer::Impl {
     renderEnter();
     camera.getMagnumCamera().setViewport(framebufferSize_);
 
-    /* Inverted projection matrix to unproject the depth value and chop the
-       near plane off. We don't care about X/Y there and the corresponding
-       parts of the matrix are zero as well so take just the lower-right part
-       of it (denoted a, b, c, d).
-
-        x 0 0 0
-        0 y 0 0
-        0 0 a b
-        0 0 c d
-
-       Doing an inverse of just the bottom right block is enough as well -- see
-       https://en.wikipedia.org/wiki/Block_matrix#Block_diagonal_matrices for
-       a proof.
-
-       Taking a 2-component vector with the first component being Z and second
-       1, the final calculation of unprojected Z is then
-
-        | a b |   | z |   | az + b |
-        | c d | * | 1 | = | cz + d |
-
-    */
-    const Matrix4 projection = camera.getMagnumCamera().projectionMatrix();
-    depthUnprojection_ = Matrix2x2{Math::swizzle<'z', 'w'>(projection[2]),
-                                   Math::swizzle<'z', 'w'>(projection[3])}
-                             .inverted();
-
-    /* The Z value comes in range [0; 1], but we need it in the range [-1; 1].
-       Instead of doing z = x*2 - 1 for every pixel, we add that to this
-       matrix:
-
-        az + b
-        a(x*2 - 1) + b
-        2ax - a + b
-        (2a)x + (b - a)
-
-      and similarly for c/d. Which means -- from the second component we
-      subtract the first, and the first we multiply by 2. */
-    depthUnprojection_[1] -= depthUnprojection_[0];
-    depthUnprojection_[0] *= 2.0;
-
-    /* Finally, because the output has Z going forward, not backward, we need
-       to negate it. There's a perspective division happening, so we have to
-       negate just the first row. */
-    depthUnprojection_.setRow(0, -depthUnprojection_.row(0));
+    depthUnprojection_ =
+        calculateDepthUnprojection(camera.getMagnumCamera().projectionMatrix());
 
     camera.draw(drawables);
     renderExit();
@@ -144,29 +103,9 @@ struct Renderer::Impl {
         {GL::PixelFormat::DepthComponent, GL::PixelType::Float});
 
     /* Unproject the Z */
-    Containers::ArrayView<const Float> data =
-        Containers::arrayCast<const Float>(depthImage.data());
-    for (std::size_t i = 0; i != data.size(); ++i) {
-      const Float z = data[i];
-
-      /* If a fragment has a depth of 1, it's due to a hole in the mesh. The
-         consumers expect 0 for things that are too far, so be nice to them.
-         We can afford using == for comparison as 1.0f has an exact
-         representation and the depth is cleared to exactly this value. */
-      if (z == 1.0f) {
-        ptr[i] = 0.0f;
-        continue;
-      }
-
-      /* The following is
-
-          (az + b) / (cz + d)
-
-         See the comment in draw() above for details. */
-      ptr[i] =
-          Math::fma(depthUnprojection_[0][0], z, depthUnprojection_[1][0]) /
-          Math::fma(depthUnprojection_[0][1], z, depthUnprojection_[1][1]);
-    }
+    unprojectDepth(depthUnprojection_,
+                   Containers::arrayCast<Float>(depthImage.data()));
+    std::memcpy(ptr, depthImage.data(), depthImage.data().size());
   }
 
   void readFrameObjectId(uint32_t* ptr) {

--- a/src/esp/gfx/test/CMakeLists.txt
+++ b/src/esp/gfx/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+corrade_add_test(gfxDepthUnprojectionTest DepthUnprojectionTest.cpp LIBRARIES gfx)

--- a/src/esp/gfx/test/CMakeLists.txt
+++ b/src/esp/gfx/test/CMakeLists.txt
@@ -1,1 +1,8 @@
-corrade_add_test(gfxDepthUnprojectionTest DepthUnprojectionTest.cpp LIBRARIES gfx)
+find_package(Magnum REQUIRED Primitives)
+
+corrade_add_test(gfxDepthUnprojectionTest DepthUnprojectionTest.cpp LIBRARIES
+  gfx
+  Magnum::MeshTools
+  Magnum::OpenGLTester
+  Magnum::Trade
+  Magnum::Primitives)

--- a/src/esp/gfx/test/DepthUnprojectionTest.cpp
+++ b/src/esp/gfx/test/DepthUnprojectionTest.cpp
@@ -128,7 +128,7 @@ void DepthUnprojectionTest::benchmarkBaseline() {
 }
 
 void DepthUnprojectionTest::benchmarkCpu() {
-  Mn::Matrix2x2 unprojection = calculateDepthUnprojection(
+  Mn::Vector2 unprojection = calculateDepthUnprojection(
       Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.001f, 100.0f));
 
   Cr::Containers::Array<float> depth{Cr::Containers::NoInit,

--- a/src/esp/gfx/test/DepthUnprojectionTest.cpp
+++ b/src/esp/gfx/test/DepthUnprojectionTest.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <Corrade/Containers/Array.h>
+#include <Corrade/TestSuite/Compare/Numeric.h>
+#include <Corrade/TestSuite/Tester.h>
+#include <Magnum/Math/FunctionsBatch.h>
+#include <Magnum/Math/Matrix4.h>
+
+#include "esp/gfx/DepthUnprojection.h"
+
+namespace Cr = Corrade;
+namespace Mn = Magnum;
+
+namespace esp {
+namespace gfx {
+namespace test {
+namespace {
+
+struct DepthUnprojectionTest : Cr::TestSuite::Tester {
+  explicit DepthUnprojectionTest();
+
+  void testCpu();
+
+  void benchmarkBaseline();
+  void benchmarkCpu();
+};
+
+using namespace Mn::Math::Literals;
+
+const struct {
+  const char* name;
+  float depth, expected;
+  Mn::Matrix4 projection;
+} TestData[]{
+    {"z=4, near=0.01, far=100", 4.0f, 4.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+    {"z=4, near=1.0, far=100", 4.0f, 4.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 1.0f, 100.0f)},
+    {"z=4, near=0.01, far=10", 4.0f, 4.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 10.0f)},
+    {"z=0.015, near=0.015, far=100", 0.015f, 0.015f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+    {"z=10, near=0.01, far=100", 10.0f, 10.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+    {"z=95, near=0.01, far=100", 95.0f, 95.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+    {"z=near", 0.01f, 0.01f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+    {"z=far", 100.0f, 0.0f,
+     Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.01f, 100.0f)},
+};
+
+CORRADE_NEVER_INLINE void unprojectBaseline(
+    Cr::Containers::ArrayView<float> depth,
+    const Mn::Matrix4& unprojection) {
+  for (float& d : depth) {
+    if (d == 1.0f) {
+      d = 0.0f;
+      continue;
+    }
+    d = -unprojection.transformPoint(Mn::Vector3::zAxis(-d)).z();
+  }
+}
+
+CORRADE_NEVER_INLINE void unprojectBaselineNoBranch(
+    Cr::Containers::ArrayView<float> depth,
+    const Mn::Matrix4& unprojection) {
+  for (float& d : depth) {
+    d = -unprojection.transformPoint(Mn::Vector3::zAxis(-d)).z();
+  }
+}
+
+const struct {
+  const char* name;
+  void (*unprojector)(Cr::Containers::ArrayView<float>, const Mn::Matrix4&);
+} UnprojectBenchmarkData[]{
+    {"", unprojectBaseline},
+    {"no branch", unprojectBaselineNoBranch},
+};
+
+DepthUnprojectionTest::DepthUnprojectionTest() {
+  addInstancedTests({&DepthUnprojectionTest::testCpu},
+                    Cr::Containers::arraySize(TestData));
+
+  addInstancedBenchmarks({&DepthUnprojectionTest::benchmarkBaseline}, 10,
+                         Cr::Containers::arraySize(UnprojectBenchmarkData));
+
+  addBenchmarks({&DepthUnprojectionTest::benchmarkCpu}, 10);
+}
+
+void DepthUnprojectionTest::testCpu() {
+  auto&& data = TestData[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+
+  Mn::Vector3 projected =
+      data.projection.transformPoint({0.95f, -0.34f, -data.depth});
+  CORRADE_COMPARE_WITH(
+      -data.projection.inverted().transformPoint(projected).z(), data.depth,
+      Cr::TestSuite::Compare::around(data.depth * 0.0002f));
+
+  float depth[] = {Mn::Math::lerpInverted(-1.0f, 1.0f, projected.z())};
+  unprojectDepth(calculateDepthUnprojection(data.projection), depth);
+  CORRADE_COMPARE_WITH(depth[0], data.expected,
+                       Cr::TestSuite::Compare::around(data.depth * 0.0002f));
+}
+
+constexpr Mn::Vector2i BenchmarkSize{1536};
+
+void DepthUnprojectionTest::benchmarkBaseline() {
+  auto&& data = UnprojectBenchmarkData[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+
+  Mn::Matrix4 unprojection =
+      Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.001f, 100.0f)
+          .inverted();
+
+  Cr::Containers::Array<float> depth{Cr::Containers::NoInit,
+                                     std::size_t(BenchmarkSize.product())};
+  for (std::size_t i = 0; i != depth.size(); ++i)
+    depth[i] = float(2 * (i % 10000)) / float(10000) - 1.0f;
+
+  CORRADE_BENCHMARK(1) { data.unprojector(depth, unprojection); }
+
+  CORRADE_COMPARE_AS(Mn::Math::max<float>(depth), 9.0f,
+                     Cr::TestSuite::Compare::Greater);
+}
+
+void DepthUnprojectionTest::benchmarkCpu() {
+  Mn::Matrix2x2 unprojection = calculateDepthUnprojection(
+      Mn::Matrix4::perspectiveProjection(60.0_degf, 1.0f, 0.001f, 100.0f));
+
+  Cr::Containers::Array<float> depth{Cr::Containers::NoInit,
+                                     std::size_t(BenchmarkSize.product())};
+  for (std::size_t i = 0; i != depth.size(); ++i)
+    depth[i] = float(i % 10000) / float(10000);
+
+  CORRADE_BENCHMARK(1) { unprojectDepth(unprojection, depth); }
+
+  CORRADE_COMPARE_AS(Mn::Math::max<float>(depth), 9.0f,
+                     Cr::TestSuite::Compare::Greater);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace gfx
+}  // namespace esp
+
+CORRADE_TEST_MAIN(esp::gfx::test::DepthUnprojectionTest)

--- a/src/esp/gfx/test/DepthUnprojectionTest.cpp
+++ b/src/esp/gfx/test/DepthUnprojectionTest.cpp
@@ -136,7 +136,7 @@ void DepthUnprojectionTest::testCpu() {
       data.projection.transformPoint({0.95f, -0.34f, -data.depth});
   CORRADE_COMPARE_WITH(
       -data.projection.inverted().transformPoint(projected).z(), data.depth,
-      Cr::TestSuite::Compare::around(data.depth * 0.0002f));
+      Cr::TestSuite::Compare::around(data.depth * 0.0006f));
 
   float depth[] = {Mn::Math::lerpInverted(-1.0f, 1.0f, projected.z())};
   unprojectDepth(calculateDepthUnprojection(data.projection), depth);

--- a/src/shaders/Shaders.conf
+++ b/src/shaders/Shaders.conf
@@ -1,6 +1,12 @@
 group = default-shaders
 
 [file]
+filename = depth.vert
+
+[file]
+filename = depth.frag
+
+[file]
 filename = primitive-id-textured-gl410.vert
 
 [file]

--- a/src/shaders/depth.frag
+++ b/src/shaders/depth.frag
@@ -1,0 +1,25 @@
+#ifdef UNPROJECT_EXISTING_DEPTH
+uniform highp sampler2D depthTexture;
+uniform highp vec2 depthUnprojection;
+
+in highp vec2 textureCoordinates;
+#else
+in highp float depth;
+#endif
+
+out highp float originalDepth;
+
+void main() {
+  #ifdef UNPROJECT_EXISTING_DEPTH
+  highp float depth = texture(depthTexture, textureCoordinates).r;
+  originalDepth =
+    #ifndef NO_FAR_PLANE_PATCHING
+    /* We can afford using == for comparison as 1.0f has an exact
+       representation and the depth is cleared to exactly this value. */
+    depth == 1.0 ? 0.0 :
+    #endif
+    depthUnprojection[1] / (depth + depthUnprojection[0]);
+  #else
+  originalDepth = depth;
+  #endif
+}

--- a/src/shaders/depth.vert
+++ b/src/shaders/depth.vert
@@ -1,0 +1,23 @@
+#ifndef UNPROJECT_EXISTING_DEPTH
+uniform highp mat4 transformationMatrix;
+uniform highp mat4 projectionMatrix;
+#endif
+
+#ifdef UNPROJECT_EXISTING_DEPTH
+out highp vec2 textureCoordinates;
+#else
+layout(location = 0) in highp vec4 position;
+out highp float depth;
+#endif
+
+void main() {
+  #ifndef UNPROJECT_EXISTING_DEPTH
+  vec4 transformed = transformationMatrix*position;
+  gl_Position = projectionMatrix*transformed;
+  depth = -transformed.z;
+  #else
+  gl_Position = vec4((gl_VertexID == 2) ?  3.0 : -1.0,
+                     (gl_VertexID == 1) ? -3.0 :  1.0, 0.0, 1.0);
+  textureCoordinates = gl_Position.xy*0.5 + vec2(0.5);
+  #endif
+}


### PR DESCRIPTION
## Motivation and Context

Added a test and a benchmark for the existing code, applied an even better optimization by @msbaines from #150 and then added a GPU-based implementation -- both a depth-only shader and a depth unprojection shader, which is meant to be used in GPU-to-GPU cases to avoid a CPU roundtrip.

While benchmarking I realized there's a huge perf penalty coming from the branch that converts depth values at the far plane to `0.0f`. Run the benchmark for yourself, results for posterity here:

![image](https://user-images.githubusercontent.com/344828/63360477-bf036380-c36e-11e9-873b-68d6a9f44ef2.png)

In general, the CPU code could be sped up about five times by removing the branching -- ~~according to @erikwijmans this is done because users expect depth values at far plane to be zero (while for me, coming from GPU background, values at far plane should have the depth value of far plane). I'm leaving the decision on you, but as far as I'm concerned, if this proves to be a perf bottleneck, I'd vote for removing the branching.~~ :heavy_check_mark: Mostly mitigated by doing the branching in a separate loop, see [my update below](https://github.com/facebookresearch/habitat-sim/pull/164#issuecomment-523413599).

OTOH, the GPU code doesn't seem to be affected by the branch -- both variants run roughly the same.

## How Has This Been Tested

While the shaders themselves aren't used anywhere yet (assuming those will get integrated into #114 by @erikwijmans), there's a full-blown test and a benchmark for the whole thing. This is the first test that uses [Corrade::TestSuite](https://doc.magnum.graphics/corrade/classCorrade_1_1TestSuite_1_1Tester.html) -- I'm happy to answer questions about its usage here.

Additionally, the unprojection algorithm docs are now directly in the header, written using *real* math -- I'm aiming to submit a PR with [m.css](https://mcss.mosra.cz)-based doc setup later this week (unless something with a higher priority comes up again): 

![image](https://user-images.githubusercontent.com/344828/63361037-b6f7f380-c36f-11e9-8540-27da0c04756c.png)
