### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
               # Rebuild with all options enabled
               ./build.sh --with-cuda --with-bullet
               cd docs
-              conda install -y -c conda-forge doxygen
+              conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils
               conda install -y -c conda-forge pelican
               mkdir -p ../build/docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   cpp_lint:
     docker:
-      - image: circleci/buildpack-deps:disco
+      - image: circleci/buildpack-deps:18.04
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           command: |
               if [ ! -d ~/miniconda ]
               then
-                curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
                 chmod +x ~/miniconda.sh
                 ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh


### PR DESCRIPTION
## Motivation and Context

Pin doxygen, repo.continuum.io moved to repo.anaconda.com, and pin to 18.04  ubuntu.

## How Has This Been Tested

On the CI.