### PR TITLE
Simulator object template bindings

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -283,8 +283,8 @@ class Simulator:
     def load_object_configs(self, path):
         return self._sim.load_object_configs(path)
 
-    def load_object_template(self, object_template_handle):
-        return self._sim.load_object_template(object_template_handle)
+    def load_object_template(self, object_template, object_template_handle):
+        return self._sim.load_object_template(object_template, object_template_handle)
 
     # --- physics functions ---
     def add_object(

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -273,6 +273,19 @@ class Simulator:
     def __del__(self):
         self.close()
 
+    # --- object template functions ---
+    def get_physics_object_library_size(self):
+        return self._sim.get_physics_object_library_size()
+
+    def get_object_template(self, template_id):
+        return self._sim.get_object_template(template_id)
+
+    def load_object_configs(self, path):
+        return self._sim.load_object_configs(path)
+
+    def load_object_template(self, object_template_handle):
+        return self._sim.load_object_template(object_template_handle)
+
     # --- physics functions ---
     def add_object(
         self,
@@ -281,9 +294,6 @@ class Simulator:
         light_setup_key=DEFAULT_LIGHTING_KEY,
     ):
         return self._sim.add_object(object_lib_index, attachment_node, light_setup_key)
-
-    def get_physics_object_library_size(self):
-        return self._sim.get_physics_object_library_size()
 
     def remove_object(
         self, object_id, delete_object_node=True, delete_visual_node=True

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -71,7 +71,7 @@ void initSimBindings(py::module& m) {
       .def("get_physics_object_library_size",
            &Simulator::getPhysicsObjectLibrarySize)
       .def("get_object_template", &Simulator::getObjectTemplate,
-           "object_template_id"_a)
+           "object_template_id"_a, pybind11::return_value_policy::reference)
       .def("load_object_configs", &Simulator::loadObjectConfigs, "path"_a)
       .def("load_object_template", &Simulator::loadObjectTemplate,
            "object_template"_a, "object_template_handle"_a)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -70,6 +70,11 @@ void initSimBindings(py::module& m) {
            "attachment_node"_a, "light_setup_key"_a, "scene_id"_a = 0)
       .def("get_physics_object_library_size",
            &Simulator::getPhysicsObjectLibrarySize)
+      .def("get_object_template", &Simulator::getObjectTemplate,
+           "object_template_id"_a)
+      .def("load_object_configs", &Simulator::loadObjectConfigs, "path"_a)
+      .def("load_object_template", &Simulator::loadObjectTemplate,
+           "object_template"_a, "object_template_handle"_a)
       .def("remove_object", &Simulator::removeObject, "object_id"_a,
            "delete_object_node"_a, "delete_visual_node"_a, "sceneID"_a = 0)
       .def("get_object_motion_type", &Simulator::getObjectMotionType,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -277,15 +277,10 @@ int Simulator::getPhysicsObjectLibrarySize() {
   return resourceManager_.getNumLibraryObjects();
 }
 
-assets::PhysicsObjectAttributes& Simulator::getPhysicsObjectAttributes(
+assets::PhysicsObjectAttributes& Simulator::getObjectTemplate(
     int templateIndex) {
   return resourceManager_.getPhysicsObjectAttributes(
       resourceManager_.getObjectConfig(templateIndex));
-}
-
-assets::PhysicsObjectAttributes& Simulator::getPhysicsObjectAttributes(
-    const std::string& templateHandle) {
-  return resourceManager_.getPhysicsObjectAttributes(templateHandle);
 }
 
 std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -124,15 +124,7 @@ class Simulator {
   /**
    * @brief Get an editable reference to a physics object template by index.
    */
-  assets::PhysicsObjectAttributes& getPhysicsObjectAttributes(
-      int templateIndex);
-
-  /**
-   * @brief Get an editable reference to a physics object template by string
-   * key.
-   */
-  assets::PhysicsObjectAttributes& getPhysicsObjectAttributes(
-      const std::string& templateHandle);
+  assets::PhysicsObjectAttributes& getObjectTemplate(int templateIndex);
 
   /**
    * @brief Load all "*.phys_properties.json" files from the provided file or

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -123,3 +123,8 @@ def test_scene_bounding_boxes(sim):
         mn.Vector3(-0.775869, -0.0233012, -1.6706), mn.Vector3(6.76937, 3.86304, 3.5359)
     )
     assert ground_truth == scene_bb
+
+
+def test_object_template_editing(sim):
+    todo = True
+    # TODO:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import os.path as osp
 import random
 
 import magnum as mn
@@ -126,5 +127,38 @@ def test_scene_bounding_boxes(sim):
 
 
 def test_object_template_editing(sim):
-    todo = True
-    # TODO:
+    cfg_settings = examples.settings.default_sim_settings.copy()
+    cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+    cfg_settings["enable_physics"] = True
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim.reconfigure(hab_cfg)
+
+    # test creating a new template with a test asset
+    transform_box_path = osp.abspath("data/test_assets/objects/transform_box.glb")
+    transform_box_template = habitat_sim.attributes.PhysicsObjectAttributes()
+    transform_box_template.set_render_mesh_handle(transform_box_path)
+    old_library_size = sim.get_physics_object_library_size()
+    transform_box_template_id = sim.load_object_template(
+        transform_box_template, "transform_box_template"
+    )
+    assert sim.get_physics_object_library_size() > old_library_size
+    assert transform_box_template_id != -1
+
+    # test loading a test asset template from file
+    sphere_path = osp.abspath("data/test_assets/objects/sphere")
+    old_library_size = sim.get_physics_object_library_size()
+    template_ids = sim.load_object_configs(sphere_path)
+    assert len(template_ids) > 0
+    assert sim.get_physics_object_library_size() > old_library_size
+
+    # test getting and editing template reference
+    sphere_template = sim.get_object_template(template_ids[0])
+    assert sphere_template.get_render_mesh_handle().endswith("sphere.glb")
+    sphere_scale = np.array([2.0, 2.0, 2.0])
+    sphere_template.set_scale(sphere_scale)
+    sphere_template2 = sim.get_object_template(template_ids[0])
+    assert sphere_template2.get_scale() == sphere_scale
+
+    # test adding a new object
+    object_id = sim.add_object(template_ids[0])
+    assert object_id != -1


### PR DESCRIPTION
## Motivation and Context

This change enables the python Simulator class to programmatically add/load new object templates and leverage template domain randomization utilities.

Related change: template reference by string key is being deprecated in favor of unique ids and the unused template getter by string key function has been removed from C++ Simulator.

## How Has This Been Tested

New python test `test_simulator.py::test_object_template_editing`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
