### PR TITLE
[optimization] compute AABB from OBB

### DIFF
--- a/src/esp/geo/geo.h
+++ b/src/esp/geo/geo.h
@@ -29,7 +29,7 @@ typedef Eigen::Transform<float, 3, Eigen::Affine, Eigen::DontAlign> Transform;
 std::vector<vec2f> convexHull2D(const std::vector<vec2f>& points);
 
 Magnum::Range3D getTransformedBB(const Magnum::Range3D& range,
-                                 const Magnum::Matrix4& T);
+                                 const Magnum::Matrix4& xform);
 
 template <typename T>
 T clamp(const T& n, const T& low, const T& high) {


### PR DESCRIPTION
For algorithm details, see my comments before the function in cpp file.

**Old** method:
do 8 matrix4x4-vertex multiplications and 8 vector min+max operations

**New** method:
convert aabb from (min, max) to (center, extent), create a matrix3x3, do 1 matrix4x4-vector
multiplication, 1 matrix3x3-vector multiplication, and convert (center,
    extent) to (min, max), which should be faster.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
