### PR TITLE
PhysicsManager CHECK cleanup

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -84,7 +84,7 @@ int PhysicsManager::addObject(const std::string& configFile,
 }
 
 int PhysicsManager::removeObject(const int physObjectID) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_.at(physObjectID)->removeObject();
   delete existingObjects_.at(physObjectID);
   existingObjects_.erase(physObjectID);
@@ -94,12 +94,12 @@ int PhysicsManager::removeObject(const int physObjectID) {
 
 bool PhysicsManager::setObjectMotionType(const int physObjectID,
                                          MotionType mt) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_[physObjectID]->setMotionType(mt);
 }
 
 MotionType PhysicsManager::getObjectMotionType(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getMotionType();
 }
 
@@ -214,204 +214,204 @@ int PhysicsManager::checkActiveObjects() {
 void PhysicsManager::applyForce(const int physObjectID,
                                 const Magnum::Vector3& force,
                                 const Magnum::Vector3& relPos) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->applyForce(force, relPos);
 }
 
 void PhysicsManager::applyImpulse(const int physObjectID,
                                   const Magnum::Vector3& impulse,
                                   const Magnum::Vector3& relPos) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->applyImpulse(impulse, relPos);
 }
 
 void PhysicsManager::applyTorque(const int physObjectID,
                                  const Magnum::Vector3& torque) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->applyTorque(torque);
 }
 
 void PhysicsManager::applyImpulseTorque(const int physObjectID,
                                         const Magnum::Vector3& impulse) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->applyImpulseTorque(impulse);
 }
 
 void PhysicsManager::setTransformation(const int physObjectID,
                                        const Magnum::Matrix4& trans) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setTransformation(trans);
 }
 void PhysicsManager::setTranslation(const int physObjectID,
                                     const Magnum::Vector3& vector) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setTranslation(vector);
 }
 void PhysicsManager::setRotation(const int physObjectID,
                                  const Magnum::Quaternion& quaternion) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setRotation(quaternion);
 }
 void PhysicsManager::resetTransformation(const int physObjectID) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->resetTransformation();
 }
 void PhysicsManager::translate(const int physObjectID,
                                const Magnum::Vector3& vector) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->translate(vector);
 }
 void PhysicsManager::translateLocal(const int physObjectID,
                                     const Magnum::Vector3& vector) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->translateLocal(vector);
 }
 void PhysicsManager::rotate(const int physObjectID,
                             const Magnum::Rad angleInRad,
                             const Magnum::Vector3& normalizedAxis) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotate(angleInRad, normalizedAxis);
 }
 
 void PhysicsManager::rotateLocal(const int physObjectID,
                                  const Magnum::Rad angleInRad,
                                  const Magnum::Vector3& normalizedAxis) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateLocal(angleInRad, normalizedAxis);
 }
 
 void PhysicsManager::rotateX(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateX(angleInRad);
 }
 void PhysicsManager::rotateY(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateY(angleInRad);
 }
 void PhysicsManager::rotateXLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateXLocal(angleInRad);
 }
 void PhysicsManager::rotateYLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateYLocal(angleInRad);
 }
 void PhysicsManager::rotateZ(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateZ(angleInRad);
 }
 void PhysicsManager::rotateZLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->rotateZLocal(angleInRad);
 }
 
 Magnum::Matrix4 PhysicsManager::getTransformation(
     const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->transformation();
 }
 
 Magnum::Vector3 PhysicsManager::getTranslation(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->translation();
 }
 
 Magnum::Quaternion PhysicsManager::getRotation(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->rotation();
 }
 
 //============ Object Setter functions =============
 void PhysicsManager::setMass(const int physObjectID, const double mass) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setMass(mass);
 }
 void PhysicsManager::setCOM(const int physObjectID,
                             const Magnum::Vector3& COM) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setCOM(COM);
 }
 void PhysicsManager::setInertiaVector(const int physObjectID,
                                       const Magnum::Vector3& inertia) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setInertiaVector(inertia);
 }
 void PhysicsManager::setScale(const int physObjectID, const double scale) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setScale(scale);
 }
 void PhysicsManager::setFrictionCoefficient(const int physObjectID,
                                             const double frictionCoefficient) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setFrictionCoefficient(frictionCoefficient);
 }
 void PhysicsManager::setRestitutionCoefficient(
     const int physObjectID,
     const double restitutionCoefficient) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setRestitutionCoefficient(
       restitutionCoefficient);
 }
 void PhysicsManager::setLinearDamping(const int physObjectID,
                                       const double linDamping) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setLinearDamping(linDamping);
 }
 void PhysicsManager::setAngularDamping(const int physObjectID,
                                        const double angDamping) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   existingObjects_[physObjectID]->setAngularDamping(angDamping);
 }
 
 //============ Object Getter functions =============
 double PhysicsManager::getMass(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getMass();
 }
 
 Magnum::Vector3 PhysicsManager::getCOM(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getCOM();
 }
 
 Magnum::Vector3 PhysicsManager::getInertiaVector(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getInertiaVector();
 }
 
 Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getInertiaMatrix();
 }
 
 double PhysicsManager::getScale(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getScale();
 }
 
 double PhysicsManager::getFrictionCoefficient(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getFrictionCoefficient();
 }
 
 double PhysicsManager::getRestitutionCoefficient(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getRestitutionCoefficient();
 }
 
 double PhysicsManager::getLinearDamping(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getLinearDamping();
 }
 
 double PhysicsManager::getAngularDamping(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getAngularDamping();
 }
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -84,10 +84,7 @@ int PhysicsManager::addObject(const std::string& configFile,
 }
 
 int PhysicsManager::removeObject(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) == 0) {
-    LOG(ERROR) << "Failed to remove object: no object with ID " << physObjectID;
-    return ID_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
   existingObjects_.at(physObjectID)->removeObject();
   delete existingObjects_.at(physObjectID);
   existingObjects_.erase(physObjectID);
@@ -97,18 +94,13 @@ int PhysicsManager::removeObject(const int physObjectID) {
 
 bool PhysicsManager::setObjectMotionType(const int physObjectID,
                                          MotionType mt) {
-  if (existingObjects_.count(physObjectID) == 0) {
-    return false;
-  } else {
-    return existingObjects_[physObjectID]->setMotionType(mt);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->setMotionType(mt);
 }
 
 MotionType PhysicsManager::getObjectMotionType(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getMotionType();
-  }
-  return MotionType::ERROR_MOTIONTYPE;
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getMotionType();
 }
 
 int PhysicsManager::allocateObjectID() {
@@ -222,283 +214,204 @@ int PhysicsManager::checkActiveObjects() {
 void PhysicsManager::applyForce(const int physObjectID,
                                 const Magnum::Vector3& force,
                                 const Magnum::Vector3& relPos) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->applyForce(force, relPos);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->applyForce(force, relPos);
 }
 
 void PhysicsManager::applyImpulse(const int physObjectID,
                                   const Magnum::Vector3& impulse,
                                   const Magnum::Vector3& relPos) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->applyImpulse(impulse, relPos);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->applyImpulse(impulse, relPos);
 }
 
 void PhysicsManager::applyTorque(const int physObjectID,
                                  const Magnum::Vector3& torque) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->applyTorque(torque);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->applyTorque(torque);
 }
 
 void PhysicsManager::applyImpulseTorque(const int physObjectID,
                                         const Magnum::Vector3& impulse) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->applyImpulseTorque(impulse);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->applyImpulseTorque(impulse);
 }
 
 void PhysicsManager::setTransformation(const int physObjectID,
                                        const Magnum::Matrix4& trans) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setTransformation(trans);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setTransformation(trans);
 }
 void PhysicsManager::setTranslation(const int physObjectID,
                                     const Magnum::Vector3& vector) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setTranslation(vector);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setTranslation(vector);
 }
 void PhysicsManager::setRotation(const int physObjectID,
                                  const Magnum::Quaternion& quaternion) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setRotation(quaternion);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setRotation(quaternion);
 }
 void PhysicsManager::resetTransformation(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->resetTransformation();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->resetTransformation();
 }
 void PhysicsManager::translate(const int physObjectID,
                                const Magnum::Vector3& vector) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->translate(vector);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->translate(vector);
 }
 void PhysicsManager::translateLocal(const int physObjectID,
                                     const Magnum::Vector3& vector) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->translateLocal(vector);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->translateLocal(vector);
 }
 void PhysicsManager::rotate(const int physObjectID,
                             const Magnum::Rad angleInRad,
                             const Magnum::Vector3& normalizedAxis) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotate(angleInRad, normalizedAxis);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotate(angleInRad, normalizedAxis);
 }
 
 void PhysicsManager::rotateLocal(const int physObjectID,
                                  const Magnum::Rad angleInRad,
                                  const Magnum::Vector3& normalizedAxis) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateLocal(angleInRad, normalizedAxis);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateLocal(angleInRad, normalizedAxis);
 }
 
 void PhysicsManager::rotateX(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateX(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateX(angleInRad);
 }
 void PhysicsManager::rotateY(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateY(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateY(angleInRad);
 }
 void PhysicsManager::rotateXLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateXLocal(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateXLocal(angleInRad);
 }
 void PhysicsManager::rotateYLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateYLocal(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateYLocal(angleInRad);
 }
 void PhysicsManager::rotateZ(const int physObjectID,
                              const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateZ(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateZ(angleInRad);
 }
 void PhysicsManager::rotateZLocal(const int physObjectID,
                                   const Magnum::Rad angleInRad) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->rotateZLocal(angleInRad);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->rotateZLocal(angleInRad);
 }
 
 Magnum::Matrix4 PhysicsManager::getTransformation(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->transformation();
-  } else {
-    return Magnum::Matrix4();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->transformation();
 }
 
 Magnum::Vector3 PhysicsManager::getTranslation(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->translation();
-  } else {
-    return Magnum::Vector3();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->translation();
 }
 
 Magnum::Quaternion PhysicsManager::getRotation(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->rotation();
-  } else {
-    return Magnum::Quaternion();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->rotation();
 }
 
 //============ Object Setter functions =============
 void PhysicsManager::setMass(const int physObjectID, const double mass) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setMass(mass);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setMass(mass);
 }
 void PhysicsManager::setCOM(const int physObjectID,
                             const Magnum::Vector3& COM) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setCOM(COM);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setCOM(COM);
 }
 void PhysicsManager::setInertiaVector(const int physObjectID,
                                       const Magnum::Vector3& inertia) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setInertiaVector(inertia);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setInertiaVector(inertia);
 }
 void PhysicsManager::setScale(const int physObjectID, const double scale) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setScale(scale);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setScale(scale);
 }
 void PhysicsManager::setFrictionCoefficient(const int physObjectID,
                                             const double frictionCoefficient) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setFrictionCoefficient(frictionCoefficient);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setFrictionCoefficient(frictionCoefficient);
 }
 void PhysicsManager::setRestitutionCoefficient(
     const int physObjectID,
     const double restitutionCoefficient) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setRestitutionCoefficient(
-        restitutionCoefficient);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setRestitutionCoefficient(
+      restitutionCoefficient);
 }
 void PhysicsManager::setLinearDamping(const int physObjectID,
                                       const double linDamping) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setLinearDamping(linDamping);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setLinearDamping(linDamping);
 }
 void PhysicsManager::setAngularDamping(const int physObjectID,
                                        const double angDamping) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    existingObjects_[physObjectID]->setAngularDamping(angDamping);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  existingObjects_[physObjectID]->setAngularDamping(angDamping);
 }
 
 //============ Object Getter functions =============
 double PhysicsManager::getMass(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getMass();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getMass();
 }
 
 Magnum::Vector3 PhysicsManager::getCOM(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getCOM();
-  } else {
-    return Magnum::Vector3();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getCOM();
 }
 
 Magnum::Vector3 PhysicsManager::getInertiaVector(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getInertiaVector();
-  } else {
-    return Magnum::Vector3();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getInertiaVector();
 }
 
 Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getInertiaMatrix();
-  } else {
-    return Magnum::Matrix3();
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getInertiaMatrix();
 }
 
 double PhysicsManager::getScale(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getScale();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getScale();
 }
 
 double PhysicsManager::getFrictionCoefficient(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getFrictionCoefficient();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getFrictionCoefficient();
 }
 
 double PhysicsManager::getRestitutionCoefficient(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getRestitutionCoefficient();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getRestitutionCoefficient();
 }
 
 double PhysicsManager::getLinearDamping(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getLinearDamping();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getLinearDamping();
 }
 
 double PhysicsManager::getAngularDamping(const int physObjectID) {
-  // TODO: talk to property library
-  if (existingObjects_.count(physObjectID) > 0) {
-    return existingObjects_[physObjectID]->getAngularDamping();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return existingObjects_[physObjectID]->getAngularDamping();
 }
 
 }  // namespace physics

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -172,8 +172,7 @@ class PhysicsManager {
   /** @brief Get the @ref MotionType of an object.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
-   * @return The object's @ref MotionType, or @ref MotionType::ERROR_MOTIONTYPE
-   * if the object is not found.
+   * @return The object's @ref MotionType
    */
   MotionType getObjectMotionType(const int physObjectID);
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -648,6 +648,16 @@ class PhysicsManager {
   virtual void debugDraw(CORRADE_UNUSED const Magnum::Matrix4& projTrans){};
 
  protected:
+  /** @brief Check that a given object ID is valid (i.e. it refers to an
+   * existing object). Terminate the program and report an error if not. This
+   * function is intended to unify object ID checking for @ref PhysicsManager
+   * functions.
+   * @param physObjectID The object ID to validate.
+   */
+  virtual void assertIDValidity(const int physObjectID) const {
+    CHECK(existingObjects_.count(physObjectID) > 0);
+  };
+
   /** @brief Check if a particular mesh can be used as a collision mesh for a
    * particular physics implemenation. Always True for base @ref PhysicsManager
    * class, since the mesh has already been successfully loaded by @ref

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -157,10 +157,9 @@ void BulletPhysicsManager::stepPhysics(double dt) {
 
 void BulletPhysicsManager::setMargin(const int physObjectID,
                                      const double margin) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
-        ->setMargin(margin);
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
+      ->setMargin(margin);
 }
 
 void BulletPhysicsManager::setSceneFrictionCoefficient(
@@ -176,12 +175,9 @@ void BulletPhysicsManager::setSceneRestitutionCoefficient(
 }
 
 double BulletPhysicsManager::getMargin(const int physObjectID) {
-  if (existingObjects_.count(physObjectID) > 0) {
-    return static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
-        ->getMargin();
-  } else {
-    return PHYSICS_ATTR_UNDEFINED;
-  }
+  CHECK(existingObjects_.count(physObjectID) > 0);
+  return static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
+      ->getMargin();
 }
 
 double BulletPhysicsManager::getSceneFrictionCoefficient() {

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -157,7 +157,7 @@ void BulletPhysicsManager::stepPhysics(double dt) {
 
 void BulletPhysicsManager::setMargin(const int physObjectID,
                                      const double margin) {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
       ->setMargin(margin);
 }
@@ -175,7 +175,7 @@ void BulletPhysicsManager::setSceneRestitutionCoefficient(
 }
 
 double BulletPhysicsManager::getMargin(const int physObjectID) const {
-  CHECK(existingObjects_.count(physObjectID) > 0);
+  assertIDValidity(physObjectID);
   return static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID))
       ->getMargin();
 }


### PR DESCRIPTION
## Motivation and Context

This PR replaces if statements in PhysicsManager and BulletPhysicsManager based on the validity of object IDs with CHECK().

As @msbaines mentioned in a review for PR #237, PhysicsManager functions taking an object ID as input should not fail silently when an invalid object ID is provided. This may allow hidden bugs to crop up. For example: setting a force or torque on an object which does not exist and then receiving no indication that the set failed resulting in extended debugging. Instead, such an invalid set should be fatal and produce a clear error message. 

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
