### PR TITLE
update semantic benchmark numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,15 +120,15 @@ The table below reports performance statistics for a test scene from the Matterp
  </tr>
  <tr>
    <td>RGB + depth + semantics*</td>
-   <td>439</td>
-   <td>346</td>
-   <td>185</td>
-   <td>502</td>
-   <td>385</td>
-   <td>336</td>
-   <td>500</td>
-   <td>390</td>
-   <td>367</td>
+   <td>709</td>
+   <td>596</td>
+   <td>394</td>
+   <td>1312</td>
+   <td>1219</td>
+   <td>979</td>
+   <td>1521</td>
+   <td>1429</td>
+   <td>1291</td>
  </tr>
 </table>
 


### PR DESCRIPTION
## Motivation and Context

Communicate new performance after semantic culling.

I kept the `*Note` section mentioning semantic performance since its still not as fast as RGB+depth.

## How Has This Been Tested

Ran: `python examples/benchmark.py --scene /datasets01/mp3d/073118/v1/habitat/17DRP5sb8fy/17DRP5sb8fy.glb --max_frames 4000 --benchmark_semantic_sensor`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
