### PR TITLE
Get rid of the warnings added in PR91

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -201,7 +201,7 @@ class Simulator:
         self._sim.set_transformation(transform, object_id, scene_id)
 
     def get_transformation(self, object_id, scene_id=0):
-        return self._sim.set_transformation(object_id, scene_id)
+        return self._sim.get_transformation(object_id, scene_id)
 
     def set_translation(self, translation, object_id, scene_id=0):
         self._sim.set_translation(translation, object_id, scene_id)

--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -131,7 +131,7 @@ void Attributes::clearAs(const DataType t) {
 //----------------------------------------//
 // return the queried entry in the double map
 // will throw an exception if the key does not exist in the double map
-const double Attributes::getDouble(const std::string& key) const {
+double Attributes::getDouble(const std::string& key) const {
   return doubleMap_.at(key);
 }
 
@@ -140,7 +140,7 @@ void Attributes::setDouble(const std::string& key, const double val) {
   doubleMap_[key] = val;
 }
 
-const int Attributes::getInt(const std::string& key) const {
+int Attributes::getInt(const std::string& key) const {
   return intMap_.at(key);
 }
 

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -52,12 +52,12 @@ class Attributes {
   //----------------------------------------//
   // return the queried entry in the double map
   // will throw an exception if the key does not exist in the double map
-  const double getDouble(const std::string& key) const;
+  double getDouble(const std::string& key) const;
 
   // set a double attribute key->val
   void setDouble(const std::string& key, const double val);
 
-  const int getInt(const std::string& key) const;
+  int getInt(const std::string& key) const;
 
   void setInt(const std::string& key, const int val);
 

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -35,10 +35,10 @@ class BaseMesh {
   bool setMeshType(SupportedMeshType type);
   SupportedMeshType getMeshType() { return type_; }
 
-  virtual void uploadBuffersToGPU(bool forceReload = false){};
+  virtual void uploadBuffersToGPU(bool){};
 
   virtual Magnum::GL::Mesh* getMagnumGLMesh() { return nullptr; }
-  virtual Magnum::GL::Mesh* getMagnumGLMesh(int submeshID) { return nullptr; }
+  virtual Magnum::GL::Mesh* getMagnumGLMesh(int) { return nullptr; }
 
   // Accessing non-render mesh data
   // Usage: (1) physics simulation

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -122,7 +122,7 @@ class ResourceManager {
   PhysicsObjectAttributes& getPhysicsObjectAttributes(
       const std::string& configFile);
 
-  const int getNumLibraryObjects() { return physicsObjectConfigList_.size(); };
+  int getNumLibraryObjects() { return physicsObjectConfigList_.size(); };
 
   const Magnum::Matrix4& getMeshTransformation(const size_t meshIndex) {
     return meshes_[meshIndex]->meshTransform_;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -9,9 +9,8 @@
 namespace esp {
 namespace physics {
 
-bool PhysicsManager::initPhysics(
-    scene::SceneNode* node,
-    const assets::PhysicsManagerAttributes& physicsManagerAttributes) {
+bool PhysicsManager::initPhysics(scene::SceneNode* node,
+                                 const assets::PhysicsManagerAttributes&) {
   physicsNode_ = node;
   //! Create new scene node
   sceneNode_ = new physics::RigidObject(physicsNode_);
@@ -110,7 +109,7 @@ bool PhysicsManager::setObjectMotionType(const int physObjectID,
   }
 }
 
-const MotionType PhysicsManager::getObjectMotionType(const int physObjectID) {
+MotionType PhysicsManager::getObjectMotionType(const int physObjectID) {
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getMotionType();
   }
@@ -156,8 +155,7 @@ int PhysicsManager::makeRigidObject(
 }
 
 //! Base physics manager has no requirement for mesh primitive
-bool PhysicsManager::isMeshPrimitiveValid(
-    const assets::CollisionMeshData& meshData) {
+bool PhysicsManager::isMeshPrimitiveValid(const assets::CollisionMeshData&) {
   return true;
 }
 
@@ -167,11 +165,11 @@ void PhysicsManager::setTimestep(double dt) {
   fixedTimeStep_ = dt;
 }
 
-void PhysicsManager::setGravity(const Magnum::Vector3& gravity) {
+void PhysicsManager::setGravity(const Magnum::Vector3&) {
   // Can't do this for kinematic simulator
 }
 
-const Magnum::Vector3 PhysicsManager::getGravity() {
+Magnum::Vector3 PhysicsManager::getGravity() {
   return Magnum::Vector3(0);
 }
 
@@ -338,8 +336,7 @@ void PhysicsManager::rotateZLocal(const int physObjectID,
   }
 }
 
-const Magnum::Matrix4 PhysicsManager::getTransformation(
-    const int physObjectID) {
+Magnum::Matrix4 PhysicsManager::getTransformation(const int physObjectID) {
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->transformation();
   } else {
@@ -347,7 +344,7 @@ const Magnum::Matrix4 PhysicsManager::getTransformation(
   }
 }
 
-const Magnum::Vector3 PhysicsManager::getTranslation(const int physObjectID) {
+Magnum::Vector3 PhysicsManager::getTranslation(const int physObjectID) {
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->translation();
   } else {
@@ -355,7 +352,7 @@ const Magnum::Vector3 PhysicsManager::getTranslation(const int physObjectID) {
   }
 }
 
-const Magnum::Quaternion PhysicsManager::getRotation(const int physObjectID) {
+Magnum::Quaternion PhysicsManager::getRotation(const int physObjectID) {
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->rotation();
   } else {
@@ -422,7 +419,7 @@ void PhysicsManager::setAngularDamping(const int physObjectID,
 }
 
 //============ Object Getter functions =============
-const double PhysicsManager::getMass(const int physObjectID) {
+double PhysicsManager::getMass(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getMass();
@@ -431,7 +428,7 @@ const double PhysicsManager::getMass(const int physObjectID) {
   }
 }
 
-const Magnum::Vector3 PhysicsManager::getCOM(const int physObjectID) {
+Magnum::Vector3 PhysicsManager::getCOM(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getCOM();
@@ -439,7 +436,8 @@ const Magnum::Vector3 PhysicsManager::getCOM(const int physObjectID) {
     return Magnum::Vector3();
   }
 }
-const Magnum::Vector3 PhysicsManager::getInertiaVector(const int physObjectID) {
+
+Magnum::Vector3 PhysicsManager::getInertiaVector(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getInertiaVector();
@@ -447,7 +445,8 @@ const Magnum::Vector3 PhysicsManager::getInertiaVector(const int physObjectID) {
     return Magnum::Vector3();
   }
 }
-const Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) {
+
+Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getInertiaMatrix();
@@ -455,7 +454,8 @@ const Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) {
     return Magnum::Matrix3();
   }
 }
-const double PhysicsManager::getScale(const int physObjectID) {
+
+double PhysicsManager::getScale(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getScale();
@@ -463,7 +463,8 @@ const double PhysicsManager::getScale(const int physObjectID) {
     return PHYSICS_ATTR_UNDEFINED;
   }
 }
-const double PhysicsManager::getFrictionCoefficient(const int physObjectID) {
+
+double PhysicsManager::getFrictionCoefficient(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getFrictionCoefficient();
@@ -471,7 +472,8 @@ const double PhysicsManager::getFrictionCoefficient(const int physObjectID) {
     return PHYSICS_ATTR_UNDEFINED;
   }
 }
-const double PhysicsManager::getRestitutionCoefficient(const int physObjectID) {
+
+double PhysicsManager::getRestitutionCoefficient(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getRestitutionCoefficient();
@@ -479,7 +481,8 @@ const double PhysicsManager::getRestitutionCoefficient(const int physObjectID) {
     return PHYSICS_ATTR_UNDEFINED;
   }
 }
-const double PhysicsManager::getLinearDamping(const int physObjectID) {
+
+double PhysicsManager::getLinearDamping(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getLinearDamping();
@@ -487,7 +490,8 @@ const double PhysicsManager::getLinearDamping(const int physObjectID) {
     return PHYSICS_ATTR_UNDEFINED;
   }
 }
-const double PhysicsManager::getAngularDamping(const int physObjectID) {
+
+double PhysicsManager::getAngularDamping(const int physObjectID) {
   // TODO: talk to property library
   if (existingObjects_.count(physObjectID) > 0) {
     return existingObjects_[physObjectID]->getAngularDamping();

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -70,10 +70,10 @@ class PhysicsManager {
   virtual int removeObject(const int physObjectID);
 
   // return the number of tracked existingObjects_
-  const int getNumRigidObjects() { return existingObjects_.size(); };
+  int getNumRigidObjects() { return existingObjects_.size(); };
 
   // return a vector of ints listing all existing object IDs
-  const std::vector<int> getExistingObjectIDs() {
+  std::vector<int> getExistingObjectIDs() {
     std::vector<int> v;
     for (auto& bro : existingObjects_) {
       v.push_back(bro.first);
@@ -83,7 +83,7 @@ class PhysicsManager {
 
   // get/set MotionType
   bool setObjectMotionType(const int physObjectID, MotionType mt);
-  const MotionType getObjectMotionType(const int physObjectID);
+  MotionType getObjectMotionType(const int physObjectID);
 
   //============ Simulator functions =============
   virtual void stepPhysics();
@@ -94,16 +94,15 @@ class PhysicsManager {
   virtual void setGravity(const Magnum::Vector3& gravity);
 
   // =========== Global Getter functions ===========
-  virtual const double getTimestep() { return fixedTimeStep_; };
-  virtual const double getWorldTime() { return worldTime_; };
-  virtual const Magnum::Vector3 getGravity();
+  virtual double getTimestep() { return fixedTimeStep_; };
+  virtual double getWorldTime() { return worldTime_; };
+  virtual Magnum::Vector3 getGravity();
 
   // =========== Scene Getter/Setter functions ===========
-  virtual const double getSceneFrictionCoefficient() { return 0.0; };
-  virtual void setSceneFrictionCoefficient(const double frictionCoefficient){};
-  virtual const double getSceneRestitutionCoefficient() { return 0.0; };
-  virtual void setSceneRestitutionCoefficient(
-      const double restitutionCoefficient){};
+  virtual double getSceneFrictionCoefficient() { return 0.0; };
+  virtual void setSceneFrictionCoefficient(const double){};
+  virtual double getSceneRestitutionCoefficient() { return 0.0; };
+  virtual void setSceneRestitutionCoefficient(const double){};
 
   // ============ Object Transformation functions =============
   void setTransformation(const int physObjectID, const Magnum::Matrix4& trans);
@@ -125,9 +124,9 @@ class PhysicsManager {
   void rotateYLocal(const int physObjectID, const Magnum::Rad angleInRad);
   void rotateZLocal(const int physObjectID, const Magnum::Rad angleInRad);
 
-  const Magnum::Matrix4 getTransformation(const int physObjectID);
-  const Magnum::Vector3 getTranslation(const int physObjectID);
-  const Magnum::Quaternion getRotation(const int physObjectID);
+  Magnum::Matrix4 getTransformation(const int physObjectID);
+  Magnum::Vector3 getTranslation(const int physObjectID);
+  Magnum::Quaternion getRotation(const int physObjectID);
 
   // ============ Object Setter functions =============
   // Setters that interface with physics need to take
@@ -143,19 +142,19 @@ class PhysicsManager {
   void setAngularDamping(const int physObjectID, const double angDamping);
 
   // ============ Object Getter functions =============
-  const double getMass(const int physObjectID);
-  const Magnum::Vector3 getCOM(const int physObjectID);
-  const Magnum::Vector3 getInertiaVector(const int physObjectID);
-  const Magnum::Matrix3 getInertiaMatrix(const int physObjectID);
-  const double getScale(const int physObjectID);
-  const double getFrictionCoefficient(const int physObjectID);
-  const double getRestitutionCoefficient(const int physObjectID);
-  const double getLinearDamping(const int physObjectID);
-  const double getAngularDamping(const int physObjectID);
+  double getMass(const int physObjectID);
+  Magnum::Vector3 getCOM(const int physObjectID);
+  Magnum::Vector3 getInertiaVector(const int physObjectID);
+  Magnum::Matrix3 getInertiaMatrix(const int physObjectID);
+  double getScale(const int physObjectID);
+  double getFrictionCoefficient(const int physObjectID);
+  double getRestitutionCoefficient(const int physObjectID);
+  double getLinearDamping(const int physObjectID);
+  double getAngularDamping(const int physObjectID);
 
   // ============= Platform dependent function =============
-  virtual const double getMargin(const int physObjectID) { return 0.0; };
-  virtual void setMargin(const int physObjectID, const double margin){};
+  virtual double getMargin(const int) { return 0.0; };
+  virtual void setMargin(const int, const double){};
 
   // =========== Debug functions ===========
   int checkActiveObjects();

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -12,8 +12,8 @@ RigidObject::RigidObject(scene::SceneNode* parent)
     : scene::SceneNode{*parent} {}
 
 bool RigidObject::initializeScene(
-    const assets::PhysicsSceneAttributes& physicsSceneAttributes,
-    const std::vector<assets::CollisionMeshData>& meshGroup) {
+    const assets::PhysicsSceneAttributes&,
+    const std::vector<assets::CollisionMeshData>&) {
   if (rigidObjectType_ != NONE) {
     LOG(ERROR) << "Cannot initialized a RigidObject more than once";
     return false;
@@ -27,8 +27,8 @@ bool RigidObject::initializeScene(
 }
 
 bool RigidObject::initializeObject(
-    const assets::PhysicsObjectAttributes& physicsObjectAttributes,
-    const std::vector<assets::CollisionMeshData>& meshGroup) {
+    const assets::PhysicsObjectAttributes&,
+    const std::vector<assets::CollisionMeshData>&) {
   // TODO (JH): Handling static/kinematic object type
   if (rigidObjectType_ != NONE) {
     LOG(ERROR) << "Cannot initialized a RigidObject more than once";
@@ -67,24 +67,22 @@ bool RigidObject::setMotionType(MotionType mt) {
   return false;
 }
 
-void RigidObject::applyForce(const Magnum::Vector3& force,
-                             const Magnum::Vector3& relPos) {
+void RigidObject::applyForce(const Magnum::Vector3&, const Magnum::Vector3&) {
   // without a physics engine we can't apply any forces...
   return;
 }
 
-void RigidObject::applyImpulse(const Magnum::Vector3& impulse,
-                               const Magnum::Vector3& relPos) {
+void RigidObject::applyImpulse(const Magnum::Vector3&, const Magnum::Vector3&) {
   // without a physics engine we can't apply any forces...
   return;
 }
 
 //! Torque interaction
-void RigidObject::applyTorque(const Magnum::Vector3& torque) {
+void RigidObject::applyTorque(const Magnum::Vector3&) {
   return;
 }
 // Impulse Torque interaction
-void RigidObject::applyImpulseTorque(const Magnum::Vector3& impulse) {
+void RigidObject::applyImpulseTorque(const Magnum::Vector3&) {
   return;
 }
 
@@ -209,17 +207,17 @@ scene::SceneNode& RigidObject::rotateZLocal(const Magnum::Rad angleInRad) {
   return *this;
 }
 
-const Magnum::Vector3 RigidObject::getCOM() {
+Magnum::Vector3 RigidObject::getCOM() {
   const Magnum::Vector3 com = Magnum::Vector3();
   return com;
 }
 
-const Magnum::Vector3 RigidObject::getInertiaVector() {
+Magnum::Vector3 RigidObject::getInertiaVector() {
   const Magnum::Vector3 inertia = Magnum::Vector3();
   return inertia;
 }
 
-const Magnum::Matrix3 RigidObject::getInertiaMatrix() {
+Magnum::Matrix3 RigidObject::getInertiaMatrix() {
   const Magnum::Matrix3 inertia = Magnum::Matrix3();
   return inertia;
 }

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -48,7 +48,7 @@ class RigidObject : public scene::SceneNode {
 
   // attempt to set the motion type. Return false=failure, true=success.
   virtual bool setMotionType(MotionType mt);
-  const MotionType getMotionType() { return objectMotionType_; };
+  MotionType getMotionType() { return objectMotionType_; };
 
   //! Force interaction
   virtual void applyForce(const Magnum::Vector3& force,
@@ -94,25 +94,25 @@ class RigidObject : public scene::SceneNode {
   // ==== Getter/Setter functions ===
   //! For kinematic objects they are dummies, for dynamic objects
   //! implemented in physics-engine specific ways
-  virtual const double getMass() { return 0.0; }
-  virtual const double getScale() { return 0.0; }
-  virtual const double getFrictionCoefficient() { return 0.0; }
-  virtual const double getRestitutionCoefficient() { return 0.0; }
-  virtual const double getLinearDamping() { return 0.0; }
-  virtual const double getAngularDamping() { return 0.0; }
-  virtual const Magnum::Vector3 getCOM();
+  virtual double getMass() { return 0.0; }
+  virtual double getScale() { return 0.0; }
+  virtual double getFrictionCoefficient() { return 0.0; }
+  virtual double getRestitutionCoefficient() { return 0.0; }
+  virtual double getLinearDamping() { return 0.0; }
+  virtual double getAngularDamping() { return 0.0; }
+  virtual Magnum::Vector3 getCOM();
   // Get local inertia
-  virtual const Magnum::Vector3 getInertiaVector();
-  virtual const Magnum::Matrix3 getInertiaMatrix();
+  virtual Magnum::Vector3 getInertiaVector();
+  virtual Magnum::Matrix3 getInertiaMatrix();
 
-  virtual void setMass(const double mass){};
-  virtual void setCOM(const Magnum::Vector3& COM){};
-  virtual void setInertia(const Magnum::Vector3& inertia){};
-  virtual void setScale(const double scale){};
-  virtual void setFrictionCoefficient(const double frictionCoefficient){};
-  virtual void setRestitutionCoefficient(const double restitutionCoefficient){};
-  virtual void setLinearDamping(const double linearDamping){};
-  virtual void setAngularDamping(const double angularDamping){};
+  virtual void setMass(const double){};
+  virtual void setCOM(const Magnum::Vector3&){};
+  virtual void setInertia(const Magnum::Vector3&){};
+  virtual void setScale(const double){};
+  virtual void setFrictionCoefficient(const double){};
+  virtual void setRestitutionCoefficient(const double){};
+  virtual void setLinearDamping(const double){};
+  virtual void setAngularDamping(const double){};
 
   // public Attributes object for user convenience.
   assets::Attributes attributes_;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -46,7 +46,7 @@ BulletPhysicsManager::~BulletPhysicsManager() {
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
 bool BulletPhysicsManager::addScene(
-    const assets::AssetInfo& info,
+    const assets::AssetInfo&,
     const assets::PhysicsSceneAttributes& physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
@@ -128,7 +128,7 @@ void BulletPhysicsManager::setGravity(const Magnum::Vector3& gravity) {
   }
 }
 
-const Magnum::Vector3 BulletPhysicsManager::getGravity() {
+Magnum::Vector3 BulletPhysicsManager::getGravity() {
   return Magnum::Vector3(bWorld_->getGravity());
 }
 
@@ -169,7 +169,7 @@ void BulletPhysicsManager::setSceneRestitutionCoefficient(
       ->setRestitutionCoefficient(restitutionCoefficient);
 }
 
-const double BulletPhysicsManager::getMargin(const int physObjectID) {
+double BulletPhysicsManager::getMargin(const int physObjectID) {
   if (existingObjects_.count(physObjectID) > 0) {
     return static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
         ->getMargin();
@@ -178,11 +178,11 @@ const double BulletPhysicsManager::getMargin(const int physObjectID) {
   }
 }
 
-const double BulletPhysicsManager::getSceneFrictionCoefficient() {
+double BulletPhysicsManager::getSceneFrictionCoefficient() {
   return static_cast<BulletRigidObject*>(sceneNode_)->getFrictionCoefficient();
 }
 
-const double BulletPhysicsManager::getSceneRestitutionCoefficient() {
+double BulletPhysicsManager::getSceneRestitutionCoefficient() {
   return static_cast<BulletRigidObject*>(sceneNode_)
       ->getRestitutionCoefficient();
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -43,7 +43,7 @@ class BulletPhysicsManager : public PhysicsManager {
 
   void setGravity(const Magnum::Vector3& gravity);
 
-  const Magnum::Vector3 getGravity();
+  Magnum::Vector3 getGravity();
 
   //============ Interact with objects =============
   // NOTE: engine specifics handled by objects themselves...
@@ -54,9 +54,9 @@ class BulletPhysicsManager : public PhysicsManager {
   void setSceneRestitutionCoefficient(const double restitutionCoefficient);
 
   //============ Bullet-specific Object Getter functions =============
-  const double getMargin(const int physObjectID);
-  const double getSceneFrictionCoefficient();
-  const double getSceneRestitutionCoefficient();
+  double getMargin(const int physObjectID);
+  double getSceneFrictionCoefficient();
+  double getSceneRestitutionCoefficient();
 
  protected:
   //! The world has to live longer than the scene because RigidBody

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -79,7 +79,7 @@ bool BulletRigidObject::initializeScene(
     //! btBvhTriangleMeshShape is the most generic/slow choice
     bSceneShapes_.emplace_back(
         std::make_unique<btBvhTriangleMeshShape>(bSceneArray_.get(), true));
-    double mass = 0.0;
+    // double mass = 0.0;
     // btVector3 bInertia(0.0, 0.0, 0.0);
     // bSceneShapes_.back()->calculateLocalInertia(mass, bInertia);
 
@@ -322,7 +322,7 @@ void BulletRigidObject::setMargin(const double margin) {
   if (rigidObjectType_ == SCENE) {
     return;
   } else {
-    for (int i = 0; i < bObjectConvexShapes_.size(); i++) {
+    for (std::size_t i = 0; i < bObjectConvexShapes_.size(); i++) {
       bObjectConvexShapes_[i]->setMargin(margin);
     }
     bObjectShape_->setMargin(margin);
@@ -336,7 +336,7 @@ void BulletRigidObject::setMass(const double mass) {
     bObjectRigidBody_->setMassProps(mass, btVector3(getInertiaVector()));
 }
 
-void BulletRigidObject::setCOM(const Magnum::Vector3& COM) {
+void BulletRigidObject::setCOM(const Magnum::Vector3&) {
   // Current not supported
   /*if (rigidObjectType_ == SCENE)
     return;
@@ -352,7 +352,7 @@ void BulletRigidObject::setInertia(const Magnum::Vector3& inertia) {
     bObjectRigidBody_->setMassProps(getMass(), btVector3(inertia));
 }
 
-void BulletRigidObject::setScale(const double scale) {
+void BulletRigidObject::setScale(const double) {
   // Currently not supported
   /*if (rigidObjectType_ == SCENE)
     return;
@@ -363,7 +363,7 @@ void BulletRigidObject::setScale(const double scale) {
 void BulletRigidObject::setFrictionCoefficient(
     const double frictionCoefficient) {
   if (rigidObjectType_ == SCENE) {
-    for (int i = 0; i < bSceneCollisionObjects_.size(); i++) {
+    for (std::size_t i = 0; i < bSceneCollisionObjects_.size(); i++) {
       bSceneCollisionObjects_[i]->setFriction(frictionCoefficient);
     }
   } else {
@@ -374,7 +374,7 @@ void BulletRigidObject::setFrictionCoefficient(
 void BulletRigidObject::setRestitutionCoefficient(
     const double restitutionCoefficient) {
   if (rigidObjectType_ == SCENE) {
-    for (int i = 0; i < bSceneCollisionObjects_.size(); i++) {
+    for (std::size_t i = 0; i < bSceneCollisionObjects_.size(); i++) {
       bSceneCollisionObjects_[i]->setRestitution(restitutionCoefficient);
     }
   } else {
@@ -398,7 +398,7 @@ void BulletRigidObject::setAngularDamping(const double angularDamping) {
   }
 }
 
-const double BulletRigidObject::getMargin() {
+double BulletRigidObject::getMargin() {
   if (rigidObjectType_ == SCENE) {
     return -1.0;
   } else {
@@ -406,7 +406,7 @@ const double BulletRigidObject::getMargin() {
   }
 }
 
-const double BulletRigidObject::getMass() {
+double BulletRigidObject::getMass() {
   if (rigidObjectType_ == SCENE) {
     return 0.0;
   } else {
@@ -414,7 +414,7 @@ const double BulletRigidObject::getMass() {
   }
 }
 
-const Magnum::Vector3 BulletRigidObject::getCOM() {
+Magnum::Vector3 BulletRigidObject::getCOM() {
   // TODO: double check the position if there is any implicit transformation
   // done
   if (rigidObjectType_ == SCENE) {
@@ -427,7 +427,7 @@ const Magnum::Vector3 BulletRigidObject::getCOM() {
   }
 }
 
-const Magnum::Vector3 BulletRigidObject::getInertiaVector() {
+Magnum::Vector3 BulletRigidObject::getInertiaVector() {
   if (rigidObjectType_ == SCENE) {
     const Magnum::Vector3 inertia = Magnum::Vector3();
     return inertia;
@@ -438,7 +438,7 @@ const Magnum::Vector3 BulletRigidObject::getInertiaVector() {
   }
 }
 
-const Magnum::Matrix3 BulletRigidObject::getInertiaMatrix() {
+Magnum::Matrix3 BulletRigidObject::getInertiaMatrix() {
   if (rigidObjectType_ == SCENE) {
     const Magnum::Matrix3 inertia = Magnum::Matrix3();
     return inertia;
@@ -449,7 +449,7 @@ const Magnum::Matrix3 BulletRigidObject::getInertiaMatrix() {
   }
 }
 
-const double BulletRigidObject::getScale() {
+double BulletRigidObject::getScale() {
   if (rigidObjectType_ == SCENE) {
     return 1.0;
     // Assume uniform scale for 3D objects
@@ -458,7 +458,7 @@ const double BulletRigidObject::getScale() {
   }
 }
 
-const double BulletRigidObject::getFrictionCoefficient() {
+double BulletRigidObject::getFrictionCoefficient() {
   if (rigidObjectType_ == SCENE) {
     if (bSceneCollisionObjects_.size() == 0) {
       return 0.0;
@@ -471,7 +471,7 @@ const double BulletRigidObject::getFrictionCoefficient() {
   }
 }
 
-const double BulletRigidObject::getRestitutionCoefficient() {
+double BulletRigidObject::getRestitutionCoefficient() {
   // Assume uniform restitution in scene parts
   if (rigidObjectType_ == SCENE) {
     if (bSceneCollisionObjects_.size() == 0) {
@@ -484,7 +484,7 @@ const double BulletRigidObject::getRestitutionCoefficient() {
   }
 }
 
-const double BulletRigidObject::getLinearDamping() {
+double BulletRigidObject::getLinearDamping() {
   if (rigidObjectType_ == SCENE) {
     return 0.0;
   } else {
@@ -492,7 +492,7 @@ const double BulletRigidObject::getLinearDamping() {
   }
 }
 
-const double BulletRigidObject::getAngularDamping() {
+double BulletRigidObject::getAngularDamping() {
   if (rigidObjectType_ == SCENE) {
     return 0.0;
   } else {

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -50,17 +50,17 @@ class BulletRigidObject : public RigidObject {
   bool removeObject();
 
   //============ Getter/setter function =============
-  const double getMass();
-  const Magnum::Vector3 getCOM();
-  const Magnum::Vector3 getInertiaVector();
-  const Magnum::Matrix3 getInertiaMatrix();
-  const double getScale();
-  const double getFrictionCoefficient();
-  const double getRestitutionCoefficient();
-  const double getLinearDamping();
-  const double getAngularDamping();
+  double getMass();
+  Magnum::Vector3 getCOM();
+  Magnum::Vector3 getInertiaVector();
+  Magnum::Matrix3 getInertiaMatrix();
+  double getScale();
+  double getFrictionCoefficient();
+  double getRestitutionCoefficient();
+  double getLinearDamping();
+  double getAngularDamping();
   //! Return margin for object, -1.0 for scene
-  const double getMargin();
+  double getMargin();
 
   void setMass(const double mass);
   void setCOM(const Magnum::Vector3& COM);


### PR DESCRIPTION
## Motivation and Context

#91 introduced a lot of warnings.  This make debugging harder.  This PR deals with those warnings.
## How Has This Been Tested

It builds/compiles both with and without `--bullet`.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

