### PR TITLE
[Bug Fix][Viewer] Fix inconsistency between mouse move and keyboard move

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,6 @@ if(BUILD_TEST)
 endif()
 
 # include source dirs
-message(STATUS "============ SOURCE ++++ " ${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR})
 
 # Physics

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ if(BUILD_TEST)
 endif()
 
 # include source dirs
+message(STATUS "============ SOURCE ++++ " ${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR})
 
 # Physics


### PR DESCRIPTION
## Motivation and Context
Play will the viewer you will find:
-) Rendering images are discontinuous when you press left mouse button to rotate + scroll to zoom in and out, and use keyboard to control the agent and the sensors;
-) Rotation on left mouse button suffers significant numerical drifts, a bit difficult to manipulate the scene.

Root cause:
Different from keyboard event, when handling mouse press and scroll event, we convert such motions directly to the render camera, not to the agent or the attached sensors.

We are suffering such artifacts for quite a long time. This is the 1st diff to fix this problem.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
