### PR TITLE
Fix CollisionMeshData bug in GenericInstanceMeshData after mesh data manipulation

### DIFF
--- a/src/esp/assets/GenericInstanceMeshData.cpp
+++ b/src/esp/assets/GenericInstanceMeshData.cpp
@@ -235,13 +235,16 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
   // simply mmap a file with the vertex buffer and index buffer.
   std::vector<Mn::UnsignedInt> objectIdIndices = removeDuplicates(objectIds_);
   Mn::GL::Buffer vertices, indices;
-  indices.setTargetHint(Mn::GL::Buffer::TargetHint::ElementArray);
-  indices.setData(
+
+  std::vector<Magnum::UnsignedInt> new_indices =
       Mn::MeshTools::combineIndexedArrays(
           std::make_pair(std::cref(objectIdIndices), std::ref(objectIds_)),
           std::make_pair(std::cref(cpu_ibo_), std::ref(cpu_vbo_)),
-          std::make_pair(std::cref(cpu_ibo_), std::ref(cpu_cbo_))),
-      Mn::GL::BufferUsage::StaticDraw);
+          std::make_pair(std::cref(cpu_ibo_), std::ref(cpu_cbo_)));
+
+  indices.setTargetHint(Mn::GL::Buffer::TargetHint::ElementArray);
+  indices.setData(new_indices, Mn::GL::BufferUsage::StaticDraw);
+
   vertices.setData(
       Mn::MeshTools::interleave(cpu_vbo_, cpu_cbo_, 1, objectIds_, 2),
       Mn::GL::BufferUsage::StaticDraw);
@@ -261,6 +264,15 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
           2)
       .setIndexBuffer(std::move(indices), 0,
                       Mn::GL::MeshIndexType::UnsignedInt);
+
+  cpu_ibo_ = std::move(new_indices);
+
+  collisionMeshData_.positions =
+      Corrade::Containers::arrayCast<Magnum::Vector3>(
+          Corrade::Containers::arrayView(cpu_vbo_.data(), cpu_vbo_.size()));
+  collisionMeshData_.indices =
+      Corrade::Containers::arrayCast<Magnum::UnsignedInt>(
+          Corrade::Containers::arrayView(cpu_ibo_.data(), cpu_ibo_.size()));
 
   buffersOnGPU_ = true;
 }

--- a/src/esp/assets/GenericInstanceMeshData.cpp
+++ b/src/esp/assets/GenericInstanceMeshData.cpp
@@ -213,12 +213,7 @@ bool GenericInstanceMeshData::loadPLY(const std::string& plyFile) {
   // later they can be accessed.
   // Note that normal and texture data are not stored
   collisionMeshData_.primitive = Magnum::MeshPrimitive::Triangles;
-  collisionMeshData_.positions =
-      Corrade::Containers::arrayCast<Magnum::Vector3>(
-          Corrade::Containers::arrayView(cpu_vbo_.data(), cpu_vbo_.size()));
-  collisionMeshData_.indices =
-      Corrade::Containers::arrayCast<Magnum::UnsignedInt>(
-          Corrade::Containers::arrayView(cpu_ibo_.data(), cpu_ibo_.size()));
+  updateCollisionMeshData();
 
   return true;
 }
@@ -267,12 +262,7 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
 
   cpu_ibo_ = std::move(new_indices);
 
-  collisionMeshData_.positions =
-      Corrade::Containers::arrayCast<Magnum::Vector3>(
-          Corrade::Containers::arrayView(cpu_vbo_.data(), cpu_vbo_.size()));
-  collisionMeshData_.indices =
-      Corrade::Containers::arrayCast<Magnum::UnsignedInt>(
-          Corrade::Containers::arrayView(cpu_ibo_.data(), cpu_ibo_.size()));
+  updateCollisionMeshData();
 
   buffersOnGPU_ = true;
 }
@@ -282,6 +272,13 @@ Magnum::GL::Mesh* GenericInstanceMeshData::getMagnumGLMesh() {
     return nullptr;
   }
   return &(renderingBuffer_->mesh);
+}
+
+void GenericInstanceMeshData::updateCollisionMeshData() {
+  collisionMeshData_.positions = Cr::Containers::arrayCast<Mn::Vector3>(
+      Cr::Containers::arrayView(cpu_vbo_));
+  collisionMeshData_.indices = Cr::Containers::arrayCast<Mn::UnsignedInt>(
+      Cr::Containers::arrayView(cpu_ibo_));
 }
 
 }  // namespace assets

--- a/src/esp/assets/GenericInstanceMeshData.h
+++ b/src/esp/assets/GenericInstanceMeshData.h
@@ -49,6 +49,8 @@ class GenericInstanceMeshData : public BaseMesh {
   }
 
  protected:
+  void updateCollisionMeshData();
+
   // ==== rendering ====
   std::unique_ptr<RenderingBuffer> renderingBuffer_ = nullptr;
 


### PR DESCRIPTION
## Motivation and Context

`CollisionMeshData` is used to reference mesh geometry during construction of collision objects for physics simulation. Manipulation of geometry data in `GenericInstanceMeshData::uploadBuffersToGPU` caused this reference set in `GenericInstanceMeshData::loadPLY` to be incorrect. This PR aims to fix this bug.

Moved from #333 as suggested by @msbaines.

## How Has This Been Tested



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
