### PR TITLE
Direct Navmesh/Meshdata handling; PluginManager instance variable

### DIFF
--- a/src/esp/assets/GenericMeshData.cpp
+++ b/src/esp/assets/GenericMeshData.cpp
@@ -44,8 +44,7 @@ Magnum::GL::Mesh* GenericMeshData::getMagnumGLMesh() {
   return &(renderingBuffer_->mesh);
 }
 
-void GenericMeshData::setMeshData(
-    Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData) {
+void GenericMeshData::setMeshData(Magnum::Trade::MeshData&& meshData) {
   /* Interleave the mesh, if not already. This makes the GPU happier (better
      cache locality for vertex fetching) and is a no-op if the source data is
      already interleaved, so doesn't hurt to have it there always. */
@@ -53,7 +52,7 @@ void GenericMeshData::setMeshData(
   /* TODO: Address that non-triangle meshes will have their collisionMeshData_
    * incorrectly calculated */
 
-  meshData_ = Mn::MeshTools::interleave(*std::move(meshData));
+  meshData_ = Mn::MeshTools::interleave(std::move(meshData));
 
   collisionMeshData_.primitive = meshData_->primitive();
 
@@ -76,16 +75,18 @@ void GenericMeshData::importAndSetMeshData(
     Magnum::Trade::AbstractImporter& importer,
     int meshID) {
   /* Guarantee mesh instance success */
-  CORRADE_INTERNAL_ASSERT_OUTPUT(meshData_ = importer.mesh(meshID));
-  setMeshData(meshData_);
+  Cr::Containers::Optional<Mn::Trade::MeshData> mesh = importer.mesh(meshID);
+  CORRADE_INTERNAL_ASSERT(mesh);
+  setMeshData(*std::move(mesh));
 }  // importAndSetMeshData
 
 void GenericMeshData::importAndSetMeshData(
     Magnum::Trade::AbstractImporter& importer,
     const std::string& meshName) {
   /* Guarantee mesh instance success */
-  CORRADE_INTERNAL_ASSERT_OUTPUT(meshData_ = importer.mesh(meshName));
-  setMeshData(meshData_);
+  Cr::Containers::Optional<Mn::Trade::MeshData> mesh = importer.mesh(meshName);
+  CORRADE_INTERNAL_ASSERT(mesh);
+  setMeshData(*std::move(mesh));
 }  // importAndSetMeshData
 
 }  // namespace assets

--- a/src/esp/assets/GenericMeshData.cpp
+++ b/src/esp/assets/GenericMeshData.cpp
@@ -44,10 +44,8 @@ Magnum::GL::Mesh* GenericMeshData::getMagnumGLMesh() {
   return &(renderingBuffer_->mesh);
 }
 
-void GenericMeshData::setMeshData(Magnum::Trade::AbstractImporter& importer,
-                                  int meshID) {
-  /* Guarantee mesh instance success */
-  CORRADE_INTERNAL_ASSERT_OUTPUT(meshData_ = importer.mesh(meshID));
+void GenericMeshData::setMeshData(
+    Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData) {
   /* Interleave the mesh, if not already. This makes the GPU happier (better
      cache locality for vertex fetching) and is a no-op if the source data is
      already interleaved, so doesn't hurt to have it there always. */
@@ -55,7 +53,7 @@ void GenericMeshData::setMeshData(Magnum::Trade::AbstractImporter& importer,
   /* TODO: Address that non-triangle meshes will have their collisionMeshData_
    * incorrectly calculated */
 
-  meshData_ = Mn::MeshTools::interleave(*std::move(meshData_));
+  meshData_ = Mn::MeshTools::interleave(*std::move(meshData));
 
   collisionMeshData_.primitive = meshData_->primitive();
 
@@ -72,15 +70,23 @@ void GenericMeshData::setMeshData(Magnum::Trade::AbstractImporter& importer,
     collisionMeshData_.indices = meshData_->mutableIndices<Mn::UnsignedInt>();
   else
     collisionMeshData_.indices = indexData_ = meshData_->indicesAsArray();
-}
+}  // setMeshData
 
-void GenericMeshData::setMeshData(Magnum::Trade::AbstractImporter& importer,
-                                  const std::string& meshName) {
-  // make sure name is appropriate for importer
-  int meshID = importer.meshForName(meshName);
-  CORRADE_ASSERT(meshID != -1, "Unknown meshName :" << meshName, );
-  setMeshData(importer, meshID);
-}
+void GenericMeshData::importAndSetMeshData(
+    Magnum::Trade::AbstractImporter& importer,
+    int meshID) {
+  /* Guarantee mesh instance success */
+  CORRADE_INTERNAL_ASSERT_OUTPUT(meshData_ = importer.mesh(meshID));
+  setMeshData(meshData_);
+}  // importAndSetMeshData
+
+void GenericMeshData::importAndSetMeshData(
+    Magnum::Trade::AbstractImporter& importer,
+    const std::string& meshName) {
+  /* Guarantee mesh instance success */
+  CORRADE_INTERNAL_ASSERT_OUTPUT(meshData_ = importer.mesh(meshName));
+  setMeshData(meshData_);
+}  // importAndSetMeshData
 
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/GenericMeshData.h
+++ b/src/esp/assets/GenericMeshData.h
@@ -58,8 +58,7 @@ class GenericMeshData : public BaseMesh {
    * as NavMesh. Sets the @ref collisionMesh_ references.
    * @param meshData the meshData to be assigned.
    */
-  void setMeshData(
-      Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData);
+  void setMeshData(Magnum::Trade::MeshData&& meshData);
 
   /**
    * @brief Load mesh data from a pre-parsed importer for a specific mesh

--- a/src/esp/assets/GenericMeshData.h
+++ b/src/esp/assets/GenericMeshData.h
@@ -53,22 +53,34 @@ class GenericMeshData : public BaseMesh {
   virtual void uploadBuffersToGPU(bool forceReload = false) override;
 
   /**
+   * @brief Set mesh data from external source, and sets the @ref collisionMesh_
+   * references.  Can be used for meshDatas that are manually synthesized, such
+   * as NavMesh. Sets the @ref collisionMesh_ references.
+   * @param meshData the meshData to be assigned.
+   */
+  void setMeshData(
+      Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData);
+
+  /**
    * @brief Load mesh data from a pre-parsed importer for a specific mesh
-   * component. Sets the @ref collisionMeshData_ references.
-   * @param importer The importer pre-loaded with asset data from file.
+   * component ID. Sets the @ref collisionMeshData_ references.
+   * @param importer The importer pre-loaded with asset data from file, or a
+   * Primitive Importer.
    * @param meshID The local identifier of a specific mesh component of the
    * asset.
    */
-  void setMeshData(Magnum::Trade::AbstractImporter& importer, int meshID);
+  void importAndSetMeshData(Magnum::Trade::AbstractImporter& importer,
+                            int meshID);
   /**
    * @brief Load mesh data from a pre-parsed importer for a specific mesh
-   * component. Sets the @ref collisionMeshData_ references.
-   * @param importer The importer pre-loaded with asset data from file.
+   * component name. Sets the @ref collisionMeshData_ references.
+   * @param importer The importer pre-loaded with asset data from file, or a
+   * Primitive Importer.
    * @param meshName The string identifier of a specific mesh - i.e. with
    * PrimitiveImporter to denote which Primitive to instantiate.
    */
-  void setMeshData(Magnum::Trade::AbstractImporter& importer,
-                   const std::string& meshName);
+  void importAndSetMeshData(Magnum::Trade::AbstractImporter& importer,
+                            const std::string& meshName);
 
   /**
    * @brief Returns a pointer to the compiled render data storage structure.

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1165,7 +1165,7 @@ void ResourceManager::buildPrimitiveAssetData(
   // check if unique name of attributes describing primitive asset is present
   // already - don't remake if so
   auto primAssetOriginHandle = primTemplate->getOriginHandle();
-  if (isPrimitiveAssetPresent(primAssetOriginHandle)) {
+  if (resourceDict_.count(primAssetOriginHandle) > 0) {
     LOG(INFO) << " Primitive Asset exists already : " << primAssetOriginHandle;
     return;
   }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -76,7 +76,7 @@ ResourceManager::ResourceManager()
     :
 #ifdef MAGNUM_BUILD_STATIC
       // avoid using plugins that might depend on different library versions
-      importManager("nonexistent")
+      importerManager_("nonexistent")
 #endif
 {
   initDefaultLightSetups();
@@ -85,10 +85,10 @@ ResourceManager::ResourceManager()
 
 void ResourceManager::initDefaultPrimAttributes() {
   // instantiate a primitive importer
-  CORRADE_INTERNAL_ASSERT(
-      primImporter = importManager.loadAndInstantiate("PrimitiveImporter"));
+  CORRADE_INTERNAL_ASSERT_OUTPUT(
+      primImporter_ = importerManager_.loadAndInstantiate("PrimitiveImporter"));
   // necessary for importer to be usable
-  primImporter->openData("");
+  primImporter_->openData("");
   // set up base primitive asset attributes
   auto capSolidAttr = CapsulePrimitiveAttributes::create(
       false, PrimitiveNames3D[static_cast<int>(PrimObjTypes::CAPSULE_SOLID)]);
@@ -1119,7 +1119,7 @@ void ResourceManager::buildPrimitiveAssetData(
   std::string primClassName = primTemplate->getPrimObjType();
   // configuration for PrimitiveImporter - replace appropriate group's data
   // before instancing prim object
-  auto conf = primImporter->configuration();
+  auto conf = primImporter_->configuration();
   auto cfgGroup = conf.group(primClassName);
   if (cfgGroup != nullptr) {  // ignore prims with no configuration like cubes
     auto newCfgGroup = primTemplate->getConfigGroup();
@@ -1138,7 +1138,7 @@ void ResourceManager::buildPrimitiveAssetData(
   // make  primitive mesh structure
   auto primMeshData = std::make_unique<GenericMeshData>(false);
   // build mesh data object
-  primMeshData->importAndSetMeshData(*primImporter, primClassName);
+  primMeshData->importAndSetMeshData(*primImporter_, primClassName);
 
   // compute the mesh bounding box
   primMeshData->BB = computeMeshBB(primMeshData.get());
@@ -1255,7 +1255,7 @@ bool ResourceManager::loadInstanceMeshData(
 
   Cr::Containers::Pointer<Importer> importer;
   CORRADE_INTERNAL_ASSERT(
-      importer = importManager.loadAndInstantiate("StanfordImporter"));
+      importer = importerManager_.loadAndInstantiate("StanfordImporter"));
 
   // if this is a new file, load it and add it to the dictionary, create
   // shaders and add it to the shaderPrograms_
@@ -1327,16 +1327,16 @@ bool ResourceManager::loadGeneralMeshData(
 
   Cr::Containers::Pointer<Importer> importer;
   CORRADE_INTERNAL_ASSERT(
-      importer = importManager.loadAndInstantiate("AnySceneImporter"));
+      importer = importerManager_.loadAndInstantiate("AnySceneImporter"));
 
   // Preferred plugins, Basis target GPU format
-  importManager.setPreferredPlugins("GltfImporter", {"TinyGltfImporter"});
+  importerManager_.setPreferredPlugins("GltfImporter", {"TinyGltfImporter"});
 #ifdef ESP_BUILD_ASSIMP_SUPPORT
-  importManager.setPreferredPlugins("ObjImporter", {"AssimpImporter"});
+  importerManager_.setPreferredPlugins("ObjImporter", {"AssimpImporter"});
 #endif
   {
     Cr::PluginManager::PluginMetadata* const metadata =
-        importManager.metadata("BasisImporter");
+        importerManager_.metadata("BasisImporter");
     Mn::GL::Context& context = Mn::GL::Context::current();
 #ifdef MAGNUM_TARGET_WEBGL
     if (context.isExtensionSupported<

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -377,33 +377,17 @@ class ResourceManager {
   //======== Accessor functions ========
   /**
    * @brief Getter for all @ref assets::CollisionMeshData associated with the
-   * particular asset referenced by the key, configFile.
+   * particular asset.
    *
-   * @param configFile The key by which the asset is referenced in @ref
-   * collisionMeshGroups_ and the @ref physicsObjTemplateLibrary_.
+   * @param collisionAssetHandle The key by which the asset is referenced in
+   * @ref collisionMeshGroups_, from the @ref physicsObjTemplateLibrary_.
    * @return A vector reference to @ref assets::CollisionMeshData instances for
    * individual components of the asset.
    */
   const std::vector<assets::CollisionMeshData>& getCollisionMesh(
-      const std::string& configFile) const {
-    return collisionMeshGroups_.at(
-        physicsObjTemplateLibrary_.at(configFile)->getCollisionAssetHandle());
-  }
-
-  /**
-   * @brief Getter for all @ref assets::CollisionMeshData associated with the
-   * particular asset referenced by the index, objectTemplateID, in @ref
-   * physicsObjTemplateLibrary_.
-   *
-   * @param objectTemplateID The index of the object template in @ref
-   * physicsObjTemplateLibrary_.
-   * @return A vector reference to @ref assets::CollisionMeshData instances for
-   * individual components of the asset.
-   */
-  const std::vector<assets::CollisionMeshData>& getCollisionMesh(
-      const int objectTemplateID) const {
-    std::string configFile = getObjectTemplateHandle(objectTemplateID);
-    return getCollisionMesh(configFile);
+      const std::string& collisionAssetHandle) const {
+    CHECK(collisionMeshGroups_.count(collisionAssetHandle) > 0);
+    return collisionMeshGroups_.at(collisionAssetHandle);
   }
 
   /**
@@ -566,23 +550,6 @@ class ResourceManager {
       const std::string& subStr = "") const {
     return getTemplateHandlesBySubStringPerType(physicsSynthObjTmpltLibByID_,
                                                 subStr);
-  }
-
-  /**
-   * @brief verify whether a primitive mesh matching the passed handle is
-   * present in system
-   * @param primOriginHandle handle descriptor of primitive asset attributes,
-   * which encodes all relevant parameters for primitive asset instantiation.
-   * @return whether an asset exists with the specified parameters
-   */
-  inline bool isPrimitiveAssetPresent(
-      const std::string& primOriginHandle) const {
-    if (primitiveMeshLibrary_.count(primOriginHandle) > 0) {
-      LOG(INFO) << "Entry for " << primOriginHandle
-                << " is already present in mesh library.";
-      return true;
-    }
-    return false;
   }
 
   /**
@@ -1150,14 +1117,6 @@ class ResourceManager {
    * addPrimitiveToDrawables for debugging or visualization purposes.
    */
   std::vector<std::unique_ptr<Magnum::GL::Mesh>> primitive_meshes_;
-
-  /**
-   * @brief Map holding primitive meshes keyed by the
-   * primitiveAttributes-derived handle describing their parameters.
-   */
-
-  std::map<std::string, std::unique_ptr<Magnum::GL::Mesh>>
-      primitiveMeshLibrary_;
 
   /**
    * @brief Maps string keys (typically property filenames) to @ref

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1081,14 +1081,14 @@ class ResourceManager {
    * @brief Plugin Manager used to instantiate importers which in turn are used
    * to load asset data
    */
-  Magnum::PluginManager::Manager<Importer> importManager;
+  Corrade::PluginManager::Manager<Importer> importerManager_;
 
   /**
    * @brief Importer used to synthesize Magnum Primitives.  This object allows
    * for similar usage to File-based importers, but requires no file to be
    * available/read.
    */
-  Corrade::Containers::Pointer<Importer> primImporter;
+  Corrade::Containers::Pointer<Importer> primImporter_;
 
   /**
    * @brief Maps string keys (typically property filenames) to physical object

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1077,6 +1077,18 @@ class ResourceManager {
   gfx::ShaderManager shaderManager_;
 
   // ======== Physical parameter data ========
+  /**
+   * @brief Plugin Manager used to instantiate importers which in turn are used
+   * to load asset data
+   */
+  Magnum::PluginManager::Manager<Importer> importManager;
+
+  /**
+   * @brief Importer used to synthesize Magnum Primitives.  This object allows
+   * for similar usage to File-based importers, but requires no file to be
+   * available/read.
+   */
+  Corrade::Containers::Pointer<Importer> primImporter;
 
   /**
    * @brief Maps string keys (typically property filenames) to physical object

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -291,52 +291,6 @@ class ResourceManager {
   std::vector<std::string> buildObjectConfigPaths(const std::string& path);
 
   /**
-   * @brief Add an object from a specified configuration file to the specified
-   * @ref DrawableGroup as a child of the specified @ref scene::SceneNode if
-   * provided.
-   *
-   * If the attributes specified by objTemplateID exists in @ref
-   * physicsObjTemplateLibrary_, and both parent and drawables are
-   * specified, than an object referenced by that key is added to the scene.
-   * @param objTemplateLibID The ID of the configuration file to parse and
-   * load.  This is expected to exist.
-   * @param parent The @ref scene::SceneNode of which the object will be a
-   * child.
-   * @param drawables The @ref DrawableGroup with which the object @ref
-   * gfx::Drawable will be rendered.
-   * @param lightSetup The @ref LightSetup key that will be used
-   * for the added component.
-   */
-  void addObjectToDrawables(int objTemplateLibID,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            const Magnum::ResourceKey& lightSetup =
-                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
-
-  /**
-   * @brief Add an object from a specified configuration file to the specified
-   * @ref DrawableGroup as a child of the specified @ref scene::SceneNode if
-   * provided.
-   *
-   * If the attributes specified by objTemplateID exists in @ref
-   * physicsObjTemplateLibrary_, and both parent and drawables are
-   * specified, than an object referenced by that key is added to the scene.
-   * @param objPhysConfigFilename The name of the configuration file to parse
-   * and load.  This is expected to exist.
-   * @param parent The @ref scene::SceneNode of which the object will be a
-   * child.
-   * @param drawables The @ref DrawableGroup with which the object @ref
-   * gfx::Drawable will be rendered.
-   * @param lightSetup The @ref LightSetup key that will be used
-   * for the added component.
-   */
-  void addObjectToDrawables(const std::string& objPhysConfigFilename,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            const Magnum::ResourceKey& lightSetup =
-                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
-
-  /**
    * @brief Load and parse a physics object template config file and generates a
    * @ref PhysicsObjectAttributes object, adding it to the @ref
    * physicsObjTemplateLibrary_.
@@ -601,6 +555,52 @@ class ResourceManager {
    */
   std::unique_ptr<MeshData> createJoinedCollisionMesh(
       const std::string& filename);
+
+  /**
+   * @brief Add an object from a specified configuration file to the specified
+   * @ref DrawableGroup as a child of the specified @ref scene::SceneNode if
+   * provided.
+   *
+   * If the attributes specified by objTemplateID exists in @ref
+   * physicsObjTemplateLibrary_, and both parent and drawables are
+   * specified, than an object referenced by that key is added to the scene.
+   * @param objTemplateLibID The ID of the configuration file to parse and
+   * load.  This is expected to exist.
+   * @param parent The @ref scene::SceneNode of which the object will be a
+   * child.
+   * @param drawables The @ref DrawableGroup with which the object @ref
+   * gfx::Drawable will be rendered.
+   * @param lightSetup The @ref LightSetup key that will be used
+   * for the added component.
+   */
+  void addObjectToDrawables(int objTemplateLibID,
+                            scene::SceneNode* parent,
+                            DrawableGroup* drawables,
+                            const Magnum::ResourceKey& lightSetup =
+                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
+
+  /**
+   * @brief Add an object from a specified configuration file to the specified
+   * @ref DrawableGroup as a child of the specified @ref scene::SceneNode if
+   * provided.
+   *
+   * If the attributes specified by objTemplateID exists in @ref
+   * physicsObjTemplateLibrary_, and both parent and drawables are
+   * specified, than an object referenced by that key is added to the scene.
+   * @param objPhysConfigFilename The name of the configuration file to parse
+   * and load.  This is expected to exist.
+   * @param parent The @ref scene::SceneNode of which the object will be a
+   * child.
+   * @param drawables The @ref DrawableGroup with which the object @ref
+   * gfx::Drawable will be rendered.
+   * @param lightSetup The @ref LightSetup key that will be used
+   * for the added component.
+   */
+  void addObjectToDrawables(const std::string& objPhysConfigFilename,
+                            scene::SceneNode* parent,
+                            DrawableGroup* drawables,
+                            const Magnum::ResourceKey& lightSetup =
+                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -77,13 +77,15 @@ bool BulletRigidObject::initializeObjectFinalize(
     // prim stuff here
 
   } else {
-    // originHandle is key in maps of relelvant quantities in resource manager
-    const std::string originHandle = physicsObjectAttributes->getOriginHandle();
+    // collision mesh handle
+    const std::string collisionAssetHandle =
+        physicsObjectAttributes->getCollisionAssetHandle();
 
     const std::vector<assets::CollisionMeshData>& meshGroup =
-        resMgr.getCollisionMesh(originHandle);
-    const assets::MeshMetaData& metaData = resMgr.getMeshMetaData(
-        physicsObjectAttributes->getCollisionAssetHandle());
+        resMgr.getCollisionMesh(collisionAssetHandle);
+    const assets::MeshMetaData& metaData =
+        resMgr.getMeshMetaData(collisionAssetHandle);
+
     if (!usingBBCollisionShape_) {
       constructBulletCompoundFromMeshes(Magnum::Matrix4{}, meshGroup,
                                         metaData.root, joinCollisionMeshes);


### PR DESCRIPTION
## Motivation and Context
This PR provides direct setting of MeshData  in GenericMeshData objects, to facilitate programmatically composed MeshData objects, such as the navMesh, in an ongoing effort to move away from custom "PrimitiveMesh" handling. A future PR will actually consume this functionality for NavMeshes.

The PluginManager object is also now treated as a protected instance variable for ResourceManager, instantiated in constructor, so that it does not need to be reinstanced everywhere an importer is required.  A primitive importer is provided as an instance variable, to be used whenever primitive meshes are needed, so it also does not need to be reinstanced.

Lastly, some existing functions were renamed/reworked to reflect recent changes with regard to attributes and how certain resources are stored/accessed.  Superfluous/redundant methods and variables were removed, and some methods were moved within ResourceManager to be closer to other similar methods.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing tests (c++ and python) passed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
