### PR TITLE
[bug fix] - PhysicsTest did not include PhysicsManager when built without bullet

### DIFF
--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -12,6 +12,7 @@
 #include "esp/gfx/Renderer.h"
 #include "esp/scene/SceneManager.h"
 
+#include "esp/physics/PhysicsManager.h"
 #ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/BulletPhysicsManager.h"
 #endif


### PR DESCRIPTION
## Motivation and Context

Build without `--bullet` was not including `PhysicsManager`. in PhysicsTest.cpp.

## How Has This Been Tested

Existing tests run with `./build.sh --run-tests`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
