### PR TITLE
Better identify physics object initialization crash with empty library in example.py

### DIFF
--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -136,6 +136,11 @@ class DemoRunner:
         object_lib_size = self._sim.get_physics_object_library_size()
         object_init_grid_dim = (3, 1, 3)
         object_init_grid = {}
+        if object_lib_size == 0:
+            print(
+                " !!!No objects loaded in library, aborting object instancing example!!!"
+            )
+            assert object_lib_size > 0
         for obj_id in range(num_objects):
             rand_obj_index = random.randint(0, object_lib_size - 1)
             # rand_obj_index = 0  # overwrite for specific object only

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -136,11 +136,9 @@ class DemoRunner:
         object_lib_size = self._sim.get_physics_object_library_size()
         object_init_grid_dim = (3, 1, 3)
         object_init_grid = {}
-        if object_lib_size == 0:
-            print(
-                " !!!No objects loaded in library, aborting object instancing example!!!"
-            )
-            assert object_lib_size > 0
+        assert (
+            object_lib_size > 0
+        ), "!!!No objects loaded in library, aborting object instancing example!!!"
         for obj_id in range(num_objects):
             rand_obj_index = random.randint(0, object_lib_size - 1)
             # rand_obj_index = 0  # overwrite for specific object only


### PR DESCRIPTION


## Motivation and Context

"example.py --enable_physics" crashes trying to instance objects from an empty object library.

Currently, this occurs when acquiring a random objectID due to empty range in random. This fix better identifies the root of the issue as an empty library.

## How Has This Been Tested

Local test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
