### PR TITLE
--basic groundwork for support of rendered physical primitives.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,3 @@ yarn-error.log*
 .npm/
 coverage_js/
 
-*.png

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ yarn-debug.log*
 yarn-error.log*
 .npm/
 coverage_js/
+
+*.png

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -579,7 +579,8 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename) {
   // check for duplicate load
   const bool objExists = physicsObjectLibrary_.count(objPhysConfigFilename) > 0;
   if (objExists) {
-    physicsObjectLibrary_[objPhysConfigFilename].getInt("objectTemplateID");
+    return physicsObjectLibrary_[objPhysConfigFilename].getInt(
+        "objectTemplateID");
   }
 
   // 1. parse the config file

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -216,7 +216,7 @@ bool ResourceManager::loadScene(
 #endif
   }
 
-  // reseat to base PhysicsManager to override previous as default behavior
+  // reset to base PhysicsManager to override previous as default behavior
   // if the desired simulator is not supported reset to "none" in metaData
   if (defaultToNoneSimulator) {
     _physicsManager.reset(new physics::PhysicsManager(this));
@@ -443,17 +443,14 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename,
   const bool objectIsLoaded =
       physicsObjectLibrary_.count(objPhysConfigFilename) > 0;
 
-  // Find objectID in resourceManager
-  int objectID = -1;
+  // Find objectTemplateID in resourceManager
+  int objectTemplateID = ID_UNDEFINED;
   if (!objectIsLoaded) {
     // Main loading function
-    objectID = loadObject(objPhysConfigFilename);
-
+    objectTemplateID = loadObject(objPhysConfigFilename);
   } else {
-    std::vector<std::string>::iterator itr =
-        std::find(physicsObjectConfigList_.begin(),
-                  physicsObjectConfigList_.end(), objPhysConfigFilename);
-    objectID = std::distance(physicsObjectConfigList_.begin(), itr);
+    objectTemplateID =
+        physicsObjectLibrary_[objPhysConfigFilename].getInt("objectTemplateID");
   }
 
   if (parent != nullptr and drawables != nullptr) {
@@ -486,7 +483,7 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename,
                  drawables, loadedAssetData.meshMetaData.root);
   }
 
-  return objectID;
+  return objectTemplateID;
 }
 
 PhysicsObjectAttributes& ResourceManager::getPhysicsObjectAttributes(
@@ -552,6 +549,9 @@ int ResourceManager::loadObject(PhysicsObjectAttributes& objectTemplate,
   if (!collisionMeshSuccess)
     objectTemplate.setString("collisionMeshHandle", renderMeshFilename);
 
+  // add object template ID to physicObjectAttribute
+  objectTemplate.setInt("objectTemplateID", physicsObjectLibrary_.size());
+
   // cache metaData, collision mesh Group
   physicsObjectLibrary_.emplace(objectTemplateHandle, objectTemplate);
   const MeshMetaData& meshMetaData =
@@ -570,8 +570,8 @@ int ResourceManager::loadObject(PhysicsObjectAttributes& objectTemplate,
   collisionMeshGroups_.emplace(objectTemplateHandle, meshGroup);
   physicsObjectConfigList_.push_back(objectTemplateHandle);
 
-  int objectID = physicsObjectConfigList_.size() - 1;
-  return objectID;
+  int objectTemplateID = objectTemplate.getInt("objectTemplateID");
+  return objectTemplateID;
 }
 
 // load object from config filename
@@ -579,13 +579,7 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename) {
   // check for duplicate load
   const bool objExists = physicsObjectLibrary_.count(objPhysConfigFilename) > 0;
   if (objExists) {
-    // TODO: this will skip the duplicate. Is there a good reason to allow
-    // duplicates?
-    std::vector<std::string>::iterator itr =
-        std::find(physicsObjectConfigList_.begin(),
-                  physicsObjectConfigList_.end(), objPhysConfigFilename);
-    int objectID = std::distance(physicsObjectConfigList_.begin(), itr);
-    return objectID;
+    physicsObjectLibrary_[objPhysConfigFilename].getInt("objectTemplateID");
   }
 
   // 1. parse the config file
@@ -765,8 +759,8 @@ int ResourceManager::loadObject(const std::string& objPhysConfigFilename) {
 }
 
 const std::vector<assets::CollisionMeshData>& ResourceManager::getCollisionMesh(
-    const int objectID) {
-  std::string configFile = getObjectConfig(objectID);
+    const int objectTemplateID) {
+  std::string configFile = getObjectConfig(objectTemplateID);
   return collisionMeshGroups_[configFile];
 }
 
@@ -775,26 +769,22 @@ const std::vector<assets::CollisionMeshData>& ResourceManager::getCollisionMesh(
   return collisionMeshGroups_[configFile];
 }
 
-int ResourceManager::getObjectID(const std::string& configFile) {
-  std::vector<std::string>::iterator itr =
-      std::find(physicsObjectConfigList_.begin(),
-                physicsObjectConfigList_.end(), configFile);
-  if (itr == physicsObjectConfigList_.cend()) {
-    return ID_UNDEFINED;
-  } else {
-    int objectID = std::distance(physicsObjectConfigList_.begin(), itr);
-    return objectID;
+int ResourceManager::getObjectTemplateID(const std::string& configFile) {
+  const bool objExists = physicsObjectLibrary_.count(configFile) > 0;
+  if (objExists) {
+    return physicsObjectLibrary_[configFile].getInt("objectTemplateID");
   }
+  return ID_UNDEFINED;
 }
 
-std::string ResourceManager::getObjectConfig(const int objectID) {
-  if (physicsObjectConfigList_.size() <= std::size_t(objectID)) {
+std::string ResourceManager::getObjectConfig(const int objectTemplateID) {
+  if (physicsObjectConfigList_.size() <= std::size_t(objectTemplateID)) {
     Corrade::Utility::Debug() << "ResourceManager::getObjectConfig - Aborting. "
                                  "No template with index "
-                              << objectID;
+                              << objectTemplateID;
     return "";
   }
-  return physicsObjectConfigList_[objectID];
+  return physicsObjectConfigList_[objectTemplateID];
 }
 
 Magnum::Range3D ResourceManager::computeMeshBB(BaseMesh* meshDataGL) {

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -266,16 +266,16 @@ class ResourceManager {
 
   /**
    * @brief Getter for all @ref assets::CollisionMeshData associated with the
-   * particular asset referenced by the index, objectID, in @ref
+   * particular asset referenced by the index, objectTemplateID, in @ref
    * physicsObjectLibrary_.
    *
-   * @param objectID The index of the object template in @ref
+   * @param objectTemplateID The index of the object template in @ref
    * physicsObjectLibrary_.
    * @return A vector reference to @ref assets::CollisionMeshData instances for
    * individual components of the asset.
    */
   const std::vector<assets::CollisionMeshData>& getCollisionMesh(
-      const int objectID);
+      const int objectTemplateID);
 
   /**
    * @brief Get the index in @ref physicsObjectLibrary_ for the object template
@@ -285,17 +285,17 @@ class ResourceManager {
    * physicsObjectLibrary_.
    * @return The index of the object template in @ref physicsObjectLibrary_.
    */
-  int getObjectID(const std::string& configFile);
+  int getObjectTemplateID(const std::string& configFile);
 
   /**
    * @brief Get the key in @ref physicsObjectLibrary_ for the object template
    * asset index.
    *
-   * @param objectID The index of the object template in @ref
+   * @param objectTemplateID The index of the object template in @ref
    * physicsObjectLibrary_.
    * @return The key referencing the asset in @ref physicsObjectLibrary_.
    */
-  std::string getObjectConfig(const int objectID);
+  std::string getObjectConfig(const int objectTemplateID);
 
   /**
    * @brief Get a reference to the physics object template for the asset
@@ -316,7 +316,7 @@ class ResourceManager {
    *
    * @return The size of the @ref physicsObjectLibrary_.
    */
-  int getNumLibraryObjects() { return physicsObjectConfigList_.size(); };
+  int getNumLibraryObjects() { return physicsObjectLibrary_.size(); };
 
   /**
    * @brief Retrieve the composition of all transforms applied to a mesh since

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -93,7 +93,7 @@ int PhysicsManager::addObject(const std::string& configFile,
                               DrawableGroup* drawables,
                               scene::SceneNode* attachmentNode,
                               const Magnum::ResourceKey& lightSetup) {
-  int resObjectID = resourceManager_->getObjectID(configFile);
+  int resObjectID = resourceManager_->getObjectTemplateID(configFile);
   //! Invoke resourceManager to draw object
   int physObjectID =
       addObject(resObjectID, drawables, attachmentNode, lightSetup);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -4,7 +4,6 @@
 
 #include <Magnum/BulletIntegration/DebugDraw.h>
 #include <Magnum/BulletIntegration/Integration.h>
-#include <Magnum/BulletIntegration/MotionState.h>
 
 #include "BulletCollision/CollisionShapes/btCompoundShape.h"
 #include "BulletCollision/CollisionShapes/btConvexHullShape.h"

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -8,8 +8,9 @@
  * @brief Struct SimulationContactResultCallback, class @ref
  * esp::physics::BulletRigidObject
  */
-
+#include <Magnum/BulletIntegration/MotionState.h>
 #include <btBulletDynamicsCommon.h>
+
 #include "BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.h"
 #include "esp/assets/Asset.h"
 #include "esp/assets/BaseMesh.h"

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -302,7 +302,8 @@ int Simulator::loadObjectTemplate(
     assets::PhysicsObjectAttributes& objectTemplate,
     const std::string& objectTemplateHandle) {
   // check for duplicate keys
-  if (resourceManager_.getObjectID(objectTemplateHandle) != ID_UNDEFINED) {
+  if (resourceManager_.getObjectTemplateID(objectTemplateHandle) !=
+      ID_UNDEFINED) {
     return ID_UNDEFINED;
   }
 


### PR DESCRIPTION
Fix includes in BulletRigidObject; refactor ResourceManager so that PhysicsObjectAttributes template tracks its own ID, (used to instance objects); Refactor ambiguous references to objectID in resource manager that really refer to object templates.

## Motivation and Context

The motivation for this fix is primarily to serve as a "first push" so that I am sure to get the process correct.  Functional changes : 

1. (Bug Fix) The include of MotionState.h in BuiletRigidObject.cpp was moved to BuiletRigidObject.h, since that is where MotionState is referenced by the code. 
2. (Refactor) ResourceManager.* : accessing object template IDs was improved by setting an ID field in the PhysicsObjectAttributes field corresponding to the template upon its creation, and then referencing that ID on demand.
3. (Refactor) ResourceManager.* : renamed all obvious references to object template ids from objectID to objectTemplateID, including getters.  Made changes in Simulation.cpp and PhysicsManager.cpp to support these changes.

## How Has This Been Tested

EDIT(JT) : I compiled the updated commit 359d98d  with --run_tests and all tests executed correctly.

Compilation and execution of viewer on  van-gogh.glb.  I am not sure of which existing tests should be used/modified for changes within these files, and welcome direction and input on this topic.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
