### PR TITLE
[esp/core] add support for FATAL in logging wrapper

### DIFF
--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -24,10 +24,12 @@ class LogMessageVoidify {
 
 #define GLOG_INFO \
   Corrade::Utility::Debug {}
-#define GLOG_ERROR \
-  Corrade::Utility::Error {}
 #define GLOG_WARNING \
   Corrade::Utility::Warning {}
+#define GLOG_ERROR \
+  Corrade::Utility::Error {}
+#define GLOG_FATAL \
+  Corrade::Utility::Fatal {}
 #define LOG(severity) GLOG_##severity
 #define LOG_IF(severity, condition) \
   !(condition) ? (void)0 : LogMessageVoidify() & LOG(severity)


### PR DESCRIPTION
This will allow code using the logging wrapper (emscripten) to
use LOG(FATAL).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Needed in order to use LOG(FATAL) in emscripten builds.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
