### PR TITLE
Add Simulator::getObjectSceneNode

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -343,6 +343,9 @@ class Simulator:
     def set_object_motion_type(self, motion_type, object_id, scene_id=0):
         return self._sim.set_object_motion_type(motion_type, object_id, scene_id)
 
+    def get_object_scene_node(self, object_id, scene_id=0):
+        return self._sim.get_object_scene_node(object_id, scene_id)
+
     def set_transformation(self, transform, object_id, scene_id=0):
         self._sim.set_transformation(transform, object_id, scene_id)
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -100,6 +100,8 @@ void initSimBindings(py::module& m) {
       .def("get_world_time", &Simulator::getWorldTime)
       .def("get_gravity", &Simulator::getGravity, "sceneID"_a = 0)
       .def("set_gravity", &Simulator::setGravity, "gravity"_a, "sceneID"_a = 0)
+      .def("get_object_scene_node", &Simulator::getObjectSceneNode,
+           "object_id"_a, "sceneID"_a = 0)
       .def("set_transformation", &Simulator::setTransformation, "transform"_a,
            "object_id"_a, "sceneID"_a = 0)
       .def("get_transformation", &Simulator::getTransformation, "object_id"_a,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -518,6 +518,7 @@ const scene::SceneNode& PhysicsManager::getObjectSceneNode(
 }
 
 scene::SceneNode& PhysicsManager::getObjectSceneNode(int physObjectID) {
+  assertIDValidity(physObjectID);
   return const_cast<scene::SceneNode&>(
       const_cast<const PhysicsManager&>(*this).getObjectSceneNode(
           physObjectID));

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -384,6 +384,14 @@ void Simulator::applyForce(const Magnum::Vector3& force,
   }
 }
 
+scene::SceneNode* Simulator::getObjectSceneNode(const int objectID,
+                                                const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    return &physicsManager_->getObjectSceneNode(objectID);
+  }
+  return nullptr;
+}
+
 // set object transform (kinemmatic control)
 void Simulator::setTransformation(const Magnum::Matrix4& transform,
                                   const int objectID,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -323,6 +323,12 @@ class Simulator {
                   const int sceneID = 0);
 
   /**
+   * @brief Get a reference to the object's scene node or nullptr if failed.
+   */
+  scene::SceneNode* getObjectSceneNode(const int objectID,
+                                       const int sceneID = 0);
+
+  /**
    * @brief Get the current 4x4 transformation matrix of an object.
    * See @ref esp::physics::PhysicsManager::getTransformation.
    * @param objectID The object ID and key identifying the object in @ref

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -64,6 +64,10 @@ def test_kinematics(sim):
     sim.set_translation(np.array([0, 1.0, 0]), object_id)
     assert np.allclose(sim.get_translation(object_id), np.array([0, 1.0, 0]))
 
+    # test object SceneNode
+    object_node = sim.get_object_scene_node(object_id)
+    assert np.allclose(sim.get_translation(object_id), object_node.translation)
+
     # test get and set transform
     sim.set_transformation(I, object_id)
     assert np.allclose(sim.get_transformation(object_id), I)


### PR DESCRIPTION
## Motivation and Context

Bounding boxes and other information can be queried from SceneNodes. Added method to query the SceneNode of an object from Simulator in C++ and python.

## How Has This Been Tested

Added a test to `tests/test_physics.py`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
