### PR TITLE
[DRAFT][WIP] Enable Phong shading + dynamic shader/drawable group selection

### DIFF
--- a/src/esp/assets/GltfMeshData.cpp
+++ b/src/esp/assets/GltfMeshData.cpp
@@ -19,7 +19,8 @@ void GltfMeshData::uploadBuffersToGPU(bool forceReload) {
   renderingBuffer_.reset();
   renderingBuffer_ = std::make_unique<GltfMeshData::RenderingBuffer>();
   // position, normals, uv, colors are bound to corresponding attributes
-  renderingBuffer_->mesh = Magnum::MeshTools::compile(*meshData_);
+  renderingBuffer_->mesh = Magnum::MeshTools::compile(
+      *meshData_, Magnum::MeshTools::CompileFlag::GenerateSmoothNormals);
   buffersOnGPU_ = true;
 }
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -895,9 +895,16 @@ gfx::DrawableGroup* ResourceManager::getDrawableGroupFromShaderConfig(
   } else if (cfg.textured) {
     shaderIdentifier += TEXTURED;
   }
-  gfx::Shader::ptr shader =
-      shaderManager_.getOrCreateShader(shaderIdentifier, cfg);
-  return sceneGraph.getOrCreateDrawableGroup(shaderIdentifier, shader);
+
+  gfx::DrawableGroup* group = sceneGraph.getDrawableGroup(shaderIdentifier);
+  if (!group) {
+    gfx::Shader::ptr shader = shaderManager_.getShader(shaderIdentifier);
+    if (!shader)
+      shader = shaderManager_.createShader(shaderIdentifier, cfg);
+    group = sceneGraph.createDrawableGroup(shaderIdentifier, shader);
+  }
+
+  return group;
 }
 
 bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
@@ -1396,8 +1403,7 @@ void ResourceManager::addMeshToDrawables(const MeshMetaData& metaData,
       if (texture) {
         // update config to include texture
         shaderCfg.textured = true;
-        createDrawable(shaderCfg, mesh, node, sceneGraph, texture,
-                       objectID);
+        createDrawable(shaderCfg, mesh, node, sceneGraph, texture, objectID);
       } else {
         // Color-only material
         createDrawable(shaderCfg, mesh, node, sceneGraph, texture, objectID,

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -855,7 +855,8 @@ void ResourceManager::translateMesh(BaseMesh* meshDataGL,
 gfx::DrawableGroup* ResourceManager::getDrawableGroupFromShaderConfig(
     const gfx::ShaderConfiguration& cfg,
     scene::SceneGraph& sceneGraph) {
-  // name prefix
+  // TODO: nicer management of built in drawable groups and shaders, don't
+  // hardcode the strings here name prefix
   static const std::string INSTANCE_MESH = "INSTANCE_MESH";
   static const std::string PTEX_MESH = "PTEX_MESH";
   static const std::string FLAT = "FLAT";

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -64,13 +64,15 @@ namespace assets {
 class ResourceManager {
  public:
   /** @brief Constructor */
+  explicit ResourceManager()
+      : tempShaderManager_{}, shaderManager_{tempShaderManager_} {};
+
+  /** @brief Constructor */
   explicit ResourceManager(gfx::ShaderManager& s) : shaderManager_{s} {};
 
   /** @brief Destructor */
   ~ResourceManager() {}
 
-  /** @brief Stores references to a set of drawable elements */
-  using DrawableGroup = gfx::DrawableGroup;
   /** @brief Convenience typedef for Importer class */
   using Importer = Magnum::Trade::AbstractImporter;
 
@@ -626,6 +628,10 @@ class ResourceManager {
   std::vector<std::string> physicsObjectConfigList_;
 
   // TODO: move shader selection out of ResourceManager
+  // HACK: to avoid changing all usages of ResourceManager, use another member
+  // if shaderManager isn't provided in constructor. This will be removed once
+  // shader selection is extracted out of ResourceManager
+  gfx::ShaderManager tempShaderManager_;
   gfx::ShaderManager& shaderManager_;
 
   // ======== Rendering Utility Functions ========

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -658,15 +658,6 @@ class ResourceManager {
                           gfx::ShaderConfiguration& shaderCfg);
 
   /**
-   * @brief Maps @ref ShaderType to specific instances of @ref
-   * Magnum::GL::AbstractShaderProgram.
-   *
-   * See @ref getShaderProgram.
-   */
-  std::map<ShaderType, std::shared_ptr<Magnum::GL::AbstractShaderProgram>>
-      shaderPrograms_;
-
-  /**
    * @brief Returns a pointer to the @ref DrawableGroup associated with a @ref
    * ShaderConfiguration
    *
@@ -693,7 +684,7 @@ class ResourceManager {
    * @param node The @ref scene::SceneNode to which the drawable will be
    * attached.
    * @param meshID Optional, the index of this mesh component stored in meshes_
-   * @param group Optional @ref SceneGraph with which the render the @ref
+   * @param sceneGraph Optional @ref SceneGraph with which the render the @ref
    * gfx::Drawable.
    * @param texture Optional texture for the mesh.
    * @param objectId Optional object type indentifier or semantic type for the
@@ -704,7 +695,7 @@ class ResourceManager {
   void createDrawable(const gfx::ShaderConfiguration& shaderCfg,
                       Magnum::GL::Mesh& mesh,
                       scene::SceneNode& node,
-                      DrawableGroup* group = nullptr,
+                      scene::SceneGraph* sceneGraph = nullptr,
                       Magnum::GL::Texture2D* texture = nullptr,
                       int objectId = ID_UNDEFINED,
                       const Magnum::Color4& color = Magnum::Color4{1});

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -355,11 +355,15 @@ class ResourceManager {
    * rendered.
    * @param meshTransformNode The @ref MeshTransformNode for component
    * identifying its mesh, material, transformation, and children.
+   * @param shaderCfg The @ref ShaderConfiguration that will be used
+   * for this component. The existence of texture or vertex color will update
+   * settings in this configuration.
    */
   void addComponent(const MeshMetaData& metaData,
                     scene::SceneNode& parent,
                     scene::SceneGraph* sceneGraph,
-                    const MeshTransformNode& meshTransformNode);
+                    const MeshTransformNode& meshTransformNode,
+                    gfx::ShaderConfiguration& shaderCfg);
 
   /**
    * @brief Load textures from importer into assets, and update metaData for an
@@ -641,50 +645,17 @@ class ResourceManager {
    * the asset via the @ref MeshMetaData.
    * @param materialIDLocal The index of the material within the material group
    * linked to the asset via the @ref MeshMetaData.
+   * @param shaderCfg The @ref ShaderConfiguration that will be used
+   * for this component. The existence of texture or vertex color will update
+   * settings in this configuration.
    */
   void addMeshToDrawables(const MeshMetaData& metaData,
                           scene::SceneNode& node,
                           scene::SceneGraph* sceneGraph,
                           int objectID,
                           int meshIDLocal,
-                          int materialIDLocal);
-
-  /**
-   * @brief Enumeration of supported shader program options.
-   */
-  enum ShaderType {
-    /**
-     * Shader program for instance mesh data. See @ref gfx::PrimitiveIDShader,
-     * @ref GenericInstanceMeshData, @ref Mp3dInstanceMeshData, @ref
-     * AssetType::INSTANCE_MESH, @ref loadInstanceMeshData.
-     */
-    INSTANCE_MESH_SHADER = 0,
-
-    /**
-     * Shader program for PTex mesh data. See @ref gfx::PTexMeshShader, @ref
-     * gfx::PTexMeshDrawable, @ref loadPTexMeshData, @ref PTexMeshData.
-     */
-    PTEX_MESH_SHADER = 1,
-
-    /**
-     * Shader program for flat shading with uniform color. Used to render object
-     * identifier or semantic types (e.g. chair, table, etc...). Also the
-     * default shader for assets with unidentified rendering parameters. See
-     * @ref Magnum::Shaders::Flat3D.
-     */
-    COLORED_SHADER = 2,
-
-    /**
-     * Shader program for vertex color shading. Used to render meshes with
-     * per-vertex colors defined.
-     */
-    VERTEX_COLORED_SHADER = 3,
-
-    /**
-     * Shader program for meshes with textured defined.
-     */
-    TEXTURED_SHADER = 4,
-  };
+                          int materialIDLocal,
+                          gfx::ShaderConfiguration& shaderCfg);
 
   /**
    * @brief Maps @ref ShaderType to specific instances of @ref
@@ -696,20 +667,27 @@ class ResourceManager {
       shaderPrograms_;
 
   /**
-   * @brief Returns a pointer to the specified shader program.
+   * @brief Returns a pointer to the @ref DrawableGroup associated with a @ref
+   * ShaderConfiguration
    *
-   * Creates a new shader program for @ref ShaderType if it does not exist.
-   * @param type The @ref ShaderType of the desired shader program.
-   * @return A pointer to the specified shader program.
+   * May create a new @ref DrawableGroup if one for the specified configuration
+   * does not exist
+   * @param cfg The @ref ShaderConfiguration of the desired @ref DrawableGroup.
+   * @param sceneGraph The @ref SceneGraph to get or create the @ref
+   * DrawableGroup from
+   * @return A pointer to a @ref DrawableGroup in the specified @ref SceneGraph
+   * which uses the specified @ref ShaderConfiguration.
    */
-  Magnum::GL::AbstractShaderProgram* getShaderProgram(ShaderType type);
+  gfx::DrawableGroup* getDrawableGroupFromShaderConfig(
+      const gfx::ShaderConfiguration& cfg,
+      scene::SceneGraph& sceneGraph);
 
   /**
    * @brief Create a @ref gfx::Drawable for the specified mesh, node,
    * and @ref ShaderType.
    *
    * Add this drawable to the @ref SceneGraph if provided.
-   * @param shaderType Indentifies the desired shader program for rendering the
+   * @param shaderCfg Indentifies the desired shader program for rendering the
    * @ref gfx::Drawable.
    * @param mesh The render mesh.
    * @param node The @ref scene::SceneNode to which the drawable will be
@@ -723,7 +701,7 @@ class ResourceManager {
    * @param color Optional color parameter for the shader program. Defaults to
    * white.
    */
-  void createDrawable(const ShaderType shaderType,
+  void createDrawable(const gfx::ShaderConfiguration& shaderCfg,
                       Magnum::GL::Mesh& mesh,
                       scene::SceneNode& node,
                       DrawableGroup* group = nullptr,

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -14,9 +14,7 @@ namespace gfx {
 Drawable::Drawable(scene::SceneNode& node,
                    Magnum::GL::Mesh& mesh,
                    DrawableGroup* group /* = nullptr */)
-    : Magnum::SceneGraph::Drawable3D{node, group},
-      node_(node),
-      mesh_(mesh) {}
+    : Magnum::SceneGraph::Drawable3D{node, group}, node_(node), mesh_(mesh) {}
 
 DrawableGroup* Drawable::drawables() {
   CORRADE_ASSERT(

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -12,12 +12,10 @@ namespace esp {
 namespace gfx {
 
 Drawable::Drawable(scene::SceneNode& node,
-                   Magnum::GL::AbstractShaderProgram& shader,
                    Magnum::GL::Mesh& mesh,
                    DrawableGroup* group /* = nullptr */)
     : Magnum::SceneGraph::Drawable3D{node, group},
       node_(node),
-      shader_(shader),
       mesh_(mesh) {}
 
 DrawableGroup* Drawable::drawables() {

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -30,7 +30,6 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    * @param group Drawable group this drawable will be added to.
    */
   Drawable(scene::SceneNode& node,
-           Magnum::GL::AbstractShaderProgram& shader,  // TODO: remove this
            Magnum::GL::Mesh& mesh,
            DrawableGroup* group = nullptr);
   virtual ~Drawable() {}
@@ -59,7 +58,6 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
                     Magnum::SceneGraph::Camera3D& camera) = 0;
 
   scene::SceneNode& node_;
-  Magnum::GL::AbstractShaderProgram& shader_;
   Magnum::GL::Mesh& mesh_;
 };
 

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -5,6 +5,7 @@
 #include "GenericDrawable.h"
 
 #include <Magnum/Shaders/Flat.h>
+#include <Magnum/Shaders/Phong.h>
 
 #include "esp/scene/SceneNode.h"
 
@@ -30,7 +31,7 @@ void GenericDrawable::draw(const Magnum::Matrix4& transformationMatrix,
   Magnum::GL::AbstractShaderProgram& shaderProgram = shader->getShaderProgram();
 
   // TODO: use polymorphism to do double dispatch here
-  if (type == PHONG_SHADER) {
+  if (shaderType == ShaderType::PHONG_SHADER) {
     Magnum::Shaders::Phong& phongShader =
         static_cast<Magnum::Shaders::Phong&>(shaderProgram);
     phongShader.setTransformationMatrix(transformationMatrix)

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -17,7 +17,6 @@ class GenericDrawable : public Drawable {
   //! Adds drawable to given group and uses provided texture, objectId, and
   //! color for textured, object id buffer and color shader output respectively
   explicit GenericDrawable(scene::SceneNode& node,
-                           Magnum::Shaders::Flat3D& shader,
                            Magnum::GL::Mesh& mesh,
                            DrawableGroup* group = nullptr,
                            Magnum::GL::Texture2D* texture = nullptr,

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -14,8 +14,7 @@ PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
                                    assets::PTexMeshData& ptexMeshData,
                                    int submeshID,
                                    DrawableGroup* group /* = nullptr */)
-    : Drawable{node, shader, ptexMeshData.getRenderingBuffer(submeshID)->mesh,
-               group},
+    : Drawable{node, ptexMeshData.getRenderingBuffer(submeshID)->mesh, group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),
 #ifndef CORRADE_TARGET_APPLE
       adjFacesBufferTexture_(
@@ -29,7 +28,8 @@ PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
 
 void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                             Magnum::SceneGraph::Camera3D& camera) {
-  PTexMeshShader& ptexMeshShader = static_cast<PTexMeshShader&>(shader_);
+  PTexMeshShader& ptexMeshShader = static_cast<PTexMeshShader&>(
+      drawables()->getShader()->getShaderProgram());
   ptexMeshShader.setExposure(exposure_)
       .setGamma(gamma_)
       .setSaturation(saturation_)

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -10,7 +10,6 @@ namespace esp {
 namespace gfx {
 
 PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
-                                   PTexMeshShader& shader,
                                    assets::PTexMeshData& ptexMeshData,
                                    int submeshID,
                                    DrawableGroup* group /* = nullptr */)

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -18,7 +18,6 @@ class PTexMeshShader;
 class PTexMeshDrawable : public Drawable {
  public:
   explicit PTexMeshDrawable(scene::SceneNode& node,
-                            PTexMeshShader& shader,
                             assets::PTexMeshData& ptexMeshData,
                             int submeshID,
                             DrawableGroup* group = nullptr);

--- a/src/esp/gfx/PrimitiveIDDrawable.cpp
+++ b/src/esp/gfx/PrimitiveIDDrawable.cpp
@@ -10,18 +10,18 @@ namespace esp {
 namespace gfx {
 
 PrimitiveIDDrawable::PrimitiveIDDrawable(scene::SceneNode& node,
-                                         PrimitiveIDShader& shader,
                                          Magnum::GL::Mesh& mesh,
                                          DrawableGroup* group /* = nullptr */)
-    : Drawable{node, shader, mesh, group} {}
+    : Drawable{node, mesh, group} {}
 
 void PrimitiveIDDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                                Magnum::SceneGraph::Camera3D& camera) {
-  PrimitiveIDShader& shader = static_cast<PrimitiveIDShader&>(shader_);
+  PrimitiveIDShader& shader = static_cast<PrimitiveIDShader&>(
+      drawables()->getShader()->getShaderProgram());
   shader.setTransformationProjectionMatrix(camera.projectionMatrix() *
                                            transformationMatrix);
 
-  mesh_.draw(shader_);
+  mesh_.draw(shader);
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/PrimitiveIDDrawable.h
+++ b/src/esp/gfx/PrimitiveIDDrawable.h
@@ -18,7 +18,6 @@ class PrimitiveIDDrawable : public Drawable {
   //! objectId, and color for textured, object id buffer and color shader
   //! output respectively
   explicit PrimitiveIDDrawable(scene::SceneNode& node,
-                               PrimitiveIDShader& shader,
                                Magnum::GL::Mesh& mesh,
                                DrawableGroup* group = nullptr);
 

--- a/src/esp/gfx/Shader.h
+++ b/src/esp/gfx/Shader.h
@@ -101,6 +101,11 @@ class Shader {
     return false;
   }
 
+  // TODO: remove this once Drawables pass themselves to Shader to render
+  Magnum::GL::AbstractShaderProgram& getShaderProgram() {
+    return *shaderProgram_;
+  }
+
  private:
   ShaderConfiguration config_;
 

--- a/src/esp/gfx/Shader.h
+++ b/src/esp/gfx/Shader.h
@@ -47,7 +47,7 @@ enum class ShaderType {
 struct ShaderConfiguration {
   ShaderType type = ShaderType::FLAT_SHADER;
   // TODO: have derived shader configurations, delete the following
-  bool textured = true;
+  bool textured = false;
   bool vertexColored = false;
 };
 

--- a/src/esp/gfx/ShaderManager.cpp
+++ b/src/esp/gfx/ShaderManager.cpp
@@ -17,6 +17,30 @@ Shader::cptr ShaderManager::getShader(const std::string& id) const {
   return it == shaders_.end() ? nullptr : it->second;
 }
 
+template <typename... ShaderArgs>
+Shader::ptr ShaderManager::createShader(std::string id, ShaderArgs&&... args) {
+  // insert a nullptr first to avoid useless construction when shader with id
+  // already exists
+  auto inserted = shaders_.emplace(std::move(id), nullptr);
+  if (!inserted.second) {
+    LOG(ERROR) << "Shader with id " << inserted.first->first
+               << " already exists";
+    return nullptr;
+  }
+
+  // now actually "insert" the shader
+  inserted.first->second.reset(new Shader{std::forward<ShaderArgs>(args)...});
+  LOG(INFO) << "Created Shader: " << inserted.first->first;
+  return inserted.first->second;
+}
+
+template <typename... ShaderArgs>
+Shader::ptr ShaderManager::getOrCreateShader(std::string id,
+                                             ShaderArgs&&... args) {
+  return getShader(id) ||
+         createShader(std::move(id), std::forward<ShaderArgs>(args));
+}
+
 bool ShaderManager::deleteShader(const std::string& id) {
   return shaders_.erase(id);
 }

--- a/src/esp/gfx/ShaderManager.cpp
+++ b/src/esp/gfx/ShaderManager.cpp
@@ -17,30 +17,6 @@ Shader::cptr ShaderManager::getShader(const std::string& id) const {
   return it == shaders_.end() ? nullptr : it->second;
 }
 
-template <typename... ShaderArgs>
-Shader::ptr ShaderManager::createShader(std::string id, ShaderArgs&&... args) {
-  // insert a nullptr first to avoid useless construction when shader with id
-  // already exists
-  auto inserted = shaders_.emplace(std::move(id), nullptr);
-  if (!inserted.second) {
-    LOG(ERROR) << "Shader with id " << inserted.first->first
-               << " already exists";
-    return nullptr;
-  }
-
-  // now actually "insert" the shader
-  inserted.first->second.reset(new Shader{std::forward<ShaderArgs>(args)...});
-  LOG(INFO) << "Created Shader: " << inserted.first->first;
-  return inserted.first->second;
-}
-
-template <typename... ShaderArgs>
-Shader::ptr ShaderManager::getOrCreateShader(std::string id,
-                                             ShaderArgs&&... args) {
-  return getShader(id) ||
-         createShader(std::move(id), std::forward<ShaderArgs>(args));
-}
-
 bool ShaderManager::deleteShader(const std::string& id) {
   return shaders_.erase(id);
 }

--- a/src/esp/gfx/ShaderManager.h
+++ b/src/esp/gfx/ShaderManager.h
@@ -57,7 +57,10 @@ class ShaderManager {
    * See @ref getShader and @ref createShader
    */
   template <typename... ShaderArgs>
-  Shader::ptr getOrCreateShader(std::string id, ShaderArgs&&... args);
+  Shader::ptr getOrCreateShader(std::string id, ShaderArgs&&... args) {
+    return getShader(id) ||
+           createShader(std::move(id), std::forward<ShaderArgs>(args)...);
+  }
 
   /**
    * @brief Deletes a @ref Shader by ID

--- a/src/esp/gfx/ShaderManager.h
+++ b/src/esp/gfx/ShaderManager.h
@@ -52,6 +52,14 @@ class ShaderManager {
   }
 
   /**
+   * @brief Get or create a @ref Shader
+   *
+   * See @ref getShader and @ref createShader
+   */
+  template <typename... ShaderArgs>
+  Shader::ptr getOrCreateShader(std::string id, ShaderArgs&&... args);
+
+  /**
    * @brief Deletes a @ref Shader by ID
    *
    * @return If a @ref Shader with specified ID existed.

--- a/src/esp/gfx/ShaderManager.h
+++ b/src/esp/gfx/ShaderManager.h
@@ -52,17 +52,6 @@ class ShaderManager {
   }
 
   /**
-   * @brief Get or create a @ref Shader
-   *
-   * See @ref getShader and @ref createShader
-   */
-  template <typename... ShaderArgs>
-  Shader::ptr getOrCreateShader(std::string id, ShaderArgs&&... args) {
-    return getShader(id) ||
-           createShader(std::move(id), std::forward<ShaderArgs>(args)...);
-  }
-
-  /**
    * @brief Deletes a @ref Shader by ID
    *
    * @return If a @ref Shader with specified ID existed.

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -47,7 +47,7 @@ bool PhysicsManager::addScene(
 }
 
 int PhysicsManager::addObject(const int objectLibIndex,
-                              DrawableGroup* drawables) {
+                              scene::SceneGraph* sceneGraph) {
   const std::string configFile =
       resourceManager_->getObjectConfig(objectLibIndex);
 
@@ -67,7 +67,7 @@ int PhysicsManager::addObject(const int objectLibIndex,
   //! Draw object via resource manager
   //! Render node as child of physics node
   resourceManager_->loadObject(configFile, existingObjects_.at(nextObjectID_),
-                               drawables);
+                               sceneGraph);
 
   if (physicsObjectAttributes.existsAs(assets::DataType::BOOL,
                                        "COM_provided")) {
@@ -85,10 +85,10 @@ int PhysicsManager::addObject(const int objectLibIndex,
 }
 
 int PhysicsManager::addObject(const std::string& configFile,
-                              DrawableGroup* drawables) {
+                              scene::SceneGraph* sceneGraph) {
   int resObjectID = resourceManager_->getObjectID(configFile);
   //! Invoke resourceManager to draw object
-  int physObjectID = addObject(resObjectID, drawables);
+  int physObjectID = addObject(resObjectID, sceneGraph);
   return physObjectID;
 }
 
@@ -430,7 +430,7 @@ double PhysicsManager::getAngularDamping(const int physObjectID) const {
 }
 
 void PhysicsManager::setObjectBBDraw(int physObjectID,
-                                     DrawableGroup* drawables,
+                                     scene::SceneGraph* sceneGraph,
                                      bool drawBB) {
   assertIDValidity(physObjectID);
   if (existingObjects_[physObjectID]->BBNode_ && !drawBB) {
@@ -447,7 +447,7 @@ void PhysicsManager::setObjectBBDraw(int physObjectID,
     existingObjects_[physObjectID]->BBNode_->MagnumObject::setTranslation(
         existingObjects_[physObjectID]->getCumulativeBB().center());
     resourceManager_->addPrimitiveToDrawables(
-        0, *existingObjects_[physObjectID]->BBNode_, drawables);
+        0, *existingObjects_[physObjectID]->BBNode_, sceneGraph);
   }
 }
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -24,7 +24,7 @@
 #include "esp/assets/GenericInstanceMeshData.h"
 #include "esp/assets/MeshData.h"
 #include "esp/assets/MeshMetaData.h"
-#include "esp/gfx/DrawableGroup.h"
+#include "esp/scene/SceneGraph.h"
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -121,9 +121,6 @@ class PhysicsManager {
     worldTime_ = 0.0;
   };
 
-  /** @brief Stores references to a set of drawable elements. */
-  using DrawableGroup = gfx::DrawableGroup;
-
   /**
    * @brief Initialize static scene collision geometry from loaded mesh data.
    * Only one 'scene' may be initialized per simulated world, but this scene may
@@ -149,12 +146,12 @@ class PhysicsManager {
    *  @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObject(const std::string& configFile, DrawableGroup* drawables);
+  int addObject(const std::string& configFile, scene::SceneGraph* sceneGraph);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::assets::ResourceManager::physicsObjectLibrary_ by object
    * library index. Queries the properties filename and calls @ref
-   * addObject(const std::string& configFile, DrawableGroup* drawables).
+   * addObject(const std::string& configFile, scene::SceneGraph* sceneGraph).
    *  @param objectLibIndex The index of the object's template in @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_
    *  @param drawables Reference to the scene graph drawables group to enable
@@ -162,7 +159,8 @@ class PhysicsManager {
    *  @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  virtual int addObject(const int objectLibIndex, DrawableGroup* drawables);
+  virtual int addObject(const int objectLibIndex,
+                        scene::SceneGraph* sceneGraph);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref
@@ -685,7 +683,9 @@ class PhysicsManager {
    * @param drawables The drawables group with which to render the bounding box.
    * @param drawBB Set rendering of the bounding box to true or false.
    */
-  void setObjectBBDraw(int physObjectID, DrawableGroup* drawables, bool drawBB);
+  void setObjectBBDraw(int physObjectID,
+                       scene::SceneGraph* sceneGraph,
+                       bool drawBB);
 
   /**
    * @brief Get a const reference to the specified object's SceneNode for info

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -98,10 +98,10 @@ int BulletPhysicsManager::makeRigidObject(
 }
 
 int BulletPhysicsManager::addObject(const int objectLibIndex,
-                                    DrawableGroup* drawables) {
+                                    scene::SceneGraph* sceneGraph) {
   // Do default load first (adds the SceneNode to the SceneGraph and computes
   // the cumulativeBB_)
-  int objID = PhysicsManager::addObject(objectLibIndex, drawables);
+  int objID = PhysicsManager::addObject(objectLibIndex, sceneGraph);
 
   // Then set the collision shape to the cumulativeBB_ if necessary
   if (objID != ID_UNDEFINED) {

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -81,7 +81,7 @@ class BulletPhysicsManager : public PhysicsManager {
                 const std::vector<assets::CollisionMeshData>& meshGroup);
 
   virtual int addObject(const int objectLibIndex,
-                        DrawableGroup* drawables) override;
+                        scene::SceneGraph* sceneGraph) override;
 
   //============ Simulator functions =============
 

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -46,31 +46,6 @@ const gfx::DrawableGroup* SceneGraph::getDrawableGroup(
   return it == drawableGroups_.end() ? nullptr : &it->second;
 }
 
-template <typename... DrawableGroupArgs>
-gfx::DrawableGroup* SceneGraph::createDrawableGroup(
-    std::string id,
-    DrawableGroupArgs&&... args) {
-  auto inserted = drawableGroups_.emplace(
-      std::piecewise_construct, std::forward_as_tuple(std::move(id)),
-      std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
-  if (!inserted.second) {
-    LOG(ERROR) << "DrawableGroup with ID: " << inserted.first->first
-               << " already exists!";
-    return nullptr;
-  }
-  LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
-  return &inserted.first->second;
-}
-
-template <typename... DrawableGroupArgs>
-gfx::DrawableGroup* SceneGraph::getOrCreateDrawableGroup(
-    std::string id,
-    DrawableGroupArgs&&... args) {
-  return getDrawableGroup(id) ||
-         createDrawableGroup(std::move(id),
-                             std::forward<DrawableGroupArgs>(args)...)
-}
-
 bool SceneGraph::deleteDrawableGroup(const std::string& id) {
   return drawableGroups_.erase(id);
 }

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -46,6 +46,31 @@ const gfx::DrawableGroup* SceneGraph::getDrawableGroup(
   return it == drawableGroups_.end() ? nullptr : &it->second;
 }
 
+template <typename... DrawableGroupArgs>
+gfx::DrawableGroup* SceneGraph::createDrawableGroup(
+    std::string id,
+    DrawableGroupArgs&&... args) {
+  auto inserted = drawableGroups_.emplace(
+      std::piecewise_construct, std::forward_as_tuple(std::move(id)),
+      std::forward_as_tuple(std::forward<DrawableGroupArgs>(args)...));
+  if (!inserted.second) {
+    LOG(ERROR) << "DrawableGroup with ID: " << inserted.first->first
+               << " already exists!";
+    return nullptr;
+  }
+  LOG(INFO) << "Created DrawableGroup: " << inserted.first->first;
+  return &inserted.first->second;
+}
+
+template <typename... DrawableGroupArgs>
+gfx::DrawableGroup* SceneGraph::getOrCreateDrawableGroup(
+    std::string id,
+    DrawableGroupArgs&&... args) {
+  return getDrawableGroup(id) ||
+         createDrawableGroup(std::move(id),
+                             std::forward<DrawableGroupArgs>(args)...)
+}
+
 bool SceneGraph::deleteDrawableGroup(const std::string& id) {
   return drawableGroups_.erase(id);
 }

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -13,10 +13,7 @@ namespace scene {
 SceneGraph::SceneGraph()
     : rootNode_{world_},
       defaultRenderCameraNode_{rootNode_},
-      defaultRenderCamera_{defaultRenderCameraNode_} {
-  // For now, just create one drawable group with empty string uuid
-  createDrawableGroup(std::string{});
-}
+      defaultRenderCamera_{defaultRenderCameraNode_} {}
 
 // set transformation, projection matrix, viewport to the default camera
 void SceneGraph::setDefaultRenderCamera(sensor::VisualSensor& sensor) {

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -94,19 +94,6 @@ class SceneGraph {
   }
 
   /**
-   * @brief Get or create a @ref DrawableGroup
-   *
-   * See @ref getDrawableGroup and @ref createDrawableGroup
-   */
-  template <typename... DrawableGroupArgs>
-  gfx::DrawableGroup* getOrCreateDrawableGroup(std::string id,
-                                               DrawableGroupArgs&&... args) {
-    return getDrawableGroup(id) ||
-           createDrawableGroup(std::move(id),
-                               std::forward<DrawableGroupArgs>(args)...);
-  }
-
-  /**
    * @brief Deletes a @ref DrawableGroup by ID
    *
    * @return If the @ref DrawableGroup with specified ID existed.

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -100,7 +100,11 @@ class SceneGraph {
    */
   template <typename... DrawableGroupArgs>
   gfx::DrawableGroup* getOrCreateDrawableGroup(std::string id,
-                                               DrawableGroupArgs&&... args);
+                                               DrawableGroupArgs&&... args) {
+    return getDrawableGroup(id) ||
+           createDrawableGroup(std::move(id),
+                               std::forward<DrawableGroupArgs>(args)...);
+  }
 
   /**
    * @brief Deletes a @ref DrawableGroup by ID

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -94,6 +94,15 @@ class SceneGraph {
   }
 
   /**
+   * @brief Get or create a @ref DrawableGroup
+   *
+   * See @ref getDrawableGroup and @ref createDrawableGroup
+   */
+  template <typename... DrawableGroupArgs>
+  gfx::DrawableGroup* getOrCreateDrawableGroup(std::string id,
+                                               DrawableGroupArgs&&... args);
+
+  /**
    * @brief Deletes a @ref DrawableGroup by ID
    *
    * @return If the @ref DrawableGroup with specified ID existed.

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -27,14 +27,6 @@ class SceneGraph {
   SceneNode& getRootNode() { return rootNode_; }
   const SceneNode& getRootNode() const { return rootNode_; }
 
-  // TODO: remove this
-  gfx::DrawableGroup& getDrawables() {
-    return drawableGroups_.at(std::string{});
-  }
-  const gfx::DrawableGroup& getDrawables() const {
-    return drawableGroups_.at(std::string{});
-  }
-
   // set the transformation, projection matrix to the default camera
   // TODO:
   // in the future, the parameter should be VisualSensor

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -90,17 +90,16 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     auto& sceneGraph = sceneManager_.getSceneGraph(activeSceneID_);
 
     auto& rootNode = sceneGraph.getRootNode();
-    auto& drawables = sceneGraph.getDrawables();
     resourceManager_.compressTextures(cfg.compressTextures);
 
     bool loadSuccess = false;
     if (config_.enablePhysics) {
       loadSuccess =
           resourceManager_.loadScene(sceneInfo, physicsManager_, &rootNode,
-                                     &drawables, cfg.physicsConfigFile);
+                                     &sceneGraph, cfg.physicsConfigFile);
     } else {
       loadSuccess =
-          resourceManager_.loadScene(sceneInfo, &rootNode, &drawables);
+          resourceManager_.loadScene(sceneInfo, &rootNode, &sceneGraph);
     }
     if (!loadSuccess) {
       LOG(ERROR) << "cannot load " << sceneFilename;
@@ -121,11 +120,10 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
         auto& semanticSceneGraph =
             sceneManager_.getSceneGraph(activeSemanticSceneID_);
         auto& semanticRootNode = semanticSceneGraph.getRootNode();
-        auto& semanticDrawables = semanticSceneGraph.getDrawables();
         const assets::AssetInfo semanticSceneInfo =
             assets::AssetInfo::fromPath(semanticMeshFilename);
         resourceManager_.loadScene(semanticSceneInfo, &semanticRootNode,
-                                   &semanticDrawables);
+                                   &semanticSceneGraph);
       }
       LOG(INFO) << "Loaded.";
     } else {
@@ -235,8 +233,7 @@ int Simulator::addObject(const int objectLibIndex, const int sceneID) {
     // TODO: change implementation to support multi-world and physics worlds to
     // own reference to a sceneGraph to avoid this.
     auto& sceneGraph_ = sceneManager_.getSceneGraph(activeSceneID_);
-    auto& drawables = sceneGraph_.getDrawables();
-    return physicsManager_->addObject(objectLibIndex, &drawables);
+    return physicsManager_->addObject(objectLibIndex, &sceneGraph_);
   }
   return ID_UNDEFINED;
 }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -319,7 +319,7 @@ class Simulator {
   // If you switch the order, you will have the error:
   // GL::Context::current(): no current context from Magnum
   // during the deconstruction
-  assets::ResourceManager resourceManager_;
+  assets::ResourceManager resourceManager_{shaderManager_};
 
   scene::SceneManager sceneManager_;
   int activeSceneID_ = ID_UNDEFINED;

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -25,6 +25,18 @@ namespace Mn = Magnum;
 
 using esp::assets::ResourceManager;
 using esp::scene::SceneManager;
+using Mn::SceneGraph::Drawable3D;
+
+std::vector<Drawable3D*> getAllDrawables(esp::scene::SceneGraph& sceneGraph) {
+  std::vector<Drawable3D*> drawables;
+  for (auto& it : sceneGraph.getDrawableGroups()) {
+    for (unsigned int iDrawable = 0; iDrawable < it.second.size();
+         ++iDrawable) {
+      drawables.push_back(&it.second[iDrawable]);
+    }
+  }
+  return drawables;
+}
 
 TEST(CullingTest, computeAbsoluteAABB) {
   // must create a GL context which will be used in the resource manager
@@ -41,17 +53,16 @@ TEST(CullingTest, computeAbsoluteAABB) {
   int sceneID = sceneManager.initSceneGraph();
   auto& sceneGraph = sceneManager.getSceneGraph(sceneID);
   esp::scene::SceneNode& sceneRootNode = sceneGraph.getRootNode();
-  auto& drawables = sceneGraph.getDrawables();
   const esp::assets::AssetInfo info =
       esp::assets::AssetInfo::fromPath(sceneFile);
   bool loadSuccess =
-      resourceManager.loadScene(info, &sceneRootNode, &drawables);
+      resourceManager.loadScene(info, &sceneRootNode, &sceneGraph);
   EXPECT_EQ(loadSuccess, true);
 
   std::vector<Mn::Range3D> aabbs;
-  for (unsigned int iDrawable = 0; iDrawable < drawables.size(); ++iDrawable) {
+  for (Drawable3D* drawable : getAllDrawables(sceneGraph)) {
     Cr::Containers::Optional<Mn::Range3D> aabb =
-        dynamic_cast<esp::scene::SceneNode&>(drawables[iDrawable].object())
+        dynamic_cast<esp::scene::SceneNode&>(drawable->object())
             .getAbsoluteAABB();
     if (aabb) {
       aabbs.emplace_back(*aabb);
@@ -111,132 +122,136 @@ TEST(CullingTest, frustumCulling) {
   int sceneID = sceneManager.initSceneGraph();
   auto& sceneGraph = sceneManager.getSceneGraph(sceneID);
   esp::scene::SceneNode& sceneRootNode = sceneGraph.getRootNode();
-  auto& drawables = sceneGraph.getDrawables();
-  const esp::assets::AssetInfo info =
-      esp::assets::AssetInfo::fromPath(sceneFile);
-  bool loadSuccess =
-      resourceManager.loadScene(info, &sceneRootNode, &drawables);
-  EXPECT_EQ(loadSuccess, true);
+  for (auto& it : sceneGraph.getDrawableGroups()) {
+    auto& drawables = it.second;
+    if (drawables.isEmpty())
+      continue;
+    const esp::assets::AssetInfo info =
+        esp::assets::AssetInfo::fromPath(sceneFile);
+    bool loadSuccess =
+        resourceManager.loadScene(info, &sceneRootNode, &sceneGraph);
+    EXPECT_EQ(loadSuccess, true);
 
-  // set the camera
-  esp::gfx::RenderCamera& renderCamera = sceneGraph.getDefaultRenderCamera();
+    // set the camera
+    esp::gfx::RenderCamera& renderCamera = sceneGraph.getDefaultRenderCamera();
 
-  // The camera to be set:
-  // pos: {7.3589f, -6.9258f,4.9583f}
-  // rotation: 77.4 deg, around {0.773, 0.334, 0.539}
-  // fov = 39.6 deg
-  // resolution: 800 x 600
-  // clip planes (near: 0.1m, far: 100m)
-  // with such a camera, the box 3 should be invisible, box 0, 1, 2, 4 should be
-  // visible.
+    // The camera to be set:
+    // pos: {7.3589f, -6.9258f,4.9583f}
+    // rotation: 77.4 deg, around {0.773, 0.334, 0.539}
+    // fov = 39.6 deg
+    // resolution: 800 x 600
+    // clip planes (near: 0.1m, far: 100m)
+    // with such a camera, the box 3 should be invisible, box 0, 1, 2, 4 should
+    // be visible.
 
-  // NOTE: the following test results have been visually verified in utility
-  // viewer
-  Mn::Vector2i frameBufferSize{800, 600};
-  renderCamera.setProjectionMatrix(frameBufferSize.x(),  // width
-                                   frameBufferSize.y(),  // height
-                                   0.01f,                // znear
-                                   100.0f,               // zfar
-                                   39.6f);               // hfov
+    // NOTE: the following test results have been visually verified in utility
+    // viewer
+    Mn::Vector2i frameBufferSize{800, 600};
+    renderCamera.setProjectionMatrix(frameBufferSize.x(),  // width
+                                     frameBufferSize.y(),  // height
+                                     0.01f,                // znear
+                                     100.0f,               // zfar
+                                     39.6f);               // hfov
 
-  esp::scene::SceneNode agentNode = sceneGraph.getRootNode().createChild();
-  esp::scene::SceneNode cameraNode = agentNode.createChild();
-  cameraNode.translate({7.3589f, -6.9258f, 4.9583f});
-  const Mn::Vector3 axis{0.773, 0.334, 0.539};
-  cameraNode.rotate(Mn::Math::Deg<float>(77.4f), axis.normalized());
-  renderCamera.node().setTransformation(cameraNode.absoluteTransformation());
+    esp::scene::SceneNode agentNode = sceneGraph.getRootNode().createChild();
+    esp::scene::SceneNode cameraNode = agentNode.createChild();
+    cameraNode.translate({7.3589f, -6.9258f, 4.9583f});
+    const Mn::Vector3 axis{0.773, 0.334, 0.539};
+    cameraNode.rotate(Mn::Math::Deg<float>(77.4f), axis.normalized());
+    renderCamera.node().setTransformation(cameraNode.absoluteTransformation());
 
-  // collect all the drawables and their transformations
-  std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                        Mn::Matrix4>>
-      drawableTransforms = renderCamera.drawableTransformations(drawables);
-
-  // do the culling (to create the testing group)
-  size_t numVisibles = renderCamera.cull(drawableTransforms);
-  auto newEndIter = drawableTransforms.begin() + numVisibles;
-
-  // create a render target
-  Mn::Matrix4 projMtx = renderCamera.projectionMatrix();
-  esp::gfx::RenderTarget::uptr target = esp::gfx::RenderTarget::create_unique(
-      frameBufferSize, esp::gfx::calculateDepthUnprojection(projMtx));
-
-  // ============== Test 1 ==================
-  // draw all the invisibles reported by cull()
-  // check passed if 0 sample is returned (that means they are indeed
-  // invisibles.)
-  {
-    // objects will contain all the invisible ones
+    // collect all the drawables and their transformations
     std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
                           Mn::Matrix4>>
-        objects = renderCamera.drawableTransformations(drawables);
+        drawableTransforms = renderCamera.drawableTransformations(drawables);
 
-    // CAREFUL:
-    // all the invisible ones are NOT stored at [newEndIter,
-    // drawableTransforms.end()]. This is because std::remove_if will only move
-    // elements, not swap elements
-    objects.erase(
-        std::remove_if(
-            objects.begin(), objects.end(),
-            [&](const std::pair<
-                std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                Mn::Matrix4>& a) {
-              for (std::vector<std::pair<
-                       std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                       Mn::Matrix4>>::iterator iter =
-                       drawableTransforms.begin();
-                   iter != newEndIter; ++iter) {
-                if (std::addressof(a.first.get()) ==
-                    std::addressof(iter->first.get())) {
-                  return true;  // it is visible, remove it
+    // do the culling (to create the testing group)
+    size_t numVisibles = renderCamera.cull(drawableTransforms);
+    auto newEndIter = drawableTransforms.begin() + numVisibles;
+
+    // create a render target
+    Mn::Matrix4 projMtx = renderCamera.projectionMatrix();
+    esp::gfx::RenderTarget::uptr target = esp::gfx::RenderTarget::create_unique(
+        frameBufferSize, esp::gfx::calculateDepthUnprojection(projMtx));
+
+    // ============== Test 1 ==================
+    // draw all the invisibles reported by cull()
+    // check passed if 0 sample is returned (that means they are indeed
+    // invisibles.)
+    {
+      // objects will contain all the invisible ones
+      std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                            Mn::Matrix4>>
+          objects = renderCamera.drawableTransformations(drawables);
+
+      // CAREFUL:
+      // all the invisible ones are NOT stored at [newEndIter,
+      // drawableTransforms.end()]. This is because std::remove_if will only
+      // move elements, not swap elements
+      objects.erase(
+          std::remove_if(
+              objects.begin(), objects.end(),
+              [&](const std::pair<
+                  std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                  Mn::Matrix4>& a) {
+                for (std::vector<std::pair<
+                         std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                         Mn::Matrix4>>::iterator iter =
+                         drawableTransforms.begin();
+                     iter != newEndIter; ++iter) {
+                  if (std::addressof(a.first.get()) ==
+                      std::addressof(iter->first.get())) {
+                    return true;  // it is visible, remove it
+                  }
                 }
-              }
-              return false;
-            }),
-        objects.end());
+                return false;
+              }),
+          objects.end());
 
+      target->renderEnter();
+      Mn::GL::SampleQuery q{Mn::GL::SampleQuery::Target::AnySamplesPassed};
+      q.begin();
+      renderCamera.MagnumCamera::draw(objects);
+      q.end();
+      target->renderExit();
+
+      EXPECT_EQ(q.result<bool>(), false);
+    }
+
+    // ============== Test 2 ==================
+    // draw the visibles one by one.
+    // check if each one is a genuine visible drawable
+    unsigned int numVisibleObjectsGroundTruth = 0;
+    auto renderOneDrawable =
+        [&](const std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                            Mn::Matrix4>& a) {
+          std::vector<std::pair<
+              std::reference_wrapper<Mn::SceneGraph::Drawable3D>, Mn::Matrix4>>
+              objects;
+          objects.emplace_back(a);
+
+          target->renderEnter();
+          Mn::GL::SampleQuery q{Mn::GL::SampleQuery::Target::AnySamplesPassed};
+          q.begin();
+          renderCamera.MagnumCamera::draw(objects);
+          q.end();
+          target->renderExit();
+
+          // check if it a genuine visible drawable
+          EXPECT_EQ(q.result<bool>(), true);
+
+          if (q.result<bool>()) {
+            numVisibleObjectsGroundTruth++;
+          }
+        };
+    for_each(drawableTransforms.begin(), newEndIter, renderOneDrawable);
+
+    // ============== Test 3 ==================
+    // draw using the RenderCamera overload draw()
     target->renderEnter();
-    Mn::GL::SampleQuery q{Mn::GL::SampleQuery::Target::AnySamplesPassed};
-    q.begin();
-    renderCamera.MagnumCamera::draw(objects);
-    q.end();
+    size_t numVisibleObjects =
+        renderCamera.draw(drawables, true /* enable frustum culling */);
     target->renderExit();
-
-    EXPECT_EQ(q.result<bool>(), false);
+    EXPECT_EQ(numVisibleObjects, numVisibleObjectsGroundTruth);
   }
-
-  // ============== Test 2 ==================
-  // draw the visibles one by one.
-  // check if each one is a genuine visible drawable
-  unsigned int numVisibleObjectsGroundTruth = 0;
-  auto renderOneDrawable =
-      [&](const std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                          Mn::Matrix4>& a) {
-        std::vector<std::pair<
-            std::reference_wrapper<Mn::SceneGraph::Drawable3D>, Mn::Matrix4>>
-            objects;
-        objects.emplace_back(a);
-
-        target->renderEnter();
-        Mn::GL::SampleQuery q{Mn::GL::SampleQuery::Target::AnySamplesPassed};
-        q.begin();
-        renderCamera.MagnumCamera::draw(objects);
-        q.end();
-        target->renderExit();
-
-        // check if it a genuine visible drawable
-        EXPECT_EQ(q.result<bool>(), true);
-
-        if (q.result<bool>()) {
-          numVisibleObjectsGroundTruth++;
-        }
-      };
-  for_each(drawableTransforms.begin(), newEndIter, renderOneDrawable);
-
-  // ============== Test 3 ==================
-  // draw using the RenderCamera overload draw()
-  target->renderEnter();
-  size_t numVisibleObjects =
-      renderCamera.draw(drawables, true /* enable frustum culling */);
-  target->renderExit();
-  EXPECT_EQ(numVisibleObjects, numVisibleObjectsGroundTruth);
 }

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -45,8 +45,7 @@ class PhysicsManagerTest : public testing::Test {
     auto& sceneGraph = sceneManager_.getSceneGraph(sceneID_);
     esp::scene::SceneNode* navSceneNode =
         &sceneGraph.getRootNode().createChild();
-    auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
-    resourceManager_.loadScene(info, physicsManager_, navSceneNode, &drawables,
+    resourceManager_.loadScene(info, physicsManager_, navSceneNode, &sceneGraph,
                                physicsConfigFile);
   }
 
@@ -171,7 +170,7 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
       physicsManager_->reset();
 
       int objectId = physicsManager_->addObject(
-          objectFile, &sceneManager_.getSceneGraph(sceneID_).getDrawables());
+          objectFile, &sceneManager_.getSceneGraph(sceneID_));
 
       Magnum::Vector3 initialPosition{0.0, 0.25, 0.0};
       physicsManager_->setTranslation(objectId, initialPosition);
@@ -272,19 +271,19 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
     esp::assets::PhysicsObjectAttributes& objectTemplate =
         resourceManager_.getPhysicsObjectAttributes(objectFile);
 
-    auto* drawables = &sceneManager_.getSceneGraph(sceneID_).getDrawables();
+    auto* sceneGraph = &sceneManager_.getSceneGraph(sceneID_);
 
     // add the unjoined object
     objectTemplate.setBool("joinCollisionMeshes", false);
-    int objectId0 = physicsManager_->addObject(objectFile, drawables);
+    int objectId0 = physicsManager_->addObject(objectFile, sceneGraph);
 
     // add the joined object
     objectTemplate.setBool("joinCollisionMeshes", true);
-    int objectId1 = physicsManager_->addObject(objectFile, drawables);
+    int objectId1 = physicsManager_->addObject(objectFile, sceneGraph);
 
     // add bounding box object
     objectTemplate.setBool("useBoundingBoxForCollision", true);
-    int objectId2 = physicsManager_->addObject(objectFile, drawables);
+    int objectId2 = physicsManager_->addObject(objectFile, sceneGraph);
 
     esp::physics::BulletPhysicsManager* bPhysManager =
         static_cast<esp::physics::BulletPhysicsManager*>(physicsManager_.get());
@@ -335,14 +334,14 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
       {0.0, 0.0, 0.0},  {-1.0, -1.0, -1.0}, {-1.0, 1.0, 1.0},
       {4.0, -3.0, 2.0}, {0.1, -0.2, -0.3}};
 
-  auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
+  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID_);
 
   for (auto& testScale : testScales) {
     objectTemplate.setMagnumVec3("scale", testScale);
 
     Magnum::Range3D boundsGroundTruth(-abs(testScale), abs(testScale));
 
-    int objectId = physicsManager_->addObject(objectFile, &drawables);
+    int objectId = physicsManager_->addObject(objectFile, &sceneGraph);
 
     const Magnum::Range3D& visualBounds =
         physicsManager_->getObjectSceneNode(objectId).getCumulativeBB();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -84,7 +84,7 @@ class Viewer : public Magnum::Platform::Application {
 
   gfx::ShaderManager shaderManager_;
 
-  assets::ResourceManager resourceManager_;
+  assets::ResourceManager resourceManager_{shaderManager_};
   // SceneManager must be before physicsManager_ as the physicsManager_
   // assumes that it "owns" things owned by the scene manager
   scene::SceneManager sceneManager_;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -170,7 +170,6 @@ Viewer::Viewer(const Arguments& arguments)
   rootNode_ = &sceneGraph_->getRootNode();
   navSceneNode_ = &rootNode_->createChild();
 
-  auto& drawables = sceneGraph_->getDrawables();
   const std::string& file = args.value("scene");
   const assets::AssetInfo info = assets::AssetInfo::fromPath(file);
 
@@ -182,14 +181,14 @@ Viewer::Viewer(const Arguments& arguments)
           << " was not found, specify an existing file in --physics-config";
     }
     if (!resourceManager_.loadScene(info, physicsManager_, navSceneNode_,
-                                    &drawables, physicsConfigFilename)) {
+                                    sceneGraph_, physicsConfigFilename)) {
       LOG(FATAL) << "cannot load " << file;
     }
     if (args.isSet("debug-bullet")) {
       debugBullet_ = true;
     }
   } else {
-    if (!resourceManager_.loadScene(info, navSceneNode_, &drawables)) {
+    if (!resourceManager_.loadScene(info, navSceneNode_, sceneGraph_)) {
       LOG(FATAL) << "cannot load " << file;
     }
   }
@@ -268,9 +267,7 @@ void Viewer::addObject(std::string configFile) {
           ->MagnumObject::transformationMatrix();  // Relative to agent bodynode
   Vector3 new_pos = T.transformPoint({0.1f, 2.5f, -2.0f});
 
-  auto& drawables = sceneGraph_->getDrawables();
-
-  int physObjectID = physicsManager_->addObject(configFile, &drawables);
+  int physObjectID = physicsManager_->addObject(configFile, sceneGraph_);
   physicsManager_->setTranslation(physObjectID, new_pos);
 
   // draw random quaternion via the method:
@@ -609,8 +606,7 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       // toggle bounding box on objects
       drawObjectBBs = !drawObjectBBs;
       for (auto id : physicsManager_->getExistingObjectIDs()) {
-        physicsManager_->setObjectBBDraw(id, &sceneGraph_->getDrawables(),
-                                         drawObjectBBs);
+        physicsManager_->setObjectBBDraw(id, sceneGraph_, drawObjectBBs);
       }
     } break;
     default:

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -397,11 +397,13 @@ void Viewer::drawEvent() {
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+  uint32_t totalDrawables = 0;
   uint32_t visibles = 0;
 
   for (auto& it : sceneGraph.getDrawableGroups()) {
     // TODO: remove || true
     if (it.second.prepareForDraw(*renderCamera_) || true) {
+      totalDrawables += it.second.size();
       visibles += renderCamera_->draw(it.second, frustumCullingEnabled_);
     }
   }
@@ -422,9 +424,8 @@ void Viewer::drawEvent() {
                      ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(2.0);
     ImGui::Text("%.1f FPS", Double(ImGui::GetIO().Framerate));
-    uint32_t total = sceneGraph.getDrawables().size();
-    ImGui::Text("%u drawables", total);
-    ImGui::Text("%u culled", total - visibles);
+    ImGui::Text("%u drawables", totalDrawables);
+    ImGui::Text("%u culled", totalDrawables - visibles);
     ImGui::End();
   }
 


### PR DESCRIPTION
## Motivation and Context

This PR enables phong shading for physics objects, and at a more general level enables usage of multiple drawable groups and shaders to be used, another step toward #319.

As a **temporary** solution to enable phong shading in master, `ResourceManager` selects drawable group and shader based on

- loadScene (uses flat) vs. loadObject (used for physics object right now - uses phong)

- existence of texture mapping

This logic will be moved out of the bloated `ResourceManager` into a `Scene` or `SceneGraph` class, which will be responsible for building the scene from meshes it retrieves from `ResourceManager` in a later PR. At this point, overriding the shader and drawable group selection by the user will also be enabled.

This PR seems large but is mostly just changing `DrawableGroup` parameter types to `SceneGraph`. This is needed since `Shader` and `DrawableGroup` selection is done based on asset info, which at this point is only known by `ResourceManager` in the mesh loading phase.

This depends on #450.

TODO: upload screenshots of new objects

## How Has This Been Tested

- Tests have been updated to use multiple groups
- Flat, Phong, textured etc. all render correctly and are put in different groups, as verified by the log messages

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
