### PR TITLE
[bug fix] Set correct asset path for the ResourceManagerTest

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CCACHE_FOUND)
 endif()
 
 set(SCENE_DATASETS ${CMAKE_CURRENT_SOURCE_DIR}/../data/scene_datasets)
-
+set(TEST_ASSETS ${CMAKE_CURRENT_SOURCE_DIR}/../data/test_assets)
 # build options
 option(BUILD_ASSIMP_SUPPORT "Whether to build assimp import library support" ON)
 option(BUILD_PYTHON_BINDINGS "Whether to build python bindings" ON)

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -19,8 +19,6 @@ namespace Cr = Corrade;
 using esp::assets::ResourceManager;
 using esp::scene::SceneManager;
 
-const std::string dataDir = Cr::Utility::Directory::join(SCENE_DATASETS, "../");
-
 TEST(ResourceManagerTest, createJoinedCollisionMesh) {
   esp::gfx::WindowlessContext::uptr context_ =
       esp::gfx::WindowlessContext::create_unique(0);
@@ -31,8 +29,8 @@ TEST(ResourceManagerTest, createJoinedCollisionMesh) {
   ResourceManager resourceManager;
   SceneManager sceneManager_;
 
-  std::string boxFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string boxFile =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
 
   int sceneID = sceneManager_.initSceneGraph();
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);

--- a/src/tests/configure.h.cmake
+++ b/src/tests/configure.h.cmake
@@ -3,5 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #define SCENE_DATASETS "${SCENE_DATASETS}"
+#define TEST_ASSETS "${TEST_ASSETS}"
 
 #define FILE_THAT_EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/IOTest.cpp"


### PR DESCRIPTION
## Motivation and Context

This PR focuses on ResourceeManagerTest only, which partially addressed the issue mentioned in #442.

Briefly, the path to the asset is wrong in previous version, which leads to failure of the the tests. The wrong path is based on SCENE_DATASETS, which by default does not exist in our repository.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local test

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
