### PR TITLE
[JS] Debounce while generating topdown map and disable it in VR

### DIFF
--- a/src/esp/bindings_js/bindings.css
+++ b/src/esp/bindings_js/bindings.css
@@ -1,3 +1,7 @@
+/** Copyright (c) Facebook, Inc. and its affiliates.
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 #radar {
   position: absolute;
   top: 70%;

--- a/src/esp/bindings_js/bindings.html
+++ b/src/esp/bindings_js/bindings.html
@@ -1,3 +1,7 @@
+<!-- Copyright (c) Facebook, Inc. and its affiliates.
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.-->
+
 <!DOCTYPE html>
 <html>
 

--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 /* global FS, Module */
 
 import WebDemo from "./modules/web_demo";

--- a/src/esp/bindings_js/modules/defaults.js
+++ b/src/esp/bindings_js/modules/defaults.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 export const defaultAgentConfig = {
   height: 1.5,
   radius: 0.1,

--- a/src/esp/bindings_js/modules/navigate.js
+++ b/src/esp/bindings_js/modules/navigate.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 /**
  * NavigateTask class
  */
@@ -101,7 +105,7 @@ class NavigateTask {
   }
 
   renderTopDown() {
-    this.topdown.moveTo(this.sim.getAgentState().position);
+    this.topdown.moveTo(this.sim.getAgentState().position, 500);
   }
 
   renderRadar() {
@@ -138,10 +142,12 @@ class NavigateTask {
     ctx.fill();
   }
 
-  render() {
+  render(options = { renderTopDown: true }) {
     this.renderImage();
     this.renderSemanticImage();
-    this.renderTopDown();
+    if (options.renderTopDown) {
+      this.renderTopDown();
+    }
   }
 
   handleAction(action) {

--- a/src/esp/bindings_js/modules/simenv_embind.js
+++ b/src/esp/bindings_js/modules/simenv_embind.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 /*global Module */
 
 /**

--- a/src/esp/bindings_js/modules/topdown.js
+++ b/src/esp/bindings_js/modules/topdown.js
@@ -55,15 +55,15 @@ class TopDownMap {
   /**
    * Update trajectory with new position
    * @param {vec3f} position - new position
+   * @param {int} throttleMs - time gap for throttle
    */
-  moveTo(position, throttleAmount = 0) {
-    if (throttleAmount !== 0) {
+  moveTo(position, throttleMs = 0) {
+    if (throttleMs !== 0) {
       if (!this.throttledMoveTo) {
-        this.throttledMoveTo = throttle(this.moveTo.bind(this), throttleAmount);
+        this.throttledMoveTo = throttle(this.moveTo.bind(this), throttleMs);
       }
       this.throttledMoveTo(position);
     } else {
-      console.log("move to called");
       /*
        * If we've gone up or down a floor, we need to create a new map.
        * A change in Y of 0.25 should be sufficient as a test.

--- a/src/esp/bindings_js/modules/topdown.js
+++ b/src/esp/bindings_js/modules/topdown.js
@@ -1,3 +1,9 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import { throttle } from "./utils";
+
 /**
  * TopDownMap class
  */
@@ -50,20 +56,28 @@ class TopDownMap {
    * Update trajectory with new position
    * @param {vec3f} position - new position
    */
-  moveTo(position) {
-    /*
-     * If we've gone up or down a floor, we need to create a new map.
-     * A change in Y of 0.25 should be sufficient as a test.
-     */
-    if (
-      position[1] < this.currentY - 0.25 ||
-      position[1] > this.currentY + 0.25
-    ) {
-      this.start(position);
+  moveTo(position, throttleAmount = 0) {
+    if (throttleAmount !== 0) {
+      if (!this.throttledMoveTo) {
+        this.throttledMoveTo = throttle(this.moveTo.bind(this), throttleAmount);
+      }
+      this.throttledMoveTo(position);
     } else {
-      let [x, y] = this.convertPosition(position);
-      this.ctx.lineTo(x, y);
-      this.ctx.stroke();
+      console.log("move to called");
+      /*
+       * If we've gone up or down a floor, we need to create a new map.
+       * A change in Y of 0.25 should be sufficient as a test.
+       */
+      if (
+        position[1] < this.currentY - 0.25 ||
+        position[1] > this.currentY + 0.25
+      ) {
+        this.start(position);
+      } else {
+        let [x, y] = this.convertPosition(position);
+        this.ctx.lineTo(x, y);
+        this.ctx.stroke();
+      }
     }
   }
 

--- a/src/esp/bindings_js/modules/utils.js
+++ b/src/esp/bindings_js/modules/utils.js
@@ -5,8 +5,8 @@
 /**
  *
  * @param {function} func Function to be throttled
- * @param {int} timeout Milliseconds for which throttle will be called
- * `func` will be called atleast one in timeout timeframe.
+ * @param {int} timeout Milliseconds interval after which throttle will be called,
+ * `func` will be called at least once in the timeout timeframe.
  */
 export function throttle(func, timeout = 500) {
   let active = false;

--- a/src/esp/bindings_js/modules/utils.js
+++ b/src/esp/bindings_js/modules/utils.js
@@ -1,0 +1,25 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ *
+ * @param {function} func Function to be throttled
+ * @param {int} timeout Milliseconds for which throttle will be called
+ * `func` will be called atleast one in timeout timeframe.
+ */
+export function throttle(func, timeout = 500) {
+  let active = false;
+
+  return function() {
+    const args = arguments;
+    const context = this;
+    if (!active) {
+      func.apply(context, args);
+      active = true;
+      window.setTimeout(() => {
+        active = false;
+      }, timeout);
+    }
+  };
+}

--- a/src/esp/bindings_js/modules/vr_demo.js
+++ b/src/esp/bindings_js/modules/vr_demo.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 /* global VRFrameData */
 import WebDemo from "./web_demo";
 import { defaultResolution, defaultAgentConfig } from "./defaults";
@@ -98,7 +102,7 @@ class VRDemo extends WebDemo {
     );
     this.currentVrDisplay.getFrameData(this.frameData);
     this.updateAgentState();
-    this.task.render();
+    this.task.render({ renderTopDown: false });
     this.currentVrDisplay.submitFrame();
     this.updateFPS();
   }

--- a/src/esp/bindings_js/modules/web_demo.js
+++ b/src/esp/bindings_js/modules/web_demo.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 /* global Module */
 import { defaultAgentConfig, defaultEpisode } from "./defaults";
 import SimEnv from "./simenv_embind";

--- a/src/esp/bindings_js/webpack.config.js
+++ b/src/esp/bindings_js/webpack.config.js
@@ -1,3 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 

--- a/src/esp/bindings_js/webvr.html
+++ b/src/esp/bindings_js/webvr.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Facebook, Inc. and its affiliates.
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.-->
 <!DOCTYPE html>
 <html>
 


### PR DESCRIPTION
## Motivation and Context

Due to slow rendering of TopDown map it slows down VR a lot. We use throttle to mitigate that for now. But the problem still remains as when this paint happens everything gets blocked. So, we disable this in VR mode. See more info on throttle and debouce [here](https://codeburst.io/throttling-and-debouncing-in-javascript-b01cad5c8edf).

I also added the missing license headers to all of the files.

## How Has This Been Tested

Manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
