### PR TITLE
(Simulator): On demand object loading

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -417,7 +417,6 @@ PhysicsManagerAttributes ResourceManager::loadPhysicsConfig(
     std::vector<std::string> validConfigPaths =
         getObjectConfigPaths(absolutePath);
     for (auto& path : validConfigPaths) {
-      Cr::Utility::Debug() << "path : " << path;
       physicsManagerAttributes.appendVecStrings("objectLibraryPaths", path);
     }
   }
@@ -772,7 +771,7 @@ int ResourceManager::getObjectID(const std::string& configFile) {
       std::find(physicsObjectConfigList_.begin(),
                 physicsObjectConfigList_.end(), configFile);
   if (itr == physicsObjectConfigList_.cend()) {
-    return -1;
+    return ID_UNDEFINED;
   } else {
     int objectID = std::distance(physicsObjectConfigList_.begin(), itr);
     return objectID;

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -194,6 +194,16 @@ class ResourceManager {
       std::string physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG);
 
   /**
+   * @brief Get all "*.phys_properties.json" files from the provided file or
+   * directory path.
+   *
+   * @param path A global path to a physics property file or directory
+   *
+   * @return A list of valid global paths to "*.phys_properties.json" files.
+   */
+  std::vector<std::string> getObjectConfigPaths(std::string path);
+
+  /**
    * @brief Load an object from a spcified configuration file into the @ref
    * physicsObjectLibrary_ and add it to the specified @ref DrawableGroup as a
    * child of the specified @ref scene::SceneNode if provided.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -198,7 +198,6 @@ class ResourceManager {
    * directory path.
    *
    * @param path A global path to a physics property file or directory
-   *
    * @return A list of valid global paths to "*.phys_properties.json" files.
    */
   std::vector<std::string> getObjectConfigPaths(std::string path);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -275,6 +275,27 @@ int Simulator::getPhysicsObjectLibrarySize() {
   return resourceManager_.getNumLibraryObjects();
 }
 
+std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
+  std::vector<int> templateIndices;
+  std::vector<std::string> validConfigPaths =
+      resourceManager_.getObjectConfigPaths(path);
+  for (auto& validPath : validConfigPaths) {
+    templateIndices.push_back(resourceManager_.loadObject(path));
+  }
+  return templateIndices;
+}
+
+int Simulator::loadObjectTemplate(
+    assets::PhysicsObjectAttributes& objectTemplate,
+    const std::string& objectTemplateHandle) {
+  // check for duplicate keys
+  if (resourceManager_.getObjectID(objectTemplateHandle) != ID_UNDEFINED) {
+    return ID_UNDEFINED;
+  }
+
+  return resourceManager_.loadObject(objectTemplate, objectTemplateHandle);
+}
+
 // return a list of existing objected IDs in a physical scene
 std::vector<int> Simulator::getExistingObjectIDs(const int sceneID) {
   if (sceneHasPhysics(sceneID)) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -280,7 +280,7 @@ std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
   std::vector<std::string> validConfigPaths =
       resourceManager_.getObjectConfigPaths(path);
   for (auto& validPath : validConfigPaths) {
-    templateIndices.push_back(resourceManager_.loadObject(path));
+    templateIndices.push_back(resourceManager_.loadObject(validPath));
   }
   return templateIndices;
 }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -139,7 +139,8 @@ class Simulator {
    *
    * @param objectTemplate A new PhysicsObjectAttributes to load.
    * @param objectTemplateHandle The desired key for referencing the new
-   * template. To register this successfully, it must not be a duplicate of an existing key.
+   * template. To register this successfully, it must not be a duplicate of an
+   * existing key.
    * @return A template index for instancing the loaded template or ID_UNDEFINED
    * if failed.
    */

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -121,9 +121,30 @@ class Simulator {
   int getPhysicsObjectLibrarySize();
 
   /**
-   * TODO:
+   * @brief Load all "*.phys_properties.json" files from the provided file or
+   * directory path.
+   *
+   * Note that duplicate loads will return the index of the existing template
+   * rather than reloading.
+   *
+   * @param path A global path to a physics property file or directory
+   * @return A list of template indices for loaded valid configs for object
+   * instancing.
    */
-  int loadObjectConfigs(std::string filepath) {}
+  std::vector<int> loadObjectConfigs(const std::string& path);
+
+  /**
+   * @brief Load the provided PhysicsObjectAttributes template into the
+   * Simulator.
+   *
+   * @param objectTemplate A new PhysicsObjectAttributes to load.
+   * @param objectTemplateHandle The desired key for referencing the new
+   * template. Must not be a duplicate of an existing key.
+   * @return A template index for instancing the loaded template or ID_UNDEFINED
+   * if failed.
+   */
+  int loadObjectTemplate(assets::PhysicsObjectAttributes& objectTemplate,
+                         const std::string& objectTemplateHandle);
 
   /**
    * @brief Remove an instanced object by ID. See @ref

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -121,6 +121,11 @@ class Simulator {
   int getPhysicsObjectLibrarySize();
 
   /**
+   * TODO:
+   */
+  int loadObjectConfigs(std::string filepath) {}
+
+  /**
    * @brief Remove an instanced object by ID. See @ref
    * esp::physics::PhysicsManager::removeObject().
    * @param objectID The ID of the object identifying it in @ref

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -139,7 +139,7 @@ class Simulator {
    *
    * @param objectTemplate A new PhysicsObjectAttributes to load.
    * @param objectTemplateHandle The desired key for referencing the new
-   * template. Must not be a duplicate of an existing key.
+   * template. To register this successfully, it must not be a duplicate of an existing key.
    * @return A template index for instancing the loaded template or ID_UNDEFINED
    * if failed.
    */

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -110,7 +110,8 @@ SimTest::SimTest() {
             &SimTest::getCustomLightingRGBAObservation,
             &SimTest::updateLightSetupRGBAObservation,
             &SimTest::updateObjectLightSetupRGBAObservation,
-            &SimTest::multipleLightingSetupsRGBAObservation});
+            &SimTest::multipleLightingSetupsRGBAObservation,
+            &SimTest::loadingObjectTemplates});
   // clang-format on
 }
 
@@ -323,6 +324,14 @@ void SimTest::loadingObjectTemplates() {
   std::vector<int> templateIndices = simulator->loadObjectConfigs(
       Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
   CORRADE_VERIFY(!templateIndices.empty());
+  for (auto index : templateIndices) {
+    CORRADE_VERIFY(index != esp::ID_UNDEFINED);
+  }
+
+  // reload again and ensure that old loaded indices are returned
+  std::vector<int> templateIndices2 = simulator->loadObjectConfigs(
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
+  CORRADE_VERIFY(templateIndices2 == templateIndices);
 
   // test fresh template
   esp::assets::PhysicsObjectAttributes newTemplate;

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -88,6 +88,7 @@ struct SimTest : Cr::TestSuite::Tester {
   void updateLightSetupRGBAObservation();
   void updateObjectLightSetupRGBAObservation();
   void multipleLightingSetupsRGBAObservation();
+  void loadingObjectTemplates();
 
   // TODO: remove outlier pixels from image and lower maxThreshold
   const Magnum::Float maxThreshold = 255.f;
@@ -313,6 +314,27 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
   simulator->setObjectLightSetup(objectID, "custom_lighting_2");
   checkPinholeCameraRGBAObservation(
       *simulator, "SimTestExpectedDifferentLighting.png", maxThreshold, 0.01f);
+}
+
+void SimTest::loadingObjectTemplates() {
+  auto simulator = getSimulator(planeScene);
+
+  // test directory of templates
+  std::vector<int> templateIndices = simulator->loadObjectConfigs(
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
+  CORRADE_VERIFY(!templateIndices.empty());
+
+  // test fresh template
+  esp::assets::PhysicsObjectAttributes newTemplate;
+  std::string boxPath =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+  newTemplate.setString("renderMeshHandle", boxPath);
+  int templateIndex = simulator->loadObjectTemplate(newTemplate, boxPath);
+  CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
+
+  // test double load
+  templateIndex = simulator->loadObjectTemplate(newTemplate, boxPath);
+  CORRADE_VERIFY(templateIndex == esp::ID_UNDEFINED);
 }
 
 }  // namespace

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -249,7 +249,7 @@ Viewer::Viewer(const Arguments& arguments)
   if (io::exists(navmeshFilename) && !args.isSet("recompute-navmesh")) {
     LOG(INFO) << "Loading navmesh from " << navmeshFilename;
     pathfinder_->loadNavMesh(navmeshFilename);
-  } else {
+  } else if (file.compare(esp::assets::EMPTY_SCENE)) {
     esp::nav::NavMeshSettings navMeshSettings;
     navMeshSettings.setDefaults();
     recomputeNavMesh(file, navMeshSettings);


### PR DESCRIPTION
## Motivation and Context

Often we want to load new objects which were not originally configured upon load. This change both refactors object loading to separate parsing of object template paths from the simulator configuration and adds `loadObjectConfigs` and `loadObjectTemplate` functions to the `Simulator` class to facilitate object loading without direct access to `ResourceManager`.

Includes a minor fix to a recent bug in `viewer.cpp` when loading "NONE" scene without a navmesh introduced in PR #531.

## How Has This Been Tested

New C++ unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
