### PR TITLE
[esp/agent] rename lookLeft/Right to turnLeft/Right

### DIFF
--- a/src/esp/agent/Agent.cpp
+++ b/src/esp/agent/Agent.cpp
@@ -16,12 +16,9 @@ using Magnum::EigenIntegration::cast;
 namespace esp {
 namespace agent {
 
-const std::set<std::string> Agent::BodyActions = {
-    "moveRight", "moveLeft", "moveForward", "moveBackward", "turnLeft",
-    "turnRight",
-    // TODO lookLeft and lookRight should not be body actions
-    // turnLeft and turnRight will take their place
-    "lookLeft", "lookRight"};
+const std::set<std::string> Agent::BodyActions = {"moveRight",   "moveLeft",
+                                                  "moveForward", "moveBackward",
+                                                  "turnLeft",    "turnRight"};
 
 Agent::Agent(scene::SceneNode& agentNode, const AgentConfiguration& cfg)
     : Magnum::SceneGraph::AbstractFeature3D(agentNode),

--- a/src/esp/agent/Agent.h
+++ b/src/esp/agent/Agent.h
@@ -65,10 +65,10 @@ struct AgentConfiguration {
   ActionSpace actionSpace = {  // default ActionSpace
       {"moveForward",
        ActionSpec::create("moveForward", ActuationMap{{"amount", 0.25f}})},
-      {"lookLeft",
-       ActionSpec::create("lookLeft", ActuationMap{{"amount", 10.0f}})},
-      {"lookRight",
-       ActionSpec::create("lookRight", ActuationMap{{"amount", 10.0f}})}};
+      {"turnLeft",
+       ActionSpec::create("turnLeft", ActuationMap{{"amount", 10.0f}})},
+      {"turnRight",
+       ActionSpec::create("turnRight", ActuationMap{{"amount", 10.0f}})}};
   std::string bodyType = "cylinder";
 
   ESP_SMART_POINTERS(AgentConfiguration)

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -10,7 +10,6 @@
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Vector3.h>
 
-#include "esp/agent/Agent.h"
 #include "esp/core/esp.h"
 #include "esp/nav/GreedyFollower.h"
 #include "esp/nav/PathFinder.h"

--- a/src/esp/bindings_js/modules/navigate.js
+++ b/src/esp/bindings_js/modules/navigate.js
@@ -34,8 +34,8 @@ class NavigateTask {
     this.radarCtx = components.radar.getContext("2d");
     this.actions = [
       { name: "moveForward", key: "w" },
-      { name: "lookLeft", key: "a" },
-      { name: "lookRight", key: "d" },
+      { name: "turnLeft", key: "a" },
+      { name: "turnRight", key: "d" },
       { name: "done", key: " " }
     ];
   }

--- a/src/esp/scene/ObjectControls.cpp
+++ b/src/esp/scene/ObjectControls.cpp
@@ -44,14 +44,14 @@ SceneNode& moveForward(SceneNode& object, float distance) {
   return moveBackward(object, -distance);
 }
 
-SceneNode& lookLeft(SceneNode& object, float angleInDegrees) {
+SceneNode& turnLeft(SceneNode& object, float angleInDegrees) {
   object.rotateYLocal(Magnum::Deg(angleInDegrees));
   object.setRotation(object.rotation().normalized());
   return object;
 }
 
-SceneNode& lookRight(SceneNode& object, float angleInDegrees) {
-  return lookLeft(object, -angleInDegrees);
+SceneNode& turnRight(SceneNode& object, float angleInDegrees) {
+  return turnLeft(object, -angleInDegrees);
 }
 
 SceneNode& lookUp(SceneNode& object, float angleInDegrees) {
@@ -71,15 +71,10 @@ ObjectControls::ObjectControls() {
   moveFuncMap_["moveDown"] = &moveDown;
   moveFuncMap_["moveForward"] = &moveForward;
   moveFuncMap_["moveBackward"] = &moveBackward;
-  moveFuncMap_["lookLeft"] = &lookLeft;
-  moveFuncMap_["lookRight"] = &lookRight;
+  moveFuncMap_["turnLeft"] = &turnLeft;
+  moveFuncMap_["turnRight"] = &turnRight;
   moveFuncMap_["lookUp"] = &lookUp;
   moveFuncMap_["lookDown"] = &lookDown;
-
-  // TODO Do we need a different function for turnLeft vs. lookLeft?
-  // Those should just be body vs. sensor, but should check
-  moveFuncMap_["turnLeft"] = &lookLeft;
-  moveFuncMap_["turnRight"] = &lookRight;
 }
 
 ObjectControls& ObjectControls::setMoveFilterFunction(

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -5,7 +5,6 @@
 #include <Corrade/Utility/Directory.h>
 #include <gtest/gtest.h>
 
-#include "esp/agent/Agent.h"
 #include "esp/core/esp.h"
 #include "esp/core/random.h"
 #include "esp/nav/PathFinder.h"

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -404,10 +404,10 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       std::exit(0);
       break;
     case KeyEvent::Key::Left:
-      controls_(*agentBodyNode_, "lookLeft", lookSensitivity);
+      controls_(*agentBodyNode_, "turnLeft", lookSensitivity);
       break;
     case KeyEvent::Key::Right:
-      controls_(*agentBodyNode_, "lookRight", lookSensitivity);
+      controls_(*agentBodyNode_, "turnRight", lookSensitivity);
       break;
     case KeyEvent::Key::Up:
       controls_(*rgbSensorNode_, "lookUp", lookSensitivity, false);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -13,7 +13,6 @@
 #include <Magnum/SceneGraph/Camera.h>
 #include <Magnum/Timeline.h>
 
-#include "esp/agent/Agent.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/RenderCamera.h"
 #include "esp/nav/PathFinder.h"


### PR DESCRIPTION
lookLeft is not correct. We are actually turning the agent body.
Since only SimulatorWithAgents is using this it should only
affect WebGL. Fixed a bunch of places where Agent.h was included
but not used in order to confirm that only WebGL was affected.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
I want to clean up and rationalize actions in Agent.h before adding lookUp and lookDown.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified that turning still works in WebGL demo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
