### PR TITLE
Prevent Assimp from appending `d` to all our binaries

### DIFF
--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -74,6 +74,11 @@ if(BUILD_ASSIMP_SUPPORT)
     set(ASSIMP_BUILD_ASSIMP_TOOLS OFF CACHE BOOL "ASSIMP_BUILD_ASSIMP_TOOLS" FORCE)
     set(ASSIMP_BUILD_TESTS OFF CACHE BOOL "ASSIMP_BUILD_TESTS" FORCE)
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "ASSIMP_BUILD_TESTS" FORCE)
+    # The following is important to avoid Assimp appending `d` to all our
+    # binaries. Works only with Assimp >= 5.0.0, and after 5.0.1 this option is
+    # prefixed with ASSIMP_, so better set both variants to future-proof this.
+    set(INJECT_DEBUG_POSTFIX OFF CACHE BOOL "" FORCE)
+    set(ASSIMP_INJECT_DEBUG_POSTFIX OFF CACHE BOOL "" FORCE)
     add_subdirectory("${DEPS_DIR}/assimp")
 
     # Help FindAssimp locate everything


### PR DESCRIPTION
## Motivation and Context

Reported by @dexter1691 -- it breaks things when doing `./build.sh --debug`, in particular it causes
the Python bindings to have a different name, which are then not found properly by Python.

## How Has This Been Tested

There should be no `d` suffix anymore in bindings produced in the Debug build.

:warning: Unfortunately the `INJECT_DEBUG_POSTFIX` option that's meant to fix this behavior wasn't working properly in the submodule commit that was in the repository, so I had to upgrade the `assimp` submodule to the `v5.0.1` tag. While I know about several things that got fixed for this version, there are also known regressions -- so please if you could check with random OBJ, STL or COLLADA files and check for suspicious behavior, it'd be great.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
