### PR TITLE
Bug fixes and stability improvements for physics simulation.

### DIFF
--- a/data/default.phys_scene_config.json
+++ b/data/default.phys_scene_config.json
@@ -1,12 +1,10 @@
 {
     "physics simulator": "bullet",
-    "timestep": 0.0041666666,
+    "timestep": 0.008,
     "gravity": [0,-9.8,0],
     "friction coefficient": 0.4,
     "restitution coefficient": 0.1,
     "rigid object paths":[
-        "objects/cheezit",
-        "objects/chefcan",
-        "objects/banana"
+        "objects"
     ]
 }

--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -14,7 +14,7 @@ namespace assets {
 PhysicsObjectAttributes::PhysicsObjectAttributes() : Configuration() {
   // fill necessary attribute defaults
   setMass(1.0);
-  setMargin(0.01);
+  setMargin(0.04);
   setScale({1.0, 1.0, 1.0});
   setCOM({0, 0, 0});
   setInertia({0, 0, 0});

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -419,10 +419,6 @@ void PhysicsManager::setInertiaVector(const int physObjectID,
   assertIDValidity(physObjectID);
   existingObjects_.at(physObjectID)->setInertiaVector(inertia);
 }
-void PhysicsManager::setScale(const int physObjectID, const double scale) {
-  assertIDValidity(physObjectID);
-  existingObjects_.at(physObjectID)->setScale(scale);
-}
 void PhysicsManager::setFrictionCoefficient(const int physObjectID,
                                             const double frictionCoefficient) {
   assertIDValidity(physObjectID);
@@ -468,7 +464,7 @@ Magnum::Matrix3 PhysicsManager::getInertiaMatrix(const int physObjectID) const {
   return existingObjects_.at(physObjectID)->getInertiaMatrix();
 }
 
-double PhysicsManager::getScale(const int physObjectID) const {
+Magnum::Vector3 PhysicsManager::getScale(const int physObjectID) const {
   assertIDValidity(physObjectID);
   return existingObjects_.at(physObjectID)->getScale();
 }

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -485,15 +485,6 @@ class PhysicsManager {
    */
   void setInertiaVector(const int physObjectID, const Magnum::Vector3& inertia);
 
-  /** @brief Set the uniform scale for an object.
-   * See @ref RigidObject::setScale.
-   * @param  physObjectID The object ID and key identifying the object in @ref
-   * PhysicsManager::existingObjects_.
-   * @param scale The new scalar uniform scale for the object relative to its
-   * initially loaded meshes.
-   */
-  void setScale(const int physObjectID, const double scale);
-
   /** @brief Set the scalar friction coefficient for an object.
    * See @ref RigidObject::setFrictionCoefficient.
    * @param  physObjectID The object ID and key identifying the object in @ref
@@ -565,14 +556,13 @@ class PhysicsManager {
    */
   Magnum::Matrix3 getInertiaMatrix(const int physObjectID) const;
 
-  /** @brief Get the scalar uniform scale of an object.
+  /** @brief Get the scale of an object set during initialization.
    * See @ref RigidObject::getScale.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
-   * @return The uniform scale of the object relative to its initialy loaded
-   * meshes.
+   * @return The scaling of the object relative to its initialy loaded meshes.
    */
-  double getScale(const int physObjectID) const;
+  Magnum::Vector3 getScale(const int physObjectID) const;
 
   /** @brief Get the scalar coefficient of friction of an object.
    * See @ref RigidObject::getFrictionCoefficient.
@@ -935,11 +925,6 @@ class PhysicsManager {
   /** @brief Tracks whether or not this @ref PhysicsManager has already been
    * initialized with @ref initPhysics. */
   bool initialized_ = false;
-
-  /** @brief Determines the maximum number of @ref fixedTimeStep_ allowed per
-   * each call of @ref stepPhysics only for @ref BulletPhysicsManager. Has no
-   * effect on @ref PhysicsManager base class. Candidate for removal... */
-  int maxSubSteps_ = 10;
 
   /** @brief The fixed amount of time over which to integrate the simulation in
    * discrete steps within @ref stepPhysics. Lower values result in better

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -49,7 +49,9 @@ bool RigidObject::initializeObject(
   //! Turn on scene flag
   rigidObjectType_ = RigidObjectType::OBJECT;
 
-  initializationAttributes_ = physicsObjectAttributes;
+  // save a copy of the template at initialization time
+  initializationAttributes_ = esp::assets::PhysicsObjectAttributes::create(
+      *physicsObjectAttributes.get());
 
   return initializeObjectFinalize(resMgr, physicsObjectAttributes, meshGroup);
 }

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -454,12 +454,12 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual double getMass() { return 0.0; }
 
-  /** @brief Get the uniform scale of the object.
-   * @return The scalar uniform scale for the object relative to its
-   * initially loaded meshes.
-   * @todo !!! not implemented !!!
+  /** @brief Get the scale of the object set during initialization.
+   * @return The scaling for the object relative to its initially loaded meshes.
    */
-  virtual double getScale() { return 0.0; }
+  virtual Magnum::Vector3 getScale() {
+    return initializationAttributes_->getScale();
+  }
 
   /** @brief Get the scalar friction coefficient of the object. Only used for
    * dervied dynamic implementations of @ref RigidObject.
@@ -525,13 +525,6 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual void setInertiaVector(
       CORRADE_UNUSED const Magnum::Vector3& inertia){};
-
-  /** @brief Set the uniform scale of the object.
-   * @param scale The new scalar uniform scale for the object relative to its
-   * initially loaded meshes.
-   * @todo !!! not implemented !!!
-   */
-  virtual void setScale(CORRADE_UNUSED const double scale){};
 
   /** @brief Set the scalar friction coefficient of the object. Only used for
    * dervied dynamic implementations of @ref RigidObject.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -164,7 +164,7 @@ void BulletPhysicsManager::stepPhysics(double dt) {
   // ==== Physics stepforward ======
   // NOTE: worldTime_ will always be a multiple of sceneMetaData_.timestep
   int numSubStepsTaken =
-      bWorld_->stepSimulation(dt, maxSubSteps_, fixedTimeStep_);
+      bWorld_->stepSimulation(dt, /*maxSubSteps*/ 10000, fixedTimeStep_);
   worldTime_ += numSubStepsTaken * fixedTimeStep_;
 }
 

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -168,10 +168,13 @@ void BulletRigidObject::constructBulletSceneFromMeshes(
     std::unique_ptr<btBvhTriangleMeshShape> meshShape =
         std::make_unique<btBvhTriangleMeshShape>(indexedVertexArray.get(),
                                                  true);
-    meshShape->setMargin(0.0);
+    meshShape->setMargin(0.04);
     meshShape->setLocalScaling(
         btVector3{transformFromLocalToWorld
                       .scaling()});  // scale is a property of the shape
+
+    // re-build the bvh after setting margin
+    meshShape->buildOptimizedBvh();
     std::unique_ptr<btCollisionObject> sceneCollisionObject =
         std::make_unique<btCollisionObject>();
     sceneCollisionObject->setCollisionShape(meshShape.get());
@@ -479,14 +482,6 @@ void BulletRigidObject::setInertiaVector(const Magnum::Vector3& inertia) {
     bObjectRigidBody_->setMassProps(getMass(), btVector3(inertia));
 }
 
-void BulletRigidObject::setScale(const double) {
-  // Currently not supported
-  /*if (rigidObjectType_ == RigidObjectType::SCENE)
-    return;
-  else
-    bObjectRigidBody_->setLinearFactor(btVector3(scale, scale, scale));*/
-}
-
 void BulletRigidObject::setFrictionCoefficient(
     const double frictionCoefficient) {
   if (rigidObjectType_ == RigidObjectType::SCENE) {
@@ -573,15 +568,6 @@ Magnum::Matrix3 BulletRigidObject::getInertiaMatrix() {
     const Magnum::Vector3 vecInertia = getInertiaVector();
     const Magnum::Matrix3 inertia = Magnum::Matrix3::fromDiagonal(vecInertia);
     return inertia;
-  }
-}
-
-double BulletRigidObject::getScale() {
-  if (rigidObjectType_ == RigidObjectType::SCENE) {
-    return 1.0;
-    // Assume uniform scale for 3D objects
-  } else {
-    return bObjectRigidBody_->getLinearFactor().x();
   }
 }
 

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -270,13 +270,6 @@ class BulletRigidObject : public RigidObject,
    */
   Magnum::Matrix3 getInertiaMatrix() override;
 
-  /** @brief Get the uniform scale of the object.
-   * @return The scalar uniform scale for the object relative to its
-   * initially loaded meshes.
-   * @todo !!! not implemented properly!!!
-   */
-  double getScale() override;
-
   /** @brief Get the scalar friction coefficient of the object.
    * See @ref btCollisionObject::getFriction.
    * @return The scalar friction coefficient of the object.
@@ -333,13 +326,6 @@ class BulletRigidObject : public RigidObject,
    * @param inertia The new diagonal for the object's inertia matrix.
    */
   void setInertiaVector(const Magnum::Vector3& inertia) override;
-
-  /** @brief Set the uniform scale of the object.
-   * @param scale The new scalar uniform scale for the object relative to its
-   * initially loaded meshes.
-   * @todo !!! not implemented !!!
-   */
-  void setScale(const double scale) override;
 
   /** @brief Set the scalar friction coefficient of the object.
    * See @ref btCollisionObject::setFriction.

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -476,7 +476,7 @@ void Viewer::drawEvent() {
   if (physicsManager_ != nullptr)
     // step physics at a fixed rate
     timeSinceLastSimulation += timeline_.previousFrameDuration();
-  if (timeSinceLastSimulation > 1.0 / 60.0) {
+  if (timeSinceLastSimulation >= 1.0 / 60.0) {
     physicsManager_->stepPhysics(1.0 / 60.0);
     timeSinceLastSimulation = 0.0;
   }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -317,7 +317,7 @@ void Viewer::addObject(std::string configFile) {
   Mn::Matrix4 T =
       agentBodyNode_
           ->MagnumObject::transformationMatrix();  // Relative to agent bodynode
-  Mn::Vector3 new_pos = T.transformPoint({0.1f, 2.5f, -2.0f});
+  Mn::Vector3 new_pos = T.transformPoint({0.1f, 1.5f, -2.0f});
 
   auto& drawables = sceneGraph_->getDrawables();
 
@@ -466,6 +466,7 @@ Mn::Vector3 Viewer::positionOnSphere(Mn::SceneGraph::Camera3D& camera,
   return (result * Mn::Vector3::yScale(-1.0f)).normalized();
 }
 
+float timeSinceLastSimulation = 0.0;
 void Viewer::drawEvent() {
   Mn::GL::defaultFramebuffer.clear(Mn::GL::FramebufferClear::Color |
                                    Mn::GL::FramebufferClear::Depth);
@@ -473,7 +474,12 @@ void Viewer::drawEvent() {
     return;
 
   if (physicsManager_ != nullptr)
-    physicsManager_->stepPhysics(timeline_.previousFrameDuration());
+    // step physics at a fixed rate
+    timeSinceLastSimulation += timeline_.previousFrameDuration();
+  if (timeSinceLastSimulation > 1.0 / 60.0) {
+    physicsManager_->stepPhysics(1.0 / 60.0);
+    timeSinceLastSimulation = 0.0;
+  }
 
   int DEFAULT_SCENE = 0;
   int sceneID = sceneID_[DEFAULT_SCENE];

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -129,8 +129,8 @@ def test_dynamics(sim):
     assert sim.get_physics_object_library_size() > 0
 
     # test adding an object to the world
-    object_id = sim.add_object(0)
-    object2_id = sim.add_object(0)
+    object_id = sim.add_object(1)
+    object2_id = sim.add_object(1)
     assert len(sim.get_existing_object_ids()) > 0
 
     # place the objects over the table in room
@@ -150,7 +150,7 @@ def test_dynamics(sim):
 
             # TODO: expose object properties (such as mass) to python
             # Counter the force of gravity on the object (it should not translate)
-            obj_mass = 0.5
+            obj_mass = 0.41
             sim.apply_force(np.array([0, obj_mass * 9.8, 0]), np.zeros(3), object_id)
 
             # apply torque to the "floating" object. It should rotate, but not translate
@@ -289,12 +289,15 @@ def test_velocity_control(sim):
 
         while sim.get_world_time() < 0.5:
             # NOTE: stepping close to default timestep to get near-constant velocity control of DYNAMIC bodies.
-            sim.step_physics(0.00416)
+            sim.step_physics(0.008)
+
+        print(sim.get_world_time())
 
         # NOTE: explicit integration, so expect some error
         ground_truth_q = mn.Quaternion([[1.0, 0, 0], 0])
+        print(sim.get_translation(object_id))
         assert np.allclose(
-            sim.get_translation(object_id), np.array([0, 1.0, 0.0]), atol=0.03
+            sim.get_translation(object_id), np.array([0, 1.0, 0.0]), atol=0.07
         )
         angle_error = mn.math.angle(ground_truth_q, sim.get_rotation(object_id))
         assert angle_error < mn.Rad(0.05)


### PR DESCRIPTION
## Motivation and Context

This change fixes several bugs and addresses simulation stability.

[Test objects](http://dl.fbaipublicfiles.com/habitat/objects_v0.1.zip) have been updated with new visuals, better physical parameters, and better convex approximations. New test scene `apartment_1` added to [example scenes](http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip). Following empirical simulation stability testing, several changes seemed beneficial. 

 - default simulation timestep and collision margins (world and objects) increased.
 - `PhysicsManager::maxSubSteps_` variable replaced with hard-coded large value and specific treatment in interactive viewer application. 
 - all post-initialization `setScale` functions have been removed. We only allow scale to be changed in templates before instancing objects.
 - `RigidObject::getScale` now returns a vector since we allow non-uniform scaling.
 - viewer.cpp `addObject` initial translation slightly lower (objects were ending up in the roof on some scenes).
 - `RigidObject::initializationAttributes_` was referencing the dynamic template. Should be a static copy from creation time.

## How Has This Been Tested

Physics tests adjusted for changes. `getScale` testing added. 

Empirical testing with viewer:
![updated_objects](https://user-images.githubusercontent.com/1445143/80168740-7c96c400-8598-11ea-911c-b4d09e61f73f.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
