### PR TITLE
Simulator::addObject should add to the active scene graph

### DIFF
--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -212,7 +212,7 @@ int Simulator::addObject(const int objectLibIndex, const int sceneID) {
   if (physicsManager_ != nullptr && sceneID >= 0 && sceneID < sceneID_.size()) {
     // TODO: change implementation to support multi-world and physics worlds to
     // own reference to a sceneGraph to avoid this.
-    auto& sceneGraph_ = sceneManager_.getSceneGraph(sceneID);
+    auto& sceneGraph_ = sceneManager_.getSceneGraph(activeSceneID_);
     auto& drawables = sceneGraph_.getDrawables();
     return physicsManager_->addObject(objectLibIndex, &drawables);
   }


### PR DESCRIPTION
## Motivation and Context

In response to issue #283.

`Simulator::addObject` takes a `sceneID` parameter for multi-scene use case. Since we don't support multi-scene physics presently, this should always add to the active scene graph instead.

This will need to be changed back in the future as we support multi-scene simulation.

## How Has This Been Tested

Local testing with multiple `sim.reconfigure()` to create several sceneIDs in the Simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
