### PR TITLE
Trigger event listener for keys at capturing phase

### DIFF
--- a/src/esp/bindings_js/modules/navigate.js
+++ b/src/esp/bindings_js/modules/navigate.js
@@ -186,15 +186,19 @@ class NavigateTask {
   }
 
   bindKeys() {
-    document.addEventListener("keydown", event => {
-      for (let a of this.actions) {
-        if (event.key === a.key) {
-          this.handleAction(a.name);
-          event.preventDefault();
-          break;
+    document.addEventListener(
+      "keydown",
+      event => {
+        for (let a of this.actions) {
+          if (event.key === a.key) {
+            this.handleAction(a.name);
+            event.preventDefault();
+            break;
+          }
         }
-      }
-    });
+      },
+      true
+    );
   }
 }
 


### PR DESCRIPTION
## Motivation and Context

Sometimes users have extensions enabled which override default key behavior. This change intends to fix that behavior by triggering the event listener for keys at the capturing phase so it can't be stopped via event.stopPropagation(). See https://stackoverflow.com/questions/13880126/override-existing-onkeydown-function

## How Has This Been Tested

Tested on viewer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
