### PR TITLE
made reset function in Simulator class reset agent state to initial s…

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -123,6 +123,7 @@ class Agent(object):
         self.body = mn.scenegraph.AbstractFeature3D(scene_node)
         scene_node.type = hsim.SceneNodeType.AGENT
         self.reconfigure(self.agent_config)
+        self.initial_state = None
 
     def reconfigure(
         self, agent_config: AgentConfiguration, reconfigure_sensors: bool = True
@@ -189,13 +190,15 @@ class Agent(object):
 
         return state
 
-    def set_state(self, state: AgentState, reset_sensors: bool = True):
+    def set_state(self, state: AgentState, reset_sensors: bool = True, is_initial: bool = False):
         r"""Sets the agents state
 
         :param state: The state to set the agent to
         :param reset_sensors: Whether or not to reset the sensors to their
             default intrinsic/extrinsic parameters before setting their
             extrinsic state
+        :param is_initial: Whether this state is the initial state of the
+            agent in the scene. Used for resetting the agent at a later time
         """
         habitat_sim.errors.assert_obj_valid(self.body)
 
@@ -225,6 +228,9 @@ class Agent(object):
                 )
             )
             s.node.rotation = quat_to_magnum(state.rotation.inverse() * v.rotation)
+
+        if is_initial:
+            self.initial_state = state
 
     @property
     def scene_node(self):

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -87,6 +87,16 @@ class Simulator:
 
     def reset(self):
         self._sim.reset()
+        for agent_id in range(len(self.agents)):
+            agent = self.get_agent(agent_id)
+            initial_agent_state = agent.initial_state
+            if initial_agent_state is None:
+                raise RuntimeError(
+                    "reset called before agent was given an initial state"
+                )
+
+            self.initialize_agent(agent_id, initial_agent_state)
+
         return self.get_sensor_observations()
 
     def _config_backend(self, config: Configuration):
@@ -181,7 +191,7 @@ class Simulator:
                     np.random.uniform(0, 2.0 * np.pi), np.array([0, 1, 0])
                 )
 
-        agent.set_state(initial_state)
+        agent.set_state(initial_state, is_initial=True)
         self._last_state = agent.state
         return agent
 

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -169,7 +169,6 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
       break;
   }
 
-  // now reset to sample agent state
   reset();
 }
 


### PR DESCRIPTION
…tate

## Motivation and Context

Made the reset function in the Simulator class of simulator.py reset the agent to its initial state. Issue from here: https://github.com/facebookresearch/habitat-sim/issues/300

## How Has This Been Tested

Tested this by instantiating the simulator class and stepping through a few actions before calling reset, then comparing the initial and final state to ensure they were the same.

## Types of changes

Created a field in the Agent class called initial_state that gets set when initialize_agent() is called in simulator.py. This makes sure that the initial state is set with a valid position in the scene (not inside a wall or some weird place like that). Then when reset is called, each agent's state is set to its initial state.

## Checklist


