### PR TITLE
[bug fix] - get CollisionMeshData for AssetType::UNKOWN assets

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -89,7 +89,7 @@ bool ResourceManager::loadScene(
   // mesh, or general mesh (e.g., MP3D)
   staticDrawableInfo_.clear();
   if (info.type == AssetType::FRL_PTEX_MESH ||
-      info.type == AssetType::MP3D_MESH ||
+      info.type == AssetType::MP3D_MESH || info.type == AssetType::UNKNOWN ||
       (info.type == AssetType::INSTANCE_MESH && splitSemanticMesh)) {
     computeAbsoluteAABBs_ = true;
   }
@@ -149,7 +149,8 @@ bool ResourceManager::loadScene(
 
       computePTexMeshAbsoluteAABBs(*meshes_[metaData.meshIndex.first]);
 #endif
-    } else if (info.type == AssetType::MP3D_MESH) {
+    } else if (info.type == AssetType::MP3D_MESH ||
+               info.type == AssetType::UNKNOWN) {
       computeGeneralMeshAbsoluteAABBs();
     } else if (info.type == AssetType::INSTANCE_MESH) {
       computeInstanceMeshAbsoluteAABBs();

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -275,9 +275,17 @@ bool ResourceManager::loadScene(
       }
 
       // GLB Mesh
-      else if (info.type == AssetType::MP3D_MESH) {
+      else if (info.type == AssetType::MP3D_MESH ||
+               info.type == AssetType::UNKNOWN) {
         GltfMeshData* gltfMeshData =
             dynamic_cast<GltfMeshData*>(meshes_[mesh_i].get());
+        if (gltfMeshData == nullptr) {
+          Corrade::Utility::Debug()
+              << "AssetInfo::AssetType type error: unsupported physical type, "
+                 "aborting. Try running without \"--enable-phyisics\" and "
+                 "consider logging an issue.";
+          return false;
+        }
         CollisionMeshData& meshData = gltfMeshData->getCollisionMeshData();
         meshGroup.push_back(meshData);
       }


### PR DESCRIPTION
## Motivation and Context

Currently, assets with 'AssetType::UNKOWN' are parsed through the gltf pipeline by default (this includes `.obj` files). However, these assets were being gated at physical scene initialization. 

After this change, 'AssetType::UNKOWN' assets for physical scenes now attempt to load 'CollisionMeshData' as 'GltfMeshData' objects. If this fails, load is aborted.

This change also enables culling for 'AssetType::UNKOWN' in the same manner.

## How Has This Been Tested

Loading an `.obj` scene in viewer.cpp

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
