### PR TITLE
[Culling][Optimization] Fustum culling with temporal coherence

### DIFF
--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -23,7 +23,7 @@ struct CullingResult {
 };
 
 /**
- * @brief do frustum culling with temporal coherency
+ * @brief do frustum culling with temporal coherence
  * @param range, the axis-aligned bounding box
  * @param frustum, the frustum
  * @param frustumPlaneIndex, the frustum plane in last frame that culled the

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -22,6 +22,8 @@ namespace gfx {
  * @param frustum, the frustum
  * @param frustumPlaneIndex, the frustum plane in last frame that culled the
  * aabb (default: 0)
+ * @return NullOpt if aabb intersects the frustum, otherwise the fustum plane
+ * index that culls the aabb,
  */
 Cr::Containers::Optional<int> rangeFrustum(const Mn::Range3D& range,
                                            const Mn::Frustum& frustum,

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -23,7 +23,7 @@ namespace gfx {
  * @param frustumPlaneIndex, the frustum plane in last frame that culled the
  * aabb (default: 0)
  * @return NullOpt if aabb intersects the frustum, otherwise the fustum plane
- * index that culls the aabb,
+ * that culls the aabb
  */
 Cr::Containers::Optional<int> rangeFrustum(const Mn::Range3D& range,
                                            const Mn::Frustum& frustum,

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -11,16 +11,10 @@
 #include <Magnum/SceneGraph/Drawable.h>
 
 namespace Mn = Magnum;
+namespace Cr = Corrade;
 
 namespace esp {
 namespace gfx {
-
-struct CullingResult {
-  // the culling result
-  bool intersected = true;
-  // the frustum plane that culled the object
-  int frustumPlaneIndex = 0;
-};
 
 /**
  * @brief do frustum culling with temporal coherence
@@ -29,9 +23,9 @@ struct CullingResult {
  * @param frustumPlaneIndex, the frustum plane in last frame that culled the
  * aabb (default: 0)
  */
-CullingResult rangeFrustum(const Mn::Range3D& range,
-                           const Mn::Frustum& frustum,
-                           int frustumPlaneIndex = 0) {
+Cr::Containers::Optional<int> rangeFrustum(const Mn::Range3D& range,
+                                           const Mn::Frustum& frustum,
+                                           int frustumPlaneIndex = 0) {
   const Mn::Vector3 center = range.min() + range.max();
   const Mn::Vector3 extent = range.max() - range.min();
 
@@ -44,10 +38,10 @@ CullingResult rangeFrustum(const Mn::Range3D& range,
     const float d = Mn::Math::dot(center, plane.xyz());
     const float r = Mn::Math::dot(extent, absPlaneNormal);
     if (d + r < -2.0 * plane.w())
-      return CullingResult{false, index};
+      return Cr::Containers::Optional<int>{index};
   }
 
-  return CullingResult{true, 0};
+  return Cr::Containers::NullOpt;
 }
 
 RenderCamera::RenderCamera(scene::SceneNode& node) : MagnumCamera{node} {
@@ -95,12 +89,13 @@ size_t RenderCamera::cull(
             node.getAbsoluteAABB();
         if (aabb) {
           // if it has an absolute aabb, it is a static mesh
-          CullingResult result =
+          Cr::Containers::Optional<int> culledPlane =
               rangeFrustum(*aabb, frustum, node.getFrustumPlaneIndex());
-          if (result.intersected == false) {
-            node.setFrustumPlaneIndex(result.frustumPlaneIndex);
+          if (culledPlane) {
+            node.setFrustumPlaneIndex(*culledPlane);
           }
-          return !result.intersected;
+          // if it has value, it means the aabb is culled
+          return (culledPlane != Cr::Containers::NullOpt);
         } else {
           // keep the drawable if its node does not have an absolute AABB
           return false;

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -84,6 +84,12 @@ class SceneNode : public MagnumObject {
   //! set the global bounding box for mesh stored in this node
   void setAbsoluteAABB(Magnum::Range3D aabb) { aabb_ = aabb; };
 
+  //! return the frustum plane in last frame that culls this node
+  int getFrustumPlaneIndex() { return frustumPlaneIndex; };
+
+  //! set frustum plane in last frame that culls this node
+  void setFrustumPlaneIndex(int index) { frustumPlaneIndex = index; };
+
  protected:
   // DO not make the following constructor public!
   // it can ONLY be called from SceneGraph class to initialize the scene graph
@@ -108,6 +114,9 @@ class SceneNode : public MagnumObject {
   //  -) it was computed using mesh vertex positions in world space;
   Corrade::Containers::Optional<Magnum::Range3D> aabb_ =
       Corrade::Containers::NullOpt;
+
+  //! the frustum plane in last frame that culls this node
+  int frustumPlaneIndex = 0;
 };
 
 }  // namespace scene


### PR DESCRIPTION
Let the simulator memorize the frustum plane index, which culls the object in the last frame.
In the current frame, it is likely the object will be rejected again by this plane. Thus, start the culling from this plane first.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
