### PR TITLE
Cache pathfinding setup

### DIFF
--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -40,7 +40,8 @@ void initShortestPathBindings(py::module& m) {
       m, "MultiGoalShortestPath")
       .def(py::init(&MultiGoalShortestPath::create<>))
       .def_readwrite("requested_start", &MultiGoalShortestPath::requestedStart)
-      .def_readwrite("requested_ends", &MultiGoalShortestPath::requestedEnds)
+      .def_property("requested_ends", &MultiGoalShortestPath::getRequestedEnds,
+                    &MultiGoalShortestPath::setRequestedEnds)
       .def_readwrite("points", &MultiGoalShortestPath::points)
       .def_readwrite("geodesic_distance",
                      &MultiGoalShortestPath::geodesicDistance);

--- a/src/esp/nav/CMakeLists.txt
+++ b/src/esp/nav/CMakeLists.txt
@@ -16,8 +16,8 @@ target_link_libraries(nav
     core
     agent
     scene
-  PRIVATE
     Detour
+  PRIVATE
     Recast
 )
 

--- a/src/esp/nav/CMakeLists.txt
+++ b/src/esp/nav/CMakeLists.txt
@@ -16,8 +16,8 @@ target_link_libraries(nav
     core
     agent
     scene
-    Detour
   PRIVATE
+    Detour
     Recast
 )
 

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1060,6 +1060,8 @@ bool PathFinder::Impl::findPath(MultiGoalShortestPath& path) {
           path.pimpl_->minTheoreticalDist[i] - movedAmount,
           (path.pimpl_->requestedEnds[i] - path.requestedStart).norm());
     }
+
+    path.pimpl_->prevRequestedStart = path.requestedStart;
   }
 
   // Explore possible goal points by their minimum theoretical distance.

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -985,7 +985,6 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
   if (path.endRefs.size() != 0)
     return true;
 
-  bool anyHasPath = false;
   for (const auto& rqEnd : path.requestedEnds) {
     dtPolyRef endRef;
     vec3f pathEnd;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -36,9 +36,6 @@ namespace esp {
 namespace nav {
 
 struct MultiGoalShortestPath::Impl {
-  Impl() = default;
-  ~Impl() = default;
-
   std::vector<vec3f> requestedEnds;
 
   std::vector<dtPolyRef> endRefs;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -44,7 +44,7 @@ struct MultiGoalShortestPath::Impl {
     pathEnds.clear();
     requestedEnds = newEnds;
 
-    minTheoreticalDist = std::vector<float>(newEnds.size(), 0);
+    minTheoreticalDist.assign(newEnds.size(), 0);
   }
 
   const std::vector<vec3f>& getRequestedEnds() const { return requestedEnds; }

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -44,7 +44,7 @@ struct MultiGoalShortestPath::Impl {
     pathEnds.clear();
     requestedEnds = newEnds;
 
-    minTheorticalDist = std::vector<float>(newEnds.size(), 0);
+    minTheoreticalDist = std::vector<float>(newEnds.size(), 0);
   }
 
   const std::vector<vec3f>& getRequestedEnds() const { return requestedEnds; }
@@ -54,7 +54,7 @@ struct MultiGoalShortestPath::Impl {
   std::vector<dtPolyRef> endRefs;
   std::vector<vec3f> pathEnds;
 
-  std::vector<float> minTheorticalDist;
+  std::vector<float> minTheoreticalDist;
   vec3f prevRequestedStart = vec3f::Zero();
 };
 
@@ -1047,7 +1047,7 @@ bool PathFinder::Impl::findPath(MultiGoalShortestPath& path) {
   if (path.pimpl_->requestedEnds.size() > 1) {
     // Bound the minimum distance any point could be from the start by either
     // how close it use to be minus how much we moved from the last search point
-    // or just the L2 distance
+    // or just the L2 distance.
 
     ShortestPath prevPath;
     prevPath.requestedStart = path.requestedStart;
@@ -1056,22 +1056,23 @@ bool PathFinder::Impl::findPath(MultiGoalShortestPath& path) {
     const float movedAmount = prevPath.geodesicDistance;
 
     for (int i = 0; i < path.pimpl_->requestedEnds.size(); ++i) {
-      path.pimpl_->minTheorticalDist[i] = std::max(
-          path.pimpl_->minTheorticalDist[i] - movedAmount,
+      path.pimpl_->minTheoreticalDist[i] = std::max(
+          path.pimpl_->minTheoreticalDist[i] - movedAmount,
           (path.pimpl_->requestedEnds[i] - path.requestedStart).norm());
     }
   }
 
+  // Explore possible goal points by their minimum theoretical distance.
   std::vector<size_t> ordering(path.pimpl_->requestedEnds.size());
   std::iota(ordering.begin(), ordering.end(), 0);
   std::sort(ordering.begin(), ordering.end(),
             [&path](const size_t a, const size_t b) -> bool {
-              return path.pimpl_->minTheorticalDist[a] <
-                     path.pimpl_->minTheorticalDist[b];
+              return path.pimpl_->minTheoreticalDist[a] <
+                     path.pimpl_->minTheoreticalDist[b];
             });
 
   for (size_t i : ordering) {
-    if (path.pimpl_->minTheorticalDist[i] > path.geodesicDistance)
+    if (path.pimpl_->minTheoreticalDist[i] > path.geodesicDistance)
       continue;
 
     const Cr::Containers::Optional<std::tuple<float, std::vector<vec3f>>>
@@ -1081,7 +1082,7 @@ bool PathFinder::Impl::findPath(MultiGoalShortestPath& path) {
                              path.pimpl_->endRefs[i], path.pimpl_->pathEnds[i]);
 
     if (findResult && std::get<0>(*findResult) < path.geodesicDistance) {
-      path.pimpl_->minTheorticalDist[i] = std::get<0>(*findResult);
+      path.pimpl_->minTheoreticalDist[i] = std::get<0>(*findResult);
       path.geodesicDistance = std::get<0>(*findResult);
       path.points = std::move(std::get<1>(*findResult));
     }

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -39,16 +39,6 @@ struct MultiGoalShortestPath::Impl {
   Impl() = default;
   ~Impl() = default;
 
-  void setRequestedEnds(const std::vector<vec3f>& newEnds) {
-    endRefs.clear();
-    pathEnds.clear();
-    requestedEnds = newEnds;
-
-    minTheoreticalDist.assign(newEnds.size(), 0);
-  }
-
-  const std::vector<vec3f>& getRequestedEnds() const { return requestedEnds; }
-
   std::vector<vec3f> requestedEnds;
 
   std::vector<dtPolyRef> endRefs;
@@ -63,11 +53,15 @@ MultiGoalShortestPath::MultiGoalShortestPath()
 
 void MultiGoalShortestPath::setRequestedEnds(
     const std::vector<vec3f>& newEnds) {
-  pimpl_->setRequestedEnds(newEnds);
+  pimpl_->endRefs.clear();
+  pimpl_->pathEnds.clear();
+  pimpl_->requestedEnds = newEnds;
+
+  pimpl_->minTheoreticalDist.assign(newEnds.size(), 0);
 }
 
 const std::vector<vec3f>& MultiGoalShortestPath::getRequestedEnds() const {
-  return pimpl_->getRequestedEnds();
+  return pimpl_->requestedEnds;
 }
 
 namespace {

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -9,8 +9,6 @@
 
 #include "esp/core/esp.h"
 
-#include "DetourNavMesh.h"
-
 namespace esp {
 // forward declaration
 namespace assets {
@@ -66,6 +64,8 @@ struct ShortestPath {
  * @ref PathFinder.findPath
  */
 struct MultiGoalShortestPath {
+  MultiGoalShortestPath();
+
   /**
    * @brief The starting point for the path
    */
@@ -74,13 +74,9 @@ struct MultiGoalShortestPath {
   /**
    * @brief Set the list of desired potential end points
    */
-  void setRequestedEnds(const std::vector<vec3f>& newEnds) {
-    endRefs.clear();
-    pathEnds.clear();
-    requestedEnds = newEnds;
-  }
+  void setRequestedEnds(const std::vector<vec3f>& newEnds);
 
-  const std::vector<vec3f>& getRequestedEnds() const { return requestedEnds; }
+  const std::vector<vec3f>& getRequestedEnds() const;
 
   /**
    * @brief A list of points that specify the shortest path on the navigation
@@ -100,13 +96,7 @@ struct MultiGoalShortestPath {
 
   friend class PathFinder;
 
- private:
-  std::vector<vec3f> requestedEnds;
-
-  std::vector<dtPolyRef> endRefs;
-  std::vector<vec3f> pathEnds;
-
-  ESP_SMART_POINTERS(MultiGoalShortestPath)
+  ESP_SMART_POINTERS_WITH_UNIQUE_PIMPL(MultiGoalShortestPath);
 };
 
 struct NavMeshSettings {

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -9,6 +9,8 @@
 
 #include "esp/core/esp.h"
 
+#include "DetourNavMesh.h"
+
 namespace esp {
 // forward declaration
 namespace assets {
@@ -16,6 +18,8 @@ class MeshData;
 }
 
 namespace nav {
+
+class PathFinder;
 
 struct HitRecord {
   vec3f hitPos;
@@ -68,9 +72,15 @@ struct MultiGoalShortestPath {
   vec3f requestedStart;
 
   /**
-   * @brief The list of desired potential end points
+   * @brief Set the list of desired potential end points
    */
-  std::vector<vec3f> requestedEnds;
+  void setRequestedEnds(const std::vector<vec3f>& newEnds) {
+    endRefs.clear();
+    pathEnds.clear();
+    requestedEnds = newEnds;
+  }
+
+  const std::vector<vec3f>& getRequestedEnds() const { return requestedEnds; }
 
   /**
    * @brief A list of points that specify the shortest path on the navigation
@@ -87,6 +97,14 @@ struct MultiGoalShortestPath {
    * Will be inf if no path exists
    */
   float geodesicDistance;
+
+  friend class PathFinder;
+
+ private:
+  std::vector<vec3f> requestedEnds;
+
+  std::vector<dtPolyRef> endRefs;
+  std::vector<vec3f> pathEnds;
 
   ESP_SMART_POINTERS(MultiGoalShortestPath)
 };

--- a/src/esp/nav/test/PathFinderTest.cpp
+++ b/src/esp/nav/test/PathFinderTest.cpp
@@ -15,10 +15,9 @@ namespace Mn = Magnum;
 
 namespace {
 
-const std::string skokloster =
-    Cr::Utility::Directory::join(SCENE_DATASETS,
-                                 "mp3d/1LXtFkjw3qL/1LXtFkjw3qL.navmesh");
-// "habitat-test-scenes/skokloster-castle.navmesh");
+const std::string skokloster = Cr::Utility::Directory::join(
+    SCENE_DATASETS,
+    "habitat-test-scenes/skokloster-castle.navmesh");
 
 struct PathFinderTest : Cr::TestSuite::Tester {
   explicit PathFinderTest();
@@ -125,9 +124,12 @@ void PathFinderTest::testCaching() {
 
   const auto endPt = pathFinder.getRandomNavigablePoint();
   noCachePath.requestedEnd = endPt;
-  cachePath.setRequestedEnds({endPt, {-1e5, -1e5, -1e5}});
+  // The caching only happens when there is more than one end point, so just
+  // duplicate!
+  cachePath.setRequestedEnds({endPt, endPt});
 
   for (int i = 0; i < 1000; ++i) {
+    CORRADE_ITERATION(i);
     const auto startPt = pathFinder.getRandomNavigablePoint();
 
     noCachePath.requestedStart = startPt;

--- a/src/esp/nav/test/PathFinderTest.cpp
+++ b/src/esp/nav/test/PathFinderTest.cpp
@@ -119,24 +119,25 @@ void PathFinderTest::testCaching() {
   pathFinder.loadNavMesh(skokloster);
   CORRADE_VERIFY(pathFinder.isLoaded());
 
-  esp::nav::ShortestPath noCachePath;
   esp::nav::MultiGoalShortestPath cachePath;
-
-  const auto endPt = pathFinder.getRandomNavigablePoint();
-  noCachePath.requestedEnd = endPt;
-  // The caching only happens when there is more than one end point, so just
-  // duplicate!
-  cachePath.setRequestedEnds({endPt, endPt});
+  {
+    std::vector<esp::vec3f> rqEnds;
+    for (int i = 0; i < 25; ++i) {
+      rqEnds.emplace_back(pathFinder.getRandomNavigablePoint());
+    }
+    cachePath.setRequestedEnds(rqEnds);
+  }
 
   for (int i = 0; i < 1000; ++i) {
     CORRADE_ITERATION(i);
-    const auto startPt = pathFinder.getRandomNavigablePoint();
 
-    noCachePath.requestedStart = startPt;
-    pathFinder.findPath(noCachePath);
-
-    cachePath.requestedStart = startPt;
+    cachePath.requestedStart = pathFinder.getRandomNavigablePoint();
     pathFinder.findPath(cachePath);
+
+    esp::nav::MultiGoalShortestPath noCachePath;
+    noCachePath.setRequestedEnds(cachePath.getRequestedEnds());
+    noCachePath.requestedStart = cachePath.requestedStart;
+    pathFinder.findPath(noCachePath);
 
     CORRADE_COMPARE(cachePath.geodesicDistance, noCachePath.geodesicDistance);
   }

--- a/src/esp/nav/test/PathFinderTest.cpp
+++ b/src/esp/nav/test/PathFinderTest.cpp
@@ -1,4 +1,4 @@
-#include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/ArrayView.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 


### PR DESCRIPTION
## Motivation and Context

I did some additional benchmarking of the multigoal path finding, and the setup for projecting all the requested ends onto the navmesh is actually the bottleneck in a lot of cases.  This PR enables that setup to be cached so that subsequent called with the same path object/end points will not have to re-project them.

This PR also speeds up multigoal path finding by leveraging temporal consistency.  It is very likely that two concurrent calls with the same end points will have very similar starting points, thus we can heavily restrict the set of locations we need to search through by using their previously known distance and updating that to provide a minimum distance the point could possibly be.  We then explore candidate points based on this minimum distance.

## How Has This Been Tested

Existing tests pass, new benchmark shows this is faster!

## Types of changes

- New feature (non-breaking change which adds functionality)

