### PR TITLE
docs: sync doc theme with website updates, random fixes.

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -651,19 +651,19 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TESTLIST      = YES
+GENERATE_TESTLIST      = NO
 
 # The GENERATE_BUGLIST tag can be used to enable (YES) or disable (NO) the bug
 # list. This list is created by putting \bug commands in the documentation.
 # The default value is: YES.
 
-GENERATE_BUGLIST       = YES
+GENERATE_BUGLIST       = NO
 
 # The GENERATE_DEPRECATEDLIST tag can be used to enable (YES) or disable (NO)
 # the deprecated list. This list is created by putting \deprecated commands in

--- a/docs/Doxyfile-public
+++ b/docs/Doxyfile-public
@@ -1,0 +1,17 @@
+@INCLUDE = Doxyfile-mcss
+
+OUTPUT_DIRECTORY       = ../build/docs-public/
+
+##! M_HTML_HEADER = "<!-- Global site tag (gtag.js) - Google Analytics -->" \
+##!  "<script async src="https://www.googletagmanager.com/gtag/js?id=UA-66408458-4"></script>" \
+##!  "<script>" \
+##!  " window.dataLayer = window.dataLayer || [];" \
+##!  " function gtag(){dataLayer.push(arguments);}" \
+##!  " gtag('js', new Date());" \
+##!  " gtag('config', 'UA-66408458-4');" \
+##!  "</script>"
+##! M_SEARCH_DOWNLOAD_BINARY = YES
+##! M_SEARCH_BASE_URL = https://aihabitat.org/docs/habitat-cpp/
+##! M_SEARCH_EXTERNAL_URL = "https://google.com/search?q=site:aihabitat.org+{query}"
+
+# kate: hl Doxyfile

--- a/docs/build-public.sh
+++ b/docs/build-public.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Propagate failures properly
+set -e
+
+mcss_path=./m.css
+
+# Regenerate the compiled CSS file
+$mcss_path/css/postprocess.py \
+  theme.css \
+  $mcss_path/css/m-grid.css \
+  $mcss_path/css/m-components.css \
+  $mcss_path/css/m-layout.css \
+  pygments-pastie.css \
+  $mcss_path/css/pygments-console.css \
+  $mcss_path/css/m-documentation.css \
+  -o theme.compiled.css
+
+# Build C++ docs first so the Python docs can make use of the tag file
+$mcss_path/documentation/doxygen.py Doxyfile-public
+
+$mcss_path/documentation/python.py conf-public.py
+
+# The file:// URLs are usually clickable in the terminal, directly opening a
+# browser
+echo "------------------------------------------------------------------------"
+echo "Public docs were successfully generated to the following location. Note"
+echo "that the search functionality requires a web server in this case."
+echo
+echo "file://$(pwd)/../build/docs-public/habitat-cpp/index.html"
+echo "file://$(pwd)/../build/docs-public/habitat-sim/index.html"

--- a/docs/conf-public.py
+++ b/docs/conf-public.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Inherit everything from the local config
+import os, sys
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+from conf import *
+
+OUTPUT = "../build/docs-public/habitat-sim/"
+
+HTML_HEADER = """<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-66408458-4"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', 'UA-66408458-4');
+</script>
+"""
+
+SEARCH_DOWNLOAD_BINARY = "searchdata-v1.bin"
+SEARCH_BASE_URL = "https://aihabitat.org/docs/habitat-sim/"
+SEARCH_EXTERNAL_URL = "https://google.com/search?q=site:aihabitat.org+{query}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,9 @@ import habitat_sim  # NOQA
 habitat_sim.logging.GlogFormatter.formatStack.__doc__ = ""
 # Monkey patch the registry to be the _Registry class instead of the singleton for docs
 habitat_sim.registry = type(habitat_sim.registry)
+# TODO: remove once utils/__init__.py is removed again
+habitat_sim.utils.__all__.remove("quat_from_angle_axis")
+habitat_sim.utils.__all__.remove("quat_rotate_vector")
 
 PROJECT_TITLE = "Habitat"
 PROJECT_SUBTITLE = "Sim Python Docs"

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -5,7 +5,7 @@
   --font-size: 16px;
   --code-font-size: 0.9em; /* *not* rem, so it follows surrounding font size */
   --line-height: normal;
-  --paragraph-indent: 1.5rem;
+  --paragraph-indent: 0.0rem;
   --paragraph-align: justify;
   --link-decoration: underline;
   --link-decoration-nav: none;

--- a/habitat_sim/utils/__init__.py
+++ b/habitat_sim/utils/__init__.py
@@ -4,9 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Added for backward compatibility with Habitat-API
+# quat_from_angle_axis and quat_rotate_vector imports
+# added for backward compatibility with Habitat-API
 # TODO @maksymets: remove after habitat-api/examples/new_actions.py will be
 # fixed
+
+
+from habitat_sim.utils import common
 from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
 
-__all__ = ["quat_from_angle_axis", "quat_rotate_vector"]
+__all__ = ["quat_from_angle_axis", "quat_rotate_vector", "common"]


### PR DESCRIPTION
## Motivation and Context

To be consistent with https://aihabitat.org main site theme. This affects habitat-api as well, as that repo looks here for the CSS.

While generating a fresh batch of docs, I discovered a crashy corner-case with the `typing` module, so this pulls in a slightly fresher m.css as well. And in #235 the `habitat_sim.utils.common` submodule got lost, so adding it back (and then reverting the temporary hack for docs so the quat-related functions aren't on two places).

## How Has This Been Tested

Things look consistent again, doc generation is neither crashing nor complaining too much.