### PR TITLE
Extend bindings for OBB and misc fixes.

### DIFF
--- a/habitat_sim/geo.py
+++ b/habitat_sim/geo.py
@@ -10,6 +10,17 @@ from habitat_sim._ext.habitat_sim_bindings.geo import (
     LEFT,
     RIGHT,
     UP,
+    compute_gravity_aligned_MOBB,
 )
 
-__all__ = ["BBox", "OBB", "UP", "GRAVITY", "FRONT", "BACK", "LEFT", "RIGHT"]
+__all__ = [
+    "BBox",
+    "OBB",
+    "UP",
+    "GRAVITY",
+    "FRONT",
+    "BACK",
+    "LEFT",
+    "RIGHT",
+    "compute_gravity_aligned_MOBB",
+]

--- a/src/esp/bindings/geoBindings.cpp
+++ b/src/esp/bindings/geoBindings.cpp
@@ -24,11 +24,24 @@ void initGeoBindings(py::module& m) {
 
   // ==== OBB ====
   py::class_<OBB>(m, "OBB")
+      .def(py::init<box3f&>())
+      .def("contains", &OBB::contains)
+      .def("closest_point", &OBB::closestPoint)
+      .def("distance", &OBB::distance)
+      .def("to_aabb", &OBB::toAABB)
       .def_property_readonly("center", &OBB::center)
       .def_property_readonly("sizes", &OBB::sizes)
       .def_property_readonly("half_extents", &OBB::halfExtents)
       .def_property_readonly(
-          "rotation", [](const OBB& self) { return self.rotation().coeffs(); });
+          "rotation", [](const OBB& self) { return self.rotation().coeffs(); })
+      .def_property_readonly(
+          "local_to_world",
+          [](const OBB& self) { return self.localToWorld().matrix(); })
+      .def_property_readonly("world_to_local", [](const OBB& self) {
+        return self.worldToLocal().matrix();
+      });
+
+  geo.def("compute_gravity_aligned_MOBB", &geo::computeGravityAlignedMOBB);
 }
 
 }  // namespace geo

--- a/src/esp/geo/OBB.cpp
+++ b/src/esp/geo/OBB.cpp
@@ -107,7 +107,7 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
     const float dd = d0[0] * d1[1] - d0[1] * d1[0];
 
     const float dx = s1[0] - s0[0];
-    const float dy = s1[1] - s0[0];
+    const float dy = s1[1] - s0[1];
     const float t = (dx * d1[1] - dy * d1[0]) / dd;
 
     return s0 + t * d0;
@@ -240,7 +240,7 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
     aabb.extend(T_w2b * pt);
   }
 
-  return OBB{aabb.center(), aabb.sizes(), T_w2b.inverse()};
+  return OBB{T_w2b.inverse() * aabb.center(), aabb.sizes(), T_w2b.inverse()};
 }
 
 }  // namespace geo

--- a/src/esp/geo/geo.cpp
+++ b/src/esp/geo/geo.cpp
@@ -39,13 +39,12 @@ std::vector<vec2f> convexHull2D(const std::vector<vec2f>& points) {
   }
 
   // Build upper hull
-  for (size_t i = idx.size() - 2, t = k + 1; i >= 0; i--) {
+  for (size_t i = idx.size() - 1, t = k + 1; i > 0; i--) {
     while (k >= t && cross(points[hullIdx[k - 2]], points[hullIdx[k - 1]],
-                           points[idx[i]]) <= 0) {
+                           points[idx[i - 1]]) <= 0) {
       k--;
     }
-
-    hullIdx[k++] = idx[i];
+    hullIdx[k++] = idx[i - 1];
   }
 
   hullIdx.resize(k - 1);

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -854,7 +854,7 @@ static float frand() {
 
 vec3f PathFinder::Impl::getRandomNavigablePoint() {
   dtPolyRef ref;
-  float inf = std::numeric_limits<float>::infinity();
+  constexpr float inf = std::numeric_limits<float>::infinity();
   vec3f pt(inf, inf, inf);
   dtStatus status =
       navQuery_->findRandomPoint(filter_.get(), frand, &ref, pt.data());

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -854,7 +854,8 @@ static float frand() {
 
 vec3f PathFinder::Impl::getRandomNavigablePoint() {
   dtPolyRef ref;
-  vec3f pt;
+  float inf = std::numeric_limits<float>::infinity();
+  vec3f pt(inf, inf, inf);
   dtStatus status =
       navQuery_->findRandomPoint(filter_.get(), frand, &ref, pt.data());
   if (!dtStatusSucceed(status)) {


### PR DESCRIPTION
## Motivation and Context

Added some functionality needed for properly using OBBs in the Habitat-API. 
1). Add new python bindings to OBB
2). Fix bugs computeMOBB and expose to python.
3). Have sampleNavigablePoint return a point that will always not be navigable if it fails. That ensure that we get a proper error state that we can check against pt(inf,inf,inf).
## How Has This Been Tested

It has been tested by being used for generating the ObjectNav datasets in the Habitat-API.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
