### PR TITLE
[js] Check for support of WebGL and WebASM

### DIFF
--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -54,7 +54,8 @@ set(bundle_files
     modules/topdown.js
     modules/web_demo.js
     modules/defaults.js
-    modules/vr_demo.js)
+    modules/vr_demo.js
+    modules/utils.js)
 
 add_custom_command(OUTPUT bundle.js
                    COMMAND npm run lint-fix

--- a/src/esp/bindings_js/bindings.css
+++ b/src/esp/bindings_js/bindings.css
@@ -17,3 +17,18 @@
   text-align: right;
   padding-right: 1em;
 }
+
+#warning {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background-color: #fff;
+  color: #000;
+}
+
+.hidden {
+  display: none;
+}

--- a/src/esp/bindings_js/bindings.html
+++ b/src/esp/bindings_js/bindings.html
@@ -13,6 +13,7 @@ LICENSE file in the root directory of this source tree.-->
 </head>
 
 <body>
+  <div class="hidden" id="warning"></div>
   <h1>Habitat</h1>
   <div id="container">
     <div id="sizer">

--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -8,6 +8,7 @@ import WebDemo from "./modules/web_demo";
 import VRDemo from "./modules/vr_demo";
 import { defaultScene } from "./modules/defaults";
 import "./bindings.css";
+import { checkWebAssemblySupport, checkWebgl2Support } from "./modules/utils";
 
 function preload(file) {
   FS.createPreloadedFile("/", file, file, true, false);
@@ -50,3 +51,29 @@ Module.onRuntimeInitialized = () => {
   }
   demo.display();
 };
+
+function checkSupport() {
+  const webgl2Support = checkWebgl2Support();
+  let message = "";
+
+  if (!webgl2Support) {
+    message = "WebGL2 is not supported on your browser. ";
+  } else if (webgl2Support === 1) {
+    message = "WebGL2 is supported on your browser, but not enabled. ";
+  }
+
+  const webasmSupport = checkWebAssemblySupport();
+
+  if (!webasmSupport) {
+    message += "Web Assembly is not supported in your browser";
+  }
+
+  if (message.length > 0) {
+    const warningElement = document.getElementById("warning");
+    warningElement.innerHTML = message;
+    // Remove the default hidden class
+    warningElement.className = "";
+  }
+}
+
+checkSupport();

--- a/src/esp/bindings_js/modules/utils.js
+++ b/src/esp/bindings_js/modules/utils.js
@@ -23,3 +23,58 @@ export function throttle(func, timeout = 500) {
     }
   };
 }
+
+/**
+ * Check whether web assembly is supported on the current browser or not.
+ * Returns false if not otherwise true.
+ */
+export function checkWebAssemblySupport() {
+  try {
+    if (
+      typeof WebAssembly === "object" &&
+      typeof WebAssembly.instantiate === "function"
+    ) {
+      const module = new WebAssembly.Module(
+        Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
+      );
+      if (module instanceof WebAssembly.Module) {
+        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+      }
+    }
+  } catch (e) {
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Checks for WebGL2 support in current browser.
+ * Returns 0 if there is no support, 1 if support is there but disabled otherwise 2.
+ */
+export function checkWebgl2Support() {
+  let canvas;
+  let ctx;
+  let hasWebgl = false;
+
+  try {
+    canvas = document.createElement("canvas");
+    ctx = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+  } catch (e) {
+    return;
+  }
+
+  if (ctx !== undefined) {
+    hasWebgl = true;
+  }
+
+  canvas = undefined;
+  if (!hasWebgl) {
+    if (typeof WebGL2RenderingContext !== "undefined") {
+      return 1;
+    } else {
+      return 0;
+    }
+  } else {
+    return 2;
+  }
+}


### PR DESCRIPTION
## Motivation and Context

On mobile browsers and other which don't support both of these, we should have a proper message to the user instead of showing asm logs. This PR aims to check for the support of both of them and then accordingly show a message to the end user.

## How Has This Been Tested

bindings.html use firefox's experimental flags to disable/enable support.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
