### PR TITLE
[esp/scene] fix scn file bounding boxes

### DIFF
--- a/tools/npz2scn.py
+++ b/tools/npz2scn.py
@@ -12,14 +12,10 @@ import numpy as np
 
 
 # Convert ndarrays to python lists so that we can serialize.
-# Transform coordinates by rotating Y-axis to Z-axis
-def fix_coords(entry: Dict[str, Any]) -> None:
-    size = entry["size"].tolist()
-    size[1], size[2] = size[2], size[1]
-    entry["size"] = size
-    loc = entry["location"].tolist()
-    loc[1], loc[2] = -loc[2], loc[1]
-    entry["location"] = loc
+def listify(entry: Dict[str, Any]) -> None:
+    for key in entry.keys():
+        if type(entry[key]) is np.ndarray:
+            entry[key] = entry[key].tolist()
 
 
 def main():
@@ -34,10 +30,10 @@ def main():
     data = np.load(args.npz_path, allow_pickle=True)["output"].item()
     objs = data["object"]
     for obj in objs.values():
-        fix_coords(obj)
+        listify(obj)
     rooms = data["room"]
     for room in rooms.values():
-        fix_coords(room)
+        listify(room)
     output = dict()
     output["objects"] = list(objs.values())
     output["rooms"] = list(rooms.values())


### PR DESCRIPTION
I was assuming that the bounding boxes from 3DSceneGraph were using
the same -y gravity coordinate system that was used by the Gibson
dataset .obj files but it appears that the bounding boxes are with
a -z gravity coordinate system.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Fix bounding boxes in .scn files.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified bounding boxes using WebGL application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
