### PR TITLE
Fix tryStep edge cases

### DIFF
--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -879,14 +879,9 @@ T PathFinder::tryStep(const T& start, const T& end) {
   // navmesh, it seems to be in 99.9% of cases for us, but there are some
   // extreme edge cases where it won't be, so explicitly get the height of the
   // surface at the endPoint and set its height to that.
-  {
-    float endPointHeight;
-    // Note, this will never fail as endPoint is always within in the poly
-    // polys[numPolys - 1]
-    navQuery_->getPolyHeight(polys[numPolys - 1], endPoint.data(),
-                             &endPointHeight);
-    endPoint[1] = endPointHeight;
-  }
+  // Note, this will never fail as endPoint is always within in the poly
+  // polys[numPolys - 1]
+  navQuery_->getPolyHeight(polys[numPolys - 1], endPoint.data(), &endPoint[1]);
 
   // Hack to deal with infinitely thin walls in recast allowing you to
   // transition between two different connected components

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -873,10 +873,12 @@ T PathFinder::tryStep(const T& start, const T& end) {
     return start;
   }
 
-  // According to recast's docs, the endPoint is not guaranteed to be actually
-  // on the surface of the navmesh, it seems to be in 99.9% of cases for us, but
-  // there are some extreme edge cases where it won't be, so explicitly get the
-  // height of the surface at the endPoint and set its height to that.
+  // According to recast's code
+  // (https://github.com/recastnavigation/recastnavigation/blob/master/Detour/Source/DetourNavMeshQuery.cpp#L2006-L2007),
+  // the endPoint is not guaranteed to be actually on the surface of the
+  // navmesh, it seems to be in 99.9% of cases for us, but there are some
+  // extreme edge cases where it won't be, so explicitly get the height of the
+  // surface at the endPoint and set its height to that.
   {
     float endPointHeight;
     // Note, this will never fail as endPoint is always within in the poly

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -106,3 +106,16 @@ TEST(NavTest, PathFinderTestCases) {
                     (testPath.requestedStart - testPath.requestedEnd).norm()),
            0.001);
 }
+
+TEST(NavTest, PathFinderTestNonNavigable) {
+  PathFinder pf;
+  pf.loadNavMesh(Cr::Utility::Directory::join(
+      SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
+
+  const vec3f nonNavigablePoint{1e2, 1e2, 1e2};
+
+  const vec3f resultPoint = pf.tryStep<vec3f>(
+      nonNavigablePoint, nonNavigablePoint + vec3f{0.25, 0, 0});
+
+  CHECK(nonNavigablePoint.isApprox(resultPoint));
+}

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -123,7 +123,7 @@ def test_sensors(scene, has_sem, sensor_type, gpu2gpu, sim, make_cfg_settings):
     # Different GPUs and different driver version will produce slightly different images
     assert np.linalg.norm(
         obs[sensor_type].astype(np.float) - gt.astype(np.float)
-    ) < 1.5e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
+    ) < 2e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
 
 
 # Tests to make sure that no sensors is supported and doesn't crash


### PR DESCRIPTION
## Motivation and Context

Currently, tryStep returns {NAN, NAN, NAN} if you give it a non-navigable, just having it return the start position seems cleaner as returning in all NANs results in a crash if you try to render from that location (which makes sense, but just not moving seems cleaner/less confusing).

Also, I found out that `moveAlongSurface` isn't guaranteed to return a point on the surface of the navmesh, only within a polygon by [x, z].  I added an explicit call to get the height of the polygon.  It seems like almost all the time, the height isn't different, but sometimes it is a bit different.

I needed to make the comparison fuzzier for the rendering test to accommodate the newly added larger MP3D mesh (we had be running into bugs in the resource manager that were only apparent on larger meshes, so I added this one). Note, this was also failing on master for me and all other tests passed with the stricter version on this PR.

## How Has This Been Tested

I had been getting NaNs very very very infrequently when running large scale RL in replica, and with these changes, that has gone away.  Existing tests also still pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

