### PR TITLE
Refactor python bindings for core::Configuration 

### DIFF
--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -22,6 +22,7 @@ modules = [
     "SensorType",
     "ShortestPath",
     "SimulatorConfiguration",
+    "Attributes",
 ]
 
 from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend

--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -22,7 +22,7 @@ modules = [
     "SensorType",
     "ShortestPath",
     "SimulatorConfiguration",
-    "Attributes",
+    "ConfigurationGroup",
 ]
 
 from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -22,17 +22,23 @@ void initEspBindings(py::module& m) {
 namespace core {
 
 void initCoreBindings(py::module& m) {
-  py::class_<Configuration, Configuration::ptr>(m, "Configuration")
+  py::class_<Configuration, Configuration::ptr>(m, "Attributes")
       .def(py::init(&Configuration::create<>))
-      .def("getBool", &Configuration::getBool)
-      .def("getString", &Configuration::getString)
-      .def("getInt", &Configuration::getInt)
-      .def("getFloat", &Configuration::getFloat)
+      .def("get_bool", &Configuration::getBool)
+      .def("get_string", &Configuration::getString)
+      .def("get_int", &Configuration::getInt)
+      .def("get_double", &Configuration::getDouble)
+      .def("get_vec3", &Configuration::getVec3)
       .def("get", &Configuration::getString)
       .def("set", &Configuration::set<std::string>)
       .def("set", &Configuration::set<int>)
-      .def("set", &Configuration::set<float>)
-      .def("set", &Configuration::set<bool>);
+      .def("set", &Configuration::set<double>)
+      .def("set", &Configuration::set<bool>)
+      .def("set", &Configuration::set<Magnum::Vector3>)
+      .def("add_string_to_group", &Configuration::addStringToGroup)
+      .def("get_string_group", &Configuration::getStringGroup)
+      .def("has_value", &Configuration::hasValue)
+      .def("remove_value", &Configuration::removeValue);
 }
 
 }  // namespace core

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -22,7 +22,7 @@ void initEspBindings(py::module& m) {
 namespace core {
 
 void initCoreBindings(py::module& m) {
-  py::class_<Configuration, Configuration::ptr>(m, "Attributes")
+  py::class_<Configuration, Configuration::ptr>(m, "ConfigurationGroup")
       .def(py::init(&Configuration::create<>))
       .def("get_bool", &Configuration::getBool)
       .def("get_string", &Configuration::getString)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -16,7 +16,7 @@ def test_config_eq():
 
 def test_core_configuration():
     # test bindings for esp::core::Configuration class
-    config = habitat_sim.bindings.Attributes()
+    config = habitat_sim.bindings.ConfigurationGroup()
     config.set("test", "test statement")
     assert config.has_value("test")
     assert config.get_string("test") == "test statement"
@@ -39,8 +39,6 @@ def test_core_configuration():
     # Magnum::Vector3 (float)
     my_vec3 = np.array([1.12345, 2.0, -3.0])
     config.set("vec3", my_vec3)
-    print(my_vec3)
-    print(config.get_vec3("vec3"))
     assert config.get_vec3("vec3") == my_vec3
     assert config.get_int("vec3") == int(my_vec3[0])
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import habitat_sim
 
 
@@ -10,3 +12,43 @@ def test_config_eq():
     )
 
     assert cfg1 == cfg2
+
+
+def test_core_configuration():
+    # test bindings for esp::core::Configuration class
+    config = habitat_sim.bindings.Attributes()
+    config.set("test", "test statement")
+    assert config.has_value("test")
+    assert config.get_string("test") == "test statement"
+
+    config.remove_value("test")
+    assert not config.has_value("test")
+
+    config.set("bool", np.array(True))
+    assert config.get_bool("bool") == True
+
+    config.set("integer", 3)
+    assert config.get("integer") == "3"
+    assert config.get_int("integer") == 3
+
+    my_double = 0.77777777777777
+    config.set("double", my_double)
+    assert config.get_double("double") == my_double
+    assert config.get_int("double") == int(my_double)
+
+    # Magnum::Vector3 (float)
+    my_vec3 = np.array([1.12345, 2.0, -3.0])
+    config.set("vec3", my_vec3)
+    print(my_vec3)
+    print(config.get_vec3("vec3"))
+    assert config.get_vec3("vec3") == my_vec3
+    assert config.get_int("vec3") == int(my_vec3[0])
+
+    # test string group
+    text_group = ["a", "b", "  c", "12", "0.1", "-=_+.,';:"]
+    for text in text_group:
+        config.add_string_to_group("text_group", text)
+
+    queried_group = config.get_string_group("text_group")
+    for ix, text in enumerate(queried_group):
+        assert text == text_group[ix]


### PR DESCRIPTION
## Motivation and Context

This change refactors the python bindings for the `esp::core::Configuration` class to support the upcoming `PhysicsObjectAttributes` bindings. The python class is renamed to `Attributes` to prevent name collision with the `Configuration` python class in `simulator.py` which is used ubiquitously throughout the code. 

This is a breaking change, but there are no uses of `esp::core::Configuration` in the current codebase.

## How Has This Been Tested

New `test_core_configuration` test in `test_configs.py`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
