### PR TITLE
--Enable construction of PrimitiveAttributes using string name

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -80,32 +80,57 @@ ResourceManager::ResourceManager()
   buildMapOfPrimTypeConstructors();
 }  // namespace assets
 void ResourceManager::buildMapOfPrimTypeConstructors() {
-  primTypeConstructorMap["capsule3DSolid"] =
-      &createPrimitiveAttributes<assets::CapsulePrimitiveAttributes, false, 0>;
-  primTypeConstructorMap["capsule3DWireframe"] =
-      &createPrimitiveAttributes<assets::CapsulePrimitiveAttributes, true, 1>;
-  primTypeConstructorMap["coneSolid"] =
-      &createPrimitiveAttributes<assets::ConePrimitiveAttributes, false, 2>;
-  primTypeConstructorMap["coneWireframe"] =
-      &createPrimitiveAttributes<assets::ConePrimitiveAttributes, true, 3>;
-  primTypeConstructorMap["cubeSolid"] =
-      &createPrimitiveAttributes<assets::CubePrimitiveAttributes, false, 4>;
-  primTypeConstructorMap["cubeWireframe"] =
-      &createPrimitiveAttributes<assets::CubePrimitiveAttributes, true, 5>;
-  primTypeConstructorMap["cylinderSolid"] =
-      &createPrimitiveAttributes<assets::CylinderPrimitiveAttributes, false, 6>;
-  primTypeConstructorMap["cylinderWireframe"] =
-      &createPrimitiveAttributes<assets::CylinderPrimitiveAttributes, true, 7>;
-  primTypeConstructorMap["icosphereSolid"] =
-      &createPrimitiveAttributes<assets::IcospherePrimitiveAttributes, false,
-                                 8>;
-  primTypeConstructorMap["icosphereWireframe"] =
-      &createPrimitiveAttributes<assets::IcospherePrimitiveAttributes, true, 9>;
-  primTypeConstructorMap["uvSphereSolid"] =
-      &createPrimitiveAttributes<assets::UVSpherePrimitiveAttributes, false,
-                                 10>;
-  primTypeConstructorMap["uvSphereWireframe"] =
-      &createPrimitiveAttributes<assets::UVSpherePrimitiveAttributes, true, 11>;
+  primTypeConstructorMap_["capsule3DSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CapsulePrimitiveAttributes, false,
+          PrimObjTypes::CAPSULE_SOLID>;
+  primTypeConstructorMap_["capsule3DWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CapsulePrimitiveAttributes, true, PrimObjTypes::CAPSULE_WF>;
+  primTypeConstructorMap_["coneSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::ConePrimitiveAttributes, false, PrimObjTypes::CONE_SOLID>;
+  primTypeConstructorMap_["coneWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::ConePrimitiveAttributes, true, PrimObjTypes::CONE_WF>;
+  primTypeConstructorMap_["cubeSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CubePrimitiveAttributes, false, PrimObjTypes::CUBE_SOLID>;
+  primTypeConstructorMap_["cubeWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CubePrimitiveAttributes, true, PrimObjTypes::CUBE_WF>;
+  primTypeConstructorMap_["cylinderSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CylinderPrimitiveAttributes, false,
+          PrimObjTypes::CYLINDER_SOLID>;
+  primTypeConstructorMap_["cylinderWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::CylinderPrimitiveAttributes, true, PrimObjTypes::CYLINDER_WF>;
+  primTypeConstructorMap_["icosphereSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::IcospherePrimitiveAttributes, false,
+          PrimObjTypes::ICOSPHERE_SOLID>;
+  primTypeConstructorMap_["icosphereWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::IcospherePrimitiveAttributes, true,
+          PrimObjTypes::ICOSPHERE_WF>;
+  primTypeConstructorMap_["uvSphereSolid"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::UVSpherePrimitiveAttributes, false,
+          PrimObjTypes::UVSPHERE_SOLID>;
+  primTypeConstructorMap_["uvSphereWireframe"] =
+      &ResourceManager::createPrimitiveAttributes<
+          assets::UVSpherePrimitiveAttributes, true, PrimObjTypes::UVSPHERE_WF>;
+  // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
+
+  // build default AbstractPrimitiveAttributes objects
+  for (const std::pair<PrimObjTypes, const char*>& elem : PrimitiveNames3DMap) {
+    if (elem.first == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      continue;
+    }
+    auto attr = buildPrimitiveAttributes(elem.second);
+    addPrimAssetTemplateToLibrary(attr);
+  }
 }  // buildMapOfPrimTypeConstructors
 
 void ResourceManager::initDefaultPrimAttributes() {
@@ -115,15 +140,9 @@ void ResourceManager::initDefaultPrimAttributes() {
   // necessary for importer to be usable
   primImporter_->openData("");
 
-  for (int i = 0;
-       i < static_cast<int>(assets::PrimObjTypes::END_PRIM_OBJ_TYPES); ++i) {
-    std::string key = PrimitiveNames3D[i];
-    auto attr = primTypeConstructorMap[key]();
-    addPrimAssetTemplateToLibrary(attr);
-  }
-
   // by this point, we should have a GL::Context so load the bb primitive.
-  // TODO: replace this completely with standard mesh
+  // TODO: replace this completely with standard mesh (i.e. treat the bb
+  // wireframe cube no differently than other primivite-based rendered objects)
   auto wfCube = primImporter_->mesh(
       primitiveAssetsTemplateLibrary_["cubeWireframe"]->getPrimObjClassName());
   primitive_meshes_.push_back(

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -114,34 +114,30 @@ enum class PrimObjTypes : uint32_t {
    */
   UVSPHERE_WF,
   /**
-  marker for no more primitive objects
-  */
+   * marker for no more primitive objects - add any new objects above this entry
+   */
   END_PRIM_OBJ_TYPES
 };
 
-constexpr const char* PrimitiveNames3D[]{
-    "capsule3DSolid",     "capsule3DWireframe", "coneSolid",
-    "coneWireframe",      "cubeSolid",          "cubeWireframe",
-    "cylinderSolid",      "cylinderWireframe",  "icosphereSolid",
-    "icosphereWireframe", "uvSphereSolid",      "uvSphereWireframe"};
-
 /**
- * @brief Build a shared pointer to the appropriate attributes for passed object
- * type
+ * @brief Constant Map holding names of all Magnum 3D primitive classes
+ * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
+ * valid primitive.
  */
-template <typename T, bool isWF, int idx>
-std::shared_ptr<AbstractPrimitiveAttributes> createPrimitiveAttributes() {
-  return T::create(isWF, idx, PrimitiveNames3D[idx]);
-}
-
-/**
- * @brief Define a map referencing function pointers to @ref
- * createPrimitiveAttributes() keyed by string names of classes being instanced
- */
-typedef std::map<
-    std::string,
-    std::shared_ptr<esp::assets::AbstractPrimitiveAttributes> (*)()>
-    map_of_primTypes;
+const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap = {
+    {PrimObjTypes::CAPSULE_SOLID, "capsule3DSolid"},
+    {PrimObjTypes::CAPSULE_WF, "capsule3DWireframe"},
+    {PrimObjTypes::CONE_SOLID, "coneSolid"},
+    {PrimObjTypes::CONE_WF, "coneWireframe"},
+    {PrimObjTypes::CUBE_SOLID, "cubeSolid"},
+    {PrimObjTypes::CUBE_WF, "cubeWireframe"},
+    {PrimObjTypes::CYLINDER_SOLID, "cylinderSolid"},
+    {PrimObjTypes::CYLINDER_WF, "cylinderWireframe"},
+    {PrimObjTypes::ICOSPHERE_SOLID, "icosphereSolid"},
+    {PrimObjTypes::ICOSPHERE_WF, "icosphereWireframe"},
+    {PrimObjTypes::UVSPHERE_SOLID, "uvSphereSolid"},
+    {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
+    {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
 
 /**
  * @brief Singleton class responsible for
@@ -712,7 +708,69 @@ class ResourceManager {
    */
   inline void compressTextures(bool newVal) { compressTextures_ = newVal; };
 
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed class name
+   */
+  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(
+      const std::string& primTypeName) {
+    CORRADE_ASSERT(
+        primTypeConstructorMap_.count(primTypeName) > 0,
+        "ResourceManager::buildPrimitiveAttributes : No primivite of type "
+            << primTypeName << " exists.  Aborting.",
+        nullptr);
+    return (*this.*primTypeConstructorMap_[primTypeName])();
+  }  // buildPrimitiveAttributes
+
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed enum value, which maps to class name via @ref
+   * PrimitiveNames3DMap
+   */
+  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(
+      PrimObjTypes& primType) {
+    CORRADE_ASSERT(
+        primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
+        "ResourceManager::buildPrimitiveAttributes : Illegal primtitive type "
+        "name sPrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
+        nullptr);
+    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])();
+  }  // buildPrimitiveAttributes
+
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed enum value, which maps to class name via @ref
+   * PrimitiveNames3DMap
+   */
+  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(int primTypeVal) {
+    CORRADE_ASSERT(
+        (primTypeVal >= 0) &&
+            (primTypeVal < static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES)),
+        "ResourceManager::buildPrimitiveAttributes : Unknown PrimObjTypes "
+        "value requested : "
+            << primTypeVal,
+        nullptr);
+    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
+                       static_cast<PrimObjTypes>(primTypeVal))])();
+  }  // buildPrimitiveAttributes
+
  private:
+  /**
+   * @brief Build a shared pointer to the appropriate attributes for passed
+   * object type as defined in @ref PrimObjTypes, where each entry except @ref
+   * END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
+   */
+  template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
+  std::shared_ptr<AbstractPrimitiveAttributes> createPrimitiveAttributes() {
+    CORRADE_ASSERT(
+        (primitiveType != PrimObjTypes::END_PRIM_OBJ_TYPES),
+        "ResourceManager::createPrimitiveAttributes : Cannot instantiate "
+        "PrimitiveAttributes object for  PrimObjTypes::END_PRIM_OBJ_TYPES",
+        nullptr);
+    int idx = static_cast<int>(primitiveType);
+    return T::create(isWireFrame, idx, PrimitiveNames3DMap.at(primitiveType));
+  }
+
   /**
    * @brief Load object templates given string list of object template
    * locations.
@@ -793,7 +851,8 @@ class ResourceManager {
                                    physicsSynthObjTmpltLibByID_);
   }
 
-  /** @brief Add object template attributes to template library map and in
+  /**
+   * @brief Add object template attributes to template library map and in
    * passed index list
    *
    * @param objectTemplate ptr to object template attributes to be added to
@@ -809,7 +868,8 @@ class ResourceManager {
                               const std::string& objectTemplateHandle,
                               std::map<int, std::string>& mapOfNames);
 
-  /** @brief Add primitive asset template attributes to appropriate template
+  /**
+   * @brief Add primitive asset template attributes to appropriate template
    * library map and index list
    *
    * @param primTemplate ptr to primitive template attributes to be added to
@@ -1158,12 +1218,22 @@ class ResourceManager {
       primitiveAssetsTemplateLibrary_;
 
   /**
+   * @brief Define a map type referencing function pointers to @ref
+   * createPrimitiveAttributes() keyed by string names of classes being
+   * instanced, as defined in @ref PrimitiveNames3D
+   */
+  typedef std::map<std::string,
+                   std::shared_ptr<esp::assets::AbstractPrimitiveAttributes> (
+                       esp::assets::ResourceManager::*)()>
+      Map_Of_PrimTypes;
+
+  /**
    * @brief Map of function pointers to instantiate a primitive attributes
    * object, keyed by the Magnum primitive class name as listed in @ref
    * PrimitiveNames3D. A primitive attributes object is instanced by accessing
    * the approrpiate function pointer.
    */
-  map_of_primTypes primTypeConstructorMap;
+  Map_Of_PrimTypes primTypeConstructorMap_;
 
   /**
    * @brief Maps string keys (typically property filenames) to physical scene
@@ -1211,6 +1281,7 @@ class ResourceManager {
   std::map<int, std::string> physicsSynthObjTmpltLibByID_;
   /**
    * @brief Maps primitive object template IDs to primitive template handles
+   * (composite strings built from specified attributes values for primitive)
    */
   std::map<int, std::string> primitiveAssetTmpltLibByID_;
 

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -165,8 +165,6 @@ BulletRigidObject::buildPrimitiveCollisionObject(
     case assets::PrimObjTypes::CAPSULE_SOLID:
     case assets::PrimObjTypes::CAPSULE_WF: {
       // use bullet capsule :  btCapsuleShape(btScalar radius,btScalar height);
-      // auto attr =
-      // std::static_pointer_cast<assets::CapsulePrimitiveAttributes::ptr>(primAttributes);
       btScalar radius = 1.0f;
       btScalar height = 2.0 * primAttributes->getHalfLength();
       return std::make_unique<btCapsuleShape>(radius, height);


### PR DESCRIPTION
Enable the construction of PrimitiveAttributes objects by accessing a map of preconfigured template function pointers keyed by string name of Magnum Primitive Class.

## Motivation and Context
As users wish to instantiate modified primitives to be used for rendering or collisions, we will want to instantiate new attributes on demand.  Instead of having a different instantiation method for each type of attributes, it would be ideal if we could reuse a single function, passing the desired type as a template parameter.  This functionality premaps calls to a template function that instantiates the appropriate shared pointer for each type of primitive currently supported.  Now, all that is required is knowledge of the name of the primitive desired to access the appropriate function to instantiate the desired primitive attributes.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
python and c++ tests have passed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
