### PR TITLE
[esp/bindinds_js] topdown: don't assume floor is at y=0

### DIFF
--- a/src/esp/bindings_js/modules/navigate.js
+++ b/src/esp/bindings_js/modules/navigate.js
@@ -54,7 +54,6 @@ class NavigateTask {
   reset() {
     this.sim.reset();
     this.setStatus("Ready");
-    this.topdown.start(this.sim.getAgentState().position);
     this.render();
   }
 
@@ -103,7 +102,6 @@ class NavigateTask {
 
   renderTopDown() {
     this.topdown.moveTo(this.sim.getAgentState().position);
-    this.topdown.draw();
   }
 
   renderRadar() {


### PR DESCRIPTION
Replica models have a floor that is non-zero. We were assuming
a floor of zero. Also, made the top-down map generation more
dynamic in order to support going up and down floors.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Top-down map was not rendering correctly for replica scenes.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
