### PR TITLE
Viewer's wiggleLastObject should only nudge in +y direction.

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -335,11 +335,6 @@ void Viewer::drawEvent() {
   if (physicsManager_ != nullptr)
     physicsManager_->stepPhysics(timeline_.previousFrameDuration());
 
-  for (auto id : physicsManager_->getExistingObjectIDs()) {
-    Corrade::Utility::Debug()
-        << "Object position: " << physicsManager_->getTranslation(id);
-  }
-
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -305,7 +305,11 @@ void Viewer::wiggleLastObject() {
   if (physicsManager_ == nullptr || objectIDs_.size() == 0)
     return;
 
-  physicsManager_->translate(objectIDs_.back(), randomDirection() * 0.1);
+  Magnum::Vector3 randDir = randomDirection();
+  // Only allow +Y so dynamic objects don't push through the floor.
+  randDir[1] = abs(randDir[1]);
+
+  physicsManager_->translate(objectIDs_.back(), randDir * 0.1);
 }
 
 Vector3 Viewer::positionOnSphere(Magnum::SceneGraph::Camera3D& camera,
@@ -330,6 +334,11 @@ void Viewer::drawEvent() {
 
   if (physicsManager_ != nullptr)
     physicsManager_->stepPhysics(timeline_.previousFrameDuration());
+
+  for (auto id : physicsManager_->getExistingObjectIDs()) {
+    Corrade::Utility::Debug()
+        << "Object position: " << physicsManager_->getTranslation(id);
+  }
 
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];


### PR DESCRIPTION
## Motivation and Context

Fix for Issue #274 where MotionType::DYNAMIC objects pushed into the ground plane kinematically fall through the floor. To remedy this, the function now only generates translations with positive Y values.

## How Has This Been Tested

Local tests.

![wiggle_up](https://user-images.githubusercontent.com/1445143/66329153-e85a5d80-e8e2-11e9-9307-aeda55e4a711.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
