### PR TITLE
Bug fix: add "reshape" functionality to utility viewer

### DIFF
--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -33,6 +33,10 @@ void RenderCamera::setProjectionMatrix(int width,
                                        float zfar,
                                        float hfov) {
   const float aspectRatio = static_cast<float>(width) / height;
+  // TODO:
+  // Warning: By dedault, SceneGraph::Camera class can handle aspect ratio
+  // preservation in the setViewport() call automatically. But here it was
+  // disabled for some reason. Will revisit.
   camera_->setAspectRatioPolicy(SceneGraph::AspectRatioPolicy::NotPreserved)
       .setProjectionMatrix(
           Matrix4::perspectiveProjection(Deg{hfov}, aspectRatio, znear, zfar))

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -364,7 +364,7 @@ void Viewer::viewportEvent(ViewportEvent& event) {
   int width = event.windowSize()[0];
   int height = event.windowSize()[1];
   renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
-} 
+}
 
 void Viewer::mousePressEvent(MouseEvent& event) {
   if (event.button() == MouseEvent::Button::Left)

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -364,7 +364,7 @@ void Viewer::viewportEvent(ViewportEvent& event) {
   int width = event.windowSize()[0];
   int height = event.windowSize()[1];
   renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
-}  // namespace
+} 
 
 void Viewer::mousePressEvent(MouseEvent& event) {
   if (event.button() == MouseEvent::Button::Left)

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -104,6 +104,10 @@ class Viewer : public Magnum::Platform::Application {
 
   bool drawObjectBBs = false;
 
+  const float hfov_ = 90.0f;
+  const float znear_ = 0.01f;
+  const float zfar_ = 1000.0f;
+
   Magnum::Timeline timeline_;
 };
 
@@ -176,12 +180,9 @@ Viewer::Viewer(const Arguments& arguments)
   rgbSensorNode_->translate({0.0f, rgbSensorHeight, 0.0f});
   agentBodyNode_->translate({0.0f, 0.0f, 5.0f});
 
-  float hfov = 90.0f;
   int width = viewportSize[0];
   int height = viewportSize[1];
-  float znear = 0.01f;
-  float zfar = 1000.0f;
-  renderCamera_->setProjectionMatrix(width, height, znear, zfar, hfov);
+  renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
 
   // Load navmesh if available
   const std::string navmeshFilename = io::changeExtension(file, ".navmesh");
@@ -359,7 +360,11 @@ void Viewer::drawEvent() {
 void Viewer::viewportEvent(ViewportEvent& event) {
   GL::defaultFramebuffer.setViewport({{}, framebufferSize()});
   renderCamera_->getMagnumCamera().setViewport(event.windowSize());
-}
+
+  int width = event.windowSize()[0];
+  int height = event.windowSize()[1];
+  renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
+}  // namespace
 
 void Viewer::mousePressEvent(MouseEvent& event) {
   if (event.button() == MouseEvent::Button::Left)


### PR DESCRIPTION
In the viewport event, we only reset the viewport but do not specify what to do when window size is changed.
This PR is to update the projection matrix to handle it.

## Motivation and Context
As titled.
The OLD version looks like this:
Initial screen:
![image](https://user-images.githubusercontent.com/931093/67814427-44874c00-fa61-11e9-817f-d052a33d570d.png)

After window size was changed:
![image](https://user-images.githubusercontent.com/931093/67814374-27527d80-fa61-11e9-825b-5d0ecc424876.png)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

Local test:
Initial screen:
![image](https://user-images.githubusercontent.com/931093/67814461-579a1c00-fa61-11e9-946a-56870c382885.png)

After window size was changed:
![image](https://user-images.githubusercontent.com/931093/67814478-641e7480-fa61-11e9-8e4b-354f5055ded4.png)




<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
