### PR TITLE
Remove zero area polys

### DIFF
--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -603,8 +603,8 @@ struct NavMeshTileHeader {
 float polyArea(const dtPoly* poly, const dtMeshTile* tile) {
   float area = 0;
   // Code to iterate over triangles from here:
-  // https://github.com/recastnavigation/recastnavigation/blob/master/Detour/Source/DetourNavMesh.cpp#L684
-  const unsigned int ip = (unsigned int)(poly - tile->polys);
+  // https://github.com/recastnavigation/recastnavigation/blob/57610fa6ef31b39020231906f8c5d40eaa8294ae/Detour/Source/DetourNavMesh.cpp#L684
+  const std::ptrdiff_t ip = poly - tile->polys;
   const dtPolyDetail* pd = &tile->detailMeshes[ip];
   for (int j = 0; j < pd->triCount; ++j) {
     const unsigned char* t = &tile->detailTris[(pd->triBase + j) * 4];
@@ -643,9 +643,12 @@ void PathFinder::removeZeroAreaPolys() {
     for (int jPoly = 0; jPoly < tile->header->polyCount; ++jPoly) {
       // Get the polygon reference from the tile and polygon id
       dtPolyRef polyRef = navMesh_->encodePolyId(iTile, tile->salt, jPoly);
-      const dtPoly* poly = 0;
-      const dtMeshTile* tmp;
+      const dtPoly* poly = nullptr;
+      const dtMeshTile* tmp = nullptr;
       navMesh_->getTileAndPolyByRefUnsafe(polyRef, &tmp, &poly);
+
+      CORRADE_INTERNAL_ASSERT(poly != nullptr);
+      CORRADE_INTERNAL_ASSERT(tmp != nullptr);
 
       if (polyArea(poly, tile) < 1e-5) {
         navMesh_->setPolyFlags(polyRef, POLYFLAGS_DISABLED);

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -603,6 +603,7 @@ struct NavMeshTileHeader {
 float polyArea(const dtPoly* poly, const dtMeshTile* tile) {
   float area = 0;
   // Code to iterate over triangles from here:
+  // https://github.com/recastnavigation/recastnavigation/blob/master/Detour/Source/DetourNavMesh.cpp#L684
   const unsigned int ip = (unsigned int)(poly - tile->polys);
   const dtPolyDetail* pd = &tile->detailMeshes[ip];
   for (int j = 0; j < pd->triCount; ++j) {

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -704,7 +704,7 @@ bool PathFinder::loadNavMesh(const std::string& path) {
   bounds_ = std::make_pair(bmin, bmax);
 
   // Some polygons have zero area for some reason.  When we navigate into a zero
-  // area polygon, things crash.  So we find all zero area polygons and make
+  // area polygon, things crash.  So we find all zero area polygons and mark
   // them as disabled/not navigable.
 
   // Iterate over all tiles

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -635,7 +635,7 @@ void PathFinder::removeZeroAreaPolys() {
   // Iterate over all tiles
   for (int iTile = 0; iTile < navMesh_->getMaxTiles(); ++iTile) {
     const dtMeshTile* tile =
-        reinterpret_cast<const dtNavMesh*>(navMesh_)->getTile(iTile);
+        const_cast<const dtNavMesh*>(navMesh_)->getTile(iTile);
     if (!tile)
       continue;
 

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -598,7 +598,7 @@ struct NavMeshTileHeader {
   int dataSize;
 };
 
-// Calculate the area of a polygon by iterating over the triangles in the detial
+// Calculate the area of a polygon by iterating over the triangles in the detail
 // mesh and computing their area
 float polyArea(const dtPoly* poly, const dtMeshTile* tile) {
   float area = 0;

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -159,6 +159,7 @@ class PathFinder : public std::enable_shared_from_this<PathFinder> {
 
  protected:
   bool initNavQuery();
+  void removeZeroAreaPolys();
   std::vector<vec3f> prevEnds;
 
   impl::IslandSystem* islandSystem_ = nullptr;

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -20,7 +20,7 @@ def test_data():
 
 
 @hypothesis.given(
-    nudge=st.tuples(st.floats(-20, 20), st.floats(-5, 5), st.floats(-20, 20))
+    nudge=st.tuples(st.floats(-10, 10), st.floats(-2.5, 2.5), st.floats(-10, 10))
 )
 @hypothesis.settings(max_examples=int(1e3))
 def test_snap_point(nudge, test_data):


### PR DESCRIPTION
## Motivation and Context

There are some zero-area polygons in the navmeshes for some reason.  Those cause issues (#370).  This PR marks the zero are polygons as disabled, effectively removing them from the navigation mesh.

I have also pulled in the latest changes from recast as those do contain stability enhancements for methods that we heavily rely on.

Fixes #370 

## How Has This Been Tested

Via the test point in #370 (I can add that point to an explicit test, but its an MP3D mesh and we don't have them on the CI).

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

