### PR TITLE
Update RenderCamera::setProjectionMatrix PyBind to snake_case

### DIFF
--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -42,7 +42,7 @@ void initGfxBindings(py::module& m) {
       to the scene node for rendering.)")
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
                           const vec3f&, const vec3f&, const vec3f&>())
-      .def("setProjectionMatrix", &RenderCamera::setProjectionMatrix, R"(
+      .def("set_projection_matrix", &RenderCamera::setProjectionMatrix, R"(
         Set this `Camera`'s projection matrix.
       )",
            "width"_a, "height"_a, "znear"_a, "zfar"_a, "hfov"_a)


### PR DESCRIPTION
## Motivation and Context

Use consistent python binding naming conventions, so update `setProjectionMatrix` to `set_projection_matrix`

## How Has This Been Tested

-Tests pass
-grepped habitat-api for usages

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
