### PR TITLE
Add python bindings for getObjectInitializationTemplate

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -301,6 +301,9 @@ class Simulator:
     def load_object_template(self, object_template, object_template_handle):
         return self._sim.load_object_template(object_template, object_template_handle)
 
+    def get_object_initialization_template(self, object_id, scene_id=0):
+        return self._sim.get_object_initialization_template(object_id, scene_id)
+
     # --- physics functions ---
     def add_object(
         self,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -77,6 +77,9 @@ void initSimBindings(py::module& m) {
       .def("load_object_configs", &Simulator::loadObjectConfigs, "path"_a)
       .def("load_object_template", &Simulator::loadObjectTemplate,
            "object_template"_a, "object_template_handle"_a)
+      .def("get_object_initialization_template",
+           &Simulator::getObjectInitializationTemplate, "object_id"_a,
+           "sceneID"_a = 0)
       .def("remove_object", &Simulator::removeObject, "object_id"_a,
            "delete_object_node"_a, "delete_visual_node"_a, "sceneID"_a = 0)
       .def("get_object_motion_type", &Simulator::getObjectMotionType,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -309,6 +309,14 @@ int Simulator::loadObjectTemplate(
   return resourceManager_.loadObjectTemplate(objTmplPtr, objectTemplateHandle);
 }
 
+const assets::PhysicsObjectAttributes::ptr
+Simulator::getObjectInitializationTemplate(int objectId, const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    return physicsManager_->getInitializationAttributes(objectId);
+  }
+  return nullptr;
+}
+
 // return a list of existing objected IDs in a physical scene
 std::vector<int> Simulator::getExistingObjectIDs(const int sceneID) {
   if (sceneHasPhysics(sceneID)) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -310,7 +310,8 @@ int Simulator::loadObjectTemplate(
 }
 
 const assets::PhysicsObjectAttributes::ptr
-Simulator::getObjectInitializationTemplate(int objectId, const int sceneID) {
+Simulator::getObjectInitializationTemplate(int objectId,
+                                           const int sceneID) const {
   if (sceneHasPhysics(sceneID)) {
     return physicsManager_->getInitializationAttributes(objectId);
   }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -160,7 +160,7 @@ class Simulator {
    */
   const assets::PhysicsObjectAttributes::ptr getObjectInitializationTemplate(
       int objectId,
-      const int sceneID = 0);
+      const int sceneID = 0) const;
 
   /**
    * @brief Remove an instanced object by ID. See @ref

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -153,6 +153,16 @@ class Simulator {
                          const std::string& objectTemplateHandle);
 
   /**
+   * @brief Get a static view of a physics object's template when the object was
+   * instanced.
+   *
+   * Use this to query the object's properties when it was initialized.
+   */
+  const assets::PhysicsObjectAttributes::ptr getObjectInitializationTemplate(
+      int objectId,
+      const int sceneID = 0);
+
+  /**
    * @brief Remove an instanced object by ID. See @ref
    * esp::physics::PhysicsManager::removeObject().
    * @param objectID The ID of the object identifying it in @ref

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -139,6 +139,8 @@ def test_dynamics(sim):
 
     # get object MotionType and continue testing if MotionType::DYNAMIC (implies a physics implementation is active)
     if sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.DYNAMIC:
+        object1_init_template = sim.get_object_initialization_template(object_id)
+        object1_mass = object1_init_template.get_mass()
         previous_object_states = [
             [sim.get_translation(object_id), sim.get_rotation(object_id)],
             [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
@@ -150,8 +152,9 @@ def test_dynamics(sim):
 
             # TODO: expose object properties (such as mass) to python
             # Counter the force of gravity on the object (it should not translate)
-            obj_mass = 0.41
-            sim.apply_force(np.array([0, obj_mass * 9.8, 0]), np.zeros(3), object_id)
+            sim.apply_force(
+                np.array([0, object1_mass * 9.8, 0]), np.zeros(3), object_id
+            )
 
             # apply torque to the "floating" object. It should rotate, but not translate
             sim.apply_torque(np.random.rand(3), object_id)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -141,6 +141,7 @@ def test_dynamics(sim):
     if sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.DYNAMIC:
         object1_init_template = sim.get_object_initialization_template(object_id)
         object1_mass = object1_init_template.get_mass()
+        grav = sim.get_gravity()
         previous_object_states = [
             [sim.get_translation(object_id), sim.get_rotation(object_id)],
             [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
@@ -152,9 +153,7 @@ def test_dynamics(sim):
 
             # TODO: expose object properties (such as mass) to python
             # Counter the force of gravity on the object (it should not translate)
-            sim.apply_force(
-                np.array([0, object1_mass * 9.8, 0]), np.zeros(3), object_id
-            )
+            sim.apply_force(-grav * object1_mass, np.zeros(3), object_id)
 
             # apply torque to the "floating" object. It should rotate, but not translate
             sim.apply_torque(np.random.rand(3), object_id)


### PR DESCRIPTION
## Motivation and Context

When an object is initialized, a copy of its construction parameters template is saved. Querying this allows for static properties of the object (unchanging after instancing) to be queried including mass, scale, friction, and restitution.

## How Has This Been Tested

Consumed this functionality in a test. If queried mass is wrong, the test will fail.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
