### PR TITLE
Blit from frameBuffer to defaultFrameBuffer viewport

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -117,8 +117,10 @@ struct RenderTarget::Impl {
   void blitRgbaToDefault() {
     framebuffer_.mapForRead(RgbaBuffer);
     GL::AbstractFramebuffer::blit(framebuffer_, GL::defaultFramebuffer,
-                                  {{}, framebufferSize()},
-                                  GL::FramebufferBlit::Color);
+                                  framebuffer_.viewport(),
+                                  GL::defaultFramebuffer.viewport(),
+                                  GL::FramebufferBlit::Color,
+                                  GL::FramebufferBlitFilter::Nearest);
   }
 
   void readFrameRgba(const MutableImageView2D& view) {

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -116,6 +116,8 @@ struct RenderTarget::Impl {
 
   void blitRgbaToDefault() {
     framebuffer_.mapForRead(RgbaBuffer);
+    ASSERT(framebuffer_.viewport() == GL::defaultFramebuffer.viewport());
+
     GL::AbstractFramebuffer::blit(
         framebuffer_, GL::defaultFramebuffer, framebuffer_.viewport(),
         GL::defaultFramebuffer.viewport(), GL::FramebufferBlit::Color,

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -116,11 +116,10 @@ struct RenderTarget::Impl {
 
   void blitRgbaToDefault() {
     framebuffer_.mapForRead(RgbaBuffer);
-    GL::AbstractFramebuffer::blit(framebuffer_, GL::defaultFramebuffer,
-                                  framebuffer_.viewport(),
-                                  GL::defaultFramebuffer.viewport(),
-                                  GL::FramebufferBlit::Color,
-                                  GL::FramebufferBlitFilter::Nearest);
+    GL::AbstractFramebuffer::blit(
+        framebuffer_, GL::defaultFramebuffer, framebuffer_.viewport(),
+        GL::defaultFramebuffer.viewport(), GL::FramebufferBlit::Color,
+        GL::FramebufferBlitFilter::Nearest);
   }
 
   void readFrameRgba(const MutableImageView2D& view) {


### PR DESCRIPTION
## Motivation and Context
- Before, we used to blit from same source rectangle to same destination
rectangle
- Instead, we should blit from source framebuffer viewport to default
frame buffer's viewport
- Also, instead of hardcoded source rectangle, we will take the source rectangle from `frameBuffer_.viewport`


## How Has This Been Tested

Tested on viewer.html and webvr.html

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
