### PR TITLE
Enable loading empty scene with scene="NONE" in simulator config

### DIFF
--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -162,7 +162,9 @@ class DemoRunner:
             self._sim.set_translation(object_position + object_offset, object_id)
             print(
                 "added object: "
-                + str(object_id) +" of type " + str(rand_obj_index)
+                + str(object_id)
+                + " of type "
+                + str(rand_obj_index)
                 + " at: "
                 + str(object_position + object_offset)
                 + " | "
@@ -170,14 +172,12 @@ class DemoRunner:
             )
 
     def do_time_steps(self):
-        
+
         total_frames = 0
         start_time = time.time()
         action_names = list(
             self._cfg.agents[self._sim_settings["default_agent"]].action_space.keys()
         )
-
-        
 
         # load an object and position the agent for physics testing
         if self._sim_settings["enable_physics"]:
@@ -348,7 +348,7 @@ class DemoRunner:
         start_state = self.init_common()
 
         # initialize and compute shortest path to goal
-        if(self._sim_settings["compute_shortest_path"]):
+        if self._sim_settings["compute_shortest_path"]:
             self._shortest_path = hsim.ShortestPath()
             self.compute_shortest_path(
                 start_state.position, self._sim_settings["goal_position"]

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -162,7 +162,7 @@ class DemoRunner:
             self._sim.set_translation(object_position + object_offset, object_id)
             print(
                 "added object: "
-                + str(object_id)
+                + str(object_id) +" of type " + str(rand_obj_index)
                 + " at: "
                 + str(object_position + object_offset)
                 + " | "
@@ -170,11 +170,14 @@ class DemoRunner:
             )
 
     def do_time_steps(self):
+        
         total_frames = 0
         start_time = time.time()
         action_names = list(
             self._cfg.agents[self._sim_settings["default_agent"]].action_space.keys()
         )
+
+        
 
         # load an object and position the agent for physics testing
         if self._sim_settings["enable_physics"]:
@@ -345,10 +348,11 @@ class DemoRunner:
         start_state = self.init_common()
 
         # initialize and compute shortest path to goal
-        self._shortest_path = hsim.ShortestPath()
-        self.compute_shortest_path(
-            start_state.position, self._sim_settings["goal_position"]
-        )
+        if(self._sim_settings["compute_shortest_path"]):
+            self._shortest_path = hsim.ShortestPath()
+            self.compute_shortest_path(
+                start_state.position, self._sim_settings["goal_position"]
+            )
 
         # set the goal headings, and compute action shortest path
         if self._sim_settings["compute_action_shortest_path"]:

--- a/examples/example.py
+++ b/examples/example.py
@@ -29,6 +29,11 @@ parser.add_argument("--seed", type=int, default=1)
 parser.add_argument("--silent", action="store_true")
 parser.add_argument("--test_fps_regression", type=int, default=0)
 parser.add_argument("--enable_physics", action="store_true")
+parser.add_argument(
+    "--physics_config_file",
+    type=str,
+    default=dr.default_sim_settings["physics_config_file"],
+)
 args = parser.parse_args()
 
 
@@ -50,6 +55,7 @@ def make_settings():
     settings["seed"] = args.seed
     settings["silent"] = args.silent
     settings["enable_physics"] = args.enable_physics
+    settings["physics_config_file"] = args.physics_config_file
 
     return settings
 

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -29,6 +29,7 @@ default_sim_settings = {
     "goal_position": [5.047, 0.199, 11.145],
     "goal_headings": [[0, -0.980_785, 0, 0.195_090], [0.0, 1.0, 0.0, 0.0]],
     "enable_physics": False,
+    "physics_config_file": "./data/default.phys_scene_config.json",
 }
 
 # build SimulatorConfiguration
@@ -38,6 +39,8 @@ def make_cfg(settings):
         sim_cfg.enable_physics = settings["enable_physics"]
     else:
         sim_cfg.enable_physics = False
+    sim_cfg.physics_config_file = settings["physics_config_file"]
+    print("sim_cfg.physics_config_file = " + sim_cfg.physics_config_file)
     sim_cfg.gpu_device_id = 0
     sim_cfg.scene.id = settings["scene"]
 

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -39,7 +39,8 @@ def make_cfg(settings):
         sim_cfg.enable_physics = settings["enable_physics"]
     else:
         sim_cfg.enable_physics = False
-    sim_cfg.physics_config_file = settings["physics_config_file"]
+    if "physics_config_file" in settings.keys():
+        sim_cfg.physics_config_file = settings["physics_config_file"]
     print("sim_cfg.physics_config_file = " + sim_cfg.physics_config_file)
     sim_cfg.gpu_device_id = 0
     sim_cfg.scene.id = settings["scene"]

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -22,10 +22,14 @@ enum class AssetType {
   NAVMESH,
 };
 
+// loading and asset info with filepath == EMPTY_SCENE creates a scene graph
+// with no scene mesh (ie. an empty scene)
+static const std::string EMPTY_SCENE = "NONE";
+
 //! AssetInfo stores information necessary to identify and load an Asset
 struct AssetInfo {
   AssetType type = AssetType::UNKNOWN;
-  std::string filepath = "";
+  std::string filepath = EMPTY_SCENE;  // empty scene
   geo::CoordinateFrame frame;
   float virtualUnitToMeters = 1.0f;
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -61,7 +61,7 @@ bool ResourceManager::loadScene(const AssetInfo& info,
                                 DrawableGroup* drawables /* = nullptr */) {
   // scene mesh loading
   bool meshSuccess = true;
-  if (info.filepath.compare("NONE") != 0) {
+  if (info.filepath.compare(EMPTY_SCENE) != 0) {
     if (!io::exists(info.filepath)) {
       LOG(ERROR) << "Cannot load from file " << info.filepath;
       meshSuccess = false;
@@ -87,7 +87,8 @@ bool ResourceManager::loadScene(const AssetInfo& info,
     }
   } else {
     LOG(INFO) << "Loading empty scene";
-    //"NONE" string indicates desire for an empty scene (no scene mesh): welcome
+    // EMPTY_SCENE (ie. "NONE") string indicates desire for an empty scene (no
+    // scene mesh): welcome
     // to the void
   }
 
@@ -175,7 +176,7 @@ bool ResourceManager::loadScene(
   //! CONSTRUCT SCENE
   const std::string& filename = info.filepath;
   // if we have a scene mesh, add it as a collision object
-  if (filename.compare("NONE") != 0) {
+  if (filename.compare(EMPTY_SCENE) != 0) {
     MeshMetaData& metaData = resourceDict_.at(filename);
     auto indexPair = metaData.meshIndex;
     int start = indexPair.first;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -60,29 +60,34 @@ bool ResourceManager::loadScene(const AssetInfo& info,
                                 scene::SceneNode* parent, /* = nullptr */
                                 DrawableGroup* drawables /* = nullptr */) {
   // scene mesh loading
-  bool meshSuccess = false;
-  if (!io::exists(info.filepath)) {
-    LOG(ERROR) << "Cannot load from file " << info.filepath;
-    meshSuccess = false;
-  } else {
-    if (info.type == AssetType::FRL_INSTANCE_MESH ||
-        info.type == AssetType::INSTANCE_MESH) {
-      meshSuccess = loadInstanceMeshData(info, parent, drawables);
-    } else if (info.type == AssetType::FRL_PTEX_MESH) {
-      meshSuccess = loadPTexMeshData(info, parent, drawables);
-    } else if (info.type == AssetType::SUNCG_SCENE) {
-      meshSuccess = loadSUNCGHouseFile(info, parent, drawables);
-    } else if (info.type == AssetType::MP3D_MESH) {
-      meshSuccess = loadGeneralMeshData(info, parent, drawables);
+  bool meshSuccess = true;
+  if(info.filepath.compare("NONE") != 0){
+    if (!io::exists(info.filepath)) {
+      LOG(ERROR) << "Cannot load from file " << info.filepath;
+      meshSuccess = false;
     } else {
-      // Unknown type, just load general mesh data
-      meshSuccess = loadGeneralMeshData(info, parent, drawables);
+      if (info.type == AssetType::FRL_INSTANCE_MESH ||
+          info.type == AssetType::INSTANCE_MESH) {
+        meshSuccess = loadInstanceMeshData(info, parent, drawables);
+      } else if (info.type == AssetType::FRL_PTEX_MESH) {
+        meshSuccess = loadPTexMeshData(info, parent, drawables);
+      } else if (info.type == AssetType::SUNCG_SCENE) {
+        meshSuccess = loadSUNCGHouseFile(info, parent, drawables);
+      } else if (info.type == AssetType::MP3D_MESH) {
+        meshSuccess = loadGeneralMeshData(info, parent, drawables);
+      } else {
+        // Unknown type, just load general mesh data
+        meshSuccess = loadGeneralMeshData(info, parent, drawables);
+      }
+      // add a scene attributes for this filename or modify the existing one
+      if (meshSuccess) {
+        physicsSceneLibrary_[info.filepath].setString("renderMeshHandle",
+                                                      info.filepath);
+      }
     }
-    // add a scene attributes for this filename or modify the existing one
-    if (meshSuccess) {
-      physicsSceneLibrary_[info.filepath].setString("renderMeshHandle",
-                                                    info.filepath);
-    }
+  }else{
+    LOG(INFO) << "Loading empty scene";
+    //"NONE" string indicates desire for an empty scene (no scene mesh): welcome to the void
   }
 
   return meshSuccess;
@@ -168,53 +173,56 @@ bool ResourceManager::loadScene(
 
   //! CONSTRUCT SCENE
   const std::string& filename = info.filepath;
-  MeshMetaData& metaData = resourceDict_.at(filename);
-  auto indexPair = metaData.meshIndex;
-  int start = indexPair.first;
-  int end = indexPair.second;
+  //if we have a scene mesh, add it as a collision object
+  if(filename.compare("NONE") != 0){
+    MeshMetaData& metaData = resourceDict_.at(filename);
+    auto indexPair = metaData.meshIndex;
+    int start = indexPair.first;
+    int end = indexPair.second;
 
-  //! Collect collision mesh group
-  std::vector<CollisionMeshData> meshGroup;
-  for (int mesh_i = start; mesh_i <= end; mesh_i++) {
-    // FRL Quad Mesh
-    if (info.type == AssetType::FRL_INSTANCE_MESH) {
-      FRLInstanceMeshData* frlMeshData =
-          dynamic_cast<FRLInstanceMeshData*>(meshes_[mesh_i].get());
-      CollisionMeshData& meshData = frlMeshData->getCollisionMeshData();
-      meshGroup.push_back(meshData);
+    //! Collect collision mesh group
+    std::vector<CollisionMeshData> meshGroup;
+    for (int mesh_i = start; mesh_i <= end; mesh_i++) {
+      // FRL Quad Mesh
+      if (info.type == AssetType::FRL_INSTANCE_MESH) {
+        FRLInstanceMeshData* frlMeshData =
+            dynamic_cast<FRLInstanceMeshData*>(meshes_[mesh_i].get());
+        CollisionMeshData& meshData = frlMeshData->getCollisionMeshData();
+        meshGroup.push_back(meshData);
+      }
+
+      // PLY Instance mesh
+      else if (info.type == AssetType::INSTANCE_MESH) {
+        GenericInstanceMeshData* insMeshData =
+            dynamic_cast<GenericInstanceMeshData*>(meshes_[mesh_i].get());
+        quatf quatFront =
+            quatf::FromTwoVectors(info.frame.front(), geo::ESP_FRONT);
+        Magnum::Quaternion quat = Magnum::Quaternion(quatFront);
+        CollisionMeshData& meshData = insMeshData->getCollisionMeshData();
+        meshGroup.push_back(meshData);
+      }
+
+      // GLB Mesh
+      else if (info.type == AssetType::MP3D_MESH) {
+        quatf quatFront =
+            quatf::FromTwoVectors(info.frame.front(), geo::ESP_FRONT);
+        Magnum::Quaternion quat = Magnum::Quaternion(quatFront);
+        GltfMeshData* gltfMeshData =
+            dynamic_cast<GltfMeshData*>(meshes_[mesh_i].get());
+        CollisionMeshData& meshData = gltfMeshData->getCollisionMeshData();
+        Magnum::Matrix4 transform =
+            Magnum::Matrix4::rotation(quat.angle(), quat.axis().normalized());
+        Magnum::MeshTools::transformPointsInPlace(transform, meshData.positions);
+        meshGroup.push_back(meshData);
+      }
     }
 
-    // PLY Instance mesh
-    else if (info.type == AssetType::INSTANCE_MESH) {
-      GenericInstanceMeshData* insMeshData =
-          dynamic_cast<GenericInstanceMeshData*>(meshes_[mesh_i].get());
-      quatf quatFront =
-          quatf::FromTwoVectors(info.frame.front(), geo::ESP_FRONT);
-      Magnum::Quaternion quat = Magnum::Quaternion(quatFront);
-      CollisionMeshData& meshData = insMeshData->getCollisionMeshData();
-      meshGroup.push_back(meshData);
+    //! Initialize collision mesh
+    bool sceneSuccess = _physicsManager->addScene(
+        info, physicsSceneLibrary_.at(info.filepath), meshGroup);
+    if (!sceneSuccess) {
+      return false;
     }
-
-    // GLB Mesh
-    else if (info.type == AssetType::MP3D_MESH) {
-      quatf quatFront =
-          quatf::FromTwoVectors(info.frame.front(), geo::ESP_FRONT);
-      Magnum::Quaternion quat = Magnum::Quaternion(quatFront);
-      GltfMeshData* gltfMeshData =
-          dynamic_cast<GltfMeshData*>(meshes_[mesh_i].get());
-      CollisionMeshData& meshData = gltfMeshData->getCollisionMeshData();
-      Magnum::Matrix4 transform =
-          Magnum::Matrix4::rotation(quat.angle(), quat.axis().normalized());
-      Magnum::MeshTools::transformPointsInPlace(transform, meshData.positions);
-      meshGroup.push_back(meshData);
-    }
-  }
-
-  //! Initialize collision mesh
-  bool sceneSuccess = _physicsManager->addScene(
-      info, physicsSceneLibrary_.at(info.filepath), meshGroup);
-  if (!sceneSuccess) {
-    return false;
   }
 
   return meshSuccess;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -61,7 +61,7 @@ bool ResourceManager::loadScene(const AssetInfo& info,
                                 DrawableGroup* drawables /* = nullptr */) {
   // scene mesh loading
   bool meshSuccess = true;
-  if(info.filepath.compare("NONE") != 0){
+  if (info.filepath.compare("NONE") != 0) {
     if (!io::exists(info.filepath)) {
       LOG(ERROR) << "Cannot load from file " << info.filepath;
       meshSuccess = false;
@@ -85,9 +85,10 @@ bool ResourceManager::loadScene(const AssetInfo& info,
                                                       info.filepath);
       }
     }
-  }else{
+  } else {
     LOG(INFO) << "Loading empty scene";
-    //"NONE" string indicates desire for an empty scene (no scene mesh): welcome to the void
+    //"NONE" string indicates desire for an empty scene (no scene mesh): welcome
+    // to the void
   }
 
   return meshSuccess;
@@ -173,8 +174,8 @@ bool ResourceManager::loadScene(
 
   //! CONSTRUCT SCENE
   const std::string& filename = info.filepath;
-  //if we have a scene mesh, add it as a collision object
-  if(filename.compare("NONE") != 0){
+  // if we have a scene mesh, add it as a collision object
+  if (filename.compare("NONE") != 0) {
     MeshMetaData& metaData = resourceDict_.at(filename);
     auto indexPair = metaData.meshIndex;
     int start = indexPair.first;
@@ -212,7 +213,8 @@ bool ResourceManager::loadScene(
         CollisionMeshData& meshData = gltfMeshData->getCollisionMeshData();
         Magnum::Matrix4 transform =
             Magnum::Matrix4::rotation(quat.angle(), quat.axis().normalized());
-        Magnum::MeshTools::transformPointsInPlace(transform, meshData.positions);
+        Magnum::MeshTools::transformPointsInPlace(transform,
+                                                  meshData.positions);
         meshGroup.push_back(meshData);
       }
     }

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -449,6 +449,8 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
                      &SimulatorConfiguration::compressTextures)
       .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
       .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
+      .def_readwrite("physics_config_file",
+                     &SimulatorConfiguration::physicsConfigFile)
       .def("__eq__",
            [](const SimulatorConfiguration& self,
               const SimulatorConfiguration& other) -> bool {

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -97,8 +97,9 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
     bool loadSuccess = false;
     if (config_.enablePhysics) {
-      loadSuccess = resourceManager_.loadScene(sceneInfo, physicsManager_,
-                                               &rootNode, &drawables);
+      loadSuccess =
+          resourceManager_.loadScene(sceneInfo, physicsManager_, &rootNode,
+                                     &drawables, cfg.physicsConfigFile);
     } else {
       loadSuccess =
           resourceManager_.loadScene(sceneInfo, &rootNode, &drawables);

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -76,7 +76,8 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   // We need to make a design decision here:
   // when doing reconfigure, shall we delete all of the previous scene graphs
   activeSceneID_ = sceneManager_.initSceneGraph();
-  //LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
+
+  // LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
   sceneID_.push_back(activeSceneID_);
 
   if (cfg.createRenderer) {

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -76,7 +76,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   // We need to make a design decision here:
   // when doing reconfigure, shall we delete all of the previous scene graphs
   activeSceneID_ = sceneManager_.initSceneGraph();
-  // LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
+  //LOG(INFO) << "Active scene graph ID = " << activeSceneID_;
   sceneID_.push_back(activeSceneID_);
 
   if (cfg.createRenderer) {


### PR DESCRIPTION
## Motivation and Context

Currently a scene mesh is required to initialize the simulator. This made sense when the simulator was rendering only the scene. Now that we have dynamic object add/remove through physics manager, some use cases may require that objects can be spawned in an empty scene. One example of this is generating RGB/D/S masks for individual objects at arbitrary viewpoints. Another is dynamically building mobile scenes from an object library with no static scene mesh.

This PR introduces the option to set scene file path to "NONE" in which case the simulator will be initialized without a scene mesh required for load.

Additional change: added python bindings for "physics_config_file" field in SimulatorConfiguration class.

## How Has This Been Tested

Local machine testing:

C++ interactive testing:
./build/viewer -- "NONE"
./build/viewer --enable-physics -- "NONE" (add objects with 'o')

python testing:
python examples/example.py --max_frames=1 --scene="NONE"
python examples/example.py --max_frames=1 --scene="NONE" --enable_physics

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
