### PR TITLE
[sensor] extract out visual parts of Sensor into VisualSensor

### DIFF
--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -56,7 +56,7 @@ void initGfxBindings(py::module& m) {
   py::class_<Renderer, Renderer::ptr>(m, "Renderer")
       .def(py::init(&Renderer::create<>))
       .def("draw",
-           py::overload_cast<sensor::Sensor&, scene::SceneGraph&>(
+           py::overload_cast<sensor::VisualSensor&, scene::SceneGraph&>(
                &Renderer::draw),
            R"(Draw given scene using the visual sensor)", "visualSensor"_a,
            "scene"_a)

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -42,17 +42,13 @@ void initSensorBindings(py::module& m) {
   py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,
              Magnum::SceneGraph::AbstractFeature3D,
              Magnum::SceneGraph::PyFeatureHolder<Sensor>>(m, "Sensor")
-      .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
-                          const SensorSpec::ptr&>())
       .def("specification", &Sensor::specification)
       .def("set_transformation_from_spec", &Sensor::setTransformationFromSpec)
       .def("is_visual_sensor", &Sensor::isVisualSensor)
       .def("get_observation", &Sensor::getObservation)
       .def_property_readonly("node", nodeGetter<Sensor>,
                              "Node this object is attached to")
-      .def_property_readonly("object", nodeGetter<Sensor>, "Alias to node")
-      .def_property_readonly("framebuffer_size", &Sensor::framebufferSize)
-      .def_property_readonly("render_target", &Sensor::renderTarget);
+      .def_property_readonly("object", nodeGetter<Sensor>, "Alias to node");
 
   // TODO fill out other SensorTypes
   // ==== enum SensorType ====
@@ -97,20 +93,20 @@ void initSensorBindings(py::module& m) {
              return self != other;
            });
 
+  // ==== VisualSensor ====
+  py::class_<VisualSensor, Magnum::SceneGraph::PyFeature<VisualSensor>, Sensor,
+             Magnum::SceneGraph::PyFeatureHolder<VisualSensor>>(m,
+                                                                "VisualSensor")
+      .def_property_readonly("framebuffer_size", &VisualSensor::framebufferSize)
+      .def_property_readonly("render_target", &VisualSensor::renderTarget);
+
   // ==== PinholeCamera (subclass of Sensor) ====
   py::class_<PinholeCamera, Magnum::SceneGraph::PyFeature<PinholeCamera>,
-             Sensor, Magnum::SceneGraph::PyFeatureHolder<PinholeCamera>>(
+             VisualSensor, Magnum::SceneGraph::PyFeatureHolder<PinholeCamera>>(
       m, "PinholeCamera")
       // initialized, attached to pinholeCameraNode, status: "valid"
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
-                          const SensorSpec::ptr&>())
-      .def("set_transformation_matrix", &PinholeCamera::setTransformationMatrix,
-           R"(Compute and set the transformation matrix to the render camera.)")
-      .def("set_projection_matrix", &PinholeCamera::setProjectionMatrix,
-           R"(Set the width, height, near, far, and hfov,
-          stored in pinhole camera to the render camera.)")
-      .def("set_viewport", &PinholeCamera::setViewport,
-           R"(Set the viewport to the render camera)");
+                          const SensorSpec::ptr&>());
 
   // ==== SensorSuite ====
   py::class_<SensorSuite, SensorSuite::ptr>(m, "SensorSuite")

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -36,7 +36,7 @@ struct Renderer::Impl {
     camera.draw(drawables);
   }
 
-  void draw(sensor::Sensor& visualSensor, scene::SceneGraph& sceneGraph) {
+  void draw(sensor::VisualSensor& visualSensor, scene::SceneGraph& sceneGraph) {
     ASSERT(visualSensor.isVisualSensor());
 
     // set the modelview matrix, projection matrix of the render camera;
@@ -45,8 +45,8 @@ struct Renderer::Impl {
     draw(sceneGraph.getDefaultRenderCamera(), sceneGraph.getDrawables());
   }
 
-  void bindRenderTarget(const sensor::Sensor::ptr& sensor) {
-    auto depthUnprojection = sensor->depthUnprojection();
+  void bindRenderTarget(sensor::VisualSensor& sensor) {
+    auto depthUnprojection = sensor.depthUnprojection();
     if (!depthUnprojection) {
       throw std::runtime_error(
           "Sensor does not have a depthUnprojection matrix");
@@ -57,8 +57,8 @@ struct Renderer::Impl {
           DepthShader::Flag::UnprojectExistingDepth);
     }
 
-    sensor->bindRenderTarget(RenderTarget::create_unique(
-        sensor->framebufferSize(), *depthUnprojection, depthShader_.get()));
+    sensor.bindRenderTarget(RenderTarget::create_unique(
+        sensor.framebufferSize(), *depthUnprojection, depthShader_.get()));
   }
 
  private:
@@ -71,12 +71,12 @@ void Renderer::draw(RenderCamera& camera, scene::SceneGraph& sceneGraph) {
   pimpl_->draw(camera, sceneGraph.getDrawables());
 }
 
-void Renderer::draw(sensor::Sensor& visualSensor,
+void Renderer::draw(sensor::VisualSensor& visualSensor,
                     scene::SceneGraph& sceneGraph) {
   pimpl_->draw(visualSensor, sceneGraph);
 }
 
-void Renderer::bindRenderTarget(const sensor::Sensor::ptr& sensor) {
+void Renderer::bindRenderTarget(sensor::VisualSensor& sensor) {
   pimpl_->bindRenderTarget(sensor);
 }
 

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -7,7 +7,7 @@
 #include "esp/core/esp.h"
 #include "esp/gfx/RenderCamera.h"
 #include "esp/scene/SceneGraph.h"
-#include "esp/sensor/Sensor.h"
+#include "esp/sensor/VisualSensor.h"
 
 namespace esp {
 namespace gfx {
@@ -20,12 +20,12 @@ class Renderer {
   void draw(RenderCamera& camera, scene::SceneGraph& sceneGraph);
 
   // draw the scene graph with the visual sensor provided by user
-  void draw(sensor::Sensor& visualSensor, scene::SceneGraph& sceneGraph);
+  void draw(sensor::VisualSensor& visualSensor, scene::SceneGraph& sceneGraph);
 
   /**
    * @brief Binds a @ref RenderTarget to the sensor
    */
-  void bindRenderTarget(const sensor::Sensor::ptr& sensor);
+  void bindRenderTarget(sensor::VisualSensor& sensor);
 
   // draw the scene graph with the default camera in scene graph
   // user needs to set the default camera so that it has correct

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+#include "SceneGraph.h"
+
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
 #include <Corrade/Utility/DebugStl.h>
-
-#include "SceneGraph.h"
 
 namespace esp {
 namespace scene {
@@ -16,7 +16,7 @@ SceneGraph::SceneGraph()
       defaultRenderCamera_{defaultRenderCameraNode_} {}
 
 // set transformation, projection matrix, viewport to the default camera
-void SceneGraph::setDefaultRenderCamera(sensor::Sensor& sensor) {
+void SceneGraph::setDefaultRenderCamera(sensor::VisualSensor& sensor) {
   ASSERT(sensor.isVisualSensor());
 
   sensor.setTransformationMatrix(defaultRenderCamera_)

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -10,7 +10,7 @@
 #include "SceneNode.h"
 #include "esp/gfx/RenderCamera.h"
 
-#include "esp/sensor/Sensor.h"
+#include "esp/sensor/VisualSensor.h"
 
 namespace esp {
 namespace scene {
@@ -30,7 +30,7 @@ class SceneGraph {
   // set the transformation, projection matrix to the default camera
   // TODO:
   // in the future, the parameter should be VisualSensor
-  void setDefaultRenderCamera(sensor::Sensor& sensor);
+  void setDefaultRenderCamera(sensor::VisualSensor& sensor);
 
   gfx::RenderCamera& getDefaultRenderCamera() { return defaultRenderCamera_; }
 

--- a/src/esp/sensor/CMakeLists.txt
+++ b/src/esp/sensor/CMakeLists.txt
@@ -3,6 +3,7 @@ set(sensor_SOURCES
   PinholeCamera.h
   Sensor.cpp
   Sensor.h
+  VisualSensor.h
 )
 
 

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -16,7 +16,7 @@ namespace sensor {
 
 PinholeCamera::PinholeCamera(scene::SceneNode& pinholeCameraNode,
                              sensor::SensorSpec::ptr spec)
-    : sensor::Sensor(pinholeCameraNode, spec) {
+    : sensor::VisualSensor(pinholeCameraNode, spec) {
   setProjectionParameters(spec);
 }
 

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Sensor.h"
+#include "VisualSensor.h"
 #include "esp/core/esp.h"
 
 namespace esp {
@@ -18,7 +18,7 @@ namespace sensor {
 // then the projection parameters, such as width_, height_ etc. cant be stored
 // in the "VisualSensor" class
 
-class PinholeCamera : public Sensor {
+class PinholeCamera : public VisualSensor {
  public:
   // constructor: the status of the pinhole camera is "valid" after
   // construction;
@@ -29,8 +29,6 @@ class PinholeCamera : public Sensor {
   void setProjectionParameters(SensorSpec::ptr spec);
 
   virtual ~PinholeCamera() {}
-
-  bool isVisualSensor() override { return true; }
 
   // set the projection matrix to the given render camera
   virtual PinholeCamera& setProjectionMatrix(

--- a/src/esp/sensor/Sensor.cpp
+++ b/src/esp/sensor/Sensor.cpp
@@ -20,11 +20,6 @@ Sensor::Sensor(scene::SceneNode& node, SensorSpec::ptr spec)
   setTransformationFromSpec();
 }
 
-bool Sensor::displayObservation(gfx::Simulator& sim) {
-  // TODO fill out display observation if sensor supports it
-  return false;
-}
-
 void SensorSuite::add(Sensor::ptr sensor) {
   const std::string uuid = sensor->specification()->uuid;
   sensors_[uuid] = sensor;

--- a/src/esp/sensor/Sensor.cpp
+++ b/src/esp/sensor/Sensor.cpp
@@ -20,16 +20,6 @@ Sensor::Sensor(scene::SceneNode& node, SensorSpec::ptr spec)
   setTransformationFromSpec();
 }
 
-bool Sensor::getObservation(gfx::Simulator& sim, Observation& obs) {
-  // TODO fill out observation
-  return false;
-}
-
-bool Sensor::getObservationSpace(ObservationSpace& space) {
-  // TODO fill out observation space
-  return false;
-}
-
 bool Sensor::displayObservation(gfx::Simulator& sim) {
   // TODO fill out display observation if sensor supports it
   return false;

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -109,7 +109,7 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
    *                to be displayed
    * @return Whether the display process was successful or not
    */
-  virtual bool displayObservation(gfx::Simulator& sim);
+  virtual bool displayObservation(gfx::Simulator& sim) = 0;
 
  protected:
   SensorSpec::ptr spec_ = nullptr;

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include <Corrade/Containers/Optional.h>
-
 #include "esp/core/esp.h"
 
 #include "esp/core/Buffer.h"
-#include "esp/gfx/RenderCamera.h"
-#include "esp/gfx/RenderTarget.h"
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -99,47 +95,13 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
 
   SensorSpec::ptr specification() const { return spec_; }
 
-  /**
-   * @brief Return the size of the framebuffer corresponding to the sensor's
-   * resolution as a [W, H] Vector2i
-   */
-  Magnum::Vector2i framebufferSize() const {
-    // NB: The sensor's resolution is in H x W format as that more cleanly
-    // corresponds to the practice of treating images as arrays that is used in
-    // modern CV and DL. However, graphics frameworks expect W x H format for
-    // frame buffer sizes
-    return {spec_->resolution[1], spec_->resolution[0]};
-  }
-
   // can be called ONLY when it is attached to a scene node
   virtual void setTransformationFromSpec();
 
   virtual bool isVisualSensor() { return false; }
 
-  // visual sensor should implement and override the following functions
-  /**
-   * @brief set the projection matrix from sensor to the render camera
-   * @return Reference to self (for method chaining)
-   */
-  virtual Sensor& setProjectionMatrix(gfx::RenderCamera& targetCamera) {
-    return *this;
-  }
-  /**
-   * @brief set the transform matrix (modelview) from sensor to the render
-   * camera
-   * @return Reference to self (for method chaining)
-   */
-  virtual Sensor& setTransformationMatrix(gfx::RenderCamera& targetCamera) {
-    return *this;
-  }
-  /**
-   * @brief set the viewport from sensor to the render camera
-   * @return Reference to self (for method chaining)
-   */
-  virtual Sensor& setViewport(gfx::RenderCamera& targetCamera) { return *this; }
-
-  virtual bool getObservation(gfx::Simulator& sim, Observation& obs);
-  virtual bool getObservationSpace(ObservationSpace& space);
+  virtual bool getObservation(gfx::Simulator& sim, Observation& obs) = 0;
+  virtual bool getObservationSpace(ObservationSpace& space) = 0;
 
   /**
    * @brief Display next observation from Simulator on default frame buffer
@@ -149,46 +111,9 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual bool displayObservation(gfx::Simulator& sim);
 
-  /**
-   * @brief Returns the parameters needed to unproject depth for the sensor.
-   *
-   * Will always be @ref Corrade::Containers::NullOpt for the base sensor class
-   * as it has no projection parameters
-   */
-  virtual Corrade::Containers::Optional<Magnum::Vector2> depthUnprojection()
-      const {
-    return Corrade::Containers::NullOpt;
-  };
-
-  /**
-   * @brief Checks to see if this sensor has a RenderTarget bound or not
-   */
-  bool hasRenderTarget() const { return tgt_ != nullptr; }
-
-  /**
-   * @brief Binds the given given RenderTarget to the sensor.  The sensor takes
-   * ownership of the RenderTarget
-   */
-  void bindRenderTarget(gfx::RenderTarget::uptr&& tgt) {
-    if (tgt->framebufferSize() != framebufferSize())
-      throw std::runtime_error("RenderTarget is not the correct size");
-    tgt_ = std::move(tgt);
-  }
-
-  /**
-   * @brief Returns a reference to the sensors render target
-   */
-  gfx::RenderTarget& renderTarget() {
-    if (!hasRenderTarget())
-      throw std::runtime_error("Sensor has no rendering target");
-    return *tgt_;
-  }
-
  protected:
   SensorSpec::ptr spec_ = nullptr;
   core::Buffer::ptr buffer_ = nullptr;
-
-  gfx::RenderTarget::uptr tgt_ = nullptr;
 
   ESP_SMART_POINTERS(Sensor)
 };

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -1,0 +1,105 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <Corrade/Containers/Optional.h>
+
+#include "esp/core/esp.h"
+
+#include "esp/gfx/RenderCamera.h"
+#include "esp/gfx/RenderTarget.h"
+#include "esp/sensor/Sensor.h"
+
+namespace esp {
+namespace sensor {
+
+// Represents a sensor that provides data from the environment to an agent
+class VisualSensor : public Sensor {
+ public:
+  using Sensor::Sensor;
+  virtual ~VisualSensor() {}
+
+  /**
+   * @brief Return the size of the framebuffer corresponding to the sensor's
+   * resolution as a [W, H] Vector2i
+   */
+  Magnum::Vector2i framebufferSize() const {
+    // NB: The sensor's resolution is in H x W format as that more cleanly
+    // corresponds to the practice of treating images as arrays that is used in
+    // modern CV and DL. However, graphics frameworks expect W x H format for
+    // frame buffer sizes
+    return {spec_->resolution[1], spec_->resolution[0]};
+  }
+
+  virtual bool isVisualSensor() override { return true; }
+
+  // visual sensor should implement and override the following functions
+  /**
+   * @brief set the projection matrix from sensor to the render camera
+   * @return Reference to self (for method chaining)
+   */
+  virtual VisualSensor& setProjectionMatrix(gfx::RenderCamera& targetCamera) {
+    return *this;
+  }
+  /**
+   * @brief set the transform matrix (modelview) from sensor to the render
+   * camera
+   * @return Reference to self (for method chaining)
+   */
+  virtual VisualSensor& setTransformationMatrix(
+      gfx::RenderCamera& targetCamera) {
+    return *this;
+  }
+  /**
+   * @brief set the viewport from sensor to the render camera
+   * @return Reference to self (for method chaining)
+   */
+  virtual VisualSensor& setViewport(gfx::RenderCamera& targetCamera) {
+    return *this;
+  }
+
+  /**
+   * @brief Returns the parameters needed to unproject depth for the sensor.
+   *
+   * Will always be @ref Corrade::Containers::NullOpt for the base sensor class
+   * as it has no projection parameters
+   */
+  virtual Corrade::Containers::Optional<Magnum::Vector2> depthUnprojection()
+      const {
+    return Corrade::Containers::NullOpt;
+  };
+
+  /**
+   * @brief Checks to see if this sensor has a RenderTarget bound or not
+   */
+  bool hasRenderTarget() const { return tgt_ != nullptr; }
+
+  /**
+   * @brief Binds the given given RenderTarget to the sensor.  The sensor takes
+   * ownership of the RenderTarget
+   */
+  void bindRenderTarget(gfx::RenderTarget::uptr&& tgt) {
+    if (tgt->framebufferSize() != framebufferSize())
+      throw std::runtime_error("RenderTarget is not the correct size");
+    tgt_ = std::move(tgt);
+  }
+
+  /**
+   * @brief Returns a reference to the sensors render target
+   */
+  gfx::RenderTarget& renderTarget() {
+    if (!hasRenderTarget())
+      throw std::runtime_error("Sensor has no rendering target");
+    return *tgt_;
+  }
+
+ protected:
+  gfx::RenderTarget::uptr tgt_ = nullptr;
+
+  ESP_SMART_POINTERS(VisualSensor)
+};
+
+}  // namespace sensor
+}  // namespace esp

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -15,7 +15,8 @@
 namespace esp {
 namespace sensor {
 
-// Represents a sensor that provides data from the environment to an agent
+// Represents a sensor that provides visual data from the environment to an
+// agent
 class VisualSensor : public Sensor {
  public:
   using Sensor::Sensor;

--- a/src/esp/sim/SimulatorWithAgents.cpp
+++ b/src/esp/sim/SimulatorWithAgents.cpp
@@ -91,7 +91,10 @@ agent::Agent::ptr SimulatorWithAgents::addAgent(
 
   // Add a RenderTarget to each of the agent's sensors
   for (auto& it : ag->getSensorSuite().getSensors()) {
-    renderer_->bindRenderTarget(it.second);
+    if (it.second->isVisualSensor()) {
+      auto sensor = static_cast<sensor::VisualSensor*>(it.second.get());
+      renderer_->bindRenderTarget(*sensor);
+    }
   }
 
   agents_.push_back(ag);


### PR DESCRIPTION
This is part of the Sensor refactor. The goal of this change is to bring the Sensor class into closer alignment with the new Sensor API design.

Also removed a few APIs we were exporting to python that didn't
really need to be exported.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Sensor refactor

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
SimTest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
