### PR TITLE
[esp/scene] add initial support for Replica_v1 semantic information

### DIFF
--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -6,12 +6,7 @@
 
 #include <string>
 
-#include <Corrade/Containers/Pointer.h>
-#include <Corrade/Utility/String.h>
-
-#include <Magnum/ImageView.h>
-#include <Magnum/PixelFormat.h>
-#include <Magnum/Trade/AbstractImageConverter.h>
+#include <Corrade/Utility/Directory.h>
 
 #include "Drawable.h"
 
@@ -24,9 +19,7 @@
 #include "esp/scene/SemanticScene.h"
 #include "esp/sensor/PinholeCamera.h"
 
-using namespace Magnum;
-using namespace Math::Literals;
-using namespace Corrade;
+namespace Cr = Corrade;
 
 namespace esp {
 namespace gfx {
@@ -139,13 +132,24 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
   semanticScene_ = nullptr;
   semanticScene_ = scene::SemanticScene::create();
-  if (io::exists(houseFilename)) {
-    scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
-  }
-
-  // also load SemanticScene for SUNCG house file
-  if (sceneInfo.type == assets::AssetType::SUNCG_SCENE) {
-    scene::SemanticScene::loadSuncgHouse(sceneFilename, *semanticScene_);
+  switch (sceneInfo.type) {
+    case assets::AssetType::INSTANCE_MESH:
+      houseFilename = Cr::Utility::Directory::join(
+          Cr::Utility::Directory::path(houseFilename), "info_semantic.json");
+      if (io::exists(houseFilename)) {
+        scene::SemanticScene::loadReplicaHouse(houseFilename, *semanticScene_);
+      }
+      break;
+    case assets::AssetType::MP3D_MESH:
+      if (io::exists(houseFilename)) {
+        scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
+      }
+      break;
+    case assets::AssetType::SUNCG_SCENE:
+      scene::SemanticScene::loadSuncgHouse(sceneFilename, *semanticScene_);
+      break;
+    default:
+      break;
   }
 
   // now reset to sample agent state

--- a/src/esp/scene/CMakeLists.txt
+++ b/src/esp/scene/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(scene STATIC
   Mp3dSemanticScene.h
   ObjectControls.cpp
   ObjectControls.h
+  ReplicaSemanticScene.cpp
+  ReplicaSemanticScene.h
   SceneConfiguration.cpp
   SceneConfiguration.h
   SceneGraph.cpp

--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "ReplicaSemanticScene.h"
+#include "SemanticScene.h"
+
+#include <map>
+#include <string>
+
+#include <Corrade/Utility/String.h>
+
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+namespace esp {
+namespace scene {
+
+constexpr int kMaxIds = 10000; /* We shouldn't every need more than this. */
+
+bool SemanticScene::loadReplicaHouse(
+    const std::string& houseFilename,
+    SemanticScene& scene,
+    const quatf& worldRotation /* = quatf::Identity() */) {
+  if (!io::exists(houseFilename)) {
+    LOG(ERROR) << "Could not load file " << houseFilename;
+    return false;
+  }
+
+  scene.categories_.clear();
+  scene.objects_.clear();
+
+  // top-level scene
+  VLOG(1) << "Parsing " << houseFilename;
+  const auto& json = io::parseJsonFile(houseFilename);
+  VLOG(1) << "Parsed.";
+
+  // categories
+  const auto& categories = json["classes"].GetArray();
+  scene.elementCounts_["categories"] = categories.Size();
+  for (const auto& category : categories) {
+    int id = category["id"].GetInt();
+    /*
+     * We store the category object at categories_[id] in order to making
+     * indexing easy.
+     */
+    if (id > kMaxIds) {
+      LOG(ERROR) << "Exceeded max number of ids";
+      continue;
+    }
+    if (scene.categories_.size() < id + 1) {
+      scene.categories_.resize(id + 1, nullptr);
+    }
+    scene.categories_[id] = std::make_shared<ReplicaObjectCategory>(
+        id, category["name"].GetString());
+  }
+
+  // objects
+  const auto& objects = json["objects"].GetArray();
+  scene.elementCounts_["objects"] = objects.Size();
+  for (const auto& jsonObject : objects) {
+    SemanticObject::ptr object = SemanticObject::create();
+    int id = jsonObject["id"].GetInt();
+    int categoryIndex = jsonObject["class_id"].GetInt();
+    /*
+     * We store the category object at categories_[id] in order to making
+     * indexing easy.
+     */
+    if (id > kMaxIds) {
+      LOG(ERROR) << "Exceeded max number of ids";
+      continue;
+    }
+    if (scene.objects_.size() < id + 1) {
+      scene.objects_.resize(id + 1, nullptr);
+    }
+    object->index_ = id;
+    if (categoryIndex < scene.categories_.size()) {
+      object->category_ = scene.categories_[categoryIndex];
+    }
+    // TODO(msb) object->obb = ;
+    scene.objects_[id] = std::move(object);
+  }
+
+  return true;
+}
+
+}  // namespace scene
+}  // namespace esp

--- a/src/esp/scene/ReplicaSemanticScene.h
+++ b/src/esp/scene/ReplicaSemanticScene.h
@@ -1,0 +1,36 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "SemanticScene.h"
+
+namespace esp {
+namespace scene {
+
+struct ReplicaObjectCategory : public SemanticCategory {
+  ReplicaObjectCategory(const int id, const std::string& name)
+      : id_(id), name_(name) {}
+
+  int index(const std::string& mapping) const override { return id_; }
+
+  std::string name(const std::string& mapping) const override {
+    if (mapping == "category" || mapping == "") {
+      return name_;
+    } else {
+      LOG(ERROR) << "Unknown mapping type: " << mapping;
+      return "UNKNOWN";
+    }
+  }
+
+ protected:
+  int id_;
+  std::string name_;
+  friend SemanticScene;
+
+  ESP_SMART_POINTERS(ReplicaObjectCategory)
+};
+
+}  // namespace scene
+}  // namespace esp

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -88,6 +88,11 @@ class SemanticScene {
                                                     geo::ESP_GRAVITY));
 
   //! load SemanticScene from a SUNCG house format file
+  static bool loadReplicaHouse(const std::string& filename,
+                               SemanticScene& scene,
+                               const quatf& rotation = quatf::Identity());
+
+  //! load SemanticScene from a SUNCG house format file
   static bool loadSuncgHouse(const std::string& filename,
                              SemanticScene& scene,
                              const quatf& rotation = quatf::Identity());


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Initial support for Replica semantic information.

## How Has This Been Tested
Testing semantic information using WebGL demo.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
