### PR TITLE
Blit to defaultFrameBuffer to directly render in EmScripten Build

### DIFF
--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -393,6 +393,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
            "Reads RGBA frame into passed img in uint8 byte format.")
       .def("read_frame_depth", &RenderTarget::readFrameDepth)
       .def("read_frame_object_id", &RenderTarget::readFrameObjectId)
+      .def("blit_rgba_to_default", &RenderTarget::blitRgbaToDefault)
 #ifdef ESP_BUILD_WITH_CUDA
       .def("read_frame_rgba_gpu",
            [](RenderTarget& self, size_t devPtr) {

--- a/src/esp/bindings_js/bindings.html
+++ b/src/esp/bindings_js/bindings.html
@@ -15,8 +15,7 @@
     <div id="sizer">
       <div id="expander">
         <div id="listener">
-          <canvas class="hidden" id="canvas"></canvas>
-          <canvas id="canvas2d" width="640" height="480" style="transform: scaleY(-1)"></canvas>
+          <canvas id="canvas" width="640" height="480"></canvas>
           <canvas id="semantic" width="640" height="480" style="transform: scaleY(-1)"></canvas>
           <canvas id="radar"></canvas>
           <pre id="log"></pre>
@@ -86,7 +85,7 @@
       const simenv = new SimEnv(config, episode, 0);
       const agent = simenv.addAgent(agentConfig);
       const task = new NavigateTask(simenv, {
-        canvas: document.getElementById('canvas2d'),
+        canvas: document.getElementById('canvas'),
         semantic: document.getElementById('semantic'),
         radar: document.getElementById('radar'),
         status: document.getElementById('status')

--- a/src/esp/bindings_js/bindings_js.cpp
+++ b/src/esp/bindings_js/bindings_js.cpp
@@ -225,6 +225,7 @@ EMSCRIPTEN_BINDINGS(habitat_sim_bindings_js) {
                 &SimulatorWithAgents::getAgentObservations)
       .function("getAgentObservation",
                 &SimulatorWithAgents::getAgentObservation)
+      .function("displayObservation", &SimulatorWithAgents::displayObservation)
       .function("getAgentObservationSpaces",
                 &Simulator_getAgentObservationSpaces)
       .function("getAgentObservationSpace", &Simulator_getAgentObservationSpace)

--- a/src/esp/bindings_js/navigate.js
+++ b/src/esp/bindings_js/navigate.js
@@ -56,9 +56,7 @@ class NavigateTask {
   }
 
   renderImage() {
-    // Not using this as of now, but useful for later tracking purposes
-    // Also, required to render everything on sim side
-    this.lastObs = this.sim.getObservation("rgb", null);
+    this.sim.displayObservation("rgb");
     this.renderRadar();
   }
 

--- a/src/esp/bindings_js/navigate.js
+++ b/src/esp/bindings_js/navigate.js
@@ -55,12 +55,6 @@ class NavigateTask {
     this.components.status.innerHTML = text;
   }
 
-  applyGamma(data, gamma) {
-    for (let i = 0; i < data.length; i++) {
-      data[i] = Math.pow(data[i]/255.0, gamma) * 255;
-    }
-  }
-
   renderImage() {
     // Not using this as of now, but useful for later tracking purposes
     // Also, required to render everything on sim side
@@ -69,6 +63,10 @@ class NavigateTask {
   }
 
   renderSemanticImage() {
+    if (this.semanticObjects.size() == 0) {
+      return;
+    }
+
     const obs = this.sim.getObservation("semantic", null);
     this.semantic_data = obs.getData();
     let data = this.semantic_data;
@@ -76,19 +74,19 @@ class NavigateTask {
     // TOOD(msb) implement a better colorization scheme
     for (let i = 0; i < 640*480; i++) {
       if (data[i*4] & 1) {
-	this.semanticImageData.data[i*4] = 255;
+        this.semanticImageData.data[i*4] = 255;
       } else {
-	this.semanticImageData.data[i*4] = 0;
+        this.semanticImageData.data[i*4] = 0;
       }
       if (data[i*4] & 2) {
-	this.semanticImageData.data[i*4+1] = 255;
+        this.semanticImageData.data[i*4+1] = 255;
       } else {
-	this.semanticImageData.data[i*4+1] = 0;
+        this.semanticImageData.data[i*4+1] = 0;
       }
       if (data[i*4] & 4) {
-	this.semanticImageData.data[i*4+2] = 255;
+        this.semanticImageData.data[i*4+2] = 255;
       } else {
-	this.semanticImageData.data[i*4+2] = 0;
+        this.semanticImageData.data[i*4+2] = 0;
       }
       this.semanticImageData.data[i*4 + 3] = 255;
     }
@@ -131,9 +129,7 @@ class NavigateTask {
 
   render() {
     this.renderImage();
-    if (this.semanticObjects.size() > 0) {
-      this.renderSemanticImage();
-    }
+    this.renderSemanticImage();
   }
 
   handleAction(action) {

--- a/src/esp/bindings_js/navigate.js
+++ b/src/esp/bindings_js/navigate.js
@@ -12,9 +12,8 @@ class NavigateTask {
   constructor(sim, components) {
     this.sim = sim;
     this.components = components;
-    this.imageCtx = components.canvas.getContext("2d");
+    this.lastObs = null;
     let shape = this.sim.getObservationSpace("rgb").shape;
-    this.imageData = this.imageCtx.createImageData(shape.get(1), shape.get(0));
     this.semanticCtx = components.semantic.getContext("2d");
     shape = this.sim.getObservationSpace("semantic").shape;
     this.semanticImageData = this.semanticCtx.createImageData(shape.get(1), shape.get(0));
@@ -63,11 +62,9 @@ class NavigateTask {
   }
 
   renderImage() {
-    const obs = this.sim.getObservation("rgb", null);
-    this.imageData.data.set(obs.getData());
-    // convert from linear to sRGB gamma
-    this.applyGamma(this.imageData.data, 2.2);
-    this.imageCtx.putImageData(this.imageData, 0, 0);
+    // Not using this as of now, but useful for later tracking purposes
+    // Also, required to render everything on sim side
+    this.lastObs = this.sim.getObservation("rgb", null);
     this.renderRadar();
   }
 
@@ -134,9 +131,9 @@ class NavigateTask {
 
   render() {
     this.renderImage();
-    if (this.semanticObjects.size() > 0)
+    if (this.semanticObjects.size() > 0) {
       this.renderSemanticImage();
-    this.renderRadar();
+    }
   }
 
   handleAction(action) {

--- a/src/esp/bindings_js/navigate.js
+++ b/src/esp/bindings_js/navigate.js
@@ -12,7 +12,6 @@ class NavigateTask {
   constructor(sim, components) {
     this.sim = sim;
     this.components = components;
-    this.lastObs = null;
     let shape = this.sim.getObservationSpace("rgb").shape;
     this.semanticCtx = components.semantic.getContext("2d");
     shape = this.sim.getObservationSpace("semantic").shape;

--- a/src/esp/bindings_js/simenv_embind.js
+++ b/src/esp/bindings_js/simenv_embind.js
@@ -1,5 +1,8 @@
 /**
  * SimEnv class
+ *
+ * TODO(aps,msb) - Add support for multiple agents instead of
+ * hardcoding 0th one.
  */
 class SimEnv {
   // PUBLIC methods.
@@ -61,6 +64,15 @@ class SimEnv {
     const obs = new Module.Observation();
     this.sim.getAgentObservation(0, sensorId, obs);
     return obs;
+  }
+
+  /**
+   * Display an observation from the given sensorId
+   * to canvas selected as default frame buffer.
+   * @param {number} sensorId - id of sensor
+   */
+  displayObservation(sensorId) {
+    this.sim.displayObservation(0, sensorId);
   }
 
   /**

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -116,10 +116,13 @@ struct RenderTarget::Impl {
 
   void blitRgbaToDefault() {
     GL::defaultFramebuffer.clearColor(Color4{1, 0, 0, 1});
-    GL::defaultFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth).bind();
+    GL::defaultFramebuffer
+        .clear(GL::FramebufferClear::Color | GL::FramebufferClear::Depth)
+        .bind();
     framebuffer_.mapForRead(RgbaBuffer);
     GL::AbstractFramebuffer::blit(framebuffer_, GL::defaultFramebuffer,
-      {{}, framebufferSize()}, GL::FramebufferBlit::Color);
+                                  {{}, framebufferSize()},
+                                  GL::FramebufferBlit::Color);
   }
 
   void readFrameRgba(const MutableImageView2D& view) {

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -115,10 +115,6 @@ struct RenderTarget::Impl {
   void renderExit() {}
 
   void blitRgbaToDefault() {
-    GL::defaultFramebuffer.clearColor(Color4{1, 0, 0, 1});
-    GL::defaultFramebuffer
-        .clear(GL::FramebufferClear::Color | GL::FramebufferClear::Depth)
-        .bind();
     framebuffer_.mapForRead(RgbaBuffer);
     GL::AbstractFramebuffer::blit(framebuffer_, GL::defaultFramebuffer,
                                   {{}, framebufferSize()},

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -114,6 +114,14 @@ struct RenderTarget::Impl {
 
   void renderExit() {}
 
+  void blitRgbaToDefault() {
+    GL::defaultFramebuffer.clearColor(Color4{1, 0, 0, 1});
+    GL::defaultFramebuffer.clear(GL::FramebufferClear::Color|GL::FramebufferClear::Depth).bind();
+    framebuffer_.mapForRead(RgbaBuffer);
+    GL::AbstractFramebuffer::blit(framebuffer_, GL::defaultFramebuffer,
+      {{}, framebufferSize()}, GL::FramebufferBlit::Color);
+  }
+
   void readFrameRgba(const MutableImageView2D& view) {
     framebuffer_.mapForRead(RgbaBuffer).read(framebuffer_.viewport(), view);
   }
@@ -261,6 +269,10 @@ void RenderTarget::readFrameDepth(const Magnum::MutableImageView2D& view) {
 
 void RenderTarget::readFrameObjectId(const Magnum::MutableImageView2D& view) {
   pimpl_->readFrameObjectId(view);
+}
+
+void RenderTarget::blitRgbaToDefault() {
+  pimpl_->blitRgbaToDefault();
 }
 
 Magnum::Vector2i RenderTarget::framebufferSize() const {

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -95,6 +95,12 @@ class RenderTarget {
    */
   void readFrameObjectId(const Magnum::MutableImageView2D& view);
 
+  /**
+   * @brief Blits the rgba buffer from internal FBO to default frame buffer
+   * which in case of EmscriptenApplication will be a canvas element.
+   */
+  void blitRgbaToDefault();
+
   // @brief Delete copy Constructor
   RenderTarget(const RenderTarget&) = delete;
   // @brief Delete copy operator

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -53,16 +53,15 @@ bool PinholeCamera::getObservation(gfx::Simulator& sim, Observation& obs) {
   if (!hasRenderTarget())
     return false;
 
-  renderTarget().renderEnter();
-
   drawObservation(sim);
   readObservation(obs);
 
-  renderTarget().renderExit();
   return true;
 }
 
 void PinholeCamera::drawObservation(gfx::Simulator& sim) {
+  renderTarget().renderEnter();
+
   gfx::Renderer::ptr renderer = sim.getRenderer();
   if (spec_->sensorType == SensorType::SEMANTIC) {
     // TODO: check sim has semantic scene graph
@@ -71,6 +70,8 @@ void PinholeCamera::drawObservation(gfx::Simulator& sim) {
     // SensorType is DEPTH or any other type
     renderer->draw(*this, sim.getActiveSceneGraph());
   }
+
+  renderTarget().renderExit();
 }
 
 void PinholeCamera::readObservation(Observation& obs) {

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -2,10 +2,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/configure.h>
+#include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
-#include <Magnum/GL/DefaultFramebuffer.h>
-#include <Corrade/configure.h>
 
 #include "PinholeCamera.h"
 #include "esp/gfx/DepthUnprojection.h"
@@ -19,9 +19,9 @@ PinholeCamera::PinholeCamera(scene::SceneNode& pinholeCameraNode,
                              sensor::SensorSpec::ptr spec)
     : sensor::Sensor(pinholeCameraNode, spec) {
   setProjectionParameters(spec);
-  #if defined(CORRADE_TARGET_EMSCRIPTEN)
-    is_webgl_build_ = true;
-  #endif
+#ifdef CORRADE_TARGET_EMSCRIPTEN
+  is_webgl_build_ = true;
+#endif
 }
 
 void PinholeCamera::setProjectionParameters(SensorSpec::ptr spec) {

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -4,6 +4,8 @@
 
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
+#include <Magnum/GL/DefaultFramebuffer.h>
+#include <Corrade/configure.h>
 
 #include "PinholeCamera.h"
 #include "esp/gfx/DepthUnprojection.h"
@@ -17,6 +19,9 @@ PinholeCamera::PinholeCamera(scene::SceneNode& pinholeCameraNode,
                              sensor::SensorSpec::ptr spec)
     : sensor::Sensor(pinholeCameraNode, spec) {
   setProjectionParameters(spec);
+  #if defined(CORRADE_TARGET_EMSCRIPTEN)
+    is_webgl_build_ = true;
+  #endif
 }
 
 void PinholeCamera::setProjectionParameters(SensorSpec::ptr spec) {
@@ -91,6 +96,9 @@ bool PinholeCamera::getObservation(gfx::Simulator& sim, Observation& obs) {
 
   renderTarget().renderExit();
 
+  if (is_webgl_build_) {
+    renderTarget().blitRgbaToDefault();
+  }
   return true;
 }
 

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -70,7 +70,6 @@ class PinholeCamera : public Sensor {
   float near_ = 0.001f;  // near clipping plane
   float far_ = 1000.0f;  // far clipping plane
   float hfov_ = 35.0f;   // field of vision (in degrees)
-  bool is_webgl_build_ = false;
 
   ESP_SMART_POINTERS(PinholeCamera)
 };

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -42,20 +42,6 @@ class PinholeCamera : public Sensor {
   virtual bool displayObservation(gfx::Simulator& sim) override;
 
   /**
-   * @brief Draw an observation using simulator's renderer
-   * @param[in] sim Instance of Simulator class for which the observation needs
-   *                to be drawn
-   */
-  void drawObservation(gfx::Simulator& sim);
-
-  /**
-   * @brief Read the observation that was rendered by the simulator
-   * @param[in,out] obs Instance of Observation class in which the observation
-   *                    will be stored
-   */
-  void readObservation(Observation& obs);
-
-  /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
    * perspective projection model.
    * See @ref gfx::calculateDepthUnprojection
@@ -72,6 +58,20 @@ class PinholeCamera : public Sensor {
   float hfov_ = 35.0f;   // field of vision (in degrees)
 
   ESP_SMART_POINTERS(PinholeCamera)
+
+  /**
+   * @brief Draw an observation using simulator's renderer
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be drawn
+   */
+  void drawObservation(gfx::Simulator& sim);
+
+  /**
+   * @brief Read the observation that was rendered by the simulator
+   * @param[in,out] obs Instance of Observation class in which the observation
+   *                    will be stored
+   */
+  void readObservation(Observation& obs);
 };
 
 }  // namespace sensor

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -36,8 +36,13 @@ class PinholeCamera : public Sensor {
   virtual void setProjectionMatrix(gfx::RenderCamera& targetCamera) override;
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs) override;
+
   virtual bool getObservationSpace(ObservationSpace& space) override;
 
+  virtual bool displayObservation(gfx::Simulator& sim) override;
+
+  void drawObservation(gfx::Simulator& sim);
+  void readObservation(Observation& obs);
   /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
    * perspective projection model.

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -53,6 +53,7 @@ class PinholeCamera : public Sensor {
   float near_ = 0.001f;  // near clipping plane
   float far_ = 1000.0f;  // far clipping plane
   float hfov_ = 35.0f;   // field of vision (in degrees)
+  bool is_webgl_build_ = false;
 
   ESP_SMART_POINTERS(PinholeCamera)
 };

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -41,8 +41,20 @@ class PinholeCamera : public Sensor {
 
   virtual bool displayObservation(gfx::Simulator& sim) override;
 
+  /**
+   * @brief Draw an observation using simulator's renderer
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be drawn
+   */
   void drawObservation(gfx::Simulator& sim);
+
+  /**
+   * @brief Read the observation that was rendered by the simulator
+   * @param[in,out] obs Instance of Observation class in which the observation
+   *                    will be stored
+   */
   void readObservation(Observation& obs);
+
   /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
    * perspective projection model.

--- a/src/esp/sensor/Sensor.cpp
+++ b/src/esp/sensor/Sensor.cpp
@@ -30,6 +30,11 @@ bool Sensor::getObservationSpace(ObservationSpace& space) {
   return false;
 }
 
+bool Sensor::displayObservation(gfx::Simulator& sim) {
+  // TODO fill out display observation if sensor supports it
+  return false;
+}
+
 void SensorSuite::add(Sensor::ptr sensor) {
   const std::string uuid = sensor->specification()->uuid;
   sensors_[uuid] = sensor;

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -119,6 +119,7 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs);
   virtual bool getObservationSpace(ObservationSpace& space);
+  virtual bool displayObservation(gfx::Simulator& sim);
 
   /**
    * @brief Returns the parameters needed to unproject depth for the sensor.

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -119,6 +119,13 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs);
   virtual bool getObservationSpace(ObservationSpace& space);
+
+  /**
+   * @brief Display next observation from Simulator on default frame buffer
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be displayed
+   * @return Whether the display process was successful or not
+   */
   virtual bool displayObservation(gfx::Simulator& sim);
 
   /**

--- a/src/esp/sim/SimulatorWithAgents.cpp
+++ b/src/esp/sim/SimulatorWithAgents.cpp
@@ -120,6 +120,19 @@ nav::PathFinder::ptr SimulatorWithAgents::getPathFinder() {
   return pathfinder_;
 }
 
+bool SimulatorWithAgents::displayObservation(int agentId,
+                                             const std::string& sensorId) {
+  agent::Agent::ptr ag = getAgent(agentId);
+
+  if (ag != nullptr) {
+    sensor::Sensor::ptr sensor = ag->getSensorSuite().get(sensorId);
+    if (sensor != nullptr) {
+      return sensor->displayObservation(*this);
+    }
+  }
+  return false;
+}
+
 bool SimulatorWithAgents::getAgentObservation(
     int agentId,
     const std::string& sensorId,

--- a/src/esp/sim/SimulatorWithAgents.h
+++ b/src/esp/sim/SimulatorWithAgents.h
@@ -29,6 +29,7 @@ class SimulatorWithAgents : public gfx::Simulator {
                              scene::SceneNode& agentParentNode);
   agent::Agent::ptr addAgent(const agent::AgentConfiguration& agentConfig);
 
+  bool displayObservation(int agentId, const std::string& sensorId);
   bool getAgentObservation(int agentId,
                            const std::string& sensorId,
                            sensor::Observation& observation);

--- a/src/esp/sim/SimulatorWithAgents.h
+++ b/src/esp/sim/SimulatorWithAgents.h
@@ -29,6 +29,14 @@ class SimulatorWithAgents : public gfx::Simulator {
                              scene::SceneNode& agentParentNode);
   agent::Agent::ptr addAgent(const agent::AgentConfiguration& agentConfig);
 
+  /**
+   * @brief Displays observations on default frame buffer for a
+   * particular sensor of an agent
+   * @param agentId    Id of the agent for which the observation is to
+   *                   be returned
+   * @param sensorId   Id of the sensor for which the observation is to
+   *                   be returned
+   */
   bool displayObservation(int agentId, const std::string& sensorId);
   bool getAgentObservation(int agentId,
                            const std::string& sensorId,


### PR DESCRIPTION
## Motivation and Context

In our Web demo, we are currently taking observation from Simulator and then pasting it on 2d canvas which is very slow. In this change, we directly blit the offscreen render target's RGBA buffer to default frame buffer which will render in the browser as canvas. This also removes custom rendering code on frontend side and relies totally on simulator now to provide that information.

## How Has This Been Tested

./build_js.sh and then manually testing in browser

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
