### PR TITLE
[esp/scene] Added loading of Gibson Semantics scene if MP3D semantic is missing, integration test

### DIFF
--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -57,6 +57,10 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     houseFilename = cfg.scene.filepaths.at("house");
   }
 
+  if (!io::exists(houseFilename)) {
+    houseFilename = io::changeExtension(sceneFilename, ".scn");
+  }
+
   const assets::AssetInfo sceneInfo =
       assets::AssetInfo::fromPath(sceneFilename);
 
@@ -129,7 +133,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
       if (!(sceneInfo.type == assets::AssetType::SUNCG_SCENE ||
             sceneInfo.type == assets::AssetType::INSTANCE_MESH ||
             sceneFilename.compare(assets::EMPTY_SCENE) == 0)) {
-        // TODO: programmatic generation of semantic meshes when no annotiations
+        // TODO: programmatic generation of semantic meshes when no annotations
         // are provided.
         LOG(WARNING) << ":\n---\n The active scene does not contain semantic "
                         "annotations. \n---";

--- a/src/esp/scene/test/CMakeLists.txt
+++ b/src/esp/scene/test/CMakeLists.txt
@@ -6,6 +6,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 
 add_executable(GibsonSceneTest GibsonSceneTest.cpp)
-target_link_libraries(GibsonSceneTest gtest_main scene)
+target_link_libraries(GibsonSceneTest gtest_main scene sim)
 
 gtest_discover_tests(GibsonSceneTest)

--- a/src/esp/scene/test/GibsonSceneTest.cpp
+++ b/src/esp/scene/test/GibsonSceneTest.cpp
@@ -6,10 +6,18 @@
 
 #include <gtest/gtest.h>
 
+#include <Corrade/Utility/Directory.h>
+#include <string>
+#include "esp/io/io.h"
 #include "esp/scene/SemanticScene.h"
+#include "esp/sim/SimulatorWithAgents.h"
 
-using esp::scene::SemanticObject;
+namespace Cr = Corrade;
+
+using esp::gfx::SimulatorConfiguration;
+using esp::scene::SceneConfiguration;
 using esp::scene::SemanticScene;
+using esp::sim::SimulatorWithAgents;
 
 const std::string houseFilename = SCENE_DIR "/GibsonSceneTest/test.scn";
 
@@ -18,10 +26,28 @@ TEST(GibsonSceneTest, Basic) {
   ASSERT_EQ(semanticScene.objects().size(), 0);
   SemanticScene::loadGibsonHouse(houseFilename, semanticScene);
   ASSERT_NE(semanticScene.objects().size(), 2);
-  std::shared_ptr<SemanticObject> object = semanticScene.objects()[1];
+  auto object = semanticScene.objects()[1];
   ASSERT_EQ(object->category()->name(""), "microwave");
   object = semanticScene.objects()[2];
   ASSERT_EQ(object->category()->name(""), "oven");
   object = semanticScene.objects()[3];
   ASSERT_EQ(object->category()->name(""), "microwave");
+}
+
+const std::string gibsonSemanticFilename =
+    Cr::Utility::Directory::join(SCENE_DATASETS, "gibson/Allensville.scn");
+
+TEST(GibsonSemanticSimTest, Basic) {
+  if (!esp::io::exists(gibsonSemanticFilename)) {
+    std::string skip_message = "Gibson's semantic scene file \"" +
+                               gibsonSemanticFilename + "\" wasn't found.";
+    GTEST_SKIP_(skip_message.c_str());
+  }
+  SimulatorConfiguration cfg;
+  cfg.scene.id = esp::io::changeExtension(gibsonSemanticFilename, ".glb");
+  SimulatorWithAgents simulator(cfg);
+  const auto& semanticScene = simulator.getSemanticScene();
+  ASSERT_EQ(semanticScene->objects().size(), 34);
+  const auto& microwave = semanticScene->objects()[1];
+  ASSERT_EQ(microwave->category()->name(""), "microwave");
 }

--- a/src/esp/scene/test/configure.h.cmake
+++ b/src/esp/scene/test/configure.h.cmake
@@ -3,3 +3,4 @@
 // LICENSE file in the root directory of this source tree.
 
 #define SCENE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+#define SCENE_DATASETS "${SCENE_DATASETS}"


### PR DESCRIPTION
## Motivation and Context
With current code state [3dscenegraph](https://3dscenegraph.stanford.edu/) semantic annotation files (*.scn) won't load, as our semantic loading pipeline triggers only on `*.house` files. To enable functionality implemented in https://github.com/facebookresearch/habitat-sim/pull/393 and https://github.com/facebookresearch/habitat-sim/issues/374 added loading of Gibson Semantics scene if MP3D semantic is missing. To test semantic loading e2e added integration test that will run only when *.scn test data is available.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Added the integration test and run it locally with `*.scn` data:
```
Running main() from /private/home/maksymets/habitat-sim/src/deps/googletest/googletest/src/gtest_main.cc
[==========] Running 2 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from GibsonSceneTest
[ RUN      ] GibsonSceneTest.Basic
[       OK ] GibsonSceneTest.Basic (2 ms)
[----------] 1 test from GibsonSceneTest (2 ms total)

[----------] 1 test from GibsonSemanticSimTest
[ RUN      ] GibsonSemanticSimTest.Basic
[       OK ] GibsonSemanticSimTest.Basic (5451 ms)
[----------] 1 test from GibsonSemanticSimTest (5451 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 2 test cases ran. (5453 ms total)
[  PASSED  ] 2 tests.
```
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
