### PR TITLE
Attributes string search

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -304,6 +304,12 @@ class Simulator:
     def get_object_initialization_template(self, object_id, scene_id=0):
         return self._sim.get_object_initialization_template(object_id, scene_id)
 
+    def get_template_handle_by_ID(self, object_id):
+        return self._sim.get_template_handle_by_ID(object_id)
+
+    def get_template_handles(self, search_str):
+        return self._sim.get_template_handles(search_str)
+
     # --- physics functions ---
     def add_object(
         self,
@@ -312,6 +318,14 @@ class Simulator:
         light_setup_key=DEFAULT_LIGHTING_KEY,
     ):
         return self._sim.add_object(object_lib_index, attachment_node, light_setup_key)
+
+    def add_object_by_handle(
+        self,
+        object_lib_handle,
+        attachment_node=None,
+        light_setup_key=DEFAULT_LIGHTING_KEY,
+    ):
+        return self._sim.add_object_by_handle(object_lib_handle, attachment_node, light_setup_key)
 
     def remove_object(
         self, object_id, delete_object_node=True, delete_visual_node=True

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -325,7 +325,9 @@ class Simulator:
         attachment_node=None,
         light_setup_key=DEFAULT_LIGHTING_KEY,
     ):
-        return self._sim.add_object_by_handle(object_lib_handle, attachment_node, light_setup_key)
+        return self._sim.add_object_by_handle(
+            object_lib_handle, attachment_node, light_setup_key
+        )
 
     def remove_object(
         self, object_id, delete_object_node=True, delete_visual_node=True

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -436,6 +436,28 @@ class ResourceManager {
   int getNumLibraryObjects() { return physicsObjTemplateLibrary_.size(); };
 
   /**
+   * @brief Get a random object attribute handle (that could possibly describe
+   * either file-based or a primitive) for the loaded file-based object
+   * templates
+   *
+   * @return a randomly selected handle corresponding to a known object
+   * attributes template, or empty string if none found
+   */
+  std::string getRandomTemplateHandle() {
+    return getRandomTemplateHandlePerType(physicsTemplatesLibByID_, "");
+  }
+  /**
+   * @brief Get a list of all templates whose origin handles contain @ref
+   * subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing object templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getTemplateHandlesBySubstring(
+      const std::string& subStr = "") {
+    return getReqTemplateHandlesBySubString(physicsTemplatesLibByID_, subStr);
+  }
+  /**
    * @brief Gets the number of loaded object templates stored in the @ref
    * physicsObjTemplateLibrary_.
    *
@@ -447,13 +469,26 @@ class ResourceManager {
    * @brief Get a random loaded attribute handle for the loaded file-based
    * object templates
    *
-   * @return a randomly selected handle corresponding to the a file-based object
+   * @return a randomly selected handle corresponding to a file-based object
    * attributes template, or empty string if none loaded
    */
   std::string getRandomFileTemplateHandle() {
-    return getRandomTemplateHandle(physicsObjTmpltLibByID_, "file-based");
+    return getRandomTemplateHandlePerType(physicsObjTmpltLibByID_,
+                                          "file-based ");
   }
 
+  /**
+   * @brief Get a list of all file-based templates whose origin handles contain
+   * @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing file-based object
+   * templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getFileTemplateHandlesBySubstring(
+      const std::string& subStr = "") {
+    return getReqTemplateHandlesBySubString(physicsObjTmpltLibByID_, subStr);
+  }
   /**
    * @brief Gets the number of primitive template objects stored in the @ref
    * physicsObjTemplateLibrary_.
@@ -470,21 +505,22 @@ class ResourceManager {
    * attributes template, or empty string if none loaded
    */
   std::string getRandomPrimTemplateHandle() {
-    return getRandomTemplateHandle(physicsPrimTmpltLibByID_, "primitive");
+    return getRandomTemplateHandlePerType(physicsPrimTmpltLibByID_,
+                                          "primitive ");
+  }
+  /**
+   * @brief Get a list of all primitive templates whose origin handles contain
+   * @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getPrimTemplateHandlesBySubstring(
+      const std::string& subStr = "") {
+    return getReqTemplateHandlesBySubString(physicsPrimTmpltLibByID_, subStr);
   }
 
- private:
-  /**
-   * @brief return a random handle selected from the passed map - is passed
-   * either map of ids->prim handles or ids->file obj template handles
-   *
-   * @return a random template handle of the chosen type, or the empty string
-   * if none loaded
-   */
-  std::string getRandomTemplateHandle(std::map<int, std::string>& mapOfHandles,
-                                      const std::string& type);
-
- public:
   /**
    * @brief Retrieve the composition of all transforms applied to a mesh
    * since it was loaded.
@@ -585,6 +621,30 @@ class ResourceManager {
    * @param tmpltFilenames list of file names of object templates
    */
   void loadObjectTemplates(const std::vector<std::string>& tmpltFilenames);
+
+  /**
+   * @brief return a random handle selected from the passed map - is passed
+   * either map of ids->prim handles or ids->file obj template handles
+   *
+   * @return a random template handle of the chosen type, or the empty string
+   * if none loaded
+   */
+  std::string getRandomTemplateHandlePerType(
+      std::map<int, std::string>& mapOfHandles,
+      const std::string& type);
+
+  /**
+   * @brief Get a list of all templates of passed type whose origin handles
+   * contain @ref subStr, ignoring subStr's case
+   * @param mapOfHandles map containing the desired object-type template handles
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getReqTemplateHandlesBySubString(
+      std::map<int, std::string>& mapOfHandles,
+      const std::string& subStr);
 
   /**
    * @brief Instantiate, or reinstatiate, PhysicsManager defined by passed

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -275,13 +275,13 @@ class ResourceManager {
       std::string physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG);
 
   /**
-   * @brief Get all "*.phys_properties.json" files from the provided file or
+   * @brief Build all "*.phys_properties.json" files from the provided file or
    * directory path.
    *
    * @param path A global path to a physics property file or directory
    * @return A list of valid global paths to "*.phys_properties.json" files.
    */
-  std::vector<std::string> getObjectConfigPaths(std::string path);
+  std::vector<std::string> buildObjectConfigPaths(const std::string& path);
 
   /**
    * @brief Add an object from a specified configuration file to the specified
@@ -363,7 +363,10 @@ class ResourceManager {
    * individual components of the asset.
    */
   const std::vector<assets::CollisionMeshData>& getCollisionMesh(
-      const std::string& configFile);
+      const std::string& configFile) const {
+    return collisionMeshGroups_.at(
+        physicsObjTemplateLibrary_.at(configFile)->getCollisionMeshHandle());
+  }
 
   /**
    * @brief Getter for all @ref assets::CollisionMeshData associated with the
@@ -376,7 +379,10 @@ class ResourceManager {
    * individual components of the asset.
    */
   const std::vector<assets::CollisionMeshData>& getCollisionMesh(
-      const int objectTemplateID);
+      const int objectTemplateID) const {
+    std::string configFile = getObjectTemplateHandle(objectTemplateID);
+    return getCollisionMesh(configFile);
+  }
 
   /**
    * @brief Get the index in @ref physicsObjTemplateLibrary_ for the object
@@ -387,7 +393,14 @@ class ResourceManager {
    * @return The index of the object template in @ref
    * physicsObjTemplateLibrary_.
    */
-  int getObjectTemplateID(const std::string& configFile);
+  int getObjectTemplateID(const std::string& configFile) const {
+    const bool objTemplateExists =
+        physicsObjTemplateLibrary_.count(configFile) > 0;
+    if (objTemplateExists) {
+      return physicsObjTemplateLibrary_.at(configFile)->getObjectTemplateID();
+    }
+    return ID_UNDEFINED;
+  }
 
   /**
    * @brief Get the key in @ref physicsObjTemplateLibrary_ for the object
@@ -397,7 +410,7 @@ class ResourceManager {
    * physicsObjTemplateLibrary_.
    * @return The key referencing the asset in @ref physicsObjTemplateLibrary_.
    */
-  std::string getObjectConfig(const int objectTemplateID);
+  std::string getObjectTemplateHandle(const int objectTemplateID) const;
 
   /**
    * @brief Get a reference to the physics object template for the asset
@@ -410,7 +423,7 @@ class ResourceManager {
    * @return A mutable reference to the object template for the asset.
    */
   PhysicsObjectAttributes::ptr getPhysicsObjectAttributes(
-      const std::string& configFile) {
+      const std::string& configFile) const {
     return physicsObjTemplateLibrary_.at(configFile);
   }
 
@@ -425,7 +438,10 @@ class ResourceManager {
    * @return A mutable reference to the object template for the asset.
    */
   PhysicsObjectAttributes::ptr getPhysicsObjectAttributes(
-      const int objectTemplateID);
+      const int objectTemplateID) const {
+    return physicsObjTemplateLibrary_.at(
+        getObjectTemplateHandle(objectTemplateID));
+  }
 
   /**
    * @brief Gets the number of object templates stored in the @ref
@@ -433,7 +449,9 @@ class ResourceManager {
    *
    * @return The size of the @ref physicsObjTemplateLibrary_.
    */
-  int getNumLibraryObjects() { return physicsObjTemplateLibrary_.size(); };
+  int getNumLibraryObjects() const {
+    return physicsObjTemplateLibrary_.size();
+  };
 
   /**
    * @brief Get a random object attribute handle (that could possibly describe
@@ -443,7 +461,7 @@ class ResourceManager {
    * @return a randomly selected handle corresponding to a known object
    * attributes template, or empty string if none found
    */
-  std::string getRandomTemplateHandle() {
+  std::string getRandomTemplateHandle() const {
     return getRandomTemplateHandlePerType(physicsTemplatesLibByID_, "");
   }
   /**
@@ -454,8 +472,9 @@ class ResourceManager {
    * substring
    */
   std::vector<std::string> getTemplateHandlesBySubstring(
-      const std::string& subStr = "") {
-    return getReqTemplateHandlesBySubString(physicsTemplatesLibByID_, subStr);
+      const std::string& subStr = "") const {
+    return getTemplateHandlesBySubStringPerType(physicsTemplatesLibByID_,
+                                                subStr);
   }
   /**
    * @brief Gets the number of loaded object templates stored in the @ref
@@ -464,7 +483,9 @@ class ResourceManager {
    * @return The number of entries in @ref physicsObjTemplateLibrary_ that are
    * loaded from files.
    */
-  int getNumFileTemplateObjects() { return physicsObjTmpltLibByID_.size(); };
+  int getNumFileTemplateObjects() const {
+    return physicsObjTmpltLibByID_.size();
+  };
   /**
    * @brief Get a random loaded attribute handle for the loaded file-based
    * object templates
@@ -472,7 +493,7 @@ class ResourceManager {
    * @return a randomly selected handle corresponding to a file-based object
    * attributes template, or empty string if none loaded
    */
-  std::string getRandomFileTemplateHandle() {
+  std::string getRandomFileTemplateHandle() const {
     return getRandomTemplateHandlePerType(physicsObjTmpltLibByID_,
                                           "file-based ");
   }
@@ -486,8 +507,9 @@ class ResourceManager {
    * substring
    */
   std::vector<std::string> getFileTemplateHandlesBySubstring(
-      const std::string& subStr = "") {
-    return getReqTemplateHandlesBySubString(physicsObjTmpltLibByID_, subStr);
+      const std::string& subStr = "") const {
+    return getTemplateHandlesBySubStringPerType(physicsObjTmpltLibByID_,
+                                                subStr);
   }
   /**
    * @brief Gets the number of primitive template objects stored in the @ref
@@ -496,7 +518,9 @@ class ResourceManager {
    * @return The number of entries in @ref physicsObjTemplateLibrary_ that
    * describe primitives.
    */
-  int getNumPrimTemplateObjects() { return physicsPrimTmpltLibByID_.size(); };
+  int getNumPrimTemplateObjects() const {
+    return physicsPrimTmpltLibByID_.size();
+  };
   /**
    * @brief Get a random loaded attribute handle for the loaded primitive object
    * templates
@@ -504,7 +528,7 @@ class ResourceManager {
    * @return a randomly selected handle corresponding to the a primitive
    * attributes template, or empty string if none loaded
    */
-  std::string getRandomPrimTemplateHandle() {
+  std::string getRandomPrimTemplateHandle() const {
     return getRandomTemplateHandlePerType(physicsPrimTmpltLibByID_,
                                           "primitive ");
   }
@@ -517,8 +541,9 @@ class ResourceManager {
    * substring
    */
   std::vector<std::string> getPrimTemplateHandlesBySubstring(
-      const std::string& subStr = "") {
-    return getReqTemplateHandlesBySubString(physicsPrimTmpltLibByID_, subStr);
+      const std::string& subStr = "") const {
+    return getTemplateHandlesBySubStringPerType(physicsPrimTmpltLibByID_,
+                                                subStr);
   }
 
   /**
@@ -530,7 +555,7 @@ class ResourceManager {
    * @return The transformation matrix mapping from the original state to
    * its current state.
    */
-  const Magnum::Matrix4& getMeshTransformation(const size_t meshIndex) {
+  const Magnum::Matrix4& getMeshTransformation(const size_t meshIndex) const {
     return meshes_[meshIndex]->meshTransform_;
   }
 
@@ -630,8 +655,8 @@ class ResourceManager {
    * if none loaded
    */
   std::string getRandomTemplateHandlePerType(
-      std::map<int, std::string>& mapOfHandles,
-      const std::string& type);
+      const std::map<int, std::string>& mapOfHandles,
+      const std::string& type) const;
 
   /**
    * @brief Get a list of all templates of passed type whose origin handles
@@ -642,9 +667,9 @@ class ResourceManager {
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
-  std::vector<std::string> getReqTemplateHandlesBySubString(
-      std::map<int, std::string>& mapOfHandles,
-      const std::string& subStr);
+  std::vector<std::string> getTemplateHandlesBySubStringPerType(
+      const std::map<int, std::string>& mapOfHandles,
+      const std::string& subStr) const;
 
   /**
    * @brief Instantiate, or reinstatiate, PhysicsManager defined by passed
@@ -793,19 +818,19 @@ class ResourceManager {
   void loadMaterials(Importer& importer, LoadedAssetData& loadedAssetData);
 
   /**
-   * @brief Get a @ref PhongMaterialData for use with flat shading
+   * @brief Build a @ref PhongMaterialData for use with flat shading
    *
    * Textures must already be loaded for the asset this material belongs to
    *
    * @param material Material data with texture IDs
    * @param textureBaseIndex Base index of the assets textures in textures_
    */
-  gfx::PhongMaterialData::uptr getFlatShadedMaterialData(
+  gfx::PhongMaterialData::uptr buildFlatShadedMaterialData(
       const Magnum::Trade::PhongMaterialData& material,
       int textureBaseIndex);
 
   /**
-   * @brief Get a @ref PhongMaterialData for use with phong shading
+   * @brief Build a @ref PhongMaterialData for use with phong shading
    *
    * Textures must already be loaded for the asset this material belongs to
    *
@@ -813,7 +838,7 @@ class ResourceManager {
    * @param textureBaseIndex Base index of the assets textures in textures_
 
    */
-  gfx::PhongMaterialData::uptr getPhongShadedMaterialData(
+  gfx::PhongMaterialData::uptr buildPhongShadedMaterialData(
       const Magnum::Trade::PhongMaterialData& material,
       int textureBaseIndex);
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -73,10 +73,6 @@ void initSimBindings(py::module& m) {
            "object_id"_a)
       .def("get_template_handles", &Simulator::getObjectTemplateHandles,
            "search_str"_a = "")
-      .def("get_file_template_handles",
-           &Simulator::getFileBasedObjectTemplateHandles, "search_str"_a = "")
-      .def("get_prim_template_handles", &Simulator::getPrimitiveTemplateHandles,
-           "search_str"_a = "")
       .def("add_object", &Simulator::addObject, "object_lib_index"_a,
            "attachment_node"_a, "light_setup_key"_a, "scene_id"_a = 0)
       .def("add_object_by_handle", &Simulator::addObjectByHandle,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -68,8 +68,17 @@ void initSimBindings(py::module& m) {
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")
       /* --- Physics functions --- */
+      .def("get_template_handles", &Simulator::getObjectTemplateHandles,
+           "search_str"_a = "")
+      .def("get_file_template_handles",
+           &Simulator::getFileBasedObjectTemplateHandles, "search_str"_a = "")
+      .def("get_prim_template_handles", &Simulator::getPrimitiveTemplateHandles,
+           "search_str"_a = "")
       .def("add_object", &Simulator::addObject, "object_lib_index"_a,
            "attachment_node"_a, "light_setup_key"_a, "scene_id"_a = 0)
+      .def("add_object_by_handle", &Simulator::addObjectByHandle,
+           "object_lib_handle"_a, "attachment_node"_a, "light_setup_key"_a,
+           "scene_id"_a = 0)
       .def("get_physics_object_library_size",
            &Simulator::getPhysicsObjectLibrarySize)
       .def("get_object_template", &Simulator::getObjectTemplate,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -68,6 +68,9 @@ void initSimBindings(py::module& m) {
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")
       /* --- Physics functions --- */
+
+      .def("get_template_handle_by_ID", &Simulator::getObjectTemplateHandleByID,
+           "object_id"_a)
       .def("get_template_handles", &Simulator::getObjectTemplateHandles,
            "search_str"_a = "")
       .def("get_file_template_handles",

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -61,7 +61,7 @@ int PhysicsManager::addObject(const int objectLibIndex,
                               scene::SceneNode* attachmentNode,
                               const Magnum::ResourceKey& lightSetup) {
   const std::string& configHandle =
-      resourceManager_.getObjectConfig(objectLibIndex);
+      resourceManager_.getObjectTemplateHandle(objectLibIndex);
   return addObject(configHandle, drawables, attachmentNode, lightSetup);
 }
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -291,21 +291,10 @@ int Simulator::addObjectByHandle(const std::string& objectLibHandle,
   return ID_UNDEFINED;
 }
 
-// return the current size of the physics object library (objects [0,size) can
-// be instanced)
-int Simulator::getPhysicsObjectLibrarySize() {
-  return resourceManager_.getNumLibraryObjects();
-}
-
-assets::PhysicsObjectAttributes::ptr Simulator::getObjectTemplate(
-    int templateId) {
-  return resourceManager_.getPhysicsObjectAttributes(templateId);
-}
-
 std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
   std::vector<int> templateIndices;
   std::vector<std::string> validConfigPaths =
-      resourceManager_.getObjectConfigPaths(path);
+      resourceManager_.buildObjectConfigPaths(path);
   for (auto& validPath : validConfigPaths) {
     templateIndices.push_back(
         resourceManager_.parseAndLoadPhysObjTemplate(validPath));

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -276,6 +276,21 @@ int Simulator::addObject(int objectLibIndex,
   return ID_UNDEFINED;
 }
 
+int Simulator::addObjectByHandle(const std::string& objectLibHandle,
+                                 scene::SceneNode* attachmentNode,
+                                 const std::string& lightSetupKey,
+                                 int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    // TODO: change implementation to support multi-world and physics worlds to
+    // own reference to a sceneGraph to avoid this.
+    auto& sceneGraph_ = sceneManager_.getSceneGraph(activeSceneID_);
+    auto& drawables = sceneGraph_.getDrawables();
+    return physicsManager_->addObject(objectLibHandle, &drawables,
+                                      attachmentNode, lightSetupKey);
+  }
+  return ID_UNDEFINED;
+}
+
 // return the current size of the physics object library (objects [0,size) can
 // be instanced)
 int Simulator::getPhysicsObjectLibrarySize() {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -89,6 +89,19 @@ class Simulator {
 
   // === Physics Simulator Functions ===
   // TODO: support multi-scene physics (default sceneID=0 currently).
+
+  /**
+   * @brief Get the string handle for the object template referenced by the
+   * passed ID
+   *
+   * @param objectTemplateID The index of the object template in the @ref
+   * ResourceManager library.
+   * @return The string key referencing the asset in @ref ResourceManager.
+   */
+  std::string getObjectTemplateHandleByID(const int objectTemplateID) const {
+    return resourceManager_.getObjectTemplateHandle(objectTemplateID);
+  }
+
   /**
    * @brief Get a list of all templates whose origin handles contain @ref
    * subStr, ignoring subStr's case
@@ -176,13 +189,16 @@ class Simulator {
    * @return The current number of templates stored in @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_.
    */
-  int getPhysicsObjectLibrarySize();
+  int getPhysicsObjectLibrarySize() const {
+    return resourceManager_.getNumLibraryObjects();
+  }
 
   /**
    * @brief Get a smart pointer to a physics object template by index.
    */
-  assets::PhysicsObjectAttributes::ptr getObjectTemplate(int templateId);
-
+  assets::PhysicsObjectAttributes::ptr getObjectTemplate(int templateId) const {
+    return resourceManager_.getPhysicsObjectAttributes(templateId);
+  }
   /**
    * @brief Load all "*.phys_properties.json" files from the provided file or
    * directory path.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -89,6 +89,42 @@ class Simulator {
 
   // === Physics Simulator Functions ===
   // TODO: support multi-scene physics (default sceneID=0 currently).
+  /**
+   * @brief Get a list of all templates whose origin handles contain @ref
+   * subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing object templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getObjectTemplateHandles(
+      const std::string& subStr = "") {
+    return resourceManager_.getTemplateHandlesBySubstring(subStr);
+  }
+  /**
+   * @brief Get a list of all file-based templates whose origin handles contain
+   * @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing file-based object
+   * templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getFileBasedObjectTemplateHandles(
+      const std::string& subStr = "") {
+    return resourceManager_.getFileTemplateHandlesBySubstring(subStr);
+  }
+
+  /**
+   * @brief Get a list of all primitive templates whose origin handles contain
+   * @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getPrimitiveTemplateHandles(
+      const std::string& subStr = "") {
+    return resourceManager_.getPrimTemplateHandlesBySubstring(subStr);
+  }
 
   /**
    * @brief Instance an object from a template index in @ref
@@ -111,6 +147,28 @@ class Simulator {
                 const std::string& lightSetupKey =
                     assets::ResourceManager::DEFAULT_LIGHTING_KEY,
                 int sceneID = 0);
+
+  /**
+   * @brief Instance an object from a template index in @ref
+   * esp::assets::ResourceManager::physicsObjectLibrary_. See @ref
+   * esp::physics::PhysicsManager::addObject().
+   * @param objectLibHandle The config/origin handle of the object's template in
+   * @ref esp::assets::ResourceManager::physicsObjectLibrary_.
+   * @param attachmentNode If provided, attach the RigidObject Feature to this
+   * node instead of creating a new one.
+   * @param lightSetupKey The string key for the LightSetup to be used by this
+   * object.
+   * @param sceneID !! Not used currently !! Specifies which physical scene to
+   * add an object to.
+   * @return The ID assigned to new object which identifies it in @ref
+   * esp::physics::PhysicsManager::existingObjects_ or @ref esp::ID_UNDEFINED if
+   * instancing fails.
+   */
+  int addObjectByHandle(const std::string& objectLibHandle,
+                        scene::SceneNode* attachmentNode = nullptr,
+                        const std::string& lightSetupKey =
+                            assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+                        int sceneID = 0);
 
   /**
    * @brief Get the current size of the physics object library. Objects [0,size)

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -395,6 +395,26 @@ void SimTest::loadingObjectTemplates() {
       Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
   CORRADE_VERIFY(templateIndices2 == templateIndices);
 
+  // test the loaded assets and accessing them by name
+  // verify that getting the template handles with empty string returns all
+  int numLoadedTemplates = templateIndices2.size();
+  std::vector<std::string> templateHandles =
+      simulator->getObjectTemplateHandles();
+  CORRADE_VERIFY(numLoadedTemplates == templateHandles.size());
+
+  // verify that querying with sub string returns template handle corresponding
+  // to that substring
+  // get full handle of an existing template
+  std::string fullTmpHndl = templateHandles[templateHandles.size() - 1];
+  // build substring
+  std::div_t len = std::div(fullTmpHndl.length(), 2);
+  // get 2nd half of handle
+  std::string tmpHndl = fullTmpHndl.substr(len.quot);
+  // get all handles that match 2nd half of known handle
+  std::vector<std::string> matchTmpltHandles =
+      simulator->getObjectTemplateHandles(tmpHndl);
+  CORRADE_VERIFY(matchTmpltHandles[0] == fullTmpHndl);
+
   // test fresh template as smart pointer
   esp::assets::PhysicsObjectAttributes::ptr newTemplate =
       esp::assets::PhysicsObjectAttributes::create();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -627,26 +627,6 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       controls_(*rgbSensorNode_, "lookDown", lookSensitivity, false);
       agentMoved = true;
       break;
-    case KeyEvent::Key::Seven: {  // test getting handles
-      std::vector<std::string> loadedHandles =
-          resourceManager_.getTemplateHandlesBySubstring();
-      std::stringstream strdat("");
-      for (auto s : loadedHandles) {
-        strdat << s << " | ";
-      }
-
-      LOG(INFO) << "Loaded Object Templates : " << strdat.str();
-      loadedHandles = resourceManager_.getTemplateHandlesBySubstring("chee");
-      strdat.str("");
-      strdat.clear();
-      for (auto s : loadedHandles) {
-        strdat << s << " | ";
-      }
-
-      LOG(INFO) << "Loaded Object Templates matching 'chee' : " << strdat.str();
-
-      break;
-    }
     case KeyEvent::Key::Eight:
       addPrimitiveObject();
       break;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -627,6 +627,26 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       controls_(*rgbSensorNode_, "lookDown", lookSensitivity, false);
       agentMoved = true;
       break;
+    case KeyEvent::Key::Seven: {  // test getting handles
+      std::vector<std::string> loadedHandles =
+          resourceManager_.getTemplateHandlesBySubstring();
+      std::stringstream strdat("");
+      for (auto s : loadedHandles) {
+        strdat << s << " | ";
+      }
+
+      LOG(INFO) << "Loaded Object Templates : " << strdat.str();
+      loadedHandles = resourceManager_.getTemplateHandlesBySubstring("chee");
+      strdat.str("");
+      strdat.clear();
+      for (auto s : loadedHandles) {
+        strdat << s << " | ";
+      }
+
+      LOG(INFO) << "Loaded Object Templates matching 'chee' : " << strdat.str();
+
+      break;
+    }
     case KeyEvent::Key::Eight:
       addPrimitiveObject();
       break;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -314,7 +314,7 @@ Viewer::Viewer(const Arguments& arguments)
 void Viewer::addObject(int ID) {
   if (physicsManager_ == nullptr)
     return;
-  addObject(resourceManager_.getObjectConfig(ID));
+  addObject(resourceManager_.getObjectTemplateHandle(ID));
 }  // addObject
 
 void Viewer::addObject(const std::string& configFile) {

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -37,14 +37,19 @@ def test_kinematics(sim):
     assert sim.get_physics_object_library_size() > 0
 
     # test adding an object to the world
-    object_id = sim.add_object(0)
+    # get handle for object 0, used to test
+    obj_handle = sim.get_template_handle_by_ID(0)
+    object_id = sim.add_object_by_handle(obj_handle)
+    #object_id = sim.add_object(0)
     assert len(sim.get_existing_object_ids()) > 0
 
     # test setting the motion type
 
-    assert sim.set_object_motion_type(habitat_sim.physics.MotionType.STATIC, object_id)
+    assert sim.set_object_motion_type(
+        habitat_sim.physics.MotionType.STATIC, object_id)
     assert (
-        sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.STATIC
+        sim.get_object_motion_type(
+            object_id) == habitat_sim.physics.MotionType.STATIC
     )
     assert sim.set_object_motion_type(
         habitat_sim.physics.MotionType.KINEMATIC, object_id
@@ -77,7 +82,9 @@ def test_kinematics(sim):
     old_object_id = sim.remove_object(object_id)
     assert len(sim.get_existing_object_ids()) == 0
 
-    object_id = sim.add_object(0)
+    obj_handle = sim.get_template_handle_by_ID(0)
+    object_id = sim.add_object_by_handle(obj_handle)
+    #object_id = sim.add_object(0)
 
     prev_time = 0.0
     for _ in range(2):
@@ -96,7 +103,9 @@ def test_kinematics(sim):
 
     # test attaching/dettaching an Agent to/from physics simulation
     agent_node = sim.agents[0].scene_node
-    sim.add_object(0, agent_node)
+    obj_handle = sim.get_template_handle_by_ID(0)
+    object_id = sim.add_object_by_handle(obj_handle, agent_node)
+    #sim.add_object(0, agent_node)
     sim.set_translation(np.random.rand(3), object_id)
     assert np.allclose(agent_node.translation, sim.get_translation(object_id))
     sim.remove_object(object_id, False)  # don't delete the agent's node
@@ -129,8 +138,11 @@ def test_dynamics(sim):
     assert sim.get_physics_object_library_size() > 0
 
     # test adding an object to the world
-    object_id = sim.add_object(1)
-    object2_id = sim.add_object(1)
+    obj_handle = sim.get_template_handle_by_ID(1)
+    object_id = sim.add_object_by_handle(obj_handle)
+    object2_id = sim.add_object_by_handle(obj_handle)
+    # object_id = sim.add_object(1)
+    # object2_id = sim.add_object(1)
     assert len(sim.get_existing_object_ids()) > 0
 
     # place the objects over the table in room
@@ -243,9 +255,12 @@ def test_velocity_control(sim):
     object_template.set_linear_damping(0.0)
     object_template.set_angular_damping(0.0)
 
+    obj_handle = sim.get_template_handle_by_ID(template_ids[0])
+
     for iteration in range(2):
         sim.reset()
-        object_id = sim.add_object(template_ids[0])
+        object_id = sim.add_object_by_handle(obj_handle)
+        #object_id = sim.add_object(template_ids[0])
         vel_control = sim.get_object_velocity_control(object_id)
 
         if iteration == 0:

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -38,8 +38,8 @@ def test_kinematics(sim):
 
     # test adding an object to the world
     # get handle for object 0, used to test
-    obj_handle = sim.get_template_handle_by_ID(0)
-    object_id = sim.add_object_by_handle(obj_handle)
+    obj_handle_list = sim.get_template_handles("cheezit")
+    object_id = sim.add_object_by_handle(obj_handle_list[0])
     # object_id = sim.add_object(0)
     assert len(sim.get_existing_object_ids()) > 0
 
@@ -80,8 +80,8 @@ def test_kinematics(sim):
     old_object_id = sim.remove_object(object_id)
     assert len(sim.get_existing_object_ids()) == 0
 
-    obj_handle = sim.get_template_handle_by_ID(0)
-    object_id = sim.add_object_by_handle(obj_handle)
+    obj_handle_list = sim.get_template_handles("cheezit")
+    object_id = sim.add_object_by_handle(obj_handle_list[0])
     # object_id = sim.add_object(0)
 
     prev_time = 0.0
@@ -101,8 +101,8 @@ def test_kinematics(sim):
 
     # test attaching/dettaching an Agent to/from physics simulation
     agent_node = sim.agents[0].scene_node
-    obj_handle = sim.get_template_handle_by_ID(0)
-    object_id = sim.add_object_by_handle(obj_handle, agent_node)
+    obj_handle_list = sim.get_template_handles("cheezit")
+    object_id = sim.add_object_by_handle(obj_handle_list[0], agent_node)
     # sim.add_object(0, agent_node)
     sim.set_translation(np.random.rand(3), object_id)
     assert np.allclose(agent_node.translation, sim.get_translation(object_id))
@@ -136,9 +136,9 @@ def test_dynamics(sim):
     assert sim.get_physics_object_library_size() > 0
 
     # test adding an object to the world
-    obj_handle = sim.get_template_handle_by_ID(1)
-    object_id = sim.add_object_by_handle(obj_handle)
-    object2_id = sim.add_object_by_handle(obj_handle)
+    obj_handle_list = sim.get_template_handles("cheezit")
+    object_id = sim.add_object_by_handle(obj_handle_list[0])
+    object2_id = sim.add_object_by_handle(obj_handle_list[0])
     # object_id = sim.add_object(1)
     # object2_id = sim.add_object(1)
     assert len(sim.get_existing_object_ids()) > 0

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -40,16 +40,14 @@ def test_kinematics(sim):
     # get handle for object 0, used to test
     obj_handle = sim.get_template_handle_by_ID(0)
     object_id = sim.add_object_by_handle(obj_handle)
-    #object_id = sim.add_object(0)
+    # object_id = sim.add_object(0)
     assert len(sim.get_existing_object_ids()) > 0
 
     # test setting the motion type
 
-    assert sim.set_object_motion_type(
-        habitat_sim.physics.MotionType.STATIC, object_id)
+    assert sim.set_object_motion_type(habitat_sim.physics.MotionType.STATIC, object_id)
     assert (
-        sim.get_object_motion_type(
-            object_id) == habitat_sim.physics.MotionType.STATIC
+        sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.STATIC
     )
     assert sim.set_object_motion_type(
         habitat_sim.physics.MotionType.KINEMATIC, object_id
@@ -84,7 +82,7 @@ def test_kinematics(sim):
 
     obj_handle = sim.get_template_handle_by_ID(0)
     object_id = sim.add_object_by_handle(obj_handle)
-    #object_id = sim.add_object(0)
+    # object_id = sim.add_object(0)
 
     prev_time = 0.0
     for _ in range(2):
@@ -105,7 +103,7 @@ def test_kinematics(sim):
     agent_node = sim.agents[0].scene_node
     obj_handle = sim.get_template_handle_by_ID(0)
     object_id = sim.add_object_by_handle(obj_handle, agent_node)
-    #sim.add_object(0, agent_node)
+    # sim.add_object(0, agent_node)
     sim.set_translation(np.random.rand(3), object_id)
     assert np.allclose(agent_node.translation, sim.get_translation(object_id))
     sim.remove_object(object_id, False)  # don't delete the agent's node
@@ -260,7 +258,7 @@ def test_velocity_control(sim):
     for iteration in range(2):
         sim.reset()
         object_id = sim.add_object_by_handle(obj_handle)
-        #object_id = sim.add_object(template_ids[0])
+        # object_id = sim.add_object(template_ids[0])
         vel_control = sim.get_object_velocity_control(object_id)
 
         if iteration == 0:


### PR DESCRIPTION
## Motivation and Context
This PR adds the ability to search by substring within the existing library of object templates in resource manager.  The user provides a substring to search for and a vector/list of all template handles that contain that substring are returned.  An empty substring returns all available handles. This functionality was extended to python bindings as well, and requisite testing was added.

Const correctness was also enforced in pure getters in Resource Manager.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ tests were added to verify the empty substring will return all handles and a partial string built from a known handle will return the full handle.  Python tests were modified so that the handle corresponding to the desired object ID was retrieved and used to instantiate the desired object.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
