### PR TITLE
--Change refs to scene and physics attributes to smart pointers

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -130,8 +130,8 @@ class ResourceManager {
    * @param info The loaded @ref AssetInfo for the scene mesh.
    * @param _physicsManager The currently defined @ref physics::PhysicsManager.
    * Will be reseated to the configured physics implementation.
-   * @param physicsManagerAttributes The meta data structure storing configured
-   * physics simulation parameters.
+   * @param physicsManagerAttributes A smart pointer to meta data structure
+   * storing configured physics simulation parameters.
    * @param parent The @ref scene::SceneNode of which the scene mesh will be
    * added as a child. Typically near the root of the scene. Expected to be
    * static.
@@ -141,7 +141,7 @@ class ResourceManager {
    */
   bool loadScene(const AssetInfo& info,
                  std::shared_ptr<physics::PhysicsManager>& _physicsManager,
-                 PhysicsManagerAttributes physicsManagerAttributes,
+                 PhysicsManagerAttributes::ptr physicsManagerAttributes,
                  scene::SceneNode* parent = nullptr,
                  DrawableGroup* drawables = nullptr,
                  const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
@@ -190,7 +190,7 @@ class ResourceManager {
    * @return The physics simulation meta data object parsed from the specified
    * configuration file.
    */
-  PhysicsManagerAttributes loadPhysicsConfig(
+  PhysicsManagerAttributes::ptr loadPhysicsConfig(
       std::string physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG);
 
   /**
@@ -746,13 +746,13 @@ class ResourceManager {
    * Templates are used by @ref physics::PhysicsManager to
    * initialize, reset scenes or switch contexts.
    */
-  std::map<std::string, PhysicsSceneAttributes> physicsSceneLibrary_;
+  std::map<std::string, PhysicsSceneAttributes::ptr> physicsSceneLibrary_;
 
   /**
    * @brief Library of physics scene attributes for
    * initializing/resetting/switching physics world contexts.
    */
-  std::map<std::string, PhysicsManagerAttributes> physicsManagerLibrary_;
+  std::map<std::string, PhysicsManagerAttributes::ptr> physicsManagerLibrary_;
 
   /**
    * @brief Primitive meshes available for instancing via @ref

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -24,7 +24,7 @@ bool PhysicsManager::initPhysics(
 }
 
 bool PhysicsManager::initPhysics_Finalize(
-    const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes) {
+    const assets::PhysicsManagerAttributes::ptr) {
   //! Create new scene node
   staticSceneObject_ =
       physics::RigidObject::create_unique(&physicsNode_->createChild());

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -19,11 +19,11 @@ bool PhysicsManager::initPhysics(
   fixedTimeStep_ = physicsManagerAttributes->getTimestep();
 
   //! Create new scene node and set up any physics-related variables
-  initialized_ = initPhysics_Finalize(physicsManagerAttributes);
+  initialized_ = initPhysicsFinalize(physicsManagerAttributes);
   return initialized_;
 }
 
-bool PhysicsManager::initPhysics_Finalize(
+bool PhysicsManager::initPhysicsFinalize(
     const assets::PhysicsManagerAttributes::ptr) {
   //! Create new scene node
   staticSceneObject_ =
@@ -46,11 +46,11 @@ bool PhysicsManager::addScene(
   }
 
   //! Initialize scene
-  bool sceneSuccess = addScene_Finalize(physicsSceneAttributes, meshGroup);
+  bool sceneSuccess = addSceneFinalize(physicsSceneAttributes, meshGroup);
   return sceneSuccess;
 }
 
-bool PhysicsManager::addScene_Finalize(
+bool PhysicsManager::addSceneFinalize(
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   //! Initialize scene

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -12,17 +12,22 @@ namespace physics {
 
 bool PhysicsManager::initPhysics(
     scene::SceneNode* node,
-    const assets::PhysicsManagerAttributes& physicsManagerAttributes) {
+    const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes) {
   physicsNode_ = node;
 
   // Copy over relevant configuration
-  fixedTimeStep_ = physicsManagerAttributes.getTimestep();
+  fixedTimeStep_ = physicsManagerAttributes->getTimestep();
 
+  //! Create new scene node and set up any physics-related variables
+  initialized_ = initPhysics_Finalize(physicsManagerAttributes);
+  return initialized_;
+}
+
+bool PhysicsManager::initPhysics_Finalize(
+    const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes) {
   //! Create new scene node
   staticSceneObject_ =
       physics::RigidObject::create_unique(&physicsNode_->createChild());
-  initialized_ = true;
-
   return true;
 }
 
@@ -31,7 +36,7 @@ PhysicsManager::~PhysicsManager() {
 }
 
 bool PhysicsManager::addScene(
-    const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
   for (const assets::CollisionMeshData& meshData : meshGroup) {
@@ -40,6 +45,14 @@ bool PhysicsManager::addScene(
     }
   }
 
+  //! Initialize scene
+  bool sceneSuccess = addScene_Finalize(physicsSceneAttributes, meshGroup);
+  return sceneSuccess;
+}
+
+bool PhysicsManager::addScene_Finalize(
+    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+    const std::vector<assets::CollisionMeshData>& meshGroup) {
   //! Initialize scene
   bool sceneSuccess =
       staticSceneObject_->initializeScene(physicsSceneAttributes, meshGroup);

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -134,6 +134,19 @@ class PhysicsManager {
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
+  /** @brief Instance a physical object from an object properties template in
+   * the @ref esp::assets::ResourceManager::physicsObjectLibrary_.
+   *  @anchor addObject_string
+   *  @param configFile The filename of the object's physical properties file
+   * used as the key to query @ref
+   * esp::assets::ResourceManager::physicsObjectLibrary_
+   *  @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
+   *  @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   *  @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
   int addObject(const std::string& configFile,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
@@ -834,13 +847,13 @@ class PhysicsManager {
   int deallocateObjectID(int physObjectID);
 
   /**
-   * @brief Finalize physics nitialization. Setup staticSceneObject_ and
+   * @brief Finalize physics initialization. Setup staticSceneObject_ and
    * initialize any other physics-related values for physics-based scenes.
    * Overidden by instancing class if physics is supported.
    * @param physicsManagerAttributes A structure containing values for physical
    * parameters necessary to initialize the physical scene and simulator.
    */
-  virtual bool initPhysics_Finalize(
+  virtual bool initPhysicsFinalize(
       const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes);
 
   /**
@@ -853,23 +866,10 @@ class PhysicsManager {
    * @return true if successful and false otherwise
    */
 
-  virtual bool addScene_Finalize(
+  virtual bool addSceneFinalize(
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
-  /** @brief Instance a physical object from an object properties template in
-   * the @ref esp::assets::ResourceManager::physicsObjectLibrary_.
-   *  @anchor addObject_string
-   *  @param configFile The filename of the object's physical properties file
-   * used as the key to query @ref
-   * esp::assets::ResourceManager::physicsObjectLibrary_
-   *  @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -104,9 +104,9 @@ class PhysicsManager {
    * @param physicsManagerAttributes A structure containing values for physical
    * parameters necessary to initialize the physical scene and simulator.
    */
-  virtual bool initPhysics(
+  bool initPhysics(
       scene::SceneNode* node,
-      const assets::PhysicsManagerAttributes& physicsManagerAttributes);
+      const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes);
 
   /**
    * @brief Reset the simulation and physical world.
@@ -125,28 +125,15 @@ class PhysicsManager {
    * Only one 'scene' may be initialized per simulated world, but this scene may
    * contain several components (e.g. GLB heirarchy).
    *
-   * @param physicsSceneAttributes a structure defining physical properties of
-   * the scene.
+   * @param physicsSceneAttributes a pointer to the structure defining physical
+   * properties of the scene.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
-  virtual bool addScene(
-      const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+  bool addScene(
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
-  /** @brief Instance a physical object from an object properties template in
-   * the @ref esp::assets::ResourceManager::physicsObjectLibrary_.
-   *  @anchor addObject_string
-   *  @param configFile The filename of the object's physical properties file
-   * used as the key to query @ref
-   * esp::assets::ResourceManager::physicsObjectLibrary_
-   *  @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
   int addObject(const std::string& configFile,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
@@ -165,12 +152,11 @@ class PhysicsManager {
    *  @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  virtual int addObject(
-      const int objectLibIndex,
-      DrawableGroup* drawables,
-      scene::SceneNode* attachmentNode = nullptr,
-      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-          assets::ResourceManager::DEFAULT_LIGHTING_KEY});
+  int addObject(const int objectLibIndex,
+                DrawableGroup* drawables,
+                scene::SceneNode* attachmentNode = nullptr,
+                const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
+                    assets::ResourceManager::DEFAULT_LIGHTING_KEY});
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref
@@ -847,6 +833,43 @@ class PhysicsManager {
    */
   int deallocateObjectID(int physObjectID);
 
+  /**
+   * @brief Finalize physics nitialization. Setup staticSceneObject_ and
+   * initialize any other physics-related values for physics-based scenes.
+   * Overidden by instancing class if physics is supported.
+   * @param physicsManagerAttributes A structure containing values for physical
+   * parameters necessary to initialize the physical scene and simulator.
+   */
+  virtual bool initPhysics_Finalize(
+      const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes);
+
+  /**
+   * @brief Finalize scene initialization for kinematic scenes.  Overidden by
+   * instancing class if physics is supported.
+   *
+   * @param physicsSceneAttributes a pointer to the structure defining physical
+   * properties of the scene.
+   * @param meshGroup collision meshs for the scene.
+   * @return true if successful and false otherwise
+   */
+
+  virtual bool addScene_Finalize(
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup);
+
+  /** @brief Instance a physical object from an object properties template in
+   * the @ref esp::assets::ResourceManager::physicsObjectLibrary_.
+   *  @anchor addObject_string
+   *  @param configFile The filename of the object's physical properties file
+   * used as the key to query @ref
+   * esp::assets::ResourceManager::physicsObjectLibrary_
+   *  @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
+   *  @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   *  @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -13,7 +13,7 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode)
       visualNode_(&rigidBodyNode->createChild()) {}
 
 bool RigidObject::initializeScene(
-    const assets::PhysicsSceneAttributes&,
+    const assets::PhysicsSceneAttributes::ptr,
     const std::vector<assets::CollisionMeshData>&) {
   if (rigidObjectType_ != RigidObjectType::NONE) {
     LOG(ERROR) << "Cannot initialized a RigidObject more than once";

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -170,7 +170,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initializeScene(
-      const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /**

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -19,7 +19,7 @@ BulletPhysicsManager::~BulletPhysicsManager() {
   staticSceneObject_.reset(nullptr);
 }
 
-bool BulletPhysicsManager::initPhysics_Finalize(
+bool BulletPhysicsManager::initPhysicsFinalize(
     const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes) {
   activePhysSimLib_ = BULLET;
 
@@ -46,7 +46,7 @@ bool BulletPhysicsManager::initPhysics_Finalize(
 
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
-bool BulletPhysicsManager::addScene_Finalize(
+bool BulletPhysicsManager::addSceneFinalize(
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -19,9 +19,8 @@ BulletPhysicsManager::~BulletPhysicsManager() {
   staticSceneObject_.reset(nullptr);
 }
 
-bool BulletPhysicsManager::initPhysics(
-    scene::SceneNode* node,
-    const assets::PhysicsManagerAttributes& physicsManagerAttributes) {
+bool BulletPhysicsManager::initPhysics_Finalize(
+    const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes) {
   activePhysSimLib_ = BULLET;
 
   //! We can potentially use other collision checking algorithms, by
@@ -35,34 +34,23 @@ bool BulletPhysicsManager::initPhysics(
       Magnum::BulletIntegration::DebugDraw::Mode::DrawConstraints);
   bWorld_->setDebugDrawer(&debugDrawer_);
 
-  // Copy over relevant configuration
-  fixedTimeStep_ = physicsManagerAttributes.getTimestep();
   // currently GLB meshes are y-up
-  bWorld_->setGravity(btVector3(physicsManagerAttributes.getVec3("gravity")));
+  bWorld_->setGravity(btVector3(physicsManagerAttributes->getVec3("gravity")));
 
-  physicsNode_ = node;
   //! Create new scene node
   staticSceneObject_ =
       physics::BulletRigidObject::create_unique(&physicsNode_->createChild());
 
-  initialized_ = true;
   return true;
 }
 
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
-bool BulletPhysicsManager::addScene(
-    const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+bool BulletPhysicsManager::addScene_Finalize(
+    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
-  // Test Mesh primitive is valid
-  for (const assets::CollisionMeshData& meshData : meshGroup) {
-    if (!isMeshPrimitiveValid(meshData)) {
-      return false;
-    }
-  }
-
   const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(
-      physicsSceneAttributes.getCollisionMeshHandle());
+      physicsSceneAttributes->getCollisionMeshHandle());
 
   //! Initialize scene
   bool sceneSuccess = static_cast<BulletRigidObject*>(staticSceneObject_.get())

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -166,13 +166,13 @@ class BulletPhysicsManager : public PhysicsManager {
  protected:
   //============ Initialization =============
   /**
-   * @brief Finalize physics nitialization: Setup staticSceneObject_ and
+   * @brief Finalize physics initialization: Setup staticSceneObject_ and
    * initialize any other physics-related values.
    * @param physicsManagerAttributes A structure containing values for physical
    * parameters necessary to initialize the physical scene and simulator.
    */
-  bool initPhysics_Finalize(const assets::PhysicsManagerAttributes::ptr
-                                physicsManagerAttributes) override;
+  bool initPhysicsFinalize(const assets::PhysicsManagerAttributes::ptr
+                               physicsManagerAttributes) override;
 
   //============ Object/Scene Instantiation =============
   /**
@@ -185,7 +185,7 @@ class BulletPhysicsManager : public PhysicsManager {
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
-  bool addScene_Finalize(
+  bool addSceneFinalize(
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup) override;
 

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -32,7 +32,7 @@ BulletRigidObject::BulletRigidObject(scene::SceneNode* rigidBodyNode)
     : RigidObject{rigidBodyNode}, MotionState(*rigidBodyNode){};
 
 bool BulletRigidObject::initializeScene(
-    const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const assets::MeshMetaData& metaData,
     const std::vector<assets::CollisionMeshData>& meshGroup,
     std::shared_ptr<btMultiBodyDynamicsWorld> bWorld) {
@@ -47,8 +47,8 @@ bool BulletRigidObject::initializeScene(
 
   constructBulletSceneFromMeshes(Magnum::Matrix4{}, meshGroup, metaData.root);
   for (auto& object : bSceneCollisionObjects_) {
-    object->setFriction(physicsSceneAttributes.getFrictionCoefficient());
-    object->setRestitution(physicsSceneAttributes.getRestitutionCoefficient());
+    object->setFriction(physicsSceneAttributes->getFrictionCoefficient());
+    object->setRestitution(physicsSceneAttributes->getRestitutionCoefficient());
     bWorld->addCollisionObject(object.get());
   }
 

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -99,7 +99,7 @@ class BulletRigidObject : public RigidObject,
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeScene(
-      const assets::PhysicsSceneAttributes& physicsSceneAttributes,
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const assets::MeshMetaData& metaData,
       const std::vector<assets::CollisionMeshData>& meshGroup,
       std::shared_ptr<btMultiBodyDynamicsWorld> bWorld);


### PR DESCRIPTION
Change map refs for scene and physics attributes to be ESP smart pointers; modify PhysicsManager physics and scene inits to more appropriately utilize inheritance and minimize dupe code.

## Motivation and Context

Following the modifications to PhysicsAttributeObjects to be ESP smart pointers, the references in resource manager to PhysicsSceneAttributes and PhysicsManagerAttributes have also been changed to shared pointers.  
Physics manager initialization functions that directly consume these attributes have also been slightly refactored to more appropriately respect inheritance and minimize code reuse.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
run_tests and pytest successfully completed, 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
