### PR TITLE
docs: add Bullet tagfile

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2149,7 +2149,8 @@ SKIP_FUNCTION_MACROS   = YES
 
 TAGFILES              = corrade.tag=https://doc.magnum.graphics/corrade/ \
                         magnum.tag=https://doc.magnum.graphics/magnum/ \
-                        stl.tag=http://en.cppreference.com/w/
+                        stl.tag=http://en.cppreference.com/w/ \
+                        bullet.tag=https://pybullet.org/Bullet/BulletFull/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -31,3 +31,11 @@ $mcss_path/css/postprocess.py \
 $mcss_path/documentation/doxygen.py Doxyfile-mcss
 
 $mcss_path/documentation/python.py conf.py
+
+# The file:// URLs are usually clickable in the terminal, directly opening a
+# browser
+echo "------------------------------------------------------------------------"
+echo "Docs were successfully generated. Open the following links to view them:"
+echo
+echo "file://$(pwd)/../build/docs/habitat-cpp/index.html"
+echo "file://$(pwd)/../build/docs/habitat-sim/index.html"

--- a/docs/developer-guide.dox
+++ b/docs/developer-guide.dox
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+namespace esp {
+
+/** @page developer-guide Developer guide
+
+<!-- TODO: this page needs to be filled with code style conventions, PR
+  workflow etc. -->
+
+@section developer-guide-tagfiles Doxygen tag files
+
+For Corrade and Magnum, up-to-date tagfiles can be found at
+https://magnum.graphics/doc-downloads/; STL tagfile is linked from there as
+well. Update the `docs/corrade.tag`, `docs/magnum.tag` and `docs/stl.tag` with
+those.
+
+For Bullet, the upstream doesn't generate or distribute a tagfile, so it's
+needed to build it manually. The current one is generated from version 2.88 and
+was created like this:
+
+@code{.sh}
+git clone https://github.com/bulletphysics/bullet3
+cd bullet3
+git checkout 2.88
+nano Doxyfile # modify it to have GENERATE_TAGFILE = bullet.tag
+doxygen # it'll complain about some CHM file, ignore that
+cp bullet.tag ../habitat-sim/docs/
+@endcode
+
+*/
+
+}


### PR DESCRIPTION
## Motivation and Context

This should prevent @aclegg3 from dying of copypaste boredom before #195 is finished ([see my comment there](https://github.com/facebookresearch/habitat-sim/pull/195#discussion_r325318523))  :) Proof (all Bullet types clickable, leading to concrete pages in https://pybullet.org/Bullet/BulletFull/):

![image](https://user-images.githubusercontent.com/344828/65161290-976bed80-da37-11e9-97c0-5871e90166b9.png)

This of course also works when referencing to any Bullet type, variable, function, page ... via `@ref`.

The tagfile is generated by hand as Bullet doesn't distribute it anywhere, added a seed of a Developer Guide page with details on how to replicate the process. This Developer Guide could be also place for the other things like code style, PR workflow and so on. Feel free to extend it :)

## How Has This Been Tested

See the image above.

:warning: **Note:** I had to do `SKIP=check-added-large-files git commit` in order to make the pre-commit hook allow me to commit the tag file. I did this already for the Magnum tagfile (which is ~3 MB) and I don't see this being a big problem -- the files are textual and thus very easily compressible, so the impact is not *that* big when cloning. Unfortunately compared to Intersphinx files used for the python docs (which are compressed on their own), Doxygen puts the information into an extremely verbose uncompressed XML.