### PR TITLE
assets: clean up PhongMaterialData usage

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1388,34 +1388,24 @@ gfx::PhongMaterialData::uptr ResourceManager::getPhongShadedMaterialData(
   finalMaterial->shininess = material.shininess();
 
   // ambient material properties
+  finalMaterial->ambientColor = material.ambientColor();
   if (material.flags() & Mn::Trade::PhongMaterialData::Flag::AmbientTexture) {
     finalMaterial->ambientTexture =
         textures_[textureBaseIndex + material.ambientTexture()].get();
-    finalMaterial->ambientColor = 0xffffffff_rgbaf;
-  } else {
-    finalMaterial->ambientColor = material.ambientColor();
   }
 
   // diffuse material properties
+  finalMaterial->diffuseColor = material.diffuseColor();
   if (material.flags() & Mn::Trade::PhongMaterialData::Flag::DiffuseTexture) {
     finalMaterial->diffuseTexture =
         textures_[textureBaseIndex + material.diffuseTexture()].get();
-    finalMaterial->diffuseColor = 0xffffffff_rgbaf;
-  } else {
-    finalMaterial->diffuseColor = material.diffuseColor();
   }
 
   // specular material properties
+  finalMaterial->specularColor = material.specularColor();
   if (material.flags() & Mn::Trade::PhongMaterialData::Flag::SpecularTexture) {
     finalMaterial->specularTexture =
         textures_[textureBaseIndex + material.specularTexture()].get();
-    finalMaterial->specularColor = 0xffffffff_rgbaf;
-  } else {
-    // remove specular highlights if shininess value doesn't make sense
-    // TODO: figure out why materials are being loaded with shininess == 1
-    finalMaterial->specularColor = finalMaterial->shininess == 1
-                                       ? 0x000000_rgbf
-                                       : material.specularColor();
   }
   return finalMaterial;
 }


### PR DESCRIPTION
## Motivation and Context

Found this while working on the promised normal map support, so opening a separate PR.

Magnum's PhongMaterialData is now able to contain both colors and textures, so the branching is no longer needed. Apart from that, `TinyGltfImporter` had an issue where shininess was imported as 1.0 instead of 80.0, and that's fixed now as well so this workaround isn't needed either.

## How Has This Been Tested

:warning: CI passes, *except* that I had to modify the Van Gogh Room GLB to not darken the texture to 60% (which was apparently caused by a less-than ideal conversion of the [source OBJ](https://sketchfab.com/3d-models/van-gogh-room-311d052a9f034ba8bce55a1a8296b6f9) from 60% of the texture as an ambient and 60% as diffuse to a GLB that had only the diffuse part left). This worked before because the diffuse factor was ignored for textured materials.

~~Modified ZIP is at https://tmp.mosra.cz/habitat-test-scenes.zip, needs to be uploaded to http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip (and then the second commit in this PR dropped). Once that's done, I'll "undraft" the PR.~~ done thanks to @erikwijmans :white_check_mark: 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
