### PR TITLE
Support ptex mesh - step 7: Disable texture buffer on Mac OSX

### DIFF
--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -36,11 +36,6 @@ namespace assets {
 
 void PTexMeshData::load(const std::string& meshFile,
                         const std::string& atlasFolder) {
-#ifdef __APPLE__
-  Cr::Utility::Fatal{-1} << "PTexMeshData::load: PTex mesh is not supported on "
-                            "Mac in current version.";
-#endif
-
   if (!io::exists(meshFile)) {
     Cr::Utility::Fatal{-1} << "PTexMeshData::load: Mesh file" << meshFile
                            << "does not exist.";
@@ -797,6 +792,7 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
     currentMesh->indexBuffer.setData(submeshes_[iMesh].ibo,
                                      Magnum::GL::BufferUsage::StaticDraw);
   }
+#ifndef __APPLE__
   LOG(INFO) << "Calculating mesh adjacency... ";
 
   std::vector<std::vector<uint32_t>> adjFaces(submeshes_.size());
@@ -805,14 +801,17 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
   for (int iMesh = 0; iMesh < submeshes_.size(); ++iMesh) {
     calculateAdjacency(submeshes_[iMesh], adjFaces[iMesh]);
   }
+#endif
 
   for (int iMesh = 0; iMesh < submeshes_.size(); ++iMesh) {
     auto& currentMesh = renderingBuffers_[iMesh];
 
+#ifndef __APPLE__
     currentMesh->adjFacesBufferTexture.setBuffer(
         Magnum::GL::BufferTextureFormat::R32UI, currentMesh->adjFacesBuffer);
     currentMesh->adjFacesBuffer.setData(adjFaces[iMesh],
                                         Magnum::GL::BufferUsage::StaticDraw);
+#endif
     GLintptr offset = 0;
     currentMesh->mesh
         .setPrimitive(Magnum::GL::MeshPrimitive::LinesAdjacency)

--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -792,7 +792,7 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
     currentMesh->indexBuffer.setData(submeshes_[iMesh].ibo,
                                      Magnum::GL::BufferUsage::StaticDraw);
   }
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
   LOG(INFO) << "Calculating mesh adjacency... ";
 
   std::vector<std::vector<uint32_t>> adjFaces(submeshes_.size());
@@ -806,7 +806,7 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
   for (int iMesh = 0; iMesh < submeshes_.size(); ++iMesh) {
     auto& currentMesh = renderingBuffers_[iMesh];
 
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
     currentMesh->adjFacesBufferTexture.setBuffer(
         Magnum::GL::BufferTextureFormat::R32UI, currentMesh->adjFacesBuffer);
     currentMesh->adjFacesBuffer.setData(adjFaces[iMesh],

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -18,7 +18,7 @@ PTexMeshDrawable::PTexMeshDrawable(
     : Drawable{node, shader, ptexMeshData.getRenderingBuffer(submeshID)->mesh,
                group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
       adjFacesBufferTexture_(
           ptexMeshData.getRenderingBuffer(submeshID)->adjFacesBufferTexture),
 #endif
@@ -36,7 +36,7 @@ void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
       .setSaturation(saturation_)
       .setAtlasTextureSize(atlasTexture_, tileSize_)
       .bindAtlasTexture(atlasTexture_)
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
       .bindAdjFacesBufferTexture(adjFacesBufferTexture_)
 #endif
       .setMVPMatrix(camera.projectionMatrix() * transformationMatrix);

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -18,12 +18,15 @@ PTexMeshDrawable::PTexMeshDrawable(
     : Drawable{node, shader, ptexMeshData.getRenderingBuffer(submeshID)->mesh,
                group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),
+#ifndef __APPLE__
       adjFacesBufferTexture_(
           ptexMeshData.getRenderingBuffer(submeshID)->adjFacesBufferTexture),
+#endif
       tileSize_(ptexMeshData.tileSize()),
       exposure_(ptexMeshData.exposure()),
       gamma_(ptexMeshData.gamma()),
-      saturation_(ptexMeshData.saturation()) {}
+      saturation_(ptexMeshData.saturation()) {
+}
 
 void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                             Magnum::SceneGraph::Camera3D& camera) {
@@ -33,7 +36,9 @@ void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
       .setSaturation(saturation_)
       .setAtlasTextureSize(atlasTexture_, tileSize_)
       .bindAtlasTexture(atlasTexture_)
+#ifndef __APPLE__
       .bindAdjFacesBufferTexture(adjFacesBufferTexture_)
+#endif
       .setMVPMatrix(camera.projectionMatrix() * transformationMatrix);
   mesh_.draw(ptexMeshShader);
 }

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -29,7 +29,9 @@ class PTexMeshDrawable : public Drawable {
                     Magnum::SceneGraph::Camera3D& camera) override;
 
   Magnum::GL::Texture2D& atlasTexture_;
+#ifndef __APPLE__
   Magnum::GL::BufferTexture& adjFacesBufferTexture_;
+#endif
   uint32_t tileSize_;
   float exposure_;
   float gamma_;

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -29,7 +29,7 @@ class PTexMeshDrawable : public Drawable {
                     Magnum::SceneGraph::Camera3D& camera) override;
 
   Magnum::GL::Texture2D& atlasTexture_;
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
   Magnum::GL::BufferTexture& adjFacesBufferTexture_;
 #endif
   uint32_t tileSize_;

--- a/src/esp/gfx/PTexMeshShader.cpp
+++ b/src/esp/gfx/PTexMeshShader.cpp
@@ -31,9 +31,11 @@ namespace gfx {
 namespace {
 enum TextureBindingPointIndex : uint8_t {
   atlas = 0,
+#ifndef __APPLE__
   adjFaces = 1,
+#endif
 };
-}
+}  // namespace
 
 PTexMeshShader::PTexMeshShader() {
   MAGNUM_ASSERT_GL_VERSION_SUPPORTED(GL::Version::GL410);
@@ -51,6 +53,9 @@ PTexMeshShader::PTexMeshShader() {
 
   vert.addSource(rs.get("ptex-default-gl410.vert"));
   geom.addSource(rs.get("ptex-default-gl410.geom"));
+#ifdef __APPLE__
+  frag.addSource("#define DISABLED_ON_MACOSX\n");
+#endif
   frag.addSource(rs.get("ptex-default-gl410.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(GL::Shader::compile({vert, geom, frag}));
@@ -62,9 +67,10 @@ PTexMeshShader::PTexMeshShader() {
   // set texture binding points in the shader;
   // see ptex fragment shader code for details
   setUniform(uniformLocation("atlasTex"), TextureBindingPointIndex::atlas);
-  // TODO: disable the "meshAdjFaces" on Mac
+#ifndef __APPLE__
   setUniform(uniformLocation("meshAdjFaces"),
              TextureBindingPointIndex::adjFaces);
+#endif
 
   // cache the uniform locations
   MVPMatrixUniform_ = uniformLocation("MVP");
@@ -86,7 +92,9 @@ PTexMeshShader& PTexMeshShader::bindAtlasTexture(
 
 PTexMeshShader& PTexMeshShader::bindAdjFacesBufferTexture(
     Magnum::GL::BufferTexture& texture) {
+#ifndef __APPLE__
   texture.bind(TextureBindingPointIndex::adjFaces);
+#endif
   return *this;
 }
 

--- a/src/esp/gfx/PTexMeshShader.cpp
+++ b/src/esp/gfx/PTexMeshShader.cpp
@@ -31,7 +31,7 @@ namespace gfx {
 namespace {
 enum TextureBindingPointIndex : uint8_t {
   atlas = 0,
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
   adjFaces = 1,
 #endif
 };
@@ -53,8 +53,8 @@ PTexMeshShader::PTexMeshShader() {
 
   vert.addSource(rs.get("ptex-default-gl410.vert"));
   geom.addSource(rs.get("ptex-default-gl410.geom"));
-#ifdef __APPLE__
-  frag.addSource("#define DISABLED_ON_MACOSX\n");
+#ifdef CORRADE_TARGET_APPLE
+  frag.addSource("#define CORRADE_TARGET_APPLE\n");
 #endif
   frag.addSource(rs.get("ptex-default-gl410.frag"));
 
@@ -67,7 +67,7 @@ PTexMeshShader::PTexMeshShader() {
   // set texture binding points in the shader;
   // see ptex fragment shader code for details
   setUniform(uniformLocation("atlasTex"), TextureBindingPointIndex::atlas);
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
   setUniform(uniformLocation("meshAdjFaces"),
              TextureBindingPointIndex::adjFaces);
 #endif
@@ -92,7 +92,7 @@ PTexMeshShader& PTexMeshShader::bindAtlasTexture(
 
 PTexMeshShader& PTexMeshShader::bindAdjFacesBufferTexture(
     Magnum::GL::BufferTexture& texture) {
-#ifndef __APPLE__
+#ifndef CORRADE_TARGET_APPLE
   texture.bind(TextureBindingPointIndex::adjFaces);
 #endif
   return *this;

--- a/src/shaders/ptex-default-gl410.frag
+++ b/src/shaders/ptex-default-gl410.frag
@@ -131,8 +131,9 @@ int indexAdjacentFaces(int faceID, inout ivec2 p, int tsize) {
 vec4 texelFetchAtlasAdj(sampler2D tex, int faceID, ivec2 p, int level) {
   int tsize = tileSize >> level;
 
+  // if the target is Mac OSX, the following function is disabled.
+#ifndef CORRADE_TARGET_APPLE 
   // fetch from adjacent face if necessary
-#ifndef DISABLED_ON_MACOSX
   faceID = indexAdjacentFaces(faceID, p, tsize);
 #endif
 

--- a/src/shaders/ptex-default-gl410.frag
+++ b/src/shaders/ptex-default-gl410.frag
@@ -132,7 +132,9 @@ vec4 texelFetchAtlasAdj(sampler2D tex, int faceID, ivec2 p, int level) {
   int tsize = tileSize >> level;
 
   // fetch from adjacent face if necessary
+#ifndef DISABLED_ON_MACOSX
   faceID = indexAdjacentFaces(faceID, p, tsize);
+#endif
 
   // clamp to tile edge
   p = clamp(p, ivec2(0, 0), ivec2(tsize - 1, tsize - 1));


### PR DESCRIPTION
## Motivation and Context
The buffer texture cannot work properly on Mac OSX. We suspect it is due to OpenGL driver shipped with the Mac OSX.
This PR is to add preprocessor directive for conditional compilation on different OS.

-) disabled the bufferTexture in PTexMeshData, Drawable, Shader;
-) disabled the "adjFace" computation;
-) disabled the index computation in shader code;  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Test it on Mac:
![image](https://user-images.githubusercontent.com/931093/66349036-cb3a8480-e90c-11e9-889d-fe8c57420f68.png)

Test it on Linux (to show it does not affect rendering on linux):
![image](https://user-images.githubusercontent.com/931093/66349024-c07fef80-e90c-11e9-965c-67a605b58546.png)


<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
