### PR TITLE
Add hsim js bindings build to CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,19 @@ jobs:
               sudo apt-get --yes --force-yes install cuda
               touch ./cuda_installed
               nvidia-smi
+      - run:
+          name: Install emscripten
+          no_output_timeout: 20m
+          background: true
+          command: |
+              if [ ! -f ~/emscripten_installed ]
+              then
+                git clone -q https://github.com/emscripten-core/emsdk.git ~/emsdk
+                cd ~/emsdk
+                ./emsdk install 1.38.38
+                ./emsdk activate 1.38.38
+                touch ~/emscripten_installed
+              fi
       - restore_cache:
           keys:
             - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
@@ -193,13 +206,22 @@ jobs:
               GTEST_COLOR=yes ./build.sh --headless --run-tests
               pytest
       - run:
+          name: Build Javascript bindings
+          command: |
+              while [ ! -f ~/emscripten_installed ]; do sleep 2; done # wait for emscripten install
+              cd habitat-sim
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat
+              export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten
+              ./build_js.sh
+      - run:
           name: Install api
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
               if [ ! -d ./habitat-api ]
               then
-                git clone https://github.com/facebookresearch/habitat-api.git
+                git clone -q https://github.com/facebookresearch/habitat-api.git
               fi
               cd habitat-api
               pip install -r requirements.txt --progress-bar off

--- a/build_js.sh
+++ b/build_js.sh
@@ -7,10 +7,22 @@ git submodule update --init --recursive
 
 DATA_DIR="$(pwd)/data/"
 
+mkdir -p build_corrade-rc
+pushd build_corrade-rc
+cmake ../src \
+    -DBUILD_GUI_VIEWERS=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    -DBUILD_ASSIMP_SUPPORT=OFF \
+    -DBUILD_DATATOOL=OFF \
+    -DBUILD_PTEX_SUPPORT=OFF
+cmake --build . --target corrade-rc
+popd
+
 mkdir -p build_js
 cd build_js
 
 cmake ../src \
+    -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/deps/corrade/src/Corrade/Utility/corrade-rc \
     -DBUILD_GUI_VIEWERS=ON \
     -DBUILD_PYTHON_BINDINGS=OFF \
     -DBUILD_ASSIMP_SUPPORT=OFF \
@@ -21,6 +33,7 @@ cmake ../src \
     -DCMAKE_TOOLCHAIN_FILE="../src/deps/corrade/toolchains/generic/Emscripten-wasm.cmake" \
     -DCMAKE_INSTALL_PREFIX="." \
     -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 --preload-file $DATA_DIR/scene_datasets/habitat-test-scenes@/" \
+    -DCMAKE_EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
 
 cmake --build . -- -j 4
 cmake --build . --target install -- -j 4

--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(hsim_bindings
     sim
 )
 
-set_target_properties(hsim_bindings PROPERTIES LINK_OPTIONS "--bind")
+set_target_properties(hsim_bindings PROPERTIES LINK_FLAGS "--bind")
 
 # copy JS/HTML/CSS scaffolding for WebGL build
 install(FILES


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

- Add javascript binding build to CircleCI in order to prevent breakages of emscripten build.
- To enable this, I needed to add logic in build_js.sh to build corrade-rc.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
CircleCI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
