### PR TITLE
Specified clang-tidy version 8 for contributing guidelines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ---
+# clang-format v8
 Language:        Cpp
 # BasedOnStyle:  Chromium
 AccessModifierOffset: -1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ clear and has sufficient instructions to be able to reproduce the issue.
 
 - C++
   - In general, we follow [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) and [Google C++ guidelines](https://google.github.io/styleguide/cppguide.html)
-  - Use `clang-format` for style enforcement and linting. Install clang-format through `brew install clang-format` on MacOS, or by downloading [binaries or sources](http://releases.llvm.org/download.html) for Ubuntu etc.
+  - Use `clang-format`(clang-format-8) for style enforcement and linting. Install clang-format through `brew install clang-format` on MacOS, or using `apt-get install -y clang-format-8` as we do for [the testing environment setup](./.circleci/config.yml) or by downloading [binaries or sources](http://releases.llvm.org/download.html) for Ubuntu etc.
 - Python
   - We follow PEP8 and use [typing](https://docs.python.org/3/library/typing.html).
   - Use `black` for style enforcement and linting. Install black through `pip install black`.


### PR DESCRIPTION
## Motivation and Context
Specified clang-tidy version 8 for contributing guidelines, as our clang config isn't backward compatible.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

