### PR TITLE
Fix resource manager load times.

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -135,7 +135,6 @@ class ResourceManager {
   //! (2) upload mesh to gpu and drawables
   //! (optional reload of GPU-side assets)
   void addComponent(Importer& importer,
-                    const AssetInfo& info,
                     const MeshMetaData& metaData,
                     scene::SceneNode& parent,
                     DrawableGroup* drawables,


### PR DESCRIPTION
## Motivation and Context

The resource manager calls `importer.openFile` a whole bunch.  This causes the MP3D meshes take 30 minutes to load.

I made `addComponent` expected that `importer.openFile(info.filepath);` was already called and removed `const AssetInfo& info` from the signature to as `importer.openFile(info.filepath);` was the only thing using that arg.

## How Has This Been Tested

Via tests and with the viewer in physics mode.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)

