### PR TITLE
Hopefully the final fix to yet another Doxygen failure

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -263,12 +263,6 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -310,13 +304,13 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 # extension. Doxygen has a built-in mapping, but you can override or extend it
 # using this tag. The format is ext=language, where ext is a file extension, and
 # language is one of the parsers supported by doxygen: IDL, Java, JavaScript,
-# Csharp (C#), C, C++, D, PHP, md (Markdown), Objective-C, Python, Slice,
+# Csharp (C#), C, C++, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL,
 # Fortran (fixed format Fortran: FortranFixed, free formatted Fortran:
 # FortranFree, unknown formatted Fortran: Fortran. In the later case the parser
 # tries to guess whether the code is fixed or free formatted code, this is the
-# default for Fortran type files), VHDL, tcl. For instance to make doxygen treat
-# .inc files as Fortran files (default is PHP), and .f files as C (default is
-# Fortran), use: inc=Fortran f=C.
+# default for Fortran type files). For instance to make doxygen treat .inc files
+# as Fortran files (default is PHP), and .f files as C (default is Fortran),
+# use: inc=Fortran f=C.
 #
 # Note: For files without extension you can use no_extension as a placeholder.
 #
@@ -855,7 +849,7 @@ INPUT_ENCODING         = UTF-8
 # *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
 # *.m, *.markdown, *.md, *.mm, *.dox (to be provided as doxygen C comment),
 # *.doc (to be provided as doxygen C comment), *.txt (to be provided as doxygen
-# C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f, *.for, *.tcl, *.vhd,
+# C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f18, *.f, *.for, *.vhd,
 # *.vhdl, *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.h \
@@ -1498,6 +1492,17 @@ TREEVIEW_WIDTH         = 250
 
 EXT_LINKS_IN_WINDOW    = NO
 
+# If the HTML_FORMULA_FORMAT option is set to svg, doxygen will use the pdf2svg
+# tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see
+# https://inkscape.org) to generate formulas as SVG images instead of PNGs for
+# the HTML output. These images will generally look nicer at scaled resolutions.
+# Possible values are: png (the default) and svg (looks nicer but requires the
+# pdf2svg or inkscape tool).
+# The default value is: png.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_FORMULA_FORMAT    = png
+
 # Use this tag to change the font size of LaTeX formulas included as images in
 # the HTML documentation. When you change the font size after a successful
 # doxygen run you need to manually remove any form_*.png images from the HTML
@@ -1553,7 +1558,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # Content Delivery Network so you can quickly see the result without installing
 # MathJax. However, it is strongly recommended to install a local copy of
 # MathJax from https://www.mathjax.org before deployment.
-# The default value is: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/.
+# The default value is: https://cdn.jsdelivr.net/npm/mathjax@2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/

--- a/docs/Doxyfile-public
+++ b/docs/Doxyfile-public
@@ -2,6 +2,8 @@
 
 OUTPUT_DIRECTORY       = ../build/docs-public/
 
+GENERATE_TAGFILE       = ../build/docs-public/habitat-cpp.tag
+
 ##! M_HTML_HEADER = "<!-- Global site tag (gtag.js) - Google Analytics -->" \
 ##!  "<script async src="https://www.googletagmanager.com/gtag/js?id=UA-66408458-4"></script>" \
 ##!  "<script>" \

--- a/docs/conf-public.py
+++ b/docs/conf-public.py
@@ -23,3 +23,6 @@ HTML_HEADER = """<!-- Global site tag (gtag.js) - Google Analytics -->
 SEARCH_DOWNLOAD_BINARY = "searchdata-v1.bin"
 SEARCH_BASE_URL = "https://aihabitat.org/docs/habitat-sim/"
 SEARCH_EXTERNAL_URL = "https://google.com/search?q=site:aihabitat.org+{query}"
+
+assert M_DOX_TAGFILES[2][0] == "../build/docs/habitat-cpp.tag"
+M_DOX_TAGFILES[2] = ("../build/docs-public/habitat-cpp.tag", "../habitat-cpp/", [], ["m-doc-external"])


### PR DESCRIPTION
## Motivation and Context

Followup to https://github.com/facebookresearch/habitat-sim/pull/624 based on a comment by @dhruvbatra. 

Yet another case of Doxygen unable to create a directory, however this time it fails silently. Sigh.
    
When generating public docs and the `build/docs/` directory didn't exist, Doxygen fails to create `build/docs/habitat-cpp.tag`, without any error, without any warning, nothing. To aid Doxygen in another case, m.css script creates `build/docs-public/` in that case, so tell Doxygen to put everything there, including the tagfile.

Also updated the Doxyfile to what 1.8.18 expects, getting rid of one warning in the output. (Tangential: the C++ docs are a *total mess*, not even my 5000 line terminal history scrollback was enough to fit all the warnings, and it seems to be getting progressively worse. Unless people actively try to minimize the warnings by building docs locally and checking the output, this will never improve.)

## How Has This Been Tested

Doc generation using `./build-public.sh` passes now even with the `build` directory not existing before.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
