### PR TITLE
--cov-append for second pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,10 +274,10 @@ jobs:
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pytest --cov-report=xml --cov=./
 
-              #re-install without bullet and run physics tests again
+              #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py
+              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
       - run:
           name: Upload test coverage
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,12 +272,12 @@ jobs:
               CORRADE_TEST_COLOR=ON GTEST_COLOR=yes ./build.sh --headless --bullet --with-cuda --run-tests --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest
+              pytest --cov-report=xml --cov=./
 
               #re-install without bullet and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest tests/test_physics.py
+              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py
       - run:
           name: Upload test coverage
           background: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test=pytest
 build_temp=build
 
 [tool:pytest]
-addopts = --verbose -rsxX -q --cov-report=xml --cov=./
+addopts = --verbose -rsxX -q
 testpaths = tests
 markers =
     gfxtest: marks a test as needing to render


### PR DESCRIPTION
## Motivation and Context

We need to add `--cov-append` for the second invocation of pytest in habitat-sim

Also moves the `--cov-report=xml --cov=./` flags to just the CI as those aren't needed locally

## How Has This Been Tested

On the CI!
