### PR TITLE
[bugfix] Handle zero angular velocity in VelocityControl::integrateTransform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
 skip_glob = ["*/deps/*", "*/build/*", "*/obselete/*"]
-known_third_party = ["PIL", "attr", "conf", "cv2", "demo_runner", "hypothesis", "magnum", "matplotlib", "numba", "numpy", "pytest", "quaternion", "scipy", "settings", "setuptools", "torch", "torchvision", "tqdm"]
+known_third_party = ["PIL", "attr", "conf", "cv2", "demo_runner", "git", "hypothesis", "magnum", "matplotlib", "numba", "numpy", "pytest", "quaternion", "scipy", "settings", "setuptools", "torch", "torchvision", "tqdm"]
 multi_line_output = 3
 force_grid_wrap = false
 line_length = 88

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -60,7 +60,7 @@ core::RigidState VelocityControl::integrateTransform(
   }
 
   // then angular
-  if (controllingAngVel) {
+  if (controllingAngVel && angVel != Magnum::Vector3{0.0}) {
     Magnum::Vector3 globalAngVel{angVel};
     if (angVelIsLocal) {
       globalAngVel = rigidState.rotation.transformVector(angVel);

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -514,6 +514,11 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
   Magnum::Quaternion qLocalGroundTruth{{-0.95782, 0, 0}, 0.287495};
   qLocalGroundTruth = qLocalGroundTruth.normalized();
 
+  // test zero velocity kinematic integration (should not change state)
+  velControl->linVel = Magnum::Vector3{0.0, 0.0, 0.0};
+  velControl->angVel = Magnum::Vector3{0.0, 0.0, 0.0};
+  physicsManager_->stepPhysics(physicsManager_->getTimestep());
+
   ASSERT_LE((physicsManager_->getTranslation(objectId) - posLocalGroundTruth)
                 .length(),
             errorEps);


### PR DESCRIPTION
## Motivation and Context

Kinematic integration of angular velocity was failing trying to normalize a zero vector. Added a check for this and a test.

## How Has This Been Tested

Added test with zero linear/angular velocity.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
