### PR TITLE
[esp/bindings_js] load scene files bases on URL parameters

### DIFF
--- a/build_js.sh
+++ b/build_js.sh
@@ -5,8 +5,6 @@ set -e
 
 git submodule update --init --recursive
 
-DATA_DIR="$(pwd)/data/"
-
 mkdir -p build_corrade-rc
 pushd build_corrade-rc
 cmake ../src \
@@ -21,13 +19,6 @@ popd
 mkdir -p build_js
 cd build_js
 
-SCENE_DATASETS_DIR=${DATA_DIR}/scene_datasets/mp3d/17DRP5sb8fy
-if [ ! -d ${SCENE_DATASETS_DIR} ]; then
-  echo "Cannot find mp3d scene 17DRP5sb8fy, falling back to habitat-test-scenes"
-  SCENE_DATASETS_DIR=${DATA_DIR}/scene_datasets/habitat-test-scenes
-fi
-
-
 cmake ../src \
     -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/deps/corrade/src/Corrade/Utility/corrade-rc \
     -DBUILD_GUI_VIEWERS=ON \
@@ -39,7 +30,7 @@ cmake ../src \
     -DCMAKE_PREFIX_PATH="$EMSCRIPTEN" \
     -DCMAKE_TOOLCHAIN_FILE="../src/deps/corrade/toolchains/generic/Emscripten-wasm.cmake" \
     -DCMAKE_INSTALL_PREFIX="." \
-    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 --preload-file ${SCENE_DATASETS_DIR}@/" \
+    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1" \
     -DCMAKE_EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
 
 cmake --build . -- -j 4
@@ -53,4 +44,4 @@ echo "python3 -m http.server"
 echo "Then open in browser:"
 echo "http://0.0.0.0:8000/build_js/utils/viewer/viewer.html?scene=skokloster-castle.glb"
 echo "Or:"
-echo "http://0.0.0.0:8000/build_js/esp/bindings_js/bindings.html"
+echo "http://0.0.0.0:8000/build_js/esp/bindings_js/bindings.html?scene=skokloster-castle.glb"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif()
 
+set(SCENE_DATASETS ${CMAKE_CURRENT_SOURCE_DIR}/../data/scene_datasets)
+
 # build options
 option(BUILD_ASSIMP_SUPPORT "Whether to build assimp import library support" ON)
 option(BUILD_PYTHON_BINDINGS "Whether to build python bindings" ON)

--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -16,6 +16,10 @@ set_target_properties(hsim_bindings PROPERTIES LINK_FLAGS "--bind")
 
 # copy JS/HTML/CSS resources for WebGL build
 set(resources
+    ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.glb
+    ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.navmesh
+    ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.glb
+    ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.navmesh
     ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
     ${MAGNUM_WEBAPPLICATION_CSS}
 )

--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -1,12 +1,25 @@
-/*global Module */
+/* global FS, Module */
 
 import WebDemo from "./modules/web_demo";
 import VRDemo from "./modules/vr_demo";
 import "./bindings.css";
 
-Module["onRuntimeInitialized"] = function() {
-  console.log("hsim_bindings initialized");
+Module.preRun.push(() => {
+  let scene = "skokloster-castle.glb";
+  for (let arg of window.location.search.substr(1).split("&")) {
+    let [key, value] = arg.split("=");
+    if (key === "scene" && value) {
+      scene = value;
+    }
+  }
+  FS.createPreloadedFile("/", scene, scene, true, false);
+  Module.scene = scene;
+  const navmesh = scene.substr(0, scene.lastIndexOf(".")) + ".navmesh";
+  FS.createPreloadedFile("/", navmesh, navmesh, true, false);
+});
 
+Module.onRuntimeInitialized = () => {
+  console.log("hsim_bindings initialized");
   let demo;
   if (window.vrEnabled) {
     if (navigator && navigator.getVRDisplays) {

--- a/src/esp/bindings_js/modules/web_demo.js
+++ b/src/esp/bindings_js/modules/web_demo.js
@@ -1,4 +1,4 @@
-/* global FS, Module */
+/* global Module */
 import { defaultAgentConfig, defaultEpisode } from "./defaults";
 import SimEnv from "./simenv_embind";
 import TopDownMap from "./topdown";
@@ -10,15 +10,7 @@ class WebDemo {
     episode = defaultEpisode
   ) {
     this.sceneConfig = new Module.SceneConfiguration();
-    try {
-      FS.stat("17DRP5sb8fy.glb");
-      this.sceneConfig.id = "17DRP5sb8fy.glb";
-    } catch (err) {
-      console.log(
-        "Can't find 17DRP5sb8fy.glb. Falling back to skokloster-castle.glb which doesn't have semantic information."
-      );
-      this.sceneConfig.id = "skokloster-castle.glb";
-    }
+    this.sceneConfig.id = Module.scene;
     this.config = new Module.SimulatorConfiguration();
     this.config.scene = this.sceneConfig;
 

--- a/src/esp/nav/test/CMakeLists.txt
+++ b/src/esp/nav/test/CMakeLists.txt
@@ -4,7 +4,6 @@
 
 find_package(Corrade REQUIRED Utility TestSuite)
 
-set(SCENE_DATASETS ${CMAKE_CURRENT_SOURCE_DIR}/../../../../data/scene_datasets)
 configure_file(configure.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,7 +8,6 @@ macro(TEST TEST_NAME)
   add_test(${TEST_NAME} ${TEST_NAME})
 endmacro(TEST)
 
-set(SCENE_DATASETS ${CMAKE_CURRENT_SOURCE_DIR}/../../data/scene_datasets)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 


### PR DESCRIPTION
Instead of using a large .data file, we preload the scene files
into the virtual filesystem based on URL scene parameter. This is
a workaround until Corrade PR#39 is ready.

This should speed up startup since we now only load the files we
need.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Speedup startup by only loading files we need for the current scene.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified that the new URL parameter scene works.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ X I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
