### PR TITLE
Update agent state set state to be less confusing

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -202,21 +202,20 @@ class Agent(object):
         :param state: The state to set the agent to
         :param reset_sensors: Whether or not to reset the sensors to their
             default intrinsic/extrinsic parameters before setting their extrinsic state.
-
-            Setting this to `False` allows the agent base state to be moved and the new
-            sensor locations inferred without changing the configuration of the sensors
-            with respect to the base state of the agent.
-
-            Default: `True`
         :param infer_sensor_states: Whether or not to infer the location of sensors based on
             the new location of the agent base state.
-
-            Setting this to `False` is useful if you'd like to directly control
-            the state of a sensor instead of moving the agent.
-
-            Default: `True`
         :param is_initial: Whether this state is the initial state of the
             agent in the scene. Used for resetting the agent at a later time
+
+        Setting ``reset_sensors`` to :py:`False`
+        allows the agent base state to be moved and the new
+        sensor locations inferred without changing the configuration of the sensors
+        with respect to the base state of the agent.
+
+        Setting ``infer_sensor_states``
+        to :py:`False` is useful if you'd like to directly control
+        the state of a sensor instead of moving the agent.
+
         """
         habitat_sim.errors.assert_obj_valid(self.body)
 
@@ -258,11 +257,20 @@ class Agent(object):
 
     @property
     def state(self):
+        r"""Get/set the agent's state.
+
+        Getting the state is equivalent to :ref:`get_state`
+
+        Setting the state is equivalent calling :ref:`set_state`
+        and only providing the state.
+        """
         return self.get_state()
 
     @state.setter
     def state(self, new_state):
-        self.set_state(new_state, reset_sensors=True)
+        self.set_state(
+            new_state, reset_sensors=True, infer_sensor_states=True, is_initial=False
+        )
 
     def close(self):
         self._sensors = None

--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -201,11 +201,18 @@ class Agent(object):
 
         :param state: The state to set the agent to
         :param reset_sensors: Whether or not to reset the sensors to their
-            default intrinsic/extrinsic parameters before setting their extrinsic state
+            default intrinsic/extrinsic parameters before setting their extrinsic state.
+
+            Setting this to `False` allows the agent base state to be moved and the new
+            sensor locations inferred without changing the configuration of the sensors
+            with respect to the base state of the agent.
 
             Default: `True`
         :param infer_sensor_states: Whether or not to infer the location of sensors based on
             the new location of the agent base state.
+
+            Setting this to `False` is useful if you'd like to directly control
+            the state of a sensor instead of moving the agent.
 
             Default: `True`
         :param is_initial: Whether this state is the initial state of the

--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -191,13 +191,23 @@ class Agent(object):
         return state
 
     def set_state(
-        self, state: AgentState, reset_sensors: bool = True, is_initial: bool = False
+        self,
+        state: AgentState,
+        reset_sensors: bool = True,
+        infer_sensor_states: bool = True,
+        is_initial: bool = False,
     ):
         r"""Sets the agents state
 
         :param state: The state to set the agent to
-        :param reset_sensors: Whether or not to reset the sensors to their default
-            location relative to the agent base state
+        :param reset_sensors: Whether or not to reset the sensors to their
+            default intrinsic/extrinsic parameters before setting their extrinsic state
+
+            Default: `True`
+        :param infer_sensor_states: Whether or not to infer the location of sensors based on
+            the new location of the agent base state.
+
+            Default: `True`
         :param is_initial: Whether this state is the initial state of the
             agent in the scene. Used for resetting the agent at a later time
         """
@@ -214,7 +224,8 @@ class Agent(object):
         if reset_sensors:
             for _, v in self._sensors.items():
                 v.set_transformation_from_spec()
-        else:
+
+        if not infer_sensor_states:
             for k, v in state.sensor_states.items():
                 assert k in self._sensors
                 if isinstance(v.rotation, list):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -39,7 +39,7 @@ def test_set_state():
     agent = habitat_sim.Agent(scene_graph.get_root_node().create_child())
 
     state = agent.state
-    agent.state = state
+    agent.set_state(state, infer_sensor_states=True)
     new_state = agent.state
 
     _check_state_same(state, new_state)
@@ -67,7 +67,7 @@ def test_change_state():
                 np.random.uniform(0, 2 * np.pi), np.array([1.0, 1.0, 1.0])
             )
 
-        agent.state = state
+        agent.set_state(state, infer_sensor_states=False)
         new_state = agent.state
 
         _check_state_same(state, new_state)


### PR DESCRIPTION
## Motivation and Context

The agent state setting is kinda confusing currently as the sensors don't follow the agent body by default, this leads to the anti-pattern of

```python
state = agent.state
state.rotation = something
agent.state = state
```
seemingly doing nothing!  This PR makes the more intuitive behavior of the sensors following the agent base the default.

## How Has This Been Tested

The example above now moves the sensors.

## Types of changes


- Breaking change (fix or feature that would cause existing functionality to change)

