### PR TITLE
Semantic scene ID assigned by default

### DIFF
--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -121,16 +121,17 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
                                    &semanticDrawables);
       }
       LOG(INFO) << "Loaded.";
-    }else{
+    } else {
       activeSemanticSceneID_ = activeSceneID_;
       // instance meshes and suncg houses contain their semantic annotations
       // empty scene has none to worry about
-      if ( !(sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
-        sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
-        sceneFilename.compare(assets::EMPTY_SCENE) == 0)) {
-          //TODO: programmatic generation of semantic meshes when no annotiations are provided.
-          LOG(WARNING)
-            << ":\n---\n The active scene does not contain semantic annotations. \n---";
+      if (!(sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
+            sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
+            sceneFilename.compare(assets::EMPTY_SCENE) == 0)) {
+        // TODO: programmatic generation of semantic meshes when no annotiations
+        // are provided.
+        LOG(WARNING) << ":\n---\n The active scene does not contain semantic "
+                        "annotations. \n---";
       }
     }
   }

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -121,13 +121,17 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
                                    &semanticDrawables);
       }
       LOG(INFO) << "Loaded.";
-    }
-
-    // instance meshes and suncg houses contain their semantic annotations
-    if (sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
-        sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
-        sceneFilename.compare(assets::EMPTY_SCENE) == 0) {
+    }else{
       activeSemanticSceneID_ = activeSceneID_;
+      // instance meshes and suncg houses contain their semantic annotations
+      // empty scene has none to worry about
+      if ( !(sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
+        sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
+        sceneFilename.compare(assets::EMPTY_SCENE) == 0)) {
+          //TODO: programmatic generation of semantic meshes when no annotiations are provided.
+          LOG(WARNING)
+            << ":\n---\n The active scene does not contain semantic annotations. \n---";
+      }
     }
   }
 

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -101,12 +101,6 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
       throw std::invalid_argument("Cannot load: " + sceneFilename);
     }
 
-    activeSemanticSceneID_ = activeSceneID_;
-    auto& semanticSceneGraph =
-        sceneManager_.getSceneGraph(activeSemanticSceneID_);
-    auto& semanticRootNode = semanticSceneGraph.getRootNode();
-    auto& semanticDrawables = semanticSceneGraph.getDrawables();
-
     if (io::exists(houseFilename)) {
       LOG(INFO) << "Loading house from " << houseFilename;
       // if semantic mesh exists, load it as well
@@ -131,7 +125,8 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
     // instance meshes and suncg houses contain their semantic annotations
     if (sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
-        sceneInfo.type == assets::AssetType::INSTANCE_MESH) {
+        sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
+        sceneFilename.compare(assets::EMPTY_SCENE) == 0) {
       activeSemanticSceneID_ = activeSceneID_;
     }
   }

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -115,6 +115,12 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
           io::removeExtension(houseFilename) + "_semantic.ply";
       if (io::exists(semanticMeshFilename)) {
         LOG(INFO) << "Loading semantic mesh " << semanticMeshFilename;
+        activeSemanticSceneID_ = sceneManager_.initSceneGraph();
+        sceneID_.push_back(activeSemanticSceneID_);
+        auto& semanticSceneGraph =
+            sceneManager_.getSceneGraph(activeSemanticSceneID_);
+        auto& semanticRootNode = semanticSceneGraph.getRootNode();
+        auto& semanticDrawables = semanticSceneGraph.getDrawables();
         const assets::AssetInfo semanticSceneInfo =
             assets::AssetInfo::fromPath(semanticMeshFilename);
         resourceManager_.loadScene(semanticSceneInfo, &semanticRootNode,

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -101,6 +101,12 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
       throw std::invalid_argument("Cannot load: " + sceneFilename);
     }
 
+    activeSemanticSceneID_ = activeSceneID_;
+    auto& semanticSceneGraph =
+        sceneManager_.getSceneGraph(activeSemanticSceneID_);
+    auto& semanticRootNode = semanticSceneGraph.getRootNode();
+    auto& semanticDrawables = semanticSceneGraph.getDrawables();
+
     if (io::exists(houseFilename)) {
       LOG(INFO) << "Loading house from " << houseFilename;
       // if semantic mesh exists, load it as well
@@ -109,12 +115,6 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
           io::removeExtension(houseFilename) + "_semantic.ply";
       if (io::exists(semanticMeshFilename)) {
         LOG(INFO) << "Loading semantic mesh " << semanticMeshFilename;
-        activeSemanticSceneID_ = sceneManager_.initSceneGraph();
-        sceneID_.push_back(activeSemanticSceneID_);
-        auto& semanticSceneGraph =
-            sceneManager_.getSceneGraph(activeSemanticSceneID_);
-        auto& semanticRootNode = semanticSceneGraph.getRootNode();
-        auto& semanticDrawables = semanticSceneGraph.getDrawables();
         const assets::AssetInfo semanticSceneInfo =
             assets::AssetInfo::fromPath(semanticMeshFilename);
         resourceManager_.loadScene(semanticSceneInfo, &semanticRootNode,


### PR DESCRIPTION
## Motivation and Context

Related to issue #284. A semantic scene ID should be assigned by default so that semantic rendering can be done regardless of the provided annotations. For example on the empty "NONE" scene.

In the future we would like to provide a method for setting those semantic annotations for physics objects programmatically.

Comments welcome.

## How Has This Been Tested

Local testing.

Empty scene with physics object rendered via rgb and semantic sensors:
![image](https://user-images.githubusercontent.com/1445143/66442278-fdbcae00-e9ee-11e9-92b6-a78c03c9bfe3.png)
(Image courtesy of a script by Daniel Huber.)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
