### PR TITLE
Update multi goal path implementation

### DIFF
--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "PathFinder.h"
-#include <numeric>
 #include <stack>
 #include <unordered_map>
 

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -882,7 +882,7 @@ float pathLength(const std::vector<vec3f>& points) {
 bool PathFinder::Impl::findPath(ShortestPath& path) {
   MultiGoalShortestPath tmp;
   tmp.requestedStart = path.requestedStart;
-  tmp.requestedEnds = {path.requestedStart};
+  tmp.requestedEnds = {path.requestedEnd};
 
   bool status = findPath(tmp);
 


### PR DESCRIPTION
## Motivation and Context

The multigoal path implementation was relying on being able to compare path lengths on the navigation mesh before optimization, this turns out to be not correct a little too often.  This PR changes it to be simply min(A* paths).

This also has the benefit of removing on our deviations from recast main!

## How Has This Been Tested

With the test!  Also added a benchmark because Corrade's test suite is fun.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
