### PR TITLE
Fixed initializer cast error on mac test compile

### DIFF
--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -128,8 +128,8 @@ TEST(ResourceManagerTest, computeAbsoluteAABB) {
                                 Mn::Vector3{1.0, -3.0, 5.0});
   // Box 3: (parent, Box 0), object "a", relative translation (-4.0, 0.0, 4.0),
   // relative rotation pi/4 (ccw) around local z-axis of Box 3
-  aabbsGroundTruth.emplace_back(Mn::Vector3{-4.0 - sqrt(2.0), -sqrt(2.0), 3.0},
-                                Mn::Vector3{-4.0 + sqrt(2.0), sqrt(2.0), 5.0});
+  aabbsGroundTruth.emplace_back(Mn::Vector3{-4 - sqrtf(2.0), -sqrtf(2.0), 3.0},
+                                Mn::Vector3{-4 + sqrtf(2.0), sqrtf(2.0), 5.0});
   // Box 4: (parent, Box 3), object "a", relative translation (8.0, 0.0, 0.0),
   // relative rotation pi/4 (ccw) around local z-axis of Box 4
   aabbsGroundTruth.emplace_back(Mn::Vector3{3.0, -1.0, 3.0},


### PR DESCRIPTION
## Motivation and Context

C++ test build was failing on macOS due to minor implicit double to float casting issue. CI was not failing, so may be system/compiler specific.

E.g.
![image](https://user-images.githubusercontent.com/1445143/73382471-6f5d8800-427c-11ea-941d-c1b2e6fb300e.png)


## How Has This Been Tested
On macOS
`./build.sh --run-tests`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
