### PR TITLE
Support ptex mesh - step 4: load and set atlas textures correctly

### DIFF
--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -12,8 +12,10 @@
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Containers/ArrayViewStl.h>
+#include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/GL/BufferTextureFormat.h>
+#include <Magnum/GL/TextureFormat.h>
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
 
@@ -614,28 +616,40 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
                         Magnum::GL::MeshIndexType::UnsignedInt);
   }
 
+  // load atlas data and upload them to GPU
+  LOG(INFO) << "loading atlas textures: ";
   for (size_t iMesh = 0; iMesh < renderingBuffers_.size(); ++iMesh) {
-    const std::string rgbFile =
-        atlasFolder_ + "/" + std::to_string(iMesh) + "-color-ptex.rgb";
-    if (!io::exists(rgbFile)) {
-      ASSERT(false, "Can't find " + rgbFile);
-    }
-    LOG(INFO) << "\rLoading atlas " << iMesh + 1 << "/"
-              << renderingBuffers_.size() << "... ";
-    LOG(INFO).flush();
+    const std::string hdrFile = Corrade::Utility::Directory::join(
+        atlasFolder_, std::to_string(iMesh) + "-color-ptex.hdr");
 
-    Cr::Containers::Array<const char, Cr::Utility::Directory::MapDeleter> data =
-        Cr::Utility::Directory::mapRead(rgbFile);
-    const int dim = static_cast<int>(std::sqrt(data.size() / 3));  // square
-    Magnum::ImageView2D image(Magnum::PixelFormat::RGB8UI, {dim, dim}, data);
+    CORRADE_ASSERT(io::exists(hdrFile), "Error : Cannot find the .hdr file ", );
+
+    LOG(INFO) << "Loading atlas " << iMesh + 1 << "/"
+              << renderingBuffers_.size() << " from " << hdrFile << ". ";
+
+    Corrade::Containers::Array<const char,
+                               Corrade::Utility::Directory::MapDeleter>
+        data = Corrade::Utility::Directory::mapRead(hdrFile);
+    // divided by 6, since there are 3 channels, R, G, B, each of which takes 1
+    // half_float (2 bytes)
+    const int dim = static_cast<int>(std::sqrt(data.size() / 6));  // square
+
+    // atlas
+    // the size of each image is dim x dim x 3 (RGB) x 2 (half_float), which
+    // equals to numBytes
+    Magnum::ImageView2D image(Magnum::PixelFormat::RGB16F, {dim, dim}, data);
+    const int mipLevelCount = Magnum::Math::log2(image.size().min()) + 1;
+    const int mipLevel = 0;
+
     renderingBuffers_[iMesh]
         ->tex.setWrapping(Magnum::GL::SamplerWrapping::ClampToEdge)
         .setMagnificationFilter(Magnum::GL::SamplerFilter::Linear)
         .setMinificationFilter(Magnum::GL::SamplerFilter::Linear)
-        // .setStorage(1, GL::TextureFormat::RGB8UI, image.size())
-        .setSubImage(0, {}, image);
+        .setStorage(mipLevelCount, Magnum::GL::TextureFormat::RGB16F,
+                    image.size())
+        .setSubImage(mipLevel, {}, image)
+        .generateMipmap();
   }
-  LOG(INFO) << "... done" << std::endl;
 
   buffersOnGPU_ = true;
 }


### PR DESCRIPTION
## Motivation and Context
This PR is to load and set the atlas textures (.hdr files) in correct format using magnum;

<!--- Why is this change required? What problem does it solve? -->
Must-have for rendering pets meshes

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
local (see #132)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
