### PR TITLE
Whitelist the TARGET_HEADLESS CMake option for EGL platforms only.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,10 +230,15 @@ class CMakeBuild(build_ext):
             build_args += ["-j{}".format(self.parallel) if self.parallel else "-j"]
 
         cmake_args += [
-            "-DBUILD_GUI_VIEWERS={}".format("ON" if not args.headless else "OFF"),
-            # So Magnum itself prefers EGL over GLX for windowless apps
-            "-DTARGET_HEADLESS={}".format("ON" if args.headless else "OFF"),
+            "-DBUILD_GUI_VIEWERS={}".format("ON" if not args.headless else "OFF")
         ]
+
+        if sys.platform not in ["darwin", "win32", "win64"]:
+            cmake_args += [
+                # So Magnum itself prefers EGL over GLX for windowless apps.
+                # Makes sense only on platforms with EGL (Linux, BSD, ...).
+                "-DTARGET_HEADLESS={}".format("ON" if args.headless else "OFF")
+            ]
         # NOTE: BUILD_TEST is intentional as opposed to BUILD_TESTS which collides
         # with definition used by some of our dependencies
         cmake_args += ["-DBUILD_TEST={}".format("ON" if args.build_tests else "OFF")]


### PR DESCRIPTION
## Motivation and Context

As reported by @msbaines. Otherwise Mac `--headless` build breaks (and probably Windows build as
well).

## How Has This Been Tested

Looks correct to my eyes. Hope the CI agrees and @msbaines too.
