### PR TITLE
Add getObjectSceneNode function to PhysicsManager

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -448,5 +448,11 @@ void PhysicsManager::setObjectBBDraw(int physObjectID,
         0, *existingObjects_[physObjectID]->BBNode_, drawables);
   }
 }
+
+const scene::SceneNode& PhysicsManager::getObjectSceneNode(int physObjectID) {
+  assertIDValidity(physObjectID);
+  return *existingObjects_[physObjectID];
+}
+
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -686,6 +686,15 @@ class PhysicsManager {
    */
   void setObjectBBDraw(int physObjectID, DrawableGroup* drawables, bool drawBB);
 
+  /**
+   * @brief Get a const reference to the specified object's SceneNode for info
+   * query purposes.
+   * @param physObjectID The object ID and key identifying the object in @ref
+   * PhysicsManager::existingObjects_.
+   * @return Const reference to the object scene node.
+   */
+  const scene::SceneNode& getObjectSceneNode(int physObjectID);
+
   /** @brief Render any debugging visualizations provided by the underlying
    * physics simulator implementation. By default does nothing. See @ref
    * BulletPhysicsManager::debugDraw.

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -82,6 +82,11 @@ TEST(PhysicsTest, JoinCompound) {
       for (int o = 0; o < num_objects; o++) {
         int objectId = physicsManager_->addObject(objectFile, nullptr);
         objectIds.push_back(o);
+
+        const esp::scene::SceneNode& node =
+            physicsManager_->getObjectSceneNode(objectId);
+        node.getId();
+
         Magnum::Matrix4 R{
             Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
             Magnum::Matrix4::rotationY(Magnum::Math::Rad<float>(-0.25))};

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -85,7 +85,6 @@ TEST(PhysicsTest, JoinCompound) {
 
         const esp::scene::SceneNode& node =
             physicsManager_->getObjectSceneNode(objectId);
-        node.getId();
 
         Magnum::Matrix4 R{
             Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
@@ -95,6 +94,8 @@ TEST(PhysicsTest, JoinCompound) {
         physicsManager_->setRotation(
             objectId, Magnum::Quaternion::fromMatrix(R.rotationNormalized()));
         physicsManager_->setTranslation(objectId, initialPosition);
+
+        ASSERT_EQ(node.absoluteTranslation(), initialPosition);
       }
 
       float timeToSim = 10.0;


### PR DESCRIPTION
##  Motivation and Context

It is often desirable to fetch the SceneNode associated with a physics object. However, we provide many PhysicsManager functions to avoid direct manipulation of SceneNode states which may invalidate simulation state. Here we add a const reference getter for a query only object SceneNode.

## How Has This Been Tested

Some testing lines in existing physics C++ test function. Will likely be moved to another test function once this functionality is needed (upcoming).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
