### PR TITLE
Assert createRenderer is configured for Simulator::recomputeNavmesh

### DIFF
--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -373,7 +373,12 @@ double Simulator::getWorldTime() {
 
 bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                                  const nav::NavMeshSettings& navMeshSettings) {
-  CHECK(config_.createRenderer);
+  CORRADE_ASSERT(
+      config_.createRenderer,
+      "Simulator::recomputeNavMesh: SimulatorConfiguration::createRenderer is "
+      "false. Scene geometry is required to recompute navmesh. No geometry is "
+      "loaded without renderer initialization.",
+      false);
 
   assets::MeshData::uptr joinedMesh =
       resourceManager_.createJoinedCollisionMesh(config_.scene.id);

--- a/src/esp/gfx/Simulator.cpp
+++ b/src/esp/gfx/Simulator.cpp
@@ -373,6 +373,8 @@ double Simulator::getWorldTime() {
 
 bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                                  const nav::NavMeshSettings& navMeshSettings) {
+  CHECK(config_.createRenderer);
+
   assets::MeshData::uptr joinedMesh =
       resourceManager_.createJoinedCollisionMesh(config_.scene.id);
 


### PR DESCRIPTION
## Motivation and Context

The `Simulator::recomputeNavmesh` function requires scene geometry to rebuild the recast navmesh for the scene. This geometry is not loaded when no sensors are configured. Trying to call this function without geometry loaded results in a failed assert during mesh joining which is non-obvious. 

This PR introduces a clearer assertion that `SimulatorConfiguration::createRenderer == true` is required to use this function.

May want to discuss whether this behavior is desired, or geometry loading should be decoupled from sensor initialization and what that would entail.

## How Has This Been Tested
Add the following code to the end of `test_recompute_navmesh.py` and see assertion failure.
```
    #test recompute navmesh with no sensors
    cfg_settings["color_sensor"] = False
    hab_cfg = examples.settings.make_cfg(cfg_settings)
    sim.reconfigure(hab_cfg)
    sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
