### PR TITLE
[tools] add Gibson semantic scene generations script

### DIFF
--- a/tools/gen_gibson_semantics.sh
+++ b/tools/gen_gibson_semantics.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# gen_gibson_semantics.sh - generate semantic scene from .npz data from
+#                           https://3dscenegraph.stanford.edu/
+
+NPZ_PATH=$1
+OBJ_PATH=$2
+OUT_PATH=$3
+
+TOOLS_DIR=$(dirname $0)
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 NPZ_PATH OBJ_PATH OUT_PATH"
+  exit 1
+fi
+
+for npz in "${NPZ_PATH}"/*.npz; do
+  filename=$(basename ${npz})
+  tmp=${filename#3DSceneGraph_}
+  scene=${tmp%.npz}
+  echo ${scene}
+  ${TOOLS_DIR}/npz2ids.py ${npz} ${OUT_PATH}/${scene}.ids
+  ${TOOLS_DIR}/npz2scn.py ${npz} ${OUT_PATH}/${scene}.scn
+  ${TOOLS_DIR}/../build/utils/datatool/datatool create_gibson_semantic_mesh ${OBJ_PATH}/${scene}/mesh.obj ${OUT_PATH}/${scene}.ids ${OUT_PATH}/${scene}_semantic.ply
+done


### PR DESCRIPTION
This script generated semantic scene information from the
https://3dscenegraph.stanford.edu/ dataset.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
This script can be used to generate Gibson semantic scene information.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
We are using the data generated from this script.
