### PR TITLE
Getter/setters for derived Attribute defaults

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -260,41 +260,218 @@ std::string Attributes::listAttributes() {
   return attributes;
 }
 
+//----------------------------------------//
+//  Derived attribute implementations
+//----------------------------------------//
+
 PhysicsObjectAttributes::PhysicsObjectAttributes() {
   // fill necessary attribute defaults
-  setDouble("mass", 1.0);
-  setDouble("margin", 0.01);
-  setMagnumVec3("scale", Magnum::Vector3(1.0, 1.0, 1.0));
-  setMagnumVec3("COM", Magnum::Vector3(0));
-  setMagnumVec3("inertia", Magnum::Vector3(0., 0., 0.));
-  setDouble("frictionCoefficient", 0.5);
-  setDouble("restitutionCoefficient", 0.1);
-  setDouble("linDamping", 0.2);
-  setDouble("angDamping", 0.2);
-  setString("originHandle", "");
-  setString("renderMeshHandle", "");
-  setString("collisionMeshHandle", "");
-  setBool("useBoundingBoxForCollision",
-          false);  // if true, override other options and TODO: use bounding box
-                   // as collision object
-  setBool("joinCollisionMeshes",
-          true);  // if true, join all meshes into one collision convex instead
-                  // of building a compound
-  setBool("requiresLighting", true);
+  setMass(1.0);
+  setMargin(0.01);
+  setScale({1.0, 1.0, 1.0});
+  setCOM({0, 0, 0});
+  setInertia({0, 0, 0});
+  setFrictionCoefficient(0.5);
+  setRestitutionCoefficient(0.1);
+  setLinearDamping(0.2);
+  setAngularDamping(0.2);
+  setOriginHandle("");
+  setRenderMeshHandle("");
+  setCollisionMeshHandle("");
+  setBoundingBoxCollisions(false);
+  setJoinCollisionMeshes(true);
+  setRequiresLighting(true);
+}
+
+// center of mass (COM)
+void PhysicsObjectAttributes::setCOM(const Magnum::Vector3& com) {
+  setMagnumVec3("COM", com);
+}
+Magnum::Vector3 PhysicsObjectAttributes::getCOM() const {
+  return getMagnumVec3("COM");
+}
+
+// collision shape inflation margin
+void PhysicsObjectAttributes::setMargin(double margin) {
+  setDouble("margin", margin);
+}
+double PhysicsObjectAttributes::getMargin() const {
+  return getDouble("margin");
+}
+
+void PhysicsObjectAttributes::setMass(double mass) {
+  setDouble("mass", mass);
+}
+double PhysicsObjectAttributes::getMass() const {
+  return getDouble("mass");
+}
+
+// inertia diagonal
+void PhysicsObjectAttributes::setInertia(const Magnum::Vector3& inertia) {
+  setMagnumVec3("inertia", inertia);
+}
+Magnum::Vector3 PhysicsObjectAttributes::getInertia() const {
+  return getMagnumVec3("inertia");
+}
+
+void PhysicsObjectAttributes::setScale(const Magnum::Vector3& scale) {
+  setMagnumVec3("scale", scale);
+}
+Magnum::Vector3 PhysicsObjectAttributes::getScale() const {
+  return getMagnumVec3("scale");
+}
+
+void PhysicsObjectAttributes::setFrictionCoefficient(
+    double frictionCoefficient) {
+  setDouble("frictionCoefficient", frictionCoefficient);
+}
+double PhysicsObjectAttributes::getFrictionCoefficient() const {
+  return getDouble("frictionCoefficient");
+}
+
+void PhysicsObjectAttributes::setRestitutionCoefficient(
+    double restitutionCoefficient) {
+  setDouble("restitutionCoefficient", restitutionCoefficient);
+}
+double PhysicsObjectAttributes::getRestitutionCoefficient() const {
+  return getDouble("restitutionCoefficient");
+}
+
+void PhysicsObjectAttributes::setLinearDamping(double linearDamping) {
+  setDouble("linDamping", linearDamping);  // TODO: change to "linearDamping"
+}
+double PhysicsObjectAttributes::getLinearDamping() const {
+  return getDouble("linDamping");
+}
+
+void PhysicsObjectAttributes::setAngularDamping(double angularDamping) {
+  setDouble("angDamping", angularDamping);  // TODO: change to "angularDamping"
+}
+double PhysicsObjectAttributes::getAngularDamping() const {
+  return getDouble("angDamping");
+}
+
+void PhysicsObjectAttributes::setOriginHandle(const std::string& originHandle) {
+  setString("originHandle", originHandle);
+}
+std::string PhysicsObjectAttributes::getOriginHandle() const {
+  return getString("originHandle");
+}
+
+void PhysicsObjectAttributes::setRenderMeshHandle(
+    const std::string& renderMeshHandle) {
+  setString("renderMeshHandle", renderMeshHandle);
+}
+std::string PhysicsObjectAttributes::getRenderMeshHandle() const {
+  return getString("renderMeshHandle");
+}
+
+void PhysicsObjectAttributes::setCollisionMeshHandle(
+    const std::string& collisionMeshHandle) {
+  setString("collisionMeshHandle", collisionMeshHandle);
+}
+std::string PhysicsObjectAttributes::getCollisionMeshHandle() const {
+  return getString("collisionMeshHandle");
+}
+
+// if true override other settings and use render mesh bounding box as collision
+// object
+void PhysicsObjectAttributes::setBoundingBoxCollisions(
+    bool useBoundingBoxForCollision) {
+  setBool("useBoundingBoxForCollision", useBoundingBoxForCollision);
+}
+bool PhysicsObjectAttributes::getBoundingBoxCollisions() const {
+  return getBool("useBoundingBoxForCollision");
+}
+
+// if true join all mesh components of an asset into a unified collision object
+void PhysicsObjectAttributes::setJoinCollisionMeshes(bool joinCollisionMeshes) {
+  setBool("joinCollisionMeshes", joinCollisionMeshes);
+}
+bool PhysicsObjectAttributes::getJoinCollisionMeshes() const {
+  return getBool("joinCollisionMeshes");
+}
+
+// if true use phong illumination model instead of flat shading
+void PhysicsObjectAttributes::setRequiresLighting(bool requiresLighting) {
+  setBool("requiresLighting", requiresLighting);
+}
+bool PhysicsObjectAttributes::getRequiresLighting() const {
+  return getBool("requiresLighting");
 }
 
 PhysicsSceneAttributes::PhysicsSceneAttributes() {
-  setMagnumVec3("gravity", Magnum::Vector3(0, -9.8, 0));
-  setDouble("frictionCoefficient", 0.4);
-  setDouble("restitutionCoefficient", 0.05);
-  setString("renderMeshHandle", "");
-  setString("collisionMeshHandle", "");
+  setGravity({0, -9.8, 0});
+  setFrictionCoefficient(0.4);
+  setRestitutionCoefficient(0.05);
+  setRenderMeshHandle("");
+  setCollisionMeshHandle("");
+}
+
+void PhysicsSceneAttributes::setGravity(const Magnum::Vector3& gravity) {
+  setMagnumVec3("gravity", gravity);
+}
+Magnum::Vector3 PhysicsSceneAttributes::getGravity() const {
+  return getMagnumVec3("gravity");
+}
+
+void PhysicsSceneAttributes::setFrictionCoefficient(
+    double frictionCoefficient) {
+  setDouble("frictionCoefficient", frictionCoefficient);
+}
+double PhysicsSceneAttributes::getFrictionCoefficient() const {
+  return getDouble("frictionCoefficient");
+}
+
+void PhysicsSceneAttributes::setRestitutionCoefficient(
+    double restitutionCoefficient) {
+  setDouble("restitutionCoefficient", restitutionCoefficient);
+}
+double PhysicsSceneAttributes::getRestitutionCoefficient() const {
+  return getDouble("restitutionCoefficient");
+}
+
+void PhysicsSceneAttributes::setRenderMeshHandle(
+    const std::string& renderMeshHandle) {
+  setString("renderMeshHandle", renderMeshHandle);
+}
+std::string PhysicsSceneAttributes::getRenderMeshHandle() const {
+  return getString("renderMeshHandle");
+}
+
+void PhysicsSceneAttributes::setCollisionMeshHandle(
+    const std::string& collisionMeshHandle) {
+  setString("collisionMeshHandle", collisionMeshHandle);
+}
+std::string PhysicsSceneAttributes::getCollisionMeshHandle() const {
+  return getString("collisionMeshHandle");
 }
 
 PhysicsManagerAttributes::PhysicsManagerAttributes() {
-  setString("simulator", "none");
-  setDouble("timestep", 0.01);
-  setInt("maxSubsteps", 10);
+  setSimulator("none");
+  setTimestep(0.01);
+  setMaxSubsteps(10);
+}
+
+void PhysicsManagerAttributes::setSimulator(const std::string& simulator) {
+  setString("simulator", simulator);
+}
+std::string PhysicsManagerAttributes::getSimulator() const {
+  return getString("simulator");
+}
+
+void PhysicsManagerAttributes::setTimestep(double timestep) {
+  setDouble("timestep", timestep);
+}
+double PhysicsManagerAttributes::getTimestep() const {
+  return getDouble("timestep");
+}
+
+void PhysicsManagerAttributes::setMaxSubsteps(int maxSubsteps) {
+  setInt("maxSubsteps", maxSubsteps);
+}
+int PhysicsManagerAttributes::getMaxSubsteps() const {
+  return getInt("maxSubsteps");
 }
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -111,18 +111,100 @@ class Attributes {
 class PhysicsObjectAttributes : public Attributes {
  public:
   PhysicsObjectAttributes();
+
+  // default value getter/setter methods
+
+  // center of mass (COM)
+  void setCOM(const Magnum::Vector3& com);
+  Magnum::Vector3 getCOM() const;
+
+  // collision shape inflation margin
+  void setMargin(double margin);
+  double getMargin() const;
+
+  void setMass(double mass);
+  double getMass() const;
+
+  // inertia diagonal
+  void setInertia(const Magnum::Vector3& inertia);
+  Magnum::Vector3 getInertia() const;
+
+  void setScale(const Magnum::Vector3& scale);
+  Magnum::Vector3 getScale() const;
+
+  void setFrictionCoefficient(double frictionCoefficient);
+  double getFrictionCoefficient() const;
+
+  void setRestitutionCoefficient(double restitutionCoefficient);
+  double getRestitutionCoefficient() const;
+
+  void setLinearDamping(double linearDamping);
+  double getLinearDamping() const;
+
+  void setAngularDamping(double angularDamping);
+  double getAngularDamping() const;
+
+  void setOriginHandle(const std::string& originHandle);
+  std::string getOriginHandle() const;
+
+  void setRenderMeshHandle(const std::string& renderMeshHandle);
+  std::string getRenderMeshHandle() const;
+
+  void setCollisionMeshHandle(const std::string& collisionMeshHandle);
+  std::string getCollisionMeshHandle() const;
+
+  // if true override other settings and use render mesh bounding box as
+  // collision object
+  void setBoundingBoxCollisions(bool useBoundingBoxForCollision);
+  bool getBoundingBoxCollisions() const;
+
+  // if true join all mesh components of an asset into a unified collision
+  // object
+  void setJoinCollisionMeshes(bool joinCollisionMeshes);
+  bool getJoinCollisionMeshes() const;
+
+  // if true use phong illumination model instead of flat shading
+  void setRequiresLighting(bool requiresLighting);
+  bool getRequiresLighting() const;
+
 };  // end PhysicsObjectAttributes class
 
 //! attributes for a single physical scene
 class PhysicsSceneAttributes : public Attributes {
  public:
   PhysicsSceneAttributes();
+
+  void setGravity(const Magnum::Vector3& gravity);
+  Magnum::Vector3 getGravity() const;
+
+  void setFrictionCoefficient(double frictionCoefficient);
+  double getFrictionCoefficient() const;
+
+  void setRestitutionCoefficient(double restitutionCoefficient);
+  double getRestitutionCoefficient() const;
+
+  void setRenderMeshHandle(const std::string& renderMeshHandle);
+  std::string getRenderMeshHandle() const;
+
+  void setCollisionMeshHandle(const std::string& collisionMeshHandle);
+  std::string getCollisionMeshHandle() const;
+
 };  // end PhysicsSceneAttributes
 
 //! attributes for a single physics manager
 class PhysicsManagerAttributes : public Attributes {
  public:
   PhysicsManagerAttributes();
+
+  void setSimulator(const std::string& simulator);
+  std::string getSimulator() const;
+
+  void setTimestep(double timestep);
+  double getTimestep() const;
+
+  void setMaxSubsteps(int maxSubsteps);
+  int getMaxSubsteps() const;
+
 };  // end PhysicsManagerAttributes
 
 }  // namespace assets

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -16,7 +16,7 @@ bool PhysicsManager::initPhysics(
   physicsNode_ = node;
 
   // Copy over relevant configuration
-  fixedTimeStep_ = physicsManagerAttributes.getDouble("timestep");
+  fixedTimeStep_ = physicsManagerAttributes.getTimestep();
 
   //! Create new scene node
   staticSceneObject_ =
@@ -77,9 +77,9 @@ int PhysicsManager::addObject(const int objectLibIndex,
   if (physicsObjectAttributes.existsAs(assets::DataType::BOOL,
                                        "COM_provided")) {
     // if the COM is provided, shift by that
-    Magnum::Vector3 comShift = -physicsObjectAttributes.getMagnumVec3("COM");
+    Magnum::Vector3 comShift = -physicsObjectAttributes.getCOM();
     // first apply scale
-    comShift = physicsObjectAttributes.getMagnumVec3("scale") * comShift;
+    comShift = physicsObjectAttributes.getScale() * comShift;
     existingObjects_.at(nextObjectID_)->shiftOrigin(comShift);
   } else {
     // otherwise use the bounding box center

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -36,7 +36,7 @@ bool BulletPhysicsManager::initPhysics(
   bWorld_->setDebugDrawer(&debugDrawer_);
 
   // Copy over relevant configuration
-  fixedTimeStep_ = physicsManagerAttributes.getDouble("timestep");
+  fixedTimeStep_ = physicsManagerAttributes.getTimestep();
   // currently GLB meshes are y-up
   bWorld_->setGravity(
       btVector3(physicsManagerAttributes.getMagnumVec3("gravity")));
@@ -63,7 +63,7 @@ bool BulletPhysicsManager::addScene(
   }
 
   const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(
-      physicsSceneAttributes.getString("collisionMeshHandle"));
+      physicsSceneAttributes.getCollisionMeshHandle());
 
   //! Initialize scene
   bool sceneSuccess = static_cast<BulletRigidObject*>(staticSceneObject_.get())
@@ -89,7 +89,7 @@ int BulletPhysicsManager::makeRigidObject(
       std::make_unique<BulletRigidObject>(objectNode);
 
   const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(
-      physicsObjectAttributes.getString("collisionMeshHandle"));
+      physicsObjectAttributes.getCollisionMeshHandle());
   bool objectSuccess =
       static_cast<BulletRigidObject*>(existingObjects_.at(newObjectID).get())
           ->initializeObject(physicsObjectAttributes, bWorld_, metaData,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -462,11 +462,11 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
         const assets::PhysicsObjectAttributes& initializationTemplate =
             physicsManager_->getInitializationAttributes(objectID);
         objectTransform.scale(Magnum::EigenIntegration::cast<vec3f>(
-            initializationTemplate.getMagnumVec3("scale")));
+            initializationTemplate.getScale()));
         std::string meshHandle =
-            initializationTemplate.getString("collisionMeshHandle");
+            initializationTemplate.getCollisionMeshHandle();
         if (meshHandle.empty()) {
-          meshHandle = initializationTemplate.getString("renderMeshHandle");
+          meshHandle = initializationTemplate.getRenderMeshHandle();
         }
         assets::MeshData::uptr joinedObjectMesh =
             resourceManager_.createJoinedCollisionMesh(meshHandle);

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -77,7 +77,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
     // if we have a simulation implementation then test a joined vs. unjoined
     // object
     esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-    physicsObjectAttributes.setString("renderMeshHandle", objectFile);
+    physicsObjectAttributes.setRenderMeshHandle(objectFile);
     resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
     // get a reference to the stored template to edit
@@ -87,9 +87,9 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
     for (int i = 0; i < 2; i++) {
       // mark the object not joined
       if (i == 0) {
-        objectTemplate.setBool("joinCollisionMeshes", false);
+        objectTemplate.setJoinCollisionMeshes(false);
       } else {
-        objectTemplate.setBool("joinCollisionMeshes", true);
+        objectTemplate.setJoinCollisionMeshes(true);
       }
 
       physicsManager_->reset();
@@ -153,9 +153,9 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
     // sphere object
 
     esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-    physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-    physicsObjectAttributes.setDouble("margin", 0.0);
-    physicsObjectAttributes.setBool("joinCollisionMeshes", false);
+    physicsObjectAttributes.setRenderMeshHandle(objectFile);
+    physicsObjectAttributes.setMargin(0.0);
+    physicsObjectAttributes.setJoinCollisionMeshes(false);
     resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
     // get a reference to the stored template to edit
@@ -164,9 +164,9 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
 
     for (int i = 0; i < 2; i++) {
       if (i == 0) {
-        objectTemplate.setBool("useBoundingBoxForCollision", false);
+        objectTemplate.setBoundingBoxCollisions(false);
       } else {
-        objectTemplate.setBool("useBoundingBoxForCollision", true);
+        objectTemplate.setBoundingBoxCollisions(true);
       }
 
       physicsManager_->reset();
@@ -223,8 +223,8 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
     esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-    physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-    physicsObjectAttributes.setDouble("margin", 0.0);
+    physicsObjectAttributes.setRenderMeshHandle(objectFile);
+    physicsObjectAttributes.setMargin(0.0);
     resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
     // generate two centered boxes with dimension 2x2x2
@@ -264,8 +264,8 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
       PhysicsManager::PhysicsSimulationLibrary::BULLET) {
     // test joined vs. unjoined
     esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-    physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-    physicsObjectAttributes.setDouble("margin", 0.1);
+    physicsObjectAttributes.setRenderMeshHandle(objectFile);
+    physicsObjectAttributes.setMargin(0.1);
 
     resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
@@ -276,15 +276,15 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
     auto* drawables = &sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
     // add the unjoined object
-    objectTemplate.setBool("joinCollisionMeshes", false);
+    objectTemplate.setJoinCollisionMeshes(false);
     int objectId0 = physicsManager_->addObject(objectFile, drawables);
 
     // add the joined object
-    objectTemplate.setBool("joinCollisionMeshes", true);
+    objectTemplate.setJoinCollisionMeshes(true);
     int objectId1 = physicsManager_->addObject(objectFile, drawables);
 
     // add bounding box object
-    objectTemplate.setBool("useBoundingBoxForCollision", true);
+    objectTemplate.setBoundingBoxCollisions(true);
     int objectId2 = physicsManager_->addObject(objectFile, drawables);
 
     esp::physics::BulletPhysicsManager* bPhysManager =
@@ -322,8 +322,8 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
 
   // test joined vs. unjoined
   esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-  physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-  physicsObjectAttributes.setDouble("margin", 0.0);
+  physicsObjectAttributes.setRenderMeshHandle(objectFile);
+  physicsObjectAttributes.setMargin(0.0);
 
   resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
@@ -339,7 +339,7 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
   for (auto& testScale : testScales) {
-    objectTemplate.setMagnumVec3("scale", testScale);
+    objectTemplate.setScale(testScale);
 
     Magnum::Range3D boundsGroundTruth(-abs(testScale), abs(testScale));
 
@@ -379,8 +379,8 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
   initScene(sceneFile);
 
   esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-  physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-  physicsObjectAttributes.setDouble("margin", 0.0);
+  physicsObjectAttributes.setRenderMeshHandle(objectFile);
+  physicsObjectAttributes.setMargin(0.0);
   resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
   auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
@@ -487,7 +487,7 @@ TEST_F(PhysicsManagerTest, TestSceneNodeAttachment) {
   initScene(sceneFile);
 
   esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-  physicsObjectAttributes.setString("renderMeshHandle", objectFile);
+  physicsObjectAttributes.setRenderMeshHandle(objectFile);
   resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 
   esp::scene::SceneNode& root =
@@ -540,10 +540,10 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
     float boxHalfExtent = 0.2;
     esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
-    physicsObjectAttributes.setString("renderMeshHandle", objectFile);
-    physicsObjectAttributes.setBool("useBoundingBoxForCollision", true);
-    physicsObjectAttributes.setMagnumVec3(
-        "scale", {boxHalfExtent, boxHalfExtent, boxHalfExtent});
+    physicsObjectAttributes.setRenderMeshHandle(objectFile);
+    physicsObjectAttributes.setBoundingBoxCollisions(true);
+    physicsObjectAttributes.setScale(
+        {boxHalfExtent, boxHalfExtent, boxHalfExtent});
     int boxId =
         resourceManager_.loadObject(physicsObjectAttributes, objectFile);
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -360,7 +360,7 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
   // test scaling
   esp::assets::PhysicsObjectAttributes& objectTemplate =
       simulator->getPhysicsObjectAttributes(0);
-  objectTemplate.setMagnumVec3("scale", {0.5, 0.5, 0.5});
+  objectTemplate.setScale({0.5, 0.5, 0.5});
   objectID = simulator->addObject(0);
   simulator->setTranslation(Magnum::Vector3{randomNavPoint}, objectID);
   simulator->setTranslation(
@@ -399,7 +399,7 @@ void SimTest::loadingObjectTemplates() {
   esp::assets::PhysicsObjectAttributes newTemplate;
   std::string boxPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
-  newTemplate.setString("renderMeshHandle", boxPath);
+  newTemplate.setRenderMeshHandle(boxPath);
   int templateIndex = simulator->loadObjectTemplate(newTemplate, boxPath);
   CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
 


### PR DESCRIPTION
## Motivation and Context

This change refactors derived classes of `assets::Attributes` to expose getter/setter methods for expected default fields. This change is preparation for python bindings and tutorials to enable user friendly manipulation of object, scene, and simulator templates (e.g. `PhysicsObjectAttributes`) for domain randomization. 

## How Has This Been Tested

Existing code (including tests) modified to use getter/setters.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
