### PR TITLE
Modify transform variable naming conventions.

### DIFF
--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -26,7 +26,7 @@ struct MeshTransformNode {
   std::vector<MeshTransformNode> children;
 
   //! Node local transform to the parent frame
-  Magnum::Matrix4 T_parent_local;
+  Magnum::Matrix4 transformFromLocalToParent;
 
   MeshTransformNode() {
     meshIDLocal = ID_UNDEFINED;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -729,8 +729,8 @@ bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
     const quatf transform = info.frame.rotationFrameToWorld();
     Magnum::Matrix4 R = Magnum::Matrix4::from(
         Magnum::Quaternion(transform).toMatrix(), Magnum::Vector3());
-    resourceDict_[filename].root.T_parent_local =
-        R * resourceDict_[filename].root.T_parent_local;
+    resourceDict_[filename].root.transformFromLocalToParent =
+        R * resourceDict_[filename].root.transformFromLocalToParent;
   }
 
   // create the scene graph by request
@@ -944,8 +944,8 @@ bool ResourceManager::loadGeneralMeshData(
     const quatf transform = info.frame.rotationFrameToWorld();
     Magnum::Matrix4 R = Magnum::Matrix4::from(
         Magnum::Quaternion(transform).toMatrix(), Magnum::Vector3());
-    resourceDict_[filename].root.T_parent_local =
-        R * resourceDict_[filename].root.T_parent_local;
+    resourceDict_[filename].root.transformFromLocalToParent =
+        R * resourceDict_[filename].root.transformFromLocalToParent;
   } else {
     metaData = resourceDict_[filename];
   }
@@ -1041,7 +1041,8 @@ void ResourceManager::loadMeshHierarchy(Importer& importer,
 
   // Add the new node to the hierarchy and set its transformation
   parent.children.push_back(MeshTransformNode());
-  parent.children.back().T_parent_local = objectData->transformation();
+  parent.children.back().transformFromLocalToParent =
+      objectData->transformation();
   parent.children.back().componentID = componentID;
 
   const int meshIDLocal = objectData->instance();
@@ -1132,7 +1133,8 @@ void ResourceManager::addComponent(const MeshMetaData& metaData,
                                    const MeshTransformNode& meshTransformNode) {
   // Add the object to the scene and set its transformation
   scene::SceneNode& node = parent.createChild();
-  node.MagnumObject::setTransformation(meshTransformNode.T_parent_local);
+  node.MagnumObject::setTransformation(
+      meshTransformNode.transformFromLocalToParent);
 
   const int meshIDLocal = meshTransformNode.meshIDLocal;
 

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -83,15 +83,16 @@ class BulletRigidObject : public RigidObject {
    * sub-component, transformed to object-local space and added to the compound
    * in a flat manner for efficiency.
    * @param bCompound The @ref btCompoundShape being constructed.
-   * @param T The cumulative local-to-world transformation matrix constructed by
-   * composition down the @ref MeshTransformNode tree to the current node.
+   * @param transformFromParentToWorld The cumulative parent-to-world
+   * transformation matrix constructed by composition down the @ref
+   * MeshTransformNode tree to the current node.
    * @param meshGroup Access structure for collision mesh data.
    * @param node The current @ref MeshTransformNode in the recursion.
    * @param join Whether or not to join sub-meshes into a single con convex
    * shape, rather than creating individual convexes under the compound.
    */
   void constructBulletCompoundFromMeshes(
-      const Magnum::Matrix4& T_world_parent,
+      const Magnum::Matrix4& transformFromParentToWorld,
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node,
       bool join);


### PR DESCRIPTION
## Motivation and Context

To make transformation variables more semantically obvious, we have agreed upon the convention: `transformationFrom<frameA>To<frameB>`. This change modifies existing transform variables to comply with this convention.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
