### PR TITLE
--Better inheritance structure

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -54,8 +54,8 @@ bool PhysicsManager::addSceneFinalize(
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   //! Initialize scene
-  bool sceneSuccess =
-      staticSceneObject_->initializeScene(physicsSceneAttributes, meshGroup);
+  bool sceneSuccess = staticSceneObject_->initializeScene(
+      resourceManager_, physicsSceneAttributes, meshGroup);
   return sceneSuccess;
 }
 
@@ -171,7 +171,8 @@ bool PhysicsManager::makeAndAddRigidObject(
     assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     scene::SceneNode* objectNode) {
   auto ptr = physics::RigidObject::create_unique(objectNode);
-  bool objSuccess = ptr->initializeObject(physicsObjectAttributes, meshGroup);
+  bool objSuccess = ptr->initializeObject(resourceManager_,
+                                          physicsObjectAttributes, meshGroup);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -13,8 +13,9 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode)
       visualNode_(&rigidBodyNode->createChild()) {}
 
 bool RigidObject::initializeScene(
-    const assets::PhysicsSceneAttributes::ptr,
-    const std::vector<assets::CollisionMeshData>&) {
+    const assets::ResourceManager* resMgr,
+    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+    const std::vector<assets::CollisionMeshData>& meshGroup) {
   if (rigidObjectType_ != RigidObjectType::NONE) {
     LOG(ERROR) << "Cannot initialized a RigidObject more than once";
     return false;
@@ -24,12 +25,20 @@ bool RigidObject::initializeScene(
   rigidObjectType_ = RigidObjectType::SCENE;
   objectMotionType_ = MotionType::STATIC;
 
+  return initializeSceneFinalize(resMgr, physicsSceneAttributes, meshGroup);
+}
+
+bool RigidObject::initializeSceneFinalize(
+    const assets::ResourceManager*,
+    const assets::PhysicsSceneAttributes::ptr,
+    const std::vector<assets::CollisionMeshData>&) {
   return true;
 }
 
 bool RigidObject::initializeObject(
+    const assets::ResourceManager* resMgr,
     const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-    const std::vector<assets::CollisionMeshData>&) {
+    const std::vector<assets::CollisionMeshData>& meshGroup) {
   // TODO (JH): Handling static/kinematic object type
   if (rigidObjectType_ != RigidObjectType::NONE) {
     LOG(ERROR) << "Cannot initialized a RigidObject more than once";
@@ -38,11 +47,18 @@ bool RigidObject::initializeObject(
 
   //! Turn on scene flag
   rigidObjectType_ = RigidObjectType::OBJECT;
-  // default kineamtic unless a simulator is initialized...
-  objectMotionType_ = MotionType::KINEMATIC;
 
   initializationAttributes_ = physicsObjectAttributes;
 
+  return initializeObjectFinalize(resMgr, physicsObjectAttributes, meshGroup);
+}
+
+bool RigidObject::initializeObjectFinalize(
+    const assets::ResourceManager*,
+    const assets::PhysicsObjectAttributes::ptr,
+    const std::vector<assets::CollisionMeshData>&) {
+  // default kineamtic unless a simulator is initialized...
+  objectMotionType_ = MotionType::KINEMATIC;
   return true;
 }
 

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -17,6 +17,7 @@
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/GenericInstanceMeshData.h"
 #include "esp/assets/MeshData.h"
+#include "esp/assets/ResourceManager.h"
 #include "esp/core/esp.h"
 #include "esp/scene/SceneNode.h"
 
@@ -24,7 +25,8 @@ namespace esp {
 
 namespace assets {
 class PhysicsObjectAttributes;
-}
+class ResourceManager;
+}  // namespace assets
 namespace physics {
 
 /**
@@ -169,7 +171,8 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @param meshGroup The collision mesh data for the scene.
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initializeScene(
+  bool initializeScene(
+      const assets::ResourceManager* resMgr,
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
@@ -182,7 +185,8 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @param meshGroup The collision mesh data for the object.
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initializeObject(
+  bool initializeObject(
+      const assets::ResourceManager* resMgr,
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
@@ -598,6 +602,37 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @brief Saved attributes when the object was initialized.
    */
   assets::PhysicsObjectAttributes::ptr initializationAttributes_;
+
+  /**
+   * @brief Finalize the initialization of this @ref RigidObject as static scene
+   * geometry.  This is overridden by inheriting objects
+   * @param resMgr Reference to resource manager, to access relevant components
+   * pertaining to the scene object
+   * @param physicsSceneAttributes The template structure defining relevant
+   * phyiscal parameters for the physical scene.
+   * @param meshGroup The collision mesh data for the scene.
+   * @return true if initialized successfully, false otherwise.
+   */
+  virtual bool initializeSceneFinalize(
+      const assets::ResourceManager* resMgr,
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup);
+
+  /**
+   * @brief Finalize initialization of this @ref RigidObject as a potentially
+   * moveable object. This is overridden by inheriting objects
+   * @param resMgr Reference to resource manager, to access relevant components
+   * pertaining to the scene object
+   * @param physicsObjectAttributes The template structure defining relevant
+   * phyiscal parameters for the object. See @ref
+   * esp::assets::ResourceManager::physicsObjectLibrary_.
+   * @param meshGroup The collision mesh data for the object.
+   * @return true if initialized successfully, false otherwise.
+   */
+  virtual bool initializeObjectFinalize(
+      const assets::ResourceManager* resMgr,
+      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /** @brief Used to synchronize other simulator's notion of the object state
    * after it was changed kinematically. Called automatically on kinematic

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -38,8 +38,8 @@ bool BulletPhysicsManager::initPhysicsFinalize(
   bWorld_->setGravity(btVector3(physicsManagerAttributes->getVec3("gravity")));
 
   //! Create new scene node
-  staticSceneObject_ =
-      physics::BulletRigidObject::create_unique(&physicsNode_->createChild());
+  staticSceneObject_ = physics::BulletRigidObject::create_unique(
+      &physicsNode_->createChild(), bWorld_);
 
   return true;
 }
@@ -49,13 +49,9 @@ bool BulletPhysicsManager::initPhysicsFinalize(
 bool BulletPhysicsManager::addSceneFinalize(
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
-  const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(
-      physicsSceneAttributes->getCollisionMeshHandle());
-
   //! Initialize scene
-  bool sceneSuccess = static_cast<BulletRigidObject*>(staticSceneObject_.get())
-                          ->initializeScene(physicsSceneAttributes, metaData,
-                                            meshGroup, bWorld_);
+  bool sceneSuccess = staticSceneObject_->initializeScene(
+      resourceManager_, physicsSceneAttributes, meshGroup);
 
   return sceneSuccess;
 }
@@ -65,11 +61,9 @@ bool BulletPhysicsManager::makeAndAddRigidObject(
     const std::vector<assets::CollisionMeshData>& meshGroup,
     assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     scene::SceneNode* objectNode) {
-  auto ptr = physics::BulletRigidObject::create_unique(objectNode);
-  const assets::MeshMetaData& metaData = resourceManager_->getMeshMetaData(
-      physicsObjectAttributes->getCollisionMeshHandle());
-  bool objSuccess = ptr->initializeObject(physicsObjectAttributes, bWorld_,
-                                          metaData, meshGroup);
+  auto ptr = physics::BulletRigidObject::create_unique(objectNode, bWorld_);
+  bool objSuccess = ptr->initializeObject(resourceManager_,
+                                          physicsObjectAttributes, meshGroup);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -80,48 +80,14 @@ class BulletRigidObject : public RigidObject,
    * @param rigidBodyNode The @ref scene::SceneNode this feature will be
    * attached to.
    */
-  BulletRigidObject(scene::SceneNode* rigidBodyNode);
+  BulletRigidObject(scene::SceneNode* rigidBodyNode,
+                    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld);
 
   /**
    * @brief Destructor cleans up simulation structures for the object.
    */
   virtual ~BulletRigidObject();
 
-  /**
-   * @brief Initializes this @ref BulletRigidObject as static scene geometry.
-   * See @ref PhysicsManager::staticSceneObject_. Sets @ref rigidObjectType_ to
-   * @ref RigidObjectType::SCENE. See @ref btCollisionObject.
-   * @param physicsSceneAttributes The template structure defining relevant
-   * phyiscal parameters for the physical scene.
-   * @param meshGroup The collision mesh data for the scene.
-   * @param bWorld The @ref btMultiBodyDynamicsWorld to which the scene should
-   * belong.
-   * @return true if initialized successfully, false otherwise.
-   */
-  bool initializeScene(
-      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
-      const assets::MeshMetaData& metaData,
-      const std::vector<assets::CollisionMeshData>& meshGroup,
-      std::shared_ptr<btMultiBodyDynamicsWorld> bWorld);
-
-  /**
-   * @brief Initializes this @ref BulletRigidObject as a @ref
-   * MotionType::DYNAMIC object. Sets @ref rigidObjectType_ to @ref
-   * RigidObjectType::OBJECT. See @ref btRigidBody.
-   * @param physicsObjectAttributes The template structure defining relevant
-   * phyiscal parameters for the object. See @ref
-   * esp::assets::ResourceManager::physicsObjectLibrary_.
-   * @param bWorld The @ref btMultiBodyDynamicsWorld to which the object should
-   * belong.
-   * @param metaData Mesh transform hierarchy information for the object.
-   * @param meshGroup The collision mesh data for the object.
-   * @return true if initialized successfully, false otherwise.
-   */
-  bool initializeObject(
-      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
-      const assets::MeshMetaData& metaData,
-      const std::vector<assets::CollisionMeshData>& meshGroup);
   /**
    * @brief Finalize this object with any necessary post-creation processes.
    */
@@ -442,6 +408,38 @@ class BulletRigidObject : public RigidObject,
   const Magnum::Range3D getCollisionShapeAabb() const;
 
  protected:
+  /**
+   * @brief Initializes this @ref BulletRigidObject as static scene geometry.
+   * See @ref PhysicsManager::staticSceneObject_. Sets @ref rigidObjectType_ to
+   * @ref RigidObjectType::SCENE. See @ref btCollisionObject.
+   * @param physicsSceneAttributes The template structure defining relevant
+   * phyiscal parameters for the physical scene.
+   * @param meshGroup The collision mesh data for the scene.
+   * @param bWorld The @ref btMultiBodyDynamicsWorld to which the scene should
+   * belong.
+   * @return true if initialized successfully, false otherwise.
+   */
+  bool initializeSceneFinalize(
+      const assets::ResourceManager* resMgr,
+      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup) override;
+
+  /**
+   * @brief Finalize initialization of this @ref BulletRigidObject as a @ref
+   * MotionType::DYNAMIC object. See @ref btRigidBody.
+   * @param resMgr Reference to resource manager, to access relevant components
+   * pertaining to the scene object
+   * @param physicsObjectAttributes The template structure defining relevant
+   * phyiscal parameters for the object. See @ref
+   * esp::assets::ResourceManager::physicsObjectLibrary_.
+   * @param meshGroup The collision mesh data for the object.
+   * @return true if initialized successfully, false otherwise.
+   */
+  bool initializeObjectFinalize(
+      const assets::ResourceManager* resMgr,
+      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup) override;
+
   /**
    * @brief Used to synchronize Bullet's notion of the object state
    * after it was changed kinematically. Called automatically on kinematic


### PR DESCRIPTION
RigidObject base class and Bullet-based child class objects now have better inheritance pathways and more obvious overloading.

## Motivation and Context

This pull request contains code to more clearly execute functionality with RigidObjects and BulletRigidObjects which inherit from them without code duplication or excess casting.  The base class functionality in rigidObject for initializing a scene object or an actual physical object is universal, while method hooks have been added for instancing/child class functionality to be added.  This will be easier to maintain (without code duplication) and easier to expand to support other physics engines.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
run_tests and pytest execute without issues.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
