### PR TITLE
cmake: prefer the python3 executable over python

### DIFF
--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -88,16 +88,20 @@ target_compile_definitions(Detour
   DT_VIRTUAL_QUERYFILTER)
 
 if(BUILD_PYTHON_BINDINGS)
-  # python interpreter
+  # Before calling find_package(PythonInterp) search for python executable not
+  # in the default paths to pick up activated virtualenv/conda python
+  find_program(PYTHON_EXECUTABLE
+    # macOS still defaults to `python` being Python 2, so look for `python3`
+    # first
+    NAMES python3 python
+    PATHS ENV PATH   # look in the PATH environment variable
+    NO_DEFAULT_PATH  # do not look anywhere else...
+  )
+
+  # Let the Find module do proper version checks on what we found (it uses the
+  # same PYTHON_EXECUTABLE variable, will pick it up from the cache)
   find_package(PythonInterp 3.6 REQUIRED)
 
-  # Search for python executable to pick up activated virtualenv/conda python
-  unset(PYTHON_EXECUTABLE CACHE)
-  find_program(PYTHON_EXECUTABLE
-    python
-      PATHS ENV PATH   # look in the PATH environment variable
-      NO_DEFAULT_PATH  # do not look anywhere else...
-  )
   message(STATUS "Bindings being generated for python at ${PYTHON_EXECUTABLE}")
 
   # Pybind11. Use a system package, if preferred. This needs to be before Magnum


### PR DESCRIPTION
## Motivation and Context

In a response to https://github.com/mosra/magnum-bindings/issues/4. On macOS (without any special setup at least), `python` defaults to python 2, and this override here is causing the version 2 to be picked up first.

@erikwijmans actually, I'm not sure about the whole check at all -- why was `find_package(PythonInterp 3.6 REQUIRED)` not enough? This override after is not doing any version checks and if version 2 gets picked up, it just happily continues without any indication of things being wrong. What would break if this whole part was not there?

## How Has This Been Tested

`/usr/bin/python` shouldn't be picked up by accident anymore.