### PR TITLE
Sort object template library directory by filename during load

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -350,7 +350,9 @@ PhysicsManagerAttributes ResourceManager::loadPhysicsConfig(
           if (Cr::Utility::Directory::isDirectory(absolutePath)) {
             LOG(INFO) << "Parsing object library directory: " + absolutePath;
             if (Cr::Utility::Directory::exists(absolutePath)) {
-              for (auto& file : Cr::Utility::Directory::list(absolutePath)) {
+              for (auto& file : Cr::Utility::Directory::list(
+                       absolutePath,
+                       Corrade::Utility::Directory::Flag::SortAscending)) {
                 std::string absoluteSubfilePath =
                     Cr::Utility::Directory::join(absolutePath, file);
                 if (Cr::Utility::String::endsWith(absoluteSubfilePath,


### PR DESCRIPTION
## Motivation and Context

Currently, when physics object configuration templates are loaded from a directory, they are not sorted by name before insertion. This results in datasets with clear ordering (e.g. numbered YCB objects) being loaded un-intuitively out of order. This change sortd configs by filename.

## How Has This Been Tested

Local testing loading YCB dataset.

Before:
<img width="349" alt="Screen Shot 2020-02-07 at 7 48 06 AM" src="https://user-images.githubusercontent.com/1445143/74043868-fc8c9500-497e-11ea-856b-7dd2c4f46d9f.png">
__
After:
<img width="341" alt="Screen Shot 2020-02-07 at 7 47 38 AM" src="https://user-images.githubusercontent.com/1445143/74043889-03b3a300-497f-11ea-9c91-058e224cbdf5.png">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
