### PR TITLE
Update git clone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ We highly recommend installing a [miniconda](https://docs.conda.io/en/latest/min
 1. Clone this github repository.
    ```bash
    # Checkout the latest stable release
-   git clone --branch stable git@github.com:facebookresearch/habitat-sim.git
+   git clone --branch stable https://github.com/facebookresearch/habitat-sim.git
    cd habitat-sim
    ```
 


### PR DESCRIPTION
## Motivation and Context

Update README to use https link `https://github.com/facebookresearch/habitat-sim.git` for git clone as it is the [recommended way](https://help.github.com/en/github/using-git/which-remote-url-should-i-use#cloning-with-https-urls-recommended) by GitHub. 

Current git@github clone link in README `git@github.com:facebookresearch/habitat-sim.git` may not work for users in general who do not have set up ssh keys.

## How Has This Been Tested

Rendered README on the local fork and cloned the repository using the updated link.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
