### PR TITLE
Multiple drawable groups

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1411,7 +1411,7 @@ void ResourceManager::createDrawable(
     const ShaderType shaderType,
     Magnum::GL::Mesh& mesh,
     scene::SceneNode& node,
-    Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */,
+    DrawableGroup* group /* = nullptr */,
     Magnum::GL::Texture2D* texture /* = nullptr */,
     int objectId /* = ID_UNDEFINED */,
     const Magnum::Color4& color /* = Magnum::Color4{1} */) {

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -28,6 +28,7 @@
 #include "GltfMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
+#include "esp/gfx/DrawableGroup.h"
 #include "esp/gfx/configure.h"
 #include "esp/physics/PhysicsManager.h"
 #include "esp/scene/SceneNode.h"
@@ -68,7 +69,7 @@ class ResourceManager {
   ~ResourceManager() {}
 
   /** @brief Stores references to a set of drawable elements */
-  using DrawableGroup = Magnum::SceneGraph::DrawableGroup3D;
+  using DrawableGroup = gfx::DrawableGroup;
   /** @brief Convenience typedef for Importer class */
   using Importer = Magnum::Trade::AbstractImporter;
 

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -3,6 +3,8 @@ set(gfx_SOURCES
   DepthUnprojection.h
   Drawable.cpp
   Drawable.h
+  DrawableGroup.cpp
+  DrawableGroup.h
   GenericDrawable.cpp
   GenericDrawable.h
   magnum.h

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -12,11 +12,18 @@ namespace gfx {
 Drawable::Drawable(scene::SceneNode& node,
                    Magnum::GL::AbstractShaderProgram& shader,
                    Magnum::GL::Mesh& mesh,
-                   Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */)
-    : Magnum::SceneGraph::Drawable3D{node, group},
+                   DrawableGroup* group /* = nullptr */)
+    // Note: it is important to NOT pass through group to the Drawable3D
+    // constructor, since this will add the drawable to the
+    // underlying group twice. This is because we customize group membership
+    // semantics using gfx::DrawableGroup
+    : Magnum::SceneGraph::Drawable3D{node},
       node_(node),
       shader_(shader),
-      mesh_(mesh) {}
+      mesh_(mesh) {
+  if (group)
+    group->add(*this);
+}
 
 }  // namespace gfx
 }  // namespace esp

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -4,6 +4,8 @@
 
 #include "Drawable.h"
 
+#include <Corrade/Utility/Assert.h>
+
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -13,16 +15,17 @@ Drawable::Drawable(scene::SceneNode& node,
                    Magnum::GL::AbstractShaderProgram& shader,
                    Magnum::GL::Mesh& mesh,
                    DrawableGroup* group /* = nullptr */)
-    // Note: it is important to NOT pass through group to the Drawable3D
-    // constructor, since this will add the drawable to the
-    // underlying group twice. This is because we customize group membership
-    // semantics using gfx::DrawableGroup
-    : Magnum::SceneGraph::Drawable3D{node},
+    : Magnum::SceneGraph::Drawable3D{node, group},
       node_(node),
       shader_(shader),
-      mesh_(mesh) {
-  if (group)
-    group->add(*this);
+      mesh_(mesh) {}
+
+DrawableGroup* Drawable::drawables() {
+  CORRADE_ASSERT(
+      dynamic_cast<DrawableGroup*>(Magnum::SceneGraph::Drawable3D::drawables()),
+      "Drawable must only be used with esp::gfx::DrawableGroup!", {});
+  return static_cast<DrawableGroup*>(
+      Magnum::SceneGraph::Drawable3D::drawables());
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -23,8 +23,6 @@ class DrawableGroupClient;
  * itself with the program.
  */
 class Drawable : public Magnum::SceneGraph::Drawable3D {
-  friend DrawableGroupClient;
-
  public:
   /**
    * @brief Constructor
@@ -40,6 +38,14 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
   virtual ~Drawable() {}
 
   virtual scene::SceneNode& getSceneNode() { return node_; }
+
+  /**
+   * @brief Get the @ref DrawableGroup this drawable is in.
+   *
+   * This overrides Magnum::SceneGraph::Drawable so that the derived @ref
+   * DrawableGroup can be used
+   */
+  DrawableGroup* drawables();
 
  protected:
   /**
@@ -57,18 +63,6 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
   scene::SceneNode& node_;
   Magnum::GL::AbstractShaderProgram& shader_;
   Magnum::GL::Mesh& mesh_;
-
-  DrawableGroup* group_ = nullptr;
-};
-
-/**
- * @brief Expose @Drawable group membership to @ref DrawableGroup
- */
-class DrawableGroupClient {
-  DrawableGroupClient() = delete;
-  static DrawableGroup* getGroup(Drawable& d) { return d.group_; }
-  static void setGroup(Drawable& d, DrawableGroup* g) { d.group_ = g; }
-  friend class DrawableGroup;
 };
 
 }  // namespace gfx

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -14,13 +14,11 @@ class SceneNode;
 }
 namespace gfx {
 
-class DrawableGroupClient;
-
 /**
  * @brief Drawable for use with @ref DrawableGroup.
  *
- * Drawable will retrieve its shader program from its group, and draw
- * itself with the program.
+ * Drawable will retrieve its shader from its group, and draw
+ * itself with the shader.
  */
 class Drawable : public Magnum::SceneGraph::Drawable3D {
  public:
@@ -55,7 +53,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    * @param camera                Camera to draw from.
    *
    * Each derived drawable class needs to implement this draw() function. It's
-   * nothing more than setting up shader parameters and drawing the mesh.
+   * nothing more than drawing itself with its group's shader.
    */
   virtual void draw(const Magnum::Matrix4& transformationMatrix,
                     Magnum::SceneGraph::Camera3D& camera) = 0;

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "esp/core/esp.h"
+#include "esp/gfx/DrawableGroup.h"
 #include "magnum.h"
 
 namespace esp {
@@ -13,25 +14,61 @@ class SceneNode;
 }
 namespace gfx {
 
+class DrawableGroupClient;
+
+/**
+ * @brief Drawable for use with @ref DrawableGroup.
+ *
+ * Drawable will retrieve its shader program from its group, and draw
+ * itself with the program.
+ */
 class Drawable : public Magnum::SceneGraph::Drawable3D {
+  friend DrawableGroupClient;
+
  public:
+  /**
+   * @brief Constructor
+   *
+   * @param node Node which will be made drawable.
+   * @param mesh Mesh to draw when on render.
+   * @param group Drawable group this drawable will be added to.
+   */
   Drawable(scene::SceneNode& node,
-           Magnum::GL::AbstractShaderProgram& shader,
+           Magnum::GL::AbstractShaderProgram& shader,  // TODO: remove this
            Magnum::GL::Mesh& mesh,
-           Magnum::SceneGraph::DrawableGroup3D* group = nullptr);
+           DrawableGroup* group = nullptr);
   virtual ~Drawable() {}
 
   virtual scene::SceneNode& getSceneNode() { return node_; }
 
  protected:
-  // Each derived drawable class needs to implement this draw() function. It's
-  // nothing more than setting up shader parameters and drawing the mesh.
+  /**
+   * @brief Draw the object using given camera
+   *
+   * @param transformationMatrix  Transformation relative to camera.
+   * @param camera                Camera to draw from.
+   *
+   * Each derived drawable class needs to implement this draw() function. It's
+   * nothing more than setting up shader parameters and drawing the mesh.
+   */
   virtual void draw(const Magnum::Matrix4& transformationMatrix,
                     Magnum::SceneGraph::Camera3D& camera) = 0;
 
   scene::SceneNode& node_;
   Magnum::GL::AbstractShaderProgram& shader_;
   Magnum::GL::Mesh& mesh_;
+
+  DrawableGroup* group_ = nullptr;
+};
+
+/**
+ * @brief Expose @Drawable group membership to @ref DrawableGroup
+ */
+class DrawableGroupClient {
+  DrawableGroupClient() = delete;
+  static DrawableGroup* getGroup(Drawable& d) { return d.group_; }
+  static void setGroup(Drawable& d, DrawableGroup* g) { d.group_ = g; }
+  friend class DrawableGroup;
 };
 
 }  // namespace gfx

--- a/src/esp/gfx/DrawableGroup.cpp
+++ b/src/esp/gfx/DrawableGroup.cpp
@@ -10,26 +10,12 @@
 namespace esp {
 namespace gfx {
 
-DrawableGroup& DrawableGroup::add(esp::gfx::Drawable& drawable) {
-  DrawableGroup* prevGroup = DrawableGroupClient::getGroup(drawable);
-  if (prevGroup)
-    prevGroup->remove(drawable);
-  Magnum::SceneGraph::DrawableGroup3D::add(drawable);
-  DrawableGroupClient::setGroup(drawable, this);
-  return *this;
-}
-
-DrawableGroup& DrawableGroup::remove(esp::gfx::Drawable& drawable) {
-  CORRADE_ASSERT(DrawableGroupClient::getGroup(drawable) == this,
-                 "DrawableGroup::remove: drawable is not part of this group",
-                 *this);
-  Magnum::SceneGraph::DrawableGroup3D::remove(drawable);
-  DrawableGroupClient::setGroup(drawable, nullptr);
-  return *this;
-}
-
 bool DrawableGroup::prepareForDraw(const RenderCamera& camera) {
-  return shader_ && shader_->prepareForDraw(*this, camera);
+  if (!shader_) {
+    return false;
+  }
+  shader_->prepareForDraw(camera);
+  return true;
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/DrawableGroup.cpp
+++ b/src/esp/gfx/DrawableGroup.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "DrawableGroup.h"
+
+#include "esp/gfx/Drawable.h"
+#include "esp/gfx/RenderCamera.h"
+
+namespace esp {
+namespace gfx {
+
+DrawableGroup& DrawableGroup::add(esp::gfx::Drawable& drawable) {
+  DrawableGroup* prevGroup = DrawableGroupClient::getGroup(drawable);
+  if (prevGroup)
+    prevGroup->remove(drawable);
+  Magnum::SceneGraph::DrawableGroup3D::add(drawable);
+  DrawableGroupClient::setGroup(drawable, this);
+  return *this;
+}
+
+DrawableGroup& DrawableGroup::remove(esp::gfx::Drawable& drawable) {
+  CORRADE_ASSERT(DrawableGroupClient::getGroup(drawable) == this,
+                 "DrawableGroup::remove: drawable is not part of this group",
+                 *this);
+  Magnum::SceneGraph::DrawableGroup3D::remove(drawable);
+  DrawableGroupClient::setGroup(drawable, nullptr);
+  return *this;
+}
+
+bool DrawableGroup::prepareForDraw(const RenderCamera& camera) {
+  return shader_ && shader_->prepareForDraw(*this, camera);
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <Magnum/SceneGraph/FeatureGroup.h>
 #include <Magnum/SceneGraph/SceneGraph.h>
 
 #include "esp/core/esp.h"
@@ -17,6 +18,7 @@ class Drawable;
 class RenderCamera;
 
 // STUB (todo: remove)
+class DrawableGroup;
 class Shader {
  public:
   bool prepareForDraw(const DrawableGroup& drawables,

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -66,6 +66,7 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
 
   /**
    * @brief Set the shader this group uses.
+   *
    * @return Reference to self (for method chaining)
    */
   DrawableGroup& setShader(Shader::ptr shader) {

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -21,10 +21,7 @@ class RenderCamera;
 class DrawableGroup;
 class Shader {
  public:
-  bool prepareForDraw(const DrawableGroup& drawables,
-                      const RenderCamera& camera) {
-    return false;
-  }
+  void prepareForDraw(const RenderCamera& camera) {}
   ESP_SMART_POINTERS(Shader);
 };
 
@@ -39,25 +36,7 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
    * @param shader Shader all @ref Drawables in this group will use.
    */
   explicit DrawableGroup(Shader::ptr shader = nullptr)
-      : Magnum::SceneGraph::DrawableGroup3D{}, shader_{std::move(shader)} {}
-
-  /**
-   * @brief Add a drawable to this group.
-   *
-   * @return Reference to self (for method chaining)
-   *
-   * If the drawable is part of another group, it is removed from it.
-   */
-  DrawableGroup& add(Drawable& drawable);
-
-  /**
-   * @brief Removes the drawable from this group.
-   *
-   * @return Reference to self (for method chaining)
-   *
-   * The drawable must be part of this group.
-   */
-  DrawableGroup& remove(Drawable& drawable);
+      : shader_{std::move(shader)} {}
 
   /**
    * @brief Get the shader this group is using.

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -1,0 +1,88 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <Magnum/SceneGraph/SceneGraph.h>
+
+#include "esp/core/esp.h"
+
+// #include "esp/gfx/Shader.h"
+
+namespace esp {
+namespace gfx {
+
+class Drawable;
+class RenderCamera;
+
+// STUB (todo: remove)
+class Shader {
+ public:
+  bool prepareForDraw(const DrawableGroup& drawables,
+                      const RenderCamera& camera) {
+    return false;
+  }
+  ESP_SMART_POINTERS(Shader);
+};
+
+/**
+ * @brief Group of drawables, and shared group parameters.
+ */
+class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
+ public:
+  /**
+   * @brief Constructor
+   *
+   * @param shader Shader all @ref Drawables in this group will use.
+   */
+  explicit DrawableGroup(Shader::ptr shader = nullptr)
+      : Magnum::SceneGraph::DrawableGroup3D{}, shader_{std::move(shader)} {}
+
+  /**
+   * @brief Add a drawable to this group.
+   *
+   * @return Reference to self (for method chaining)
+   *
+   * If the drawable is part of another group, it is removed from it.
+   */
+  DrawableGroup& add(Drawable& drawable);
+
+  /**
+   * @brief Removes the drawable from this group.
+   *
+   * @return Reference to self (for method chaining)
+   *
+   * The drawable must be part of this group.
+   */
+  DrawableGroup& remove(Drawable& drawable);
+
+  /**
+   * @brief Get the shader this group is using.
+   */
+  Shader::ptr getShader() { return shader_; }
+
+  /**
+   * @brief Set the shader this group uses.
+   * @return Reference to self (for method chaining)
+   */
+  DrawableGroup& setShader(Shader::ptr shader) {
+    shader_ = std::move(shader);
+    return *this;
+  }
+
+  /**
+   * @brief Prepare to draw group with given @ref RenderCamera
+   *
+   * @return Whether the @ref DrawableGroup is in a valid state to be drawn
+   */
+  bool prepareForDraw(const RenderCamera& camera);
+
+ private:
+  Shader::ptr shader_ = nullptr;
+
+  ESP_SMART_POINTERS(DrawableGroup);
+};
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -15,7 +15,7 @@ GenericDrawable::GenericDrawable(
     scene::SceneNode& node,
     Magnum::Shaders::Flat3D& shader,
     Magnum::GL::Mesh& mesh,
-    Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */,
+    DrawableGroup* group /* = nullptr */,
     Magnum::GL::Texture2D* texture /* = nullptr */,
     int objectId /* = ID_UNDEFINED */,
     const Magnum::Color4& color /* = Magnum::Color4{1} */)

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -19,7 +19,7 @@ class GenericDrawable : public Drawable {
   explicit GenericDrawable(scene::SceneNode& node,
                            Magnum::Shaders::Flat3D& shader,
                            Magnum::GL::Mesh& mesh,
-                           Magnum::SceneGraph::DrawableGroup3D* group = nullptr,
+                           DrawableGroup* group = nullptr,
                            Magnum::GL::Texture2D* texture = nullptr,
                            int objectId = ID_UNDEFINED,
                            const Magnum::Color4& color = Magnum::Color4{1});

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -9,12 +9,11 @@
 namespace esp {
 namespace gfx {
 
-PTexMeshDrawable::PTexMeshDrawable(
-    scene::SceneNode& node,
-    PTexMeshShader& shader,
-    assets::PTexMeshData& ptexMeshData,
-    int submeshID,
-    Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */)
+PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
+                                   PTexMeshShader& shader,
+                                   assets::PTexMeshData& ptexMeshData,
+                                   int submeshID,
+                                   DrawableGroup* group /* = nullptr */)
     : Drawable{node, shader, ptexMeshData.getRenderingBuffer(submeshID)->mesh,
                group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -17,12 +17,11 @@ class PTexMeshShader;
 
 class PTexMeshDrawable : public Drawable {
  public:
-  explicit PTexMeshDrawable(
-      scene::SceneNode& node,
-      PTexMeshShader& shader,
-      assets::PTexMeshData& ptexMeshData,
-      int submeshID,
-      Magnum::SceneGraph::DrawableGroup3D* group = nullptr);
+  explicit PTexMeshDrawable(scene::SceneNode& node,
+                            PTexMeshShader& shader,
+                            assets::PTexMeshData& ptexMeshData,
+                            int submeshID,
+                            DrawableGroup* group = nullptr);
 
  protected:
   virtual void draw(const Magnum::Matrix4& transformationMatrix,

--- a/src/esp/gfx/PrimitiveIDDrawable.cpp
+++ b/src/esp/gfx/PrimitiveIDDrawable.cpp
@@ -9,11 +9,10 @@
 namespace esp {
 namespace gfx {
 
-PrimitiveIDDrawable::PrimitiveIDDrawable(
-    scene::SceneNode& node,
-    PrimitiveIDShader& shader,
-    Magnum::GL::Mesh& mesh,
-    Magnum::SceneGraph::DrawableGroup3D* group /* = nullptr */)
+PrimitiveIDDrawable::PrimitiveIDDrawable(scene::SceneNode& node,
+                                         PrimitiveIDShader& shader,
+                                         Magnum::GL::Mesh& mesh,
+                                         DrawableGroup* group /* = nullptr */)
     : Drawable{node, shader, mesh, group} {}
 
 void PrimitiveIDDrawable::draw(const Magnum::Matrix4& transformationMatrix,

--- a/src/esp/gfx/PrimitiveIDDrawable.h
+++ b/src/esp/gfx/PrimitiveIDDrawable.h
@@ -17,11 +17,10 @@ class PrimitiveIDDrawable : public Drawable {
   //! and mesh. Adds drawable to given group and uses provided texture,
   //! objectId, and color for textured, object id buffer and color shader
   //! output respectively
-  explicit PrimitiveIDDrawable(
-      scene::SceneNode& node,
-      PrimitiveIDShader& shader,
-      Magnum::GL::Mesh& mesh,
-      Magnum::SceneGraph::DrawableGroup3D* group = nullptr);
+  explicit PrimitiveIDDrawable(scene::SceneNode& node,
+                               PrimitiveIDShader& shader,
+                               Magnum::GL::Mesh& mesh,
+                               DrawableGroup* group = nullptr);
 
  protected:
   virtual void draw(const Magnum::Matrix4& transformationMatrix,

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -32,8 +32,13 @@ struct Renderer::Impl {
   }
   ~Impl() { LOG(INFO) << "Deconstructing Renderer"; }
 
-  void draw(RenderCamera& camera, MagnumDrawableGroup& drawables) {
-    camera.draw(drawables);
+  void draw(RenderCamera& camera, scene::SceneGraph& sceneGraph) {
+    for (auto& it : sceneGraph.getDrawableGroups()) {
+      // TODO: remove || true
+      if (it.second.prepareForDraw(camera) || true) {
+        camera.draw(it.second);
+      }
+    }
   }
 
   void draw(sensor::VisualSensor& visualSensor, scene::SceneGraph& sceneGraph) {
@@ -42,7 +47,7 @@ struct Renderer::Impl {
     // set the modelview matrix, projection matrix of the render camera;
     sceneGraph.setDefaultRenderCamera(visualSensor);
 
-    draw(sceneGraph.getDefaultRenderCamera(), sceneGraph.getDrawables());
+    draw(sceneGraph.getDefaultRenderCamera(), sceneGraph);
   }
 
   void bindRenderTarget(sensor::VisualSensor& sensor) {
@@ -68,7 +73,7 @@ struct Renderer::Impl {
 Renderer::Renderer() : pimpl_(spimpl::make_unique_impl<Impl>()) {}
 
 void Renderer::draw(RenderCamera& camera, scene::SceneGraph& sceneGraph) {
-  pimpl_->draw(camera, sceneGraph.getDrawables());
+  pimpl_->draw(camera, sceneGraph);
 }
 
 void Renderer::draw(sensor::VisualSensor& visualSensor,

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -24,6 +24,7 @@
 #include "esp/assets/GenericInstanceMeshData.h"
 #include "esp/assets/MeshData.h"
 #include "esp/assets/MeshMetaData.h"
+#include "esp/gfx/DrawableGroup.h"
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -121,7 +122,7 @@ class PhysicsManager {
   };
 
   /** @brief Stores references to a set of drawable elements. */
-  using DrawableGroup = Magnum::SceneGraph::DrawableGroup3D;
+  using DrawableGroup = gfx::DrawableGroup;
 
   /**
    * @brief Initialize static scene collision geometry from loaded mesh data.

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -50,11 +50,16 @@ template <typename... DrawableGroupArgs>
 gfx::DrawableGroup* SceneGraph::createDrawableGroup(
     std::string id,
     DrawableGroupArgs&&... args) {
+  // auto inserted = drawableGroups_.emplace(
+  //     std::piecewise_construct, std::make_tuple(std::move(id)),
+  //     std::tuple<DrawableGroupArgs&&...>(
+  //         std::forward<DrawableGroupArgs>(args)...));
   auto inserted = drawableGroups_.emplace(
-      std::move(id), std::forward<DrawableGroupArgs>(args)...);
+      std::piecewise_construct, std::make_tuple(std::move(id)),
+      std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
   if (inserted.second) {
     LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
-    return inserted.first->second;
+    return &inserted.first->second;
   }
   return nullptr;
 }

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -50,12 +50,8 @@ template <typename... DrawableGroupArgs>
 gfx::DrawableGroup* SceneGraph::createDrawableGroup(
     std::string id,
     DrawableGroupArgs&&... args) {
-  // auto inserted = drawableGroups_.emplace(
-  //     std::piecewise_construct, std::make_tuple(std::move(id)),
-  //     std::tuple<DrawableGroupArgs&&...>(
-  //         std::forward<DrawableGroupArgs>(args)...));
   auto inserted = drawableGroups_.emplace(
-      std::piecewise_construct, std::make_tuple(std::move(id)),
+      std::piecewise_construct, std::forward_as_tuple(std::move(id)),
       std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
   if (inserted.second) {
     LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -53,11 +53,13 @@ gfx::DrawableGroup* SceneGraph::createDrawableGroup(
   auto inserted = drawableGroups_.emplace(
       std::piecewise_construct, std::forward_as_tuple(std::move(id)),
       std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
-  if (inserted.second) {
-    LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
-    return &inserted.first->second;
+  if (!inserted.second) {
+    LOG(ERROR) << "DrawableGroup with ID: " << inserted.first->first
+               << " already exists!";
+    return nullptr;
   }
-  return nullptr;
+  LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
+  return &inserted.first->second;
 }
 
 bool SceneGraph::deleteDrawableGroup(const std::string& id) {

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -13,7 +13,10 @@ namespace scene {
 SceneGraph::SceneGraph()
     : rootNode_{world_},
       defaultRenderCameraNode_{rootNode_},
-      defaultRenderCamera_{defaultRenderCameraNode_} {}
+      defaultRenderCamera_{defaultRenderCameraNode_} {
+  // For now, just create one drawable group with empty string uuid
+  createDrawableGroup(std::string{});
+}
 
 // set transformation, projection matrix, viewport to the default camera
 void SceneGraph::setDefaultRenderCamera(sensor::VisualSensor& sensor) {
@@ -30,6 +33,34 @@ bool SceneGraph::isRootNode(SceneNode& node) {
   CORRADE_ASSERT(parent != nullptr,
                  "SceneGraph::isRootNode: the node is illegal.", false);
   return (parent->parent() == nullptr ? true : false);
+}
+
+gfx::DrawableGroup* SceneGraph::getDrawableGroup(const std::string& id) {
+  auto it = drawableGroups_.find(id);
+  return it == drawableGroups_.end() ? nullptr : &it->second;
+}
+
+const gfx::DrawableGroup* SceneGraph::getDrawableGroup(
+    const std::string& id) const {
+  auto it = drawableGroups_.find(id);
+  return it == drawableGroups_.end() ? nullptr : &it->second;
+}
+
+template <typename... DrawableGroupArgs>
+gfx::DrawableGroup* SceneGraph::createDrawableGroup(
+    std::string id,
+    DrawableGroupArgs&&... args) {
+  auto inserted = drawableGroups_.emplace(
+      std::move(id), std::forward<DrawableGroupArgs>(args)...);
+  if (inserted.second) {
+    LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
+    return inserted.first->second;
+  }
+  return nullptr;
+}
+
+bool SceneGraph::deleteDrawableGroup(const std::string& id) {
+  return drawableGroups_.erase(id);
 }
 
 }  // namespace scene

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -46,22 +46,6 @@ const gfx::DrawableGroup* SceneGraph::getDrawableGroup(
   return it == drawableGroups_.end() ? nullptr : &it->second;
 }
 
-template <typename... DrawableGroupArgs>
-gfx::DrawableGroup* SceneGraph::createDrawableGroup(
-    std::string id,
-    DrawableGroupArgs&&... args) {
-  auto inserted = drawableGroups_.emplace(
-      std::piecewise_construct, std::forward_as_tuple(std::move(id)),
-      std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
-  if (!inserted.second) {
-    LOG(ERROR) << "DrawableGroup with ID: " << inserted.first->first
-               << " already exists!";
-    return nullptr;
-  }
-  LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
-  return &inserted.first->second;
-}
-
 bool SceneGraph::deleteDrawableGroup(const std::string& id) {
   return drawableGroups_.erase(id);
 }

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -57,8 +57,9 @@ class SceneGraph {
 
   /** @overload */
   const DrawableGroups& getDrawableGroups() const { return drawableGroups_; }
+
   /**
-   * @brief Gets a @ref DrawableGroup by ID
+   * @brief Get a @ref DrawableGroup by ID
    *
    * @return Pointer to @ref DrawableGroup, or nullptr if shader does not exist.
    *
@@ -82,9 +83,9 @@ class SceneGraph {
                                           DrawableGroupArgs&&... args);
 
   /**
-   * @brief Deletes a @ref DrawableGroup
+   * @brief Deletes a @ref DrawableGroup by ID
    *
-   * @return If the @ref Shader existed.
+   * @return If the @ref DrawableGroup with specified ID existed.
    */
   bool deleteDrawableGroup(const std::string& id);
 

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "esp/core/esp.h"
 #include "esp/gfx/magnum.h"
 
@@ -17,7 +19,7 @@ namespace esp {
 namespace scene {
 class SceneGraph {
  public:
-  using DrawableGroups = std::map<std::string, gfx::DrawableGroup>;
+  using DrawableGroups = std::unordered_map<std::string, gfx::DrawableGroup>;
 
   SceneGraph();
   virtual ~SceneGraph() { LOG(INFO) << "Deconstructing SceneGraph"; };

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -80,7 +80,18 @@ class SceneGraph {
    */
   template <typename... DrawableGroupArgs>
   gfx::DrawableGroup* createDrawableGroup(std::string id,
-                                          DrawableGroupArgs&&... args);
+                                          DrawableGroupArgs&&... args) {
+    auto inserted = drawableGroups_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(std::move(id)),
+        std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
+    if (!inserted.second) {
+      LOG(ERROR) << "DrawableGroup with ID: " << inserted.first->first
+                 << " already exists!";
+      return nullptr;
+    }
+    LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
+    return &inserted.first->second;
+  }
 
   /**
    * @brief Deletes a @ref DrawableGroup by ID

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,6 +39,9 @@ target_include_directories(CullingTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 TEST(SuncgTest scene)
 target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+TEST(SceneGraphTest scene)
+target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 # Some tests are LOUD, we don't want to include their full log (but OTOH we
 # want to have full log from others, so this is a compromise)
 set_tests_properties(

--- a/src/tests/SceneGraphTest.cpp
+++ b/src/tests/SceneGraphTest.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "esp/scene/SceneGraph.h"
+
+using esp::gfx::DrawableGroup;
+using esp::scene::SceneGraph;
+
+class SceneGraphTest : public ::testing::Test {
+ protected:
+  void SetUp() override { numInitialGroups = g.getDrawableGroups().size(); }
+
+  size_t numInitialGroups;
+  SceneGraph g;
+  const std::string groupName = "testGroup";
+};
+
+TEST_F(SceneGraphTest, GetDrawableGroup) {
+  EXPECT_EQ(g.getDrawableGroup("not created"), nullptr);
+
+  DrawableGroup* group = g.createDrawableGroup(groupName);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(g.getDrawableGroups().size(), numInitialGroups + 1);
+  ASSERT_EQ(g.getDrawableGroup(groupName), group);
+}
+
+TEST_F(SceneGraphTest, DeleteDrawableGroup) {
+  EXPECT_FALSE(g.deleteDrawableGroup("not created"));
+
+  DrawableGroup* group = g.createDrawableGroup(groupName);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(g.getDrawableGroup(groupName), group);
+
+  ASSERT_TRUE(g.deleteDrawableGroup(groupName));
+  EXPECT_EQ(g.getDrawableGroups().size(), numInitialGroups);
+  ASSERT_EQ(g.getDrawableGroup(groupName), nullptr);
+}

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -398,8 +398,14 @@ void Viewer::drawEvent() {
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
-  uint32_t visibles =
-      renderCamera_->draw(sceneGraph.getDrawables(), frustumCullingEnabled_);
+  uint32_t visibles = 0;
+
+  for (auto& it : sceneGraph.getDrawableGroups()) {
+    // TODO: remove || true
+    if (it.second.prepareForDraw(*renderCamera_) || true) {
+      visibles += renderCamera_->draw(it.second, frustumCullingEnabled_);
+    }
+  }
 
   if (debugBullet_) {
     Magnum::Matrix4 camM(renderCamera_->cameraMatrix());


### PR DESCRIPTION
## Motivation and Context

As part of the configurable Shader project, we need to have multiple DrawableGroups instead of using only 1. Each Drawable also needs a pointer to their drawable group in order to retrieve its shader at render time. This PR lays the groundwork for this to happen, while minimizing the number of changes by still using a single default group.

Part of #319 

## How Has This Been Tested

Need to add tests before merge (will update).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
