### PR TITLE
Viewer: set agent position from navmesh if loaded in initialization 

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -212,6 +212,11 @@ Viewer::Viewer(const Arguments& arguments)
 
   // connect controls to navmesh if loaded
   if (pathfinder_->isLoaded()) {
+    // some scenes could have pathable roof polygons. We are not filtering
+    // those starting points here.
+    vec3f position = pathfinder_->getRandomNavigablePoint();
+    agentBodyNode_->setTranslation(Vector3(position));
+
     controls_.setMoveFilterFunction([&](const vec3f& start, const vec3f& end) {
       vec3f currentPosition = pathfinder_->tryStep(start, end);
       LOG(INFO) << "position=" << currentPosition.transpose() << " rotation="


### PR DESCRIPTION
## Motivation and Context

Currently the agent position in viewer is hardcoded in initialization resulting in cases where the agent is initialized outside of the scene as shown for the `van-gogh-room.glb` below:

![image](https://user-images.githubusercontent.com/1445143/71192010-5654c680-223c-11ea-916a-2ed9beb13a75.png)


## How Has This Been Tested

Running viewer for multiple scenes (e.g. `van-gogh-room.glb`):
![image](https://user-images.githubusercontent.com/1445143/71192086-7be1d000-223c-11ea-980a-32c3ffbdd795.png)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
