### PR TITLE
Speedup incremental build of WebGL

### DIFF
--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -14,12 +14,21 @@ target_link_libraries(hsim_bindings
 
 set_target_properties(hsim_bindings PROPERTIES LINK_FLAGS "--bind")
 
-# copy JS/HTML/CSS scaffolding for WebGL build
-install(FILES
-  bindings.html
-  bindings.css
-  navigate.js
-  simenv_embind.js
-  ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
-  ${MAGNUM_WEBAPPLICATION_CSS}
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+# copy JS/HTML/CSS resources for WebGL build
+set(resources
+    bindings.html
+    bindings.css
+    navigate.js
+    simenv_embind.js
+    ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
+    ${MAGNUM_WEBAPPLICATION_CSS}
+)
+
+foreach(resource ${resources})
+  get_filename_component(filename ${resource} NAME)
+  get_filename_component(path ${resource} ABSOLUTE)
+  add_custom_command(
+      TARGET hsim_bindings POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E create_symlink
+          ${path} ${CMAKE_CURRENT_BINARY_DIR}/${filename})
+endforeach()


### PR DESCRIPTION
Currently an incremental build requires an install which requires
all targets be built. By avoid an install, I can avoid building
the viewer.js target, cutting my incremental build time in half.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Currently an incremental build requires an install which requires
all targets be built. By avoid an install, I can avoid building
the viewer.js target, cutting my incremental build time in half.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
