### PR TITLE
Physics primitives (non-colliding)

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -40,6 +40,8 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
   setInertia({0, 0, 0});
   setLinearDamping(0.2);
   setAngularDamping(0.2);
+  // default collisions will be mesh for physics objects
+  setUseMeshCollision(true);
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);

--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -41,6 +41,9 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
   setLinearDamping(0.2);
   setAngularDamping(0.2);
   // default collisions will be mesh for physics objects
+  // primitive-based objects do not currently support mesh collisions, however,
+  // due to issues with how non-triangle meshes (i.e. wireframes) are handled in
+  // @ref GenericMeshData::setMeshData
   setUseMeshCollision(true);
 
   setBoundingBoxCollisions(false);
@@ -74,7 +77,7 @@ PhysicsManagerAttributes::PhysicsManagerAttributes(
  *
  * AbstractPrimitiveAttributes::~AbstractPrimitiveAttributes() {}
  */
-PhysicsCapsulePrimAttributes::PhysicsCapsulePrimAttributes(
+CapsulePrimitiveAttributes::CapsulePrimitiveAttributes(
     bool isWireframe,
     const std::string& primObjType)
     : AbstractPrimitiveAttributes(isWireframe, primObjType) {
@@ -91,9 +94,8 @@ PhysicsCapsulePrimAttributes::PhysicsCapsulePrimAttributes(
   buildOriginHandle();  // build handle based on config
 }  // PhysicsCapsulePrimAttributes
 
-PhysicsConePrimAttributes::PhysicsConePrimAttributes(
-    bool isWireframe,
-    const std::string& primObjType)
+ConePrimitiveAttributes::ConePrimitiveAttributes(bool isWireframe,
+                                                 const std::string& primObjType)
     : AbstractPrimitiveAttributes(isWireframe, primObjType) {
   setHalfLength(1.25);
 
@@ -107,7 +109,7 @@ PhysicsConePrimAttributes::PhysicsConePrimAttributes(
   buildOriginHandle();  // build handle based on config
 }  // PhysicsConePrimAttributes
 
-PhysicsCylinderPrimAttributes::PhysicsCylinderPrimAttributes(
+CylinderPrimitiveAttributes::CylinderPrimitiveAttributes(
     bool isWireframe,
     const std::string& primObjType)
     : AbstractPrimitiveAttributes(isWireframe, primObjType) {
@@ -123,7 +125,7 @@ PhysicsCylinderPrimAttributes::PhysicsCylinderPrimAttributes(
   buildOriginHandle();  // build handle based on config
 }  // PhysicsCylinderPrimAttributes
 
-PhysicsUVSpherePrimAttributes::PhysicsUVSpherePrimAttributes(
+UVSpherePrimitiveAttributes::UVSpherePrimitiveAttributes(
     bool isWireframe,
     const std::string& primObjType)
     : AbstractPrimitiveAttributes(isWireframe, primObjType) {

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -232,8 +232,7 @@ class AbstractPrimitiveAttributes : public esp::core::Configuration {
       : Configuration() {
     setIsWireframe(isWireframe);
     setPrimObjType(primObjType);
-    // primitives will use implicit collisions
-    setUseMeshCollision(false);
+
     if (!isWireframe) {  // solid
       setUseTextureCoords(false);
       setUseTangents(false);
@@ -317,24 +316,23 @@ class AbstractPrimitiveAttributes : public esp::core::Configuration {
    */
   void buildOriginHandle() {
     std::ostringstream oHndlStrm;
-    oHndlStrm << getPrimObjType() << buildOriginHandleIndiv();
+    oHndlStrm << getPrimObjType() << buildOriginHandleDetail();
     setOriginHandle(oHndlStrm.str());
   }
   // helper for origin handle construction
   std::string getBoolDispStr(bool val) const {
     return (val ? "true" : "false");
   }
-  virtual std::string buildOriginHandleIndiv() { return ""; }
+  virtual std::string buildOriginHandleDetail() { return ""; }
 
  public:
   ESP_SMART_POINTERS(AbstractPrimitiveAttributes)
 };  // class AbstractPrimitiveAttributes
 
 //! attributes describing primitive capsule objects
-class PhysicsCapsulePrimAttributes : public AbstractPrimitiveAttributes {
+class CapsulePrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
-  PhysicsCapsulePrimAttributes(bool isWireframe,
-                               const std::string& primObjType);
+  CapsulePrimitiveAttributes(bool isWireframe, const std::string& primObjType);
 
   void setHemisphereRings(int hemisphereRings) {
     setInt("hemisphereRings", hemisphereRings);
@@ -347,7 +345,7 @@ class PhysicsCapsulePrimAttributes : public AbstractPrimitiveAttributes {
     buildOriginHandle();  // build handle based on config
   }
   int getCylinderRings() const { return getInt("cylinderRings"); }
-  virtual std::string buildOriginHandleIndiv() override {
+  virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_hemiRings_" << getHemisphereRings() << "_cylRings_"
               << getCylinderRings() << "_segments_" << getNumSegments()
@@ -357,14 +355,14 @@ class PhysicsCapsulePrimAttributes : public AbstractPrimitiveAttributes {
                 << "_useTangents_" << getBoolDispStr(getUseTangents());
     }
     return oHndlStrm.str();
-  }  // buildOriginHandleIndiv
+  }  // buildOriginHandleDetail
 
-  ESP_SMART_POINTERS(PhysicsCapsulePrimAttributes)
-};  // class PhysicsCapsulePrimAttributes
+  ESP_SMART_POINTERS(CapsulePrimitiveAttributes)
+};  // class CapsulePrimitiveAttributes
 
-class PhysicsConePrimAttributes : public AbstractPrimitiveAttributes {
+class ConePrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
-  PhysicsConePrimAttributes(bool isWireframe, const std::string& primObjType);
+  ConePrimitiveAttributes(bool isWireframe, const std::string& primObjType);
 
   // only solid cones can have end capped
   void setCapEnd(bool capEnd) {
@@ -373,7 +371,7 @@ class PhysicsConePrimAttributes : public AbstractPrimitiveAttributes {
   }
   bool getCapEnd() const { return getBool("capEnd"); }
 
-  virtual std::string buildOriginHandleIndiv() override {
+  virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_segments_" << getNumSegments() << "_halfLen_"
               << getHalfLength();
@@ -384,25 +382,24 @@ class PhysicsConePrimAttributes : public AbstractPrimitiveAttributes {
                 << getBoolDispStr(getCapEnd());
     }
     return oHndlStrm.str();
-  }  // buildOriginHandleIndiv
+  }  // buildOriginHandleDetail
 
-  ESP_SMART_POINTERS(PhysicsConePrimAttributes)
-};  // class PhysicsConePrimAttributes
+  ESP_SMART_POINTERS(ConePrimitiveAttributes)
+};  // class ConePrimitiveAttributes
 
-class PhysicsCubePrimAttributes : public AbstractPrimitiveAttributes {
+class CubePrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
-  PhysicsCubePrimAttributes(bool isWireframe, const std::string& primObjType)
+  CubePrimitiveAttributes(bool isWireframe, const std::string& primObjType)
       : AbstractPrimitiveAttributes(isWireframe, primObjType) {
     buildOriginHandle();  // build handle based on config
   }
 
-  ESP_SMART_POINTERS(PhysicsCubePrimAttributes)
-};  // class PhysicsCubePrimAttributes
+  ESP_SMART_POINTERS(CubePrimitiveAttributes)
+};  // class CubePrimitiveAttributes
 
-class PhysicsCylinderPrimAttributes : public AbstractPrimitiveAttributes {
+class CylinderPrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
-  PhysicsCylinderPrimAttributes(bool isWireframe,
-                                const std::string& primObjType);
+  CylinderPrimitiveAttributes(bool isWireframe, const std::string& primObjType);
 
   // only solid culinders can have ends capped
   void setCapEnds(bool capEnds) {
@@ -411,7 +408,7 @@ class PhysicsCylinderPrimAttributes : public AbstractPrimitiveAttributes {
   }
   bool getCapEnds() const { return getBool("capEnds"); }
 
-  virtual std::string buildOriginHandleIndiv() override {
+  virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_rings_" << getNumRings() << "_segments_" << getNumSegments()
               << "_halfLen_" << getHalfLength();
@@ -421,16 +418,15 @@ class PhysicsCylinderPrimAttributes : public AbstractPrimitiveAttributes {
                 << "_capEnds_" << getBoolDispStr(getCapEnds());
     }
     return oHndlStrm.str();
-  }  // buildOriginHandleIndiv
+  }  // buildOriginHandleDetail
 
-  ESP_SMART_POINTERS(PhysicsCylinderPrimAttributes)
-};  // class PhysicsCylinderPrimAttributes
+  ESP_SMART_POINTERS(CylinderPrimitiveAttributes)
+};  // class CylinderPrimitiveAttributes
 
-class PhysicsIcospherePrimAttributes : public AbstractPrimitiveAttributes {
+class IcospherePrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
   // note there is no magnum primitive implementation of a wireframe icosphere
-  PhysicsIcospherePrimAttributes(bool isWireframe,
-                                 const std::string& primObjType)
+  IcospherePrimitiveAttributes(bool isWireframe, const std::string& primObjType)
       : AbstractPrimitiveAttributes(isWireframe, primObjType) {
     // setting manually because wireframe icosphere does not currently support
     // subdiv > 1 and setSubdivisions checks for wireframe
@@ -446,22 +442,21 @@ class PhysicsIcospherePrimAttributes : public AbstractPrimitiveAttributes {
   }
   int getSubdivisions() const { return getInt("subdivisions"); }
 
-  virtual std::string buildOriginHandleIndiv() override {
+  virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     // wireframe subdivision currently does not change
     // but think about the possibilities.
     oHndlStrm << "_subdivs_" << getSubdivisions();
     return oHndlStrm.str();
-  }  // buildOriginHandleIndiv
+  }  // buildOriginHandleDetail
 
-  ESP_SMART_POINTERS(PhysicsIcospherePrimAttributes)
-};  // class PhysicsIcospherePrimAttributes
+  ESP_SMART_POINTERS(IcospherePrimitiveAttributes)
+};  // class IcospherePrimitiveAttributes
 
-class PhysicsUVSpherePrimAttributes : public AbstractPrimitiveAttributes {
+class UVSpherePrimitiveAttributes : public AbstractPrimitiveAttributes {
  public:
-  PhysicsUVSpherePrimAttributes(bool isWireframe,
-                                const std::string& primObjType);
-  virtual std::string buildOriginHandleIndiv() override {
+  UVSpherePrimitiveAttributes(bool isWireframe, const std::string& primObjType);
+  virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_rings_" << getNumRings() << "_segments_" << getNumSegments();
     if (!getIsWireframe()) {
@@ -469,10 +464,10 @@ class PhysicsUVSpherePrimAttributes : public AbstractPrimitiveAttributes {
                 << "_useTangents_" << getBoolDispStr(getUseTangents());
     }
     return oHndlStrm.str();
-  }  // buildOriginHandleIndiv
+  }  // buildOriginHandleDetail
 
-  ESP_SMART_POINTERS(PhysicsUVSpherePrimAttributes)
-};  // class PhysicsUVSpherePrimAttributes
+  ESP_SMART_POINTERS(UVSpherePrimitiveAttributes)
+};  // class UVSpherePrimitiveAttributes
 
 ///////////////////////////////////////
 // end primitive object attributes

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -232,6 +232,8 @@ class AbstractPrimitiveAttributes : public esp::core::Configuration {
       : Configuration() {
     setIsWireframe(isWireframe);
     setPrimObjType(primObjType);
+    // primitives will use implicit collisions
+    setUseMeshCollision(false);
     if (!isWireframe) {  // solid
       setUseTextureCoords(false);
       setUseTangents(false);

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_RESOURCEMANAGER_H_
+#define ESP_ASSETS_RESOURCEMANAGER_H_
 
 /** @file
  * @brief Class @ref esp::assets::ResourceManager, enum @ref
@@ -1204,3 +1205,5 @@ class ResourceManager {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_RESOURCEMANAGER_H_

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -342,12 +342,23 @@ class ResourceManager {
    * physicsObjTemplateLibrary_.
    *
    * @param objPhysConfigFilename The configuration file to parse and load.
-   * @return The index in the @ref physicsObjTemplateLibrary_ to which the key,
-   * objPhysConfigFilename, referes. Can be used to reference the object
-   * template, but can change if the @ref physicsObjTemplateLibrary_ is
+   * @return The ID of the attributes in the @ref physicsObjTemplateLibrary_ to
+   * which the key, objPhysConfigFilename, referes. Can be used to reference the
+   * object template, but can change if the @ref physicsObjTemplateLibrary_ is
    * modified.
    */
   int parseAndLoadPhysObjTemplate(const std::string& objPhysConfigFilename);
+
+  /**
+   * @brief Instantiate a @ref PhysicsObjectAttributes and add to @ref
+   * physicsObjTemplateLibrary_ for a synthetic(primitive-based) object
+   *
+   * @param primAssetHandle The string name of the primitive asset used as a
+   * render asset for the desired object.
+   * @return The ID of the attributes in the @ref physicsObjTemplateLibrary_ to
+   * which the key, synthesized from primAssetHandle, refers.
+   */
+  int buildAndRegisterPrimPhysObjTemplate(const std::string& primAssetHandle);
 
   /**
    * @brief Add a @ref PhysicsObjectAttributes object to the @ref
@@ -571,7 +582,6 @@ class ResourceManager {
                 << " is already present in mesh library.";
       return true;
     }
-
     return false;
   }
 
@@ -585,17 +595,6 @@ class ResourceManager {
    * instantiate
    */
   void buildPrimitiveAssetData(AbstractPrimitiveAttributes::ptr primTemplate);
-
-  /**
-   * @brief build a primitive asset based on passed template parameters.  If
-   * exists already, does nothing.
-   * @param primTemplate pointer to attributes describing primitive to
-   * instantiate
-   * @param primImporter the importer object used to instantiate the primitive
-   * mesh object
-   */
-  void buildPrimitiveAssetData(AbstractPrimitiveAttributes::ptr primTemplate,
-                               Importer& primImporter);
 
   /**
    * @brief Retrieve the composition of all transforms applied to a mesh

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -523,39 +523,79 @@ class ResourceManager {
                                                 subStr);
   }
   /**
-   * @brief Gets the number of primitive template objects stored in the @ref
-   * physicsObjTemplateLibrary_.
+   * @brief Gets the number of synthesized (primitive-based)  template objects
+   * stored in the @ref physicsObjTemplateLibrary_.
    *
    * @return The number of entries in @ref physicsObjTemplateLibrary_ that
    * describe primitives.
    */
-  int getNumPrimTemplateObjects() const {
+  int getNumSynthTemplateObjects() const {
     return physicsSynthObjTmpltLibByID_.size();
   };
   /**
-   * @brief Get a random loaded attribute handle for the loaded primitive object
-   * templates
+   * @brief Get a random loaded attribute handle for the loaded synthesized
+   * (primitive-based) object templates
    *
    * @return a randomly selected handle corresponding to the a primitive
    * attributes template, or empty string if none loaded
    */
-  std::string getRandomPrimTemplateHandle() const {
+  std::string getRandomSynthTemplateHandle() const {
     return getRandomTemplateHandlePerType(physicsSynthObjTmpltLibByID_,
-                                          "primitive ");
+                                          "synthesized ");
   }
   /**
-   * @brief Get a list of all primitive templates whose origin handles contain
-   * @ref subStr, ignoring subStr's case
+   * @brief Get a list of all synthesized (primitive-based) object templates
+   * whose origin handles contain @ref subStr, ignoring subStr's case
    * @param subStr substring to search for within existing primitive object
    * templates
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
-  std::vector<std::string> getPrimTemplateHandlesBySubstring(
+  std::vector<std::string> getSynthTemplateHandlesBySubstring(
       const std::string& subStr = "") const {
     return getTemplateHandlesBySubStringPerType(physicsSynthObjTmpltLibByID_,
                                                 subStr);
   }
+
+  /**
+   * @brief verify whether a primitive mesh matching the passed handle is
+   * present in system
+   * @param primOriginHandle handle descriptor of primitive asset attributes,
+   * which encodes all relevant parameters for primitive asset instantiation.
+   * @return whether an asset exists with the specified parameters
+   */
+  inline bool isPrimitiveAssetPresent(
+      const std::string& primOriginHandle) const {
+    if (primitiveMeshLibrary_.count(primOriginHandle) > 0) {
+      LOG(INFO) << "Entry for " << primOriginHandle
+                << " is already present in mesh library.";
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * @brief build a primitive asset based on passed template parameters.  If
+   * exists already, does nothing.  Will create a PrimitiveImporter and call
+   * appropriate method.
+   * TODO: This will become primary method once ImportManager can be an
+   * instance variable of ResoureManager
+   * @param primTemplate pointer to attributes describing primitive to
+   * instantiate
+   */
+  void buildPrimitiveAssetData(AbstractPrimitiveAttributes::ptr primTemplate);
+
+  /**
+   * @brief build a primitive asset based on passed template parameters.  If
+   * exists already, does nothing.
+   * @param primTemplate pointer to attributes describing primitive to
+   * instantiate
+   * @param primImporter the importer object used to instantiate the primitive
+   * mesh object
+   */
+  void buildPrimitiveAssetData(AbstractPrimitiveAttributes::ptr primTemplate,
+                               Importer& primImporter);
 
   /**
    * @brief Retrieve the composition of all transforms applied to a mesh
@@ -678,7 +718,8 @@ class ResourceManager {
   /**
    * @brief Get a list of all templates of passed type whose origin handles
    * contain @ref subStr, ignoring subStr's case
-   * @param mapOfHandles map containing the desired object-type template handles
+   * @param mapOfHandles map containing the desired object-type template
+   * handles
    * @param subStr substring to search for within existing primitive object
    * templates
    * @return vector of 0 or more template handles containing the passed
@@ -1112,18 +1153,28 @@ class ResourceManager {
   std::vector<std::unique_ptr<Magnum::GL::Mesh>> primitive_meshes_;
 
   /**
+   * @brief Map holding primitive meshes keyed by the
+   * primitiveAttributes-derived handle describing their parameters.
+   */
+
+  std::map<std::string, std::unique_ptr<Magnum::GL::Mesh>>
+      primitiveMeshLibrary_;
+
+  /**
    * @brief Maps string keys (typically property filenames) to @ref
    * CollisionMeshData for all components of a loaded asset.
    */
   std::map<std::string, std::vector<CollisionMeshData>> collisionMeshGroups_;
 
   /**
-   * @brief Maps all object attribute IDs to the appropriate handles used by lib
+   * @brief Maps all object attribute IDs to the appropriate handles used by
+   * lib
    */
   std::map<int, std::string> physicsTemplatesLibByID_;
 
   /**
-   * @brief Maps loaded object template IDs to the appropriate template handles
+   * @brief Maps loaded object template IDs to the appropriate template
+   * handles
    */
   std::map<int, std::string> physicsFileObjTmpltLibByID_;
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -73,8 +73,6 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
   //! Test Mesh primitive is valid
   assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       resourceManager_.getPhysicsObjectAttributes(configFileHandle);
-  const std::vector<assets::CollisionMeshData>& meshGroup =
-      resourceManager_.getCollisionMesh(configFileHandle);
 
   //! Make rigid object and add it to existingObjects
   int nextObjectID_ = allocateObjectID();
@@ -83,12 +81,11 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     objectNode = &staticSceneObject_->node().createChild();
   }
 
-  bool objectSuccess = makeAndAddRigidObject(
-      nextObjectID_, meshGroup, physicsObjectAttributes, objectNode);
+  bool objectSuccess =
+      makeAndAddRigidObject(nextObjectID_, physicsObjectAttributes, objectNode);
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);
-    // existingObjects_.erase(newObjectID);
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
@@ -163,12 +160,11 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
 
 bool PhysicsManager::makeAndAddRigidObject(
     int newObjectID,
-    const std::vector<assets::CollisionMeshData>& meshGroup,
     assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     scene::SceneNode* objectNode) {
   auto ptr = physics::RigidObject::create_unique(objectNode);
-  bool objSuccess = ptr->initializeObject(resourceManager_,
-                                          physicsObjectAttributes, meshGroup);
+  bool objSuccess =
+      ptr->initializeObject(resourceManager_, physicsObjectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -872,7 +872,6 @@ class PhysicsManager {
    */
   virtual bool makeAndAddRigidObject(
       int newObjectID,
-      const std::vector<assets::CollisionMeshData>& meshGroup,
       assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       scene::SceneNode* objectNode);
 

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -38,10 +38,8 @@ bool RigidObject::initializeSceneFinalize(
 }
 
 bool RigidObject::initializeObject(
-    const assets::ResourceManager& resMgr,
-    const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-    const std::vector<assets::CollisionMeshData>& meshGroup) {
-  // TODO (JH): Handling static/kinematic object type
+    assets::ResourceManager& resMgr,
+    const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes) {
   if (rigidObjectType_ != RigidObjectType::NONE) {
     LOG(ERROR) << "Cannot initialize a RigidObject more than once";
     return false;
@@ -54,13 +52,12 @@ bool RigidObject::initializeObject(
   initializationAttributes_ = esp::assets::PhysicsObjectAttributes::create(
       *physicsObjectAttributes.get());
 
-  return initializeObjectFinalize(resMgr, physicsObjectAttributes, meshGroup);
+  return initializeObjectFinalize(resMgr, physicsObjectAttributes);
 }
 
 bool RigidObject::initializeObjectFinalize(
-    const assets::ResourceManager&,
-    const assets::PhysicsObjectAttributes::ptr,
-    const std::vector<assets::CollisionMeshData>&) {
+    assets::ResourceManager&,
+    const assets::PhysicsObjectAttributes::ptr) {
   // default kineamtic unless a simulator is initialized...
   objectMotionType_ = MotionType::KINEMATIC;
   return true;

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -194,13 +194,11 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @param physicsObjectAttributes The template structure defining relevant
    * phyiscal parameters for the object. See @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_.
-   * @param meshGroup The collision mesh data for the object.
    * @return true if initialized successfully, false otherwise.
    */
   bool initializeObject(
-      const assets::ResourceManager& resMgr,
-      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      const std::vector<assets::CollisionMeshData>& meshGroup);
+      assets::ResourceManager& resMgr,
+      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes);
 
   /**
    * @brief Finalize this object with any necessary post-creation processes.
@@ -645,13 +643,11 @@ class RigidObject : public Magnum::SceneGraph::AbstractFeature3D {
    * @param physicsObjectAttributes The template structure defining relevant
    * phyiscal parameters for the object. See @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_.
-   * @param meshGroup The collision mesh data for the object.
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initializeObjectFinalize(
-      const assets::ResourceManager& resMgr,
-      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      const std::vector<assets::CollisionMeshData>& meshGroup);
+      assets::ResourceManager& resMgr,
+      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes);
 
  protected:
   /** @brief Used to synchronize other simulator's notion of the object state

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -57,12 +57,11 @@ bool BulletPhysicsManager::addSceneFinalize(
 
 bool BulletPhysicsManager::makeAndAddRigidObject(
     int newObjectID,
-    const std::vector<assets::CollisionMeshData>& meshGroup,
     assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
     scene::SceneNode* objectNode) {
   auto ptr = physics::BulletRigidObject::create_unique(objectNode, bWorld_);
-  bool objSuccess = ptr->initializeObject(resourceManager_,
-                                          physicsObjectAttributes, meshGroup);
+  bool objSuccess =
+      ptr->initializeObject(resourceManager_, physicsObjectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -202,7 +202,6 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   bool makeAndAddRigidObject(
       int newObjectID,
-      const std::vector<assets::CollisionMeshData>& meshGroup,
       assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
       scene::SceneNode* objectNode) override;
 

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -53,13 +53,9 @@ bool BulletRigidObject::initializeSceneFinalize(
 }  // end BulletRigidObject::initializeScene
 
 bool BulletRigidObject::initializeObjectFinalize(
-    const assets::ResourceManager& resMgr,
-    const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-    const std::vector<assets::CollisionMeshData>& meshGroup) {
+    assets::ResourceManager& resMgr,
+    const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes) {
   objectMotionType_ = MotionType::DYNAMIC;
-
-  const assets::MeshMetaData& metaData = resMgr.getMeshMetaData(
-      physicsObjectAttributes->getCollisionAssetHandle());
 
   //! Physical parameters
   double margin = physicsObjectAttributes->getMargin();
@@ -76,18 +72,31 @@ bool BulletRigidObject::initializeObjectFinalize(
   //! The components are combined into a convex compound shape
   bObjectShape_ = std::make_unique<btCompoundShape>();
 
-  if (!usingBBCollisionShape_) {
-    constructBulletCompoundFromMeshes(Magnum::Matrix4{}, meshGroup,
-                                      metaData.root, joinCollisionMeshes);
+  if (!physicsObjectAttributes
+           ->getUseMeshCollision()) {  // if using prim collider
+    // prim stuff here
 
-    // add the final object after joining meshes
-    if (joinCollisionMeshes) {
-      bObjectConvexShapes_.back()->setMargin(0.0);
-      bObjectConvexShapes_.back()->recalcLocalAabb();
-      bObjectShape_->addChildShape(btTransform::getIdentity(),
-                                   bObjectConvexShapes_.back().get());
+  } else {
+    // originHandle is key in maps of relelvant quantities in resource manager
+    const std::string configFile = physicsObjectAttributes->getOriginHandle();
+
+    const std::vector<assets::CollisionMeshData>& meshGroup =
+        resMgr.getCollisionMesh(configFile);
+    const assets::MeshMetaData& metaData = resMgr.getMeshMetaData(
+        physicsObjectAttributes->getCollisionMeshHandle());
+    if (!usingBBCollisionShape_) {
+      constructBulletCompoundFromMeshes(Magnum::Matrix4{}, meshGroup,
+                                        metaData.root, joinCollisionMeshes);
+
+      // add the final object after joining meshes
+      if (joinCollisionMeshes) {
+        bObjectConvexShapes_.back()->setMargin(0.0);
+        bObjectConvexShapes_.back()->recalcLocalAabb();
+        bObjectShape_->addChildShape(btTransform::getIdentity(),
+                                     bObjectConvexShapes_.back().get());
+      }
     }
-  }
+  }  // if using mesh collider
 
   //! Set properties
   bObjectShape_->setMargin(margin);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -78,12 +78,12 @@ bool BulletRigidObject::initializeObjectFinalize(
 
   } else {
     // originHandle is key in maps of relelvant quantities in resource manager
-    const std::string configFile = physicsObjectAttributes->getOriginHandle();
+    const std::string originHandle = physicsObjectAttributes->getOriginHandle();
 
     const std::vector<assets::CollisionMeshData>& meshGroup =
-        resMgr.getCollisionMesh(configFile);
+        resMgr.getCollisionMesh(originHandle);
     const assets::MeshMetaData& metaData = resMgr.getMeshMetaData(
-        physicsObjectAttributes->getCollisionMeshHandle());
+        physicsObjectAttributes->getCollisionAssetHandle());
     if (!usingBBCollisionShape_) {
       constructBulletCompoundFromMeshes(Magnum::Matrix4{}, meshGroup,
                                         metaData.root, joinCollisionMeshes);

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -418,13 +418,11 @@ class BulletRigidObject : public RigidObject,
    * @param physicsObjectAttributes The template structure defining relevant
    * phyiscal parameters for the object. See @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_.
-   * @param meshGroup The collision mesh data for the object.
    * @return true if initialized successfully, false otherwise.
    */
-  bool initializeObjectFinalize(
-      const assets::ResourceManager& resMgr,
-      const assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      const std::vector<assets::CollisionMeshData>& meshGroup) override;
+  bool initializeObjectFinalize(assets::ResourceManager& resMgr,
+                                const assets::PhysicsObjectAttributes::ptr
+                                    physicsObjectAttributes) override;
 
  protected:
   /**

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -127,16 +127,16 @@ class Simulator {
   }
 
   /**
-   * @brief Get a list of all primitive templates whose origin handles contain
-   * @ref subStr, ignoring subStr's case
+   * @brief Get a list of all synthesized (primitive-based) templates whose
+   * origin handles contains @ref subStr, ignoring subStr's case
    * @param subStr substring to search for within existing primitive object
    * templates
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
-  std::vector<std::string> getPrimitiveTemplateHandles(
+  std::vector<std::string> getSynthesizedObjectTemplateHandles(
       const std::string& subStr = "") {
-    return resourceManager_.getPrimTemplateHandlesBySubstring(subStr);
+    return resourceManager_.getSynthTemplateHandlesBySubstring(subStr);
   }
 
   /**

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -226,8 +226,8 @@ void SimTest::getSceneWithLightingRGBAObservation() {
 
 void SimTest::getDefaultLightingRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-
-  int objectID = simulator->addObject(0);
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
@@ -237,8 +237,9 @@ void SimTest::getDefaultLightingRGBAObservation() {
 
 void SimTest::getCustomLightingRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-
-  int objectID = simulator->addObject(0, nullptr, "custom_lighting_1");
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID =
+      simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
@@ -250,7 +251,8 @@ void SimTest::updateLightSetupRGBAObservation() {
   auto simulator = getSimulator(vangogh);
 
   // update default lighting
-  int objectID = simulator->addObject(0);
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
@@ -263,7 +265,8 @@ void SimTest::updateLightSetupRGBAObservation() {
   simulator->removeObject(objectID);
 
   // update custom lighting
-  objectID = simulator->addObject(0, nullptr, "custom_lighting_1");
+  objectID =
+      simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
@@ -277,8 +280,8 @@ void SimTest::updateLightSetupRGBAObservation() {
 
 void SimTest::updateObjectLightSetupRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-
-  int objectID = simulator->addObject(0);
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
   checkPinholeCameraRGBAObservation(
@@ -299,11 +302,14 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
   auto simulator = getSimulator(planeScene);
 
   // make sure updates apply to all objects using the light setup
-  int objectID = simulator->addObject(0, nullptr, "custom_lighting_1");
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID =
+      simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({0.0f, 0.5f, -0.5f}, objectID);
 
-  int otherObjectID = simulator->addObject(0, nullptr, "custom_lighting_1");
+  int otherObjectID =
+      simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(otherObjectID != esp::ID_UNDEFINED);
   simulator->setTranslation({2.0f, 0.5f, -0.5f}, otherObjectID);
 
@@ -339,7 +345,8 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
   }
 
   // add static object at a known navigable point
-  int objectID = simulator->addObject(0);
+  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  int objectID = simulator->addObjectByHandle(objs[0]);
   simulator->setTranslation(Magnum::Vector3{randomNavPoint}, objectID);
   simulator->setObjectMotionType(esp::physics::MotionType::STATIC, objectID);
   CORRADE_VERIFY(
@@ -361,7 +368,7 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
   esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
       simulator->getObjectTemplate(0);
   objectTemplate->setScale({0.5, 0.5, 0.5});
-  objectID = simulator->addObject(0);
+  objectID = simulator->addObjectByHandle(objs[0]);
   simulator->setTranslation(Magnum::Vector3{randomNavPoint}, objectID);
   simulator->setTranslation(
       simulator->getTranslation(objectID) + Magnum::Vector3{0, 0.5, 0},
@@ -399,7 +406,7 @@ void SimTest::loadingObjectTemplates() {
   // verify that getting the template handles with empty string returns all
   int numLoadedTemplates = templateIndices2.size();
   std::vector<std::string> templateHandles =
-      simulator->getObjectTemplateHandles();
+      simulator->getFileBasedObjectTemplateHandles();
   CORRADE_VERIFY(numLoadedTemplates == templateHandles.size());
 
   // verify that querying with sub string returns template handle corresponding

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -337,7 +337,7 @@ void Viewer::addObject(const std::string& configFile) {
 
 }  // addObject
 
-// add template derived object from keypress
+// add file-based template derived object from keypress
 void Viewer::addTemplateObject() {
   if (physicsManager_ != nullptr) {
     int numObjTemplates = resourceManager_.getNumFileTemplateObjects();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -354,9 +354,9 @@ void Viewer::addTemplateObject() {
 void Viewer::addPrimitiveObject() {
   // TODO : use this to implement synthesizing rendered physical objects
   if (physicsManager_ != nullptr) {
-    int numObjPrims = resourceManager_.getNumPrimTemplateObjects();
+    int numObjPrims = resourceManager_.getNumSynthTemplateObjects();
     if (numObjPrims > 0) {
-      addObject(resourceManager_.getRandomPrimTemplateHandle());
+      addObject(resourceManager_.getRandomSynthTemplateHandle());
     } else
       LOG(WARNING) << "No primitive templates available, can't add any objects";
   } else


### PR DESCRIPTION
## Motivation and Context
This PR introduces synthesized, primitive-based physical objects.  Currently they do not support collision (a future PR will provide implicit collision calculation support in Bullet; mesh-based collision support will follow at a later date).  

These synthesized primitive objects consume Magnum::Primitives as rendering assets, and use the default physical quantities as specified in the PhysicsObjectAttributes constructors, but otherwise follow the same code path and use cases as the file-loaded physical objects.  

![Screenshot from 2020-05-05 14-44-48](https://user-images.githubusercontent.com/1093953/81110034-f9a33100-8ee8-11ea-82a2-dc31110607a8.png)

Sim test was also modified to instantiate objects based on the name of the object template desired.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Existing tests all pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
