### PR TITLE
Revert testing code change to viewer physics timestep.

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -350,8 +350,7 @@ void Viewer::drawEvent() {
     return;
 
   if (physicsManager_ != nullptr)
-    // physicsManager_->stepPhysics(timeline_.previousFrameDuration());
-    physicsManager_->stepPhysics(0.1);
+    physicsManager_->stepPhysics(timeline_.previousFrameDuration());
 
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];


### PR DESCRIPTION
## Motivation and Context

Revert a change to the physics timestep from testing PR #317.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
