### PR TITLE
Revert #322 and add "reshape" functionality to utility viewer

### DIFF
--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -15,6 +15,7 @@ RenderCamera::RenderCamera(scene::SceneNode& node)
     : Magnum::SceneGraph::AbstractFeature3D{node} {
   node.setType(scene::SceneNodeType::CAMERA);
   camera_ = new MagnumCamera(node);
+  camera_->setAspectRatioPolicy(SceneGraph::AspectRatioPolicy::NotPreserved);
 }
 
 RenderCamera::RenderCamera(scene::SceneNode& node,
@@ -33,12 +34,8 @@ void RenderCamera::setProjectionMatrix(int width,
                                        float zfar,
                                        float hfov) {
   const float aspectRatio = static_cast<float>(width) / height;
-  // TODO:
-  // Warning: By dedault, SceneGraph::Camera class can handle aspect ratio
-  // preservation in the setViewport() call automatically. But here it was
-  // disabled for some reason. Will revisit.
-  camera_->setAspectRatioPolicy(SceneGraph::AspectRatioPolicy::NotPreserved)
-      .setProjectionMatrix(
+  camera_
+      ->setProjectionMatrix(
           Matrix4::perspectiveProjection(Deg{hfov}, aspectRatio, znear, zfar))
       .setViewport(Magnum::Vector2i(width, height));
 }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -104,10 +104,6 @@ class Viewer : public Magnum::Platform::Application {
 
   bool drawObjectBBs = false;
 
-  const float hfov_ = 90.0f;
-  const float znear_ = 0.01f;
-  const float zfar_ = 1000.0f;
-
   Magnum::Timeline timeline_;
 };
 
@@ -182,7 +178,10 @@ Viewer::Viewer(const Arguments& arguments)
 
   int width = viewportSize[0];
   int height = viewportSize[1];
-  renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
+  float znear = 0.01f;
+  float zfar = 1000.0f;
+  float hfov = 90.0f;
+  renderCamera_->setProjectionMatrix(width, height, znear, zfar, hfov);
   renderCamera_->getMagnumCamera().setAspectRatioPolicy(
       Magnum::SceneGraph::AspectRatioPolicy::Extend);
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -176,11 +176,11 @@ Viewer::Viewer(const Arguments& arguments)
   rgbSensorNode_->translate({0.0f, rgbSensorHeight, 0.0f});
   agentBodyNode_->translate({0.0f, 0.0f, 5.0f});
 
-  renderCamera_->setProjectionMatrix(viewportSize[0],  // width
-                                     viewportSize[1],  // height
-                                     0.01f,            // znear
-                                     1000.0f,          // zfar
-                                     90.0f);           // hfov
+  renderCamera_->setProjectionMatrix(viewportSize.x(),  // width
+                                     viewportSize.y(),  // height
+                                     0.01f,             // znear
+                                     1000.0f,           // zfar
+                                     90.0f);            // hfov
   renderCamera_->getMagnumCamera().setAspectRatioPolicy(
       Magnum::SceneGraph::AspectRatioPolicy::Extend);
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -183,6 +183,8 @@ Viewer::Viewer(const Arguments& arguments)
   int width = viewportSize[0];
   int height = viewportSize[1];
   renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
+  renderCamera_->getMagnumCamera().setAspectRatioPolicy(
+      Magnum::SceneGraph::AspectRatioPolicy::Extend);
 
   // Load navmesh if available
   const std::string navmeshFilename = io::changeExtension(file, ".navmesh");

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -362,10 +362,6 @@ void Viewer::drawEvent() {
 void Viewer::viewportEvent(ViewportEvent& event) {
   GL::defaultFramebuffer.setViewport({{}, framebufferSize()});
   renderCamera_->getMagnumCamera().setViewport(event.windowSize());
-
-  int width = event.windowSize()[0];
-  int height = event.windowSize()[1];
-  renderCamera_->setProjectionMatrix(width, height, znear_, zfar_, hfov_);
 }
 
 void Viewer::mousePressEvent(MouseEvent& event) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -176,12 +176,11 @@ Viewer::Viewer(const Arguments& arguments)
   rgbSensorNode_->translate({0.0f, rgbSensorHeight, 0.0f});
   agentBodyNode_->translate({0.0f, 0.0f, 5.0f});
 
-  int width = viewportSize[0];
-  int height = viewportSize[1];
-  float znear = 0.01f;
-  float zfar = 1000.0f;
-  float hfov = 90.0f;
-  renderCamera_->setProjectionMatrix(width, height, znear, zfar, hfov);
+  renderCamera_->setProjectionMatrix(viewportSize[0],  // width
+                                     viewportSize[1],  // height
+                                     0.01f,            // znear
+                                     1000.0f,          // zfar
+                                     90.0f);           // hfov
   renderCamera_->getMagnumCamera().setAspectRatioPolicy(
       Magnum::SceneGraph::AspectRatioPolicy::Extend);
 


### PR DESCRIPTION
-) revert the extra code and comments in #322;
-) move setAspectRatioPolicy out of the setProjectionMatrix;
-) set the correct policy in the viewer;

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See #322 
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local test:

Original window:
![image](https://user-images.githubusercontent.com/931093/67969921-613d9400-fbc7-11e9-93cf-2cef4c5d427a.png)

After window size was changed:
![image](https://user-images.githubusercontent.com/931093/67969982-774b5480-fbc7-11e9-990a-f76d39dc0303.png)



<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
