### PR TITLE
Support JS formatting and linting through ESLint and Prettier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,19 @@ jobs:
           name: run clang-format
           command: |
             find . -not -path "*/\.*" -not -path "*/deps/*" -not -path "*/obsolete/*" -not -path "*/build/*" | grep -E ".*\.cpp$|.*\.h$|.*\.cu$|.*\.hpp$" | xargs -I {} bash -c "diff -u <(cat {}) <(clang-format -style=file {})"
-
+  js_lint:
+    docker:
+      - image: circleci/node:11.9
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: |
+            npm install
+      - run:
+          name: run eslint
+          command: |
+            npm run lint
   install_and_test_ubuntu:
     <<: *gpu
     steps:
@@ -261,4 +273,5 @@ workflows:
     jobs:
       - python_lint
       - cpp_lint
+      - js_lint
       - install_and_test_ubuntu

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2018,
+    "sourceType": "module"
   },
   "rules": {
     "no-console": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "plugins": [
+    "html"
+  ],
   "env": {
     "browser": true,
     "commonjs": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "node": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
+  "rules": {
+    "no-console": "off",
+    "strict": ["error", "global"],
+    "curly": "warn",
+    "prettier/prettier": "error"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,11 @@ build_js/
 build_corrade-rc/
 
 .setuppy_args_cache.json
+
+# JS
+node_modules/
+package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,8 @@ repos:
     -   id: eslint
         args: [--fix, --ext .html,.js]
         additional_dependencies:
-        -   eslint@6.4.0
-        -   eslint-config-prettier@6.3.0
-        -   eslint-plugin-prettier@3.1.0
-        -   prettier@1.18.2
+        - eslint@6.4.0
+        - eslint-config-prettier@6.3.0
+        - eslint-plugin-prettier@3.1.0
+        - eslint-plugin-html@6.0.0
+        - prettier@1.18.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     rev: v6.4.0
     hooks:
     -   id: eslint
+        args: ['--fix', '--ext .html,.js']
         additional_dependencies:
         -   eslint@6.4.0
         -   eslint-config-prettier@6.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,13 @@ repos:
       types: [text]
       files: '.*\.cpp|.*\.h'
       language: system
+
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v6.4.0
+    hooks:
+    -   id: eslint
+        additional_dependencies:
+        -   eslint@6.4.0
+        -   eslint-config-prettier@6.3.0
+        -   eslint-plugin-prettier@3.1.0
+        -   prettier@1.18.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: v6.4.0
     hooks:
     -   id: eslint
-        args: ['--fix', '--ext .html,.js']
+        args: [--fix, --ext .html,.js]
         additional_dependencies:
         -   eslint@6.4.0
         -   eslint-config-prettier@6.3.0

--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ We use `black` and `isort` for linting and code style of python code.
 Install `black` and `isort` through `pip install -U black isort`.
 They can then be ran via `black .` and `isort`.
 
+We use `eslint` with `prettier` plugin for linting, formatting and code style of JS code.
+Install these dependencies through `npm install`. Then, for fixing linting/formatting errors run `npm run lint-fix`. Make sure you have a node version > 8 for this.
+
 We also offer pre-commit hooks to help with automatically formatting code.
 Install the pre-commit hooks with `pip install pre-commit && pre-commit install`.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "habitat-sim",
+  "version": "0.1.2",
+  "description": "A high performance simulator for training embodied agents",
+  "devDependencies": {
+    "eslint": "^6.4.0",
+    "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "prettier": "^1.18.2"
+  },
+  "scripts": {
+    "test": "node ./src/esp/bindings_js/tests/**/*_test.js",
+    "format": "prettier --trailing-comma es5 --single-quote './src/esp/bindings_js/**/*.js'",
+    "lint": "eslint ./src/esp/bindings_js",
+    "lint-fix": "eslint --fix ./src/esp/bindings_js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookresearch/habitat-sim.git"
+  },
+  "keywords": [
+    "embodied",
+    "sim",
+    "ai",
+    "agents"
+  ],
+  "author": "FAIR A-STAR",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/facebookresearch/habitat-sim/issues"
+  },
+  "homepage": "https://github.com/facebookresearch/habitat-sim#readme"
+}

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "devDependencies": {
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.18.2"
   },
   "scripts": {
     "test": "node ./src/esp/bindings_js/tests/**/*_test.js",
     "format": "prettier --trailing-comma es5 --single-quote './src/esp/bindings_js/**/*.js'",
-    "lint": "eslint ./src/esp/bindings_js",
-    "lint-fix": "eslint --fix ./src/esp/bindings_js"
+    "lint": "eslint --ext .html,.js ./src/esp/bindings_js",
+    "lint-fix": "eslint --ext .html,.js --fix ./src/esp/bindings_js"
   },
   "repository": {
     "type": "git",

--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -20,6 +20,7 @@ set(resources
     bindings.css
     navigate.js
     simenv_embind.js
+    runtime.js
     ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
     ${MAGNUM_WEBAPPLICATION_CSS}
 )

--- a/src/esp/bindings_js/bindings.html
+++ b/src/esp/bindings_js/bindings.html
@@ -30,73 +30,7 @@
   <script src="simenv_embind.js"></script>
   <script src="WindowlessEmscriptenApplication.js"></script>
   <script async src="hsim_bindings.js"></script>
-  <script>
-    Module["onRuntimeInitialized"] = function() {
-      console.log("hsim_bindings initialized");
-
-      const sensorConfigs = [{
-        uuid: 'rgb',
-        sensorType: Module.SensorType.COLOR,
-        resolution: [480, 640]
-      },
-      {
-        uuid: 'semantic',
-        sensorType: Module.SensorType.SEMANTIC,
-        resolution: [480, 640]
-      }];
-
-      const agentConfig = {
-        height: 1.5,
-        radius: 0.1,
-        mass: 32.0,
-        linearAcceleration: 20.0,
-        angularAcceleration: 4*Math.PI,
-        linearFriction: 0.5,
-        angularFriction: 1.0,
-        coefficientOfRestitution: 0.0,
-        sensorSpecifications: sensorConfigs
-      };
-
-      const startState = {
-        position: [-1.2676633596420288, 0.2047852873802185, 12.595427513122559],
-        rotation: [0, 0.4536385088584658, 0, 0.8911857849408661]
-      };
-
-      const goal = {
-        position: [2.2896811962127686, 0.11950381100177765, 16.97636604309082]
-      };
-
-      const episode = {
-        startState: startState,
-        goal: goal
-      };
-
-      let sceneConfig = new Module.SceneConfiguration();
-      try {
-        FS.stat("17DRP5sb8fy.glb");
-        sceneConfig.id = "17DRP5sb8fy.glb";
-      } catch(err) {
-        console.log("Can't find 17DRP5sb8fy.glb. Falling back to skokloster-castle.glb which doesn't have semantic information.");
-        sceneConfig.id = "skokloster-castle.glb";
-      }
-      let config = new Module.SimulatorConfiguration();
-      config.scene = sceneConfig;
-
-      const simenv = new SimEnv(config, episode, 0);
-      const agent = simenv.addAgent(agentConfig);
-      const task = new NavigateTask(simenv, {
-        canvas: document.getElementById('canvas'),
-        semantic: document.getElementById('semantic'),
-        radar: document.getElementById('radar'),
-        status: document.getElementById('status')
-      });
-      task.init();
-      task.reset();
-
-      window.config = config;
-      window.sim = simenv;
-    };
-  </script>
+  <script async src="runtime.js"></script>
 </body>
 
 </html>

--- a/src/esp/bindings_js/navigate.js
+++ b/src/esp/bindings_js/navigate.js
@@ -1,6 +1,7 @@
 /**
  * NavigateTask class
  */
+// eslint-disable-next-line no-unused-vars
 class NavigateTask {
   // PUBLIC methods.
 
@@ -15,20 +16,27 @@ class NavigateTask {
     let shape = this.sim.getObservationSpace("rgb").shape;
     this.semanticCtx = components.semantic.getContext("2d");
     shape = this.sim.getObservationSpace("semantic").shape;
-    this.semanticImageData = this.semanticCtx.createImageData(shape.get(1), shape.get(0));
+    this.semanticImageData = this.semanticCtx.createImageData(
+      shape.get(1),
+      shape.get(0)
+    );
     this.semanticObjects = this.sim.sim.getSemanticScene().objects;
-    components.canvas.onmousedown = e => { this.handleMouseDown(e); }
+    components.canvas.onmousedown = e => {
+      this.handleMouseDown(e);
+    };
     this.radarCtx = components.radar.getContext("2d");
     this.actions = [
-      { name: 'moveForward', key: 'w' },
-      { name: 'lookLeft', key: 'a', },
-      { name: 'lookRight', key: 'd' },
-      { name: 'done', key: ' ' }
+      { name: "moveForward", key: "w" },
+      { name: "lookLeft", key: "a" },
+      { name: "lookRight", key: "d" },
+      { name: "done", key: " " }
     ];
   }
 
   handleMouseDown(event) {
-    let objectId = this.semantic_data[(640*event.offsetY + event.offsetX)*4];
+    let objectId = this.semantic_data[
+      (640 * event.offsetY + event.offsetX) * 4
+    ];
     this.setStatus(this.semanticObjects.get(objectId).category.getName(""));
   }
 
@@ -44,7 +52,7 @@ class NavigateTask {
    */
   reset() {
     this.sim.reset();
-    this.setStatus('Ready');
+    this.setStatus("Ready");
     this.render();
   }
 
@@ -69,45 +77,46 @@ class NavigateTask {
     let data = this.semantic_data;
 
     // TOOD(msb) implement a better colorization scheme
-    for (let i = 0; i < 640*480; i++) {
-      if (data[i*4] & 1) {
-        this.semanticImageData.data[i*4] = 255;
+    for (let i = 0; i < 640 * 480; i++) {
+      if (data[i * 4] & 1) {
+        this.semanticImageData.data[i * 4] = 255;
       } else {
-        this.semanticImageData.data[i*4] = 0;
+        this.semanticImageData.data[i * 4] = 0;
       }
-      if (data[i*4] & 2) {
-        this.semanticImageData.data[i*4+1] = 255;
+      if (data[i * 4] & 2) {
+        this.semanticImageData.data[i * 4 + 1] = 255;
       } else {
-        this.semanticImageData.data[i*4+1] = 0;
+        this.semanticImageData.data[i * 4 + 1] = 0;
       }
-      if (data[i*4] & 4) {
-        this.semanticImageData.data[i*4+2] = 255;
+      if (data[i * 4] & 4) {
+        this.semanticImageData.data[i * 4 + 2] = 255;
       } else {
-        this.semanticImageData.data[i*4+2] = 0;
+        this.semanticImageData.data[i * 4 + 2] = 0;
       }
-      this.semanticImageData.data[i*4 + 3] = 255;
+      this.semanticImageData.data[i * 4 + 3] = 255;
     }
 
     this.semanticCtx.putImageData(this.semanticImageData, 0, 0);
   }
 
   renderRadar() {
-    const width = 100, height = 100;
-    let radius = width/2;
-    let centerX = width/2;
-    let centerY = height/2;
+    const width = 100,
+      height = 100;
+    let radius = width / 2;
+    let centerX = width / 2;
+    let centerY = height / 2;
     let ctx = this.radarCtx;
     ctx.clearRect(0, 0, width, height);
     ctx.globalAlpha = 0.5;
     // draw circle
     ctx.fillStyle = "darkslategray";
-    ctx.arc(centerX, centerY, radius, 0, 2*Math.PI);
+    ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
     ctx.fill();
     // draw sector
     ctx.fillStyle = "darkgray";
     ctx.beginPath();
     // TODO(msb) Currently 90 degress but should really use fov.
-    ctx.arc(centerX, centerY, radius, -Math.PI*3/4, -Math.PI/4);
+    ctx.arc(centerX, centerY, radius, (-Math.PI * 3) / 4, -Math.PI / 4);
     ctx.lineTo(centerX, centerY);
     ctx.closePath();
     ctx.fill();
@@ -116,11 +125,11 @@ class NavigateTask {
     ctx.beginPath();
     let magnitude, angle;
     [magnitude, angle] = this.sim.distanceToGoal();
-    let normalized = magnitude/(magnitude+1);
-    let targetX = centerX + Math.sin(angle)*radius*normalized;
-    let targetY = centerY - Math.cos(angle)*radius*normalized;
+    let normalized = magnitude / (magnitude + 1);
+    let targetX = centerX + Math.sin(angle) * radius * normalized;
+    let targetY = centerY - Math.cos(angle) * radius * normalized;
     ctx.fillStyle = "maroon";
-    ctx.arc(targetX, targetY, 3, 0, 2*Math.PI);
+    ctx.arc(targetX, targetY, 3, 0, 2 * Math.PI);
     ctx.fill();
   }
 
@@ -136,7 +145,7 @@ class NavigateTask {
   }
 
   bindKeys() {
-    document.addEventListener('keyup', (event) => {
+    document.addEventListener("keyup", event => {
       const key = String.fromCharCode(event.which).toLowerCase();
       for (let a of this.actions) {
         if (key === a.key) {

--- a/src/esp/bindings_js/runtime.js
+++ b/src/esp/bindings_js/runtime.js
@@ -1,0 +1,73 @@
+/*global Module, SimEnv, NavigateTask, FS*/
+/** TODO(aps): Shift to babel based compilation to properly
+ *  support older browsers
+ */
+Module["onRuntimeInitialized"] = function() {
+  console.log("hsim_bindings initialized");
+
+  const sensorConfigs = [
+    {
+      uuid: "rgb",
+      sensorType: Module.SensorType.COLOR,
+      resolution: [480, 640]
+    },
+    {
+      uuid: "semantic",
+      sensorType: Module.SensorType.SEMANTIC,
+      resolution: [480, 640]
+    }
+  ];
+
+  const agentConfig = {
+    height: 1.5,
+    radius: 0.1,
+    mass: 32.0,
+    linearAcceleration: 20.0,
+    angularAcceleration: 4 * Math.PI,
+    linearFriction: 0.5,
+    angularFriction: 1.0,
+    coefficientOfRestitution: 0.0,
+    sensorSpecifications: sensorConfigs
+  };
+
+  const startState = {
+    position: [-1.2676633596420288, 0.2047852873802185, 12.595427513122559],
+    rotation: [0, 0.4536385088584658, 0, 0.8911857849408661]
+  };
+
+  const goal = {
+    position: [2.2896811962127686, 0.11950381100177765, 16.97636604309082]
+  };
+
+  const episode = {
+    startState: startState,
+    goal: goal
+  };
+
+  let sceneConfig = new Module.SceneConfiguration();
+  try {
+    FS.stat("17DRP5sb8fy.glb");
+    sceneConfig.id = "17DRP5sb8fy.glb";
+  } catch (err) {
+    console.log(
+      "Can't find 17DRP5sb8fy.glb. Falling back to skokloster-castle.glb which doesn't have semantic information."
+    );
+    sceneConfig.id = "skokloster-castle.glb";
+  }
+  let config = new Module.SimulatorConfiguration();
+  config.scene = sceneConfig;
+
+  const simenv = new SimEnv(config, episode, 0);
+  simenv.addAgent(agentConfig);
+  const task = new NavigateTask(simenv, {
+    canvas: document.getElementById("canvas"),
+    semantic: document.getElementById("semantic"),
+    radar: document.getElementById("radar"),
+    status: document.getElementById("status")
+  });
+  task.init();
+  task.reset();
+
+  window.config = config;
+  window.sim = simenv;
+};

--- a/src/esp/bindings_js/simenv_embind.js
+++ b/src/esp/bindings_js/simenv_embind.js
@@ -1,9 +1,12 @@
+/*global Module */
+
 /**
  * SimEnv class
  *
  * TODO(aps,msb) - Add support for multiple agents instead of
  * hardcoding 0th one.
  */
+// eslint-disable-next-line no-unused-vars
 class SimEnv {
   // PUBLIC methods.
 
@@ -14,7 +17,7 @@ class SimEnv {
    * @param {number} agentId - default agent id
    */
   constructor(config, episode, agentId) {
-    this.sim = new Module.Simulator(config);;
+    this.sim = new Module.Simulator(config);
     this.episode = episode;
     this.initialAgentState = this.createAgentState(episode.startState);
     this.defaultAgentId = agentId;
@@ -60,7 +63,7 @@ class SimEnv {
    * @param {number} sensorId - id of sensor
    * @returns {Observation} observation from sensor
    */
-  getObservation(sensorId, buffer) {
+  getObservation(sensorId) {
     const obs = new Module.Observation();
     this.sim.getAgentObservation(0, sensorId, obs);
     return obs;
@@ -110,22 +113,22 @@ class SimEnv {
     [qx, qy, qz, qw] = q;
 
     // i = q' * v
-    let ix = qw*x - qy*z + qz*y;
-    let iy = qw*y - qz*x + qx*z;
-    let iz = qw*z - qx*y + qy*x;
-    let iw = qx*x + qy*y + qz*z;
+    let ix = qw * x - qy * z + qz * y;
+    let iy = qw * y - qz * x + qx * z;
+    let iz = qw * z - qx * y + qy * x;
+    let iw = qx * x + qy * y + qz * z;
 
     // r = i * q
     let r = [];
-    r[0] = ix*qw + iw*qx + iy*qz - iz*qy;
-    r[1] = iy*qw + iw*qy + iz*qx - ix*qz;
-    r[2] = iz*qw + iw*qz + ix*qy - iy*qx;
+    r[0] = ix * qw + iw * qx + iy * qz - iz * qy;
+    r[1] = iy * qw + iw * qy + iz * qx - ix * qz;
+    r[2] = iz * qw + iw * qz + ix * qy - iy * qx;
 
     return r;
   }
 
   cartesian_to_polar(x, y) {
-    return [Math.sqrt(x*x + y*y), Math.atan2(y, x)];
+    return [Math.sqrt(x * x + y * y), Math.atan2(y, x)];
   }
 
   createSensorSpec(config) {
@@ -141,12 +144,12 @@ class SimEnv {
     const converted = new Module.AgentConfiguration();
     for (let key in config) {
       let value = config[key];
-      if (key === 'sensorSpecifications') {
-	const sensorSpecs = new Module.VectorSensorSpec();
-	for (let c of value) {
-	  sensorSpecs.push_back(this.createSensorSpec(c));
-	}
-	value = sensorSpecs;
+      if (key === "sensorSpecifications") {
+        const sensorSpecs = new Module.VectorSensorSpec();
+        for (let c of value) {
+          sensorSpecs.push_back(this.createSensorSpec(c));
+        }
+        value = sensorSpecs;
       }
       converted[key] = value;
     }


### PR DESCRIPTION
## Motivation and Context

ESLint is a linter for JS while Prettier is a formatter. Both are kind of a standard in industry and FB also uses them. Prettier can be used along with ESLint with help of a plugin.

This PR introduces following things:
- ESLint based linting and Prettier based formatting. Use `npm run lint` to see if there are any lint issues and `npm run lint-fix` to fix those issues.
- Add a new CircleCI task for checking if JS is properly linted
- Precommit hook for JS linting
- ESLint configuration files and package.json for easy install of deps
- Updates to existing files so that they comply with ESLint and Prettier
- Move the inline script code in `bindings.html` to a separate file `runtime.js`

Later, I will introduce a PR to introduce Babel based compilation so we can fully move to ES6. This will also remove the need to having the custom overrides for globals and classes we have in this PR. package.json will also be helpful later when we will plan to distribute habitat-sim's js version through npm. This will also ease testing of JS code later on.


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
./build_js.sh and tested the bindings.html directly

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
