### PR TITLE
Store mesh transform hierarchy (Issue #301 fix part 1/2)

### DIFF
--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -25,8 +25,8 @@ struct MeshTransformNode {
 
   std::vector<MeshTransformNode> children;
 
-  //! Node local transform
-  Magnum::Matrix4 T;
+  //! Node local transform to the parent frame
+  Magnum::Matrix4 T_parent_local;
 
   MeshTransformNode() {
     meshIDLocal = ID_UNDEFINED;
@@ -34,11 +34,13 @@ struct MeshTransformNode {
     componentID = ID_UNDEFINED;
   };
 
+  //! copy constructor which duplicates the @ref MeshTransformNode tree of which
+  //! val is the root.
   MeshTransformNode(const MeshTransformNode& val) {
     componentID = val.componentID;
     meshIDLocal = val.meshIDLocal;
     materialIDLocal = val.materialIDLocal;
-    T = Magnum::Matrix4(val.T);
+    T_parent_local = Magnum::Matrix4(val.T_parent_local);
     for (auto& child : val.children) {
       children.push_back(MeshTransformNode(child));
     }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -819,7 +819,6 @@ bool ResourceManager::loadGeneralMeshData(
       LOG(ERROR) << "Cannot open file " << filename;
       return false;
     }
-    LOG(INFO) << "opened file " << filename;
     // if this is a new file, load it and add it to the dictionary
     loadTextures(*importer, &metaData);
     loadMaterials(*importer, &metaData);
@@ -960,14 +959,10 @@ void ResourceManager::loadMeshHierarchy(Importer& importer,
     return;
   }
 
-  LOG(INFO) << "loadMeshHierarchy: " << componentID << " T: ";
-
   // Add the new node to the hierarchy and set its transformation
   parent.children.push_back(MeshTransformNode());
   parent.children.back().T = objectData->transformation();
   parent.children.back().componentID = componentID;
-
-  Cr::Utility::Debug() << parent.children.back().T;
 
   const int meshIDLocal = objectData->instance();
 
@@ -978,8 +973,6 @@ void ResourceManager::loadMeshHierarchy(Importer& importer,
     parent.children.back().materialIDLocal =
         static_cast<Magnum::Trade::MeshObjectData3D*>(objectData.get())
             ->material();
-    LOG(INFO) << "  mesh: " << meshIDLocal
-              << " material: " << parent.children.back().materialIDLocal;
   }
 
   // Recursively add children
@@ -1047,9 +1040,6 @@ void ResourceManager::addComponent(const MeshMetaData& metaData,
                                    scene::SceneNode& parent,
                                    DrawableGroup* drawables,
                                    MeshTransformNode& meshTransformNode) {
-  LOG(INFO) << "addComponent: " << meshTransformNode.componentID << " T: ";
-  Cr::Utility::Debug() << meshTransformNode.T;
-
   // Add the object to the scene and set its transformation
   scene::SceneNode& node = parent.createChild();
   node.MagnumObject::setTransformation(meshTransformNode.T);
@@ -1062,8 +1052,6 @@ void ResourceManager::addComponent(const MeshMetaData& metaData,
     const int materialIDLocal = meshTransformNode.materialIDLocal;
     addMeshToDrawables(metaData, node, drawables, meshTransformNode.componentID,
                        meshIDLocal, materialIDLocal);
-    LOG(INFO) << "  mesh: " << meshIDLocal
-              << " material: " << meshTransformNode.materialIDLocal;
   }
 
   // Recursively add children

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -847,7 +847,6 @@ bool ResourceManager::loadGeneralMeshData(
       LOG(ERROR) << "No default scene available and no meshes found, exiting";
       return false;
     }
-
     magnumMeshDict_.emplace(filename, magnumData);
   } else {
     metaData = resourceDict_[filename];
@@ -864,7 +863,6 @@ bool ResourceManager::loadGeneralMeshData(
 
     //! Do instantiate object
     MeshMetaData& metaData = resourceDict_[filename];
-
     const bool forceReload = false;
     // re-bind position, normals, uv, colors etc. to the corresponding buffers
     // under *current* gl context

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -979,7 +979,7 @@ void ResourceManager::loadMeshHierarchy(Importer& importer,
 
   // Add the new node to the hierarchy and set its transformation
   parent.children.push_back(MeshTransformNode());
-  parent.children.back().T = objectData->transformation();
+  parent.children.back().T_parent_local = objectData->transformation();
   parent.children.back().componentID = componentID;
 
   const int meshIDLocal = objectData->instance();
@@ -1060,7 +1060,7 @@ void ResourceManager::addComponent(const MeshMetaData& metaData,
                                    MeshTransformNode& meshTransformNode) {
   // Add the object to the scene and set its transformation
   scene::SceneNode& node = parent.createChild();
-  node.MagnumObject::setTransformation(meshTransformNode.T);
+  node.MagnumObject::setTransformation(meshTransformNode.T_parent_local);
 
   const int meshIDLocal = meshTransformNode.meshIDLocal;
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -366,17 +366,10 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename,
     const std::string& filename =
         physicsObjectAttributes.getString("renderMeshHandle");
 
-    MeshMetaData meshMetaData = resourceDict_[filename];
-    scene::SceneNode& newNode = parent->createChild();
-    AssetInfo renderMeshinfo = AssetInfo::fromPath(filename);
-    Magnum::PluginManager::Manager<Importer> manager;
-    std::unique_ptr<Importer> importer =
-        manager.loadAndInstantiate("AnySceneImporter");
-    manager.setPreferredPlugins("GltfImporter", {"TinyGltfImporter"});
-    manager.setPreferredPlugins("ObjImporter", {"AssimpImporter"});
-    importer->openFile(renderMeshinfo.filepath);
+    MeshMetaData& meshMetaData = resourceDict_[filename];
+
     for (auto componentID : magnumMeshDict_[filename]) {
-      addComponent(*importer, meshMetaData, newNode, drawables, componentID);
+      addComponent(meshMetaData, *parent, drawables, meshMetaData.root);
     }
   }
 
@@ -826,6 +819,7 @@ bool ResourceManager::loadGeneralMeshData(
       LOG(ERROR) << "Cannot open file " << filename;
       return false;
     }
+    LOG(INFO) << "opened file " << filename;
     // if this is a new file, load it and add it to the dictionary
     loadTextures(*importer, &metaData);
     loadMaterials(*importer, &metaData);
@@ -842,16 +836,19 @@ bool ResourceManager::loadGeneralMeshData(
       }
       for (unsigned int sceneDataID : sceneData->children3D()) {
         magnumData.emplace_back(sceneDataID);
+        loadMeshHierarchy(*importer, resourceDict_[filename].root, sceneDataID);
       }
     } else if (importer->mesh3DCount() && meshes_[metaData.meshIndex.first]) {
       // no default scene --- standalone OBJ/PLY files, for example
       // take a wild guess and load the first mesh with the first material
       // addMeshToDrawables(metaData, *parent, drawables, ID_UNDEFINED, 0, 0);
       magnumData.emplace_back(0);
+      loadMeshHierarchy(*importer, resourceDict_[filename].root, 0);
     } else {
       LOG(ERROR) << "No default scene available and no meshes found, exiting";
       return false;
     }
+
     magnumMeshDict_.emplace(filename, magnumData);
   } else {
     metaData = resourceDict_[filename];
@@ -868,6 +865,7 @@ bool ResourceManager::loadGeneralMeshData(
 
     //! Do instantiate object
     MeshMetaData& metaData = resourceDict_[filename];
+
     const bool forceReload = false;
     // re-bind position, normals, uv, colors etc. to the corresponding buffers
     // under *current* gl context
@@ -881,20 +879,11 @@ bool ResourceManager::loadGeneralMeshData(
       }
     }  // forceReload
 
-    if (fileIsLoaded) {
-      // if the file was loaded, the importer didn't open the file, so open it
-      // before adding components
-      if (!importer->openFile(filename)) {
-        LOG(ERROR) << "Cannot open file " << filename;
-        return false;
-      }
-    }
-
     const quatf transform = info.frame.rotationFrameToWorld();
     newNode.setRotation(Magnum::Quaternion(transform));
     // Recursively add all children
     for (auto sceneDataID : magnumMeshDict_[filename]) {
-      addComponent(*importer, metaData, newNode, drawables, sceneDataID);
+      addComponent(metaData, newNode, drawables, metaData.root);
     }
     return true;
   }
@@ -959,6 +948,46 @@ void ResourceManager::loadMeshes(Importer& importer,
   }
 }
 
+//! Recursively load the transformation chain specified by the mesh file
+void ResourceManager::loadMeshHierarchy(Importer& importer,
+                                        MeshTransformNode& parent,
+                                        int componentID) {
+  std::unique_ptr<Magnum::Trade::ObjectData3D> objectData =
+      importer.object3D(componentID);
+  if (!objectData) {
+    LOG(ERROR) << "Cannot import object " << importer.object3DName(componentID)
+               << ", skipping";
+    return;
+  }
+
+  LOG(INFO) << "loadMeshHierarchy: " << componentID << " T: ";
+
+  // Add the new node to the hierarchy and set its transformation
+  parent.children.push_back(MeshTransformNode());
+  parent.children.back().T = objectData->transformation();
+  parent.children.back().componentID = componentID;
+
+  Cr::Utility::Debug() << parent.children.back().T;
+
+  const int meshIDLocal = objectData->instance();
+
+  // Add a mesh index
+  if (objectData->instanceType() == Magnum::Trade::ObjectInstanceType3D::Mesh &&
+      meshIDLocal != ID_UNDEFINED) {
+    parent.children.back().meshIDLocal = meshIDLocal;
+    parent.children.back().materialIDLocal =
+        static_cast<Magnum::Trade::MeshObjectData3D*>(objectData.get())
+            ->material();
+    LOG(INFO) << "  mesh: " << meshIDLocal
+              << " material: " << parent.children.back().materialIDLocal;
+  }
+
+  // Recursively add children
+  for (auto childObjectID : objectData->children()) {
+    loadMeshHierarchy(importer, parent.children.back(), childObjectID);
+  }
+}
+
 void ResourceManager::loadTextures(Importer& importer, MeshMetaData* metaData) {
   int textureStart = textures_.size();
   int textureEnd = textureStart + importer.textureCount() - 1;
@@ -1014,39 +1043,32 @@ void ResourceManager::loadTextures(Importer& importer, MeshMetaData* metaData) {
 //! Add component to rendering stack, based on importer loading
 //! TODO (JH): decouple importer part, so that objects can be
 //! instantiated any time after initial loading
-void ResourceManager::addComponent(Importer& importer,
-                                   const MeshMetaData& metaData,
+void ResourceManager::addComponent(const MeshMetaData& metaData,
                                    scene::SceneNode& parent,
                                    DrawableGroup* drawables,
-                                   int componentID) {
-  std::unique_ptr<Magnum::Trade::ObjectData3D> objectData =
-      importer.object3D(componentID);
-  if (!objectData) {
-    LOG(ERROR) << "Cannot import object " << importer.object3DName(componentID)
-               << ", skipping";
-    return;
-  }
+                                   MeshTransformNode& meshTransformNode) {
+  LOG(INFO) << "addComponent: " << meshTransformNode.componentID << " T: ";
+  Cr::Utility::Debug() << meshTransformNode.T;
 
   // Add the object to the scene and set its transformation
   scene::SceneNode& node = parent.createChild();
-  node.MagnumObject::setTransformation(objectData->transformation());
+  node.MagnumObject::setTransformation(meshTransformNode.T);
 
-  const int meshIDLocal = objectData->instance();
-  const int meshID = metaData.meshIndex.first + meshIDLocal;
+  const int meshIDLocal = meshTransformNode.meshIDLocal;
 
   // Add a drawable if the object has a mesh and the mesh is loaded
-  if (objectData->instanceType() == Magnum::Trade::ObjectInstanceType3D::Mesh &&
-      meshIDLocal != ID_UNDEFINED && meshes_[meshID]) {
-    const int materialIDLocal =
-        static_cast<Magnum::Trade::MeshObjectData3D*>(objectData.get())
-            ->material();
-    addMeshToDrawables(metaData, node, drawables, componentID, meshIDLocal,
-                       materialIDLocal);
+  if (meshIDLocal != ID_UNDEFINED) {
+    const int meshID = metaData.meshIndex.first + meshIDLocal;
+    const int materialIDLocal = meshTransformNode.materialIDLocal;
+    addMeshToDrawables(metaData, node, drawables, meshTransformNode.componentID,
+                       meshIDLocal, materialIDLocal);
+    LOG(INFO) << "  mesh: " << meshIDLocal
+              << " material: " << meshTransformNode.materialIDLocal;
   }
 
   // Recursively add children
-  for (auto childObjectID : objectData->children()) {
-    addComponent(importer, metaData, node, drawables, childObjectID);
+  for (auto& child : meshTransformNode.children) {
+    addComponent(metaData, node, drawables, child);
   }
 }
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -139,11 +139,10 @@ class ResourceManager {
   //! (1) create scene node
   //! (2) upload mesh to gpu and drawables
   //! (optional reload of GPU-side assets)
-  void addComponent(Importer& importer,
-                    const MeshMetaData& metaData,
+  void addComponent(const MeshMetaData& metaData,
                     scene::SceneNode& parent,
                     DrawableGroup* drawables,
-                    int objectID);
+                    MeshTransformNode& meshTransformNode);
 
   //! Load textures from importer into assets, and update metaData
   void loadTextures(Importer& importer, MeshMetaData* metaData);
@@ -153,6 +152,11 @@ class ResourceManager {
                   MeshMetaData* metaData,
                   bool shiftOrigin = false,
                   Magnum::Vector3 offset = Magnum::Vector3(0, 0, 0));
+
+  //! Load the mesh transformation hierarchy for the imported file
+  void loadMeshHierarchy(Importer& importer,
+                         MeshTransformNode& parent,
+                         int componentID);
 
   //! Load materials from importer into assets, and update metaData
   void loadMaterials(Importer& importer, MeshMetaData* metaData);

--- a/src/esp/bindings_js/modules/navigate.js
+++ b/src/esp/bindings_js/modules/navigate.js
@@ -190,6 +190,7 @@ class NavigateTask {
       for (let a of this.actions) {
         if (event.key === a.key) {
           this.handleAction(a.name);
+          event.preventDefault();
           break;
         }
       }


### PR DESCRIPTION
## Motivation and Context

This is the first step toward a solution for Issue #301 .

In order to build collision objects from mesh hierarchies, we first need to store them. 

Since the hierarchies are metadata, this PR adds a `MeshTransformNode` data structure to the `MeshMetaData` structure. When a mesh is loaded into assets the hierarchy is computed and stored.

Now that the hierarchy of transforms is available, we no longer need Importer to reload the source files in order to add objects to the scene graph with `addComponent`. This has been refactored.

No previously exposed functionality should change as a result of this refactor.

## How Has This Been Tested

Local testing with physics.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
