### PR TITLE
Clang Tidy: don't treat deprecation warnings as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,4 +12,10 @@ google-*,
 -google-runtime-references
 '
 
-WarningsAsErrors: '*'
+# Let deprecation warnings through. From time to time, Magnum annotates APIs
+# with deprecation warnings, suggesting people to upgrade to newer / better
+# designed / more flexible APIs. Treating such warnings as error is
+# counterproductive, since the first thing you want to do after an upgrade is
+# compiling existing *unchanged* code and ensuring all tests pass, and only
+# then start updating the code.
+WarningsAsErrors: '*,-clang-diagnostic-deprecated-declarations'


### PR DESCRIPTION
## Motivation and Context

I hope this is not too much of a controversial change — while upgrading Habitat to make use of the new Magnum [MeshData](https://doc.magnum.graphics/magnum/classMagnum_1_1Trade_1_1MeshData.html) APIs (PR with that comes right next), the first thing I did before adapting all code was bumping submodules and letting the CI check that existing code continues to work, to avoid repeating what happened in #496. It *did* work (even though there's >35kLOC changes on Magnum side), *except* that Clang Tidy failed the build due to the newly appearing deprecation warnings. To fix that I'd be forced to update all code first, losing the chance of knowing what exactly is responsible for a potential new test failure.

This PR makes Clang Tidy let deprecation warnings through. In case of Magnum at least, when an API gets deprecated, it usually stays in the codebase for at least one more year so everyone has enough time to upgrade, and using deprecated APIs isn't a critical error. This change should also give developers more headroom when updating Magnum — sometimes one might want to pull fresh master to have a critical bug fixed, but delay adapting of deprecated code for later.

## How Has This Been Tested

The `meshdata` branch that I'm currently working on builds green on the CI without deprecation warnings affecting its state.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
