### PR TITLE
Add Simulator::setObjectBBDraw and python bindings

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -385,6 +385,9 @@ class Simulator:
     def contact_test(self, object_id, scene_id=0):
         return self._sim.contact_test(object_id, scene_id)
 
+    def set_object_bb_draw(self, draw_bb, object_id, scene_id=0):
+        return self._sim.set_object_bb_draw(draw_bb, object_id, scene_id)
+
     def step_physics(self, dt, scene_id=0):
         self._sim.step_world(dt)
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -128,6 +128,8 @@ void initSimBindings(py::module& m) {
            "sceneID"_a = 0)
       .def("contact_test", &Simulator::contactTest, "object_id"_a,
            "sceneID"_a = 0)
+      .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
+           "object_id"_a, "sceneID"_a = 0)
       .def("recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
            "navmesh_settings"_a, "include_static_objects"_a)
       .def("get_light_setup", &Simulator::getLightSetup,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -476,6 +476,16 @@ bool Simulator::contactTest(const int objectID, const int sceneID) {
   return false;
 }
 
+void Simulator::setObjectBBDraw(bool drawBB,
+                                const int objectID,
+                                const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    auto& sceneGraph_ = sceneManager_.getSceneGraph(activeSceneID_);
+    auto& drawables = sceneGraph_.getDrawables();
+    physicsManager_->setObjectBBDraw(objectID, &drawables, drawBB);
+  }
+}
+
 double Simulator::stepWorld(const double dt) {
   if (physicsManager_ != nullptr) {
     physicsManager_->stepPhysics(dt);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -416,7 +416,7 @@ class Simulator {
    * the object.
    * @return A vector3 representation of the object's linear velocity.
    */
-  Magnum::Vector3 getLinearVelocity(const int objectID, const int sceneID);
+  Magnum::Vector3 getLinearVelocity(const int objectID, const int sceneID = 0);
 
   /**
    * @brief Set the Angular Velocity of object.
@@ -440,7 +440,23 @@ class Simulator {
    * the object.
    * @return A vector3 representation of the object's angular velocity.
    */
-  Magnum::Vector3 getAngularVelocity(const int objectID, const int sceneID);
+  Magnum::Vector3 getAngularVelocity(const int objectID, const int sceneID = 0);
+
+  /**
+   * @brief Turn on/off rendering for the bounding box of the object's visual
+   * component.
+   *
+   * Assumes the new @ref esp::gfx::Drawable for the bounding box should be
+   * added to the active @ref esp::gfx::SceneGraph's default drawable group. See
+   * @ref esp::gfx::SceneGraph::getDrawables().
+   *
+   * @param drawBB Whether or not the render the bounding box.
+   * @param objectID The object ID and key identifying the object in @ref
+   * esp::physics::PhysicsManager::existingObjects_.
+   * @param sceneID !! Not used currently !! Specifies which physical scene of
+   * the object.
+   */
+  void setObjectBBDraw(bool drawBB, const int objectID, const int sceneID = 0);
 
   /**
    * @brief Discrete collision check for contact between an object and the


### PR DESCRIPTION
## Motivation and Context

Users may want to visualize an object's render asset bounding box (Axis-Aligned in the object's local space) in python.

## How Has This Been Tested

Tested locally with python script:

![image](https://user-images.githubusercontent.com/1445143/80649065-2dccac80-8a26-11ea-9201-f0a2ffe73bee.png)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
