### PR TITLE
Exclude test code from coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,8 @@ jobs:
               #Uploading test coverage for C++ code
               lcov --directory . --capture --output-file coverage.info
               lcov --remove coverage.info "*/deps/*" --output-file coverage.info > /dev/null
+              lcov --remove coverage.info "*/test/*" --output-file coverage.info > /dev/null
+              lcov --remove coverage.info "*/tests/*" --output-file coverage.info > /dev/null
               bash <(curl -s https://codecov.io/bash) -f coverage.info -cF CPP
       - run:
           name: Build documentation

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    */tests/*


### PR DESCRIPTION
## Motivation and Context

*(This a bad thing to do on April Fools, I know.)*

Discovered this while checking how well are meshes with semantic info tested (not really, https://github.com/facebookresearch/habitat-sim/issues/556#issuecomment-607211470). Tests for C++ and Python code are one third of the total code size (~1.7kLoC, while the total code size is ~5k), and as it usually is with tests, those are ran in full with >95% coverage. This however skews the coverage percentage into suspiciously high numbers, making us think the codebase is covered better than it actually is.

This is consistent with how coverage is measured for all Magnum projects, and I'd personally say it's a good thing to do -- however you may have a different opinion about this :) I'm open for a discussion. The only potential disadvantage of this is that you don't see how fully are the tests ran anymore, but a missed test should cause a coverage drop also for the code it's supposed to run, so it should be okay.

## How Has This Been Tested

Reported code coverage dropped significantly, as expected: https://codecov.io/gh/facebookresearch/habitat-sim/branch/exclude-tests-from-coverage

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)