### PR TITLE
Make debugDrawer mutable and debugDraw const

### DIFF
--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -650,7 +650,8 @@ class PhysicsManager {
    * @param projTrans The composed projection and transformation matrix for the
    * render camera.
    */
-  virtual void debugDraw(CORRADE_UNUSED const Magnum::Matrix4& projTrans){};
+  virtual void debugDraw(
+      CORRADE_UNUSED const Magnum::Matrix4& projTrans) const {};
 
  protected:
   /** @brief Check if a particular mesh can be used as a collision mesh for a

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -193,7 +193,7 @@ double BulletPhysicsManager::getSceneRestitutionCoefficient() const {
       ->getRestitutionCoefficient();
 }
 
-void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) {
+void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
   debugDrawer_.setTransformationProjectionMatrix(projTrans);
   bWorld_->debugDrawWorld();
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -159,7 +159,7 @@ class BulletPhysicsManager : public PhysicsManager {
    * @param projTrans The composed projection and transformation matrix for the
    * render camera.
    */
-  virtual void debugDraw(const Magnum::Matrix4& projTrans) override;
+  virtual void debugDraw(const Magnum::Matrix4& projTrans) const override;
 
  protected:
   btDbvtBroadphase bBroadphase_;
@@ -170,7 +170,7 @@ class BulletPhysicsManager : public PhysicsManager {
   /** @brief A pointer to the Bullet world. See @ref btDiscreteDynamicsWorld.*/
   std::shared_ptr<btDiscreteDynamicsWorld> bWorld_;
 
-  Magnum::BulletIntegration::DebugDraw debugDrawer_;
+  mutable Magnum::BulletIntegration::DebugDraw debugDrawer_;
 
  private:
   /** @brief Check if a particular mesh can be used as a collision mesh for


### PR DESCRIPTION
## Motivation and Context

The debugDraw function in PhysicsManager should be const. It was not since the debugDrawer_ in BulletPhysicsManager is updated with a new transform when this function is called. To remedy this, debugDrawer_ has is been made mutable. 

Based on a comment by @msbaines in PR #298. 👍  

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
