### PR TITLE
Refactor RenderCamera to inherit from MagnumCamera

### DIFF
--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -36,7 +36,7 @@ namespace gfx {
 void initGfxBindings(py::module& m) {
   // ==== RenderCamera ====
   py::class_<RenderCamera, Magnum::SceneGraph::PyFeature<RenderCamera>,
-             Magnum::SceneGraph::AbstractFeature3D,
+             Magnum::SceneGraph::Camera3D,
              Magnum::SceneGraph::PyFeatureHolder<RenderCamera>>(
       m, "Camera",
       R"(RenderCamera: The object of this class is a camera attached
@@ -47,12 +47,6 @@ void initGfxBindings(py::module& m) {
         Set this `Camera`'s projection matrix.
       )",
            "width"_a, "height"_a, "znear"_a, "zfar"_a, "hfov"_a)
-      .def("getProjectionMatrix", &RenderCamera::getProjectionMatrix, R"(
-        Get this `Camera`'s projection matrix.
-      )")
-      .def("getCameraMatrix", &RenderCamera::getCameraMatrix, R"(
-        Get this `Camera`'s camera matrix.
-      )")
       .def_property_readonly("node", nodeGetter<RenderCamera>,
                              "Node this object is attached to")
       .def_property_readonly("object", nodeGetter<RenderCamera>,

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -11,12 +11,9 @@ namespace Mn = Magnum;
 namespace esp {
 namespace gfx {
 
-RenderCamera::RenderCamera(scene::SceneNode& node)
-    : Mn::SceneGraph::AbstractFeature3D{node} {
+RenderCamera::RenderCamera(scene::SceneNode& node) : MagnumCamera{node} {
   node.setType(scene::SceneNodeType::CAMERA);
-  camera_ = new MagnumCamera(node);
-  camera_->setAspectRatioPolicy(
-      Mn::SceneGraph::AspectRatioPolicy::NotPreserved);
+  setAspectRatioPolicy(Mn::SceneGraph::AspectRatioPolicy::NotPreserved);
 }
 
 RenderCamera::RenderCamera(scene::SceneNode& node,
@@ -29,32 +26,23 @@ RenderCamera::RenderCamera(scene::SceneNode& node,
       Mn::Vector3{eye}, Mn::Vector3{target}, Mn::Vector3{up}));
 }
 
-void RenderCamera::setProjectionMatrix(int width,
-                                       int height,
-                                       float znear,
-                                       float zfar,
-                                       float hfov) {
+RenderCamera& RenderCamera::setProjectionMatrix(int width,
+                                                int height,
+                                                float znear,
+                                                float zfar,
+                                                float hfov) {
   const float aspectRatio = static_cast<float>(width) / height;
-  camera_
-      ->setProjectionMatrix(Mn::Matrix4::perspectiveProjection(
-          Mn::Deg{hfov}, aspectRatio, znear, zfar))
+  MagnumCamera::setProjectionMatrix(
+      Mn::Matrix4::perspectiveProjection(Mn::Deg{hfov}, aspectRatio, znear,
+                                         zfar))
       .setViewport(Magnum::Vector2i(width, height));
+  return *this;
 }
 
-mat4f RenderCamera::getProjectionMatrix() {
-  return Eigen::Map<mat4f>(camera_->projectionMatrix().data());
-}
-
-mat4f RenderCamera::getCameraMatrix() {
-  return Eigen::Map<mat4f>(camera_->cameraMatrix().data());
-}
-
-MagnumCamera& RenderCamera::getMagnumCamera() {
-  return *camera_;
-}
-
-void RenderCamera::draw(MagnumDrawableGroup& drawables) {
-  camera_->draw(drawables);
+RenderCamera& RenderCamera::draw(MagnumDrawableGroup& drawables) {
+  // TODO: visibility culling
+  MagnumCamera::draw(drawables);
+  return *this;
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -12,7 +12,7 @@
 namespace esp {
 namespace gfx {
 
-class RenderCamera : public Magnum::SceneGraph::AbstractFeature3D {
+class RenderCamera : public MagnumCamera {
  public:
   RenderCamera(scene::SceneNode& node);
   RenderCamera(scene::SceneNode& node,
@@ -29,31 +29,21 @@ class RenderCamera : public Magnum::SceneGraph::AbstractFeature3D {
 
   // Overloads to avoid confusion
   scene::SceneNode& object() {
-    return static_cast<scene::SceneNode&>(
-        Magnum::SceneGraph::AbstractFeature3D::object());
+    return static_cast<scene::SceneNode&>(MagnumCamera::object());
   }
   const scene::SceneNode& object() const {
-    return static_cast<const scene::SceneNode&>(
-        Magnum::SceneGraph::AbstractFeature3D::object());
+    return static_cast<const scene::SceneNode&>(MagnumCamera::object());
   }
 
-  void setProjectionMatrix(int width,
-                           int height,
-                           float znear,
-                           float zfar,
-                           float hfov);
+  RenderCamera& setProjectionMatrix(int width,
+                                    int height,
+                                    float znear,
+                                    float zfar,
+                                    float hfov);
 
-  mat4f getProjectionMatrix();
-
-  mat4f getCameraMatrix();
-
-  MagnumCamera& getMagnumCamera();
-
-  void draw(MagnumDrawableGroup& drawables);
+  RenderCamera& draw(MagnumDrawableGroup& drawables);
 
  protected:
-  MagnumCamera* camera_ = nullptr;
-
   ESP_SMART_POINTERS(RenderCamera)
 };
 

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -71,7 +71,7 @@ PinholeCamera& PinholeCamera::setTransformationMatrix(
 }
 
 PinholeCamera& PinholeCamera::setViewport(gfx::RenderCamera& targetCamera) {
-  targetCamera.getMagnumCamera().setViewport(this->framebufferSize());
+  targetCamera.setViewport(this->framebufferSize());
   return *this;
 }
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -2,7 +2,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/Utility/Directory.h>
+#include <Magnum/ImageView.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/PixelFormat.h>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -11,10 +15,17 @@
 #include "configure.h"
 
 namespace Cr = Corrade;
+namespace Mn = Magnum;
 
+using esp::agent::AgentConfiguration;
 using esp::gfx::SimulatorConfiguration;
 using esp::nav::PathFinder;
 using esp::scene::SceneConfiguration;
+using esp::sensor::Observation;
+using esp::sensor::ObservationSpace;
+using esp::sensor::ObservationSpaceType;
+using esp::sensor::SensorSpec;
+using esp::sensor::SensorType;
 using esp::sim::SimulatorWithAgents;
 
 const std::string vangogh =
@@ -23,6 +34,21 @@ const std::string vangogh =
 const std::string skokloster =
     Cr::Utility::Directory::join(SCENE_DATASETS,
                                  "habitat-test-scenes/skokloster-castle.glb");
+
+// TODO(MM): move following to common test utils module
+template <typename T, typename U>
+bool equalWithTolerance(const T& lhs, const T& rhs, U tolerance) {
+  return std::abs(rhs - lhs) <= std::abs(tolerance);
+}
+
+bool pixelEqualWithChannelTolerance(const Mn::Color4ub& lhs,
+                                    const Mn::Color4ub& rhs,
+                                    int tolerance) {
+  return equalWithTolerance(lhs.r(), rhs.r(), tolerance) &&
+         equalWithTolerance(lhs.g(), rhs.g(), tolerance) &&
+         equalWithTolerance(lhs.b(), rhs.b(), tolerance) &&
+         equalWithTolerance(lhs.a(), rhs.a(), tolerance);
+}
 
 TEST(SimTest, Basic) {
   SimulatorConfiguration cfg;
@@ -52,4 +78,48 @@ TEST(SimTest, Reset) {
   PathFinder::ptr pathfinder = simulator.getPathFinder();
   simulator.reset();
   ASSERT_EQ(pathfinder, simulator.getPathFinder());
+}
+
+TEST(SimTest, GetPinholeCameraRGBAObservation) {
+  SimulatorConfiguration simConfig{};
+  simConfig.scene.id = vangogh;
+
+  // do not rely on default SensorSpec default constructor to remain constant
+  auto pinholeCameraSpec = SensorSpec::create();
+  pinholeCameraSpec->sensorSubtype = "pinhole";
+  pinholeCameraSpec->sensorType = SensorType::COLOR;
+  pinholeCameraSpec->position = {0.0f, 1.5f, 5.0f};
+  pinholeCameraSpec->resolution = {100, 100};
+
+  SimulatorWithAgents simulator(simConfig);
+  AgentConfiguration agentConfig{};
+  agentConfig.sensorSpecifications = {pinholeCameraSpec};
+  simulator.addAgent(agentConfig);
+
+  Observation observation;
+  ObservationSpace obsSpace;
+  ASSERT_TRUE(simulator.getAgentObservation(
+      simConfig.defaultAgentId, pinholeCameraSpec->uuid, observation));
+  ASSERT_TRUE(simulator.getAgentObservationSpace(
+      simConfig.defaultAgentId, pinholeCameraSpec->uuid, obsSpace));
+
+  std::vector<size_t> expectedShape{
+      {static_cast<size_t>(pinholeCameraSpec->resolution[0]),
+       static_cast<size_t>(pinholeCameraSpec->resolution[1]), 4}};
+
+  ASSERT_EQ(obsSpace.spaceType, ObservationSpaceType::TENSOR);
+  ASSERT_EQ(obsSpace.dataType, esp::core::DataType::DT_UINT8);
+  ASSERT_EQ(obsSpace.shape, expectedShape);
+  ASSERT_EQ(observation.buffer->shape, expectedShape);
+
+  // test one pixel
+  Mn::ImageView2D image{
+      Mn::PixelFormat::RGBA8Unorm,
+      {pinholeCameraSpec->resolution[0], pinholeCameraSpec->resolution[1]},
+      observation.buffer->data};
+
+  Mn::Color4ub pixel = image.pixels<Mn::Color4ub>()[50][50];
+  Mn::Color4ub expectedPixel{0x40, 0x6C, 0x46, 0xB5};
+
+  ASSERT_TRUE(pixelEqualWithChannelTolerance(pixel, expectedPixel, 5));
 }

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -112,13 +112,17 @@ TEST(SimTest, GetPinholeCameraRGBAObservation) {
   ASSERT_EQ(obsSpace.shape, expectedShape);
   ASSERT_EQ(observation.buffer->shape, expectedShape);
 
-  // test one pixel
+  // Compare one pixel (center of image) with previously rendered ground truth
+  // TODO: compare more than one pixel
   Mn::ImageView2D image{
       Mn::PixelFormat::RGBA8Unorm,
       {pinholeCameraSpec->resolution[0], pinholeCameraSpec->resolution[1]},
       observation.buffer->data};
 
   Mn::Color4ub pixel = image.pixels<Mn::Color4ub>()[50][50];
+
+  // Ground truth: hardcoded from previous render
+  // TODO: move various sensor configurations and expected ground truths
   Mn::Color4ub expectedPixel{0x40, 0x6C, 0x46, 0xB5};
 
   ASSERT_TRUE(pixelEqualWithChannelTolerance(pixel, expectedPixel, 5));

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -122,7 +122,8 @@ TEST(SimTest, GetPinholeCameraRGBAObservation) {
   Mn::Color4ub pixel = image.pixels<Mn::Color4ub>()[50][50];
 
   // Ground truth: hardcoded from previous render
-  // TODO: move various sensor configurations and expected ground truths
+  // TODO: move various sensor configurations and expected ground truths to
+  // common test util
   Mn::Color4ub expectedPixel{0x40, 0x6C, 0x46, 0xB5};
 
   ASSERT_TRUE(pixelEqualWithChannelTolerance(pixel, expectedPixel, 5));

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -203,7 +203,7 @@ Viewer::Viewer(const Arguments& arguments)
                                      0.01f,             // znear
                                      1000.0f,           // zfar
                                      90.0f);            // hfov
-  renderCamera_->getMagnumCamera().setAspectRatioPolicy(
+  renderCamera_->setAspectRatioPolicy(
       Magnum::SceneGraph::AspectRatioPolicy::Extend);
 
   // Load navmesh if available
@@ -385,11 +385,11 @@ void Viewer::drawEvent() {
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
-  renderCamera_->getMagnumCamera().draw(sceneGraph.getDrawables());
+  renderCamera_->draw(sceneGraph.getDrawables());
 
   if (debugBullet_) {
-    Magnum::Matrix4 camM(renderCamera_->getCameraMatrix());
-    Magnum::Matrix4 projM(renderCamera_->getProjectionMatrix());
+    Magnum::Matrix4 camM(renderCamera_->cameraMatrix());
+    Magnum::Matrix4 projM(renderCamera_->projectionMatrix());
 
     physicsManager_->debugDraw(projM * camM);
   }
@@ -429,15 +429,14 @@ void Viewer::drawEvent() {
 
 void Viewer::viewportEvent(ViewportEvent& event) {
   GL::defaultFramebuffer.setViewport({{}, framebufferSize()});
-  renderCamera_->getMagnumCamera().setViewport(event.windowSize());
+  renderCamera_->setViewport(event.windowSize());
   imgui_.relayout(Vector2{event.windowSize()} / event.dpiScaling(),
                   event.windowSize(), event.framebufferSize());
 }
 
 void Viewer::mousePressEvent(MouseEvent& event) {
   if (event.button() == MouseEvent::Button::Left)
-    previousPosition_ =
-        positionOnSphere(renderCamera_->getMagnumCamera(), event.position());
+    previousPosition_ = positionOnSphere(*renderCamera_, event.position());
 
   event.setAccepted();
 }
@@ -472,7 +471,7 @@ void Viewer::mouseMoveEvent(MouseMoveEvent& event) {
   }
 
   const Vector3 currentPosition =
-      positionOnSphere(renderCamera_->getMagnumCamera(), event.position());
+      positionOnSphere(*renderCamera_, event.position());
   const Vector3 axis = Math::cross(previousPosition_, currentPosition);
 
   if (previousPosition_.length() < 0.001f || axis.length() < 0.001f) {


### PR DESCRIPTION
## Motivation and Context

Addresses #391 
- Eliminates the getMagnumCamera(...) in the interface API;
- gains all the existing APIs in MagnumCamera;
- The development could be easier in Frustum Culling project. Culling can happen in the RenderCamera class;

## How Has This Been Tested

- Manual testing using viewer app
- Manual testing ensuring `MagnumCamera` api accessible from python bindings
- habitat-sim and habitat-api have been grepped for usages of `RenderCamera`
- passes all tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
