### PR TITLE
Support ptex mesh - step 1: fix texture binding points, number of primitives.

### DIFF
--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -14,12 +14,11 @@ using namespace Corrade::Utility::String;
 AssetInfo AssetInfo::fromPath(const std::string& path) {
   AssetInfo info{AssetType::UNKNOWN, path};
 
-  if (endsWith(path, "semantic_quad_mesh.ply")) {
-    info.type = AssetType::FRL_INSTANCE_MESH;
-  } else if (endsWith(path, "_semantic.ply")) {
+  if (endsWith(path, "_semantic.ply")) {
     info.type = AssetType::INSTANCE_MESH;
-  } else if (endsWith(path, "ptex_quad_mesh.ply")) {
+  } else if (endsWith(path, "mesh.ply")) {
     info.type = AssetType::FRL_PTEX_MESH;
+    info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
   } else if (endsWith(path, "house.json")) {
     info.type = AssetType::SUNCG_SCENE;
   } else if (endsWith(path, ".glb")) {

--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -14,16 +14,10 @@ using namespace Corrade::Utility::String;
 AssetInfo AssetInfo::fromPath(const std::string& path) {
   AssetInfo info{AssetType::UNKNOWN, path};
 
-  if (endsWith(path, "mesh_semantic.ply")) {
-    info.type = AssetType::FRL_INSTANCE_MESH;
-  } else if (endsWith(path, "_semantic.ply")) {
-    ASSERT(!endsWith(path, "mesh_semantic.ply"));
+  if (endsWith(path, "_semantic.ply")) {
     info.type = AssetType::INSTANCE_MESH;
   } else if (endsWith(path, "mesh.ply")) {
     info.type = AssetType::FRL_PTEX_MESH;
-    // the gravity in replica dataset is -Z;
-    // create a coordinate for the mesh by rotating the default ESP
-    // coordinate frame to -Z gravity
     info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
   } else if (endsWith(path, "house.json")) {
     info.type = AssetType::SUNCG_SCENE;

--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -14,10 +14,16 @@ using namespace Corrade::Utility::String;
 AssetInfo AssetInfo::fromPath(const std::string& path) {
   AssetInfo info{AssetType::UNKNOWN, path};
 
-  if (endsWith(path, "_semantic.ply")) {
+  if (endsWith(path, "mesh_semantic.ply")) {
+    info.type = AssetType::FRL_INSTANCE_MESH;
+  } else if (endsWith(path, "_semantic.ply")) {
+    ASSERT(!endsWith(path, "mesh_semantic.ply"));
     info.type = AssetType::INSTANCE_MESH;
   } else if (endsWith(path, "mesh.ply")) {
     info.type = AssetType::FRL_PTEX_MESH;
+    // the gravity in replica dataset is -Z;
+    // create a coordinate for the mesh by rotating the default ESP
+    // coordinate frame to -Z gravity
     info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
   } else if (endsWith(path, "house.json")) {
     info.type = AssetType::SUNCG_SCENE;

--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -602,7 +602,8 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
                                   currentMesh->abo);
     currentMesh->abo.setData(adjFaces[iMesh],
                              Magnum::GL::BufferUsage::StaticDraw);
-    currentMesh->mesh.setPrimitive(Magnum::GL::MeshPrimitive::LinesAdjacency)
+    currentMesh->mesh
+        .setPrimitive(Magnum::GL::MeshPrimitive::LinesAdjacency)
         // Warning:
         // CANNOT use currentMesh.ibo.size() when calling
         // setCount because that returns the number of bytes of the buffer, NOT

--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -603,7 +603,11 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
     currentMesh->abo.setData(adjFaces[iMesh],
                              Magnum::GL::BufferUsage::StaticDraw);
     currentMesh->mesh.setPrimitive(Magnum::GL::MeshPrimitive::LinesAdjacency)
-        .setCount(currentMesh->ibo.size() / 2)
+        // Warning:
+        // CANNOT use currentMesh.ibo.size() when calling
+        // setCount because that returns the number of bytes of the buffer, NOT
+        // the index counts
+        .setCount(submeshes_[iMesh].ibo.size())
         .addVertexBuffer(currentMesh->vbo, 0, gfx::PTexMeshShader::Position{})
         .setIndexBuffer(currentMesh->ibo, 0,
                         Magnum::GL::MeshIndexType::UnsignedInt);

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -701,9 +701,8 @@ bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
   // if this is a new file, load it and add it to the dictionary
   const std::string& filename = info.filepath;
   if (resourceDict_.count(filename) == 0) {
-    const std::string atlasDir =
-        Corrade::Utility::String::stripSuffix(filename, "ptex_quad_mesh.ply") +
-        "ptex_textures";
+    const auto atlasDir = Corrade::Utility::Directory::join(
+        Corrade::Utility::Directory::path(filename), "textures");
 
     meshes_.emplace_back(std::make_unique<PTexMeshData>());
     int index = meshes_.size() - 1;
@@ -730,6 +729,8 @@ bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
 
       for (int jSubmesh = 0; jSubmesh < pTexMeshData->getSize(); ++jSubmesh) {
         scene::SceneNode& node = parent->createChild();
+        const quatf transform = info.frame.rotationFrameToWorld();
+        node.setRotation(Magnum::Quaternion(transform));
         new gfx::PTexMeshDrawable{node, *ptexShader, *pTexMeshData, jSubmesh,
                                   drawables};
       }

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -24,10 +24,10 @@ PTexMeshDrawable::PTexMeshDrawable(
 
 void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                             Magnum::SceneGraph::Camera3D& camera) {
-  adjTex_.bind(1);
   PTexMeshShader& ptexMeshShader = static_cast<PTexMeshShader&>(shader_);
-  ptexMeshShader.bindTexture(tex_, 0)
-      .setPTexUniforms(tex_, tileSize_, exposure_)
+  ptexMeshShader.setPTexUniforms(tex_, tileSize_, exposure_)
+      .bindAtlasTexture(tex_)
+      .bindAdjFacesBufferTexture(adjTex_)
       .setMVPMatrix(camera.projectionMatrix() * transformationMatrix);
   mesh_.draw(ptexMeshShader);
 }

--- a/src/esp/gfx/PTexMeshShader.cpp
+++ b/src/esp/gfx/PTexMeshShader.cpp
@@ -72,6 +72,9 @@ PTexMeshShader::PTexMeshShader() {
              TextureBindingPointIndex::adjFaces);
 }
 
+// Note: the texture binding points are explicitly specified above.
+// Cannot use "explicit uniform location" directly in shader since
+// it requires GL4.3 (We stick to GL4.1 for MacOS).
 PTexMeshShader& PTexMeshShader::bindAtlasTexture(
     Magnum::GL::Texture2D& texture) {
   texture.bind(TextureBindingPointIndex::atlas);

--- a/src/esp/gfx/PTexMeshShader.cpp
+++ b/src/esp/gfx/PTexMeshShader.cpp
@@ -33,6 +33,13 @@ using namespace Magnum;
 namespace esp {
 namespace gfx {
 
+namespace {
+enum TextureBindingPointIndex : uint8_t {
+  atlas = 0,
+  adjFaces = 1,
+};
+}
+
 PTexMeshShader::PTexMeshShader() {
   MAGNUM_ASSERT_GL_VERSION_SUPPORTED(GL::Version::GL410);
 
@@ -56,6 +63,25 @@ PTexMeshShader::PTexMeshShader() {
   attachShaders({vert, geom, frag});
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+  // set texture binding points in the shader;
+  // see ptex fragment shader code for details
+  setUniform(uniformLocation("atlasTex"), TextureBindingPointIndex::atlas);
+  // TODO: disable the "meshAdjFaces" on Mac
+  setUniform(uniformLocation("meshAdjFaces"),
+             TextureBindingPointIndex::adjFaces);
+}
+
+PTexMeshShader& PTexMeshShader::bindAtlasTexture(
+    Magnum::GL::Texture2D& texture) {
+  texture.bind(TextureBindingPointIndex::atlas);
+  return *this;
+}
+
+PTexMeshShader& PTexMeshShader::bindAdjFacesBufferTexture(
+    Magnum::GL::BufferTexture& texture) {
+  texture.bind(TextureBindingPointIndex::adjFaces);
+  return *this;
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/PTexMeshShader.h
+++ b/src/esp/gfx/PTexMeshShader.h
@@ -28,12 +28,10 @@ class PTexMeshShader : public Magnum::GL::AbstractShaderProgram {
   explicit PTexMeshShader();
 
   // ======== texture binding ========
-  // Note: the texture binding points are explicitly specified in .cpp
-  // Cannot use "explicit uniform location" directly in shader since
-  // it requires GL4.3 (We stick to GL4.1 for MacOS).
   PTexMeshShader& bindAtlasTexture(Magnum::GL::Texture2D& texture);
   PTexMeshShader& bindAdjFacesBufferTexture(Magnum::GL::BufferTexture& texture);
 
+  // ======== set uniforms ===========
   PTexMeshShader& setMVPMatrix(const Magnum::Matrix4& matrix) {
     setUniform(uniformLocation("MVP"), matrix);
     return *this;

--- a/src/esp/gfx/PTexMeshShader.h
+++ b/src/esp/gfx/PTexMeshShader.h
@@ -27,13 +27,12 @@ class PTexMeshShader : public Magnum::GL::AbstractShaderProgram {
 
   explicit PTexMeshShader();
 
-   // ======== texture binding ========
+  // ======== texture binding ========
   // Note: the texture binding points are explicitly specified in .cpp
   // Cannot use "explicit uniform location" directly in shader since
   // it requires GL4.3 (We stick to GL4.1 for MacOS).
   PTexMeshShader& bindAtlasTexture(Magnum::GL::Texture2D& texture);
   PTexMeshShader& bindAdjFacesBufferTexture(Magnum::GL::BufferTexture& texture);
-
 
   PTexMeshShader& setMVPMatrix(const Magnum::Matrix4& matrix) {
     setUniform(uniformLocation("MVP"), matrix);

--- a/src/esp/gfx/PTexMeshShader.h
+++ b/src/esp/gfx/PTexMeshShader.h
@@ -27,11 +27,13 @@ class PTexMeshShader : public Magnum::GL::AbstractShaderProgram {
 
   explicit PTexMeshShader();
 
-  PTexMeshShader& bindTexture(Magnum::GL::Texture2D& texture,
-                              uint32_t textureUnit = 0) {
-    texture.bind(textureUnit);
-    return *this;
-  }
+   // ======== texture binding ========
+  // Note: the texture binding points are explicitly specified in .cpp
+  // Cannot use "explicit uniform location" directly in shader since
+  // it requires GL4.3 (We stick to GL4.1 for MacOS).
+  PTexMeshShader& bindAtlasTexture(Magnum::GL::Texture2D& texture);
+  PTexMeshShader& bindAdjFacesBufferTexture(Magnum::GL::BufferTexture& texture);
+
 
   PTexMeshShader& setMVPMatrix(const Magnum::Matrix4& matrix) {
     setUniform(uniformLocation("MVP"), matrix);


### PR DESCRIPTION
We would like to support ptex mesh rendering in our simulator.

Status before step 1:
Code was implemented, no compile error; 
Cannot render the ptex mesh in the utility viewer or in headless mode;
The viewer can be run but returns a black screen;

In this PR:
-) it fixes the texture binding points for adjFaces (buffer texture) and atlas textures;
-) it sets correct number of primitives when setup the magnum;
-) it updates the Asset.cpp to recognize the ptex mesh in publicly released Replica data set;

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1st step to support ptex mesh rendering
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local. No compile error.
If would eventually work (tested in #132) once all the mandatory fix are done.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
