### PR TITLE
--Make physical object asset loading/instantiation on demand

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -40,10 +40,12 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
   setInertia({0, 0, 0});
   setLinearDamping(0.2);
   setAngularDamping(0.2);
-  // default collisions will be mesh for physics objects
+  // default rendering and collisions will be mesh for physics objects
   // primitive-based objects do not currently support mesh collisions, however,
   // due to issues with how non-triangle meshes (i.e. wireframes) are handled in
   // @ref GenericMeshData::setMeshData
+  setRenderAssetIsPrimitive(false);
+  setCollisionAssetIsPrimitive(false);
   setUseMeshCollision(true);
 
   setBoundingBoxCollisions(false);

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -57,16 +57,38 @@ class AbstractPhysicsAttributes : public esp::core::Configuration {
 
   void setRenderAssetHandle(const std::string& renderAssetHandle) {
     setString("renderAssetHandle", renderAssetHandle);
+    setIsDirty();
   }
   std::string getRenderAssetHandle() const {
     return getString("renderAssetHandle");
   }
 
+  // whether this object uses file-based mesh render object or
+  // primitive(implicit) render shapes
+  void setRenderAssetIsPrimitive(bool renderAssetIsPrimitive) {
+    setBool("renderAssetIsPrimitive", renderAssetIsPrimitive);
+  }
+
+  bool getRenderAssetIsPrimitive() const {
+    return getBool("renderAssetIsPrimitive");
+  }
+
   void setCollisionAssetHandle(const std::string& collisionAssetHandle) {
     setString("collisionAssetHandle", collisionAssetHandle);
+    setIsDirty();
   }
   std::string getCollisionAssetHandle() const {
     return getString("collisionAssetHandle");
+  }
+
+  // whether this object uses file-based mesh render object or
+  // primitive(implicit) render shapes
+  void setCollisionAssetIsPrimitive(bool collisionAssetIsPrimitive) {
+    setBool("collisionAssetIsPrimitive", collisionAssetIsPrimitive);
+  }
+
+  bool getCollisionAssetIsPrimitive() const {
+    return getBool("collisionAssetIsPrimitive");
   }
 
   // whether this object uses mesh collision or primitive(implicit) collision
@@ -77,7 +99,11 @@ class AbstractPhysicsAttributes : public esp::core::Configuration {
 
   bool getUseMeshCollision() const { return getBool("useMeshCollision"); }
 
+  bool getIsDirty() const { return getBool("__isDirty"); }
+  void setIsClean() { setBool("__isDirty", false); }
+
  protected:
+  void setIsDirty() { setBool("__isDirty", true); }
   std::string getBoolDispStr(bool val) const {
     return (val ? "true" : "false");
   }

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_BASEMESH_H_
+#define ESP_ASSETS_BASEMESH_H_
 
 /** @file
  * @brief enum @ref esp::assets::SupportedMeshType, Class @ref
@@ -182,3 +183,5 @@ class BaseMesh {
 };
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_BASEMESH_H_

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -150,7 +150,7 @@ void ResourceManager::initDefaultPrimAttributes() {
       std::make_unique<Magnum::GL::Mesh>(Magnum::MeshTools::compile(*wfCube)));
 
   // build default primtive object templates corresponding to given default
-  // assets
+  // asset templates
   for (auto primAsset : primitiveAssetsTemplateLibrary_) {
     buildAndRegisterPrimPhysObjTemplate(primAsset.first);
   }
@@ -619,7 +619,8 @@ int ResourceManager::addPrimAssetTemplateToLibrary(
   return primAssetTemplateID;
 }  // addPrimAssetTemplateToLibrary
 
-int ResourceManager::loadObjectTemplate(
+// registerObjectTemplate
+int ResourceManager::registerObjectTemplate(
     PhysicsObjectAttributes::ptr objectTemplate,
     const std::string& objectTemplateHandle) {
   if (physicsObjTemplateLibrary_.count(objectTemplateHandle) != 0) {
@@ -636,6 +637,7 @@ int ResourceManager::loadObjectTemplate(
   //! Get render and collision mesh names
   // AssetInfo renderMeshinfo;
   std::string renderMeshFilename = objectTemplate->getRenderAssetHandle();
+
   bool renderMeshSuccess = loadObjectMeshDataFromFile(
       renderMeshFilename, objectTemplateHandle, "render", requiresLighting);
 
@@ -643,6 +645,7 @@ int ResourceManager::loadObjectTemplate(
   // mesh since we will use it to render
   // AssetInfo collisionMeshinfo;
   std::string collisionMeshFilename = objectTemplate->getCollisionAssetHandle();
+
   bool collisionMeshSuccess = loadObjectMeshDataFromFile(
       collisionMeshFilename, objectTemplateHandle, "collision",
       !renderMeshSuccess && requiresLighting);
@@ -685,7 +688,7 @@ int ResourceManager::loadObjectTemplate(
       objectTemplate, objectTemplateHandle, physicsFileObjTmpltLibByID_);
 
   return objectTemplateID;
-}  // loadObjectTemplate
+}  // registerObjectTemplate
 
 std::string ResourceManager::getRandomTemplateHandlePerType(
     const std::map<int, std::string>& mapOfHandles,
@@ -928,7 +931,7 @@ int ResourceManager::parseAndLoadPhysObjTemplate(
   physicsObjectAttributes->setCollisionAssetHandle(collisionMeshFilename);
 
   // 5. load the parsed file into the library
-  return loadObjectTemplate(physicsObjectAttributes, objPhysConfigFilename);
+  return registerObjectTemplate(physicsObjectAttributes, objPhysConfigFilename);
 }  // parseAndLoadPhysObjTemplate
 
 int ResourceManager::buildAndRegisterPrimPhysObjTemplate(
@@ -960,7 +963,6 @@ int ResourceManager::buildAndRegisterPrimPhysObjTemplate(
   // CollisionMesh
 
   // set margin to be 0
-
   physicsObjectAttributes->setMargin(0.0);
   // make smaller
   const Magnum::Vector3 scale(0.1, 0.1, 0.1);

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -371,8 +371,8 @@ class ResourceManager {
   std::string getObjectTemplateHandle(const int objectTemplateID) const {
     CORRADE_ASSERT(physicsTemplatesLibByID_.count(objectTemplateID) > 0,
                    "ResourceManager::getObjectTemplateHandle : No loaded or "
-                   "primitive template with index "
-                       << objectTemplateID << " exists.",
+                   "primitive template with index"
+                       << objectTemplateID << "exists. Aborting",
                    "");
     return physicsTemplatesLibByID_.at(objectTemplateID);
   }  // getObjectTemplateHandle
@@ -388,8 +388,8 @@ class ResourceManager {
     CORRADE_ASSERT(
         (primitiveAssetsTemplateLibrary_.count(primTemplateHandle) > 0),
         "ResourceManager::getPrimitiveTemplateAttributes : Unknown primitive "
-        "template handle : "
-            << primTemplateHandle,
+        "template handle :"
+            << primTemplateHandle << ". Aborting",
         nullptr);
     return primitiveAssetsTemplateLibrary_.at(primTemplateHandle);
   }
@@ -409,7 +409,8 @@ class ResourceManager {
     CORRADE_ASSERT(
         (physicsObjTemplateLibrary_.count(templateHandle) > 0),
         "ResourceManager::getPhysicsObjectAttributes : Unknown template handle "
-        ": " << templateHandle,
+        ":" << templateHandle
+            << ". Aborting",
         nullptr);
     return physicsObjTemplateLibrary_.at(templateHandle);
   }
@@ -430,20 +431,10 @@ class ResourceManager {
     CORRADE_ASSERT((physicsObjTemplateLibrary_.count(key) > 0),
                    "ResourceManager::getPhysicsObjectAttributes : Unknown "
                    "object template ID:"
-                       << objectTemplateID,
+                       << objectTemplateID << ". Aborting",
                    nullptr);
     return physicsObjTemplateLibrary_.at(key);
   }
-
-  /**
-   * @brief returns whether the passed string corresponds to a valid file name
-   * that exists in file system
-   * @param filename String to check if valid file name
-   * @return whether or not filename is valid and exists in file system
-   */
-
-  bool checkIsValidFileName(const std::string& filename,
-                            const std::string& type);
 
   /**
    * @brief Gets the number of object templates stored in the @ref
@@ -722,8 +713,8 @@ class ResourceManager {
       const std::string& primTypeName) {
     CORRADE_ASSERT(
         primTypeConstructorMap_.count(primTypeName) > 0,
-        "ResourceManager::buildPrimitiveAttributes : No primivite of type "
-            << primTypeName << " exists.  Aborting.",
+        "ResourceManager::buildPrimitiveAttributes : No primivite of type"
+            << primTypeName << "exists.  Aborting.",
         nullptr);
     return (*this.*primTypeConstructorMap_[primTypeName])();
   }  // buildPrimitiveAttributes
@@ -753,8 +744,8 @@ class ResourceManager {
         (primTypeVal >= 0) &&
             (primTypeVal < static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES)),
         "ResourceManager::buildPrimitiveAttributes : Unknown PrimObjTypes "
-        "value requested : "
-            << primTypeVal,
+        "value requested :"
+            << primTypeVal << ". Aborting",
         nullptr);
     return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
                        static_cast<PrimObjTypes>(primTypeVal))])();
@@ -771,7 +762,8 @@ class ResourceManager {
     CORRADE_ASSERT(
         (primitiveType != PrimObjTypes::END_PRIM_OBJ_TYPES),
         "ResourceManager::createPrimitiveAttributes : Cannot instantiate "
-        "PrimitiveAttributes object for  PrimObjTypes::END_PRIM_OBJ_TYPES",
+        "PrimitiveAttributes object for PrimObjTypes::END_PRIM_OBJ_TYPES. "
+        "Aborting.",
         nullptr);
     int idx = static_cast<int>(primitiveType);
     return T::create(isWireFrame, idx, PrimitiveNames3DMap.at(primitiveType));
@@ -1232,20 +1224,8 @@ class ResourceManager {
    * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
    * a valid primitive.
    */
-  const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap = {
-      {PrimObjTypes::CAPSULE_SOLID, "capsule3DSolid"},
-      {PrimObjTypes::CAPSULE_WF, "capsule3DWireframe"},
-      {PrimObjTypes::CONE_SOLID, "coneSolid"},
-      {PrimObjTypes::CONE_WF, "coneWireframe"},
-      {PrimObjTypes::CUBE_SOLID, "cubeSolid"},
-      {PrimObjTypes::CUBE_WF, "cubeWireframe"},
-      {PrimObjTypes::CYLINDER_SOLID, "cylinderSolid"},
-      {PrimObjTypes::CYLINDER_WF, "cylinderWireframe"},
-      {PrimObjTypes::ICOSPHERE_SOLID, "icosphereSolid"},
-      {PrimObjTypes::ICOSPHERE_WF, "icosphereWireframe"},
-      {PrimObjTypes::UVSPHERE_SOLID, "uvSphereSolid"},
-      {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
-      {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
+  static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
+
   /**
    * @brief Define a map type referencing function pointers to @ref
    * createPrimitiveAttributes() keyed by string names of classes being

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1205,6 +1205,11 @@ class ResourceManager {
   Corrade::Containers::Pointer<Importer> primitiveImporter_;
 
   /**
+   * @brief Importer used to load files
+   */
+  Corrade::Containers::Pointer<Importer> fileImporter_;
+
+  /**
    * @brief Maps string keys (typically property filenames) to physical object
    * templates.
    *

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -120,26 +120,6 @@ enum class PrimObjTypes : uint32_t {
 };
 
 /**
- * @brief Constant Map holding names of all Magnum 3D primitive classes
- * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
- * valid primitive.
- */
-const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap = {
-    {PrimObjTypes::CAPSULE_SOLID, "capsule3DSolid"},
-    {PrimObjTypes::CAPSULE_WF, "capsule3DWireframe"},
-    {PrimObjTypes::CONE_SOLID, "coneSolid"},
-    {PrimObjTypes::CONE_WF, "coneWireframe"},
-    {PrimObjTypes::CUBE_SOLID, "cubeSolid"},
-    {PrimObjTypes::CUBE_WF, "cubeWireframe"},
-    {PrimObjTypes::CYLINDER_SOLID, "cylinderSolid"},
-    {PrimObjTypes::CYLINDER_WF, "cylinderWireframe"},
-    {PrimObjTypes::ICOSPHERE_SOLID, "icosphereSolid"},
-    {PrimObjTypes::ICOSPHERE_WF, "icosphereWireframe"},
-    {PrimObjTypes::UVSPHERE_SOLID, "uvSphereSolid"},
-    {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
-    {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
-
-/**
  * @brief Singleton class responsible for
  * loading and managing common simulator assets such as meshes, textures, and
  * materials.
@@ -772,14 +752,14 @@ class ResourceManager {
   }
 
   /**
-   * @brief Load object templates given string list of object template
-   * locations.
+   * @brief Load all file-based object templates given string list of object
+   * template file locations.
    *
    * This will take the list of file names currently specified in
    * physicsManagerAttributes and load the referenced object templates.
    * @param tmpltFilenames list of file names of object templates
    */
-  void loadObjectTemplates(const std::vector<std::string>& tmpltFilenames);
+  void loadAllObjectTemplates(const std::vector<std::string>& tmpltFilenames);
 
   /**
    * @brief return a random handle selected from the passed map - is passed
@@ -1196,7 +1176,7 @@ class ResourceManager {
    * for similar usage to File-based importers, but requires no file to be
    * available/read.
    */
-  Corrade::Containers::Pointer<Importer> primImporter_;
+  Corrade::Containers::Pointer<Importer> primitiveImporter_;
 
   /**
    * @brief Maps string keys (typically property filenames) to physical object
@@ -1216,7 +1196,25 @@ class ResourceManager {
    */
   std::map<std::string, AbstractPrimitiveAttributes::ptr>
       primitiveAssetsTemplateLibrary_;
-
+  /**
+   * @brief Constant Map holding names of all Magnum 3D primitive classes
+   * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
+   * a valid primitive.
+   */
+  const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap = {
+      {PrimObjTypes::CAPSULE_SOLID, "capsule3DSolid"},
+      {PrimObjTypes::CAPSULE_WF, "capsule3DWireframe"},
+      {PrimObjTypes::CONE_SOLID, "coneSolid"},
+      {PrimObjTypes::CONE_WF, "coneWireframe"},
+      {PrimObjTypes::CUBE_SOLID, "cubeSolid"},
+      {PrimObjTypes::CUBE_WF, "cubeWireframe"},
+      {PrimObjTypes::CYLINDER_SOLID, "cylinderSolid"},
+      {PrimObjTypes::CYLINDER_WF, "cylinderWireframe"},
+      {PrimObjTypes::ICOSPHERE_SOLID, "icosphereSolid"},
+      {PrimObjTypes::ICOSPHERE_WF, "icosphereWireframe"},
+      {PrimObjTypes::UVSPHERE_SOLID, "uvSphereSolid"},
+      {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
+      {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
   /**
    * @brief Define a map type referencing function pointers to @ref
    * createPrimitiveAttributes() keyed by string names of classes being

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -327,8 +327,8 @@ class ResourceManager {
    * @return The index in the @ref physicsObjTemplateLibrary_ of object
    * template.
    */
-  int loadObjectTemplate(PhysicsObjectAttributes::ptr objectTemplate,
-                         const std::string& objectTemplateHandle);
+  int registerObjectTemplate(PhysicsObjectAttributes::ptr objectTemplate,
+                             const std::string& objectTemplateHandle);
 
   //======== Accessor functions ========
   /**
@@ -347,42 +347,30 @@ class ResourceManager {
   }
 
   /**
-   * @brief Get the index in @ref physicsObjTemplateLibrary_ for the object
-   * template asset identified by the key, templateHandle.
-   *
-   * @param templateHandle The key referencing the asset in @ref
-   * physicsObjTemplateLibrary_.
-   * @return The index of the object template in @ref
-   * physicsObjTemplateLibrary_.
-   */
-  int getObjectTemplateID(const std::string& templateHandle) const {
-    const bool objTemplateExists =
-        physicsObjTemplateLibrary_.count(templateHandle) > 0;
-    if (objTemplateExists) {
-      return physicsObjTemplateLibrary_.at(templateHandle)
-          ->getObjectTemplateID();
-    }
-    return ID_UNDEFINED;
-  }
-
-  /**
    * @brief Get the key in @ref physicsObjTemplateLibrary_ for the object
    * template asset index.
    *
    * @param objectTemplateID The index of the object template in @ref
    * physicsObjTemplateLibrary_.
-   * @return The key referencing the asset in @ref physicsObjTemplateLibrary_.
+   * @return The key referencing the asset in @ref physicsObjTemplateLibrary_,
+   * or an empty string if does not exist.
    */
   std::string getObjectTemplateHandle(const int objectTemplateID) const;
 
   /**
    * @brief Get a ref to the primitive attributes object for the primitive
-   * identified by the string key
+   * identified by the string key.
    * @param primTemplateHandle the string key of the attributes desired
-   * @return the desired primitive attributes
+   * @return the desired primitive attributes, or nullptr if does not exist
    */
   AbstractPrimitiveAttributes::ptr getPrimitiveTemplateAttributes(
       const std::string& primTemplateHandle) const {
+    CORRADE_ASSERT(
+        (primitiveAssetsTemplateLibrary_.count(primTemplateHandle) > 0),
+        "ResourceManager::getPrimitiveTemplateAttributes : unknown Primitive "
+        "template Handle : "
+            << primTemplateHandle,
+        nullptr);
     return primitiveAssetsTemplateLibrary_.at(primTemplateHandle);
   }
 
@@ -390,14 +378,19 @@ class ResourceManager {
    * @brief Get a reference to the physics object template for the asset
    * identified by the key, templateHandle.  physicsObjTemplateLibrary_
    *
-   * Can be used to manipulate an object
-   * template before instancing new objects.
+   * Can be used to manipulate an object template before instancing new objects.
    * @param templateHandle The key referencing the asset in @ref
    * physicsObjTemplateLibrary_.
-   * @return A mutable reference to the object template for the asset.
+   * @return A mutable reference to the object template for the asset, or
+   * nullptr if does not exist
    */
   PhysicsObjectAttributes::ptr getPhysicsObjectAttributes(
       const std::string& templateHandle) const {
+    CORRADE_ASSERT(
+        (physicsObjTemplateLibrary_.count(templateHandle) > 0),
+        "ResourceManager::getPhysicsObjectAttributes : unknown template handle "
+        ": " << templateHandle,
+        nullptr);
     return physicsObjTemplateLibrary_.at(templateHandle);
   }
 
@@ -405,16 +398,20 @@ class ResourceManager {
    * @brief Get a reference to the physics object template for the asset
    * identified by the objectTemplateID.
    *
-   * Can be used to manipulate an object
-   * template before instancing new objects.
-   * @param ObjTmplID The key referencing the asset in @ref
+   * Can be used to manipulate an object template before instancing new objects.
+   * @param objectTemplateID The key referencing the asset in @ref
    * physicsObjTemplateLibrary_.
-   * @return A mutable reference to the object template for the asset.
+   * @return A mutable reference to the object template for the asset, or
+   * nullptr if does not exist
    */
   PhysicsObjectAttributes::ptr getPhysicsObjectAttributes(
       const int objectTemplateID) const {
-    return physicsObjTemplateLibrary_.at(
-        getObjectTemplateHandle(objectTemplateID));
+    std::string key = getObjectTemplateHandle(objectTemplateID);
+    CORRADE_ASSERT((physicsObjTemplateLibrary_.count(key) > 0),
+                   "ResourceManager::getPhysicsObjectAttributes : unknown ID:"
+                       << objectTemplateID,
+                   nullptr);
+    return physicsObjTemplateLibrary_.at(key);
   }
 
   /**

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -97,7 +97,7 @@ void initSimBindings(py::module& m) {
       .def("get_object_template", &Simulator::getObjectTemplate,
            "object_template_id"_a, pybind11::return_value_policy::reference)
       .def("load_object_configs", &Simulator::loadObjectConfigs, "path"_a)
-      .def("load_object_template", &Simulator::loadObjectTemplate,
+      .def("load_object_template", &Simulator::registerObjectTemplate,
            "object_template"_a, "object_template_handle"_a)
       .def("get_object_initialization_template",
            &Simulator::getObjectInitializationTemplate, "object_id"_a,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -79,9 +79,15 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
   if (attachmentNode == nullptr) {
     objectNode = &staticSceneObject_->node().createChild();
   }
+  // verify whether necessary assets exist, and if not, instantiate them
+  bool instanceSuccess =
+      resourceManager_.instantiateAssetsOnDemand(configFileHandle);
 
-  bool objectSuccess =
-      makeAndAddRigidObject(nextObjectID_, physicsObjectAttributes, objectNode);
+  bool objectSuccess = false;
+  if (instanceSuccess) {  // only make object if asset instantiation succeeds
+    objectSuccess = makeAndAddRigidObject(nextObjectID_,
+                                          physicsObjectAttributes, objectNode);
+  }
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -80,14 +80,10 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     objectNode = &staticSceneObject_->node().createChild();
   }
   // verify whether necessary assets exist, and if not, instantiate them
-  bool instanceSuccess =
-      resourceManager_.instantiateAssetsOnDemand(configFileHandle);
-
-  bool objectSuccess = false;
-  if (instanceSuccess) {  // only make object if asset instantiation succeeds
-    objectSuccess = makeAndAddRigidObject(nextObjectID_,
-                                          physicsObjectAttributes, objectNode);
-  }
+  // only make object if asset instantiation succeeds (short circuit)
+  bool objectSuccess =
+      resourceManager_.instantiateAssetsOnDemand(configFileHandle) &&
+      makeAndAddRigidObject(nextObjectID_, physicsObjectAttributes, objectNode);
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_PHYSICS_PHYSICSMANAGER_H_
+#define ESP_PHYSICS_PHYSICSMANAGER_H_
 
 /** @file
  * @brief Class @ref esp::physics::PhysicsManager, enum @ref
@@ -944,3 +945,5 @@ class PhysicsManager {
 }  // namespace physics
 
 }  // namespace esp
+
+#endif  // ESP_PHYSICS_PHYSICSMANAGER_H_

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+
 #ifndef ESP_PHYSICS_RIGIDOBJECT_H_
 #define ESP_PHYSICS_RIGIDOBJECT_H_
 

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -47,6 +47,7 @@ BulletRigidObject::~BulletRigidObject() {
     }
   }
 }  //~BulletRigidObject
+
 bool BulletRigidObject::initializationFinalize(
     const assets::ResourceManager& resMgr) {
   objectMotionType_ = MotionType::DYNAMIC;

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -4,6 +4,7 @@
 
 #ifndef ESP_PHYSICS_BULLET_BULLETRIGIDOBJECT_H_
 #define ESP_PHYSICS_BULLET_BULLETRIGIDOBJECT_H_
+
 /** @file
  * @brief Struct SimulationContactResultCallback, class @ref
  * esp::physics::BulletRigidObject

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -340,8 +340,8 @@ std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
 int Simulator::registerObjectTemplate(
     assets::PhysicsObjectAttributes::ptr objTmplPtr,
     const std::string& objectTemplateHandle) {
-  return resourceManager_.registerObjectTemplate(objTmplPtr,
-                                                 objectTemplateHandle);
+  return resourceManager_->registerObjectTemplate(objTmplPtr,
+                                                  objectTemplateHandle);
 }
 
 const assets::PhysicsObjectAttributes::ptr

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -337,15 +337,11 @@ std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
   return templateIndices;
 }
 
-int Simulator::loadObjectTemplate(
+int Simulator::registerObjectTemplate(
     assets::PhysicsObjectAttributes::ptr objTmplPtr,
     const std::string& objectTemplateHandle) {
-  // check for duplicate keys
-  if (resourceManager_->getObjectTemplateID(objectTemplateHandle) !=
-      ID_UNDEFINED) {
-    return ID_UNDEFINED;
-  }
-  return resourceManager_->loadObjectTemplate(objTmplPtr, objectTemplateHandle);
+  return resourceManager_.registerObjectTemplate(objTmplPtr,
+                                                 objectTemplateHandle);
 }
 
 const assets::PhysicsObjectAttributes::ptr

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SIM_SIMULATOR_H_
+#define ESP_SIM_SIMULATOR_H_
 
 #include "esp/agent/Agent.h"
 #include "esp/assets/ResourceManager.h"
@@ -671,3 +672,5 @@ class Simulator {
 
 }  // namespace sim
 }  // namespace esp
+
+#endif  // ESP_SIM_SIMULATOR_H_

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -217,7 +217,7 @@ class Simulator {
    */
   assets::PhysicsObjectAttributes::ptr getObjectTemplateByName(
       const std::string& templateHandle) const {
-    return resourceManager_.getPhysicsObjectAttributes(templateHandle);
+    return resourceManager_->getPhysicsObjectAttributes(templateHandle);
   }
   /**
    * @brief Load all "*.phys_properties.json" files from the provided file or

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -213,6 +213,13 @@ class Simulator {
     return resourceManager_->getPhysicsObjectAttributes(templateId);
   }
   /**
+   * @brief Get a smart pointer to a physics object template by handle.
+   */
+  assets::PhysicsObjectAttributes::ptr getObjectTemplateByName(
+      const std::string& templateHandle) const {
+    return resourceManager_.getPhysicsObjectAttributes(templateHandle);
+  }
+  /**
    * @brief Load all "*.phys_properties.json" files from the provided file or
    * directory path.
    *
@@ -226,18 +233,17 @@ class Simulator {
   std::vector<int> loadObjectConfigs(const std::string& path);
 
   /**
-   * @brief Load the provided PhysicsObjectAttributes template into the
+   * @brief Register the provided PhysicsObjectAttributes template into the
    * Simulator.
    *
    * @param objectTemplate A new PhysicsObjectAttributes to load.
-   * @param objectTemplateHandle The desired key for referencing the new
-   * template. To register this successfully, it must not be a duplicate of an
-   * existing key.
+   * @param objectTemplateHandle The desired key for referencing the new or
+   * modified template.
    * @return A template index for instancing the loaded template or ID_UNDEFINED
    * if failed.
    */
-  int loadObjectTemplate(assets::PhysicsObjectAttributes::ptr objTmplPtr,
-                         const std::string& objectTemplateHandle);
+  int registerObjectTemplate(assets::PhysicsObjectAttributes::ptr objTmplPtr,
+                             const std::string& objectTemplateHandle);
 
   /**
    * @brief Get a static view of a physics object's template when the object was

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -80,7 +80,8 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
-    resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
+                                            objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
@@ -160,7 +161,8 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.0);
     physicsObjectAttributes->setJoinCollisionMeshes(false);
-    resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
+                                            objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
@@ -231,7 +233,8 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.0);
-    resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
+                                            objectFile);
 
     // generate two centered boxes with dimension 2x2x2
     int objectId0 = physicsManager_->addObject(objectFile, nullptr);
@@ -275,7 +278,8 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.1);
 
-    resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
+                                            objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
@@ -335,7 +339,7 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
   physicsObjectAttributes->setMargin(0.0);
 
-  resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
 
   // get a reference to the stored template to edit
   esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
@@ -400,7 +404,7 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
   physicsObjectAttributes->setMargin(0.0);
-  resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
 
   auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
@@ -544,7 +548,7 @@ TEST_F(PhysicsManagerTest, TestSceneNodeAttachment) {
   esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
-  resourceManager_.loadObjectTemplate(physicsObjectAttributes, objectFile);
+  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
 
   esp::scene::SceneNode& root =
       sceneManager_.getSceneGraph(sceneID_).getRootNode();
@@ -605,8 +609,8 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
     physicsObjectAttributes->setBoundingBoxCollisions(true);
     physicsObjectAttributes->setScale(
         {boxHalfExtent, boxHalfExtent, boxHalfExtent});
-    int boxId = resourceManager_.loadObjectTemplate(physicsObjectAttributes,
-                                                    objectFile);
+    int boxId = resourceManager_.registerObjectTemplate(physicsObjectAttributes,
+                                                        objectFile);
 
     auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -428,12 +428,19 @@ void SimTest::loadingObjectTemplates() {
   std::string boxPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
   newTemplate->setRenderAssetHandle(boxPath);
-  int templateIndex = simulator->loadObjectTemplate(newTemplate, boxPath);
+  int templateIndex = simulator->registerObjectTemplate(newTemplate, boxPath);
   CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
+  // change render asset for object template named boxPath
+  std::string chairPath =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/chair.glb");
+  newTemplate->setRenderAssetHandle(chairPath);
+  int templateIndex2 = simulator->registerObjectTemplate(newTemplate, boxPath);
 
-  // test double load
-  templateIndex = simulator->loadObjectTemplate(newTemplate, boxPath);
-  CORRADE_VERIFY(templateIndex == esp::ID_UNDEFINED);
+  CORRADE_VERIFY(templateIndex2 != esp::ID_UNDEFINED);
+  CORRADE_VERIFY(templateIndex2 == templateIndex);
+  esp::assets::PhysicsObjectAttributes::ptr newTemplate2 =
+      simulator->getObjectTemplateByName(boxPath);
+  CORRADE_VERIFY(newTemplate2->getRenderAssetHandle() == chairPath);
 }
 
 }  // namespace


### PR DESCRIPTION
## Motivation and Context
This PR changes how rendering and collision assets for physical objects (both file-based and primitive-based) are loaded.  Now, on program start, the assets requested are verified to exist but not loaded/instantiated.  Instead the required assets for an object are instantiated when the first object using a particular asset is instanced.  This will allow many physical objects to be made available without loading all their assets immediately, nor filling memory with object assets that may not even be used.  The program also starts much faster now, since the load time for the assets has been deferred until they are actually used.

Also, checks are put in place in case a user decides to change a template's render or collision asset handle and forgets to register this modified template.  Now, whenever values are changed that would require re-registering (verifying existence of a mesh file, for instance) a flag is set within the template invisibly, which forces re-registration whenever that template is consumed.

Lastly, some big fixes and improvements (such as replacing pragma's for named header guards) are also added.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing cpp and python tests have passed.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
