### PR TITLE
Add e2e test for frustum culling

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -83,6 +83,8 @@ class Simulator:
         del self._sim
         self._sim = None
 
+        self.config = None
+
     def seed(self, new_seed):
         self._sim.seed(new_seed)
         self.pathfinder.seed(new_seed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def make_cfg_settings():
         depth_sensor=True,
         silent=True,
         scene=_test_scene,
+        frustum_culling=True,
     )
 
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -130,7 +130,6 @@ def test_sensors(
     # thus we need to force a reload when frustum culling gets swapped
     if cfg.sim_cfg.frustum_culling != sim.config.sim_cfg.frustum_culling:
         sim.close()
-        print("Swapping")
 
     sim.reconfigure(cfg)
 


### PR DESCRIPTION
## Motivation and Context

Finding a bug in #564 brought up that we don't have an e2e test for frustum culling ATM.  This PR adds frustum culling to the list of things we test in the existing e2e sensor test.

## How Has This Been Tested

Via  itself!

## Types of changes

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

