### PR TITLE
Enable Magnum BulletIntegration DebugDraw in viewer.

### DIFF
--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -644,6 +644,8 @@ class PhysicsManager {
   void applyImpulseTorque(const int physObjectID,
                           const Magnum::Vector3& impulse);
 
+  virtual void debugDraw(CORRADE_UNUSED Magnum::Matrix4 projTrans){};
+
  protected:
   /** @brief Check if a particular mesh can be used as a collision mesh for a
    * particular physics implemenation. Always True for base @ref PhysicsManager

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -644,7 +644,13 @@ class PhysicsManager {
   void applyImpulseTorque(const int physObjectID,
                           const Magnum::Vector3& impulse);
 
-  virtual void debugDraw(CORRADE_UNUSED Magnum::Matrix4 projTrans){};
+  /** @brief Render any debugging visualizations provided by the underlying
+   * physics simulator implementation. By default does nothing. See @ref
+   * BulletPhysicsManager::debugDraw.
+   * @param projTrans The composed projection and transformation matrix for the
+   * render camera.
+   */
+  virtual void debugDraw(CORRADE_UNUSED const Magnum::Matrix4& projTrans){};
 
  protected:
   /** @brief Check if a particular mesh can be used as a collision mesh for a

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -23,6 +23,11 @@ bool BulletPhysicsManager::initPhysics(
   bWorld_ = std::make_shared<btDiscreteDynamicsWorld>(
       &bDispatcher_, &bBroadphase_, &bSolver_, &bCollisionConfig_);
 
+  debugDrawer_.setMode(
+      Magnum::BulletIntegration::DebugDraw::Mode::DrawWireframe |
+      Magnum::BulletIntegration::DebugDraw::Mode::DrawConstraints);
+  bWorld_->setDebugDrawer(&debugDrawer_);
+
   // Copy over relevant configuration
   fixedTimeStep_ = physicsManagerAttributes.getDouble("timestep");
   // currently GLB meshes are y-up
@@ -186,6 +191,11 @@ double BulletPhysicsManager::getSceneFrictionCoefficient() {
 double BulletPhysicsManager::getSceneRestitutionCoefficient() {
   return static_cast<BulletRigidObject*>(sceneNode_)
       ->getRestitutionCoefficient();
+}
+
+void BulletPhysicsManager::debugDraw(Magnum::Matrix4 projTrans) {
+  debugDrawer_.setTransformationProjectionMatrix(projTrans);
+  bWorld_->debugDrawWorld();
 }
 
 }  // namespace physics

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -193,7 +193,7 @@ double BulletPhysicsManager::getSceneRestitutionCoefficient() {
       ->getRestitutionCoefficient();
 }
 
-void BulletPhysicsManager::debugDraw(Magnum::Matrix4 projTrans) {
+void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) {
   debugDrawer_.setTransformationProjectionMatrix(projTrans);
   bWorld_->debugDrawWorld();
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -153,6 +153,8 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   double getSceneRestitutionCoefficient();
 
+  virtual void debugDraw(Magnum::Matrix4 projTrans);
+
  protected:
   btDbvtBroadphase bBroadphase_;
   btDefaultCollisionConfiguration bCollisionConfig_;
@@ -161,6 +163,8 @@ class BulletPhysicsManager : public PhysicsManager {
 
   /** @brief A pointer to the Bullet world. See @ref btDiscreteDynamicsWorld.*/
   std::shared_ptr<btDiscreteDynamicsWorld> bWorld_;
+
+  Magnum::BulletIntegration::DebugDraw debugDrawer_;
 
  private:
   /** @brief Check if a particular mesh can be used as a collision mesh for

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -153,7 +153,13 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   double getSceneRestitutionCoefficient();
 
-  virtual void debugDraw(Magnum::Matrix4 projTrans);
+  /** @brief Render the debugging visualizations provided by @ref
+   * Magnum::BulletIntegration::DebugDraw. This draws wireframes for all
+   * collision objects.
+   * @param projTrans The composed projection and transformation matrix for the
+   * render camera.
+   */
+  virtual void debugDraw(const Magnum::Matrix4& projTrans);
 
  protected:
   btDbvtBroadphase bBroadphase_;


### PR DESCRIPTION
## Motivation and Context

To diagnose future Bullet physics issues, we would like to register Habitat-sim state with Bullet physics state visually. Magnum/BulletIntegration/DebugDraw provides this. This PR pulls debug functionality into the viewer demo.

## How Has This Been Tested

Local testing:

Skokloster Castle:
![image](https://user-images.githubusercontent.com/1445143/66857218-a8772400-ef3b-11e9-8d5f-51e7eb7a710a.png)

CODA room:
![image](https://user-images.githubusercontent.com/1445143/66857328-e411ee00-ef3b-11e9-9f7f-86750ae276c0.png)

Empty scene with objects:
![debug_objects](https://user-images.githubusercontent.com/1445143/66857658-934ec500-ef3c-11e9-8f61-c8bf2cedecc7.gif)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
