### PR TITLE
Sharing of rendering results

### DIFF
--- a/habitat_sim/sensors/sensor_suite.py
+++ b/habitat_sim/sensors/sensor_suite.py
@@ -1,10 +1,18 @@
-import habitat_sim.bindings as hsim
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import OrderedDict
+
+from habitat_sim.sensor import Sensor
 
 
-class SensorSuite(dict):
+class SensorSuite(OrderedDict):
     r"""Holds all the agents sensors. Simply a dictionary with an extra method
     to lookup the name of a sensor as the key
     """
 
-    def add(self, sensor: hsim.Sensor):
+    def add(self, sensor: Sensor):
         self[sensor.specification().uuid] = sensor

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import os.path as osp
 import time
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 import attr
@@ -58,7 +61,7 @@ class Simulator:
     _sim: SimulatorBackend = attr.ib(default=None, init=False)
     _num_total_frames: int = attr.ib(default=0, init=False)
     _default_agent: Agent = attr.ib(init=False, default=None)
-    _sensors: Dict = attr.ib(factory=dict, init=False)
+    _sensors: Dict = attr.ib(factory=OrderedDict, init=False)
     _previous_step_time = 0.0  # track the compute time of each step
 
     def __attrs_post_init__(self):
@@ -71,7 +74,7 @@ class Simulator:
             sensor.close()
             del sensor
 
-        self._sensors = {}
+        self._sensors = OrderedDict()
 
         for agent in self.agents:
             agent.close()
@@ -200,7 +203,7 @@ class Simulator:
         self._default_agent = self.get_agent(config.sim_cfg.default_agent_id)
 
         agent_cfg = config.agents[config.sim_cfg.default_agent_id]
-        self._sensors = {}
+        self._sensors = OrderedDict()
         for spec in agent_cfg.sensor_specifications:
             self._sensors[spec.uuid] = Sensor(
                 sim=self._sim, agent=self._default_agent, sensor_id=spec.uuid
@@ -243,8 +246,10 @@ class Simulator:
         return self._sim.semantic_scene
 
     def get_sensor_observations(self):
+        already_drawn = []
         for _, sensor in self._sensors.items():
-            sensor.draw_observation()
+            sensor.draw_observation(already_drawn)
+            already_drawn.append(sensor)
 
         observations = {}
         for sensor_uuid, sensor in self._sensors.items():
@@ -458,6 +463,8 @@ class Sensor:
 
         self._sim.renderer.bind_render_target(self._sensor_object)
 
+        self._borrowed_render_target = None
+
         if self._spec.gpu2gpu_transfer:
             assert cuda_enabled, "Must build habitat sim with cuda for gpu2gpu-transfer"
 
@@ -512,7 +519,43 @@ class Sensor:
             self._spec.noise_model, self._spec.uuid
         )
 
-    def draw_observation(self):
+    def _attempt_to_borrow(self, already_drawn: Optional[List[Sensor]] = None):
+        if already_drawn is None or len(already_drawn) == 0:
+            return None
+
+        borrowable_types = [SensorType.DEPTH, SensorType.COLOR]
+
+        # We can borrow from semantic also if all scene graphs are the same
+        if self._sim.is_semantic_scene_graph_shared:
+            borrowable_types.append(SensorType.SEMANTIC)
+
+        if self._spec.sensor_type not in borrowable_types:
+            return None
+
+        for other in already_drawn:
+            if (
+                other._spec.sensor_type in borrowable_types
+                and all(other._spec.resolution[0:2] == self._spec.resolution[0:2])
+                and other._spec.sensor_subtype == self._spec.sensor_subtype
+                and other._spec.parameters == self._spec.parameters
+                and (
+                    np.linalg.norm(
+                        other._sensor_object.object.absolute_transformation()
+                        - self._sensor_object.object.absolute_transformation()
+                    )
+                    <= 1e-5
+                )
+            ):
+                return other
+
+        return None
+
+    def draw_observation(self, already_drawn: Optional[List[Sensor]] = None):
+        r"""Draw the observation for this sensor
+
+        :param already_drawn: The list of sensor that have already drawn their observations.
+        A sensor will try to borrow the render result from another sensor if possible
+        """
         # sanity check:
 
         # see if the sensor is attached to a scene graph, otherwise it is invalid,
@@ -543,14 +586,25 @@ class Sensor:
         agent_node = self._agent.scene_node
         agent_node.parent = scene.get_root_node()
 
-        with self._sensor_object.render_target as tgt:
-            self._sim.renderer.draw(
-                self._sensor_object, scene, self._sim.frustum_culling
+        borrowable_sensor = self._attempt_to_borrow(already_drawn)
+
+        # If borrowing fails, draw for ourselves
+        if borrowable_sensor is None:
+            with self._sensor_object.render_target as tgt:
+                self._sim.renderer.draw(
+                    self._sensor_object, scene, self._sim.frustum_culling
+                )
+        else:
+            self._borrowed_render_target = (
+                borrowable_sensor._sensor_object.render_target
             )
 
     def get_observation(self):
 
-        tgt = self._sensor_object.render_target
+        if self._borrowed_render_target:
+            tgt = self._borrowed_render_target
+        else:
+            tgt = self._sensor_object.render_target
 
         if self._spec.gpu2gpu_transfer:
             with torch.cuda.device(self._buffer.device):
@@ -584,9 +638,12 @@ class Sensor:
 
             obs = np.flip(self._buffer, axis=0)
 
+        self._borrowed_render_target = None
+
         return self._noise_model(obs)
 
     def close(self):
         self._sim = None
         self._agent = None
         self._sensor_object = None
+        self._borrowed_render_target = None

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import annotations
-
 import os.path as osp
 import time
 from collections import OrderedDict
@@ -519,7 +517,7 @@ class Sensor:
             self._spec.noise_model, self._spec.uuid
         )
 
-    def _attempt_to_borrow(self, already_drawn: Optional[List[Sensor]] = None):
+    def _attempt_to_borrow(self, already_drawn: Optional[List["Sensor"]] = None):
         if already_drawn is None or len(already_drawn) == 0:
             return None
 
@@ -550,7 +548,7 @@ class Sensor:
 
         return None
 
-    def draw_observation(self, already_drawn: Optional[List[Sensor]] = None):
+    def draw_observation(self, already_drawn: Optional[List["Sensor"]] = None):
         r"""Draw the observation for this sensor
 
         :param already_drawn: The list of sensor that have already drawn their observations.
@@ -600,9 +598,9 @@ class Sensor:
             )
 
     def get_observation(self):
-
-        if self._borrowed_render_target:
+        if self._borrowed_render_target is not None:
             tgt = self._borrowed_render_target
+            self._borrowed_render_target = None
         else:
             tgt = self._sensor_object.render_target
 
@@ -638,12 +636,9 @@ class Sensor:
 
             obs = np.flip(self._buffer, axis=0)
 
-        self._borrowed_render_target = None
-
         return self._noise_model(obs)
 
     def close(self):
         self._sim = None
         self._agent = None
         self._sensor_object = None
-        self._borrowed_render_target = None

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -82,6 +82,7 @@ void initGfxBindings(py::module& m) {
       .def("read_frame_depth", &RenderTarget::readFrameDepth)
       .def("read_frame_object_id", &RenderTarget::readFrameObjectId)
       .def("blit_rgba_to_default", &RenderTarget::blitRgbaToDefault)
+      .def("blit_from", &RenderTarget::blitFrom)
 #ifdef ESP_BUILD_WITH_CUDA
       .def("read_frame_rgba_gpu",
            [](RenderTarget& self, size_t devPtr) {

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -58,6 +58,8 @@ void initSimBindings(py::module& m) {
            &Simulator::getActiveSemanticSceneGraph,
            R"(PYTHON DOES NOT GET OWNERSHIP)",
            pybind11::return_value_policy::reference)
+      .def_property_readonly("is_semantic_scene_graph_shared",
+                             &Simulator::isSemanticSceneGraphShared)
       .def_property_readonly("semantic_scene", &Simulator::getSemanticScene)
       .def_property_readonly("renderer", &Simulator::getRenderer)
       .def("seed", &Simulator::seed, "new_seed"_a)

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -62,7 +62,9 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
 
   m.import("magnum.scenegraph");
 
-  py::bind_map<std::map<std::string, std::string>>(m, "MapStringString");
+  py::bind_map<std::map<std::string, std::string>>(m, "MapStringString")
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 
   // NOTE(msb) These need to be run in dependency order.
   // TODO(msb) gfx, scene, and sensor should not cross-depend

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -118,12 +118,22 @@ struct RenderTarget::Impl {
 
   void blitRgbaToDefault() {
     framebuffer_.mapForRead(RgbaBuffer);
-    ASSERT(framebuffer_.viewport() == Mn::GL::defaultFramebuffer.viewport());
+    CORRADE_INTERNAL_ASSERT(other.framebuffer_.viewport() ==
+                            framebuffer_.viewport());
 
     Mn::GL::AbstractFramebuffer::blit(
         framebuffer_, Mn::GL::defaultFramebuffer, framebuffer_.viewport(),
         Mn::GL::defaultFramebuffer.viewport(), Mn::GL::FramebufferBlit::Color,
         Mn::GL::FramebufferBlitFilter::Nearest);
+  }
+
+  void blitFrom(RenderTarget::Impl& other) {
+    other.framebuffer_.mapForRead(RgbaBuffer);
+    other.framebuffer_.mapForRead(ObjectIdBuffer);
+    CORRADE_INTERNAL_ASSERT(other.framebuffer_.viewport() ==
+                            framebuffer_.viewport());
+    Mn::GL::AbstractFramebuffer::blit(other.framebuffer_, framebuffer_,
+                                      framebuffer_.viewport(), {});
   }
 
   void readFrameRgba(const Mn::MutableImageView2D& view) {
@@ -277,6 +287,10 @@ void RenderTarget::readFrameObjectId(const Mn::MutableImageView2D& view) {
 
 void RenderTarget::blitRgbaToDefault() {
   pimpl_->blitRgbaToDefault();
+}
+
+void RenderTarget::blitFrom(RenderTarget& other) {
+  pimpl_->blitFrom(*other.pimpl_);
 }
 
 Mn::Vector2i RenderTarget::framebufferSize() const {

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -101,6 +101,8 @@ class RenderTarget {
    */
   void blitRgbaToDefault();
 
+  void blitFrom(RenderTarget& other);
+
   // @brief Delete copy Constructor
   RenderTarget(const RenderTarget&) = delete;
   // @brief Delete copy operator

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -242,6 +242,10 @@ scene::SceneGraph& Simulator::getActiveSemanticSceneGraph() {
   return sceneManager_.getSceneGraph(activeSemanticSceneID_);
 }
 
+bool Simulator::isSemanticSceneGraphShared() {
+  return activeSemanticSceneID_ == activeSceneID_;
+}
+
 bool operator==(const SimulatorConfiguration& a,
                 const SimulatorConfiguration& b) {
   return a.scene == b.scene && a.defaultAgentId == b.defaultAgentId &&

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -78,6 +78,12 @@ class Simulator {
   scene::SceneGraph& getActiveSceneGraph();
   scene::SceneGraph& getActiveSemanticSceneGraph();
 
+  /**
+   * @brief Whether or not the active SceneGraph and active Semantic SceneGraph
+   * are the same
+   */
+  bool isSemanticSceneGraphShared();
+
   void saveFrame(const std::string& filename);
 
   /**


### PR DESCRIPTION
## Motivation and Context

Habitat-sim currently has the ability to draw RGB, Depth, and Semantic observations all on the same render pass, however, this isn't currently leveraged!  This PR adds the ability for sensor to "borrow" eachother's render results so that if you draw for an RGB sensor and have a Depth sensor that is configured identically, the Depth sensor won't invoke another draw but will instead just read the Depth Buffer from the RGB draw. For Replica scenes, we can share between RGB, Depth, and Semantic!

One question for reviewers:  I also tried an implementation that copies between RenderTargets instead of sharing them.  While this seems safer, that copy obviously has a cost and grows with resolution.  We currently don't make any assumptions that would be violated by this direct sharing so maybe it is fine?  If we do want this copy, my testing says that the cost of doing the copy in `draw_observation` is pretty high (performance with GPU2GPU drops to bellow without for 256x256 for instance).  Doing the copy in `get_observation` is less costly.

@mosra I left the code to copy between framebuffers in the PR to see if you knew if there was a way to do it faster.

## How Has This Been Tested

New tests.

I re-ran the benchmark on the normal MP3D test scene and got

```
 ====== FPS (512 x 512, depth_only): 5624.3 =============
 ================ Performance (FPS) NPROC=1 ========
Resolution      rgb             rgbd            depth_only
128 x 128       3151.7          1510.4          2361.9
256 x 256       2750.8          1137.1          1893.8
512 x 512       1607.2          697.9           1315.9
 ====================================================
 ================ Performance (FPS) NPROC=3 =============
Resolution      rgb             rgbd            depth_only
128 x 128       7684.1          3423.9          5935.4
256 x 256       6339.5          2885.4          4878.6
512 x 512       3817.1          1929.5          3610.2
 ======================================================
 ================ Performance (FPS) NPROC=5 ===============
Resolution      rgb             rgbd            depth_only
128 x 128       10651.7         4819.9          9146.4
256 x 256       8940.7          4056.9          7848.4
512 x 512       6674.5          2939.8          5624.3
 =====================================================
```

Comparing to the existing results, this maybe matter for higher resolutions, but otherwise it suprisingly doesn't.  However, `17DRP5sb8fy` is a reasonably lightweight scene.  

`1LXtFkjw3qL` on the otherhand is much heavier and here it matters.  Before the PR:
```
 ================ Performance (FPS) NPROC=1 ==========
Resolution      rgb             rgbd            depth_only
128 x 128       1227.5          557.1           1129.8
256 x 256       1128.7          501.7           918.3
512 x 512       833.3           415.0           802.9
 =================================================
```

After:
```
 ================ Performance (FPS) NPROC=1 ========
Resolution      rgb             rgbd            depth_only
128 x 128       1289.9          868.7           1073.2
256 x 256       1270.8          855.0           1044.9
512 x 512       994.9           566.6           843.0
 ===============================================
```

Then with GPU2GPU transfer enabled we get very close to zero-cost RGB-D

```
 ================ Performance (FPS) NPROC=1 ======
Resolution      rgb             rgbd            depth_only
128 x 128       1319.1          909.5           1219.3
256 x 256       1426.3          924.4           1207.0
512 x 512       1364.3          959.6           1125.2
 ==========================================
```

## Types of changes


 New feature (non-breaking change which adds functionality)
