### PR TITLE
Attribute managers

### DIFF
--- a/habitat_sim/attributes.py
+++ b/habitat_sim/attributes.py
@@ -3,8 +3,27 @@
 # LICENSE file in the root directory of this source tree.
 
 from habitat_sim._ext.habitat_sim_bindings import (
+    AbstractAttributes,
     AbstractPhysicsAttributes,
+    AbstractPrimitiveAttributes,
+    CapsulePrimitiveAttributes,
+    ConePrimitiveAttributes,
+    CubePrimitiveAttributes,
+    CylinderPrimitiveAttributes,
+    IcospherePrimitiveAttributes,
     PhysicsObjectAttributes,
+    UVSpherePrimitiveAttributes,
 )
 
-__all__ = ["AbstractPhysicsAttributes", "PhysicsObjectAttributes"]
+__all__ = [
+    "AbstractAttributes",
+    "AbstractPhysicsAttributes",
+    "AbstractPrimitiveAttributes",
+    "CapsulePrimitiveAttributes",
+    "ConePrimitiveAttributes",
+    "CubePrimitiveAttributes",
+    "CylinderPrimitiveAttributes",
+    "IcospherePrimitiveAttributes",
+    "PhysicsObjectAttributes",
+    "UVSpherePrimitiveAttributes",
+]

--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -13,8 +13,7 @@ namespace assets {
 
 AbstractPhysicsAttributes::AbstractPhysicsAttributes(
     const std::string& originHandle)
-    : Configuration() {
-  setOriginHandle(originHandle);
+    : AbstractAttributes(originHandle) {
   setFrictionCoefficient(0.5);
   setRestitutionCoefficient(0.1);
   setRenderAssetHandle("");
@@ -65,9 +64,8 @@ PhysicsSceneAttributes::PhysicsSceneAttributes(const std::string& originHandle)
 
 PhysicsManagerAttributes::PhysicsManagerAttributes(
     const std::string& originHandle)
-    : Configuration() {
+    : AbstractAttributes(originHandle) {
   setSimulator("none");
-  setOriginHandle(originHandle);
   setTimestep(0.01);
   setMaxSubsteps(10);
 }  // PhysicsManagerAttributes ctor

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -383,7 +383,7 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
    * - will be either 2 or 4 for primitives value checking
    * @return whether check passes
    */
-  bool isValMultOfDiv(int val, int div) {
+  bool isValueMultipleOfDivisor(int val, int div) {
     return (val >= div) && (val % div == 0);
   }
 
@@ -433,8 +433,9 @@ class CapsulePrimitiveAttributes : public AbstractPrimitiveAttributes {
    * type
    */
   virtual bool isValidTemplate() override {
-    bool wfCheck = ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
-                    (!getIsWireframe() && getNumSegments() > 2));
+    bool wfCheck =
+        ((getIsWireframe() && isValueMultipleOfDivisor(getNumSegments(), 4)) ||
+         (!getIsWireframe() && getNumSegments() > 2));
 
     return (getCylinderRings() > 0 && getHemisphereRings() > 0 && wfCheck &&
             getHalfLength() > 0);
@@ -477,7 +478,7 @@ class ConePrimitiveAttributes : public AbstractPrimitiveAttributes {
    */
   virtual bool isValidTemplate() override {
     bool wfCheck =
-        ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
+        ((getIsWireframe() && isValueMultipleOfDivisor(getNumSegments(), 4)) ||
          (!getIsWireframe() && getNumSegments() > 2 && getNumRings() > 0));
 
     return (getHalfLength() > 0 && wfCheck);
@@ -543,8 +544,9 @@ class CylinderPrimitiveAttributes : public AbstractPrimitiveAttributes {
    * type
    */
   virtual bool isValidTemplate() override {
-    bool wfCheck = ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
-                    (!getIsWireframe() && getNumSegments() > 2));
+    bool wfCheck =
+        ((getIsWireframe() && isValueMultipleOfDivisor(getNumSegments(), 4)) ||
+         (!getIsWireframe() && getNumSegments() > 2));
     return getNumRings() > 0 && getHalfLength() > 0 && wfCheck;
   }
 
@@ -622,8 +624,9 @@ class UVSpherePrimitiveAttributes : public AbstractPrimitiveAttributes {
    * type
    */
   virtual bool isValidTemplate() override {
-    return ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4) &&
-             isValMultOfDiv(getNumRings(), 2)) ||
+    return ((getIsWireframe() &&
+             isValueMultipleOfDivisor(getNumSegments(), 4) &&
+             isValueMultipleOfDivisor(getNumRings(), 2)) ||
             (!getIsWireframe() && getNumRings() > 1 && getNumSegments() > 2));
   }
 

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -332,6 +332,15 @@ class AbstractPrimitiveAttributes : public esp::core::Configuration {
   }
 
   int getPrimObjType() const { return getInt("primObjType"); }
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type.
+   * AbstractPrimitiveAttributes is never valid for any primitive - should be
+   * overridden in prim-specific class.
+   * @return whether or not the template holds valid data for desired primitive
+   * type.
+   */
+  virtual bool isValidTemplate() { return false; }
 
  private:
   // Should never change, only set by ctor
@@ -347,6 +356,18 @@ class AbstractPrimitiveAttributes : public esp::core::Configuration {
   void setIsWireframe(bool isWireframe) { setBool("isWireframe", isWireframe); }
 
  protected:
+  /**
+   * @brief Verifies that @ref val is larger than, and a multiple of, divisor
+   * div
+   * @param val the value to check
+   * @param div the divsior (value to verify is greater than and a multiple of)
+   * - will be either 2 or 4 for primitives value checking
+   * @return whether check passes
+   */
+  bool isValMultOfDiv(int val, int div) {
+    return (val >= div) && (val % div == 0);
+  }
+
   /**
    * @brief Origin handle for primitive attribute-based templates should reflect
    * the parameters used to construct the primitive, and so should only be set
@@ -385,6 +406,22 @@ class CapsulePrimitiveAttributes : public AbstractPrimitiveAttributes {
     buildOriginHandle();  // build handle based on config
   }
   int getCylinderRings() const { return getInt("cylinderRings"); }
+
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override {
+    bool wfCheck = ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
+                    (!getIsWireframe() && getNumSegments() > 2));
+
+    return (getCylinderRings() > 0 && getHemisphereRings() > 0 && wfCheck &&
+            getHalfLength() > 0);
+  }
+
+ protected:
   virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_hemiRings_" << getHemisphereRings() << "_cylRings_"
@@ -413,6 +450,21 @@ class ConePrimitiveAttributes : public AbstractPrimitiveAttributes {
   }
   bool getCapEnd() const { return getBool("capEnd"); }
 
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override {
+    bool wfCheck =
+        ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
+         (!getIsWireframe() && getNumSegments() > 2 && getNumRings() > 0));
+
+    return (getHalfLength() > 0 && wfCheck);
+  }
+
+ protected:
   virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_segments_" << getNumSegments() << "_halfLen_"
@@ -440,6 +492,15 @@ class CubePrimitiveAttributes : public AbstractPrimitiveAttributes {
     buildOriginHandle();  // build handle based on config
   }
 
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type. Cube
+   * primitives require no values and so this attributes is always valid.
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override { return true; }
+
   ESP_SMART_POINTERS(CubePrimitiveAttributes)
 };  // class CubePrimitiveAttributes
 
@@ -456,6 +517,19 @@ class CylinderPrimitiveAttributes : public AbstractPrimitiveAttributes {
   }
   bool getCapEnds() const { return getBool("capEnds"); }
 
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override {
+    bool wfCheck = ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4)) ||
+                    (!getIsWireframe() && getNumSegments() > 2));
+    return getNumRings() > 0 && getHalfLength() > 0 && wfCheck;
+  }
+
+ protected:
   virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_rings_" << getNumRings() << "_segments_" << getNumSegments()
@@ -494,6 +568,17 @@ class IcospherePrimitiveAttributes : public AbstractPrimitiveAttributes {
   }
   int getSubdivisions() const { return getInt("subdivisions"); }
 
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override {
+    return (getIsWireframe() || (!getIsWireframe() && getSubdivisions() >= 0));
+  }
+
+ protected:
   virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     // wireframe subdivision currently does not change
@@ -510,6 +595,20 @@ class UVSpherePrimitiveAttributes : public AbstractPrimitiveAttributes {
   UVSpherePrimitiveAttributes(bool isWireframe,
                               int primObjType,
                               const std::string& primObjClassName);
+
+  /**
+   * @brief This will determine if the stated template has the required
+   * quantities needed to instantiate a primitive properly of desired type
+   * @return whether or not the template holds valid data for desired primitive
+   * type
+   */
+  virtual bool isValidTemplate() override {
+    return ((getIsWireframe() && isValMultOfDiv(getNumSegments(), 4) &&
+             isValMultOfDiv(getNumRings(), 2)) ||
+            (!getIsWireframe() && getNumRings() > 1 && getNumSegments() > 2));
+  }
+
+ protected:
   virtual std::string buildOriginHandleDetail() override {
     std::ostringstream oHndlStrm;
     oHndlStrm << "_rings_" << getNumRings() << "_segments_" << getNumSegments();

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -14,8 +14,19 @@ set(assets_SOURCES
   MeshMetaData.h
   Mp3dInstanceMeshData.cpp
   Mp3dInstanceMeshData.h
+  managers/AttributesManagerBase.h
+  # managers/AssetAttributesManager.h
+  # managers/AssetAttributesManager.cpp
+  # managers/ObjectAttributesManager.h
+  # managers/ObjectAttributesManager.cpp
+  managers/PhysicsAttributesManager.h
+  managers/PhysicsAttributesManager.cpp
+  managers/SceneAttributesManager.h
+  managers/SceneAttributesManager.cpp
+  
   ResourceManager.cpp
   ResourceManager.h
+
 )
 
 if(BUILD_PTEX_SUPPORT)

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -315,9 +315,6 @@ void ResourceManager::initPhysicsManager(
       physicsManagerAttributes->getStringGroup("objectLibraryPaths"));
 }  // ResourceManager::initPhysicsManager
 
-//   return _physicsManager;
-// }  // ResourceManager::buildPhysicsManager
-
 //! (1) Read config and set physics timestep
 //! (2) loadScene() with PhysicsSceneMetaData
 // TODO (JH): this function seems to entangle certain physicsManager functions

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -35,6 +35,11 @@
 #include "esp/gfx/configure.h"
 #include "esp/scene/SceneNode.h"
 
+// #include "managers/AssetAttributesManager.h"
+// #include "managers/ObjectAttributesManager.h"
+#include "managers/PhysicsAttributesManager.h"
+#include "managers/SceneAttributesManager.h"
+
 // forward declarations
 namespace Magnum {
 namespace Trade {
@@ -272,41 +277,6 @@ class ResourceManager {
           NO_LIGHT_KEY});
 
   /**
-   * @brief Instantiate a shared pointer to a @ref physics::PhysicsManager for
-   * the world from the parameters defined in the referenced configuration file.
-   *
-   * @param physicsFilename The physics configuration file from which to
-   * re-instatiate the @ref physics::PhysicsManager and parse object templates
-   * for the
-   * @ref physicsObjTemplateLibrary_. Defaults to the file location @ref
-   * ESP_DEFAULT_PHYS_SCENE_CONFIG set by cmake. @return The created @ref
-   * physics::PhysicsManager
-   */
-  std::shared_ptr<physics::PhysicsManager> buildPhysicsManager(
-      std::string physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG);
-
-  /**
-   * @brief Parses global physics simulation parameters (such as timestep,
-   * gravity, simulator implementation) from the specified configuration file.
-   *
-   * @param physicsFilename The configuration file to parse. Defaults to the
-   * file location @ref ESP_DEFAULT_PHYS_SCENE_CONFIG set by cmake.
-   * @return The physics simulation meta data object parsed from the specified
-   * configuration file.
-   */
-  PhysicsManagerAttributes::ptr loadPhysicsConfig(
-      std::string physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG);
-
-  /**
-   * @brief Build all "*.phys_properties.json" files from the provided file or
-   * directory path.
-   *
-   * @param path A global path to a physics property file or directory
-   * @return A list of valid global paths to "*.phys_properties.json" files.
-   */
-  std::vector<std::string> buildObjectConfigPaths(const std::string& path);
-
-  /**
    * @brief Load and parse a physics object template config file and generates a
    * @ref PhysicsObjectAttributes object, adding it to the @ref
    * physicsObjTemplateLibrary_.
@@ -374,9 +344,35 @@ class ResourceManager {
     return collisionMeshGroups_.at(collisionAssetHandle);
   }
 
+  // /**
+  //  * @brief Return manager for construction and access to asset attributes.
+  //  */
+  // managers::AssetAttributesManager::ptr getAssetAttributesManager() {
+  //   return assetAttributesManager_;
+  // }
+  // /**
+  //  * @brief Return manager for construction and access to object attributes.
+  //  */
+  // managers::ObjectAttributesManager::ptr getObjectAttributesManager() {
+  //   return objectAttributesManager_;
+  // }
   /**
-   * @brief Get the key in @ref primitiveAssetTmpltLibByID_ for the object
-   * template asset index.
+   * @brief Return manager for construction and access to physics world
+   * attributes.
+   */
+  managers::PhysicsAttributesManager::ptr getPhysicsAttributesManager() {
+    return physicsAttributesManager_;
+  }
+  /**
+   * @brief Return manager for construction and access to scene attributes.
+   */
+  managers::SceneAttributesManager::ptr getsceneAttributesManager() {
+    return sceneAttributesManager_;
+  }
+
+  /**
+   * @brief Get the key in @ref primitiveAssetTemplateLibrary_ for the passed
+   * object template asset ID.
    *
    * @param objectTemplateID The index of the object template in @ref
    * primitiveAssetTmpltLibByID_.
@@ -1299,6 +1295,24 @@ class ResourceManager {
   Corrade::Containers::Pointer<Importer> fileImporter_;
 
   // ======== Physical parameter data ========
+
+  // /**
+  //  * @brief Manages all construction and access to asset attributes.
+  //  */
+  // managers::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
+  // /**
+  //  * @brief Manages all construction and access to object attributes.
+  //  */
+  // managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+  /**
+   * @brief Manages all construction and access to physics world attributes.
+   */
+  managers::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
+  /**
+   * @brief Manages all construction and access to scene attributes.
+   */
+  managers::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
+
   /**
    * @brief Maps string keys (typically property filenames) to physical object
    * templates.
@@ -1325,21 +1339,6 @@ class ResourceManager {
    * the approrpiate function pointer.
    */
   Map_Of_PrimTypes primTypeConstructorMap_;
-
-  /**
-   * @brief Maps string keys (typically property filenames) to physical scene
-   * templates.
-   *
-   * Templates are used by @ref physics::PhysicsManager to
-   * initialize, reset scenes or switch contexts.
-   */
-  std::map<std::string, PhysicsSceneAttributes::ptr> physicsSceneLibrary_;
-
-  /**
-   * @brief Library of physics scene attributes for
-   * initializing/resetting/switching physics world contexts.
-   */
-  std::map<std::string, PhysicsManagerAttributes::ptr> physicsManagerLibrary_;
 
   /**
    * @brief Primitive meshes available for instancing via @ref

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "AssetAttributesManager.h"
+#include "AttributesManagerBase.h"
+
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/ConfigurationGroup.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+const std::map<PrimObjTypes, const char*>
+    AssetAttributesManager::PrimitiveNames3DMap = {
+        {PrimObjTypes::CAPSULE_SOLID, "capsule3DSolid"},
+        {PrimObjTypes::CAPSULE_WF, "capsule3DWireframe"},
+        {PrimObjTypes::CONE_SOLID, "coneSolid"},
+        {PrimObjTypes::CONE_WF, "coneWireframe"},
+        {PrimObjTypes::CUBE_SOLID, "cubeSolid"},
+        {PrimObjTypes::CUBE_WF, "cubeWireframe"},
+        {PrimObjTypes::CYLINDER_SOLID, "cylinderSolid"},
+        {PrimObjTypes::CYLINDER_WF, "cylinderWireframe"},
+        {PrimObjTypes::ICOSPHERE_SOLID, "icosphereSolid"},
+        {PrimObjTypes::ICOSPHERE_WF, "icosphereWireframe"},
+        {PrimObjTypes::UVSPHERE_SOLID, "uvSphereSolid"},
+        {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
+        {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
+
+void AssetAttributesManager::buildMapOfPrimTypeConstructors() {
+  // function pointers to asset attributes constructors
+  primTypeConstructorMap_["capsule3DSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CapsulePrimitiveAttributes, false,
+          PrimObjTypes::CAPSULE_SOLID>;
+  primTypeConstructorMap_["capsule3DWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CapsulePrimitiveAttributes, true, PrimObjTypes::CAPSULE_WF>;
+  primTypeConstructorMap_["coneSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::ConePrimitiveAttributes, false, PrimObjTypes::CONE_SOLID>;
+  primTypeConstructorMap_["coneWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::ConePrimitiveAttributes, true, PrimObjTypes::CONE_WF>;
+  primTypeConstructorMap_["cubeSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CubePrimitiveAttributes, false, PrimObjTypes::CUBE_SOLID>;
+  primTypeConstructorMap_["cubeWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CubePrimitiveAttributes, true, PrimObjTypes::CUBE_WF>;
+  primTypeConstructorMap_["cylinderSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CylinderPrimitiveAttributes, false,
+          PrimObjTypes::CYLINDER_SOLID>;
+  primTypeConstructorMap_["cylinderWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::CylinderPrimitiveAttributes, true, PrimObjTypes::CYLINDER_WF>;
+  primTypeConstructorMap_["icosphereSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::IcospherePrimitiveAttributes, false,
+          PrimObjTypes::ICOSPHERE_SOLID>;
+  primTypeConstructorMap_["icosphereWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::IcospherePrimitiveAttributes, true,
+          PrimObjTypes::ICOSPHERE_WF>;
+  primTypeConstructorMap_["uvSphereSolid"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::UVSpherePrimitiveAttributes, false,
+          PrimObjTypes::UVSPHERE_SOLID>;
+  primTypeConstructorMap_["uvSphereWireframe"] =
+      &AssetAttributesManager::createPrimAttributes<
+          assets::UVSpherePrimitiveAttributes, true, PrimObjTypes::UVSPHERE_WF>;
+
+  // function pointers to asset attributes copy constructors
+  primTypeCopyConstructorMap_["capsule3DSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CapsulePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["capsule3DWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CapsulePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["coneSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::ConePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["coneWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::ConePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["cubeSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CubePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["cubeWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CubePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["cylinderSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CylinderPrimitiveAttributes>;
+  primTypeCopyConstructorMap_["cylinderWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::CylinderPrimitiveAttributes>;
+  primTypeCopyConstructorMap_["icosphereSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::IcospherePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["icosphereWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::IcospherePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["uvSphereSolid"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::UVSpherePrimitiveAttributes>;
+  primTypeCopyConstructorMap_["uvSphereWireframe"] =
+      &AssetAttributesManager::createPrimAttributesCopy<
+          assets::UVSpherePrimitiveAttributes>;
+  // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
+
+  // build default AbstractPrimitiveAttributes objects
+  for (const std::pair<PrimObjTypes, const char*>& elem : PrimitiveNames3DMap) {
+    if (elem.first == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      continue;
+    }
+    createAttributesTemplate(elem.second, true);
+  }
+}  // buildMapOfPrimTypeConstructors
+
+std::shared_ptr<AbstractPrimitiveAttributes>
+AssetAttributesManager::createAttributesTemplate(
+    const std::string& primClassName,
+    bool registerTemplate) {
+  auto primAssetAttributes = buildPrimAttributes(primClassName);
+
+  if (registerTemplate) {
+    registerAttributesTemplate(primAssetAttributes, "");
+  }
+  return primAssetAttributes;
+}  // AssetAttributesManager::createAttributesTemplate
+
+std::shared_ptr<AbstractPrimitiveAttributes>
+AssetAttributesManager::createAttributesTemplate(PrimObjTypes primObjType,
+                                                 bool registerTemplate) {
+  auto primAssetAttributes = buildPrimAttributes(primObjType);
+
+  if (registerTemplate) {
+    registerAttributesTemplate(primAssetAttributes, "");
+  }
+  return primAssetAttributes;
+}  // AssetAttributesManager::createAttributesTemplate
+
+int AssetAttributesManager::registerAttributesTemplate(
+    std::shared_ptr<AbstractPrimitiveAttributes> primAttributesTemplate,
+    const std::string&) {
+  std::string primAttributesHandle = primAttributesTemplate->getOriginHandle();
+  // verify that attributes has been edited in a legal manner
+  CORRADE_ASSERT(
+      primAttributesTemplate->isValidTemplate(),
+      "AssetAttributesManager::registerAttributesTemplate : Primitive "
+      "asset attributes template named"
+          << primAttributesHandle
+          << "is not configured properly for specified prmitive"
+          << primAttributesTemplate->getPrimObjClassName() << ". Aborting.",
+      ID_UNDEFINED);
+
+  // return either the ID of the existing template referenced by
+  // primAttributesHandle, or the next available ID if not found.
+  int primTemplateID =
+      addTemplateToLibrary(primAttributesTemplate, primAttributesHandle);
+  return primTemplateID;
+}  // AssetAttributesManager::registerAttributesTemplate
+
+std::shared_ptr<AbstractPrimitiveAttributes>
+AssetAttributesManager::getAttributesTemplateCopy(
+    const std::string& primTemplateHandle) {
+  CORRADE_ASSERT((templateLibrary_.count(primTemplateHandle) > 0),
+                 "AssetAttributesManager::getAttributesCopy : Unknown "
+                 "template handle :"
+                     << primTemplateHandle << ". Aborting",
+                 nullptr);
+  // need to return copy so that user mods do not modify existing
+  // asset template
+  auto orig = templateLibrary_.at(primTemplateHandle);
+  // build a copy of existing template
+  return copyPrimAttributes(orig);
+}  // AssetAttributesManager::getPrimAssetAttributesCopy
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -1,0 +1,311 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_ASSETS_MANAGERS_ASSETATTRIBUTEMANAGER_H_
+#define ESP_ASSETS_MANAGERS_ASSETATTRIBUTEMANAGER_H_
+
+#include "AttributesManagerBase.h"
+namespace esp {
+namespace assets {
+/**
+ * @brief The kinds of primitive modelled objects supported.  Paired with
+ * Magnum::Primitive namespace objects
+ */
+enum class PrimObjTypes : uint32_t {
+  /**
+   * Primitive object corresponding to Magnum::Primitives::capsule3DSolid
+   */
+  CAPSULE_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::capsule3DWireframe
+   */
+  CAPSULE_WF,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::coneSolid
+   */
+  CONE_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::coneWireframe
+   */
+  CONE_WF,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::cubeSolid
+   */
+  CUBE_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::cubeWireframe
+   */
+  CUBE_WF,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::cylinderSolid
+   */
+  CYLINDER_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::cylinderWireframe
+   */
+  CYLINDER_WF,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::icosphereSolid
+   */
+  ICOSPHERE_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::icosphereWireframe
+   */
+  ICOSPHERE_WF,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::uvSphereSolid
+   */
+  UVSPHERE_SOLID,
+  /**
+   * Primitive object corresponding to Magnum::Primitives::uvSphereWireframe
+   */
+  UVSPHERE_WF,
+  /**
+   * marker for no more primitive objects - add any new objects above this entry
+   */
+  END_PRIM_OBJ_TYPES
+};
+namespace managers {
+
+class AssetAttributesManager
+    : public AttributesManager<AbstractPrimitiveAttributes> {
+ public:
+  /**
+   * @brief Constant Map holding names of all Magnum 3D primitive classes
+   * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
+   * a valid primitive.
+   */
+  static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
+  AssetAttributesManager()
+      : AttributesManager<AbstractPrimitiveAttributes>::AttributesManager() {
+    buildMapOfPrimTypeConstructors();
+  }
+
+  /**
+   * @brief Creates an instance of a primtive asset attributes template
+   * described by passed string.
+   * For primitive assets this is the Magnum primitive class name
+   *
+   * @param primClassName a string descriptor of the primitive asset
+   * template to be created, corresponding to the Magnum Primitive class
+   * name.
+   * @param registerTemplate whether to add this template to the library or
+   * not. If the user is going to edit this template, this should be false.
+   * @return a reference to the desired template.
+   */
+
+  std::shared_ptr<AbstractPrimitiveAttributes> createAttributesTemplate(
+      const std::string& primClassName,
+      bool registerTemplate = true);
+
+  /**
+   * @brief Creates an instance of a primtive asset attributes template
+   * described by passed enum value. For primitive assets this mapes to the
+   * Magnum primitive class name
+   *
+   * @param primObjType an enum value denoting the class of the primitive to
+   * instantiate
+   * @param registerTemplate whether to add this template to the library or
+   * not. If the user is going to edit this template, this should be false.
+   * @return a reference to the desired template.
+   */
+  std::shared_ptr<AbstractPrimitiveAttributes> createAttributesTemplate(
+      PrimObjTypes primObjType,
+      bool registerTemplate = true);
+
+  /**
+   * @brief Add an @ref AbstractPrimitiveAttributes object to the @ref
+   * templateLibrary_.
+   *
+   * @param attributesTemplate The attributes template.
+   * @param attributesTemplateHandle The key for referencing the template in the
+   * @ref templateLibrary_.
+   * @return The index in the @ref templateLibrary_ of object
+   * template.
+   */
+  int registerAttributesTemplate(
+      std::shared_ptr<AbstractPrimitiveAttributes> attributesTemplate,
+      const std::string& attributesTemplateHandle);
+
+  /**
+   * @brief Get list of primitive asset template handles used as keys in @ref
+   * primitiveAssetTemplateLibrary_ related to passed primitive descriptor enum.
+   *
+   * @param primType Enum
+   * @param contains whether to search for keys containing, or not containing,
+   * @ref subStr
+   * @return list containing 0 or more string keys corresponding to templates in
+   * @ref primitiveAssetTemplateLibrary_ that contain the passed substring
+   */
+  std::vector<std::string> getTemplateHandlesByPrimType(
+      PrimObjTypes primType,
+      bool contains = true) const {
+    CORRADE_ASSERT(primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
+                   "AssetAttributesManager::getTemplateHandlesByPrimType : "
+                   "Illegal primtitive type "
+                   "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
+                   {});
+    std::string subStr = PrimitiveNames3DMap.at(primType);
+    return getTemplateHandlesBySubStringPerType(templateLibKeyByID_, subStr,
+                                                contains);
+  }  // getTemplateHandlesByPrimType
+
+  /**
+   * @brief Return a copy of the primitive asset attributes object specified
+   * by passed handle.  This is the version that should be accessed by the
+   * user.
+   * @param primTemplateHandle the string key of the attributes desired -
+   * this key will be synthesized based on attributes values.
+   * @return a copy of the desired primitive attributes, or nullptr if does
+   * not exist
+   */
+
+  std::shared_ptr<AbstractPrimitiveAttributes> getAttributesTemplateCopy(
+      const std::string& primTemplateHandle);
+
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed class name
+   */
+  std::shared_ptr<AbstractPrimitiveAttributes> copyPrimAttributes(
+      const std::shared_ptr<AbstractPrimitiveAttributes>& origAttr) {
+    std::string primTypeName = origAttr->getPrimObjClassName();
+    return (*this.*primTypeCopyConstructorMap_[primTypeName])(origAttr);
+  }  // buildPrimAttributes
+
+ protected:
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed class name
+   */
+  std::shared_ptr<AbstractPrimitiveAttributes> buildPrimAttributes(
+      const std::string& primTypeName) {
+    CORRADE_ASSERT(
+        primTypeConstructorMap_.count(primTypeName) > 0,
+        "AssetAttributesManager::buildPrimAttributes : No primivite of type"
+            << primTypeName << "exists.  Aborting.",
+        nullptr);
+    return (*this.*primTypeConstructorMap_[primTypeName])();
+  }  // buildPrimAttributes
+
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed enum value, which maps to class name via @ref
+   * PrimitiveNames3DMap
+   */
+  std::shared_ptr<AbstractPrimitiveAttributes> buildPrimAttributes(
+      PrimObjTypes primType) {
+    CORRADE_ASSERT(
+        primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
+        "AssetAttributesManager::buildPrimAttributes : Illegal primtitive type "
+        "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
+        nullptr);
+    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])();
+  }  // buildPrimAttributes
+
+  /**
+   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
+   * with passed enum value, which maps to class name via @ref
+   * PrimitiveNames3DMap
+   */
+  std::shared_ptr<AbstractPrimitiveAttributes> buildPrimAttributes(
+      int primTypeVal) {
+    CORRADE_ASSERT(
+        (primTypeVal >= 0) &&
+            (primTypeVal < static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES)),
+        "AssetAttributesManager::buildPrimAttributes : Unknown PrimObjTypes "
+        "value requested :"
+            << primTypeVal << ". Aborting",
+        nullptr);
+    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
+                       static_cast<PrimObjTypes>(primTypeVal))])();
+  }  // buildPrimAttributes
+
+  /**
+   * @brief Build a shared pointer to the appropriate attributes for passed
+   * object type as defined in @ref PrimObjTypes, where each entry except @ref
+   * END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
+   */
+  template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
+  std::shared_ptr<AbstractPrimitiveAttributes> createPrimAttributes() {
+    CORRADE_ASSERT(
+        (primitiveType != PrimObjTypes::END_PRIM_OBJ_TYPES),
+        "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
+        "AbstractPrimitiveAttributes object for "
+        "PrimObjTypes::END_PRIM_OBJ_TYPES. "
+        "Aborting.",
+        nullptr);
+    int idx = static_cast<int>(primitiveType);
+    return T::create(isWireFrame, idx, PrimitiveNames3DMap.at(primitiveType));
+  }
+
+  /**
+   * @brief Build a shared pointer to the appropriate attributes for passed
+   * object type as defined in @ref PrimObjTypes, where each entry except @ref
+   * END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
+   * @param orig original object of type t being copied
+   */
+  template <typename T>
+  std::shared_ptr<AbstractPrimitiveAttributes> createPrimAttributesCopy(
+      const std::shared_ptr<AbstractPrimitiveAttributes>& orig) {
+    return T::create(*(static_cast<T*>(orig.get())));
+  }
+
+ protected:
+  /**
+   * @brief This function will assign the appropriately configured function
+   * pointers for @ref createPrimAttributes calls for each type of
+   * supported primitive to the @ref primTypeConstructorMap, keyed by type of
+   * primtive
+   */
+  void buildMapOfPrimTypeConstructors();
+
+  /**
+   * @brief Define a map type referencing function pointers to @ref
+   * createPrimAttributes() and @ref createPrimAttributesCopy keyed by
+   * string names of classes being instanced, as defined in @ref
+   * PrimNames3D
+   */
+  typedef std::map<std::string,
+                   std::shared_ptr<esp::assets::AbstractPrimitiveAttributes> (
+                       AssetAttributesManager::*)()>
+      Map_Of_PrimTypeCtors;
+
+  /**
+   * @brief Define a map type referencing function pointers to @ref
+   * createPrimAttributes() and @ref createPrimAttributesCopy keyed by
+   * string names of classes being instanced, as defined in @ref
+   * PrimNames3D
+   */
+  typedef std::map<std::string,
+                   std::shared_ptr<esp::assets::AbstractPrimitiveAttributes> (
+                       AssetAttributesManager::*)(
+                       const std::shared_ptr<AbstractPrimitiveAttributes>&)>
+      Map_Of_PrimTypeCopyCtors;
+
+  /**
+   * @brief Map of function pointers to instantiate a primitive attributes
+   * object, keyed by the Magnum primitive class name as listed in @ref
+   * PrimNames3D. A primitive attributes object is instanced by accessing
+   * the approrpiate function pointer.
+   */
+  Map_Of_PrimTypeCtors primTypeConstructorMap_;
+
+  /**
+   * @brief Map of function pointers to instantiate a primitive attributes
+   * object, keyed by the Magnum primitive class name as listed in @ref
+   * PrimNames3D. A primitive attributes object is instanced by accessing
+   * the approrpiate function pointer.
+   */
+  Map_Of_PrimTypeCopyCtors primTypeCopyConstructorMap_;
+
+ public:
+  ESP_SMART_POINTERS(AssetAttributesManager)
+
+};  // AssetAttributesManager
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp
+
+#endif  // ESP_ASSETS_MANAGERS_ASSETATTRIBUTEMANAGER_H_

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -20,6 +20,8 @@
 
 #include "esp/assets/Attributes.h"
 
+namespace Cr = Corrade;
+
 namespace esp {
 namespace assets {
 
@@ -35,9 +37,6 @@ namespace managers {
 template <class T>
 class AttributesManager {
  public:
-  AttributesManager() {}
-  ~AttributesManager() {}
-
   //   //======== Accessor functions ========
 
   /**
@@ -253,11 +252,6 @@ class AttributesManager {
 
 /////////////////////////////
 // Class Template Definitions
-// template <typename T>
-// AttributesManager<T>::AttributesManager() {}
-
-// template <typename T>
-// AttributesManager<T>::~AttributesManager() {}
 
 template <typename T>
 std::string AttributesManager<T>::getRandomTemplateHandlePerType(
@@ -300,24 +294,18 @@ AttributesManager<T>::getTemplateHandlesBySubStringPerType(
     return res;
   }
   // build search criteria
-  std::string strToLookFor(subStr);
+  std::string strToLookFor = Cr::Utility::String::lowercase(subStr);
 
   int strSize = strToLookFor.length();
-  // force lowercase
-  std::transform(strToLookFor.begin(), strToLookFor.end(), strToLookFor.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
 
   for (std::map<int, std::string>::const_iterator iter = mapOfHandles.begin();
        iter != mapOfHandles.end(); ++iter) {
-    std::string key(iter->second);
+    std::string key = Cr::Utility::String::lowercase(iter->second);
     // be sure that key is big enough to search in (otherwise find has undefined
     // behavior)
     if (key.length() < strSize) {
       continue;
     }
-    // force lowercase - search is case insensitive
-    std::transform(key.begin(), key.end(), key.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
     bool found = (std::string::npos != key.find(strToLookFor));
     if (found == contains) {
       // if found and searching for contains, or not found and searching for not

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -1,0 +1,334 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_ASSETS_MANAGERS_ATTRIBUTEMANAGERBASE_H_
+#define ESP_ASSETS_MANAGERS_ATTRIBUTEMANAGERBASE_H_
+
+/** @file
+ * @brief Class Template @ref esp::assets::AttributesManager
+ */
+
+#include <map>
+
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/ConfigurationGroup.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+#include "esp/assets/Attributes.h"
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+/**
+ * @brief Template Class defining responsibilities for managing attributes for
+ * different types of objects, such as scenes, primitive assets, physical
+ * objects, etc.
+ * @tparam T the type of attributes object this class references
+ */
+
+template <class T>
+class AttributesManager {
+ public:
+  AttributesManager() {}
+  ~AttributesManager() {}
+
+  //   //======== Accessor functions ========
+
+  /**
+   * @brief Gets the number of object templates stored in the @ref
+   * templateLibrary_.
+   *
+   * @return The size of the @ref templateLibrary_.
+   */
+  int getNumTemplates() const { return templateLibrary_.size(); }
+
+  /**
+   * @brief Checks whether template library has passed string handle as key
+   * @param handle the key to look for
+   */
+  bool getTemplateLibHasHandle(const std::string& handle) const {
+    return templateLibrary_.count(handle) > 0;
+  }
+
+  /**
+   * @brief Get a reference to the attributes template for the asset
+   * identified by the objectTemplateID.
+   *
+   * Can be used to manipulate a template before instancing new objects.
+   * @param objectTemplateID The ID of the template.  Is mapped to the key
+   * referencing the asset in @ref templateLibrary_ by @ref
+   templateLibKeyByID_.
+   * @return A mutable reference to the object template, or nullptr if does
+   not
+   * exist
+   */
+  std::shared_ptr<T> getAttributesTemplate(const int objectTemplateID) const {
+    std::string key = getTemplateHandleByID(objectTemplateID);
+    CORRADE_ASSERT(getTemplateLibHasHandle(key),
+                   "AttributesManager::getAttributesTemplate : Unknown "
+                   "object template ID:"
+                       << objectTemplateID << ". Aborting",
+                   nullptr);
+    return templateLibrary_.at(key);
+  }  // getAttributesTemplate
+
+  /**
+   * @brief Get a reference to the attributes template for the asset
+   * identified by the passed templateHandle.
+   *
+   * Can be used to manipulate a template before instancing new objects.
+   * @param templateHandle The key referencing the asset in @ref
+   * templateLibrary_.
+   * @return A mutable reference to the object template, or nullptr if does
+   not
+   * exist
+   */
+  std::shared_ptr<T> getAttributesTemplate(
+      const std::string& templateHandle) const {
+    CORRADE_ASSERT(getTemplateLibHasHandle(templateHandle),
+                   "AttributesManager::getAttributesTemplate : Unknown "
+                   "object template Handle:"
+                       << templateHandle << ". Aborting",
+                   nullptr);
+    return templateLibrary_.at(templateHandle);
+  }  // getAttributesTemplate
+
+  /**
+   * @brief Get the key in @ref templateLibrary_ for the object
+   * template index.
+   *
+   * @param templateID The index of the template in @ref templateLibrary_.
+   * @return The key referencing the template in @ref
+   * templateLibrary_, or an empty string if does not exist.
+   */
+  std::string getTemplateHandleByID(const int templateID) const {
+    CORRADE_ASSERT(templateLibKeyByID_.count(templateID) > 0,
+                   "AttributesManager::getTemplateHandleByID : Unknown "
+                   "object template ID:"
+                       << templateID << ". Aborting",
+                   nullptr);
+    return templateLibKeyByID_.at(templateID);
+  }  // getTemplateHandleByID
+
+  /**
+   * @brief Get the ID of the template in @ref templateLibrary_ for the given
+   * template Handle, if exists.  If getNext is true then returns size of
+   * library, otherwise throws assertion and returns ID_UNDEFINED
+   *
+   * @param templateHandle The string key referencing the template in @ref
+   * templateLibrary_.  Usually the origin handle.
+   * @param getNext Whether to get the next available ID if not found, or to
+   * throw an assertion.  Defaults to false
+   * @return The key referencing the template in @ref
+   * templateLibrary_, or an empty string if does not exist.
+   */
+  int getTemplateIDByHandle(const std::string& templateHandle,
+                            bool getNext = false) const {
+    if (getTemplateLibHasHandle(templateHandle)) {
+      return templateLibrary_.at(templateHandle)->getObjectTemplateID();
+    } else {
+      if (!getNext) {
+        CORRADE_ASSERT(false,
+                       "AttributesManager::getTemplateIDByHandle : No template "
+                       " with handle "
+                           << templateHandle << "exists. Aborting",
+                       ID_UNDEFINED);
+
+      } else {
+        // TODO : This needs to return an unused ID number, to support deleting
+        // templates
+        return templateLibrary_.size();
+      }
+    }
+  }  // getTemplateIDByHandle
+
+  /**
+   * @brief Get a random object attribute handle (that could possibly
+   describe
+   * either file-based or a primitive) for the loaded file-based object
+   * templates
+   *
+   * @return a randomly selected handle corresponding to a known object
+   * attributes template, or empty string if none found
+   */
+  std::string getRandomTemplateHandle() const {
+    return getRandomTemplateHandlePerType(templateLibKeyByID_, "");
+  }
+
+  /**
+   * @brief Get a list of all templates whose origin handles contain @ref
+   * subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @param contains whether to search for keys containing, or not
+   containing,
+   * @ref subStr
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getTemplateHandlesBySubstring(
+      const std::string& subStr = "",
+      bool contains = true) const {
+    return getTemplateHandlesBySubStringPerType(templateLibKeyByID_, subStr,
+                                                contains);
+  }
+
+  // protected:
+  /**
+   * @brief add passed template to library, setting objectTemplateID
+   * appropriately.  Called internally by registerTemplate.
+   *
+   * @param attributesTemplate the template to add to the library
+   * @param attributesHandle the origin handle/name of the template to add
+   * @return the objectTemplateID of the template
+   */
+
+  int addTemplateToLibrary(
+      std::shared_ptr<T> attributesTemplate,
+      const std::string& attributesHandle) {  // return either the ID of the
+                                              // existing template referenced by
+    // attributesHandle, or the next available ID if not found.
+    int attributesTemplateID = getTemplateIDByHandle(attributesHandle, true);
+    attributesTemplate->setObjectTemplateID(attributesTemplateID);
+    templateLibrary_[attributesHandle] = attributesTemplate;
+    templateLibKeyByID_.emplace(attributesTemplateID, attributesHandle);
+    return attributesTemplateID;
+  }
+
+  /**
+   * @brief Return a random handle selected from the passed map
+   *
+   * @param mapOfHandles map containing the desired attribute-type template
+   * handles
+   * @param type the type of attributes being retrieved, for debug message
+   * @return a random template handle of the chosen type, or the empty
+   * string if none loaded
+   */
+  std::string getRandomTemplateHandlePerType(
+      const std::map<int, std::string>& mapOfHandles,
+      const std::string& type) const;
+
+  /**
+   * @brief Get a list of all templates of passed type whose origin handles
+   * contain @ref subStr, ignoring subStr's case
+   * @param mapOfHandles map containing the desired object-type template
+   * handles
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @param contains Whether to search for handles containing, or not
+   * containting, @ref subStr
+   * @return vector of 0 or more template handles containing/not containing
+   the
+   * passed substring
+   */
+  std::vector<std::string> getTemplateHandlesBySubStringPerType(
+      const std::map<int, std::string>& mapOfHandles,
+      const std::string& subStr,
+      bool contains) const;
+
+  //   // ======== Instance Variables ========
+
+  /**
+   * @brief Maps string keys to attributes templates
+   */
+  std::map<std::string, std::shared_ptr<T>> templateLibrary_;
+
+  /**
+   * @brief Maps all object attribute IDs to the appropriate handles used
+   by
+   * lib
+   */
+  std::map<int, std::string> templateLibKeyByID_;
+
+ public:
+  ESP_SMART_POINTERS(AttributesManager)
+
+};  // class AttributesManager
+
+/////////////////////////////
+// Class Template Definitions
+// template <typename T>
+// AttributesManager<T>::AttributesManager() {}
+
+// template <typename T>
+// AttributesManager<T>::~AttributesManager() {}
+
+template <typename T>
+std::string AttributesManager<T>::getRandomTemplateHandlePerType(
+    const std::map<int, std::string>& mapOfHandles,
+    const std::string& type) const {
+  int numVals = mapOfHandles.size();
+  if (numVals == 0) {
+    LOG(ERROR) << "Attempting to get a random " << type
+               << "object template handle but none are loaded; Aboring";
+    return "";
+  }
+  int randIDX = rand() % numVals;
+
+  std::string res;
+  for (std::pair<std::map<int, std::string>::const_iterator, int> iter(
+           mapOfHandles.begin(), 0);
+       (iter.first != mapOfHandles.end() && iter.second <= randIDX);
+       ++iter.first, ++iter.second) {
+    res = iter.first->second;
+  }
+  return res;
+}  // getRandomTemplateHandlePerType
+
+template <typename T>
+std::vector<std::string>
+AttributesManager<T>::getTemplateHandlesBySubStringPerType(
+    const std::map<int, std::string>& mapOfHandles,
+    const std::string& subStr,
+    bool contains) const {
+  std::vector<std::string> res;
+  // if empty return empty vector
+  if (mapOfHandles.size() == 0) {
+    return res;
+  }
+  // if search string is empty, return all values
+  if (subStr.length() == 0) {
+    for (auto elem : mapOfHandles) {
+      res.push_back(elem.second);
+    }
+    return res;
+  }
+  // build search criteria
+  std::string strToLookFor(subStr);
+
+  int strSize = strToLookFor.length();
+  // force lowercase
+  std::transform(strToLookFor.begin(), strToLookFor.end(), strToLookFor.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  for (std::map<int, std::string>::const_iterator iter = mapOfHandles.begin();
+       iter != mapOfHandles.end(); ++iter) {
+    std::string key(iter->second);
+    // be sure that key is big enough to search in (otherwise find has undefined
+    // behavior)
+    if (key.length() < strSize) {
+      continue;
+    }
+    // force lowercase - search is case insensitive
+    std::transform(key.begin(), key.end(), key.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    bool found = (std::string::npos != key.find(strToLookFor));
+    if (found == contains) {
+      // if found and searching for contains, or not found and searching for not
+      // contains
+      res.push_back(iter->second);
+    }
+  }
+  return res;
+}  // getTemplateHandlesBySubStringPerType
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp
+#endif  // ESP_ASSETS_MANAGERS_ATTRIBUTESMANAGERBASE_H_

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -1,0 +1,327 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "ObjectAttributesManager.h"
+#include "AttributesManagerBase.h"
+
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/ConfigurationGroup.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+namespace Cr = Corrade;
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+PhysicsObjectAttributes::ptr ObjectAttributesManager::createAttributesTemplate(
+    const std::string& attributesTemplateHandle,
+    bool registerTemplate) {
+  PhysicsObjectAttributes::ptr objAttributes;
+  if (assetAttributesMgr_->getTemplateLibHasHandle(attributesTemplateHandle)) {
+    objAttributes = buildPrimBasedPhysObjTemplate(attributesTemplateHandle);
+  } else {
+    objAttributes = parseAndLoadPhysObjTemplate(attributesTemplateHandle);
+  }
+  if (registerTemplate) {
+    registerAttributesTemplate(objAttributes, attributesTemplateHandle);
+  }
+  return objAttributes;
+}  // ObjectAttributesManager::createAttributesTemplate
+
+int ObjectAttributesManager::registerAttributesTemplate(
+    PhysicsObjectAttributes::ptr objectTemplate,
+    const std::string& objectTemplateHandle) {
+  CORRADE_ASSERT(
+      objectTemplate->getRenderAssetHandle() != "",
+      "ResourceManager::registerObjectTemplate : Attributes template named"
+          << objectTemplateHandle
+          << "does not have a valid render asset handle specified. Aborting.",
+      ID_UNDEFINED);
+  // In case not constructed with origin handle as parameter
+  objectTemplate->setOriginHandle(objectTemplateHandle);
+  std::map<int, std::string>* mapToUse;
+  // Handles for rendering and collision assets
+  std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
+  std::string collisionAssetHandle = objectTemplate->getCollisionAssetHandle();
+
+  if (templateLibrary_.count(renderAssetHandle) > 0) {
+    // If renderAssetHandle corresponds to valid/existing primitive attributes
+    // then setRenderAssetIsPrimitive to true and set map to
+    // physicsSynthObjTmpltLibByID_
+    objectTemplate->setRenderAssetIsPrimitive(true);
+    mapToUse = &physicsSynthObjTmpltLibByID_;
+  } else if (Corrade::Utility::Directory::exists(renderAssetHandle)) {
+    // Check if renderAssetHandle is valid file name and is found in file system
+    // - if so then setRenderAssetIsPrimitive to false and map set to
+    // physicsFileObjTmpltLibByID_ - use primitiveImporter to check if file
+    // exists
+    objectTemplate->setRenderAssetIsPrimitive(false);
+    mapToUse = &physicsFileObjTmpltLibByID_;
+  } else {
+    // If renderAssetHandle is neither valid file name nor existing primitive
+    // attributes template hande, fail
+    LOG(ERROR) << "ResourceManager::registerObjectTemplate : Render asset "
+                  "template handle : "
+               << renderAssetHandle
+               << " specified in object template with handle : "
+               << objectTemplateHandle
+               << " does not correspond to existing file or primitive render "
+                  "asset.  Aborting. ";
+    return ID_UNDEFINED;
+  }
+
+  if (templateLibrary_.count(collisionAssetHandle) > 0) {
+    // If collisionAssetHandle corresponds to valid/existing primitive
+    // attributes then setCollisionAssetIsPrimitive to true
+    objectTemplate->setCollisionAssetIsPrimitive(true);
+  } else if (Corrade::Utility::Directory::exists(collisionAssetHandle)) {
+    // Check if collisionAssetHandle is valid file name and is found in file
+    // system - if so then setCollisionAssetIsPrimitive to false
+    objectTemplate->setCollisionAssetIsPrimitive(false);
+  } else {
+    // Else, means no collision data specified, use specified render data
+    objectTemplate->setCollisionAssetHandle(renderAssetHandle);
+    objectTemplate->setCollisionAssetIsPrimitive(
+        objectTemplate->getRenderAssetIsPrimitive());
+  }
+
+  // Clear dirty flag from when asset handles are changed
+  objectTemplate->setIsClean();
+
+  // Add object template to template library
+  int objectTemplateID =
+      addTemplateToLibrary(objectTemplate, objectTemplateHandle);
+
+  mapToUse->emplace(objectTemplateID, objectTemplateHandle);
+
+  return objectTemplateID;
+}  // ObjectAttributesManager::registerAttributesTemplate
+
+PhysicsObjectAttributes::ptr
+ObjectAttributesManager::parseAndLoadPhysObjTemplate(
+    const std::string& objPhysConfigFilename) {
+  // check for duplicate load
+  const bool objTemplateExists =
+      templateLibrary_.count(objPhysConfigFilename) > 0;
+  if (objTemplateExists) {
+    return templateLibrary_.at(objPhysConfigFilename);
+  }
+
+  // 1. parse the config file
+  io::JsonDocument objPhysicsConfig;
+  if (Corrade::Utility::Directory::exists(objPhysConfigFilename)) {
+    try {
+      objPhysicsConfig = io::parseJsonFile(objPhysConfigFilename);
+    } catch (...) {
+      LOG(ERROR) << "Failed to parse JSON: " << objPhysConfigFilename
+                 << ". Aborting parseAndLoadPhysObjTemplate.";
+      return nullptr;
+    }
+  } else {
+    LOG(ERROR) << "File " << objPhysConfigFilename
+               << " does not exist. Aborting parseAndLoadPhysObjTemplate.";
+    return nullptr;
+  }
+
+  // 2. construct a physicsObjectMetaData
+  auto physicsObjectAttributes =
+      PhysicsObjectAttributes::create(objPhysConfigFilename);
+
+  // NOTE: these paths should be relative to the properties file
+  std::string propertiesFileDirectory =
+      objPhysConfigFilename.substr(0, objPhysConfigFilename.find_last_of("/"));
+
+  // 3. load physical properties to override defaults (set in
+  // PhysicsObjectMetaData.h) load the mass
+  if (objPhysicsConfig.HasMember("mass")) {
+    if (objPhysicsConfig["mass"].IsNumber()) {
+      physicsObjectAttributes->setMass(objPhysicsConfig["mass"].GetDouble());
+    }
+  }
+
+  // optional set bounding box as collision object
+  if (objPhysicsConfig.HasMember("use bounding box for collision")) {
+    if (objPhysicsConfig["use bounding box for collision"].IsBool()) {
+      physicsObjectAttributes->setBoundingBoxCollisions(
+          objPhysicsConfig["use bounding box for collision"].GetBool());
+    }
+  }
+
+  // load the center of mass (in the local frame of the object)
+  // if COM is provided, use it for mesh shift
+  if (objPhysicsConfig.HasMember("COM")) {
+    if (objPhysicsConfig["COM"].IsArray()) {
+      Magnum::Vector3 COM;
+      for (rapidjson::SizeType i = 0; i < objPhysicsConfig["COM"].Size(); i++) {
+        if (!objPhysicsConfig["COM"][i].IsNumber()) {
+          // invalid config
+          LOG(ERROR) << " Invalid value in object physics config - COM array";
+          break;
+        } else {
+          COM[i] = objPhysicsConfig["COM"][i].GetDouble();
+        }
+      }
+      physicsObjectAttributes->setCOM(COM);
+      // set a flag which we can find later so we don't override the desired
+      // COM with BB center.
+      physicsObjectAttributes->setBool("COM_provided", true);
+    }
+  }
+
+  // scaling
+  if (objPhysicsConfig.HasMember("scale")) {
+    if (objPhysicsConfig["scale"].IsArray()) {
+      Magnum::Vector3 scale;
+      for (rapidjson::SizeType i = 0; i < objPhysicsConfig["scale"].Size();
+           i++) {
+        if (!objPhysicsConfig["scale"][i].IsNumber()) {
+          // invalid config
+          LOG(ERROR) << " Invalid value in object physics config - scale array";
+          break;
+        } else {
+          scale[i] = objPhysicsConfig["scale"][i].GetDouble();
+        }
+      }
+      physicsObjectAttributes->setScale(scale);
+    }
+  }
+
+  // load the inertia diagonal
+  if (objPhysicsConfig.HasMember("inertia")) {
+    if (objPhysicsConfig["inertia"].IsArray()) {
+      Magnum::Vector3 inertia;
+      for (rapidjson::SizeType i = 0; i < objPhysicsConfig["inertia"].Size();
+           i++) {
+        if (!objPhysicsConfig["inertia"][i].IsNumber()) {
+          // invalid config
+          LOG(ERROR)
+              << " Invalid value in object physics config - inertia array";
+          break;
+        } else {
+          inertia[i] = objPhysicsConfig["inertia"][i].GetDouble();
+        }
+      }
+      physicsObjectAttributes->setInertia(inertia);
+    }
+  }
+
+  // load the friction coefficient
+  if (objPhysicsConfig.HasMember("friction coefficient")) {
+    if (objPhysicsConfig["friction coefficient"].IsNumber()) {
+      physicsObjectAttributes->setFrictionCoefficient(
+          objPhysicsConfig["friction coefficient"].GetDouble());
+    } else {
+      LOG(ERROR)
+          << " Invalid value in object physics config - friction coefficient";
+    }
+  }
+
+  // load the restitution coefficient
+  if (objPhysicsConfig.HasMember("restitution coefficient")) {
+    if (objPhysicsConfig["restitution coefficient"].IsNumber()) {
+      physicsObjectAttributes->setRestitutionCoefficient(
+          objPhysicsConfig["restitution coefficient"].GetDouble());
+    } else {
+      LOG(ERROR) << " Invalid value in object physics config - restitution "
+                    "coefficient";
+    }
+  }
+
+  //! Get collision configuration options if specified
+  if (objPhysicsConfig.HasMember("join collision meshes")) {
+    if (objPhysicsConfig["join collision meshes"].IsBool()) {
+      physicsObjectAttributes->setJoinCollisionMeshes(
+          objPhysicsConfig["join collision meshes"].GetBool());
+    } else {
+      LOG(ERROR) << " Invalid value in object physics config - join "
+                    "collision meshes";
+    }
+  }
+
+  // if object will be flat or phong shaded
+  if (objPhysicsConfig.HasMember("requires lighting")) {
+    if (objPhysicsConfig["requires lighting"].IsBool()) {
+      physicsObjectAttributes->setRequiresLighting(
+          objPhysicsConfig["requires lighting"].GetBool());
+    } else {
+      LOG(ERROR)
+          << " Invalid value in object physics config - requires lighting";
+    }
+  }
+
+  // 4. parse render and collision mesh filepaths
+  std::string renderMeshFilename = "";
+  std::string collisionMeshFilename = "";
+
+  if (objPhysicsConfig.HasMember("render mesh")) {
+    if (objPhysicsConfig["render mesh"].IsString()) {
+      renderMeshFilename = Cr::Utility::Directory::join(
+          propertiesFileDirectory, objPhysicsConfig["render mesh"].GetString());
+    } else {
+      LOG(ERROR) << " Invalid value in object physics config - render mesh";
+    }
+  }
+  if (objPhysicsConfig.HasMember("collision mesh")) {
+    if (objPhysicsConfig["collision mesh"].IsString()) {
+      collisionMeshFilename = Cr::Utility::Directory::join(
+          propertiesFileDirectory,
+          objPhysicsConfig["collision mesh"].GetString());
+    } else {
+      LOG(ERROR) << " Invalid value in object physics config - collision mesh";
+    }
+  }
+
+  physicsObjectAttributes->setRenderAssetHandle(renderMeshFilename);
+  physicsObjectAttributes->setCollisionAssetHandle(collisionMeshFilename);
+  physicsObjectAttributes->setUseMeshCollision(true);
+
+  return physicsObjectAttributes;
+}  // parseAndLoadPhysObjTemplate
+
+PhysicsObjectAttributes::ptr
+ObjectAttributesManager::buildPrimBasedPhysObjTemplate(
+    const std::string& primAssetHandle) {
+  // verify that a primitive asset with the given handle exists
+
+  CORRADE_ASSERT(assetAttributesMgr_->getTemplateLibHasHandle(primAssetHandle),
+                 " No primitive with handle '"
+                     << primAssetHandle
+                     << "' exists so cannot build physical object.  Aborting.",
+                 nullptr);
+
+  // verify that a template with this asset's name does not exist
+  if (templateLibrary_.count(primAssetHandle) > 0) {
+    return templateLibrary_.at(primAssetHandle);
+  }
+
+  // construct a PhysicsObjectAttributes
+  auto physicsObjectAttributes =
+      PhysicsObjectAttributes::create(primAssetHandle);
+  // set margin to be 0
+  physicsObjectAttributes->setMargin(0.0);
+  // make smaller as default size - prims are approx meter in size
+  physicsObjectAttributes->setScale({0.1, 0.1, 0.1});
+
+  // set render mesh handle
+  physicsObjectAttributes->setRenderAssetHandle(primAssetHandle);
+  // set collision mesh/primitive handle and default for primitives to not use
+  // mesh collisions
+  physicsObjectAttributes->setCollisionAssetHandle(primAssetHandle);
+  physicsObjectAttributes->setUseMeshCollision(false);
+  // NOTE to eventually use mesh collisions with primitive objects, a collision
+  // primitive mesh needs to be configured and set in MeshMetaData and
+  // CollisionMesh
+  return physicsObjectAttributes;
+}  // ResourceManager::buildPrimBasedPhysObjTemplate
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -1,0 +1,193 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_ASSETS_MANAGERS_OBJECTATTRIBUTEMANAGER_H_
+#define ESP_ASSETS_MANAGERS_OBJECTATTRIBUTEMANAGER_H_
+
+#include <Corrade/Utility/Assert.h>
+
+#include "AssetAttributesManager.h"
+#include "AttributesManagerBase.h"
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+/**
+ * @brief single instance class managing templates describing physical objects
+ */
+class ObjectAttributesManager
+    : public AttributesManager<PhysicsObjectAttributes> {
+ public:
+  using AttributesManager<PhysicsObjectAttributes>::AttributesManager;
+  void setAssetAttributesManager(
+      AssetAttributesManager::ptr assetAttributesMgr) {
+    assetAttributesMgr_ = assetAttributesMgr;
+  }
+
+  /**
+   * @brief Creates an instance of a template described by passed string, or
+   * returns existing instance if there is one. For physical objects, this is
+   * either a file name or a reference to a primitive template used in the
+   * construction of the object.
+   *
+   * @param attributesTemplateHandle the origin of the desired template to be
+   * created, either a file name or an existing primitive asset template. If is
+   * not an origin handle to an existing primitive, assumes is file name.
+   * @param registerTemplate whether to add this template to the library or not.
+   * If the user is going to edit this template, this should be false.
+   * @return a reference to the desired template.
+   */
+
+  std::shared_ptr<PhysicsObjectAttributes> createAttributesTemplate(
+      const std::string& attributesTemplateHandle,
+      bool registerTemplate = true);
+
+  /**
+   * @brief Add a @ref AbstractAttributes object to the @ref
+   * templateLibrary_.
+   *
+   * @param objectTemplate The attributes template.
+   * @param objectTemplateHandle The key for referencing the template in the
+   * @ref templateLibrary_. Will be set as origin handle for template.
+   * @return The index in the @ref templateLibrary_ of object
+   * template.
+   */
+  int registerAttributesTemplate(
+      std::shared_ptr<PhysicsObjectAttributes> objectTemplate,
+      const std::string& objectTemplateHandle);
+
+  /**
+   * @brief Gets the number of file-based loaded object templates stored in the
+   * @ref physicsObjTemplateLibrary_.
+   *
+   * @return The number of entries in @ref physicsObjTemplateLibrary_ that are
+   * loaded from files.
+   */
+  int getNumFileTemplateObjects() const {
+    return physicsFileObjTmpltLibByID_.size();
+  };
+  /**
+   * @brief Get a random loaded attribute handle for the loaded file-based
+   * object templates
+   *
+   * @return a randomly selected handle corresponding to a file-based object
+   * attributes template, or empty string if none loaded
+   */
+  std::string getRandomFileTemplateHandle() const {
+    return this->getRandomTemplateHandlePerType(physicsFileObjTmpltLibByID_,
+                                                "file-based ");
+  }
+
+  /**
+   * @brief Get a list of all file-based templates whose origin handles contain
+   * @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing file-based object
+   * templates
+   * @param contains whether to search for keys containing, or not containing,
+   * @ref subStr
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getFileTemplateHandlesBySubstring(
+      const std::string& subStr = "",
+      bool contains = true) const {
+    return this->getTemplateHandlesBySubStringPerType(
+        physicsFileObjTmpltLibByID_, subStr, contains);
+  }
+  /**
+   * @brief Gets the number of synthesized (primitive-based)  template objects
+   * stored in the @ref physicsObjTemplateLibrary_.
+   *
+   * @return The number of entries in @ref physicsObjTemplateLibrary_ that
+   * describe primitives.
+   */
+  int getNumSynthTemplateObjects() const {
+    return physicsSynthObjTmpltLibByID_.size();
+  };
+  /**
+   * @brief Get a random loaded attribute handle for the loaded synthesized
+   * (primitive-based) object templates
+   *
+   * @return a randomly selected handle corresponding to the a primitive
+   * attributes template, or empty string if none loaded
+   */
+  std::string getRandomSynthTemplateHandle() const {
+    return this->getRandomTemplateHandlePerType(physicsSynthObjTmpltLibByID_,
+                                                "synthesized ");
+  }
+  /**
+   * @brief Get a list of all synthesized (primitive-based) object templates
+   * whose origin handles contain @ref subStr, ignoring subStr's case
+   * @param subStr substring to search for within existing primitive object
+   * templates
+   * @param contains whether to search for keys containing, or not containing,
+   * @ref subStr
+   * @return vector of 0 or more template handles containing the passed
+   * substring
+   */
+  std::vector<std::string> getSynthTemplateHandlesBySubstring(
+      const std::string& subStr = "",
+      bool contains = true) const {
+    return this->getTemplateHandlesBySubStringPerType(
+        physicsSynthObjTmpltLibByID_, subStr, contains);
+  }
+
+ protected:
+  /**
+   * @brief Load and parse a physics object template config file and generate a
+   * @ref PhysicsObjectAttributes object.
+   *
+   * @param objPhysConfigFilename The configuration file to parse and load.
+   * @return The object attributes specified by the config file.
+   */
+  PhysicsObjectAttributes::ptr parseAndLoadPhysObjTemplate(
+      const std::string& objPhysConfigFilename);
+
+  /**
+   * @brief Instantiate a @ref PhysicsObjectAttributes for a
+   * synthetic(primitive-based render) object. NOTE : Must be registered to be
+   * available for use via @ref registerObjectTemplate.  This method is provided
+   * so the user can modify a specified physics object template before
+   * registering it.
+   *
+   * @param primAssetHandle The string name of the primitive asset attributes to
+   * be used to synthesize a render asset and solve collisions implicitly for
+   * the desired object.  Will also become the default handle of the resultant
+   * @ref physicsObjectAttributes template
+   * @return The @ref physicsObjectAttributes template based on the passed
+   * primitive
+   */
+  PhysicsObjectAttributes::ptr buildPrimBasedPhysObjTemplate(
+      const std::string& primAssetHandle);
+
+  /**
+   * @brief Reference to AssetAttributesManager to give access to primitive
+   * attributes for object construction
+   */
+  AssetAttributesManager::ptr assetAttributesMgr_ = nullptr;
+
+  /**
+   * @brief Maps loaded object template IDs to the appropriate template
+   * handles
+   */
+  std::map<int, std::string> physicsFileObjTmpltLibByID_;
+
+  /**
+   * @brief Maps synthesized, primitive-based object template IDs to the
+   * appropriate template handles
+   */
+  std::map<int, std::string> physicsSynthObjTmpltLibByID_;
+
+ public:
+  ESP_SMART_POINTERS(ObjectAttributesManager)
+
+};  // ObjectAttributesManager
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp
+
+#endif  // ESP_ASSETS_MANAGERS_OBJECTATTRIBUTEMANAGER_H_

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "PhysicsAttributesManager.h"
+#include "AttributesManagerBase.h"
+
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/ConfigurationGroup.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+namespace Cr = Corrade;
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+PhysicsManagerAttributes::ptr
+PhysicsAttributesManager::createAttributesTemplate(
+    const std::string& physicsFilename,
+    bool registerTemplate) {
+  CORRADE_ASSERT(
+      Cr::Utility::Directory::exists(physicsFilename),
+      "PhysicsAttributesManager::createAttributesTemplate : Specified Filename "
+      ":" << physicsFilename
+          << "cannot be found.  Aborting",
+      nullptr);
+
+  // Load the global scene config JSON here
+  io::JsonDocument scenePhysicsConfig = io::parseJsonFile(physicsFilename);
+  // In-memory representation of scene meta data
+  PhysicsManagerAttributes::ptr physicsManagerAttributes =
+      PhysicsManagerAttributes::create(physicsFilename);
+
+  // load the simulator preference
+  // default is "none" simulator
+  if (scenePhysicsConfig.HasMember("physics simulator")) {
+    if (scenePhysicsConfig["physics simulator"].IsString()) {
+      physicsManagerAttributes->setSimulator(
+          scenePhysicsConfig["physics simulator"].GetString());
+    }
+  }
+
+  // load the physics timestep
+  if (scenePhysicsConfig.HasMember("timestep")) {
+    if (scenePhysicsConfig["timestep"].IsNumber()) {
+      physicsManagerAttributes->setTimestep(
+          scenePhysicsConfig["timestep"].GetDouble());
+    }
+  }
+
+  if (scenePhysicsConfig.HasMember("friction coefficient") &&
+      scenePhysicsConfig["friction coefficient"].IsNumber()) {
+    physicsManagerAttributes->setFrictionCoefficient(
+        scenePhysicsConfig["friction coefficient"].GetDouble());
+  } else {
+    LOG(ERROR) << " Invalid value in scene config - friction coefficient";
+  }
+
+  if (scenePhysicsConfig.HasMember("restitution coefficient") &&
+      scenePhysicsConfig["restitution coefficient"].IsNumber()) {
+    physicsManagerAttributes->setRestitutionCoefficient(
+        scenePhysicsConfig["restitution coefficient"].GetDouble());
+  } else {
+    LOG(ERROR) << " Invalid value in scene config - restitution coefficient";
+  }
+
+  // load gravity
+  if (scenePhysicsConfig.HasMember("gravity")) {
+    if (scenePhysicsConfig["gravity"].IsArray()) {
+      Magnum::Vector3 grav;
+      for (rapidjson::SizeType i = 0; i < scenePhysicsConfig["gravity"].Size();
+           i++) {
+        if (!scenePhysicsConfig["gravity"][i].IsNumber()) {
+          // invalid config
+          LOG(ERROR) << "Invalid value in physics gravity array";
+          break;
+        } else {
+          grav[i] = scenePhysicsConfig["gravity"][i].GetDouble();
+        }
+      }
+      physicsManagerAttributes->setGravity(grav);
+    }
+  }
+
+  // load the rigid object library metadata (no physics init yet...)
+  if (scenePhysicsConfig.HasMember("rigid object paths") &&
+      scenePhysicsConfig["rigid object paths"].IsArray()) {
+    std::string configDirectory =
+        physicsFilename.substr(0, physicsFilename.find_last_of("/"));
+
+    const auto& paths = scenePhysicsConfig["rigid object paths"];
+    for (rapidjson::SizeType i = 0; i < paths.Size(); i++) {
+      if (!paths[i].IsString()) {
+        LOG(ERROR) << "Invalid value in physics scene config -rigid object "
+                      "library- array "
+                   << i;
+        continue;
+      }
+
+      std::string absolutePath =
+          Cr::Utility::Directory::join(configDirectory, paths[i].GetString());
+      std::vector<std::string> validConfigPaths =
+          buildObjectConfigPaths(absolutePath);
+      for (auto& path : validConfigPaths) {
+        physicsManagerAttributes->addStringToGroup("objectLibraryPaths", path);
+      }
+    }
+  }  // if load rigid object library metadata
+
+  if (registerTemplate) {
+    registerAttributesTemplate(physicsManagerAttributes, physicsFilename);
+  }
+
+  return physicsManagerAttributes;
+}  // PhysicsAttributesManager::createAttributesTemplate
+
+std::vector<std::string> PhysicsAttributesManager::buildObjectConfigPaths(
+    const std::string& path) {
+  std::vector<std::string> paths;
+
+  namespace Directory = Cr::Utility::Directory;
+  std::string objPhysPropertiesFilename = path;
+  if (!Corrade::Utility::String::endsWith(objPhysPropertiesFilename,
+                                          ".phys_properties.json")) {
+    objPhysPropertiesFilename = path + ".phys_properties.json";
+  }
+  const bool dirExists = Directory::isDirectory(path);
+  const bool fileExists = Directory::exists(objPhysPropertiesFilename);
+
+  if (!dirExists && !fileExists) {
+    LOG(WARNING) << "Cannot find " << path << " or "
+                 << objPhysPropertiesFilename << ". Aborting parse.";
+    return paths;
+  }
+
+  if (fileExists) {
+    paths.push_back(objPhysPropertiesFilename);
+  }
+
+  if (dirExists) {
+    LOG(INFO) << "Parsing object library directory: " + path;
+    for (auto& file : Directory::list(path, Directory::Flag::SortAscending)) {
+      std::string absoluteSubfilePath = Directory::join(path, file);
+      if (Cr::Utility::String::endsWith(absoluteSubfilePath,
+                                        ".phys_properties.json")) {
+        paths.push_back(absoluteSubfilePath);
+      }
+    }
+  }
+
+  return paths;
+}  // PhysicsAttributesManager::buildObjectConfigPaths
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -1,0 +1,86 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_ASSETS_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
+#define ESP_ASSETS_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
+
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+#include "AttributesManagerBase.h"
+
+#include "esp/gfx/configure.h"
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+namespace Cr = Corrade;
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+class PhysicsAttributesManager
+    : public AttributesManager<PhysicsManagerAttributes> {
+ public:
+  using AttributesManager<PhysicsManagerAttributes>::AttributesManager;
+  /**
+   * @brief Creates an instance of a physics world template described by passed
+   * string. For physics templates, this a file name. Parses global physics
+   * simulation parameters (such as timestep, gravity, simulator implementation)
+   * from the specified configuration file.
+   *
+   * @param physicsFilename The configuration file to parse. Defaults to the
+   * file location @ref ESP_DEFAULT_PHYS_SCENE_CONFIG set by cmake.
+   * @param registerTemplate whether to add this template to the library or not.
+   * If the user is going to edit this template, this should be false.
+   * @return a reference to the physics simulation meta data object parsed from
+   * the specified configuration file.
+   */
+  PhysicsManagerAttributes::ptr createAttributesTemplate(
+      const std::string& physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG,
+      bool registerTemplate = true);
+
+  /**
+   * @brief Add a @ref PhysicsManagerAttributes::ptr object to the @ref
+   * templateLibrary_.
+   *
+   * @param physicsAttributesTemplate The attributes template.
+   * @param physicsAttributesHandle The key for referencing the template in the
+   * @ref templateLibrary_.
+   * @return The index in the @ref templateLibrary_ of object
+   * template.
+   */
+  int registerAttributesTemplate(
+      PhysicsManagerAttributes::ptr physicsAttributesTemplate,
+      const std::string& physicsAttributesHandle) {
+    // return either the ID of the existing template referenced by
+    // physicsAttributesHandle, or the next available ID if not found.
+    int physicsTemplateID = addTemplateToLibrary(physicsAttributesTemplate,
+                                                 physicsAttributesHandle);
+    return physicsTemplateID;
+  }  // PhysicsAttributesManager::registerAttributesTemplate
+
+  /**
+   * @brief Build all "*.phys_properties.json" files from the provided file or
+   * directory path.
+   *
+   * @param path A global path to a physics property file or directory
+   * @return A list of valid global paths to "*.phys_properties.json" files.
+   */
+  std::vector<std::string> buildObjectConfigPaths(const std::string& path);
+
+ protected:
+  // instance vars
+
+ public:
+  ESP_SMART_POINTERS(PhysicsAttributesManager)
+
+};  // PhysicsAttributesManager
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp
+
+#endif  // ESP_ASSETS_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "SceneAttributesManager.h"
+#include "AttributesManagerBase.h"
+
+#include <Corrade/Utility/Assert.h>
+#include <Corrade/Utility/ConfigurationGroup.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/String.h>
+
+namespace esp {
+namespace assets {
+
+namespace managers {
+
+std::shared_ptr<PhysicsSceneAttributes>
+SceneAttributesManager::createAttributesTemplate(
+    const std::string& sceneAttributesHandle,
+    bool registerTemplate) {
+  const bool physSceneExists =
+      templateLibrary_.count(sceneAttributesHandle) > 0;
+  PhysicsSceneAttributes::ptr sceneAttributesTemplate;
+  if (!physSceneExists) {
+    sceneAttributesTemplate =
+        PhysicsSceneAttributes::create(sceneAttributesHandle);
+  } else {
+    sceneAttributesTemplate = templateLibrary_.at(sceneAttributesHandle);
+  }
+  sceneAttributesTemplate->setRenderAssetHandle(sceneAttributesHandle);
+  sceneAttributesTemplate->setCollisionAssetHandle(sceneAttributesHandle);
+
+  if (registerTemplate) {
+    registerAttributesTemplate(sceneAttributesTemplate, sceneAttributesHandle);
+  }
+
+  return sceneAttributesTemplate;
+}  // SceneAttributesManager::createAttributesTemplate
+
+// template class AttributesManager<PhysicsSceneAttributes>;
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -1,0 +1,81 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_ASSETS_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+#define ESP_ASSETS_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+
+#include "AttributesManagerBase.h"
+namespace esp {
+namespace assets {
+
+namespace managers {
+class SceneAttributesManager
+    : public AttributesManager<PhysicsSceneAttributes> {
+ public:
+  using AttributesManager<PhysicsSceneAttributes>::AttributesManager;
+  /**
+   * @brief Creates an instance of a scene template described by passed
+   string.
+   * For scene templates, this a file name.
+   *
+   * @param sceneAttributesHandle the origin of the desired template to be
+   * created, in this case, a file name.
+   * @param registerTemplate whether to add this template to the library or not.
+   * If the user is going to edit this template, this should be false.
+   * @return a reference to the desired template.
+   */
+
+  PhysicsSceneAttributes::ptr createAttributesTemplate(
+      const std::string& sceneAttributesHandle,
+      bool registerTemplate = true);
+  /**
+   * @brief Add a @ref std::shared_ptr<attributesType> object to the
+   * @ref templateLibrary_.
+   *
+   * @param sceneAttributesTemplate The attributes template.
+   * @param sceneAttributesHandle The key for referencing the template in the
+   * @ref templateLibrary_.
+   * @return The index in the @ref templateLibrary_ of object
+   * template.
+   */
+  int registerAttributesTemplate(
+      PhysicsSceneAttributes::ptr sceneAttributesTemplate,
+      const std::string& sceneAttributesHandle) {
+    // return either the ID of the existing template referenced by
+    // sceneAttributesHandle, or the next available ID if not found.
+    int sceneTemplateID = this->addTemplateToLibrary(sceneAttributesTemplate,
+                                                     sceneAttributesHandle);
+    return sceneTemplateID;
+  }  // SceneAttributesManager::registerAttributesTemplate
+
+  /**
+   * @brief Sets all relevant attributes to all scenes based on passed @ref
+   * physicsManagerAttributes.
+   *
+   * @param physicsManagerAttributes The attributes describing the physics world
+   * this scene lives in.
+   */
+  void setSceneValsFromPhysicsAttributes(
+      PhysicsManagerAttributes::ptr physicsManagerAttributes) {
+    for (auto sceneAttr : templateLibrary_) {
+      sceneAttr.second->setFrictionCoefficient(
+          physicsManagerAttributes->getFrictionCoefficient());
+      sceneAttr.second->setRestitutionCoefficient(
+          physicsManagerAttributes->getRestitutionCoefficient());
+    }
+  }  // SceneAttributesManager::setSceneValsFromPhysicsAttributes
+
+ protected:
+  // instance vars
+
+ public:
+  ESP_SMART_POINTERS(SceneAttributesManager)
+
+};  // SceneAttributesManager
+
+}  // namespace managers
+}  // namespace assets
+}  // namespace esp
+
+#endif  // ESP_ASSETS_MANAGERS_SCENEATTRIBUTEMANAGER_H_

--- a/src/esp/bindings/attributesBindings.cpp
+++ b/src/esp/bindings/attributesBindings.cpp
@@ -33,11 +33,32 @@ void initAttributesBindings(py::module& m) {
       .value("UVSPHERE_WF", assets::PrimObjTypes::UVSPHERE_WF)
       .value("END_PRIM_OBJ_TYPE", assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
 
+  // ==== AbstractAttributes ====
+  py::class_<AbstractAttributes, esp::core::Configuration,
+             AbstractAttributes::ptr>(m, "AbstractAttributes")
+      .def(py::init(&AbstractAttributes::create<>))
+      .def(py::init(&AbstractAttributes::create<const std::string&>))
+      .def("set_origin_handle", &AbstractAttributes::setOriginHandle,
+           "origin_handle"_a)
+      .def("get_origin_handle", &AbstractAttributes::getOriginHandle);
+
   // ==== AbstractPhysicsAttributes ====
-  py::class_<AbstractPhysicsAttributes, esp::core::Configuration,
+  py::class_<AbstractPhysicsAttributes, AbstractAttributes,
              AbstractPhysicsAttributes::ptr>(m, "AbstractPhysicsAttributes")
       .def(py::init(&AbstractPhysicsAttributes::create<>))
-      .def(py::init(&AbstractPhysicsAttributes::create<const std::string&>));
+      .def(py::init(&AbstractPhysicsAttributes::create<const std::string&>))
+      .def("set_scale", &AbstractPhysicsAttributes::setScale, "scale"_a)
+      .def("get_scale", &AbstractPhysicsAttributes::getScale)
+      .def("set_friction_coefficient",
+           &AbstractPhysicsAttributes::setFrictionCoefficient,
+           "friction_coefficient"_a)
+      .def("get_friction_coefficient",
+           &AbstractPhysicsAttributes::getFrictionCoefficient)
+      .def("set_restitution_coefficient",
+           &AbstractPhysicsAttributes::setRestitutionCoefficient,
+           "restitution_coefficient"_a)
+      .def("get_restitution_coefficient",
+           &AbstractPhysicsAttributes::getRestitutionCoefficient);
 
   // ==== PhysicsObjectAttributes ====
   py::class_<PhysicsObjectAttributes, AbstractPhysicsAttributes,
@@ -52,27 +73,13 @@ void initAttributesBindings(py::module& m) {
       .def("get_mass", &PhysicsObjectAttributes::getMass)
       .def("set_inertia", &PhysicsObjectAttributes::setInertia, "inertia"_a)
       .def("get_inertia", &PhysicsObjectAttributes::getInertia)
-      .def("set_scale", &PhysicsObjectAttributes::setScale, "scale"_a)
-      .def("get_scale", &PhysicsObjectAttributes::getScale)
-      .def("set_friction_coefficient",
-           &PhysicsObjectAttributes::setFrictionCoefficient,
-           "friction_coefficient"_a)
-      .def("get_friction_coefficient",
-           &PhysicsObjectAttributes::getFrictionCoefficient)
-      .def("set_restitution_coefficient",
-           &PhysicsObjectAttributes::setRestitutionCoefficient,
-           "restitution_coefficient"_a)
-      .def("get_restitution_coefficient",
-           &PhysicsObjectAttributes::getRestitutionCoefficient)
+
       .def("set_linear_damping", &PhysicsObjectAttributes::setLinearDamping,
            "linear_damping"_a)
       .def("get_linear_damping", &PhysicsObjectAttributes::getLinearDamping)
       .def("set_angular_damping", &PhysicsObjectAttributes::setAngularDamping,
            "angular_damping"_a)
       .def("get_angular_damping", &PhysicsObjectAttributes::getAngularDamping)
-      .def("set_origin_handle", &PhysicsObjectAttributes::setOriginHandle,
-           "origin_handle"_a)
-      .def("get_origin_handle", &PhysicsObjectAttributes::getOriginHandle)
       .def("set_render_asset_handle",
            &PhysicsObjectAttributes::setRenderAssetHandle,
            "render_asset_handle"_a)
@@ -99,11 +106,10 @@ void initAttributesBindings(py::module& m) {
            &PhysicsObjectAttributes::getRequiresLighting);
 
   // ==== AbstractPrimitiveAttributes ====
-  py::class_<AbstractPrimitiveAttributes, esp::core::Configuration,
+  py::class_<AbstractPrimitiveAttributes, AbstractAttributes,
              AbstractPrimitiveAttributes::ptr>(m, "AbstractPrimitiveAttributes")
       .def(py::init(
           &AbstractPrimitiveAttributes::create<bool, int, const std::string&>))
-      .def("get_origin_handle", &AbstractPrimitiveAttributes::getOriginHandle)
       .def("get_is_wireframe", &AbstractPrimitiveAttributes::getIsWireframe)
       .def("set_use_texture_coords",
            &AbstractPrimitiveAttributes::setUseTextureCoords,

--- a/src/esp/bindings/attributesBindings.cpp
+++ b/src/esp/bindings/attributesBindings.cpp
@@ -8,6 +8,7 @@
 #include <Magnum/Python.h>
 
 #include "esp/assets/Attributes.h"
+#include "esp/assets/ResourceManager.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;
@@ -16,6 +17,22 @@ namespace esp {
 namespace assets {
 
 void initAttributesBindings(py::module& m) {
+  // ==== PrimObjTypes enum describing types of primitives supported ====
+  py::enum_<assets::PrimObjTypes>(m, "PrimObjTypes")
+      .value("CAPSULE_SOLID", assets::PrimObjTypes::CAPSULE_SOLID)
+      .value("CAPSULE_WF", assets::PrimObjTypes::CAPSULE_WF)
+      .value("CONE_SOLID", assets::PrimObjTypes::CONE_SOLID)
+      .value("CONE_WF", assets::PrimObjTypes::CONE_WF)
+      .value("CUBE_SOLID", assets::PrimObjTypes::CUBE_SOLID)
+      .value("CUBE_WF", assets::PrimObjTypes::CUBE_WF)
+      .value("CYLINDER_SOLID", assets::PrimObjTypes::CYLINDER_SOLID)
+      .value("CYLINDER_WF", assets::PrimObjTypes::CYLINDER_WF)
+      .value("ICOSPHERE_SOLID", assets::PrimObjTypes::ICOSPHERE_SOLID)
+      .value("ICOSPHERE_WF", assets::PrimObjTypes::ICOSPHERE_WF)
+      .value("UVSPHERE_SOLID", assets::PrimObjTypes::UVSPHERE_SOLID)
+      .value("UVSPHERE_WF", assets::PrimObjTypes::UVSPHERE_WF)
+      .value("END_PRIM_OBJ_TYPE", assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
+
   // ==== AbstractPhysicsAttributes ====
   py::class_<AbstractPhysicsAttributes, esp::core::Configuration,
              AbstractPhysicsAttributes::ptr>(m, "AbstractPhysicsAttributes")
@@ -80,7 +97,90 @@ void initAttributesBindings(py::module& m) {
            &PhysicsObjectAttributes::setRequiresLighting, "requires_lighting"_a)
       .def("get_requires_lighting",
            &PhysicsObjectAttributes::getRequiresLighting);
-}
+
+  // ==== AbstractPrimitiveAttributes ====
+  py::class_<AbstractPrimitiveAttributes, esp::core::Configuration,
+             AbstractPrimitiveAttributes::ptr>(m, "AbstractPrimitiveAttributes")
+      .def(py::init(
+          &AbstractPrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("get_origin_handle", &AbstractPrimitiveAttributes::getOriginHandle)
+      .def("get_is_wireframe", &AbstractPrimitiveAttributes::getIsWireframe)
+      .def("set_use_texture_coords",
+           &AbstractPrimitiveAttributes::setUseTextureCoords,
+           "use_texture_coords"_a)
+      .def("get_use_texture_coords",
+           &AbstractPrimitiveAttributes::getUseTextureCoords)
+      .def("set_use_tangents", &AbstractPrimitiveAttributes::setUseTangents,
+           "use_tangents"_a)
+      .def("get_use_tangents", &AbstractPrimitiveAttributes::getUseTangents)
+
+      .def("set_num_rings", &AbstractPrimitiveAttributes::setNumRings,
+           "num_rings"_a)
+      .def("get_num_rings", &AbstractPrimitiveAttributes::getNumRings)
+      .def("set_num_segments", &AbstractPrimitiveAttributes::setNumSegments,
+           "num_segments"_a)
+      .def("get_num_segments", &AbstractPrimitiveAttributes::getNumSegments)
+      .def("set_half_length", &AbstractPrimitiveAttributes::setHalfLength,
+           "half_length"_a)
+      .def("get_half_length", &AbstractPrimitiveAttributes::getHalfLength)
+      .def("get_prim_obj_class_name",
+           &AbstractPrimitiveAttributes::getPrimObjClassName)
+      .def("get_prim_obj_type", &AbstractPrimitiveAttributes::getPrimObjType);
+
+  // ==== CapsulePrimitiveAttributes ====
+  py::class_<CapsulePrimitiveAttributes, AbstractPrimitiveAttributes,
+             CapsulePrimitiveAttributes::ptr>(m, "CapsulePrimitiveAttributes")
+      .def(py::init(
+          &CapsulePrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("set_hemisphere_rings",
+           &CapsulePrimitiveAttributes::setHemisphereRings,
+           "hemisphere_rings"_a)
+      .def("get_hemisphere_rings",
+           &CapsulePrimitiveAttributes::getHemisphereRings)
+      .def("set_cylinder_rings", &CapsulePrimitiveAttributes::setCylinderRings,
+           "cylinder_rings"_a)
+      .def("get_cylinder_rings", &CapsulePrimitiveAttributes::getCylinderRings);
+
+  // ==== ConePrimitiveAttributes ====
+  py::class_<ConePrimitiveAttributes, AbstractPrimitiveAttributes,
+             ConePrimitiveAttributes::ptr>(m, "ConePrimitiveAttributes")
+      .def(py::init(
+          &ConePrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("set_cap_end", &ConePrimitiveAttributes::setCapEnd, "cap_end"_a)
+      .def("get_cap_end", &ConePrimitiveAttributes::getCapEnd);
+
+  // ==== CubePrimitiveAttributes ====
+  py::class_<CubePrimitiveAttributes, AbstractPrimitiveAttributes,
+             CubePrimitiveAttributes::ptr>(m, "CubePrimitiveAttributes")
+      .def(py::init(
+          &CubePrimitiveAttributes::create<bool, int, const std::string&>));
+
+  // ==== CylinderPrimitiveAttributes ====
+  py::class_<CylinderPrimitiveAttributes, AbstractPrimitiveAttributes,
+             CylinderPrimitiveAttributes::ptr>(m, "CylinderPrimitiveAttributes")
+      .def(py::init(
+          &CylinderPrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("set_cap_ends", &CylinderPrimitiveAttributes::setCapEnds,
+           "cap_ends"_a)
+      .def("get_cap_ends", &CylinderPrimitiveAttributes::getCapEnds);
+
+  // ==== IcospherePrimitiveAttributes ====
+  py::class_<IcospherePrimitiveAttributes, AbstractPrimitiveAttributes,
+             IcospherePrimitiveAttributes::ptr>(m,
+                                                "IcospherePrimitiveAttributes")
+      .def(py::init(
+          &IcospherePrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("set_subdivisions", &IcospherePrimitiveAttributes::setSubdivisions,
+           "subdivisions"_a)
+      .def("get_subdivisions", &IcospherePrimitiveAttributes::getSubdivisions);
+
+  // ==== UVSpherePrimitiveAttributes ====
+  py::class_<UVSpherePrimitiveAttributes, AbstractPrimitiveAttributes,
+             UVSpherePrimitiveAttributes::ptr>(m, "UVSpherePrimitiveAttributes")
+      .def(py::init(
+          &UVSpherePrimitiveAttributes::create<bool, int, const std::string&>));
+
+}  // initAttributesBindings
 
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -328,8 +328,10 @@ int Simulator::addObjectByHandle(const std::string& objectLibHandle,
 
 std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
   std::vector<int> templateIndices;
+  auto physicsAttributesManager =
+      resourceManager_->getPhysicsAttributesManager();
   std::vector<std::string> validConfigPaths =
-      resourceManager_->buildObjectConfigPaths(path);
+      physicsAttributesManager->buildObjectConfigPaths(path);
   for (auto& validPath : validConfigPaths) {
     templateIndices.push_back(
         resourceManager_->parseAndLoadPhysObjTemplate(validPath));

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -155,7 +155,6 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
     // if we have a simulation implementation then test bounding box vs mesh for
     // sphere object
 
-    // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -228,7 +227,6 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
 
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
-    // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -272,7 +270,6 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
   if (physicsManager_->getPhysicsSimulationLibrary() ==
       PhysicsManager::PhysicsSimulationLibrary::BULLET) {
     // test joined vs. unjoined
-    // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -310,7 +307,7 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
     const Magnum::Range3D AabbOb1 =
         bPhysManager->getCollisionShapeAabb(objectId1);
     const Magnum::Range3D AabbOb2 =
-        bPhysManager->getCollisionShapeAabb(objectId1);
+        bPhysManager->getCollisionShapeAabb(objectId2);
 
     Magnum::Range3D objectGroundTruth({-1.1, -1.1, -1.1}, {1.1, 1.1, 1.1});
     Magnum::Range3D sceneGroundTruth({-1.04, -1.04, -1.04}, {1.04, 1.04, 1.04});
@@ -333,7 +330,6 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   initScene("NONE");
 
   // test joined vs. unjoined
-  // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
   esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -399,7 +395,6 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
 
   initScene(sceneFile);
 
-  // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
   esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -544,7 +539,6 @@ TEST_F(PhysicsManagerTest, TestSceneNodeAttachment) {
 
   initScene(sceneFile);
 
-  // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
   esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
@@ -602,7 +596,7 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
     float boxHalfExtent = 0.2;
-    // esp::assets::PhysicsObjectAttributes physicsObjectAttributes;
+
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -40,7 +40,6 @@ def test_kinematics(sim):
     # get handle for object 0, used to test
     obj_handle_list = sim.get_template_handles("cheezit")
     object_id = sim.add_object_by_handle(obj_handle_list[0])
-    # object_id = sim.add_object(0)
     assert len(sim.get_existing_object_ids()) > 0
 
     # test setting the motion type
@@ -86,7 +85,6 @@ def test_kinematics(sim):
 
     obj_handle_list = sim.get_template_handles("cheezit")
     object_id = sim.add_object_by_handle(obj_handle_list[0])
-    # object_id = sim.add_object(0)
 
     prev_time = 0.0
     for _ in range(2):
@@ -262,7 +260,6 @@ def test_velocity_control(sim):
     for iteration in range(2):
         sim.reset()
         object_id = sim.add_object_by_handle(obj_handle)
-        # object_id = sim.add_object(template_ids[0])
         vel_control = sim.get_object_velocity_control(object_id)
 
         if iteration == 0:


### PR DESCRIPTION
## Motivation and Context
As per comments in #639, the accessor methods for attributes quantities are becoming absurdly long.  This is because of the extant chaining for all of these quantities through Simulator and into ResourceManager - full context must be given to differentiate functionality with respect to Simulator.  Furthermore, in order to support flexible editing capabilities, ResourceManager is becoming intolerably large, filled with nearly duplicated methods to handle attributes, and only stands to get larger as new attribute-related functionality is implemented.

Enter AttributeManagers.  This PR introduces AttributesManagers as a mechanism for managing instantiation and interaction with all attributes.  No more going through Simulator->ResourceManager for every attribute-related interaction, now the user will just request the appropriate attribute manager and consume it to directly work on the attributes themselves.

This PR includes a first pass of all 4 AttributeManager implementations, and uses SceneAttributeManager and PhysicsAttributeManager within ResourceManager directly, to provide a proof of concept.  The implementations for ObjectAttributeManager and AssetAttributeManager are included for review but are not yet consumed.

Also, this PR has some small bug fixes and comment cleanup.

  
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
c++ and python tests passed.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
