### PR TITLE
[Culling] optimization: do not erase invisible objects

### DIFF
--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -77,18 +77,22 @@ uint32_t RenderCamera::draw(MagnumDrawableGroup& drawables,
     return drawables.size();
   }
 
-  std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                        Mn::Matrix4>>
-      drawableTransforms = drawableTransformations(drawables);
+  // dt is short for drawable transformations
+  using dt =
+      std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                            Mn::Matrix4>>;
+  dt drawableTransforms = drawableTransformations(drawables);
 
   // draw just the visible part
   size_t numVisibles = cull(drawableTransforms);
-  // erase all items that did not pass the frustum visibility test
-  drawableTransforms.erase(drawableTransforms.begin() + numVisibles,
-                           drawableTransforms.end());
 
-  MagnumCamera::draw(drawableTransforms);
-  return drawableTransforms.size();
+  dt::iterator iter = drawableTransforms.begin();
+  for (size_t iDrawable = 0; iDrawable < numVisibles; ++iDrawable) {
+    iter->first.get().draw(iter->second, *this);
+    iter++;
+  }
+
+  return numVisibles;
 }
 
 }  // namespace gfx


### PR DESCRIPTION
We do not have to strictly conform to the "erase-remove" idiom. After std::remove_if is applied, we simply render the visible objects, which locate at the 1st part of the vector, while ignore the invisible ones, which are in the 2nd part. It can save a little bit for us.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
