### PR TITLE
Call torch.cuda.set_device

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -288,6 +288,7 @@ class Sensor:
                 import torch
 
             device = torch.device("cuda", self._sim.gpu_device)
+            torch.cuda.set_device(device)
 
             resolution = self._spec.resolution
             if self._spec.sensor_type == hsim.SensorType.SEMANTIC:


### PR DESCRIPTION
## Motivation and Context

On a multi-gpu system, it seems like you need to call `torch.cuda.set_device(device)` so that the cuda runtime environment gets loaded only on the intended device (otherwise it seems to get loaded on both the intended device and GPU 0).

## How Has This Been Tested

Locally.  Without this fix, every process would eventually load cuda runtime on GPU0 even tho I am trying to use just GPU1.  With this, GPU0 stays clean.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)

