### PR TITLE
python bindings for SceneNode bounding boxes

### DIFF
--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -79,13 +79,12 @@ void initSceneBindings(py::module& m) {
           "compute_cumulative_bb",
           [](SceneNode& self) { self.computeCumulativeBB(); },
           R"(Recursively compute the approximate axis aligned bounding boxes of the SceneGraph sub-tree rooted at this node.)")
-      .def(
-          "get_cumulative_bb",
-          [](SceneNode& self) { return self.getCumulativeBB(); },
-          R"(Get the approximate axis aligned bounding box of the SceneGraph sub-tree rooted at this node.)")
-      .def(
-          "get_mesh_bb", [](SceneNode& self) { return self.getMeshBB(); },
-          R"(Get the axis aligned bounding box of the mesh drawables attached to this node.)")
+      .def_property_readonly(
+          "cumulative_bb", &SceneNode::getCumulativeBB,
+          R"(The approximate axis aligned bounding box of the SceneGraph sub-tree rooted at this node.)")
+      .def_property_readonly(
+          "mesh_bb", &SceneNode::getMeshBB,
+          R"(The axis aligned bounding box of the mesh drawables attached to this node.)")
       .def_property_readonly("absolute_translation",
                              &SceneNode::absoluteTranslation);
 

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -75,6 +75,17 @@ void initSceneBindings(py::module& m) {
       .def(
           "create_child", [](SceneNode& self) { return &self.createChild(); },
           R"(Creates a child node, and sets its parent to the current node.)")
+      .def(
+          "compute_cumulative_bb",
+          [](SceneNode& self) { self.computeCumulativeBB(); },
+          R"(Recursively compute the approximate axis aligned bounding boxes of the SceneGraph sub-tree rooted at this node.)")
+      .def(
+          "get_cumulative_bb",
+          [](SceneNode& self) { return self.getCumulativeBB(); },
+          R"(Get the approximate axis aligned bounding box of the SceneGraph sub-tree rooted at this node.)")
+      .def(
+          "get_mesh_bb", [](SceneNode& self) { return self.getMeshBB(); },
+          R"(Get the axis aligned bounding box of the mesh drawables attached to this node.)")
       .def_property_readonly("absolute_translation",
                              &SceneNode::absoluteTranslation);
 

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -76,8 +76,7 @@ void initSceneBindings(py::module& m) {
           "create_child", [](SceneNode& self) { return &self.createChild(); },
           R"(Creates a child node, and sets its parent to the current node.)")
       .def(
-          "compute_cumulative_bb",
-          [](SceneNode& self) { self.computeCumulativeBB(); },
+          "compute_cumulative_bb", &SceneNode::computeCumulativeBB,
           R"(Recursively compute the approximate axis aligned bounding boxes of the SceneGraph sub-tree rooted at this node.)")
       .def_property_readonly(
           "cumulative_bb", &SceneNode::getCumulativeBB,

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -118,7 +118,7 @@ def test_scene_bounding_boxes(sim):
     scene_graph = sim._sim.get_active_scene_graph()
     root_node = scene_graph.get_root_node()
     root_node.compute_cumulative_bb()
-    scene_bb = root_node.get_cumulative_bb()
+    scene_bb = root_node.cumulative_bb
     ground_truth = mn.Range3D.from_size(
         mn.Vector3(-0.775869, -0.0233012, -1.6706), mn.Vector3(6.76937, 3.86304, 3.5359)
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import random
 
+import magnum as mn
 import numpy as np
 import pytest
 
@@ -107,3 +108,18 @@ def test_subproc_fns(test_fn):
     p.join()
 
     assert p.exitcode == 0
+
+
+def test_scene_bounding_boxes(sim):
+    cfg_settings = examples.settings.default_sim_settings.copy()
+    cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim.reconfigure(hab_cfg)
+    scene_graph = sim._sim.get_active_scene_graph()
+    root_node = scene_graph.get_root_node()
+    root_node.compute_cumulative_bb()
+    scene_bb = root_node.get_cumulative_bb()
+    ground_truth = mn.Range3D.from_size(
+        mn.Vector3(-0.775869, -0.0233012, -1.6706), mn.Vector3(6.76937, 3.86304, 3.5359)
+    )
+    assert ground_truth == scene_bb


### PR DESCRIPTION
## Motivation and Context

For domain randomization, it is often useful to sample a 3D position from inside a scene. This PR enables users to compute/query the approximate scene bounding box from the SceneGraph root node (or any other SceneNode of interest).

## How Has This Been Tested

added python test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
