### PR TITLE
Fix: Handle exit code 1 if there is no changes to doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ jobs:
               git config --global user.email habitat@fb.com
               NOW=$(date +"%m-%d-%Y")
               git add .
-              git commit -m "Build habitat-sim ${NOW}"
+              git diff-index --quiet HEAD || git commit -m "Build habitat-sim ${NOW}"
               git push origin master
 
               # Deploy to public
@@ -462,7 +462,7 @@ jobs:
               rsync -a published/ ./.
               rm -rf published
               git add .
-              git commit -m "Build habitat-sim ${NOW}"
+              git diff-index --quiet HEAD || git commit -m "Build habitat-sim ${NOW}"
               git push origin gh-pages
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,4 +478,4 @@ workflows:
             - install_and_test_ubuntu
           filters:
             branches:
-              only: master
+              only: fix_autodoc # change to master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,4 +478,4 @@ workflows:
             - install_and_test_ubuntu
           filters:
             branches:
-              only: fix_autodoc # change to master
+              only: master


### PR DESCRIPTION
## Motivation and Context
Automatic documentation build [fails when there is no changes to push](https://app.circleci.com/jobs/github/facebookresearch/habitat-sim/5795). Added the check if there are changes to commit first.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Switched running for current branch to check success.
<!--- Please describe here how your modifications have been tested. -->

