### PR TITLE
[WIP] Override frame in SimulatorConfiguration

### DIFF
--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -331,6 +331,34 @@ class DemoRunner:
             download_and_unzip(default_sim_settings["test_scene_data_url"], ".")
             print("Downloaded and extracted test scenes data.")
 
+        # default:
+        # world_frame_quat = habitat_sim.utils.common.quat_to_magnum(habitat_sim.utils.common.quat_from_two_vectors(habitat_sim.geo.GRAVITY, habitat_sim.geo.FRONT))
+        # rotated:
+        # world_frame_quat = habitat_sim.utils.common.quat_to_magnum(habitat_sim.utils.common.quat_from_two_vectors(habitat_sim.geo.GRAVITY, habitat_sim.geo.FRONT))
+        world_frame_quat = habitat_sim.utils.common.quat_from_two_vectors(
+            habitat_sim.geo.GRAVITY, habitat_sim.geo.FRONT
+        )
+        new_up = habitat_sim.utils.common.quat_rotate_vector(
+            world_frame_quat, habitat_sim.geo.UP
+        )
+        new_front = habitat_sim.utils.common.quat_rotate_vector(
+            world_frame_quat, habitat_sim.geo.FRONT
+        )
+        print(new_front)
+        grav_rotation = habitat_sim.utils.common.quat_from_angle_axis(
+            1.56, habitat_sim.geo.FRONT
+        )
+        new_front = habitat_sim.utils.common.quat_rotate_vector(
+            grav_rotation, new_front
+        )
+        print(new_front)
+
+        # world_frame_quat = grav_rotation * world_frame_quat
+        # self._cfg.sim_cfg.world_frame = habitat_sim.geo.CoordinateFrame(world_frame_quat, np.array([0,0,0.0]))
+        self._cfg.sim_cfg.world_frame = habitat_sim.geo.CoordinateFrame(
+            new_up, new_front, np.array([0, 0, 0.0])
+        )
+
         # create a simulator (Simulator python class object, not the backend simulator)
         self._sim = habitat_sim.Simulator(self._cfg)
 

--- a/habitat_sim/geo.py
+++ b/habitat_sim/geo.py
@@ -2,7 +2,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from habitat_sim._ext.habitat_sim_bindings import OBB, BBox
+from habitat_sim._ext.habitat_sim_bindings import OBB, BBox, CoordinateFrame
 from habitat_sim._ext.habitat_sim_bindings.geo import (
     BACK,
     FRONT,
@@ -23,4 +23,5 @@ __all__ = [
     "LEFT",
     "RIGHT",
     "compute_gravity_aligned_MOBB",
+    "CoordinateFrame",
 ]

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -43,6 +43,7 @@ void initSimBindings(py::module& m) {
                      &SimulatorConfiguration::physicsConfigFile)
       .def_readwrite("scene_light_setup",
                      &SimulatorConfiguration::sceneLightSetup)
+      .def_readwrite("world_frame", &SimulatorConfiguration::worldFrame)
       .def(py::self == py::self)
       .def(py::self != py::self);
 

--- a/src/esp/bindings/geoBindings.cpp
+++ b/src/esp/bindings/geoBindings.cpp
@@ -4,10 +4,12 @@
 
 #include "esp/bindings/bindings.h"
 
+#include "esp/geo/CoordinateFrame.h"
 #include "esp/geo/OBB.h"
 #include "esp/geo/geo.h"
 
 namespace py = pybind11;
+using py::literals::operator""_a;
 
 namespace esp {
 namespace geo {
@@ -42,6 +44,26 @@ void initGeoBindings(py::module& m) {
       });
 
   geo.def("compute_gravity_aligned_MOBB", &geo::computeGravityAlignedMOBB);
+
+  // ==== CoordinateFrame ===
+  py::class_<CoordinateFrame, CoordinateFrame::ptr>(m, "CoordinateFrame")
+      .def(py::init(&CoordinateFrame::create<>))
+      .def(py::init(
+          &CoordinateFrame::create<const vec3f&, const vec3f&, const vec3f&>))
+      .def(py::init(&CoordinateFrame::create<const quatf&, const vec3f&>))
+      .def(py::init(
+          &CoordinateFrame::create<const Magnum::Quaternion&, const vec3f&>))
+      .def("origin", &CoordinateFrame::origin)
+      .def("up", &CoordinateFrame::up)
+      .def("gravity", &CoordinateFrame::gravity)
+      .def("front", &CoordinateFrame::front)
+      .def("back", &CoordinateFrame::back)
+      .def("rotation_world_to_frame", &CoordinateFrame::rotationWorldToFrame)
+      .def("rotation_frame_to_world", &CoordinateFrame::rotationFrameToWorld)
+      //.def("transformation_world_to_frame",
+      //&CoordinateFrame::transformationWorldToFrame)
+      .def("to_json", &CoordinateFrame::toJson)
+      .def("from_json", &CoordinateFrame::fromJson, "json"_a);
 }
 
 }  // namespace geo

--- a/src/esp/geo/CoordinateFrame.cpp
+++ b/src/esp/geo/CoordinateFrame.cpp
@@ -7,6 +7,9 @@
 #include "esp/geo/geo.h"
 #include "esp/io/json.h"
 
+#include <Magnum/EigenIntegration/GeometryIntegration.h>
+#include <Magnum/EigenIntegration/Integration.h>
+
 namespace esp {
 namespace geo {
 
@@ -20,6 +23,12 @@ CoordinateFrame::CoordinateFrame(const vec3f& up /* = ESP_UP */,
 CoordinateFrame::CoordinateFrame(const quatf& rotation,
                                  const vec3f& origin /* = vec3f(0, 0, 0) */)
     : CoordinateFrame(rotation * ESP_UP, rotation * ESP_FRONT, origin) {}
+
+CoordinateFrame::CoordinateFrame(const Magnum::Quaternion& rotation,
+                                 const vec3f& origin /* = vec3f(0, 0, 0) */)
+    : CoordinateFrame(quatf(rotation) * ESP_UP,
+                      quatf(rotation) * ESP_FRONT,
+                      origin) {}
 
 CoordinateFrame::CoordinateFrame(const std::string& json) {
   fromJson(json);

--- a/src/esp/geo/CoordinateFrame.h
+++ b/src/esp/geo/CoordinateFrame.h
@@ -19,6 +19,8 @@ class CoordinateFrame {
                   const vec3f& front = ESP_FRONT,
                   const vec3f& origin = vec3f::Zero());
   CoordinateFrame(const quatf& rotation, const vec3f& origin = vec3f::Zero());
+  CoordinateFrame(const Magnum::Quaternion& rotation,
+                  const vec3f& origin = vec3f::Zero());
   explicit CoordinateFrame(const std::string& json);
 
   //! Returns position of origin of this CoordinateFrame relative to parent

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -81,6 +81,12 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   }
 
   assets::AssetInfo sceneInfo = assets::AssetInfo::fromPath(sceneFilename);
+
+  // override the default frame
+  if (cfg.worldFrame != nullptr) {
+    sceneInfo.frame = *cfg.worldFrame.get();
+  }
+
   sceneInfo.requiresLighting =
       cfg.sceneLightSetup != assets::ResourceManager::NO_LIGHT_KEY;
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -54,6 +54,8 @@ struct SimulatorConfiguration {
   /** @brief Light setup key for scene */
   std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
 
+  geo::CoordinateFrame::ptr worldFrame = nullptr;
+
   ESP_SMART_POINTERS(SimulatorConfiguration)
 };
 bool operator==(const SimulatorConfiguration& a,


### PR DESCRIPTION
## Motivation and Context

Work in progress.

Enable users to configure the coordinate frame of their scene with `SimulatorConfiguration` which overrides defaults on construction.

Notes:
- does not change navmesh

## How Has This Been Tested

running example.py with hardcoded modifications in demo_runner.py

default frame:
![default](https://user-images.githubusercontent.com/1445143/78300154-e5d06d80-74eb-11ea-8728-812aedc0142e.png)

rotated frame:
![rotated](https://user-images.githubusercontent.com/1445143/78300162-e832c780-74eb-11ea-8c97-023d4d5955b0.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
