### PR TITLE
Added MotionType setting to python

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -257,6 +257,9 @@ class Simulator:
     def get_object_motion_type(self, object_id, scene_id=0):
         return self._sim.get_object_motion_type(object_id, scene_id)
 
+    def set_object_motion_type(self, motion_type, object_id, scene_id=0):
+        return self._sim.set_object_motion_type(motion_type, object_id, scene_id)
+
     def set_transformation(self, transform, object_id, scene_id=0):
         self._sim.set_transformation(transform, object_id, scene_id)
 

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -545,6 +545,8 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
            "sceneID"_a = 0)
       .def("get_object_motion_type", &Simulator::getObjectMotionType,
            "object_id"_a, "sceneID"_a = 0)
+      .def("set_object_motion_type", &Simulator::setObjectMotionType,
+           "motion_type"_a, "object_id"_a, "sceneID"_a = 0)
       .def("get_existing_object_ids", &Simulator::getExistingObjectIDs,
            "sceneID"_a = 0)
       .def("step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0)

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -255,6 +255,15 @@ esp::physics::MotionType Simulator::getObjectMotionType(const int objectID,
   return esp::physics::MotionType::ERROR_MOTIONTYPE;
 }
 
+bool Simulator::setObjectMotionType(const esp::physics::MotionType& motionType,
+                                    const int objectID,
+                                    const int sceneID) {
+  if (physicsManager_ != nullptr && sceneID >= 0 && sceneID < sceneID_.size()) {
+    return physicsManager_->setObjectMotionType(objectID, motionType);
+  }
+  return false;
+}
+
 // apply forces and torques to objects
 void Simulator::applyTorque(const Magnum::Vector3& tau,
                             const int objectID,

--- a/src/esp/gfx/Simulator.h
+++ b/src/esp/gfx/Simulator.h
@@ -137,6 +137,20 @@ class Simulator {
                                                const int sceneID = 0);
 
   /**
+   * @brief Set the @ref esp::physics::MotionType of an object.
+   * See @ref esp::physics::PhysicsManager::getExistingObjectIDs.
+   * @param motionType The desired motion type of the object
+   * @param objectID The ID of the object identifying it in @ref
+   * esp::physics::PhysicsManager::existingObjects_.
+   * @param sceneID !! Not used currently !! Specifies which physical scene to
+   * query.
+   * @return whether or not the set was successful.
+   */
+  bool setObjectMotionType(const esp::physics::MotionType& motionType,
+                           const int objectID,
+                           const int sceneID = 0);
+
+  /**
    * @brief Apply torque to an object. See @ref
    * esp::physics::PhysicsManager::applyTorque.
    * @param tau The desired torque to apply.

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -38,6 +38,20 @@ def test_kinematics(sim):
     object_id = sim.add_object(0)
     assert len(sim.get_existing_object_ids()) > 0
 
+    # test setting the motion type
+
+    assert sim.set_object_motion_type(habitat_sim.physics.MotionType.STATIC, object_id)
+    assert (
+        sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.STATIC
+    )
+    assert sim.set_object_motion_type(
+        habitat_sim.physics.MotionType.KINEMATIC, object_id
+    )
+    assert (
+        sim.get_object_motion_type(object_id)
+        == habitat_sim.physics.MotionType.KINEMATIC
+    )
+
     # test kinematics
     I = np.identity(4)
 
@@ -145,7 +159,7 @@ def test_dynamics(sim):
             assert previous_object_states[0][0] == sim.get_translation(object_id)
             assert previous_object_states[0][1] != sim.get_rotation(object_id)
 
-            # 2nd object should rotation and translate
+            # 2nd object should rotate and translate
             assert previous_object_states[1][0] != sim.get_translation(object2_id)
             assert previous_object_states[1][1] != sim.get_rotation(object2_id)
 
@@ -153,3 +167,18 @@ def test_dynamics(sim):
                 [sim.get_translation(object_id), sim.get_rotation(object_id)],
                 [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
             ]
+
+        # test setting DYNAMIC object to KINEMATIC
+        assert sim.set_object_motion_type(
+            habitat_sim.physics.MotionType.KINEMATIC, object2_id
+        )
+        assert (
+            sim.get_object_motion_type(object2_id)
+            == habitat_sim.physics.MotionType.KINEMATIC
+        )
+
+        obs = sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+
+        # 2nd object should not longer rotate or translate
+        assert previous_object_states[1][0] == sim.get_translation(object2_id)
+        assert previous_object_states[1][1] == sim.get_rotation(object2_id)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -179,6 +179,6 @@ def test_dynamics(sim):
 
         obs = sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
 
-        # 2nd object should not longer rotate or translate
+        # 2nd object should no longer rotate or translate
         assert previous_object_states[1][0] == sim.get_translation(object2_id)
         assert previous_object_states[1][1] == sim.get_rotation(object2_id)


### PR DESCRIPTION
## Motivation and Context

Default `MotionType` for objects is determined by the active simulator. For dynamics simulators (e.g. Bullet), this default is `MotionType::DYNAMIC`. However, many use cases require kinematic or static objects. This should be settable in python as in C++.

## How Has This Been Tested

Local testing and new CI testing code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
