### PR TITLE
Support ptex mesh - Step 2: fix the shader

### DIFF
--- a/src/shaders/ptex-default-gl410.frag
+++ b/src/shaders/ptex-default-gl410.frag
@@ -1,6 +1,6 @@
 uniform int tileSize;
 uniform int widthInTiles;
-uniform samplerBuffer meshAdjFaces;
+uniform usamplerBuffer meshAdjFaces;
 
 ivec2 FaceToAtlasPos(int faceID, int tileSize) {
   ivec2 tilePos;
@@ -29,7 +29,7 @@ const uint FACE_MASK = 0x3FFFFFFF;
 
 int GetAdjFace(int face, int edge, out int rot) {
   // uint data = meshAdjFaces[face * 4 + edge];
-  uint data = uint(texelFetch(meshAdjFaces, face * 4 + edge));
+  uint data = texelFetch(meshAdjFaces, face * 4 + edge).r;
   rot = int(data >> ROTATION_SHIFT);
   return int(data & FACE_MASK);
 }

--- a/src/shaders/ptex-default-gl410.geom
+++ b/src/shaders/ptex-default-gl410.geom
@@ -6,8 +6,12 @@ out vec2 uv;
 void main() {
   gl_PrimitiveID = gl_PrimitiveIDIn;
 
-  uv = vec2(1.0, 0.0);
-  gl_Position = gl_in[1].gl_Position;
+  // the triangle trip generated is (3, 0, 2, 1),
+  // which is is different from replicaSDK.
+  // The winding of the two triangles (3, 0, 2) and (2, 0, 1)
+  // is CCW.
+  uv = vec2(0.0, 1.0);
+  gl_Position = gl_in[3].gl_Position;
   EmitVertex();
 
   uv = vec2(0.0, 0.0);
@@ -18,8 +22,8 @@ void main() {
   gl_Position = gl_in[2].gl_Position;
   EmitVertex();
 
-  uv = vec2(0.0, 1.0);
-  gl_Position = gl_in[3].gl_Position;
+  uv = vec2(1.0, 0.0);
+  gl_Position = gl_in[1].gl_Position;
   EmitVertex();
 
   EndPrimitive();

--- a/src/shaders/ptex-default-gl410.geom
+++ b/src/shaders/ptex-default-gl410.geom
@@ -6,8 +6,8 @@ out vec2 uv;
 void main() {
   gl_PrimitiveID = gl_PrimitiveIDIn;
 
-  // the triangle trip generated is (3, 0, 2, 1),
-  // which is is different from replicaSDK.
+  // the triangle strip generated is (3, 0, 2, 1),
+  // which is different from replicaSDK.
   // The winding of the two triangles (3, 0, 2) and (2, 0, 1)
   // is CCW.
   uv = vec2(0.0, 1.0);


### PR DESCRIPTION
This PR is to
-) fix the winding of triangles in the geometry shader;
-) apply correct uv;
-) use a more standard way to read data from the buffer texture;

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To support ptex mesh rendering in our simulator
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local on Mac and Linux. See details at #132 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
