### PR TITLE
Default to random start position and allow URI decoding

### DIFF
--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -12,7 +12,8 @@ import "./bindings.css";
 import {
   checkWebAssemblySupport,
   checkWebgl2Support,
-  getInfoSemanticUrl
+  getInfoSemanticUrl,
+  buildConfigFromURLParameters
 } from "./modules/utils";
 
 function preload(url) {
@@ -28,12 +29,7 @@ function preload(url) {
 Module.preRun.push(() => {
   let config = {};
   config.scene = defaultScene;
-  for (let arg of window.location.search.substr(1).split("&")) {
-    let [key, value] = arg.split("=");
-    if (key && value) {
-      config[key] = value;
-    }
-  }
+  buildConfigFromURLParameters(config);
   const scene = config.scene;
   Module.scene = preload(scene);
   const fileNoExtension = scene.substr(0, scene.lastIndexOf("."));
@@ -62,6 +58,7 @@ Module.onRuntimeInitialized = () => {
   if (!demo) {
     demo = new WebDemo();
   }
+
   demo.display();
 };
 

--- a/src/esp/bindings_js/modules/simenv_embind.js
+++ b/src/esp/bindings_js/modules/simenv_embind.js
@@ -19,10 +19,14 @@ class SimEnv {
    * @param {Object} episode - episode to run
    * @param {number} agentId - default agent id
    */
-  constructor(config, episode, agentId) {
+  constructor(config, episode = {}, agentId = 0) {
     this.sim = new Module.Simulator(config);
     this.episode = episode;
-    this.initialAgentState = this.createAgentState(episode.startState);
+    this.initialAgentState = null;
+
+    if (Object.keys(episode).length > 0) {
+      this.initialAgentState = this.createAgentState(episode.startState);
+    }
     this.selectedAgentId = agentId;
   }
 
@@ -31,8 +35,10 @@ class SimEnv {
    */
   reset() {
     this.sim.reset();
-    const agent = this.sim.getAgent(this.selectedAgentId);
-    agent.setState(this.initialAgentState, true);
+    if (this.initialAgentState !== null) {
+      const agent = this.sim.getAgent(this.selectedAgentId);
+      agent.setState(this.initialAgentState, true);
+    }
   }
 
   changeAgent(agentId) {
@@ -112,6 +118,9 @@ class SimEnv {
    * @returns {Array} [magnitude, clockwise-angle (in radians)]
    */
   distanceToGoal() {
+    if (Object.keys(this.episode).length === 0) {
+      return [0, 0];
+    }
     let dst = this.episode.goal.position;
     let state = this.getAgentState();
     let src = state.position;

--- a/src/esp/bindings_js/modules/utils.js
+++ b/src/esp/bindings_js/modules/utils.js
@@ -91,3 +91,13 @@ export function getInfoSemanticUrl(mainUrl) {
   }
   return splits.join("/") + infoSemanticPath;
 }
+
+export function buildConfigFromURLParameters(config = {}) {
+  for (let arg of window.location.search.substr(1).split("&")) {
+    let [key, value] = arg.split("=");
+    if (key && value) {
+      config[key] = decodeURIComponent(value);
+    }
+  }
+  return config;
+}

--- a/src/esp/bindings_js/modules/web_demo.js
+++ b/src/esp/bindings_js/modules/web_demo.js
@@ -11,6 +11,7 @@ import {
 import SimEnv from "./simenv_embind";
 import TopDownMap from "./topdown";
 import NavigateTask from "./navigate";
+import { buildConfigFromURLParameters } from "./utils";
 
 class WebDemo {
   currentResolution = defaultResolution;
@@ -89,7 +90,14 @@ class WebDemo {
     return agentConfig;
   }
 
-  display(agentConfig = defaultAgentConfig, episode = defaultEpisode) {
+  display(agentConfig = defaultAgentConfig, episode) {
+    const config = buildConfigFromURLParameters();
+    if (config.useDefaultEpisode) {
+      episode = defaultEpisode;
+    } else {
+      episode = {};
+    }
+
     this.initializeModules(agentConfig, episode);
 
     this.task.init();

--- a/src/esp/bindings_js/modules/web_demo.js
+++ b/src/esp/bindings_js/modules/web_demo.js
@@ -90,12 +90,10 @@ class WebDemo {
     return agentConfig;
   }
 
-  display(agentConfig = defaultAgentConfig, episode) {
+  display(agentConfig = defaultAgentConfig, episode = {}) {
     const config = buildConfigFromURLParameters();
     if (config.useDefaultEpisode) {
       episode = defaultEpisode;
-    } else {
-      episode = {};
     }
 
     this.initializeModules(agentConfig, episode);

--- a/src/esp/bindings_js/tests/utils.test.js
+++ b/src/esp/bindings_js/tests/utils.test.js
@@ -1,4 +1,8 @@
-import { throttle, getInfoSemanticUrl } from "../modules/utils";
+import {
+  throttle,
+  getInfoSemanticUrl,
+  buildConfigFromURLParameters
+} from "../modules/utils";
 
 test("throttle should work properly", () => {
   let count = 0;
@@ -42,4 +46,15 @@ test("info semantic.json should have correct path", () => {
   scenePaths.forEach((item, index) => {
     expect(getInfoSemanticUrl(item)).toEqual(expectedInfoPaths[index]);
   });
+});
+
+test("configuration should be built from url parameters", () => {
+  delete window.location;
+  window.location = {};
+  window.location.search = "?a=b&c&d=true&e=1";
+  const config = buildConfigFromURLParameters();
+  expect(config.a).toEqual("b");
+  expect(config.c).toBeUndefined();
+  expect(config.d).toEqual("true");
+  expect(config.e).toEqual("1");
 });


### PR DESCRIPTION
## Motivation and Context

Our default start position has been hardcoded for castle scene. We need to rely back on SimulatorWithAgents to set a default position for us. You can reset back to default episode by adding `&useDefaultEpisode=1` to the back of your url.

This allows van-gogh and replica apartment to be rendered inside web browser.

Other than that some of the link sharing websites URI encode the URLs so they should be decoded back on our end.

## How Has This Been Tested

Tests have been added for the changes that were made in this PR. And as mentioned in chat on the URLs shared there.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
