### PR TITLE
[utils/viewer] only check for physics config is physics is enabled

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -97,7 +97,6 @@ class Viewer : public Magnum::Platform::Application {
   scene::ObjectControls controls_;
   Magnum::Vector3 previousPosition_;
 
-  bool enablePhysics_;
   std::vector<int> objectIDs_;
 
   Magnum::Timeline timeline_;
@@ -128,14 +127,6 @@ Viewer::Viewer(const Arguments& arguments)
       .parse(arguments.argc, arguments.argv);
 
   const auto viewportSize = GL::defaultFramebuffer.viewport().size();
-  enablePhysics_ = args.isSet("enable-physics");
-  std::string physicsConfigFilename = args.value("physics-config");
-  if (!Utility::Directory::exists(physicsConfigFilename)) {
-    LOG(ERROR)
-        << physicsConfigFilename
-        << " was not found, specify an existing file in --physics-config";
-    std::exit(1);
-  }
 
   // Setup renderer and shader defaults
   GL::Renderer::enable(GL::Renderer::Feature::DepthTest);
@@ -151,16 +142,20 @@ Viewer::Viewer(const Arguments& arguments)
   const std::string& file = args.value("scene");
   const assets::AssetInfo info = assets::AssetInfo::fromPath(file);
 
-  if (enablePhysics_) {
+  if (args.isSet("enable-physics")) {
+    std::string physicsConfigFilename = args.value("physics-config");
+    if (!Utility::Directory::exists(physicsConfigFilename)) {
+      LOG(FATAL)
+          << physicsConfigFilename
+          << " was not found, specify an existing file in --physics-config";
+    }
     if (!resourceManager_.loadScene(info, physicsManager_, navSceneNode_,
                                     &drawables, physicsConfigFilename)) {
-      LOG(ERROR) << "cannot load " << file;
-      std::exit(1);
+      LOG(FATAL) << "cannot load " << file;
     }
   } else {
     if (!resourceManager_.loadScene(info, navSceneNode_, &drawables)) {
-      LOG(ERROR) << "cannot load " << file;
-      std::exit(1);
+      LOG(FATAL) << "cannot load " << file;
     }
   }
 


### PR DESCRIPTION
For WebGL, all resources need to be explicitly loaded. This gets
us part way to WebGL viewer working again.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Trying to get viewer working again with WebGL.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified that with this change, viewer works without a physics config when enable
physics is not true.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
