### PR TITLE
Remove redundant render contexts in display observation

### DIFF
--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -106,12 +106,8 @@ bool PinholeCamera::displayObservation(gfx::Simulator& sim) {
     return false;
   }
 
-  renderTarget().renderEnter();
-
   drawObservation(sim);
   renderTarget().blitRgbaToDefault();
-
-  renderTarget().renderExit();
 
   return true;
 }


### PR DESCRIPTION
## Motivation and Context

Thanks @erikwijmans for pointing the redundant render context calls out. This PR specifically removes those.

## How Has This Been Tested

build and bindings.html test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
