### PR TITLE
--Change rigid body finalizing methods access to private.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -209,7 +209,7 @@ bool ResourceManager::loadScene(
   bool defaultToNoneSimulator = true;
   if (physicsManagerAttributes->getSimulator().compare("bullet") == 0) {
 #ifdef ESP_BUILD_WITH_BULLET
-    _physicsManager.reset(new physics::BulletPhysicsManager(this));
+    _physicsManager.reset(new physics::BulletPhysicsManager(*this));
     defaultToNoneSimulator = false;
 #else
     LOG(WARNING)
@@ -223,7 +223,7 @@ bool ResourceManager::loadScene(
   // reset to base PhysicsManager to override previous as default behavior
   // if the desired simulator is not supported reset to "none" in metaData
   if (defaultToNoneSimulator) {
-    _physicsManager.reset(new physics::PhysicsManager(this));
+    _physicsManager.reset(new physics::PhysicsManager(*this));
     physicsManagerAttributes->setSimulator("none");
   }
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -65,9 +65,9 @@ int PhysicsManager::addObject(const int objectLibIndex,
                               const Magnum::ResourceKey& lightSetup) {
   //! Test Mesh primitive is valid
   assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
-      resourceManager_->getPhysicsObjectAttributes(objectLibIndex);
+      resourceManager_.getPhysicsObjectAttributes(objectLibIndex);
   const std::vector<assets::CollisionMeshData>& meshGroup =
-      resourceManager_->getCollisionMesh(objectLibIndex);
+      resourceManager_.getCollisionMesh(objectLibIndex);
 
   //! Make rigid object and add it to existingObjects
   int nextObjectID_ = allocateObjectID();
@@ -91,7 +91,7 @@ int PhysicsManager::addObject(const int objectLibIndex,
 
   //! Draw object via resource manager
   //! Render node as child of physics node
-  resourceManager_->addObjectToDrawables(
+  resourceManager_.addObjectToDrawables(
       objectLibIndex, existingObjects_.at(nextObjectID_)->visualNode_,
       drawables, lightSetup);
   existingObjects_.at(nextObjectID_)->node().computeCumulativeBB();
@@ -117,7 +117,7 @@ int PhysicsManager::addObject(const std::string& configFile,
                               DrawableGroup* drawables,
                               scene::SceneNode* attachmentNode,
                               const Magnum::ResourceKey& lightSetup) {
-  int resObjectID = resourceManager_->getObjectTemplateID(configFile);
+  int resObjectID = resourceManager_.getObjectTemplateID(configFile);
   //! Invoke resourceManager to draw object
   int physObjectID =
       addObject(resObjectID, drawables, attachmentNode, lightSetup);
@@ -514,7 +514,7 @@ void PhysicsManager::setObjectBBDraw(int physObjectID,
             existingObjects_[physObjectID]
                 ->visualNode_->getCumulativeBB()
                 .center());
-    resourceManager_->addPrimitiveToDrawables(
+    resourceManager_.addPrimitiveToDrawables(
         0, *existingObjects_.at(physObjectID)->BBNode_, drawables);
   }
 }

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -88,9 +88,8 @@ class PhysicsManager {
    * tracks the assets this
    * @ref PhysicsManager will have access to.
    */
-  explicit PhysicsManager(assets::ResourceManager* _resourceManager) {
-    resourceManager_ = _resourceManager;
-  };
+  explicit PhysicsManager(assets::ResourceManager& _resourceManager)
+      : resourceManager_(_resourceManager){};
 
   /** @brief Destructor*/
   virtual ~PhysicsManager();
@@ -888,7 +887,7 @@ class PhysicsManager {
 
   /** @brief A pointer to a @ref esp::assets::ResourceManager which holds assets
    * that can be accessed by this @ref PhysicsManager*/
-  assets::ResourceManager* resourceManager_;
+  assets::ResourceManager& resourceManager_;
 
   /** @brief The current physics library implementation used by this
    * @ref PhysicsManager. Can be used to correctly cast the @ref PhysicsManager

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -13,7 +13,7 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode)
       visualNode_(&rigidBodyNode->createChild()) {}
 
 bool RigidObject::initializeScene(
-    const assets::ResourceManager* resMgr,
+    const assets::ResourceManager& resMgr,
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   if (rigidObjectType_ != RigidObjectType::NONE) {
@@ -29,14 +29,14 @@ bool RigidObject::initializeScene(
 }
 
 bool RigidObject::initializeSceneFinalize(
-    const assets::ResourceManager*,
+    const assets::ResourceManager&,
     const assets::PhysicsSceneAttributes::ptr,
     const std::vector<assets::CollisionMeshData>&) {
   return true;
 }
 
 bool RigidObject::initializeObject(
-    const assets::ResourceManager* resMgr,
+    const assets::ResourceManager& resMgr,
     const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // TODO (JH): Handling static/kinematic object type
@@ -54,7 +54,7 @@ bool RigidObject::initializeObject(
 }
 
 bool RigidObject::initializeObjectFinalize(
-    const assets::ResourceManager*,
+    const assets::ResourceManager&,
     const assets::PhysicsObjectAttributes::ptr,
     const std::vector<assets::CollisionMeshData>&) {
   // default kineamtic unless a simulator is initialized...

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -147,6 +147,11 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
   RigidObject(scene::SceneNode* rigidBodyNode);
 
   /**
+   * @brief Virtual destructor for a @ref RigidObject.
+   */
+  virtual ~RigidObject(){};
+
+  /**
    * @brief Get the scene node being attached to.
    */
   scene::SceneNode& node() { return object(); }
@@ -172,7 +177,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeScene(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
@@ -186,7 +191,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeObject(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
@@ -194,11 +199,6 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @brief Finalize this object with any necessary post-creation processes.
    */
   virtual void finalizeObject() {}
-
-  /**
-   * @brief Virtual destructor for a @ref RigidObject.
-   */
-  virtual ~RigidObject(){};
 
   /**
    * @brief Check whether object is being actively simulated, or sleeping.
@@ -614,7 +614,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initializeSceneFinalize(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
@@ -630,7 +630,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initializeObjectFinalize(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -603,6 +603,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    */
   assets::PhysicsObjectAttributes::ptr initializationAttributes_;
 
+ private:
   /**
    * @brief Finalize the initialization of this @ref RigidObject as static scene
    * geometry.  This is overridden by inheriting objects
@@ -634,6 +635,7 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
+ protected:
   /** @brief Used to synchronize other simulator's notion of the object state
    * after it was changed kinematically. Called automatically on kinematic
    * updates.*/

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -47,7 +47,7 @@ class BulletPhysicsManager : public PhysicsManager {
    * tracks the assets this
    * @ref BulletPhysicsManager will have access to.
    */
-  explicit BulletPhysicsManager(assets::ResourceManager* _resourceManager)
+  explicit BulletPhysicsManager(assets::ResourceManager& _resourceManager)
       : PhysicsManager(_resourceManager){};
 
   /** @brief Destructor which destructs necessary Bullet physics structures.*/

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -36,11 +36,11 @@ BulletRigidObject::BulletRigidObject(
       bWorld_(bWorld) {}
 
 bool BulletRigidObject::initializeSceneFinalize(
-    const assets::ResourceManager* resMgr,
+    const assets::ResourceManager& resMgr,
     const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   const assets::MeshMetaData& metaData =
-      resMgr->getMeshMetaData(physicsSceneAttributes->getCollisionMeshHandle());
+      resMgr.getMeshMetaData(physicsSceneAttributes->getCollisionMeshHandle());
 
   constructBulletSceneFromMeshes(Magnum::Matrix4{}, meshGroup, metaData.root);
   for (auto& object : bSceneCollisionObjects_) {
@@ -53,13 +53,13 @@ bool BulletRigidObject::initializeSceneFinalize(
 }  // end BulletRigidObject::initializeScene
 
 bool BulletRigidObject::initializeObjectFinalize(
-    const assets::ResourceManager* resMgr,
+    const assets::ResourceManager& resMgr,
     const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   objectMotionType_ = MotionType::DYNAMIC;
 
-  const assets::MeshMetaData& metaData = resMgr->getMeshMetaData(
-      physicsObjectAttributes->getCollisionMeshHandle());
+  const assets::MeshMetaData& metaData =
+      resMgr.getMeshMetaData(physicsObjectAttributes->getCollisionMeshHandle());
 
   //! Physical parameters
   double margin = physicsObjectAttributes->getMargin();

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -420,7 +420,7 @@ class BulletRigidObject : public RigidObject,
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeSceneFinalize(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup) override;
 
@@ -436,7 +436,7 @@ class BulletRigidObject : public RigidObject,
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeObjectFinalize(
-      const assets::ResourceManager* resMgr,
+      const assets::ResourceManager& resMgr,
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup) override;
 

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -407,7 +407,7 @@ class BulletRigidObject : public RigidObject,
    */
   const Magnum::Range3D getCollisionShapeAabb() const;
 
- protected:
+ private:
   /**
    * @brief Initializes this @ref BulletRigidObject as static scene geometry.
    * See @ref PhysicsManager::staticSceneObject_. Sets @ref rigidObjectType_ to
@@ -440,6 +440,7 @@ class BulletRigidObject : public RigidObject,
       const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup) override;
 
+ protected:
   /**
    * @brief Used to synchronize Bullet's notion of the object state
    * after it was changed kinematically. Called automatically on kinematic


### PR DESCRIPTION
## Motivation and Context
This pull request addresses 2 issues that were raised in #573 :  
1) access to ResourceManager via the various physics managers should be changed from ptr to reference
2) access to rigid body finalizing methods should be elevated to private from protected
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
--run_test and pytest both passed without issues
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
