### PR TITLE
[esp/bindings_js] add back support for semantic information

### DIFF
--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -2,20 +2,31 @@
 
 import WebDemo from "./modules/web_demo";
 import VRDemo from "./modules/vr_demo";
+import { defaultScene } from "./modules/defaults";
 import "./bindings.css";
 
+function preload(file) {
+  FS.createPreloadedFile("/", file, file, true, false);
+}
+
 Module.preRun.push(() => {
-  let scene = "skokloster-castle.glb";
+  let config = {};
+  config.scene = defaultScene;
   for (let arg of window.location.search.substr(1).split("&")) {
     let [key, value] = arg.split("=");
-    if (key === "scene" && value) {
-      scene = value;
+    if (key && value) {
+      config[key] = value;
     }
   }
-  FS.createPreloadedFile("/", scene, scene, true, false);
+  const scene = config.scene;
+  preload(scene);
   Module.scene = scene;
-  const navmesh = scene.substr(0, scene.lastIndexOf(".")) + ".navmesh";
-  FS.createPreloadedFile("/", navmesh, navmesh, true, false);
+  const fileNoExtension = scene.substr(0, scene.lastIndexOf("."));
+  preload(fileNoExtension + ".navmesh");
+  if (config.semantic === "mp3d") {
+    preload(fileNoExtension + ".house");
+    preload(fileNoExtension + "_semantic.ply");
+  }
 });
 
 Module.onRuntimeInitialized = () => {

--- a/src/esp/bindings_js/modules/defaults.js
+++ b/src/esp/bindings_js/modules/defaults.js
@@ -24,3 +24,5 @@ export const defaultEpisode = {
 };
 
 export const defaultResolution = { height: 480, width: 640 };
+
+export const defaultScene = "skokloster-castle.glb";


### PR DESCRIPTION
My earlier change where I allowed specifying the scene broke
semantic mesh support. Adding back semantic mesh support as
a URL parameter.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Get semantic mesh working again with WebGL port.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Tested via http://0.0.0.0:8000/esp/bindings_js/bindings.html?scene=17DRP5sb8fy.glb&semantic=mp3d

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
