### PR TITLE
[esp/gfx] fix regression: Viewer wasn't using navmesh for navigation

### DIFF
--- a/src/esp/gfx/Viewer.cpp
+++ b/src/esp/gfx/Viewer.cpp
@@ -120,18 +120,17 @@ Viewer::Viewer(const Arguments& arguments)
   }
 
   // connect controls to navmesh if loaded
-  /*
   if (pathfinder_->isLoaded()) {
-      controls_.setMoveFilterFunction([&](const vec3f& start, const vec3f& end)
-  { vec3f currentPosition = pathfinder_->tryStep(start, end); LOG(INFO) <<
-  "position=" << currentPosition.transpose() << " rotation="
-                  << quatf(agentBodyNode_->rotation()).coeffs().transpose();
-        LOG(INFO) << "Distance to closest obstacle: "
-                  << pathfinder_->distanceToClosestObstacle(currentPosition);
-        return currentPosition;
-      });
-    }
-    */
+    controls_.setMoveFilterFunction([&](const vec3f& start, const vec3f& end) {
+      vec3f currentPosition = pathfinder_->tryStep(start, end);
+      LOG(INFO) << "position=" << currentPosition.transpose() << " rotation="
+                << quatf(agentBodyNode_->rotation()).coeffs().transpose();
+      LOG(INFO) << "Distance to closest obstacle: "
+                << pathfinder_->distanceToClosestObstacle(currentPosition);
+
+      return currentPosition;
+    });
+  }
 
   renderCamera_->node().setTransformation(
       cameraNode_->absoluteTransformation());


### PR DESCRIPTION
The setting of the MoveFilterFunction was commented out when we
adding support for physics.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Fix issue #236 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified that the navmesh is now respected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
