### PR TITLE
Agent position random seeding

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -221,7 +221,7 @@ class Simulator:
             if self.pathfinder.is_loaded:
                 initial_state.position = self.pathfinder.get_random_navigable_point()
                 initial_state.rotation = quat_from_angle_axis(
-                    np.random.uniform(0, 2.0 * np.pi), np.array([0, 1, 0])
+                    self._sim.random.uniform_float(0, 2.0 * np.pi), np.array([0, 1, 0])
                 )
 
         agent.set_state(initial_state, is_initial=True)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -165,6 +165,8 @@ class Simulator:
             navmesh_settings.agent_height = default_agent_config.height
             self.recompute_navmesh(self.pathfinder, navmesh_settings)
 
+        self.pathfinder.seed(config.sim_cfg.random_seed)
+
     def reconfigure(self, config: Configuration):
         assert len(config.agents) > 0
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -64,6 +64,7 @@ void initSimBindings(py::module& m) {
       .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
       .def("reset", &Simulator::reset)
       .def_property_readonly("gpu_device", &Simulator::gpuDevice)
+      .def_property_readonly("random", &Simulator::random)
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -28,6 +28,7 @@ void initSimBindings(py::module& m) {
       m, "SimulatorConfiguration")
       .def(py::init(&SimulatorConfiguration::create<>))
       .def_readwrite("scene", &SimulatorConfiguration::scene)
+      .def_readwrite("random_seed", &SimulatorConfiguration::randomSeed)
       .def_readwrite("default_agent_id",
                      &SimulatorConfiguration::defaultAgentId)
       .def_readwrite("default_camera_uuid",

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -4,6 +4,7 @@
 
 #include "esp/bindings/bindings.h"
 
+#include "esp/core//random.h"
 #include "esp/core/Configuration.h"
 #include "esp/core/RigidState.h"
 
@@ -47,6 +48,16 @@ void initCoreBindings(py::module& m) {
                                         const Magnum::Vector3&>))
       .def_readwrite("rotation", &RigidState::rotation)
       .def_readwrite("translation", &RigidState::translation);
+
+  py::class_<Random, Random::ptr>(m, "Random")
+      .def(py::init(&Random::create<>))
+      .def("seed", &Random::seed)
+      .def("uniform_float_01", &Random::uniform_float_01)
+      .def("uniform_float", &Random::uniform_float)
+      .def("uniform_int", py::overload_cast<>(&Random::uniform_int))
+      .def("uniform_int", py::overload_cast<int, int>(&Random::uniform_int))
+      .def("uniform_uint", &Random::uniform_uint)
+      .def("normal_float_01", &Random::normal_float_01);
 }
 
 }  // namespace core

--- a/src/esp/core/random.h
+++ b/src/esp/core/random.h
@@ -6,6 +6,8 @@
 
 #include <random>
 
+#include "esp.h"
+
 namespace esp {
 namespace core {
 
@@ -52,6 +54,8 @@ class Random {
   std::uniform_int_distribution<int> uniform_int_;
   std::uniform_int_distribution<uint32_t> uniform_uint32_;
   std::normal_distribution<float> normal_float_01_;
+
+  ESP_SMART_POINTERS(Random);
 };
 
 }  // namespace core

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -27,7 +27,8 @@ namespace Cr = Corrade;
 namespace esp {
 namespace sim {
 
-Simulator::Simulator(const SimulatorConfiguration& cfg) {
+Simulator::Simulator(const SimulatorConfiguration& cfg)
+    : random_{core::Random::create()} {
   // initalize members according to cfg
   // NOTE: NOT SO GREAT NOW THAT WE HAVE virtual functions
   //       Maybe better not to do this reconfigure
@@ -213,7 +214,7 @@ void Simulator::reset() {
 }
 
 void Simulator::seed(uint32_t newSeed) {
-  random_.seed(newSeed);
+  random_->seed(newSeed);
   pathfinder_->seed(newSeed);
 }
 
@@ -583,7 +584,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
 void Simulator::sampleRandomAgentState(agent::AgentState& agentState) {
   if (pathfinder_->isLoaded()) {
     agentState.position = pathfinder_->getRandomNavigablePoint();
-    const float randomAngleRad = random_.uniform_float_01() * M_PI;
+    const float randomAngleRad = random_->uniform_float_01() * M_PI;
     quatf rotation(Eigen::AngleAxisf(randomAngleRad, vec3f::UnitY()));
     agentState.rotation = rotation.coeffs();
     // TODO: any other AgentState members should be randomized?

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -28,7 +28,7 @@ namespace esp {
 namespace sim {
 
 Simulator::Simulator(const SimulatorConfiguration& cfg)
-    : random_{core::Random::create()} {
+    : random_{core::Random::create(cfg.randomSeed)} {
   // initalize members according to cfg
   // NOTE: NOT SO GREAT NOW THAT WE HAVE virtual functions
   //       Maybe better not to do this reconfigure
@@ -68,6 +68,9 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   } else {
     LOG(WARNING) << "Navmesh file not found, checked at " << navmeshFilename;
   }
+
+  // Calling to seeding needs to be done after the pathfinder creation
+  seed(config_.randomSeed);
 
   std::string houseFilename = io::changeExtension(sceneFilename, ".house");
   if (!io::exists(houseFilename)) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -37,6 +37,7 @@ struct SimulatorConfiguration {
   scene::SceneConfiguration scene;
   int defaultAgentId = 0;
   int gpuDeviceId = 0;
+  unsigned int randomSeed = 0;
   std::string defaultCameraUuid = "rgba_camera";
   bool compressTextures = false;
   bool createRenderer = true;
@@ -596,7 +597,10 @@ class Simulator {
                            int sceneID = 0);
 
   /**
-   * @brief Getter for PRNG
+   * @brief Getter for PRNG.
+   *
+   * Use this where-ever possible so that habitat won't be effect by
+   * python's random or np.random modules
    */
   core::Random::ptr random() { return random_; }
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -595,6 +595,11 @@ class Simulator {
                            const std::string& lightSetupKey,
                            int sceneID = 0);
 
+  /**
+   * @brief Getter for PRNG
+   */
+  core::Random::ptr random() { return random_; }
+
  protected:
   Simulator(){};
 
@@ -628,7 +633,7 @@ class Simulator {
 
   std::shared_ptr<physics::PhysicsManager> physicsManager_ = nullptr;
 
-  core::Random random_;
+  core::Random::ptr random_;
   SimulatorConfiguration config_;
 
   std::vector<agent::Agent::ptr> agents_;


### PR DESCRIPTION
## Motivation and Context

Add random seed to the simulators config and expose core::Random to python so that the initial agent position/orientation is a) independent of np.random and b) consistent.

@mathfac I believe this won't effect habitat-api at all.  Habitat-api already calls `.seed` in habitat sim, so the random seed in the config here is irrelevant.

## How Has This Been Tested

Took the random seeding out of my little viewer script and the agent always spawns at the same location!

## Types of changes

 Bug fix (non-breaking change which fixes an issue)
