### PR TITLE
Disable PluginManager dynamic plugin loading for static magnum builds

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -791,7 +791,13 @@ bool ResourceManager::loadGeneralMeshData(
   // Mesh & metaData container
   MeshMetaData metaData;
 
+#ifndef MAGNUM_BUILD_STATIC
   Magnum::PluginManager::Manager<Importer> manager;
+#else
+  // avoid using plugins that might depend on different library versions
+  Magnum::PluginManager::Manager<Importer> manager{"nonexistent"};
+#endif
+
   std::unique_ptr<Importer> importer =
       manager.loadAndInstantiate("AnySceneImporter");
 


### PR DESCRIPTION
## Motivation and Context

Static builds could pick up different-versioned dynamic plugins for Magnum, resulting in version mismatch errors such as:
```
Trade::JpegImporter::image2D(): error: Wrong JPEG library version: library is 90, caller expects 80
```

This is particularly confusing when building inside conda or venv where a hermetic build is expected. The change in this PR disables dynamic plugin loading for static magnum builds.

## How Has This Been Tested

Built static build locally. Confirmed `build/viewer` no longer exhibits above version mismatch error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
