### PR TITLE
Faster RGB & Depth noise models

### DIFF
--- a/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/habitat_sim/nav/greedy_geodesic_follower.py
@@ -65,7 +65,7 @@ class GreedyGeodesicFollower(object):
     def _find_action(self, name):
         candidates = list(
             filter(
-                lambda v: v[1].name == name,
+                lambda v: name in v[1].name,
                 self.agent.agent_config.action_space.items(),
             )
         )

--- a/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/habitat_sim/nav/greedy_geodesic_follower.py
@@ -65,7 +65,7 @@ class GreedyGeodesicFollower(object):
     def _find_action(self, name):
         candidates = list(
             filter(
-                lambda v: name in v[1].name,
+                lambda v: v[1].name == name,
                 self.agent.agent_config.action_space.items(),
             )
         )

--- a/habitat_sim/sensors/noise_models/gaussian_noise_model.py
+++ b/habitat_sim/sensors/noise_models/gaussian_noise_model.py
@@ -19,19 +19,9 @@ def _simulate(image, intensity_constant, mean, sigma):
         np.random.randn(image.shape[0], image.shape[1], image.shape[2]) * sigma + mean
     ) * intensity_constant
 
-    noisy_rgb = np.empty_like(image)
-
-    # Parallelize just the outer loop.  This doesn't change the speed
-    # noticably but reduces CPU usage compared to all parallel loops
-    for i in numba.prange(image.shape[0]):
-        for j in range(image.shape[1]):
-            for k in range(image.shape[2]):
-                noisy_val = image[i, j, k] / 255.0 + noise[i, j, k]
-                noisy_val = max(min(noisy_val, 1.0), 0.0)
-                noisy_val = noisy_val * 255.0
-                noisy_rgb[j, i, k] = noisy_val
-
-    return noisy_rgb
+    return (np.maximum(np.minimum(image / 255.0 + noise, 1.0), 0.0) * 255.0).astype(
+        np.uint8
+    )
 
 
 @attr.s(auto_attribs=True)

--- a/habitat_sim/sensors/noise_models/gaussian_noise_model.py
+++ b/habitat_sim/sensors/noise_models/gaussian_noise_model.py
@@ -13,7 +13,7 @@ from habitat_sim.sensor import SensorType
 from habitat_sim.sensors.noise_models.sensor_noise_model import SensorNoiseModel
 
 
-@numba.jit(nopython=True, parallel=True)
+@numba.jit(nopython=True, parallel=True, fastmath=True)
 def _simulate(image, intensity_constant, mean, sigma):
     noise = (
         np.random.randn(image.shape[0], image.shape[1], image.shape[2]) * sigma + mean

--- a/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -23,7 +23,7 @@ torch = None
 
 # Read about the noise model here: http://www.alexteichman.com/octo/clams/
 # Original source code: http://redwood-data.org/indoor/data/simdepth.py
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, fastmath=True)
 def _undistort(x, y, z, model):
     i2 = int((z + 1) / 2)
     i1 = int(i2 - 1)
@@ -38,7 +38,7 @@ def _undistort(x, y, z, model):
         return z / f
 
 
-@numba.jit(nopython=True, parallel=True)
+@numba.jit(nopython=True, parallel=True, fastmath=True)
 def _simulate(gt_depth, model, noise_multiplier):
     noisy_depth = np.empty_like(gt_depth)
 

--- a/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -43,10 +43,13 @@ def _simulate(gt_depth, model, noise_multiplier):
     noisy_depth = np.empty_like(gt_depth)
 
     H, W = gt_depth.shape
-    ymax, xmax = H - 1, W - 1
+    ymax, xmax = H - 1.0, W - 1.0
 
     rand_nums = np.random.randn(H, W, 3).astype(np.float32)
-    for j in range(H):
+
+    # Parallelize just the outer loop.  This doesn't change the speed
+    # noticably but reduces CPU usage compared to two parallel loops
+    for j in numba.prange(H):
         for i in range(W):
             y = int(
                 min(max(j + rand_nums[j, i, 0] * 0.25 * noise_multiplier, 0.0), ymax)


### PR DESCRIPTION
## Motivation and Context
We noticed that RGB noise models are 7x times slower than whole Habitat step call.
@erikwijmans with @Skylion007  made our RGB noise models 50x faster with following PR.
- One minor change is to make GreedyFollower compatible with PyRobot actions. The change makes it possible to build shortest path on the fly with noise actuations.

## How Has This Been Tested
Existing [HSIM noise tests](https://github.com/facebookresearch/habitat-sim/blob/master/tests/test_sensors.py#L152-L207), [HAPI noise tests](https://github.com/facebookresearch/habitat-api/blob/master/test/test_sensors.py#L329).
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
