### PR TITLE
Set modelview, projection matrices, viewport respectively from sensor to render camera

### DIFF
--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -452,9 +452,13 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       // initialized, attached to pinholeCameraNode, status: "valid"
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
                           const sensor::SensorSpec::ptr&>())
+      .def("set_modelview_matrix", &sensor::PinholeCamera::setModelViewMatrix,
+           R"(Compute and set the modelview matrix to the render camera.)")
       .def("set_projection_matrix", &sensor::PinholeCamera::setProjectionMatrix,
            R"(Set the width, height, near, far, and hfov,
-          stored in pinhole camera to the render camera.)");
+          stored in pinhole camera to the render camera.)")
+      .def("set_viewport", &sensor::PinholeCamera::setViewport,
+           R"(Set the viewport to the render camera)");
 
   // ==== SensorSuite ====
   py::class_<SensorSuite, SensorSuite::ptr>(m, "SensorSuite")

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -452,8 +452,9 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       // initialized, attached to pinholeCameraNode, status: "valid"
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
                           const sensor::SensorSpec::ptr&>())
-      .def("set_modelview_matrix", &sensor::PinholeCamera::setModelViewMatrix,
-           R"(Compute and set the modelview matrix to the render camera.)")
+      .def("set_transformation_matrix",
+           &sensor::PinholeCamera::setTransformationMatrix,
+           R"(Compute and set the transformation matrix to the render camera.)")
       .def("set_projection_matrix", &sensor::PinholeCamera::setProjectionMatrix,
            R"(Set the width, height, near, far, and hfov,
           stored in pinhole camera to the render camera.)")

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -15,7 +15,7 @@ SceneGraph::SceneGraph()
 void SceneGraph::setDefaultRenderCamera(sensor::Sensor& sensor) {
   ASSERT(sensor.isVisualSensor());
 
-  sensor.setModelViewMatrix(defaultRenderCamera_)
+  sensor.setTransformationMatrix(defaultRenderCamera_)
       .setProjectionMatrix(defaultRenderCamera_)
       .setViewport(defaultRenderCamera_);
 }

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "SceneGraph.h"
 #include <Magnum/Math/Algorithms/GramSchmidt.h>
+#include "SceneGraph.h"
 
 namespace esp {
 namespace scene {
@@ -13,32 +13,13 @@ SceneGraph::SceneGraph()
       defaultRenderCameraNode_{rootNode_},
       defaultRenderCamera_{defaultRenderCameraNode_} {}
 
-// set transformation and projection matrix to the default camera
+// set transformation, projection matrix, viewport to the default camera
 void SceneGraph::setDefaultRenderCamera(sensor::Sensor& sensor) {
   ASSERT(sensor.isVisualSensor());
 
-  Magnum::Matrix4 T = sensor.node().absoluteTransformation();
-  Magnum::Matrix3 R = T.rotationScaling();
-  Magnum::Math::Algorithms::gramSchmidtOrthonormalizeInPlace(R);
-
-  VLOG(1) << "||R - GS(R)|| = "
-          << Eigen::Map<mat3f>((R - T.rotationShear()).data()).norm();
-
-  T = Magnum::Matrix4::from(R, T.translation()) *
-      Magnum::Matrix4::scaling(T.scaling());
-
-  // set the transformation to the default camera
-  // so that the camera has the correct modelview matrix for rendering;
-  // to do it,
-  // obtain the *absolute* transformation from the sensor node,
-  // apply it as the *relative* transformation between the default camera and
-  // its parent, which is rootNode_.
-  defaultRenderCameraNode_.setTransformation(T);
-
-  // set the projection matrix to the default camera
-  sensor.setProjectionMatrix(defaultRenderCamera_);
-
-  defaultRenderCamera_.getMagnumCamera().setViewport(sensor.framebufferSize());
+  sensor.setModelViewMatrix(defaultRenderCamera_)
+      .setProjectionMatrix(defaultRenderCamera_)
+      .setViewport(defaultRenderCamera_);
 }
 
 }  // namespace scene

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-
-#include <Magnum/Math/Algorithms/GramSchmidt.h>
 #include "SceneGraph.h"
 
 namespace esp {

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -1,6 +1,10 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+
 #include "SceneGraph.h"
 
 namespace esp {
@@ -18,6 +22,14 @@ void SceneGraph::setDefaultRenderCamera(sensor::Sensor& sensor) {
   sensor.setTransformationMatrix(defaultRenderCamera_)
       .setProjectionMatrix(defaultRenderCamera_)
       .setViewport(defaultRenderCamera_);
+}
+
+bool SceneGraph::isRootNode(SceneNode& node) {
+  auto parent = node.parent();
+  // if the parent is null, it means the node is the world_ node.
+  CORRADE_ASSERT(parent != nullptr,
+                 "SceneGraph::isRootNode: the node is illegal.", false);
+  return (parent->parent() == nullptr ? true : false);
 }
 
 }  // namespace scene

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -34,6 +34,10 @@ class SceneGraph {
 
   gfx::RenderCamera& getDefaultRenderCamera() { return defaultRenderCamera_; }
 
+  /* @brief check if the scene node is the root node of the scene graph.
+   */
+  static bool isRootNode(SceneNode& node);
+
  protected:
   MagnumScene world_;
 

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -59,7 +59,7 @@ PinholeCamera& PinholeCamera::setTransformationMatrix(
   // if parent is the root node, then skip it!
   if (parent != nullptr) {
     relativeTransform =
-        parent->absoluteTransformation().inverted() * absTransform;
+        parent->absoluteTransformation().inverted() * relativeTransform;
   }
   targetCamera.node().setTransformation(relativeTransform);
   return *this;

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -3,8 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <Magnum/ImageView.h>
-#include <Magnum/PixelFormat.h>
 #include <Magnum/Math/Algorithms/GramSchmidt.h>
+#include <Magnum/PixelFormat.h>
 
 #include "PinholeCamera.h"
 #include "esp/gfx/DepthUnprojection.h"
@@ -29,21 +29,23 @@ void PinholeCamera::setProjectionParameters(SensorSpec::ptr spec) {
   hfov_ = std::atof(spec_->parameters.at("hfov").c_str());
 }
 
-PinholeCamera& PinholeCamera::setProjectionMatrix(gfx::RenderCamera& targetCamera) {
+PinholeCamera& PinholeCamera::setProjectionMatrix(
+    gfx::RenderCamera& targetCamera) {
   targetCamera.setProjectionMatrix(width_, height_, near_, far_, hfov_);
   return *this;
 }
 
-PinholeCamera& PinholeCamera::setModelViewMatrix(gfx::RenderCamera& targetCamera) {
+PinholeCamera& PinholeCamera::setModelViewMatrix(
+    gfx::RenderCamera& targetCamera) {
   Magnum::Matrix4 T = this->node().absoluteTransformation();
   Magnum::Matrix3 R = T.rotationScaling();
   Magnum::Math::Algorithms::gramSchmidtOrthonormalizeInPlace(R);
 
   VLOG(1) << "||R - GS(R)|| = "
-    << Eigen::Map<mat3f>((R - T.rotationShear()).data()).norm();
+          << Eigen::Map<mat3f>((R - T.rotationShear()).data()).norm();
 
   T = Magnum::Matrix4::from(R, T.translation()) *
-    Magnum::Matrix4::scaling(T.scaling());
+      Magnum::Matrix4::scaling(T.scaling());
 
   // set the transformation to the camera
   // so that the camera has the correct modelview matrix for rendering;

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -4,6 +4,7 @@
 
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
+#include <Magnum/Math/Algorithms/GramSchmidt.h>
 
 #include "PinholeCamera.h"
 #include "esp/gfx/DepthUnprojection.h"
@@ -28,8 +29,35 @@ void PinholeCamera::setProjectionParameters(SensorSpec::ptr spec) {
   hfov_ = std::atof(spec_->parameters.at("hfov").c_str());
 }
 
-void PinholeCamera::setProjectionMatrix(gfx::RenderCamera& targetCamera) {
+PinholeCamera& PinholeCamera::setProjectionMatrix(gfx::RenderCamera& targetCamera) {
   targetCamera.setProjectionMatrix(width_, height_, near_, far_, hfov_);
+  return *this;
+}
+
+PinholeCamera& PinholeCamera::setModelViewMatrix(gfx::RenderCamera& targetCamera) {
+  Magnum::Matrix4 T = this->node().absoluteTransformation();
+  Magnum::Matrix3 R = T.rotationScaling();
+  Magnum::Math::Algorithms::gramSchmidtOrthonormalizeInPlace(R);
+
+  VLOG(1) << "||R - GS(R)|| = "
+    << Eigen::Map<mat3f>((R - T.rotationShear()).data()).norm();
+
+  T = Magnum::Matrix4::from(R, T.translation()) *
+    Magnum::Matrix4::scaling(T.scaling());
+
+  // set the transformation to the camera
+  // so that the camera has the correct modelview matrix for rendering;
+  // to do it,
+  // obtain the *absolute* transformation from the sensor node,
+  // apply it as the *relative* transformation between the default camera and
+  // its parent, which is rootNode_.
+  targetCamera.node().setTransformation(T);
+  return *this;
+}
+
+PinholeCamera& PinholeCamera::setViewport(gfx::RenderCamera& targetCamera) {
+  targetCamera.getMagnumCamera().setViewport(this->framebufferSize());
+  return *this;
 }
 
 bool PinholeCamera::getObservationSpace(ObservationSpace& space) {

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -33,9 +33,11 @@ class PinholeCamera : public Sensor {
   bool isVisualSensor() override { return true; }
 
   // set the projection parameters to the given render camera
-  virtual PinholeCamera& setProjectionMatrix(gfx::RenderCamera& targetCamera) override;
+  virtual PinholeCamera& setProjectionMatrix(
+      gfx::RenderCamera& targetCamera) override;
   // set the modelview parameters to the given render camera
-  virtual PinholeCamera& setModelViewMatrix(gfx::RenderCamera& targetCamera) override;
+  virtual PinholeCamera& setModelViewMatrix(
+      gfx::RenderCamera& targetCamera) override;
   // set the view port parameters to the given render camera
   virtual PinholeCamera& setViewport(gfx::RenderCamera& targetCamera) override;
 

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -33,7 +33,11 @@ class PinholeCamera : public Sensor {
   bool isVisualSensor() override { return true; }
 
   // set the projection parameters to the given render camera
-  virtual void setProjectionMatrix(gfx::RenderCamera& targetCamera) override;
+  virtual PinholeCamera& setProjectionMatrix(gfx::RenderCamera& targetCamera) override;
+  // set the modelview parameters to the given render camera
+  virtual PinholeCamera& setModelViewMatrix(gfx::RenderCamera& targetCamera) override;
+  // set the view port parameters to the given render camera
+  virtual PinholeCamera& setViewport(gfx::RenderCamera& targetCamera) override;
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs) override;
 

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -32,13 +32,13 @@ class PinholeCamera : public Sensor {
 
   bool isVisualSensor() override { return true; }
 
-  // set the projection parameters to the given render camera
+  // set the projection matrix to the given render camera
   virtual PinholeCamera& setProjectionMatrix(
       gfx::RenderCamera& targetCamera) override;
-  // set the modelview parameters to the given render camera
-  virtual PinholeCamera& setModelViewMatrix(
+  // set the transformation matrix to the given render camera
+  virtual PinholeCamera& setTransformationMatrix(
       gfx::RenderCamera& targetCamera) override;
-  // set the view port parameters to the given render camera
+  // set the view port to the given render camera
   virtual PinholeCamera& setViewport(gfx::RenderCamera& targetCamera) override;
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs) override;

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -115,12 +115,25 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
   virtual bool isVisualSensor() { return false; }
 
   // visual sensor should implement and override the following functions
+  /**
+   * @brief set the projection matrix from sensor to the render camera
+   * @return Reference to self (for method chaining)
+   */
   virtual Sensor& setProjectionMatrix(gfx::RenderCamera& targetCamera) {
     return *this;
   }
-  virtual Sensor& setModelViewMatrix(gfx::RenderCamera& targetCamera) {
+  /**
+   * @brief set the transform matrix (modelview) from sensor to the render
+   * camera
+   * @return Reference to self (for method chaining)
+   */
+  virtual Sensor& setTransformationMatrix(gfx::RenderCamera& targetCamera) {
     return *this;
   }
+  /**
+   * @brief set the viewport from sensor to the render camera
+   * @return Reference to self (for method chaining)
+   */
   virtual Sensor& setViewport(gfx::RenderCamera& targetCamera) { return *this; }
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs);

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -114,8 +114,14 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual bool isVisualSensor() { return false; }
 
-  // visual sensor should implement and override this function
-  virtual void setProjectionMatrix(gfx::RenderCamera& targetCamera){};
+  // visual sensor should implement and override the following functions
+  virtual Sensor& setProjectionMatrix(gfx::RenderCamera& targetCamera) {
+    return *this;
+  }
+  virtual Sensor& setModelViewMatrix(gfx::RenderCamera& targetCamera) {
+    return *this;
+  }
+  virtual Sensor& setViewport(gfx::RenderCamera& targetCamera) { return *this; }
 
   virtual bool getObservation(gfx::Simulator& sim, Observation& obs);
   virtual bool getObservationSpace(ObservationSpace& space);


### PR DESCRIPTION
## Motivation and Context

Set the camera matrices (model view, proj), viewport **uniformly** from sensor to the render camera;
When people create their own visual sensor (other than pinhole camera), they can inherit from the "Sensor" class, and customize and implement their own version of aforementioned functions;

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

Test it with the example model (the castle):
<img width="874" alt="Screen Shot 2019-10-08 at 4 48 56 PM" src="https://user-images.githubusercontent.com/931093/66442624-6193a680-e9f0-11e9-8f85-cd9afd741b70.png">


<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
