### PR TITLE
[WIP] Shadows proof of concept

### DIFF
--- a/data/test_assets/objects/nested_box.phys_properties.json
+++ b/data/test_assets/objects/nested_box.phys_properties.json
@@ -1,4 +1,5 @@
 {
     "render mesh": "nested_box.glb",
-    "join collision meshes": true
+    "join collision meshes": true,
+    "use bounding box for collision": true
 }

--- a/data/test_assets/objects/nested_box.phys_properties.json
+++ b/data/test_assets/objects/nested_box.phys_properties.json
@@ -1,5 +1,4 @@
 {
     "render mesh": "nested_box.glb",
-    "join collision meshes": true,
-    "use bounding box for collision": true
+    "join collision meshes": true
 }

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -413,7 +413,8 @@ class ResourceManager {
                     scene::SceneNode& parent,
                     const Magnum::ResourceKey& lightSetup,
                     DrawableGroup* drawables,
-                    const MeshTransformNode& meshTransformNode);
+                    const MeshTransformNode& meshTransformNode,
+                    bool castsShadow = false);
 
   /**
    * @brief Load textures from importer into assets, and update metaData for an
@@ -759,7 +760,8 @@ class ResourceManager {
                           DrawableGroup* drawables,
                           int objectID,
                           int meshIDLocal,
-                          int materialIDLocal);
+                          int materialIDLocal,
+                          bool castsShadow);
 
   /**
    * @brief Create a @ref gfx::Drawable for the specified mesh, node,
@@ -789,7 +791,8 @@ class ResourceManager {
                              const Magnum::ResourceKey& lightSetup,
                              const Magnum::ResourceKey& material,
                              DrawableGroup* group = nullptr,
-                             int objectId = ID_UNDEFINED);
+                             int objectId = ID_UNDEFINED,
+                             bool castsShadow = false);
 
   /**
    * @brief Flag to denote the desire to compress textures. TODO: unused?

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -24,6 +24,14 @@ set(gfx_SOURCES
   RenderTarget.h
   ShaderManager.cpp
   ShaderManager.h
+  shadows/ShadowLight.cpp
+  shadows/ShadowLight.h
+  shadows/ShadowCasterDrawable.cpp
+  shadows/ShadowCasterDrawable.h
+  shadows/ShadowCasterShader.cpp
+  shadows/ShadowCasterShader.h
+  shadows/PhongShadowReceiverShader.cpp
+  shadows/PhongShadowReceiverShader.h
 )
 
 # If ptex support is enabled add relevant source files

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -7,6 +7,7 @@
 #include <Magnum/SceneGraph/FeatureGroup.h>
 
 #include "esp/core/esp.h"
+#include "esp/gfx/RenderCamera.h"
 
 namespace esp {
 namespace gfx {
@@ -16,7 +17,7 @@ class RenderCamera;
 /**
  * @brief Group of drawables, and shared group parameters.
  */
-class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
+class DrawableGroup : public MagnumDrawableGroup {
  public:
   virtual ~DrawableGroup(){};
 
@@ -26,6 +27,14 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
    * @return Whether the @ref DrawableGroup is in a valid state to be drawn
    */
   virtual bool prepareForDraw(const RenderCamera&) { return true; }
+
+  // TODO: this should be overridden and used to compute absolute transforms of
+  // shadow receivers and transformations relative to the camera in one step
+  virtual std::vector<
+      std::pair<std::reference_wrapper<MagnumDrawable>, Magnum::Matrix4>>
+  getDrawableTransforms(RenderCamera& camera) {
+    return camera.drawableTransformations(*this);
+  }
 
   ESP_SMART_POINTERS(DrawableGroup)
 };

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -11,19 +11,30 @@
 namespace esp {
 namespace gfx {
 
-GenericDrawable::GenericDrawable(scene::SceneNode& node,
-                                 Magnum::GL::Mesh& mesh,
-                                 ShaderManager& shaderManager,
-                                 const Magnum::ResourceKey& lightSetup,
-                                 const Magnum::ResourceKey& materialData,
-                                 DrawableGroup* group /* = nullptr */,
-                                 int objectId /* = ID_UNDEFINED */)
+GenericDrawable::GenericDrawable(
+    scene::SceneNode& node,
+    Magnum::GL::Mesh& mesh,
+    ShaderManager& shaderManager,
+    const Magnum::ResourceKey& lightSetup,
+    const Magnum::ResourceKey& materialData,
+    DrawableGroup* group /* = nullptr */,
+    int objectId /* = ID_UNDEFINED */,
+    scene::SceneGraph::ShadowMapRegistry* shadowMapRegistry,
+    bool shadeFacesFacingAwayFromLight)
     : Drawable{node, mesh, group},
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetup)},
       materialData_{
           shaderManager.get<MaterialData, PhongMaterialData>(materialData)},
-      objectId_(objectId) {
+      objectId_(objectId),
+      receivesShadow_{shadowMapRegistry != nullptr},
+      shadowMapRegistry_{shadowMapRegistry},
+      shadeFacesFacingAwayFromLight_{shadeFacesFacingAwayFromLight} {
+  if (receivesShadow_) {
+    lightSetupShadowMaps_ =
+        shadowMapRegistry_->get<scene::SceneGraph::LightSetupShadowMaps>(
+            lightSetup);
+  }
   // update the shader early here to to avoid doing it during the render loop
   updateShader();
 }
@@ -72,33 +83,63 @@ void GenericDrawable::draw(const Magnum::Matrix4& transformationMatrix,
   if (materialData_->specularTexture)
     shader_->bindSpecularTexture(*(materialData_->specularTexture));
 
+  if (receivesShadow_ && lightSetupShadowMaps_) {
+    // TODO: support more than 1 shadow light
+    ShadowLight* shadowLight = (*lightSetupShadowMaps_)[0];
+
+    Corrade::Containers::Array<Magnum::Matrix4> shadowMatrices{
+        Corrade::Containers::NoInit, shadowLight->layerCount()};
+    for (std::size_t layerIndex = 0; layerIndex != shadowLight->layerCount();
+         ++layerIndex) {
+      shadowMatrices[layerIndex] = shadowLight->layerMatrix(layerIndex);
+    }
+
+    (*shader_)
+        // TODO: used cached model matrix computed at same time as
+        // transformationMatrix
+        .setModelMatrix(object().absoluteTransformationMatrix())
+        .setShadowmapMatrices(shadowMatrices)
+        .setShadowmapTexture(shadowLight->shadowTexture())
+        .setShadeFacesFacingAwayFromLight(shadeFacesFacingAwayFromLight_)
+        .setShadowLightDirection(shadowLight->getLightDirection())
+        // TODO: make this dynamic
+        .setShadowBias(0.0008f);
+  }
+
   mesh_.draw(*shader_);
 }
 
 void GenericDrawable::updateShader() {
   Magnum::UnsignedInt lightCount = lightSetup_->size();
-  Magnum::Shaders::Phong::Flags flags = Magnum::Shaders::Phong::Flag::ObjectId;
+  PhongShadowReceiverShader::Flags flags =
+      PhongShadowReceiverShader::Flag::ObjectId;
+  Magnum::UnsignedInt layerCount = 0;
+  if (lightSetupShadowMaps_) {
+    layerCount = static_cast<Magnum::UnsignedInt>(
+        (*lightSetupShadowMaps_)[0]->layerCount());
+  }
 
   if (materialData_->ambientTexture)
-    flags |= Magnum::Shaders::Phong::Flag::AmbientTexture;
+    flags |= PhongShadowReceiverShader::Flag::AmbientTexture;
   if (materialData_->diffuseTexture)
-    flags |= Magnum::Shaders::Phong::Flag::DiffuseTexture;
+    flags |= PhongShadowReceiverShader::Flag::DiffuseTexture;
   if (materialData_->specularTexture)
-    flags |= Magnum::Shaders::Phong::Flag::SpecularTexture;
+    flags |= PhongShadowReceiverShader::Flag::SpecularTexture;
 
   if (!shader_ || shader_->lightCount() != lightCount ||
-      shader_->flags() != flags) {
+      shader_->flags() != flags || shader_->getNumLayers() != layerCount) {
     // if the number of lights or flags have changed, we need to fetch a
     // compatible shader
     shader_ =
         shaderManager_
-            .get<Magnum::GL::AbstractShaderProgram, Magnum::Shaders::Phong>(
-                getShaderKey(lightCount, flags));
+            .get<Magnum::GL::AbstractShaderProgram, PhongShadowReceiverShader>(
+                getShaderKey(lightCount, flags, layerCount));
 
     // if no shader with desired number of lights and flags exists, create one
     if (!shader_) {
       shaderManager_.set<Magnum::GL::AbstractShaderProgram>(
-          shader_.key(), new Magnum::Shaders::Phong{flags, lightCount},
+          shader_.key(),
+          new PhongShadowReceiverShader{flags, lightCount, layerCount},
           Magnum::ResourceDataState::Final,
           Magnum::ResourcePolicy::ReferenceCounted);
     }
@@ -107,10 +148,12 @@ void GenericDrawable::updateShader() {
 
 Magnum::ResourceKey GenericDrawable::getShaderKey(
     Magnum::UnsignedInt lightCount,
-    Magnum::Shaders::Phong::Flags flags) const {
+    PhongShadowReceiverShader::Flags flags,
+    Magnum::UnsignedInt layerCount) const {
   return Corrade::Utility::formatString(
       SHADER_KEY_TEMPLATE, lightCount,
-      static_cast<Magnum::Shaders::Phong::Flags::UnderlyingType>(flags));
+      static_cast<PhongShadowReceiverShader::Flags::UnderlyingType>(flags),
+      layerCount);
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <Magnum/Shaders/Phong.h>
-
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/ShaderManager.h"
+#include "esp/gfx/shadows/PhongShadowReceiverShader.h"
 
 namespace esp {
 namespace gfx {
@@ -17,17 +16,21 @@ class GenericDrawable : public Drawable {
   //! Create a GenericDrawable for the given object using shader and mesh.
   //! Adds drawable to given group and uses provided texture, objectId, and
   //! color for textured, object id buffer and color shader output respectively
-  explicit GenericDrawable(scene::SceneNode& node,
-                           Magnum::GL::Mesh& mesh,
-                           ShaderManager& shaderManager,
-                           const Magnum::ResourceKey& lightSetup,
-                           const Magnum::ResourceKey& materialData,
-                           DrawableGroup* group = nullptr,
-                           int objectId = ID_UNDEFINED);
+  explicit GenericDrawable(
+      scene::SceneNode& node,
+      Magnum::GL::Mesh& mesh,
+      ShaderManager& shaderManager,
+      const Magnum::ResourceKey& lightSetup,
+      const Magnum::ResourceKey& materialData,
+      DrawableGroup* group = nullptr,
+      int objectId = ID_UNDEFINED,
+      scene::SceneGraph::ShadowMapRegistry* shadowMapRegistry = nullptr,
+      bool shadeFacesFacingAwayFromLight = false);
 
   void setLightSetup(const Magnum::ResourceKey& lightSetup) override;
 
-  static constexpr const char* SHADER_KEY_TEMPLATE = "Phong-lights={}-flags={}";
+  static constexpr const char* SHADER_KEY_TEMPLATE =
+      "Phong-lights={}-flags={}-layers={}";
 
  protected:
   virtual void draw(const Magnum::Matrix4& transformationMatrix,
@@ -36,7 +39,8 @@ class GenericDrawable : public Drawable {
   void updateShader();
 
   Magnum::ResourceKey getShaderKey(Magnum::UnsignedInt lightCount,
-                                   Magnum::Shaders::Phong::Flags flags) const;
+                                   PhongShadowReceiverShader::Flags flags,
+                                   Magnum::UnsignedInt layerCount) const;
 
   Magnum::GL::Texture2D* texture_;
   int objectId_;
@@ -44,10 +48,15 @@ class GenericDrawable : public Drawable {
 
   // shader parameters
   ShaderManager& shaderManager_;
-  Magnum::Resource<Magnum::GL::AbstractShaderProgram, Magnum::Shaders::Phong>
+  Magnum::Resource<Magnum::GL::AbstractShaderProgram, PhongShadowReceiverShader>
       shader_;
   Magnum::Resource<MaterialData, PhongMaterialData> materialData_;
   Magnum::Resource<LightSetup> lightSetup_;
+  Magnum::Resource<scene::SceneGraph::LightSetupShadowMaps>
+      lightSetupShadowMaps_;
+  scene::SceneGraph::ShadowMapRegistry* shadowMapRegistry_ = nullptr;
+  bool receivesShadow_;
+  bool shadeFacesFacingAwayFromLight_;
 };
 
 }  // namespace gfx

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -26,8 +26,13 @@ enum class LightPositionModel {
 /** @brief Contains a single light's information */
 struct LightInfo {
   Magnum::Vector3 position;
-  Magnum::Color4 color;
+  Magnum::Color4 color = Magnum::Color4{1};
   LightPositionModel model = LightPositionModel::GLOBAL;
+  // TODO: actually use these
+  /* @brief If this light casts shadows */
+  bool castsShadow = false;
+  /* @brief If the shadows casted by this light are constant */
+  bool staticShadows = false;
 };
 
 bool operator==(const LightInfo& a, const LightInfo& b);

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -10,6 +10,8 @@
 #include <Magnum/Math/Range.h>
 #include <Magnum/SceneGraph/Drawable.h>
 
+#include "esp/gfx/DrawableGroup.h"
+
 namespace Mn = Magnum;
 namespace Cr = Corrade;
 
@@ -107,16 +109,20 @@ size_t RenderCamera::cull(
   return (newEndIter - drawableTransforms.begin());
 }
 
-uint32_t RenderCamera::draw(MagnumDrawableGroup& drawables,
-                            bool frustumCulling) {
-  if (!frustumCulling) {
-    MagnumCamera::draw(drawables);
-    return drawables.size();
-  }
+uint32_t RenderCamera::draw(DrawableGroup& drawables, bool frustumCulling) {
+  auto transforms = drawables.getDrawableTransforms(*this);
+  return draw(transforms, frustumCulling);
+}
 
-  std::vector<std::pair<std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
-                        Mn::Matrix4>>
-      drawableTransforms = drawableTransformations(drawables);
+uint32_t RenderCamera::draw(
+    std::vector<
+        std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>,
+                  Magnum::Matrix4>>& drawableTransforms,
+    bool frustumCulling) {
+  if (!frustumCulling) {
+    MagnumCamera::draw(drawableTransforms);
+    return drawableTransforms.size();
+  }
 
   // draw just the visible part
   size_t numVisibles = cull(drawableTransforms);

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -12,6 +12,8 @@
 namespace esp {
 namespace gfx {
 
+class DrawableGroup;
+
 class RenderCamera : public MagnumCamera {
  public:
   RenderCamera(scene::SceneNode& node);
@@ -47,7 +49,15 @@ class RenderCamera : public MagnumCamera {
    * @param frustumCulling, whether do frustum culling or not, default: false
    * @return the number of drawables that are drawn
    */
-  uint32_t draw(MagnumDrawableGroup& drawables, bool frustumCulling = false);
+  uint32_t draw(DrawableGroup& drawables, bool frustumCulling = false);
+
+  /** @brief Overload */
+  uint32_t draw(
+      std::vector<
+          std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>,
+                    Magnum::Matrix4>>& drawableTransforms,
+      bool frustumCulling = false);
+
   /**
    * @brief performs the frustum culling
    * @param drawableTransforms, a vector of pairs of Drawable3D object and its

--- a/src/esp/gfx/shadows/PhongShadowReceiverShader.cpp
+++ b/src/esp/gfx/shadows/PhongShadowReceiverShader.cpp
@@ -1,0 +1,397 @@
+/*
+    Originally written by Vladimir Vondrus as part of the Magnum Library
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+*/
+
+#include "PhongShadowReceiverShader.h"
+
+#include <Corrade/Containers/Reference.h>
+#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Resource.h>
+#include <Corrade/Containers/EnumSet.hpp>
+
+#include "Magnum/GL/Context.h"
+#include "Magnum/GL/Extensions.h"
+#include "Magnum/GL/Shader.h"
+#include "Magnum/GL/Texture.h"
+#include "Magnum/GL/TextureArray.h"
+#include "Magnum/Math/Color.h"
+#include "Magnum/Math/Matrix4.h"
+
+// This is to import the "resources" at runtime.
+// When the resource is compiled into static library,
+// it must be explicitly initialized via this macro, and should be called
+// *outside* of any namespace.
+static void importShaderResources() {
+  CORRADE_RESOURCE_INITIALIZE(ShaderResources)
+}
+
+namespace esp {
+namespace gfx {
+
+namespace Mn = Magnum;
+namespace Cr = Corrade;
+
+namespace {
+enum : Magnum::Int {
+  AmbientTextureLayer = 0,
+  DiffuseTextureLayer = 1,
+  SpecularTextureLayer = 2,
+  NormalTextureLayer = 3,
+  ShadowmapTextureLayer = 4,
+};
+}
+
+PhongShadowReceiverShader::PhongShadowReceiverShader(
+    const Flags flags,
+    const Magnum::UnsignedInt lightCount,
+    const Magnum::UnsignedInt numShadowMapLayers)
+    : _flags{flags},
+      _lightCount{lightCount},
+      numShadowMapLayers_{numShadowMapLayers} {
+#ifndef MAGNUM_TARGET_WEBGL
+  MAGNUM_ASSERT_GL_VERSION_SUPPORTED(Magnum::GL::Version::GL410);
+#endif
+  /* Import resources on static build, if not already */
+  if (!Cr::Utility::Resource::hasGroup("default-shaders"))
+    importShaderResources();
+  Cr::Utility::Resource rs("default-shaders");
+
+#ifdef MAGNUM_TARGET_WEBGL
+  Magnum::GL::Version version = Magnum::GL::Version::GLES300;
+#else
+  Magnum::GL::Version version = Magnum::GL::Version::GL410;
+#endif
+
+  Mn::GL::Shader vert{version, Mn::GL::Shader::Type::Vertex};
+  Mn::GL::Shader frag{version, Mn::GL::Shader::Type::Fragment};
+
+  std::string lightInitializer;
+  if (lightCount) {
+    /* Initializer for the light color array -- we need a list of vec4(1.0)
+       joined by commas. For GLES we'll simply upload the values directly. */
+    constexpr const char lightInitializerPreamble[] =
+        "#define LIGHT_COLOR_INITIALIZER ";
+    constexpr std::size_t lightInitializerPreambleSize =
+        Cr::Containers::arraySize(lightInitializerPreamble) - 1;
+    constexpr const char lightInitializerItem[] = "vec4(1.0), ";
+    constexpr std::size_t lightInitializerItemSize =
+        Cr::Containers::arraySize(lightInitializerItem) - 1;
+    lightInitializer.reserve(
+        Cr::Containers::arraySize(lightInitializerPreamble) - 1 +
+        lightCount * lightInitializerItemSize);
+    lightInitializer.append(lightInitializerPreamble,
+                            lightInitializerPreambleSize);
+    for (std::size_t i = 0; i != lightCount; ++i)
+      lightInitializer.append(lightInitializerItem, lightInitializerItemSize);
+
+    /* Drop the last comma and add a newline at the end */
+    lightInitializer[lightInitializer.size() - 2] = '\n';
+    lightInitializer.resize(lightInitializer.size() - 1);
+  }
+
+  std::string shadowMapLevelsInitializer = "#define NUM_SHADOW_MAP_LEVELS " +
+                                           std::to_string(numShadowMapLayers_) +
+                                           "\n";
+
+  vert.addSource(flags & (Flag::AmbientTexture | Flag::DiffuseTexture |
+                          Flag::SpecularTexture | Flag::NormalTexture)
+                     ? "#define TEXTURED\n"
+                     : "")
+      .addSource(flags & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n" : "")
+      .addSource(flags & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
+      .addSource(
+          Cr::Utility::formatString("#define LIGHT_COUNT {}\n", lightCount))
+      .addSource(shadowMapLevelsInitializer)
+      .addSource(rs.get("phong-shadow-receiver.vert"));
+  frag.addSource(flags & Flag::AmbientTexture ? "#define AMBIENT_TEXTURE\n"
+                                              : "")
+      .addSource(flags & Flag::DiffuseTexture ? "#define DIFFUSE_TEXTURE\n"
+                                              : "")
+      .addSource(flags & Flag::SpecularTexture ? "#define SPECULAR_TEXTURE\n"
+                                               : "")
+      .addSource(flags & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n" : "")
+      .addSource(flags & Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
+      .addSource(flags & Flag::AlphaMask ? "#define ALPHA_MASK\n" : "")
+      .addSource(flags & Flag::ObjectId ? "#define OBJECT_ID\n" : "")
+      .addSource(shadowMapLevelsInitializer)
+      .addSource(
+          Cr::Utility::formatString("#define LIGHT_COUNT {}\n", lightCount));
+  if (lightCount)
+    frag.addSource(std::move(lightInitializer));
+  frag.addSource(rs.get("phong-shadow-receiver.frag"));
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
+
+  attachShaders({vert, frag});
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+  _transformationMatrixUniform = uniformLocation("transformationMatrix");
+  _projectionMatrixUniform = uniformLocation("projectionMatrix");
+  _ambientColorUniform = uniformLocation("ambientColor");
+  if (lightCount) {
+    _normalMatrixUniform = uniformLocation("normalMatrix");
+    _diffuseColorUniform = uniformLocation("diffuseColor");
+    _specularColorUniform = uniformLocation("specularColor");
+    _shininessUniform = uniformLocation("shininess");
+    _lightPositionsUniform = uniformLocation("lightPositions");
+    _lightColorsUniform = uniformLocation("lightColors");
+    // shadows
+    modelMatrixUniform_ = uniformLocation("modelMatrix");
+    shadowLightDirectionUniform_ = uniformLocation("shadowLightDirection");
+    shadowBiasUniform_ = uniformLocation("shadowBias");
+    shadowMapMatrixUniform_ = uniformLocation("shadowmapMatrix");
+    shadeFacesFacingAwayFromLight_ =
+        uniformLocation("shadeFacesFacingAwayFromLight");
+  }
+  if (flags & Flag::AlphaMask)
+    _alphaMaskUniform = uniformLocation("alphaMask");
+  if (flags & Flag::ObjectId)
+    _objectIdUniform = uniformLocation("objectId");
+
+  if (flags & Flag::AmbientTexture)
+    setUniform(uniformLocation("ambientTexture"), AmbientTextureLayer);
+  if (lightCount) {
+    if (flags & Flag::DiffuseTexture)
+      setUniform(uniformLocation("diffuseTexture"), DiffuseTextureLayer);
+    if (flags & Flag::SpecularTexture)
+      setUniform(uniformLocation("specularTexture"), SpecularTextureLayer);
+    if (flags & Flag::NormalTexture)
+      setUniform(uniformLocation("normalTexture"), NormalTextureLayer);
+
+    setUniform(uniformLocation("shadowmapTexture"), ShadowmapTextureLayer);
+  }
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setAmbientColor(
+    const Magnum::Color4& color) {
+  setUniform(_ambientColorUniform, color);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::bindAmbientTexture(
+    Mn::GL::Texture2D& texture) {
+  CORRADE_ASSERT(_flags & Flag::AmbientTexture,
+                 "PhongShadowReceiverShader::bindAmbientTexture(): "
+                 "the shader was not "
+                 "created with ambient texture enabled",
+                 *this);
+  texture.bind(AmbientTextureLayer);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setDiffuseColor(
+    const Magnum::Color4& color) {
+  if (_lightCount)
+    setUniform(_diffuseColorUniform, color);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::bindDiffuseTexture(
+    Mn::GL::Texture2D& texture) {
+  CORRADE_ASSERT(_flags & Flag::DiffuseTexture,
+                 "PhongShadowReceiverShader::bindDiffuseTexture(): "
+                 "the shader was not "
+                 "created with diffuse texture enabled",
+                 *this);
+  if (_lightCount)
+    texture.bind(DiffuseTextureLayer);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setSpecularColor(
+    const Magnum::Color4& color) {
+  if (_lightCount)
+    setUniform(_specularColorUniform, color);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::bindSpecularTexture(
+    Mn::GL::Texture2D& texture) {
+  CORRADE_ASSERT(_flags & Flag::SpecularTexture,
+                 "PhongShadowReceiverShader::bindSpecularTexture(): "
+                 "the shader was not "
+                 "created with specular texture enabled",
+                 *this);
+  if (_lightCount)
+    texture.bind(SpecularTextureLayer);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::bindNormalTexture(
+    Mn::GL::Texture2D& texture) {
+  CORRADE_ASSERT(_flags & Flag::NormalTexture,
+                 "PhongShadowReceiverShader::bindNormalTexture(): the "
+                 "shader was not "
+                 "created with normal texture enabled",
+                 *this);
+  if (_lightCount)
+    texture.bind(NormalTextureLayer);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::bindTextures(
+    Mn::GL::Texture2D* ambient,
+    Mn::GL::Texture2D* diffuse,
+    Mn::GL::Texture2D* specular,
+    Mn::GL::Texture2D* normal) {
+  CORRADE_ASSERT(_flags & (Flag::AmbientTexture | Flag::DiffuseTexture |
+                           Flag::SpecularTexture | Flag::NormalTexture),
+                 "PhongShadowReceiverShader::bindTextures(): the "
+                 "shader was not created "
+                 "with any textures enabled",
+                 *this);
+  Mn::GL::AbstractTexture::bind(AmbientTextureLayer,
+                                {ambient, diffuse, specular, normal});
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setShininess(
+    Mn::Float shininess) {
+  if (_lightCount)
+    setUniform(_shininessUniform, shininess);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setAlphaMask(
+    Mn::Float mask) {
+  CORRADE_ASSERT(_flags & Flag::AlphaMask,
+                 "PhongShadowReceiverShader::setAlphaMask(): the "
+                 "shader was not created "
+                 "with alpha mask enabled",
+                 *this);
+  setUniform(_alphaMaskUniform, mask);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setObjectId(
+    Magnum::UnsignedInt id) {
+  CORRADE_ASSERT(_flags & Flag::ObjectId,
+                 "PhongShadowReceiverShader::setObjectId(): the "
+                 "shader was not created "
+                 "with object ID enabled",
+                 *this);
+  setUniform(_objectIdUniform, id);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setTransformationMatrix(
+    const Mn::Matrix4& matrix) {
+  setUniform(_transformationMatrixUniform, matrix);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setNormalMatrix(
+    const Mn::Matrix3x3& matrix) {
+  if (_lightCount)
+    setUniform(_normalMatrixUniform, matrix);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setProjectionMatrix(
+    const Mn::Matrix4& matrix) {
+  setUniform(_projectionMatrixUniform, matrix);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightPositions(
+    const Cr::Containers::ArrayView<const Mn::Vector3> positions) {
+  CORRADE_ASSERT(_lightCount == positions.size(),
+                 "PhongShadowReceiverShader::setLightPositions(): expected"
+                     << _lightCount << "items but got" << positions.size(),
+                 *this);
+  if (_lightCount)
+    setUniform(_lightPositionsUniform, positions);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightPosition(
+    Magnum::UnsignedInt id,
+    const Mn::Vector3& position) {
+  CORRADE_ASSERT(id < _lightCount,
+                 "PhongShadowReceiverShader::setLightPosition(): light ID"
+                     << id << "is out of bounds for" << _lightCount << "lights",
+                 *this);
+  setUniform(_lightPositionsUniform + id, position);
+  return *this;
+}
+
+/* It's light, but can't be in the header because MSVC needs to know the size
+   of Mn::Vector3 for the initializer list use */
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightPositions(
+    std::initializer_list<Mn::Vector3> lights) {
+  return setLightPositions({lights.begin(), lights.size()});
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightColors(
+    const Cr::Containers::ArrayView<const Magnum::Color4> colors) {
+  CORRADE_ASSERT(_lightCount == colors.size(),
+                 "PhongShadowReceiverShader::setLightColors(): expected"
+                     << _lightCount << "items but got" << colors.size(),
+                 *this);
+  if (_lightCount)
+    setUniform(_lightColorsUniform, colors);
+  return *this;
+}
+
+/* It's light, but can't be in the header because MSVC needs to know the size
+   of Color for the initializer list use */
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightColors(
+    std::initializer_list<Magnum::Color4> colors) {
+  return setLightColors({colors.begin(), colors.size()});
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setLightColor(
+    Magnum::UnsignedInt id,
+    const Magnum::Color4& color) {
+  CORRADE_ASSERT(id < _lightCount,
+                 "PhongShadowReceiverShader::setLightColor(): light ID"
+                     << id << "is out of bounds for" << _lightCount << "lights",
+                 *this);
+  setUniform(_lightColorsUniform + id, color);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setModelMatrix(
+    const Magnum::Matrix4& matrix) {
+  setUniform(modelMatrixUniform_, matrix);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setShadowmapMatrices(
+    Corrade::Containers::ArrayView<const Magnum::Matrix4> matrices) {
+  setUniform(shadowMapMatrixUniform_, matrices);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setShadowLightDirection(
+    const Magnum::Vector3& vector) {
+  setUniform(shadowLightDirectionUniform_, vector);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setShadowmapTexture(
+    Magnum::GL::Texture2DArray& texture) {
+  texture.bind(ShadowmapTextureLayer);
+  return *this;
+}
+
+PhongShadowReceiverShader& PhongShadowReceiverShader::setShadowBias(
+    const Magnum::Float bias) {
+  if (_lightCount)
+    setUniform(shadowBiasUniform_, bias);
+  return *this;
+}
+
+PhongShadowReceiverShader&
+PhongShadowReceiverShader::setShadeFacesFacingAwayFromLight(bool shadeFaces) {
+  if (_lightCount)
+    setUniform(shadeFacesFacingAwayFromLight_, shadeFaces);
+  return *this;
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/PhongShadowReceiverShader.h
+++ b/src/esp/gfx/shadows/PhongShadowReceiverShader.h
@@ -1,0 +1,515 @@
+#pragma once
+/*
+    Originally written by Vladimir Vondrus as part of the Magnum Library
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+*/
+
+#include "Magnum/GL/AbstractShaderProgram.h"
+#include "Magnum/Shaders/Generic.h"
+#include "Magnum/Shaders/visibility.h"
+
+namespace esp {
+namespace gfx {
+
+class PhongShadowReceiverShader : public Magnum::GL::AbstractShaderProgram {
+ public:
+  /**
+   * @brief Vertex position
+   *
+   * @ref shaders-generic "Generic attribute",
+   * @ref Magnum::Vector3 "Vector3".
+   */
+  typedef Magnum::Shaders::Generic3D::Position Position;
+
+  /**
+   * @brief Normal direction
+   *
+   * @ref shaders-generic "Generic attribute",
+   * @ref Magnum::Vector3 "Vector3".
+   */
+  typedef Magnum::Shaders::Generic3D::Normal Normal;
+
+  /**
+   * @brief Tangent direction
+   * @m_since{2019,10}
+   *
+   * @ref shaders-generic "Generic attribute",
+   * @ref Magnum::Vector3 "Vector3", used only if
+   * @ref Flag::NormalTexture is set.
+   */
+  typedef Magnum::Shaders::Generic3D::Tangent Tangent;
+
+  /**
+   * @brief 2D texture coordinates
+   *
+   * @ref shaders-generic "Generic attribute",
+   * @ref Magnum::Vector2 "Vector2", used only if at least one of
+   * @ref Flag::AmbientTexture, @ref Flag::DiffuseTexture and
+   * @ref Flag::SpecularTexture is set.
+   */
+  typedef Magnum::Shaders::Generic3D::TextureCoordinates TextureCoordinates;
+
+  /**
+   * @brief Three-component vertex color
+   * @m_since{2019,10}
+   *
+   * @ref shaders-generic "Generic attribute", @ref Magnum::Color3. Use
+   * either this or the @ref Color4 attribute. Used only if
+   * @ref Flag::VertexColor is set.
+   */
+  typedef Magnum::Shaders::Generic3D::Color3 Color3;
+
+  /**
+   * @brief Four-component vertex color
+   * @m_since{2019,10}
+   *
+   * @ref shaders-generic "Generic attribute", @ref Magnum::Color4. Use
+   * either this or the @ref Color3 attribute. Used only if
+   * @ref Flag::VertexColor is set.
+   */
+  typedef Magnum::Shaders::Generic3D::Color4 Color4;
+
+  enum : Magnum::UnsignedInt {
+    /**
+     * Color shader output. @ref shaders-generic "Generic output",
+     * present always. Expects three- or four-component floating-point
+     * or normalized buffer attachment.
+     * @m_since{2019,10}
+     */
+    ColorOutput = Magnum::Shaders::Generic3D::ColorOutput,
+
+    /**
+     * Object ID shader output. @ref shaders-generic "Generic output",
+     * present only if @ref Flag::ObjectId is set. Expects a
+     * single-component unsigned integral attachment. Writes the value
+     * set in @ref setObjectId() there, see
+     * @ref Shaders-Phong-usage-object-id for more information.
+     * @requires_gles30 Object ID output requires integer buffer
+     *      attachments, which are not available in OpenGL ES 2.0 or
+     *      WebGL 1.0.
+     * @m_since{2019,10}
+     */
+    ObjectIdOutput = Magnum::Shaders::Generic3D::ObjectIdOutput
+
+  };
+
+  /**
+   * @brief Flag
+   *
+   * @see @ref Flags, @ref flags()
+   */
+  enum class Flag : Magnum::UnsignedByte {
+    /**
+     * Multiply ambient color with a texture.
+     * @see @ref setAmbientColor(), @ref bindAmbientTexture()
+     */
+    AmbientTexture = 1 << 0,
+
+    /**
+     * Multiply diffuse color with a texture.
+     * @see @ref setDiffuseColor(), @ref bindDiffuseTexture()
+     */
+    DiffuseTexture = 1 << 1,
+
+    /**
+     * Multiply specular color with a texture.
+     * @see @ref setSpecularColor(), @ref bindSpecularTexture()
+     */
+    SpecularTexture = 1 << 2,
+
+    /**
+     * Modify normals according to a texture. Requires the
+     * @ref Tangent attribute to be present.
+     * @m_since{2019,10}
+     */
+    NormalTexture = 1 << 4,
+
+    /**
+     * Enable alpha masking. If the combined fragment color has an
+     * alpha less than the value specified with @ref setAlphaMask(),
+     * given fragment is discarded.
+     *
+     * This uses the @glsl discard @ce operation which is known to have
+     * considerable performance impact on some platforms. While useful
+     * for cheap alpha masking that doesn't require depth sorting,
+     * with proper depth sorting and blending you'll usually get much
+     * better performance and output quality.
+     */
+    AlphaMask = 1 << 3,
+
+    /**
+     * Multiply diffuse color with a vertex color. Requires either
+     * the @ref Color3 or @ref Color4 attribute to be present.
+     * @m_since{2019,10}
+     */
+    VertexColor = 1 << 5,
+
+    /**
+     * Enable object ID output. See @ref Shaders-Phong-usage-object-id
+     * for more information.
+     * @requires_gles30 Object ID output requires integer buffer
+     *      attachments, which are not available in OpenGL ES 2.0 or
+     *      WebGL 1.0.
+     * @m_since{2019,10}
+     */
+    ObjectId = 1 << 6
+
+  };
+
+  /**
+   * @brief Flags
+   *
+   * @see @ref flags()
+   */
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+
+  /**
+   * @brief Constructor
+   * @param flags         Flags
+   * @param lightCount    Count of light sources
+   */
+  explicit PhongShadowReceiverShader(
+      Flags flags = {},
+      Magnum::UnsignedInt lightCount = 1,
+      const Magnum::UnsignedInt numShadowMapLayers = 1);
+
+  /**
+   * @brief Construct without creating the underlying OpenGL object
+   *
+   * The constructed instance is equivalent to a moved-from state. Useful
+   * in cases where you will overwrite the instance later anyway. Move
+   * another object over it to make it useful.
+   *
+   * This function can be safely used for constructing (and later
+   * destructing) objects even without any OpenGL context being active.
+   * However note that this is a low-level and a potentially dangerous
+   * API, see the documentation of @ref NoCreate for alternatives.
+   */
+  explicit PhongShadowReceiverShader(Magnum::NoCreateT) noexcept
+      : Magnum::GL::AbstractShaderProgram{Magnum::NoCreate} {}
+
+  /** @brief Copying is not allowed */
+  PhongShadowReceiverShader(const PhongShadowReceiverShader&) = delete;
+
+  /** @brief Move constructor */
+  PhongShadowReceiverShader(PhongShadowReceiverShader&&) noexcept = default;
+
+  /** @brief Copying is not allowed */
+  PhongShadowReceiverShader& operator=(const PhongShadowReceiverShader&) =
+      delete;
+
+  /** @brief Move assignment */
+  PhongShadowReceiverShader& operator=(PhongShadowReceiverShader&&) noexcept =
+      default;
+
+  /** @brief Flags */
+  Flags flags() const { return _flags; }
+
+  /** @brief Light count */
+  Magnum::UnsignedInt lightCount() const { return _lightCount; }
+
+  /**
+   * @brief Set ambient color
+   * @return Reference to self (for method chaining)
+   *
+   * If @ref Flag::AmbientTexture is set, default value is
+   * @cpp 0xffffffff_rgbaf @ce and the color will be multiplied with
+   * ambient texture, otherwise default value is @cpp 0x00000000_rgbaf @ce.
+   * @see @ref bindAmbientTexture()
+   */
+  PhongShadowReceiverShader& setAmbientColor(const Magnum::Color4& color);
+
+  /**
+   * @brief Bind an ambient texture
+   * @return Reference to self (for method chaining)
+   *
+   * Expects that the shader was created with @ref Flag::AmbientTexture
+   * enabled.
+   * @see @ref bindTextures(), @ref setAmbientColor()
+   */
+  PhongShadowReceiverShader& bindAmbientTexture(Magnum::GL::Texture2D& texture);
+
+  /**
+   * @brief Set diffuse color
+   * @return Reference to self (for method chaining)
+   *
+   * Initial value is @cpp 0xffffffff_rgbaf @ce. If @ref lightCount() is
+   * zero, this function is a no-op, as diffuse color doesn't contribute
+   * to the output in that case.
+   * @see @ref bindDiffuseTexture()
+   */
+  PhongShadowReceiverShader& setDiffuseColor(const Magnum::Color4& color);
+
+  /**
+   * @brief Bind a diffuse texture
+   * @return Reference to self (for method chaining)
+   *
+   * Expects that the shader was created with @ref Flag::DiffuseTexture
+   * enabled. If @ref lightCount() is zero, this function is a no-op, as
+   * diffuse color doesn't contribute to the output in that case.
+   * @see @ref bindTextures(), @ref setDiffuseColor()
+   */
+  PhongShadowReceiverShader& bindDiffuseTexture(Magnum::GL::Texture2D& texture);
+
+  /**
+   * @brief Bind a normal texture
+   * @return Reference to self (for method chaining)
+   * @m_since{2019,10}
+   *
+   * Expects that the shader was created with @ref Flag::NormalTexture
+   * enabled and the @ref Tangent attribute was supplied. If
+   * @ref lightCount() is zero, this function is a no-op, as normals
+   * dosn't contribute to the output in that case.
+   * @see @ref bindTextures()
+   */
+  PhongShadowReceiverShader& bindNormalTexture(Magnum::GL::Texture2D& texture);
+
+  /**
+   * @brief Set specular color
+   * @return Reference to self (for method chaining)
+   *
+   * Initial value is @cpp 0xffffffff_rgbaf @ce. Color will be multiplied
+   * with specular texture if @ref Flag::SpecularTexture is set. If you
+   * want to have a fully diffuse material, set specular color to
+   * @cpp 0x000000ff_rgbaf @ce. If @ref lightCount() is zero, this
+   * function is a no-op, as specular color doesn't contribute to the
+   * output in that case.
+   * @see @ref bindSpecularTexture()
+   */
+  PhongShadowReceiverShader& setSpecularColor(const Magnum::Color4& color);
+
+  /**
+   * @brief Bind a specular texture
+   * @return Reference to self (for method chaining)
+   *
+   * Expects that the shader was created with @ref Flag::SpecularTexture
+   * enabled. If @ref lightCount() is zero, this function is a no-op, as
+   * specular color doesn't contribute to the output in that case.
+   * @see @ref bindTextures(), @ref setSpecularColor()
+   */
+  PhongShadowReceiverShader& bindSpecularTexture(
+      Magnum::GL::Texture2D& texture);
+
+  /**
+   * @brief Bind textures
+   * @return Reference to self (for method chaining)
+   *
+   * A particular texture has effect only if particular texture flag from
+   * @ref Phong::Flag "Flag" is set, you can use @cpp nullptr @ce for the
+   * rest. Expects that the shader was created with at least one of
+   * @ref Flag::AmbientTexture, @ref Flag::DiffuseTexture,
+   * @ref Flag::SpecularTexture or @ref Flag::NormalTexture enabled. More
+   * efficient than setting each texture separately.
+   * @see @ref bindAmbientTexture(), @ref bindDiffuseTexture(),
+   *      @ref bindSpecularTexture(), @ref bindNormalTexture()
+   */
+  PhongShadowReceiverShader& bindTextures(Magnum::GL::Texture2D* ambient,
+                                          Magnum::GL::Texture2D* diffuse,
+                                          Magnum::GL::Texture2D* specular,
+                                          Magnum::GL::Texture2D* normal);
+
+  /**
+   * @brief Set shininess
+   * @return Reference to self (for method chaining)
+   *
+   * The larger value, the harder surface (smaller specular highlight).
+   * Initial value is @cpp 80.0f @ce. If @ref lightCount() is zero, this
+   * function is a no-op, as specular color doesn't contribute to the
+   * output in that case.
+   */
+  PhongShadowReceiverShader& setShininess(Magnum::Float shininess);
+
+  /**
+   * @brief Set alpha mask value
+   * @return Reference to self (for method chaining)
+   *
+   * Expects that the shader was created with @ref Flag::AlphaMask
+   * enabled. Fragments with alpha values smaller than the mask value
+   * will be discarded. Initial value is @cpp 0.5f @ce. See the flag
+   * documentation for further information.
+   */
+  PhongShadowReceiverShader& setAlphaMask(Magnum::Float mask);
+
+  /**
+   * @brief Set object ID
+   * @return Reference to self (for method chaining)
+   *
+   * Expects that the shader was created with @ref Flag::ObjectId
+   * enabled. Value set here is written to the @ref ObjectIdOutput, see
+   * @ref Shaders-Phong-usage-object-id for more information. Default is
+   * @cpp 0 @ce.
+   * @requires_gles30 Object ID output requires integer buffer
+   *      attachments, which are not available in OpenGL ES 2.0 or WebGL
+   *      1.0.
+   */
+  PhongShadowReceiverShader& setObjectId(Magnum::UnsignedInt id);
+
+  /**
+   * @brief Set transformation matrix
+   * @return Reference to self (for method chaining)
+   *
+   * You need to set also @ref setNormalMatrix() with a corresponding
+   * value. Initial value is an identity matrix.
+   */
+  PhongShadowReceiverShader& setTransformationMatrix(
+      const Magnum::Matrix4& matrix);
+
+  /**
+   * @brief Set normal matrix
+   * @return Reference to self (for method chaining)
+   *
+   * The matrix doesn't need to be normalized, as the renormalization
+   * must be done in the shader anyway. You need to set also
+   * @ref setTransformationMatrix() with a corresponding value. Initial
+   * value is an identity matrix. If @ref lightCount() is zero, this
+   * function is a no-op, as normals don't contribute to the output in
+   * that case.
+   * @see @ref Math::Matrix4::normalMatrix()
+   */
+  PhongShadowReceiverShader& setNormalMatrix(const Magnum::Matrix3x3& matrix);
+
+  /**
+   * @brief Set projection matrix
+   * @return Reference to self (for method chaining)
+   *
+   * Initial value is an identity matrix (i.e., an orthographic
+   * projection of the default @f$ [ -\boldsymbol{1} ; \boldsymbol{1} ] @f$
+   * cube).
+   */
+  PhongShadowReceiverShader& setProjectionMatrix(const Magnum::Matrix4& matrix);
+
+  /**
+   * @brief Set light positions
+   * @return Reference to self (for method chaining)
+   *
+   * Initial values are zero vectors --- that will in most cases cause
+   * the object to be rendered black (or in the ambient color), as the
+   * lights are is inside of it. Expects that the size of the @p lights
+   * array is the same as @ref lightCount().
+   * @see @ref setLightPosition(UnsignedInt, const Vector3&),
+   *      @ref setLightPosition(const Vector3&)
+   */
+  PhongShadowReceiverShader& setLightPositions(
+      Corrade::Containers::ArrayView<const Magnum::Vector3> lights);
+
+  /** @overload */
+  PhongShadowReceiverShader& setLightPositions(
+      std::initializer_list<Magnum::Vector3> lights);
+
+  /**
+   * @brief Set position for given light
+   * @return Reference to self (for method chaining)
+   *
+   * Unlike @ref setLightPosition() updates just a single light position.
+   * Expects that @p id is less than @ref lightCount().
+   * @see @ref setLightPosition(const Vector3&)
+   */
+  PhongShadowReceiverShader& setLightPosition(Magnum::UnsignedInt id,
+                                              const Magnum::Vector3& position);
+
+  /**
+   * @brief Set light position
+   * @return Reference to self (for method chaining)
+   *
+   * Convenience alternative to @ref setLightPositions() when there is
+   * just one light.
+   * @see @ref setLightPosition(Magnum::UnsignedInt, const Vector3&)
+   */
+  PhongShadowReceiverShader& setLightPosition(const Magnum::Vector3& position) {
+    return setLightPositions({&position, 1});
+  }
+
+  /**
+   * @brief Set light colors
+   * @return Reference to self (for method chaining)
+   *
+   * Initial values are @cpp 0xffffffff_rgbaf @ce. Expects that the size
+   * of the @p colors array is the same as @ref lightCount().
+   */
+  PhongShadowReceiverShader& setLightColors(
+      Corrade::Containers::ArrayView<const Magnum::Color4> colors);
+
+  /** @overload */
+  PhongShadowReceiverShader& setLightColors(
+      std::initializer_list<Magnum::Color4> colors);
+
+  /**
+   * @brief Set position for given light
+   * @return Reference to self (for method chaining)
+   *
+   * Unlike @ref setLightColors() updates just a single light color.
+   * Expects that @p id is less than @ref lightCount().
+   * @see @ref setLightColor(const Magnum::Color4&)
+   */
+  PhongShadowReceiverShader& setLightColor(Magnum::UnsignedInt id,
+                                           const Magnum::Color4& color);
+
+  /**
+   * @brief Set light color
+   * @return Reference to self (for method chaining)
+   *
+   * Convenience alternative to @ref setLightColors() when there is just
+   * one light.
+   * @see @ref setLightColor(Magnum::UnsignedInt, const Magnum::Color4&)
+   */
+  PhongShadowReceiverShader& setLightColor(const Magnum::Color4& color) {
+    return setLightColors({&color, 1});
+  }
+
+  PhongShadowReceiverShader& setTransformationProjectionMatrix(
+      const Magnum::Matrix4& matrix);
+
+  /**
+   * @brief Set model matrix
+   *
+   * Matrix that transforms from local model space -> world space (used
+   * for lighting).
+   */
+  PhongShadowReceiverShader& setModelMatrix(const Magnum::Matrix4& matrix);
+
+  /**
+   * @brief Set shadowmap matrices
+   *
+   * Matrix that transforms from world space -> shadow texture space.
+   */
+  PhongShadowReceiverShader& setShadowmapMatrices(
+      Corrade::Containers::ArrayView<const Magnum::Matrix4> matrices);
+
+  /** @brief Set world-space direction to the light source */
+  PhongShadowReceiverShader& setShadowLightDirection(
+      const Magnum::Vector3& vector3);
+
+  /** @brief Set shadow map texture array */
+  PhongShadowReceiverShader& setShadowmapTexture(
+      Magnum::GL::Texture2DArray& texture);
+
+  /** @brief Set shadow bias */
+  PhongShadowReceiverShader& setShadowBias(const Magnum::Float bias);
+
+  PhongShadowReceiverShader& setShadeFacesFacingAwayFromLight(bool shadeFaces);
+
+  Magnum::UnsignedInt getNumLayers() const { return numShadowMapLayers_; }
+
+ private:
+  Flags _flags;
+  Magnum::UnsignedInt _lightCount;
+  Magnum::UnsignedInt numShadowMapLayers_;
+  Magnum::Int _transformationMatrixUniform{0}, _projectionMatrixUniform{1},
+      _normalMatrixUniform{2}, shadeFacesFacingAwayFromLight_{3},
+      _ambientColorUniform{4}, _diffuseColorUniform{5},
+      _specularColorUniform{6}, _shininessUniform{7}, _alphaMaskUniform{8};
+  Magnum::Int _objectIdUniform{9};
+  Magnum::Int modelMatrixUniform_{10};
+  Magnum::Int shadowLightDirectionUniform_{11};
+  Magnum::Int shadowBiasUniform_{12};
+  Magnum::Int shadowMapMatrixUniform_{13};
+  Magnum::Int _lightPositionsUniform{14},
+      _lightColorsUniform; /* 14 + lightCount, set in the constructor */
+};
+
+CORRADE_ENUMSET_OPERATORS(PhongShadowReceiverShader::Flags)
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowCasterDrawable.cpp
+++ b/src/esp/gfx/shadows/ShadowCasterDrawable.cpp
@@ -1,0 +1,69 @@
+/*
+    This file is part of Magnum.
+
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+
+    This is free and unencumbered software released into the public domain.
+
+    Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+    this software, either in source code form or as a compiled binary, for any
+    purpose, commercial or non-commercial, and by any means.
+
+    In jurisdictions that recognize copyright laws, the author or authors of
+    this software dedicate any and all copyright interest in the software to
+    the public domain. We make this dedication for the benefit of the public
+    at large and to the detriment of our heirs and successors. We intend this
+    dedication to be an overt act of relinquishment in perpetuity of all
+    present and future rights to this software under copyright law.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "ShadowCasterDrawable.h"
+
+#include <Magnum/SceneGraph/Camera.h>
+
+#include "ShadowCasterShader.h"
+
+namespace esp {
+namespace gfx {
+
+// static constexpr arrays require redundant definitions until C++17
+constexpr char ShadowCasterDrawable::SHADER_KEY[];
+
+namespace Mn = Magnum;
+
+ShadowCasterDrawable::ShadowCasterDrawable(scene::SceneNode& node,
+                                           Magnum::GL::Mesh& mesh,
+                                           ShaderManager& shaderManager,
+                                           DrawableGroup* group)
+    : Drawable{node, mesh, group} {
+  auto shaderResource =
+      shaderManager.get<Magnum::GL::AbstractShaderProgram, ShadowCasterShader>(
+          SHADER_KEY);
+
+  if (!shaderResource) {
+    shaderManager.set<Magnum::GL::AbstractShaderProgram>(
+        shaderResource.key(), new ShadowCasterShader{});
+  }
+  shader_ = &(*shaderResource);
+}
+
+void ShadowCasterDrawable::draw(const Mn::Matrix4& transformationMatrix,
+                                Mn::SceneGraph::Camera3D& shadowCamera) {
+  shader_->setTransformationMatrix(shadowCamera.projectionMatrix() *
+                                   transformationMatrix);
+  mesh_.draw(*shader_);
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowCasterDrawable.h
+++ b/src/esp/gfx/shadows/ShadowCasterDrawable.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+#include <Magnum/GL/Mesh.h>
+#include <Magnum/SceneGraph/Drawable.h>
+#include <Magnum/SceneGraph/Object.h>
+
+#include "esp/gfx/Drawable.h"
+#include "esp/gfx/DrawableGroup.h"
+#include "esp/gfx/ShaderManager.h"
+#include "esp/scene/SceneNode.h"
+
+namespace esp {
+namespace gfx {
+
+class ShadowCasterShader;
+
+class ShadowCasterDrawable : public Drawable {
+ public:
+  explicit ShadowCasterDrawable(scene::SceneNode& node,
+                                Magnum::GL::Mesh& mesh,
+                                ShaderManager& shaderManager,
+                                DrawableGroup* group = nullptr);
+
+  static constexpr char SHADER_KEY[] = "ShadowCasterShader";
+
+  void draw(const Magnum::Matrix4& transformationMatrix,
+            Magnum::SceneGraph::Camera3D& shadowCamera) override;
+
+ private:
+  ShadowCasterShader* shader_ = nullptr;
+};
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowCasterShader.cpp
+++ b/src/esp/gfx/shadows/ShadowCasterShader.cpp
@@ -1,0 +1,63 @@
+/*
+
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+#include "ShadowCasterShader.h"
+
+#include <Corrade/Containers/Reference.h>
+#include <Corrade/Utility/Resource.h>
+#include <Magnum/GL/Context.h>
+#include <Magnum/GL/Shader.h>
+#include <Magnum/GL/Version.h>
+#include <Magnum/Math/Matrix4.h>
+
+// This is to import the "resources" at runtime.
+// When the resource is compiled into static library,
+// it must be explicitly initialized via this macro, and should be called
+// *outside* of any namespace.
+static void importShaderResources() {
+  CORRADE_RESOURCE_INITIALIZE(ShaderResources)
+}
+
+namespace esp {
+namespace gfx {
+
+namespace Mn = Magnum;
+
+ShadowCasterShader::ShadowCasterShader() {
+  MAGNUM_ASSERT_GL_VERSION_SUPPORTED(Mn::GL::Version::GL330);
+
+  if (!Corrade::Utility::Resource::hasGroup("default-shaders")) {
+    importShaderResources();
+  }
+
+  const Mn::Utility::Resource rs{"default-shaders"};
+
+  Mn::GL::Shader vert{Mn::GL::Version::GL330, Mn::GL::Shader::Type::Vertex};
+  Mn::GL::Shader frag{Mn::GL::Version::GL330, Mn::GL::Shader::Type::Fragment};
+
+  vert.addSource(rs.get("ShadowCaster.vert"));
+  frag.addSource(rs.get("ShadowCaster.frag"));
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
+
+  attachShaders({vert, frag});
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+  _transformationMatrixUniform = uniformLocation("transformationMatrix");
+}
+
+ShadowCasterShader& ShadowCasterShader::setTransformationMatrix(
+    const Mn::Matrix4& matrix) {
+  setUniform(_transformationMatrixUniform, matrix);
+  return *this;
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowCasterShader.cpp
+++ b/src/esp/gfx/shadows/ShadowCasterShader.cpp
@@ -38,8 +38,14 @@ ShadowCasterShader::ShadowCasterShader() {
 
   const Mn::Utility::Resource rs{"default-shaders"};
 
-  Mn::GL::Shader vert{Mn::GL::Version::GL330, Mn::GL::Shader::Type::Vertex};
-  Mn::GL::Shader frag{Mn::GL::Version::GL330, Mn::GL::Shader::Type::Fragment};
+#ifdef MAGNUM_TARGET_WEBGL
+  Magnum::GL::Version version = Magnum::GL::Version::GLES300;
+#else
+  Magnum::GL::Version version = Magnum::GL::Version::GL410;
+#endif
+
+  Mn::GL::Shader vert{version, Mn::GL::Shader::Type::Vertex};
+  Mn::GL::Shader frag{version, Mn::GL::Shader::Type::Fragment};
 
   vert.addSource(rs.get("ShadowCaster.vert"));
   frag.addSource(rs.get("ShadowCaster.frag"));

--- a/src/esp/gfx/shadows/ShadowCasterShader.cpp
+++ b/src/esp/gfx/shadows/ShadowCasterShader.cpp
@@ -30,8 +30,9 @@ namespace gfx {
 namespace Mn = Magnum;
 
 ShadowCasterShader::ShadowCasterShader() {
-  MAGNUM_ASSERT_GL_VERSION_SUPPORTED(Mn::GL::Version::GL330);
-
+#ifndef MAGNUM_TARGET_WEBGL
+  MAGNUM_ASSERT_GL_VERSION_SUPPORTED(Magnum::GL::Version::GL410);
+#endif
   if (!Corrade::Utility::Resource::hasGroup("default-shaders")) {
     importShaderResources();
   }

--- a/src/esp/gfx/shadows/ShadowCasterShader.h
+++ b/src/esp/gfx/shadows/ShadowCasterShader.h
@@ -1,0 +1,34 @@
+#pragma once
+/*
+
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+#include <Magnum/GL/AbstractShaderProgram.h>
+
+namespace esp {
+namespace gfx {
+
+class ShadowCasterShader : public Magnum::GL::AbstractShaderProgram {
+ public:
+  explicit ShadowCasterShader();
+
+  /**
+   * @brief Set transformation matrix
+   *
+   * Matrix that transforms from local model space -> world space ->
+   * camera space -> clip coordinates (aka model-view-projection
+   * matrix).
+   */
+  ShadowCasterShader& setTransformationMatrix(const Magnum::Matrix4& matrix);
+
+ private:
+  Magnum::Int _transformationMatrixUniform;
+};
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowLight.cpp
+++ b/src/esp/gfx/shadows/ShadowLight.cpp
@@ -1,0 +1,262 @@
+/*
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+#include "ShadowLight.h"
+
+#include <Magnum/GL/DefaultFramebuffer.h>
+#include <Magnum/GL/PixelFormat.h>
+#include <Magnum/GL/Renderer.h>
+#include <Magnum/GL/TextureFormat.h>
+#include <Magnum/ImageView.h>
+#include <Magnum/Math/Frustum.h>
+#include <Magnum/SceneGraph/FeatureGroup.h>
+#include <Magnum/SceneGraph/MatrixTransformation3D.h>
+#include <Magnum/SceneGraph/Scene.h>
+#include <algorithm>
+
+#include "esp/geo/geo.h"
+#include "esp/gfx/shadows/ShadowCasterDrawable.h"
+#include "esp/scene/SceneNode.h"
+
+namespace Mn = Magnum;
+namespace esp {
+namespace gfx {
+
+ShadowLight::ShadowLight(scene::SceneNode& parent)
+    : Mn::SceneGraph::Camera3D{parent}, shadowTexture_{Mn::NoCreate} {
+  setAspectRatioPolicy(Mn::SceneGraph::AspectRatioPolicy::NotPreserved);
+}
+
+void ShadowLight::setupShadowmaps(Mn::Int numShadowLevels,
+                                  const Mn::Vector2i& size) {
+  layers_.clear();
+
+  (shadowTexture_ = Mn::GL::Texture2DArray{})
+      .setImage(0, Mn::GL::TextureFormat::DepthComponent,
+                Mn::ImageView3D{Mn::GL::PixelFormat::DepthComponent,
+                                Mn::GL::PixelType::Float,
+                                {size, numShadowLevels}})
+      .setMaxLevel(0)
+      .setCompareFunction(Mn::GL::SamplerCompareFunction::LessOrEqual)
+      .setCompareMode(Mn::GL::SamplerCompareMode::CompareRefToTexture)
+      .setMinificationFilter(Mn::GL::SamplerFilter::Linear,
+                             Mn::GL::SamplerMipmap::Base)
+      .setMagnificationFilter(Mn::GL::SamplerFilter::Linear);
+
+  for (std::int_fast32_t i = 0; i < numShadowLevels; ++i) {
+    layers_.emplace_back(size);
+    Mn::GL::Framebuffer& shadowFramebuffer = layers_.back().shadowFramebuffer;
+    shadowFramebuffer
+        .attachTextureLayer(Mn::GL::Framebuffer::BufferAttachment::Depth,
+                            shadowTexture_, 0, i)
+        .mapForDraw(Mn::GL::Framebuffer::DrawAttachment::None)
+        .bind();
+    CORRADE_INTERNAL_ASSERT(
+        shadowFramebuffer.checkStatus(Mn::GL::FramebufferTarget::Draw) ==
+        Mn::GL::Framebuffer::Status::Complete);
+  }
+}
+
+ShadowLight::ShadowLayerData::ShadowLayerData(const Mn::Vector2i& size)
+    : shadowFramebuffer{{{}, size}} {}
+
+void ShadowLight::setTarget(const Mn::Vector3& lightDirection,
+                            const Mn::Vector3& screenDirection,
+                            MagnumCamera& mainCamera) {
+  Mn::Matrix4 cameraMatrix =
+      Mn::Matrix4::lookAt({}, -lightDirection, screenDirection);
+  lightDirection_ = lightDirection;
+  const Mn::Matrix3x3 cameraRotationMatrix = cameraMatrix.rotation();
+  const Mn::Matrix3x3 inverseCameraRotationMatrix =
+      cameraRotationMatrix.inverted();
+
+  for (std::size_t layerIndex = 0; layerIndex != layers_.size(); ++layerIndex) {
+    std::vector<Mn::Vector3> mainCameraFrustumCorners =
+        layerFrustumCorners(mainCamera, Mn::Int(layerIndex));
+    ShadowLayerData& layer = layers_[layerIndex];
+
+    /* Calculate the AABB in shadow-camera space */
+    Mn::Vector3 min{std::numeric_limits<Mn::Float>::max()},
+        max{std::numeric_limits<Mn::Float>::lowest()};
+    for (Mn::Vector3 worldPoint : mainCameraFrustumCorners) {
+      Mn::Vector3 cameraPoint = inverseCameraRotationMatrix * worldPoint;
+      min = Mn::Math::min(min, cameraPoint);
+      max = Mn::Math::max(max, cameraPoint);
+    }
+
+    /* Place the shadow camera at the mid-point of the camera box */
+    const Mn::Vector3 mid = (min + max) * 0.5f;
+    const Mn::Vector3 cameraPosition = cameraRotationMatrix * mid;
+
+    const Mn::Vector3 range = max - min;
+    /* Set up the initial extends of the shadow map's render volume. Note
+       we will adjust this later when we render. */
+    layer.orthographicSize = range.xy();
+    layer.orthographicNear = -0.5f * range.z();
+    layer.orthographicFar = 0.5f * range.z();
+    cameraMatrix.translation() = cameraPosition;
+    layer.shadowCameraMatrix = cameraMatrix;
+  }
+}
+
+Mn::Float ShadowLight::cutZ(const Mn::Int layer) const {
+  return layers_[layer].cutPlane;
+}
+
+void ShadowLight::setupSplitDistances(const Mn::Float zNear,
+                                      const Mn::Float zFar,
+                                      const Mn::Float power) {
+  /* props http://stackoverflow.com/a/33465663 */
+  for (std::size_t i = 0; i != layers_.size(); ++i) {
+    const Mn::Float linearDepth =
+        zNear +
+        std::pow(Mn::Float(i + 1) / layers_.size(), power) * (zFar - zNear);
+    const Mn::Float nonLinearDepth =
+        (zFar + zNear - 2.0f * zNear * zFar / linearDepth) / (zFar - zNear);
+    layers_[i].cutPlane = (nonLinearDepth + 1.0f) / 2.0f;
+  }
+}
+
+Mn::Float ShadowLight::cutDistance(const Mn::Float zNear,
+                                   const Mn::Float zFar,
+                                   const Mn::Int layer) const {
+  const Mn::Float depthSample = 2.0f * layers_[layer].cutPlane - 1.0f;
+  const Mn::Float zLinear =
+      2.0f * zNear * zFar / (zFar + zNear - depthSample * (zFar - zNear));
+  return zLinear;
+}
+
+std::vector<Mn::Vector3> ShadowLight::layerFrustumCorners(
+    MagnumCamera& mainCamera,
+    const Mn::Int layer) {
+  const Mn::Float z0 = layer == 0 ? 0 : layers_[layer - 1].cutPlane;
+  const Mn::Float z1 = layers_[layer].cutPlane;
+  return cameraFrustumCorners(mainCamera, z0, z1);
+}
+
+std::vector<Mn::Vector3> ShadowLight::cameraFrustumCorners(
+    MagnumCamera& mainCamera,
+    const Mn::Float z0,
+    const Mn::Float z1) {
+  const Mn::Matrix4 imvp =
+      (mainCamera.projectionMatrix() * mainCamera.cameraMatrix()).inverted();
+  return frustumCorners(imvp, z0, z1);
+}
+
+std::vector<Mn::Vector3> ShadowLight::frustumCorners(const Mn::Matrix4& imvp,
+                                                     const Mn::Float z0,
+                                                     const Mn::Float z1) {
+  return {imvp.transformPoint({-1, -1, z0}), imvp.transformPoint({1, -1, z0}),
+          imvp.transformPoint({-1, 1, z0}),  imvp.transformPoint({1, 1, z0}),
+          imvp.transformPoint({-1, -1, z1}), imvp.transformPoint({1, -1, z1}),
+          imvp.transformPoint({-1, 1, z1}),  imvp.transformPoint({1, 1, z1})};
+}
+
+bool ShadowLight::isCulledByPlanes(
+    const Mn::Range3D& bb,
+    const std::vector<Magnum::Vector4>& clipPlanes) const {
+  const Mn::Vector3 center = bb.center();
+  const Mn::Vector3 extent = bb.max() - bb.min();
+  return std::any_of(clipPlanes.begin(), clipPlanes.end(),
+                     [&center, &extent](const Magnum::Vector4& plane) {
+                       const Mn::Vector3 absPlaneNormal =
+                           Mn::Math::abs(plane.xyz());
+
+                       const float d = Mn::Math::dot(center, plane.xyz());
+                       const float r = Mn::Math::dot(extent, absPlaneNormal);
+                       return (d + r < -2.0 * plane.w());
+                     });
+}
+
+void ShadowLight::generateLayerShadowMap(ShadowLayerData& d,
+                                         MagnumDrawableGroup& drawables) {
+  Mn::Float orthographicNear = d.orthographicNear;
+  const Mn::Float orthographicFar = d.orthographicFar;
+
+  /* Move this whole object to the right place to render each layer */
+  object().setTransformation(d.shadowCameraMatrix).setClean();
+  setProjectionMatrix(Mn::Matrix4::orthographicProjection(
+      d.orthographicSize, orthographicNear, orthographicFar));
+
+  // const std::vector<Mn::Vector4> clipPlanes = calculateClipPlanes();
+  // camera frustum in camera coordinates
+  const Mn::Frustum frustum = Mn::Frustum::fromMatrix(projectionMatrix());
+  // Skip out the near plane because we need to include shadow casters
+  // traveling the direction the camera is facing.
+  const std::vector<Mn::Vector4> clipPlanes{frustum.left(), frustum.right(),
+                                            frustum.top(), frustum.bottom(),
+                                            frustum.far()};
+  std::vector<std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>,
+                        Magnum::Matrix4>>
+      drawableTransforms = drawableTransformations(drawables);
+
+  /* Rebuild the list of objects we will draw by clipping them with the
+     shadow camera's planes */
+  std::size_t transformationsOutIndex = 0;
+  drawableTransforms.erase(
+      std::remove_if(drawableTransforms.begin(), drawableTransforms.end(),
+                     [&clipPlanes, &orthographicNear,
+                      this](const std::pair<
+                            std::reference_wrapper<Mn::SceneGraph::Drawable3D>,
+                            Mn::Matrix4>& drawableTransform) {
+                       auto& node = static_cast<scene::SceneNode&>(
+                           drawableTransform.first.get().object());
+
+                       // get this objects bounding box relative to camera
+                       Magnum::Range3D range = geo::getTransformedBB(
+                           node.getMeshBB(), drawableTransform.second);
+
+                       if (isCulledByPlanes(range, clipPlanes))
+                         return true;
+
+                       /* If this object extends in front of the near plane,
+                          extend the near plane. We negate the z because the
+                          negative z is forward away from the camera, but the
+                          near/far planes are measured forwards. */
+                       // TODO: need to implement proper distance
+                       const Mn::Float nearestPoint = -100.f;
+                       orthographicNear =
+                           Mn::Math::min(orthographicNear, nearestPoint);
+                       return false;
+                     }),
+      drawableTransforms.end());
+
+  /* Recalculate the projection matrix with new near plane. */
+  const Mn::Matrix4 shadowCameraProjectionMatrix =
+      Mn::Matrix4::orthographicProjection(d.orthographicSize, orthographicNear,
+                                          orthographicFar);
+
+  /* Projecting world points normalized device coordinates means they range
+  -1 -> 1. Use this bias matrix so we go straight from world -> texture
+  space */
+  constexpr const Mn::Matrix4 bias{{0.5f, 0.0f, 0.0f, 0.0f},
+                                   {0.0f, 0.5f, 0.0f, 0.0f},
+                                   {0.0f, 0.0f, 0.5f, 0.0f},
+                                   {0.5f, 0.5f, 0.5f, 1.0f}};
+  d.shadowMatrix = bias * shadowCameraProjectionMatrix * cameraMatrix();
+  setProjectionMatrix(shadowCameraProjectionMatrix);
+
+  d.shadowFramebuffer.clear(Mn::GL::FramebufferClear::Depth).bind();
+  draw(drawableTransforms);
+}
+
+void ShadowLight::generateShadowMaps(MagnumDrawableGroup& drawables) {
+  /* Compute transformations of all objects in the group relative to the
+   * camera
+   */
+  Mn::GL::Renderer::setDepthMask(true);
+
+  for (auto& layer : layers_) {
+    generateLayerShadowMap(layer, drawables);
+  }
+
+  Mn::GL::defaultFramebuffer.bind();
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/shadows/ShadowLight.h
+++ b/src/esp/gfx/shadows/ShadowLight.h
@@ -1,0 +1,143 @@
+#pragma once
+/*
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+#include <Magnum/GL/Framebuffer.h>
+#include <Magnum/GL/TextureArray.h>
+#include <Magnum/Resource.h>
+#include <Magnum/SceneGraph/AbstractFeature.h>
+#include <Magnum/SceneGraph/Camera.h>
+#include <Magnum/SceneGraph/Drawable.h>
+
+#include <esp/gfx/magnum.h>
+#include <esp/scene/SceneNode.h>
+
+namespace esp {
+namespace gfx {
+
+/**
+@brief A special camera used to render shadow maps
+
+The object it's attached to should face the direction that the light travels.
+*/
+class ShadowLight : public MagnumCamera {
+ public:
+  static std::vector<Magnum::Vector3> cameraFrustumCorners(
+      MagnumCamera& mainCamera,
+      Magnum::Float z0 = -1.0f,
+      Magnum::Float z1 = 1.0f);
+
+  static std::vector<Magnum::Vector3> frustumCorners(
+      const Magnum::Matrix4& imvp,
+      Magnum::Float z0,
+      Magnum::Float z1);
+
+  explicit ShadowLight(scene::SceneNode& parent);
+
+  // Get the scene node being attached to.
+  scene::SceneNode& node() { return object(); }
+  const scene::SceneNode& node() const { return object(); }
+
+  // Overloads to avoid confusion
+  scene::SceneNode& object() {
+    return static_cast<scene::SceneNode&>(MagnumCamera::object());
+  }
+  const scene::SceneNode& object() const {
+    return static_cast<const scene::SceneNode&>(MagnumCamera::object());
+  }
+
+  /**
+   * @brief Initialize the shadow map texture array and framebuffers
+   *
+   * Should be called before @ref setupSplitDistances().
+   */
+  void setupShadowmaps(Magnum::Int numShadowLevels,
+                       const Magnum::Vector2i& size);
+
+  /**
+   * @brief Set up the distances we should cut the view frustum along
+   *
+   * The distances will be distributed along a power series. Should be
+   * called after @ref setupShadowmaps().
+   */
+  void setupSplitDistances(Magnum::Float cameraNear,
+                           Magnum::Float cameraFar,
+                           Magnum::Float power);
+
+  /**
+   * @brief Computes all the matrices for the shadow map splits
+   * @param lightDirection    Direction of travel of the light
+   * @param screenDirection   Crossed with light direction to determine
+   *      orientation of the shadow maps. Use the forward direction of
+   *      the camera for best resolution use, or use a constant value for
+   *      more stable shadows.
+   * @param mainCamera        The camera to use to determine the optimal
+   *      splits (normally, the main camera that the shadows will be
+   *      rendered to)
+   *
+   * Should be called whenever your camera moves.
+   */
+  void setTarget(const Magnum::Vector3& lightDirection,
+                 const Magnum::Vector3& screenDirection,
+                 MagnumCamera& mainCamera);
+
+  /**
+   * @brief Render a group of shadow-casting drawables to the shadow maps
+   */
+  void generateShadowMaps(MagnumDrawableGroup& drawables);
+
+  std::vector<Magnum::Vector3> layerFrustumCorners(MagnumCamera& mainCamera,
+                                                   Magnum::Int layer);
+
+  Magnum::Float cutZ(Magnum::Int layer) const;
+
+  Magnum::Float cutDistance(Magnum::Float zNear,
+                            Magnum::Float zFar,
+                            Magnum::Int layer) const;
+
+  std::size_t layerCount() const { return layers_.size(); }
+
+  const Magnum::Matrix4& layerMatrix(Magnum::Int layer) const {
+    return layers_[layer].shadowMatrix;
+  }
+
+  std::vector<Magnum::Vector4> calculateClipPlanes();
+
+  Magnum::GL::Texture2DArray& shadowTexture() { return shadowTexture_; }
+
+  const Magnum::Vector3& getLightDirection() const { return lightDirection_; }
+
+ private:
+  struct ShadowLayerData {
+    Magnum::GL::Framebuffer shadowFramebuffer;
+    Magnum::Matrix4 shadowCameraMatrix;
+    Magnum::Matrix4 shadowMatrix;
+    Magnum::Vector2 orthographicSize;
+    Magnum::Float orthographicNear, orthographicFar;
+    Magnum::Float cutPlane;
+
+    explicit ShadowLayerData(const Magnum::Vector2i& size);
+  };
+
+  void generateLayerShadowMap(ShadowLayerData& d,
+                              MagnumDrawableGroup& drawables);
+
+  bool isCulledByPlanes(const Magnum::Range3D& bb,
+                        const std::vector<Magnum::Vector4>& clipPlanes) const;
+
+  Magnum::GL::Texture2DArray shadowTexture_;
+
+  std::vector<ShadowLayerData> layers_;
+
+  Magnum::Vector3 lightDirection_;
+
+  ESP_SMART_POINTERS(ShadowLight)
+};
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/scene/SceneGraph.cpp
+++ b/src/esp/scene/SceneGraph.cpp
@@ -11,7 +11,7 @@ namespace esp {
 namespace scene {
 
 SceneGraph::SceneGraph()
-    : rootNode_{world_},
+    : rootNode_{*this},
       defaultRenderCameraNode_{rootNode_},
       defaultRenderCamera_{defaultRenderCameraNode_} {
   // For now, just create one drawable group with empty string uuid

--- a/src/shaders/Shaders.conf
+++ b/src/shaders/Shaders.conf
@@ -20,3 +20,15 @@ filename = ptex-default-gl410.geom
 
 [file]
 filename = ptex-default-gl410.frag
+
+[file]
+filename=ShadowCaster.vert
+
+[file]
+filename=ShadowCaster.frag
+
+[file]
+filename=phong-shadow-receiver.vert
+
+[file]
+filename=phong-shadow-receiver.frag

--- a/src/shaders/ShadowCaster.frag
+++ b/src/shaders/ShadowCaster.frag
@@ -1,0 +1,16 @@
+/*
+    This file is part of Magnum.
+
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+out float fragmentdepth;
+
+void main() {
+  /* Not really needed, OpenGL does it anyway */
+  fragmentdepth = gl_FragCoord.z;
+}

--- a/src/shaders/ShadowCaster.vert
+++ b/src/shaders/ShadowCaster.vert
@@ -1,0 +1,17 @@
+/*
+    This file is part of Magnum.
+
+    Original authors — credit is appreciated but not required:
+
+        2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 —
+            Vladimír Vondruš <mosra@centrum.cz>
+        2016 — Bill Robinson <airbaggins@gmail.com>
+*/
+
+uniform highp mat4 transformationMatrix;
+
+in highp vec4 position;
+
+void main() {
+  gl_Position = transformationMatrix * position;
+}

--- a/src/shaders/phong-shadow-receiver.frag
+++ b/src/shaders/phong-shadow-receiver.frag
@@ -1,0 +1,269 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/* Outputs */
+#define COLOR_OUTPUT_ATTRIBUTE_LOCATION 0
+#define OBJECT_ID_OUTPUT_ATTRIBUTE_LOCATION 1
+
+#ifndef RUNTIME_CONST
+#define const
+#endif
+
+#ifdef AMBIENT_TEXTURE
+uniform lowp sampler2D ambientTexture;
+#endif
+
+uniform lowp vec4 ambientColor
+#ifndef GL_ES
+#ifndef AMBIENT_TEXTURE
+    = vec4(0.0)
+#else
+    = vec4(1.0)
+#endif
+#endif
+    ;
+
+#if LIGHT_COUNT
+#ifdef DIFFUSE_TEXTURE
+uniform lowp sampler2D diffuseTexture;
+#endif
+
+uniform lowp vec4 diffuseColor
+#ifndef GL_ES
+    = vec4(1.0)
+#endif
+    ;
+
+#ifdef SPECULAR_TEXTURE
+uniform lowp sampler2D specularTexture;
+#endif
+
+#ifdef NORMAL_TEXTURE
+uniform lowp sampler2D normalTexture;
+#endif
+
+uniform lowp vec4 specularColor
+#ifndef GL_ES
+    = vec4(1.0)
+#endif
+    ;
+
+uniform mediump float shininess
+#ifndef GL_ES
+    = 80.0
+#endif
+    ;
+
+uniform float shadowBias = 0.001;
+uniform sampler2DArrayShadow shadowmapTexture;
+uniform highp vec3 shadowLightDirection = vec3(1.0);
+uniform bool shadeFacesFacingAwayFromLight = false;
+#endif
+
+#ifdef ALPHA_MASK
+uniform lowp float alphaMask
+#ifndef GL_ES
+    = 0.5
+#endif
+    ;
+#endif
+
+#ifdef OBJECT_ID
+/* mediump is just 2^10, which might not be enough, this is 2^16 */
+uniform highp uint objectId; /* defaults to zero */
+#endif
+
+#if LIGHT_COUNT
+/* Needs to be last because it uses locations 10 + LIGHT_COUNT to
+   10 + 2*LIGHT_COUNT - 1. Location 10 is lightPositions. Also it can't be
+   specified as 10 + LIGHT_COUNT because that requires ARB_enhanced_layouts. */
+uniform lowp vec4 lightColors[LIGHT_COUNT]
+#ifndef GL_ES
+    = vec4[](LIGHT_COLOR_INITIALIZER)
+#endif
+    ;
+#endif
+
+#if LIGHT_COUNT
+in mediump vec3 transformedNormal;
+in mediump vec3 absoluteTransformedNormal;
+
+#ifdef NORMAL_TEXTURE
+in mediump vec3 transformedTangent;
+#endif
+in highp vec3 lightDirections[LIGHT_COUNT];
+in highp vec3 shadowCoords[NUM_SHADOW_MAP_LEVELS];
+in highp vec3 cameraDirection;
+#endif
+
+#if defined(AMBIENT_TEXTURE) || defined(DIFFUSE_TEXTURE) || \
+    defined(SPECULAR_TEXTURE) || defined(NORMAL_TEXTURE)
+in mediump vec2 interpolatedTextureCoords;
+#endif
+
+#ifdef VERTEX_COLOR
+in lowp vec4 interpolatedVertexColor;
+#endif
+
+layout(location = COLOR_OUTPUT_ATTRIBUTE_LOCATION) out lowp vec4 fragmentColor;
+#ifdef OBJECT_ID
+layout(location = OBJECT_ID_OUTPUT_ATTRIBUTE_LOCATION)
+    /* mediump is just 2^10, which might not be enough, this is 2^16 */
+    out highp uint fragmentObjectId;
+#endif
+
+void main() {
+  lowp const vec4 finalAmbientColor =
+#ifdef AMBIENT_TEXTURE
+      texture(ambientTexture, interpolatedTextureCoords) *
+#endif
+      ambientColor;
+#if LIGHT_COUNT
+  lowp const vec4 finalDiffuseColor =
+#ifdef DIFFUSE_TEXTURE
+      texture(diffuseTexture, interpolatedTextureCoords) *
+#endif
+#ifdef VERTEX_COLOR
+      interpolatedVertexColor *
+#endif
+      diffuseColor;
+  lowp const vec4 finalSpecularColor =
+#ifdef SPECULAR_TEXTURE
+      texture(specularTexture, interpolatedTextureCoords) *
+#endif
+      specularColor;
+#endif
+
+  /* Ambient color */
+  fragmentColor = finalAmbientColor;
+
+#if LIGHT_COUNT
+  /* Normal */
+  mediump vec3 normalizedTransformedNormal = normalize(transformedNormal);
+
+  /* shadows */
+  mediump vec3 normalizedAbsoluteTransformedNormal =
+      normalize(absoluteTransformedNormal);
+
+  /* You might want to source this from a texture or a vertex color */
+  vec3 albedo = vec3(1.0, 1.0, 1.0);
+
+#ifdef NORMAL_TEXTURE
+  mediump vec3 normalizedTransformedTangent = normalize(transformedTangent);
+  mediump mat3 tbn = mat3(normalizedTransformedTangent,
+                          normalize(cross(normalizedTransformedNormal,
+                                          normalizedTransformedTangent)),
+                          normalizedTransformedNormal);
+  normalizedTransformedNormal =
+      tbn *
+      (texture(normalTexture, interpolatedTextureCoords).rgb * 2.0 - vec3(1.0));
+#endif
+
+  /* Add diffuse color for each light */
+  for (int i = 0; i < LIGHT_COUNT; ++i) {
+    highp vec3 normalizedLightDirection = normalize(lightDirections[i]);
+    lowp float intensity =
+        max(0.0, dot(normalizedTransformedNormal, normalizedLightDirection));
+    lowp vec4 colorFromLight =
+        vec4(finalDiffuseColor.rgb * lightColors[i].rgb * intensity,
+             lightColors[i].a * finalDiffuseColor.a / float(LIGHT_COUNT));
+
+    /* Add specular color, if needed */
+    if (intensity > 0.001) {
+      highp vec3 reflection =
+          reflect(-normalizedLightDirection, normalizedTransformedNormal);
+      mediump float specularity = clamp(
+          pow(max(0.0, dot(normalize(cameraDirection), reflection)), shininess),
+          0.0, 1.0);
+      colorFromLight +=
+          vec4(finalSpecularColor.rgb * specularity, finalSpecularColor.a);
+    }
+
+    /* Shadow calculation */
+    /* TODO: support multiple lights, use actual light direction here */
+    /* Is the normal of this face pointing towards the light?
+       if pointing away from the light anyway, we know it's in the shade, don't
+        bother shadow map lookup */
+    float visibility = 1.0;
+    if (shadeFacesFacingAwayFromLight &&
+        dot(normalize(absoluteTransformedNormal),
+            normalize(shadowLightDirection)) <= 0) {
+      visibility = 0.0f;
+    } else {
+      int shadowLevel = 0;
+      bool inRange = false;
+
+      /* Starting with highest resolution shadow map, find one we're in range
+         of */
+      for (; shadowLevel < NUM_SHADOW_MAP_LEVELS; ++shadowLevel) {
+        vec3 shadowCoord = shadowCoords[shadowLevel];
+        inRange = shadowCoord.x >= 0 && shadowCoord.y >= 0 &&
+                  shadowCoord.x < 1 && shadowCoord.y < 1 &&
+                  shadowCoord.z >= 0 && shadowCoord.z < 1;
+        if (inRange) {
+          visibility = texture(
+              shadowmapTexture,
+              vec4(shadowCoord.xy, shadowLevel, shadowCoord.z - shadowBias));
+          break;
+        }
+      }
+#ifdef DEBUG_SHADOWMAP_LEVELS
+      switch (shadowLevel) {
+        case 0:
+          albedo *= vec3(1, 0, 0);
+          break;
+        case 1:
+          albedo *= vec3(1, 1, 0);
+          break;
+        case 2:
+          albedo *= vec3(0, 1, 0);
+          break;
+        case 3:
+          albedo *= vec3(0, 1, 1);
+          break;
+        default:
+          albedo *= vec3(1, 0, 1);
+          break;
+      }
+#endif
+    }
+
+    colorFromLight.rgb = colorFromLight.rgb * visibility * albedo;
+    fragmentColor += colorFromLight;
+  }
+#endif
+
+#ifdef ALPHA_MASK
+  /* Using <= because if mask is set to 1.0, it should discard all, similarly
+     as when using 0, it should only discard what's already invisible
+     anyway. */
+  if (fragmentColor.a <= alphaMask)
+    discard;
+#endif
+
+#ifdef OBJECT_ID
+  fragmentObjectId = objectId;
+#endif
+}

--- a/src/shaders/phong-shadow-receiver.vert
+++ b/src/shaders/phong-shadow-receiver.vert
@@ -1,0 +1,128 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#define POSITION_ATTRIBUTE_LOCATION 0
+#define TEXTURECOORDINATES_ATTRIBUTE_LOCATION 1
+#define NORMAL_ATTRIBUTE_LOCATION 2
+#define COLOR_ATTRIBUTE_LOCATION 3
+#define TANGENT_ATTRIBUTE_LOCATION 4
+
+uniform highp mat4 transformationMatrix = mat4(1.0);
+
+uniform highp mat4 projectionMatrix = mat4(1.0);
+
+#if LIGHT_COUNT
+uniform mediump mat3 normalMatrix = mat3(1.0);
+#endif
+
+#if LIGHT_COUNT
+// for shadows
+uniform highp mat4 modelMatrix = mat4(1.0);
+
+/* Needs to be last because it uses locations 10 to 10 + LIGHT_COUNT - 1 */
+uniform highp vec3 lightPositions[LIGHT_COUNT]; /* defaults to zero */
+
+// for shadows
+uniform highp mat4 shadowmapMatrix[NUM_SHADOW_MAP_LEVELS];
+#endif
+
+layout(location = POSITION_ATTRIBUTE_LOCATION) in highp vec4 position;
+
+#if LIGHT_COUNT
+layout(location = NORMAL_ATTRIBUTE_LOCATION) in mediump vec3 normal;
+
+#ifdef NORMAL_TEXTURE
+layout(location = TANGENT_ATTRIBUTE_LOCATION) in mediump vec3 tangent;
+#endif
+#endif
+
+#ifdef TEXTURED
+layout(location = TEXTURECOORDINATES_ATTRIBUTE_LOCATION) in mediump vec2
+    textureCoords;
+
+out mediump vec2 interpolatedTextureCoords;
+#endif
+
+#ifdef VERTEX_COLOR
+layout(location = COLOR_ATTRIBUTE_LOCATION) in lowp vec4 vertexColor;
+
+out lowp vec4 interpolatedVertexColor;
+#endif
+
+#if LIGHT_COUNT
+out mediump vec3 transformedNormal;
+out mediump vec3 absoluteTransformedNormal;
+#ifdef NORMAL_TEXTURE
+out mediump vec3 transformedTangent;
+#endif
+out highp vec3 lightDirections[LIGHT_COUNT];
+out highp vec3 shadowCoords[NUM_SHADOW_MAP_LEVELS];
+out highp vec3 cameraDirection;
+#endif
+
+void main() {
+  /* Transformed vertex position */
+  highp vec4 transformedPosition4 = transformationMatrix * position;
+  highp vec3 transformedPosition =
+      transformedPosition4.xyz / transformedPosition4.w;
+
+#if LIGHT_COUNT
+  /* Transformed normal and tangent vector */
+  transformedNormal = normalMatrix * normal;
+#ifdef NORMAL_TEXTURE
+  transformedTangent = normalMatrix * tangent;
+#endif
+
+  /* Direction to the light */
+  for (int i = 0; i < LIGHT_COUNT; ++i)
+    lightDirections[i] = normalize(lightPositions[i] - transformedPosition);
+
+  /* Direction to the camera */
+  cameraDirection = -transformedPosition;
+
+  /* Shadows */
+
+  /* normal in world coordinates */
+  absoluteTransformedNormal = mat3(modelMatrix) * normal;
+
+  vec4 worldPos4 = modelMatrix * position;
+  for (int i = 0; i < shadowmapMatrix.length(); i++) {
+    shadowCoords[i] = (shadowmapMatrix[i] * worldPos4).xyz;
+  }
+#endif
+
+  /* Transform the position */
+  gl_Position = projectionMatrix * transformedPosition4;
+
+#ifdef TEXTURED
+  /* Texture coordinates, if needed */
+  interpolatedTextureCoords = textureCoords;
+#endif
+
+#ifdef VERTEX_COLOR
+  /* Vertex colors, if enabled */
+  interpolatedVertexColor = vertexColor;
+#endif
+}


### PR DESCRIPTION
## Motivation and Context

This is a proof of concept that was quickly hacked together, then basically scrapped due to its low priority.
Since tomorrow is my last day :( putting it up as a draft so it doesn't get lost if anyone ever wants to return this idea.

Uses cascaded shadow mapping technique.
See:
* https://doc.magnum.graphics/magnum/examples-shadows.html
* https://docs.microsoft.com/en-us/windows/win32/dxtecharts/cascaded-shadow-maps
* http://ogldev.atspace.co.uk/www/tutorial49/tutorial49.html

#### Issues
* There is a disconnect between our lights (point lights) and the lights the shadow light uses. This PR just uses a hacked together single hardcoded light direction to determine shadows for all lights.
To fix this, we would need to either:
* Support point light shadows: https://learnopengl.com/Advanced-Lighting/Shadows/Point-Shadows
* Add directional light support to light setups

## How Has This Been Tested

Look at the shadows!!!
![test_image_save](https://user-images.githubusercontent.com/24686092/76824192-a0b1f900-67d3-11ea-9e71-6d7ad8b6bd52.png)

To run this example, need to pass `--scene-requires-lighting` to the viewer, since it doesn't really make sense to have shadows on a flat shaded mesh.
Ie: `./build/viewer --enable-physics --scene-requires-lighting -- ~/habitat-data/scene_datasets/habitat-test-scenes/apartment_1/apartment_1.glb`


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
