### PR TITLE
[esp/sim] move Simulator to sim namespace

### DIFF
--- a/habitat_sim/__init__.py
+++ b/habitat_sim/__init__.py
@@ -24,6 +24,7 @@ if not getattr(builtins, "__HSIM_SETUP__", False):
         nav,
         scene,
         sensor,
+        sim,
         simulator,
         utils,
     )

--- a/habitat_sim/gfx.py
+++ b/habitat_sim/gfx.py
@@ -3,13 +3,5 @@
 # LICENSE file in the root directory of this source tree.
 
 from habitat_sim._ext.habitat_sim_bindings import Camera, Renderer, RenderTarget
-from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
-from habitat_sim._ext.habitat_sim_bindings import SimulatorConfiguration
 
-__all__ = [
-    "SimulatorBackend",
-    "SimulatorConfiguration",
-    "Camera",
-    "Renderer",
-    "RenderTarget",
-]
+__all__ = ["Camera", "Renderer", "RenderTarget"]

--- a/habitat_sim/sim.py
+++ b/habitat_sim/sim.py
@@ -1,0 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
+from habitat_sim._ext.habitat_sim_bindings import SimulatorConfiguration
+
+__all__ = ["SimulatorBackend", "SimulatorConfiguration"]

--- a/src/esp/bindings/CMakeLists.txt
+++ b/src/esp/bindings/CMakeLists.txt
@@ -8,6 +8,7 @@ pybind11_add_module(habitat_sim_bindings
   SceneBindings.cpp
   SensorBindings.cpp
   ShortestPathBindings.cpp
+  SimBindings.cpp
 )
 target_link_libraries(habitat_sim_bindings
   PRIVATE

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -13,7 +13,6 @@
 
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
-#include "esp/gfx/Simulator.h"
 #include "esp/scene/SemanticScene.h"
 
 namespace py = pybind11;
@@ -111,87 +110,6 @@ void initGfxBindings(py::module& m) {
 #endif
       .def("render_enter", &RenderTarget::renderEnter)
       .def("render_exit", &RenderTarget::renderExit);
-
-  // Needed by Sensor
-  py::class_<Simulator, Simulator::ptr> simulator(m, "Simulator");
-
-  // ==== SimulatorConfiguration ====
-  py::class_<SimulatorConfiguration, SimulatorConfiguration::ptr>(
-      m, "SimulatorConfiguration")
-      .def(py::init(&SimulatorConfiguration::create<>))
-      .def_readwrite("scene", &SimulatorConfiguration::scene)
-      .def_readwrite("default_agent_id",
-                     &SimulatorConfiguration::defaultAgentId)
-      .def_readwrite("default_camera_uuid",
-                     &SimulatorConfiguration::defaultCameraUuid)
-      .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId)
-      .def_readwrite("compress_textures",
-                     &SimulatorConfiguration::compressTextures)
-      .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
-      .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
-      .def_readwrite("physics_config_file",
-                     &SimulatorConfiguration::physicsConfigFile)
-      .def("__eq__",
-           [](const SimulatorConfiguration& self,
-              const SimulatorConfiguration& other) -> bool {
-             return self == other;
-           })
-      .def("__neq__",
-           [](const SimulatorConfiguration& self,
-              const SimulatorConfiguration& other) -> bool {
-             return self != other;
-           });
-
-  // ==== Simulator ====
-  simulator.def(py::init(&Simulator::create<const SimulatorConfiguration&>))
-      .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
-           R"(PYTHON DOES NOT GET OWNERSHIP)",
-           pybind11::return_value_policy::reference)
-      .def("get_active_semantic_scene_graph",
-           &Simulator::getActiveSemanticSceneGraph,
-           R"(PYTHON DOES NOT GET OWNERSHIP)",
-           pybind11::return_value_policy::reference)
-      .def_property_readonly("semantic_scene", &Simulator::getSemanticScene)
-      .def_property_readonly("renderer", &Simulator::getRenderer)
-      .def("seed", &Simulator::seed, "new_seed"_a)
-      .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
-      .def("reset", &Simulator::reset)
-      .def_property_readonly("gpu_device", &Simulator::gpuDevice)
-      /* --- Physics functions --- */
-      .def("add_object", &Simulator::addObject, "object_lib_index"_a,
-           "scene_id"_a = 0)
-      .def("get_physics_object_library_size",
-           &Simulator::getPhysicsObjectLibrarySize)
-      .def("remove_object", &Simulator::removeObject, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("get_object_motion_type", &Simulator::getObjectMotionType,
-           "object_id"_a, "sceneID"_a = 0)
-      .def("set_object_motion_type", &Simulator::setObjectMotionType,
-           "motion_type"_a, "object_id"_a, "sceneID"_a = 0)
-      .def("get_existing_object_ids", &Simulator::getExistingObjectIDs,
-           "sceneID"_a = 0)
-      .def("step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0)
-      .def("get_world_time", &Simulator::getWorldTime)
-      .def("set_transformation", &Simulator::setTransformation, "transform"_a,
-           "object_id"_a, "sceneID"_a = 0)
-      .def("get_transformation", &Simulator::getTransformation, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("set_translation", &Simulator::setTranslation, "translation"_a,
-           "object_id"_a, "sceneID"_a = 0)
-      .def("get_translation", &Simulator::getTranslation, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("set_rotation", &Simulator::setRotation, "rotation"_a, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("get_rotation", &Simulator::getRotation, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("apply_force", &Simulator::applyForce, "force"_a,
-           "relative_position"_a, "object_id"_a, "sceneID"_a = 0)
-      .def("apply_torque", &Simulator::applyTorque, "torque"_a, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("contact_test", &Simulator::contactTest, "object_id"_a,
-           "sceneID"_a = 0)
-      .def("recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
-           "navmesh_settings"_a);
 }
 
 }  // namespace gfx

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -10,12 +10,12 @@
 #include <Magnum/Python.h>
 #include <Magnum/SceneGraph/Python.h>
 
-#include "esp/gfx/Simulator.h"
 #include "esp/sensor/PinholeCamera.h"
 #ifdef ESP_BUILD_WITH_CUDA
 #include "esp/sensor/RedwoodNoiseModel.h"
 #endif
 #include "esp/sensor/Sensor.h"
+#include "esp/sim/Simulator.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "esp/bindings/bindings.h"
+
+#include <Magnum/ImageView.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/SceneGraph/SceneGraph.h>
+
+#include <Magnum/Python.h>
+#include <Magnum/SceneGraph/Python.h>
+
+#include "esp/gfx/RenderCamera.h"
+#include "esp/gfx/Renderer.h"
+#include "esp/scene/SemanticScene.h"
+#include "esp/sim/Simulator.h"
+
+namespace py = pybind11;
+using py::literals::operator""_a;
+
+namespace esp {
+namespace sim {
+
+void initSimBindings(py::module& m) {
+  // ==== SimulatorConfiguration ====
+  py::class_<SimulatorConfiguration, SimulatorConfiguration::ptr>(
+      m, "SimulatorConfiguration")
+      .def(py::init(&SimulatorConfiguration::create<>))
+      .def_readwrite("scene", &SimulatorConfiguration::scene)
+      .def_readwrite("default_agent_id",
+                     &SimulatorConfiguration::defaultAgentId)
+      .def_readwrite("default_camera_uuid",
+                     &SimulatorConfiguration::defaultCameraUuid)
+      .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId)
+      .def_readwrite("compress_textures",
+                     &SimulatorConfiguration::compressTextures)
+      .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
+      .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
+      .def_readwrite("physics_config_file",
+                     &SimulatorConfiguration::physicsConfigFile)
+      .def("__eq__",
+           [](const SimulatorConfiguration& self,
+              const SimulatorConfiguration& other) -> bool {
+             return self == other;
+           })
+      .def("__neq__",
+           [](const SimulatorConfiguration& self,
+              const SimulatorConfiguration& other) -> bool {
+             return self != other;
+           });
+
+  // ==== Simulator ====
+  py::class_<Simulator, Simulator::ptr>(m, "Simulator")
+      .def(py::init(&Simulator::create<const SimulatorConfiguration&>))
+      .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
+           R"(PYTHON DOES NOT GET OWNERSHIP)",
+           pybind11::return_value_policy::reference)
+      .def("get_active_semantic_scene_graph",
+           &Simulator::getActiveSemanticSceneGraph,
+           R"(PYTHON DOES NOT GET OWNERSHIP)",
+           pybind11::return_value_policy::reference)
+      .def_property_readonly("semantic_scene", &Simulator::getSemanticScene)
+      .def_property_readonly("renderer", &Simulator::getRenderer)
+      .def("seed", &Simulator::seed, "new_seed"_a)
+      .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
+      .def("reset", &Simulator::reset)
+      .def_property_readonly("gpu_device", &Simulator::gpuDevice)
+      /* --- Physics functions --- */
+      .def("add_object", &Simulator::addObject, "object_lib_index"_a,
+           "scene_id"_a = 0)
+      .def("get_physics_object_library_size",
+           &Simulator::getPhysicsObjectLibrarySize)
+      .def("remove_object", &Simulator::removeObject, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("get_object_motion_type", &Simulator::getObjectMotionType,
+           "object_id"_a, "sceneID"_a = 0)
+      .def("set_object_motion_type", &Simulator::setObjectMotionType,
+           "motion_type"_a, "object_id"_a, "sceneID"_a = 0)
+      .def("get_existing_object_ids", &Simulator::getExistingObjectIDs,
+           "sceneID"_a = 0)
+      .def("step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0)
+      .def("get_world_time", &Simulator::getWorldTime)
+      .def("set_transformation", &Simulator::setTransformation, "transform"_a,
+           "object_id"_a, "sceneID"_a = 0)
+      .def("get_transformation", &Simulator::getTransformation, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("set_translation", &Simulator::setTranslation, "translation"_a,
+           "object_id"_a, "sceneID"_a = 0)
+      .def("get_translation", &Simulator::getTranslation, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("set_rotation", &Simulator::setRotation, "rotation"_a, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("get_rotation", &Simulator::getRotation, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("apply_force", &Simulator::applyForce, "force"_a,
+           "relative_position"_a, "object_id"_a, "sceneID"_a = 0)
+      .def("apply_torque", &Simulator::applyTorque, "torque"_a, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("contact_test", &Simulator::contactTest, "object_id"_a,
+           "sceneID"_a = 0)
+      .def("recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
+           "navmesh_settings"_a);
+}
+
+}  // namespace sim
+}  // namespace esp

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   esp::physics::initPhysicsBindings(m);
   esp::scene::initSceneBindings(m);
   esp::sensor::initSensorBindings(m);
+  esp::sim::initSimBindings(m);
 
   py::bind_map<std::map<std::string, std::string>>(m, "MapStringString");
 }

--- a/src/esp/bindings/bindings.h
+++ b/src/esp/bindings/bindings.h
@@ -29,4 +29,8 @@ namespace sensor {
 void initSensorBindings(pybind11::module& m);
 }
 
+namespace sim {
+void initSimBindings(pybind11::module& m);
+}
+
 }  // namespace esp

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -14,8 +14,6 @@ set(gfx_SOURCES
   RenderCamera.h
   Renderer.cpp
   Renderer.h
-  Simulator.cpp
-  Simulator.h
   WindowlessContext.cpp
   WindowlessContext.h
   RenderTarget.cpp

--- a/src/esp/scene/test/GibsonSceneTest.cpp
+++ b/src/esp/scene/test/GibsonSceneTest.cpp
@@ -14,9 +14,9 @@
 
 namespace Cr = Corrade;
 
-using esp::gfx::SimulatorConfiguration;
 using esp::scene::SceneConfiguration;
 using esp::scene::SemanticScene;
+using esp::sim::SimulatorConfiguration;
 using esp::sim::SimulatorWithAgents;
 
 const std::string houseFilename = SCENE_DIR "/GibsonSceneTest/test.scn";

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -9,7 +9,7 @@
 #include "PinholeCamera.h"
 #include "esp/gfx/DepthUnprojection.h"
 #include "esp/gfx/Renderer.h"
-#include "esp/gfx/Simulator.h"
+#include "esp/sim/Simulator.h"
 
 namespace esp {
 namespace sensor {
@@ -89,7 +89,7 @@ bool PinholeCamera::getObservationSpace(ObservationSpace& space) {
   return true;
 }
 
-bool PinholeCamera::getObservation(gfx::Simulator& sim, Observation& obs) {
+bool PinholeCamera::getObservation(sim::Simulator& sim, Observation& obs) {
   // TODO: check if sensor is valid?
   // TODO: have different classes for the different types of sensors
   //
@@ -102,7 +102,7 @@ bool PinholeCamera::getObservation(gfx::Simulator& sim, Observation& obs) {
   return true;
 }
 
-void PinholeCamera::drawObservation(gfx::Simulator& sim) {
+void PinholeCamera::drawObservation(sim::Simulator& sim) {
   renderTarget().renderEnter();
 
   gfx::Renderer::ptr renderer = sim.getRenderer();
@@ -144,7 +144,7 @@ void PinholeCamera::readObservation(Observation& obs) {
   }
 }
 
-bool PinholeCamera::displayObservation(gfx::Simulator& sim) {
+bool PinholeCamera::displayObservation(sim::Simulator& sim) {
   if (!hasRenderTarget()) {
     return false;
   }

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -39,11 +39,11 @@ class PinholeCamera : public VisualSensor {
   // set the view port to the given render camera
   virtual PinholeCamera& setViewport(gfx::RenderCamera& targetCamera) override;
 
-  virtual bool getObservation(gfx::Simulator& sim, Observation& obs) override;
+  virtual bool getObservation(sim::Simulator& sim, Observation& obs) override;
 
   virtual bool getObservationSpace(ObservationSpace& space) override;
 
-  virtual bool displayObservation(gfx::Simulator& sim) override;
+  virtual bool displayObservation(sim::Simulator& sim) override;
 
   /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
@@ -68,7 +68,7 @@ class PinholeCamera : public VisualSensor {
    * @param[in] sim Instance of Simulator class for which the observation needs
    *                to be drawn
    */
-  void drawObservation(gfx::Simulator& sim);
+  void drawObservation(sim::Simulator& sim);
 
   /**
    * @brief Read the observation that was rendered by the simulator

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -10,7 +10,7 @@
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
-namespace gfx {
+namespace sim {
 class Simulator;
 }
 
@@ -100,7 +100,7 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual bool isVisualSensor() { return false; }
 
-  virtual bool getObservation(gfx::Simulator& sim, Observation& obs) = 0;
+  virtual bool getObservation(sim::Simulator& sim, Observation& obs) = 0;
   virtual bool getObservationSpace(ObservationSpace& space) = 0;
 
   /**
@@ -109,7 +109,7 @@ class Sensor : public Magnum::SceneGraph::AbstractFeature3D {
    *                to be displayed
    * @return Whether the display process was successful or not
    */
-  virtual bool displayObservation(gfx::Simulator& sim) = 0;
+  virtual bool displayObservation(sim::Simulator& sim) = 0;
 
  protected:
   SensorSpec::ptr spec_ = nullptr;

--- a/src/esp/sim/CMakeLists.txt
+++ b/src/esp/sim/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(sim STATIC
+  Simulator.cpp
+  Simulator.h
   SimulatorWithAgents.cpp
   SimulatorWithAgents.h
 )

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -9,9 +9,8 @@
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/String.h>
 
-#include "Drawable.h"
-
 #include "esp/core/esp.h"
+#include "esp/gfx/Drawable.h"
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/io/io.h"
@@ -23,7 +22,7 @@
 namespace Cr = Corrade;
 
 namespace esp {
-namespace gfx {
+namespace sim {
 
 Simulator::Simulator(const SimulatorConfiguration& cfg) {
   // initalize members according to cfg
@@ -85,7 +84,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
     // reinitalize members
     if (!renderer_) {
-      renderer_ = Renderer::create();
+      renderer_ = gfx::Renderer::create();
     }
 
     auto& sceneGraph = sceneManager_.getSceneGraph(activeSceneID_);
@@ -186,7 +185,7 @@ void Simulator::seed(uint32_t newSeed) {
   random_.seed(newSeed);
 }
 
-std::shared_ptr<Renderer> Simulator::getRenderer() {
+std::shared_ptr<gfx::Renderer> Simulator::getRenderer() {
   return renderer_;
 }
 
@@ -385,5 +384,5 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
   return true;
 }
 
-}  // namespace gfx
+}  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -25,9 +25,12 @@ namespace scene {
 class SemanticScene;
 }  // namespace scene
 namespace gfx {
-
-// forward declarations
 class Renderer;
+}  // namespace gfx
+}  // namespace esp
+
+namespace esp {
+namespace sim {
 
 struct SimulatorConfiguration {
   scene::SceneConfiguration scene;
@@ -61,7 +64,7 @@ class Simulator {
 
   virtual void seed(uint32_t newSeed);
 
-  std::shared_ptr<Renderer> getRenderer();
+  std::shared_ptr<gfx::Renderer> getRenderer();
   std::shared_ptr<physics::PhysicsManager> getPhysicsManager();
   std::shared_ptr<scene::SemanticScene> getSemanticScene();
 
@@ -301,8 +304,8 @@ class Simulator {
  protected:
   Simulator(){};
 
-  WindowlessContext::uptr context_ = nullptr;
-  std::shared_ptr<Renderer> renderer_ = nullptr;
+  gfx::WindowlessContext::uptr context_ = nullptr;
+  std::shared_ptr<gfx::Renderer> renderer_ = nullptr;
   // CANNOT make the specification of resourceManager_ above the context_!
   // Because when deconstructing the resourceManager_, it needs
   // the GL::Context
@@ -326,5 +329,5 @@ class Simulator {
   ESP_SMART_POINTERS(Simulator)
 };
 
-}  // namespace gfx
+}  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/SimulatorWithAgents.cpp
+++ b/src/esp/sim/SimulatorWithAgents.cpp
@@ -9,8 +9,8 @@
 namespace esp {
 namespace sim {
 
-SimulatorWithAgents::SimulatorWithAgents(const gfx::SimulatorConfiguration& cfg)
-    : gfx::Simulator() {
+SimulatorWithAgents::SimulatorWithAgents(const SimulatorConfiguration& cfg)
+    : Simulator() {
   // NOTE: NOT SO GREAT NOW THAT WE HAVE virtual functions
   //       Maybe better not to do this reconfigure
   reconfigure(cfg);
@@ -19,13 +19,13 @@ SimulatorWithAgents::SimulatorWithAgents(const gfx::SimulatorConfiguration& cfg)
 SimulatorWithAgents::~SimulatorWithAgents() {}
 
 void SimulatorWithAgents::seed(uint32_t newSeed) {
-  gfx::Simulator::seed(newSeed);
+  Simulator::seed(newSeed);
   pathfinder_->seed(newSeed);
 }
 
 void SimulatorWithAgents::reset() {
   // connect controls to navmesh if loaded
-  gfx::Simulator::reset();
+  Simulator::reset();
 
   for (int iAgent = 0; iAgent < agents_.size(); ++iAgent) {
     auto& agent = agents_[iAgent];
@@ -38,7 +38,7 @@ void SimulatorWithAgents::reset() {
   }
 }
 
-void SimulatorWithAgents::reconfigure(const gfx::SimulatorConfiguration& cfg) {
+void SimulatorWithAgents::reconfigure(const SimulatorConfiguration& cfg) {
   LOG(INFO) << "SimulatorWithAgents::reconfigure";
   if (cfg == config_) {
     reset();
@@ -64,7 +64,7 @@ void SimulatorWithAgents::reconfigure(const gfx::SimulatorConfiguration& cfg) {
     LOG(WARNING) << "Navmesh file not found, checked at " << navmeshFilename;
   }
 
-  gfx::Simulator::reconfigure(cfg);
+  Simulator::reconfigure(cfg);
 }
 
 // Agents

--- a/src/esp/sim/SimulatorWithAgents.h
+++ b/src/esp/sim/SimulatorWithAgents.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "esp/gfx/Simulator.h"
+#include "esp/sim/Simulator.h"
 
 #include "esp/agent/Agent.h"
 #include "esp/nav/PathFinder.h"
@@ -12,12 +12,12 @@
 namespace esp {
 namespace sim {
 
-class SimulatorWithAgents : public gfx::Simulator {
+class SimulatorWithAgents : public Simulator {
  public:
-  SimulatorWithAgents(const gfx::SimulatorConfiguration& cfg);
+  SimulatorWithAgents(const SimulatorConfiguration& cfg);
   virtual ~SimulatorWithAgents();
 
-  virtual void reconfigure(const gfx::SimulatorConfiguration& cfg) override;
+  virtual void reconfigure(const SimulatorConfiguration& cfg) override;
   virtual void reset() override;
   virtual void seed(uint32_t newSeed) override;
 

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 #include <string>
 
-#include "esp/gfx/Simulator.h"
+#include "esp/sim/Simulator.h"
 
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/Renderer.h"

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -18,7 +18,6 @@ namespace Cr = Corrade;
 namespace Mn = Magnum;
 
 using esp::agent::AgentConfiguration;
-using esp::gfx::SimulatorConfiguration;
 using esp::nav::PathFinder;
 using esp::scene::SceneConfiguration;
 using esp::sensor::Observation;
@@ -26,6 +25,7 @@ using esp::sensor::ObservationSpace;
 using esp::sensor::ObservationSpaceType;
 using esp::sensor::SensorSpec;
 using esp::sensor::SensorType;
+using esp::sim::SimulatorConfiguration;
 using esp::sim::SimulatorWithAgents;
 
 const std::string vangogh =

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -34,8 +34,8 @@
 #include "esp/gfx/Drawable.h"
 #include "esp/io/io.h"
 
-#include "esp/gfx/Simulator.h"
 #include "esp/scene/SceneConfiguration.h"
+#include "esp/sim/Simulator.h"
 
 #include "esp/gfx/configure.h"
 


### PR DESCRIPTION
Goal is to collapse Simulator and SimulatorWithAgents into one class.
Moved Simulator to sim namespace an in intermediate step. Next step
is to pull up SimulatorWithAgents logic into Simulator.

The change is part of the sensor refactoring.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Collapse Simulator and SimulatorWithAgents into one class.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
SimTest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
