### PR TITLE
Constrained LookUp and LookDown

### DIFF
--- a/habitat_sim/agent/controls/__init__.py
+++ b/habitat_sim/agent/controls/__init__.py
@@ -4,13 +4,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from habitat_sim.agent.controls.controls import ActuationSpec, SceneNodeControl
+from habitat_sim.agent.controls.controls import (
+    ActuationSpec,
+    ConstrainedActuationSpec,
+    SceneNodeControl,
+)
 from habitat_sim.agent.controls.default_controls import *
 from habitat_sim.agent.controls.object_controls import ObjectControls
 from habitat_sim.agent.controls.pyrobot_noisy_controls import PyRobotNoisyActuationSpec
 
 __all__ = [
     "ActuationSpec",
+    "ConstrainedActuationSpec",
     "ObjectControls",
     "SceneNodeControl",
     "PyRobotNoisyActuationSpec",

--- a/habitat_sim/agent/controls/__init__.py
+++ b/habitat_sim/agent/controls/__init__.py
@@ -4,18 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from habitat_sim.agent.controls.controls import (
-    ActuationSpec,
-    ConstrainedActuationSpec,
-    SceneNodeControl,
-)
+from habitat_sim.agent.controls.controls import ActuationSpec, SceneNodeControl
 from habitat_sim.agent.controls.default_controls import *
 from habitat_sim.agent.controls.object_controls import ObjectControls
 from habitat_sim.agent.controls.pyrobot_noisy_controls import PyRobotNoisyActuationSpec
 
 __all__ = [
     "ActuationSpec",
-    "ConstrainedActuationSpec",
     "ObjectControls",
     "SceneNodeControl",
     "PyRobotNoisyActuationSpec",

--- a/habitat_sim/agent/controls/controls.py
+++ b/habitat_sim/agent/controls/controls.py
@@ -15,7 +15,7 @@ import habitat_sim.bindings as hsim
 
 
 @attr.s(auto_attribs=True)
-class ActuationSpec(object):
+class ActuationSpec:
     r"""Struct to hold parameters for the default actions
 
     :property amount: The amount the control moves the scene node by
@@ -26,6 +26,19 @@ class ActuationSpec(object):
     """
 
     amount: float
+
+
+@attr.s(auto_attribs=True)
+class ConstrainedActuationSpec(ActuationSpec):
+    r"""Struct to hold parameters for default actions with constraints
+
+    :property constraint: The constraint amount
+
+    This struct is currently for LookUp and LookDown where we want to contrain
+    the amount you can lookup/loopdown to something reasonable
+    """
+
+    constraint: float
 
 
 @attr.s(auto_attribs=True)

--- a/habitat_sim/agent/controls/controls.py
+++ b/habitat_sim/agent/controls/controls.py
@@ -19,6 +19,8 @@ class ActuationSpec:
     r"""Struct to hold parameters for the default actions
 
     :property amount: The amount the control moves the scene node by
+    :property constraint: A constraint on the actuation.  Currently only applies to the
+        maximum amount the agent can lookup or loopdown
 
     The default actions only have one parameters, the amount
     they move the scene node by, however other actions may have any number of
@@ -26,19 +28,7 @@ class ActuationSpec:
     """
 
     amount: float
-
-
-@attr.s(auto_attribs=True)
-class ConstrainedActuationSpec(ActuationSpec):
-    r"""Struct to hold parameters for default actions with constraints
-
-    :property constraint: The constraint amount
-
-    This struct is currently for LookUp and LookDown where we want to contrain
-    the amount you can lookup/loopdown to something reasonable
-    """
-
-    constraint: float
+    constraint: Optional[float] = None
 
 
 @attr.s(auto_attribs=True)

--- a/habitat_sim/agent/controls/default_controls.py
+++ b/habitat_sim/agent/controls/default_controls.py
@@ -4,11 +4,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import magnum as mn
+from typing import Union
 
-import habitat_sim.bindings as hsim
-from habitat_sim.agent.controls.controls import ActuationSpec, SceneNodeControl
+import magnum as mn
+import numpy as np
+
+from habitat_sim.agent.controls.controls import (
+    ActuationSpec,
+    ConstrainedActuationSpec,
+    SceneNodeControl,
+)
 from habitat_sim.registry import registry
+from habitat_sim.scene import SceneNode
 
 __all__ = []
 
@@ -18,67 +25,79 @@ _Y_AXIS = 1
 _Z_AXIS = 2
 
 _rotate_local_fns = [
-    hsim.SceneNode.rotate_x_local,
-    hsim.SceneNode.rotate_y_local,
-    hsim.SceneNode.rotate_z_local,
+    SceneNode.rotate_x_local,
+    SceneNode.rotate_y_local,
+    SceneNode.rotate_z_local,
 ]
 
 
-def _move_along(scene_node: hsim.SceneNode, distance: float, axis: int):
+def _move_along(scene_node: SceneNode, distance: float, axis: int):
     ax = scene_node.transformation[axis].xyz
     scene_node.translate_local(ax * distance)
 
 
-def _rotate_local(scene_node: hsim.SceneNode, theta: float, axis: int):
+def _rotate_local(scene_node: SceneNode, theta: float, axis: int):
     _rotate_local_fns[axis](scene_node, mn.Deg(theta))
     scene_node.rotation = scene_node.rotation.normalized()
 
 
+def _apply_look_constraint(scene_node: SceneNode, constraint: float):
+    constraint = mn.Deg(constraint)
+    rotation = scene_node.rotation
+    look_axis = rotation.transform_vector(mn.Vector3(0, 0, -1))
+    look_angle = mn.Rad(np.arctan2(look_axis[1], -look_axis[2]))
+
+    if look_angle > constraint:
+        _rotate_local(scene_node, constraint - look_angle, _X_AXIS)
+    elif look_angle < -constraint:
+        _rotate_local(scene_node, -look_angle - constraint, _X_AXIS)
+
+
 @registry.register_move_fn(body_action=True)
 class MoveBackward(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _Z_AXIS)
 
 
 @registry.register_move_fn(body_action=True)
 class MoveForward(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _Z_AXIS)
 
 
 @registry.register_move_fn(body_action=True)
 class MoveRight(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _X_AXIS)
 
 
 @registry.register_move_fn(body_action=True)
 class MoveLeft(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _X_AXIS)
 
 
 @registry.register_move_fn(body_action=False)
 class MoveUp(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, actuation_spec.amount, _Y_AXIS)
 
 
 @registry.register_move_fn(body_action=False)
 class MoveDown(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _move_along(scene_node, -actuation_spec.amount, _Y_AXIS)
 
 
 @registry.register_move_fn(body_action=False)
 class LookLeft(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, actuation_spec.amount, _Y_AXIS)
 
 
 @registry.register_move_fn(body_action=False)
 class LookRight(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(self, scene_node: SceneNode, actuation_spec: ActuationSpec):
         _rotate_local(scene_node, -actuation_spec.amount, _Y_AXIS)
 
 
@@ -88,11 +107,25 @@ registry.register_move_fn(LookRight, name="turn_right", body_action=True)
 
 @registry.register_move_fn(body_action=False)
 class LookUp(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(
+        self,
+        scene_node: SceneNode,
+        actuation_spec: Union[ActuationSpec, ConstrainedActuationSpec],
+    ):
         _rotate_local(scene_node, actuation_spec.amount, _X_AXIS)
+
+        if isinstance(actuation_spec, ConstrainedActuationSpec):
+            _apply_look_constraint(scene_node, actuation_spec.constraint)
 
 
 @registry.register_move_fn(body_action=False)
 class LookDown(SceneNodeControl):
-    def __call__(self, scene_node: hsim.SceneNode, actuation_spec: ActuationSpec):
+    def __call__(
+        self,
+        scene_node: SceneNode,
+        actuation_spec: Union[ActuationSpec, ConstrainedActuationSpec],
+    ):
         _rotate_local(scene_node, -actuation_spec.amount, _X_AXIS)
+
+        if isinstance(actuation_spec, ConstrainedActuationSpec):
+            _apply_look_constraint(scene_node, actuation_spec.constraint)

--- a/habitat_sim/agent/controls/default_controls.py
+++ b/habitat_sim/agent/controls/default_controls.py
@@ -59,9 +59,9 @@ def _rotate_local(
         constraint = mn.Deg(constraint)
 
         if new_angle > constraint:
-            theta = constraint - current_angle
+            theta = constraint - look_angle
         elif new_angle < -constraint:
-            theta = -constraint - current_angle
+            theta = -constraint - look_angle
 
     _rotate_local_fns[axis](scene_node, mn.Deg(theta))
     scene_node.rotation = scene_node.rotation.normalized()

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -208,7 +208,7 @@ def test_constrainted(
     node = scene_graph.get_root_node().create_child()
     node.rotation = initial_rotation
 
-    spec = habitat_sim.agent.controls.ConstrainedActuationSpec(
+    spec = habitat_sim.agent.controls.ActuationSpec(
         actuation_amount, actuation_constraint
     )
     habitat_sim.registry.get_move_fn(control_name)(node, spec)
@@ -227,4 +227,4 @@ def test_constrainted(
     look_axis = final_rotation.transform_vector(mn.Vector3(0, 0, -1))
     look_angle = mn.Deg(mn.Rad(np.arctan2(look_axis[1], -look_axis[2])))
 
-    assert np.abs(float(expected_angle - look_angle)) < 1e-3
+    assert np.abs(float(expected_angle - look_angle)) < 1e-1

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -5,6 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import attr
+import hypothesis
+import hypothesis.strategies as st
+import magnum as mn
 import numpy as np
 import pytest
 import quaternion
@@ -181,3 +184,47 @@ def test_default_sensor_contorls(action, expected):
     for k, v in state.sensor_states.items():
         assert k in new_state.sensor_states
         _check_state_expected(v, new_state.sensor_states[k], expected)
+
+
+@pytest.fixture()
+def scene_graph():
+    return habitat_sim.SceneGraph()
+
+
+@pytest.mark.parametrize("control_name", ["look_up", "look_down"])
+@hypothesis.given(
+    actuation_amount=st.floats(0, 60), actuation_constraint=st.floats(0, 60)
+)
+def test_constrainted(
+    scene_graph, control_name, actuation_amount, actuation_constraint
+):
+    initial_look_angle = mn.Deg(
+        np.random.uniform(-actuation_constraint, actuation_constraint)
+    )
+    initial_rotation = mn.Quaternion.rotation(
+        mn.Rad(initial_look_angle), mn.Vector3(1, 0, 0)
+    )
+
+    node = scene_graph.get_root_node().create_child()
+    node.rotation = initial_rotation
+
+    spec = habitat_sim.agent.controls.ConstrainedActuationSpec(
+        actuation_amount, actuation_constraint
+    )
+    habitat_sim.registry.get_move_fn(control_name)(node, spec)
+
+    expected_angle = initial_look_angle + mn.Deg(
+        -actuation_amount if control_name == "look_down" else actuation_amount
+    )
+
+    if expected_angle > mn.Deg(actuation_constraint):
+        expected_angle = mn.Deg(actuation_constraint)
+    elif expected_angle < mn.Deg(-actuation_constraint):
+        expected_angle = mn.Deg(-actuation_constraint)
+
+    final_rotation = node.rotation
+
+    look_axis = final_rotation.transform_vector(mn.Vector3(0, 0, -1))
+    look_angle = mn.Deg(mn.Rad(np.arctan2(look_axis[1], -look_axis[2])))
+
+    assert np.abs(float(expected_angle - look_angle)) < 1e-3


### PR DESCRIPTION
## Motivation and Context

Our current LookUp and LookDown actions allow you to spin a full 360 degrees.  This is very unrealistic.  This PR introduces a constraint to that.

## How Has This Been Tested

Via the test

## Types of changes


- New feature (non-breaking change which adds functionality)
