### PR TITLE
Fixed seeding to work as desired

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py tests/test_random_seed.py
+              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
+              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py tests/test_random_seed.py
 
               . ~/.bashrc
               export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -83,7 +83,7 @@ class Simulator:
         self._sim = None
 
     def seed(self, new_seed):
-        self._sim.seed(new_seed)
+        self.pathfinder.seed(new_seed)
 
     def reset(self):
         self._sim.reset()

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -83,6 +83,7 @@ class Simulator:
         self._sim = None
 
     def seed(self, new_seed):
+        self._sim.seed(new_seed)
         self.pathfinder.seed(new_seed)
 
     def reset(self):

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -71,6 +71,7 @@ void initShortestPathBindings(py::module& m) {
   py::class_<PathFinder, PathFinder::ptr>(m, "PathFinder")
       .def(py::init(&PathFinder::create<>))
       .def("get_bounds", &PathFinder::bounds)
+      .def("seed", &PathFinder::seed)
       .def("get_random_navigable_point", &PathFinder::getRandomNavigablePoint)
       .def("find_path", py::overload_cast<ShortestPath&>(&PathFinder::findPath),
            "path"_a)

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -119,3 +119,29 @@ TEST(NavTest, PathFinderTestNonNavigable) {
 
   CHECK(nonNavigablePoint.isApprox(resultPoint));
 }
+
+TEST(NavTest, PathFinderTestSeed) {
+  PathFinder pf;
+  pf.loadNavMesh(Cr::Utility::Directory::join(
+      SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
+
+  // The same seed should produce the same point
+  pf.seed(1);
+  vec3f firstPoint = pf.getRandomNavigablePoint();
+  pf.seed(1);
+  vec3f secondPoint = pf.getRandomNavigablePoint();
+  ASSERT_TRUE(firstPoint == secondPoint);
+
+  // Different seeds should produce different points
+  pf.seed(2);
+  vec3f firstPoint2 = pf.getRandomNavigablePoint();
+  pf.seed(3);
+  vec3f secondPoint2 = pf.getRandomNavigablePoint();
+  ASSERT_TRUE(firstPoint2 != secondPoint2);
+
+  // One seed should produce different points when sampled twice
+  pf.seed(4);
+  vec3f firstPoint3 = pf.getRandomNavigablePoint();
+  vec3f secondPoint3 = pf.getRandomNavigablePoint();
+  ASSERT_TRUE(firstPoint3 != secondPoint3);
+}

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,25 +1,8 @@
-import os
-import sys
-
 import examples.settings
 import habitat_sim
 
-cwd = os.getcwd()
-if cwd not in sys.path:
-    sys.path.append(cwd)
 
-
-def test_random_seed():
-    # put the path to your test scene here. You MUST define a scene instead of
-    # just the default otherwise this will segfault
-    test_scene = "./data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
-    cfg_settings = examples.settings.default_sim_settings.copy()
-
-    # keyword "NONE" initializes a scene with no scene mesh
-    cfg_settings["scene"] = test_scene
-    hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim = habitat_sim.Simulator(hab_cfg)
-
+def test_random_seed(sim):
     # Test that the same seed gives the same point
     sim.seed(1)
     point1 = sim.pathfinder.get_random_navigable_point()

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import examples.settings
+import habitat_sim
+
+cwd = os.getcwd()
+if cwd not in sys.path:
+    sys.path.append(cwd)
+
+
+def test_random_seed():
+    # put the path to your test scene here. You MUST define a scene instead of
+    # just the default otherwise this will segfault
+    test_scene = "./data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+    cfg_settings = examples.settings.default_sim_settings.copy()
+
+    # keyword "NONE" initializes a scene with no scene mesh
+    cfg_settings["scene"] = test_scene
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim = habitat_sim.Simulator(hab_cfg)
+
+    # Test that the same seed gives the same point
+    sim.seed(1)
+    point1 = sim.pathfinder.get_random_navigable_point()
+    sim.seed(1)
+    point2 = sim.pathfinder.get_random_navigable_point()
+    assert all(point1 == point2)
+
+    # Test that different seeds give different points
+    sim.seed(2)
+    point1 = sim.pathfinder.get_random_navigable_point()
+    sim.seed(3)
+    point2 = sim.pathfinder.get_random_navigable_point()
+    assert any(point1 != point2)
+
+    # Test that the same seed gives different points when sampled twice
+    sim.seed(4)
+    point1 = sim.pathfinder.get_random_navigable_point()
+    point2 = sim.pathfinder.get_random_navigable_point()
+    assert any(point1 != point2)


### PR DESCRIPTION
## Motivation and Context

Previously, calling sim.seed() followed by sim.pathfinder.get_random_navigable_point() would not work as expected. The same seed would not result in the same point. More information can be found in this issue: https://github.com/facebookresearch/habitat-sim/issues/44

Now seeding with the same seed results in the same navigable point deterministically.

## How Has This Been Tested

Added a test in tests/test_random_seed.py that tests seeding in various circumstances (same seed, different seeds, multiple samples of random points) and verified that it works as desired. Run this individual test with
$pytest tests/test_random_seed.py

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

