### PR TITLE
Allow agent reference to be kept

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -106,15 +106,19 @@ class Agent(object):
     """
 
     agent_config: AgentConfiguration
-    sensors: SensorSuite
+    _sensors: SensorSuite
     controls: ObjectControls
     body: mn.scenegraph.AbstractFeature3D
 
     def __init__(
-        self, scene_node: hsim.SceneNode, agent_config=None, sensors=None, controls=None
+        self,
+        scene_node: hsim.SceneNode,
+        agent_config=None,
+        _sensors=None,
+        controls=None,
     ):
         self.agent_config = agent_config if agent_config else AgentConfiguration()
-        self.sensors = sensors if sensors else SensorSuite()
+        self._sensors = _sensors if _sensors else SensorSuite()
         self.controls = controls if controls else ObjectControls()
         self.body = mn.scenegraph.AbstractFeature3D(scene_node)
         scene_node.type = hsim.SceneNodeType.AGENT
@@ -134,9 +138,9 @@ class Agent(object):
         self.agent_config = agent_config
 
         if reconfigure_sensors:
-            self.sensors.clear()
+            self._sensors.clear()
             for spec in self.agent_config.sensor_specifications:
-                self.sensors.add(
+                self._sensors.add(
                     hsim.PinholeCamera(self.scene_node.create_child(), spec)
                 )
 
@@ -160,7 +164,7 @@ class Agent(object):
                 self.scene_node, action.name, action.actuation, apply_filter=True
             )
         else:
-            for _, v in self.sensors.items():
+            for _, v in self._sensors.items():
                 habitat_sim.errors.assert_obj_valid(v)
                 self.controls.action(
                     v.object, action.name, action.actuation, apply_filter=False
@@ -174,7 +178,7 @@ class Agent(object):
             np.array(self.body.object.absolute_translation), self.body.object.rotation
         )
 
-        for k, v in self.sensors.items():
+        for k, v in self._sensors.items():
             habitat_sim.errors.assert_obj_valid(v)
             state.sensor_states[k] = SixDOFPose(
                 np.array(v.node.absolute_translation),
@@ -204,15 +208,15 @@ class Agent(object):
         self.body.object.rotation = quat_to_magnum(state.rotation)
 
         if reset_sensors:
-            for _, v in self.sensors.items():
+            for _, v in self._sensors.items():
                 v.set_transformation_from_spec()
 
         for k, v in state.sensor_states.items():
-            assert k in self.sensors
+            assert k in self._sensors
             if isinstance(v.rotation, list):
                 v.rotation = quat_from_coeffs(v.rotation)
 
-            s = self.sensors[k]
+            s = self._sensors[k]
 
             s.node.reset_transformation()
             s.node.translate(
@@ -234,3 +238,6 @@ class Agent(object):
     @state.setter
     def state(self, new_state):
         self.set_state(new_state, reset_sensors=True)
+
+    def close(self):
+        self._sensors = None

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -64,11 +64,13 @@ class Simulator:
 
     def close(self):
         for sensor in self._sensors.values():
+            sensor.close()
             del sensor
 
         self._sensors = {}
 
         for agent in self.agents:
+            agent.close()
             del agent
 
         self.agents = []
@@ -296,7 +298,7 @@ class Sensor:
 
         # sensor is an attached object to the scene node
         # store such "attached object" in _sensor_object
-        self._sensor_object = self._agent.sensors.get(sensor_id)
+        self._sensor_object = self._agent._sensors.get(sensor_id)
         self._spec = self._sensor_object.specification()
 
         self._sim.renderer.bind_render_target(self._sensor_object)
@@ -420,3 +422,8 @@ class Sensor:
                 )
 
             return np.flip(self._buffer, axis=0).copy()
+
+    def close(self):
+        self._sim = None
+        self._agent = None
+        self._sensor_object = None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -22,15 +22,15 @@ def test_reconfigure():
     agent = habitat_sim.Agent(scene_graph.get_root_node().create_child())
 
     habitat_sim.errors.assert_obj_valid(agent.body)
-    for _, v in agent.sensors.items():
+    for _, v in agent._sensors.items():
         habitat_sim.errors.assert_obj_valid(v)
 
     agent.reconfigure(agent.agent_config)
-    for _, v in agent.sensors.items():
+    for _, v in agent._sensors.items():
         habitat_sim.errors.assert_obj_valid(v)
 
     agent.reconfigure(agent.agent_config, True)
-    for _, v in agent.sensors.items():
+    for _, v in agent._sensors.items():
         habitat_sim.errors.assert_obj_valid(v)
 
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import random
 
 import examples.settings
@@ -40,3 +41,31 @@ def test_empty_scene(sim):
     # test that empty frames can be rendered without a scene mesh
     for _ in range(2):
         obs = sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+
+
+def _test_keep_agent_tgt():
+    sim_cfg = habitat_sim.SimulatorConfiguration()
+    agent_config = habitat_sim.AgentConfiguration()
+
+    sim_cfg.scene.id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+
+    sim = habitat_sim.Simulator(habitat_sim.Configuration(sim_cfg, [agent_config]))
+
+    agent = sim.get_agent(0)
+
+    sim.close()
+    sim = None
+
+
+# Make sure you can keep a reference to an agent alive without crashing
+def test_keep_agent():
+    mp_ctx = multiprocessing.get_context("spawn")
+
+    # Run this test in a subprocess as things with OpenGL
+    # contexts get messy
+    p = mp_ctx.Process(target=_test_keep_agent_tgt)
+
+    p.start()
+    p.join()
+
+    assert p.exitcode == 0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -48,13 +48,14 @@ def _test_keep_agent_tgt():
     agent_config = habitat_sim.AgentConfiguration()
 
     sim_cfg.scene.id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+    agents = []
 
-    sim = habitat_sim.Simulator(habitat_sim.Configuration(sim_cfg, [agent_config]))
+    for _ in range(3):
+        sim = habitat_sim.Simulator(habitat_sim.Configuration(sim_cfg, [agent_config]))
 
-    agent = sim.get_agent(0)
+        agents.append(sim.get_agent(0))
 
-    sim.close()
-    sim = None
+        sim.close()
 
 
 # Make sure you can keep a reference to an agent alive without crashing


### PR DESCRIPTION
## Motivation and Context

Habitat-sim currently crashes if you do

```
agent = sim.get_agent(0)
sim.close()
```

as the sensors have OpenGL related things, but the simulator owns the OpenGL context.

Also makes `sensors` on the agent private, so we don't have to go down this rabbit hole further.

## How Has This Been Tested

With the test!

## Types of changes


- Bug fix (non-breaking change which fixes an issue)

