### PR TITLE
Fix semantic region index logic

### DIFF
--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -74,7 +74,8 @@ std::string Mp3dObjectCategory::name(const std::string& mapping) const {
 }
 
 int Mp3dRegionCategory::index(const std::string& mapping) const {
-  return labelCode_ - 'a';
+  return std::distance(kRegionCategoryMap.begin(),
+                       kRegionCategoryMap.find(labelCode_));
 }
 
 std::string Mp3dRegionCategory::name(const std::string& mapping) const {

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -40,7 +40,8 @@ TEST(Mp3dTest, Load) {
     LOG(INFO) << "Level{id:" << level->id() << ",aabb:" << level->aabb() << "}";
     for (auto& region : level->regions()) {
       LOG(INFO) << "Region{id:" << region->id() << ",aabb:" << region->aabb()
-                << ",category:" << region->category()->name() << "}";
+                << ",category:" << region->category()->name()
+                << ",index:" << region->category()->index() << "}";
       for (auto& object : region->objects()) {
         LOG(INFO) << "Object{id:" << object->id() << ",obb:" << object->obb()
                   << ",category:" << object->category()->name() << "}";


### PR DESCRIPTION
## Motivation and Context

The semantic region index logic isn't correct currently.  Doesn't deal with the capital letters or the gap in the label codes.  This PR uses the ordering in the `std::map` to get indexes to each label code.


## How Has This Been Tested

Locally -- category indexes now look fine!

 Bug fix (non-breaking change which fixes an issue)