### PR TITLE
Set correct navmesh for the ptex mesh

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -107,10 +107,9 @@ class Simulator:
             scene_basename = osp.basename(config.sim_cfg.scene.id)
             if scene_basename == "mesh.ply":
                 scene_dir = osp.dirname(config.sim_cfg.scene.id)
-                scene_path = osp.join(scene_dir, "habitat", scene_basename)
+                navmesh_filenname = osp.join(scene_dir, "habitat", "mesh_semantic.navmesh")
             else:
-                scene_path = config.sim_cfg.scene.id
-            navmesh_filenname = osp.splitext(scene_path)[0] + ".navmesh"
+                navmesh_filenname = osp.splitext(config.sim_cfg.scene.id)[0] + ".navmesh"
 
         self.pathfinder = hsim.PathFinder()
         if osp.exists(navmesh_filenname):

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -107,9 +107,13 @@ class Simulator:
             scene_basename = osp.basename(config.sim_cfg.scene.id)
             if scene_basename == "mesh.ply":
                 scene_dir = osp.dirname(config.sim_cfg.scene.id)
-                navmesh_filenname = osp.join(scene_dir, "habitat", "mesh_semantic.navmesh")
+                navmesh_filenname = osp.join(
+                    scene_dir, "habitat", "mesh_semantic.navmesh"
+                )
             else:
-                navmesh_filenname = osp.splitext(config.sim_cfg.scene.id)[0] + ".navmesh"
+                navmesh_filenname = (
+                    osp.splitext(config.sim_cfg.scene.id)[0] + ".navmesh"
+                )
 
         self.pathfinder = hsim.PathFinder()
         if osp.exists(navmesh_filenname):

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -105,6 +105,9 @@ class Simulator:
             navmesh_filenname = config.sim_cfg.scene.filepaths["navmesh"]
         else:
             scene_basename = osp.basename(config.sim_cfg.scene.id)
+            # "mesh.ply" is identified as a replica model, whose navmesh
+            # is named as "mesh_semantic.navmesh" and is placed in the
+            # subfolder called "habitat" (a level deeper than the "mesh.ply")
             if scene_basename == "mesh.ply":
                 scene_dir = osp.dirname(config.sim_cfg.scene.id)
                 navmesh_filenname = osp.join(

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -104,7 +104,13 @@ class Simulator:
         if "navmesh" in config.sim_cfg.scene.filepaths:
             navmesh_filenname = config.sim_cfg.scene.filepaths["navmesh"]
         else:
-            navmesh_filenname = osp.splitext(config.sim_cfg.scene.id)[0] + ".navmesh"
+            scene_basename = osp.basename(config.sim_cfg.scene.id)
+            if scene_basename == "mesh.ply":
+                scene_dir = osp.dirname(config.sim_cfg.scene.id)
+                scene_path = osp.join(scene_dir, "habitat", scene_basename)
+            else:
+                scene_path = config.sim_cfg.scene.id
+            navmesh_filenname = osp.splitext(scene_path)[0] + ".navmesh"
 
         self.pathfinder = hsim.PathFinder()
         if osp.exists(navmesh_filenname):


### PR DESCRIPTION
## Motivation and Context
As titled.
Currently the simulator.py cannot set and load the navmesh for replica model correctly.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
local run banchmark.py

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
