### PR TITLE
Make PyTorch dependency optional in redwood_depth_noise_model

### DIFF
--- a/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -17,10 +17,8 @@ from habitat_sim.sensors.noise_models.sensor_noise_model import SensorNoiseModel
 
 if cuda_enabled:
     from habitat_sim._ext.habitat_sim_bindings import RedwoodNoiseModelGPUImpl
-    try:
-        import torch
-    except ImportError:
-        torch = None
+
+torch = None
 
 
 # Read about the noise model here: http://www.alexteichman.com/octo/clams/
@@ -124,16 +122,19 @@ class RedwoodDepthNoiseModel(SensorNoiseModel):
         return sensor_type == SensorType.DEPTH
 
     def simulate(self, gt_depth):
+        global torch
         if cuda_enabled:
-            if torch is not None and torch.is_tensor(gt_depth):
+            if isinstance(gt_depth, np.ndarray):
+                return self._impl.simulate_from_cpu(gt_depth)
+            else:
+                if torch is None:
+                    import torch
                 noisy_depth = torch.empty_like(gt_depth)
                 rows, cols = gt_depth.size()
                 self._impl.simulate_from_gpu(
                     gt_depth.data_ptr(), rows, cols, noisy_depth.data_ptr()
                 )
                 return noisy_depth
-            else:
-                return self._impl.simulate_from_cpu(gt_depth)
         else:
             return self._impl.simulate(gt_depth)
 

--- a/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -17,7 +17,10 @@ from habitat_sim.sensors.noise_models.sensor_noise_model import SensorNoiseModel
 
 if cuda_enabled:
     from habitat_sim._ext.habitat_sim_bindings import RedwoodNoiseModelGPUImpl
-    import torch
+    try:
+        import torch
+    except ImportError:
+        torch = None
 
 
 # Read about the noise model here: http://www.alexteichman.com/octo/clams/
@@ -122,7 +125,7 @@ class RedwoodDepthNoiseModel(SensorNoiseModel):
 
     def simulate(self, gt_depth):
         if cuda_enabled:
-            if torch.is_tensor(gt_depth):
+            if torch is not None and torch.is_tensor(gt_depth):
                 noisy_depth = torch.empty_like(gt_depth)
                 rows, cols = gt_depth.size()
                 self._impl.simulate_from_gpu(


### PR DESCRIPTION
## Motivation and Context

Since 0.1.4, attempting to import habitat_sim without having PyTorch installed results in `ModuleNotFoundError`. This PR fixes that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
