### PR TITLE
Fix: Added build sha to doc update key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
               git submodule update --init
               ./build-public.sh
       - save_cache:
-          key: docs-{{ .Branch }}
+          key: docs-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           background: true
           paths:
             - ./habitat-sim/build/docs-public
@@ -427,7 +427,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: docs-{{ .Branch }}
+          key: docs-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - add_ssh_keys:
           fingerprints:
             - "18:88:e0:37:b1:b3:7a:23:aa:1e:f7:43:a8:5b:8e:05"


### PR DESCRIPTION
## Motivation and Context
Fix: Added build sha to doc update key to avoid stale doc build. In CircleCI cache can't be overwritten with same key.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

