### PR TITLE
[tests/js] Add testing support for JS through Jest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: run clang-format
           command: |
             find . -not -path "*/\.*" -not -path "*/deps/*" -not -path "*/obsolete/*" -not -path "*/build/*" | grep -E ".*\.cpp$|.*\.h$|.*\.cu$|.*\.hpp$" | xargs -I {} bash -c "diff -u <(cat {}) <(clang-format -style=file {})"
-  js_lint:
+  js_lint_and_test:
     docker:
       - image: circleci/node:11.9
     steps:
@@ -59,6 +59,10 @@ jobs:
           name: run eslint
           command: |
             npm run lint
+      - run:
+          name: run tests
+          command: |
+            npm run test
   install_and_test_ubuntu:
     <<: *gpu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,5 +303,5 @@ workflows:
     jobs:
       - python_lint
       - cpp_lint
-      - js_lint
+      - js_lint_and_test
       - install_and_test_ubuntu

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "browser": true,
     "commonjs": true,
     "node": true,
-    "es6": true
+    "es6": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/preset-env": "^7.6.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "css-loader": "^3.2.0",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
@@ -15,6 +16,7 @@
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0",
     "html-webpack-plugin": "^3.2.0",
+    "jest": "^24.9.0",
     "minimist": "^1.2.0",
     "prettier": "^1.18.2",
     "style-loader": "^1.0.0",
@@ -22,7 +24,7 @@
     "webpack-cli": "^3.3.9"
   },
   "scripts": {
-    "test": "node ./src/esp/bindings_js/tests/**/*_test.js",
+    "test": "jest ./src/esp/bindings_js/tests/",
     "format": "prettier --trailing-comma es5 --single-quote './src/esp/bindings_js/**/*.js'",
     "build": "webpack --config ./src/esp/bindings_js/webpack.config.js",
     "lint": "eslint --ext .html,.js ./src/esp/bindings_js",
@@ -38,7 +40,14 @@
     ],
     "plugins": [
       "@babel/plugin-proposal-class-properties"
-    ]
+    ],
+    "env": {
+      "test": {
+        "plugins": [
+          "transform-es2015-modules-commonjs"
+        ]
+      }
+    }
   },
   "keywords": [
     "embodied",

--- a/src/esp/bindings_js/tests/utils.test.js
+++ b/src/esp/bindings_js/tests/utils.test.js
@@ -1,0 +1,23 @@
+import { throttle } from "../modules/utils";
+
+test("throttle should work properly", () => {
+  let count = 0;
+  let interval;
+  const startTime = Date.now();
+  function incrementCounter(resolve) {
+    if (count === 5) {
+      resolve(count);
+    } else {
+      count += 1;
+    }
+  }
+
+  return new Promise((resolve) => {
+    interval = window.setInterval(throttle(() => incrementCounter(resolve), 500), 50);
+  }).then((count) => {
+    window.clearInterval(interval);
+    expect(count).toEqual(5);
+    expect(Date.now() - startTime).toBeGreaterThan(2500);
+    return count;
+  })
+});

--- a/src/esp/bindings_js/tests/utils.test.js
+++ b/src/esp/bindings_js/tests/utils.test.js
@@ -12,12 +12,15 @@ test("throttle should work properly", () => {
     }
   }
 
-  return new Promise((resolve) => {
-    interval = window.setInterval(throttle(() => incrementCounter(resolve), 500), 50);
-  }).then((count) => {
+  return new Promise(resolve => {
+    interval = window.setInterval(
+      throttle(() => incrementCounter(resolve), 500),
+      50
+    );
+  }).then(count => {
     window.clearInterval(interval);
     expect(count).toEqual(5);
     expect(Date.now() - startTime).toBeGreaterThan(2500);
     return count;
-  })
+  });
 });

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -42,7 +42,7 @@ def test_no_move_fun():
         agent.act("move_forward")
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, cmp=False)
 class ExpectedDelta:
     delta_pos: np.ndarray = attr.Factory(lambda: np.array([0, 0, 0]))
     delta_rot: np.quaternion = attr.Factory(lambda: np.quaternion(1, 0, 0, 0))


### PR DESCRIPTION
- Running `npm test` will run JS tests using Jest
- Tests live inside tests folder in bindings_js and are suffixed with
.test.js extension

## Motivation and Context

Add support for testing on JS side using Jest.

Also includes a complex testing example of throttle function 

## How Has This Been Tested

`npm test`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
