### PR TITLE
Expose snap point

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: setup
           command: |
-              sudo pip install -U black "isort[pyproject]" numpy pytest sphinx pillow tqdm
+              sudo pip install -U black "isort[pyproject]" numpy pytest sphinx pillow tqdm hypothesis
               sudo pip install -r requirements.txt --progress-bar off
       - run:
           name: run black
@@ -129,7 +129,7 @@ jobs:
                 export PATH=$HOME/miniconda/bin:$PATH
                 conda create -y -n habitat python=3.6
                 . activate habitat
-                conda install -q -y -c conda-forge ninja numpy pytest ccache
+                conda install -q -y -c conda-forge ninja numpy pytest ccache hypothesis
               fi
       - run:
           name: Install emscripten

--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -16,7 +16,7 @@
 .. py:function:: habitat_sim.agent.ObjectControls.__init__
     :summary: Constructor
     :param move_filter_fn: A function that is applied after actions to handle
-        collisions, This should generally be ``_try_step`` or the default
+        collisions, This should generally be `nav.PathFinder.try_step`
 
 .. docs for bindings go here -- doing all the formatting in a C++ raw string is
     worse than a hangover
@@ -68,6 +68,22 @@
     translation indicates that the given point is not navigable. The amount of
     y-translation allowed is specified by :p:`max_y_delta` to account for
     slight differences in floor height.
+
+.. py:function:: habitat_sim.nav.PathFinder.try_step
+    :summary: Find a valid location for the agent to actually step to when it attempts to step between start and end
+
+    :param start: The starting location of the agent
+    :param end: The desired end location
+    :return: The actual ending location, if such a location exists, or ``{NAN, NAN, NAN}``
+
+.. py:function:: habitat_sim.nav.PathFinder.snap_point
+    :summary: Snaps a point to the closet navigable location
+
+    Will only search within a 4x8x4 cube centerred around the point.
+    If there is no navigable location within that cube, no navigable point will be found.
+
+    :param pt: The starting location of the agent
+    :return: The navigable point, if one exists, or ``{NAN, NAN, NAN}``
 
 .. dump of whatever else was in the other PR
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
 skip_glob = ["*/deps/*", "*/build/*", "*/obselete/*"]
-known_third_party = ["PIL", "attr", "conf", "demo_runner", "magnum", "numpy", "pytest", "quaternion", "scipy", "settings", "setuptools", "tqdm"]
+known_third_party = ["PIL", "attr", "conf", "demo_runner", "hypothesis", "magnum", "numpy", "pytest", "quaternion", "scipy", "settings", "setuptools", "tqdm"]
 multi_line_output = 3
 force_grid_wrap = false
 line_length = 88

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -56,6 +56,8 @@ void initShortestPathBindings(py::module& m) {
       .def("try_step", &PathFinder::tryStep<Magnum::Vector3>, "start"_a,
            "end"_a)
       .def("try_step", &PathFinder::tryStep<vec3f>, "start"_a, "end"_a)
+      .def("snap_point", &PathFinder::snapPoint<Magnum::Vector3>)
+      .def("snap_point", &PathFinder::snapPoint<vec3f>)
       .def("island_radius", &PathFinder::islandRadius, "pt"_a)
       .def_property_readonly("is_loaded", &PathFinder::isLoaded)
       .def("load_nav_mesh", &PathFinder::loadNavMesh)

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -40,9 +40,17 @@ std::tuple<dtStatus, dtPolyRef, vec3f> projectToPoly(
   // and polyRef == 0
   constexpr float polyPickExt[3] = {2, 4, 2};  // [2 * dx, 2 * dy, 2 * dz]
   dtPolyRef polyRef;
-  vec3f polyXYZ;
+  // Initialize with all NANs at dtStatusSucceed(status) == true does NOT mean
+  // that it found a point to project to..........
+  vec3f polyXYZ{NAN, NAN, NAN};
   dtStatus status = navQuery->findNearestPoly(pt.data(), polyPickExt, filter,
                                               &polyRef, polyXYZ.data());
+
+  // So let's call it a failure if it didn't actually find a point....
+  if (std::isnan(polyXYZ[0]))
+    status = DT_FAILURE;
+
+  polyXYZ = vec3f{};
 
   return std::make_tuple(status, polyRef, polyXYZ);
 }
@@ -856,6 +864,9 @@ T PathFinder::tryStep(const T& start, const T& end) {
                               filter_, endPoint.data(), polys, &numPolys,
                               MAX_POLYS);
 
+  if (numPolys == 0)
+    return {NAN, NAN, NAN};
+
   // Hack to deal with infinitely thin walls in recast allowing you to
   // transition between two different connected components
   // First check to see if the endPoint as returned by `moveAlongSurface`
@@ -893,6 +904,24 @@ template vec3f PathFinder::tryStep<vec3f>(const vec3f&, const vec3f&);
 template Magnum::Vector3 PathFinder::tryStep<Magnum::Vector3>(
     const Magnum::Vector3&,
     const Magnum::Vector3&);
+
+template <typename T>
+T PathFinder::snapPoint(const T& pt) {
+  dtStatus status;
+  vec3f projectedPt;
+  std::tie(status, std::ignore, projectedPt) =
+      projectToPoly(pt, navQuery_, filter_);
+
+  if (dtStatusSucceed(status)) {
+    return T{projectedPt};
+  } else {
+    return {NAN, NAN, NAN};
+  }
+}
+
+template vec3f PathFinder::snapPoint<vec3f>(const vec3f& pt);
+template Magnum::Vector3 PathFinder::snapPoint<Magnum::Vector3>(
+    const Magnum::Vector3& pt);
 
 float PathFinder::islandRadius(const vec3f& pt) const {
   dtPolyRef ptRef;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -50,8 +50,6 @@ std::tuple<dtStatus, dtPolyRef, vec3f> projectToPoly(
   if (std::isnan(polyXYZ[0]))
     status = DT_FAILURE;
 
-  polyXYZ = vec3f{};
-
   return std::make_tuple(status, polyRef, polyXYZ);
 }
 }  // namespace

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -130,6 +130,9 @@ class PathFinder : public std::enable_shared_from_this<PathFinder> {
   template <typename T>
   T tryStep(const T& start, const T& end);
 
+  template <typename T>
+  T snapPoint(const T& pt);
+
   bool loadNavMesh(const std::string& path);
 
   bool saveNavMesh(const std::string& path);

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -44,8 +44,8 @@ def test_no_move_fun():
 
 @attr.s(auto_attribs=True)
 class ExpectedDelta:
-    delta_pos: np.array = np.array([0, 0, 0])
-    delta_rot: np.quaternion = np.quaternion(1, 0, 0, 0)
+    delta_pos: np.ndarray = attr.Factory(lambda: np.array([0, 0, 0]))
+    delta_rot: np.quaternion = attr.Factory(lambda: np.quaternion(1, 0, 0, 0))
 
 
 def _check_state_same(s1, s2):

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -18,13 +18,14 @@ def test_data():
     return pf, pf.get_random_navigable_point()
 
 
-@hypothesis.given(nx=st.floats(-20, 20), ny=st.floats(-5, 5), nz=st.floats(-20, 20))
+@hypothesis.given(
+    nudge=st.tuples(st.floats(-20, 20), st.floats(-5, 5), st.floats(-20, 20))
+)
 @hypothesis.settings(max_examples=int(1e3))
-def test_snap_point(nx, ny, nz, test_data):
+def test_snap_point(nudge, test_data):
     pf, start_pt = test_data
 
-    n = np.array([nx, ny, nz])
-    pt = start_pt + n
+    pt = start_pt + nudge
 
     proj_pt = pf.snap_point(pt)
     hypothesis.assume(not math.isnan(proj_pt[0]))

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -1,0 +1,32 @@
+import math
+
+import hypothesis
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+
+import habitat_sim
+
+
+@pytest.fixture(scope="function")
+def test_data():
+    pf = habitat_sim.PathFinder()
+    pf.load_nav_mesh(
+        "data/scene_datasets/habitat-test-scenes/skokloster-castle.navmesh"
+    )
+
+    return pf, pf.get_random_navigable_point()
+
+
+@hypothesis.given(nx=st.floats(-20, 20), ny=st.floats(-5, 5), nz=st.floats(-20, 20))
+@hypothesis.settings(max_examples=int(1e3))
+def test_snap_point(nx, ny, nz, test_data):
+    pf, start_pt = test_data
+
+    n = np.array([nx, ny, nz])
+    pt = start_pt + n
+
+    proj_pt = pf.snap_point(pt)
+    hypothesis.assume(not math.isnan(proj_pt[0]))
+
+    assert pf.is_navigable(proj_pt), "{} -> {} not navigable!".format(pt, proj_pt)

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -15,6 +15,7 @@ def test_data():
         "data/scene_datasets/habitat-test-scenes/skokloster-castle.navmesh"
     )
 
+    # The test point won't be deterministic
     return pf, pf.get_random_navigable_point()
 
 


### PR DESCRIPTION
## Motivation and Context

Expose projectToPoly as `snap_point`.  Sometimes it is useful to be able to snap a point to the nearest navigable point, people had been using `pathfinder.try_step(pt, pt)` to do that, but this has some weird edge cases.

## How Has This Been Tested

Via the test!  If you swap `snap_point(pt)` for `try_step(pt, pt)`, it finds a failure very fast.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

