### PR TITLE
[esp/bindings] fix a bunch of pybind11 doc reference issues

### DIFF
--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -38,18 +38,6 @@ void initSensorBindings(py::module& m) {
   // ==== Observation ====
   py::class_<Observation, Observation::ptr>(m, "Observation");
 
-  // ==== Sensor ====
-  py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,
-             Magnum::SceneGraph::AbstractFeature3D,
-             Magnum::SceneGraph::PyFeatureHolder<Sensor>>(m, "Sensor")
-      .def("specification", &Sensor::specification)
-      .def("set_transformation_from_spec", &Sensor::setTransformationFromSpec)
-      .def("is_visual_sensor", &Sensor::isVisualSensor)
-      .def("get_observation", &Sensor::getObservation)
-      .def_property_readonly("node", nodeGetter<Sensor>,
-                             "Node this object is attached to")
-      .def_property_readonly("object", nodeGetter<Sensor>, "Alias to node");
-
   // TODO fill out other SensorTypes
   // ==== enum SensorType ====
   py::enum_<SensorType>(m, "SensorType")
@@ -58,6 +46,7 @@ void initSensorBindings(py::module& m) {
       .value("DEPTH", SensorType::DEPTH)
       .value("SEMANTIC", SensorType::SEMANTIC);
 
+  // ==== SensorSpec ====
   py::class_<SensorSpec, SensorSpec::ptr>(m, "SensorSpec", py::dynamic_attr())
       .def(py::init(&SensorSpec::create<>))
       .def_readwrite("uuid", &SensorSpec::uuid)
@@ -92,6 +81,18 @@ void initSensorBindings(py::module& m) {
            [](const SensorSpec& self, const SensorSpec& other) -> bool {
              return self != other;
            });
+
+  // ==== Sensor ====
+  py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,
+             Magnum::SceneGraph::AbstractFeature3D,
+             Magnum::SceneGraph::PyFeatureHolder<Sensor>>(m, "Sensor")
+      .def("specification", &Sensor::specification)
+      .def("set_transformation_from_spec", &Sensor::setTransformationFromSpec)
+      .def("is_visual_sensor", &Sensor::isVisualSensor)
+      .def("get_observation", &Sensor::getObservation)
+      .def_property_readonly("node", nodeGetter<Sensor>,
+                             "Node this object is attached to")
+      .def_property_readonly("object", nodeGetter<Sensor>, "Alias to node");
 
   // ==== VisualSensor ====
   py::class_<VisualSensor, Magnum::SceneGraph::PyFeature<VisualSensor>, Sensor,

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -61,15 +61,18 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
 
   m.import("magnum.scenegraph");
 
+  py::bind_map<std::map<std::string, std::string>>(m, "MapStringString");
+
+  // NOTE(msb) These need to be run in dependency order.
+  // TODO(msb) gfx, scene, and sensor should not cross-depend
+  // TODO(msb) sim and sensor should not cross-depend
   esp::initEspBindings(m);
   esp::core::initCoreBindings(m);
   esp::geo::initGeoBindings(m);
-  esp::gfx::initGfxBindings(m);
-  esp::nav::initShortestPathBindings(m);
   esp::physics::initPhysicsBindings(m);
   esp::scene::initSceneBindings(m);
+  esp::gfx::initGfxBindings(m);
   esp::sensor::initSensorBindings(m);
+  esp::nav::initShortestPathBindings(m);
   esp::sim::initSimBindings(m);
-
-  py::bind_map<std::map<std::string, std::string>>(m, "MapStringString");
 }


### PR DESCRIPTION
This does not fix all pybind11 doc errors. There are still a few
unresolved due to cross-references between some namespaces.

The cross-references can be avoided and I think the architecture
will benefit as a result. I hope to address this as part of the
sensor refactor.

Remaining errors:

WARNING:root:cannot parse pybind11 function signature bind_render_target(self: habitat_sim._ext.habitat_sim_bindings.Renderer, arg0: esp::sensor::VisualSensor) -> None
WARNING:root:cannot parse pybind11 function signature draw(self: habitat_sim._ext.habitat_sim_bindings.Renderer, visualSensor: esp::sensor::VisualSensor, scene: habitat_sim._ext.habitat_sim_bindings.SceneGraph) -> None
WARNING:root:cannot parse pybind11 function signature get_default_render_camera(self: habitat_sim._ext.habitat_sim_bindings.SceneGraph) -> esp::gfx::RenderCamera
WARNING:root:cannot parse pybind11 function signature set_default_render_camera_parameters(self: habitat_sim._ext.habitat_sim_bindings.SceneGraph, targetSceneNode: esp::sensor::VisualSensor) -> None
WARNING:root:cannot parse pybind11 function signature get_observation(self: habitat_sim._ext.habitat_sim_bindings.Sensor, arg0: esp::sim::Simulator, arg1: habitat_sim._ext.habitat_sim_bindings.Observation) -> bool
WARNING:root:cannot parse pybind11 function signature get_observation(self: habitat_sim._ext.habitat_sim_bindings.Sensor, arg0: esp::sim::Simulator, arg1: habitat_sim._ext.habitat_sim_bindings.Observation) -> bool
WARNING:root:cannot parse pybind11 function signature get_observation(self: habitat_sim._ext.habitat_sim_bindings.Sensor, arg0: esp::sim::Simulator, arg1: habitat_sim._ext.habitat_sim_bindings.Observation) -> bool

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Bring pybind11 doc errors down to zero.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
doc build

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
