### PR TITLE
Attributes managers objects and assets

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -12,8 +12,9 @@ namespace assets {
 //----------------------------------------//
 
 AbstractPhysicsAttributes::AbstractPhysicsAttributes(
+    const std::string& classKey,
     const std::string& originHandle)
-    : AbstractAttributes(originHandle) {
+    : AbstractAttributes(classKey, originHandle) {
   setFrictionCoefficient(0.5);
   setRestitutionCoefficient(0.1);
   setRenderAssetHandle("");
@@ -30,7 +31,7 @@ AbstractPhysicsAttributes::AbstractPhysicsAttributes(
 
 PhysicsObjectAttributes::PhysicsObjectAttributes(
     const std::string& originHandle)
-    : AbstractPhysicsAttributes(originHandle) {
+    : AbstractPhysicsAttributes("PhysicsObjectAttributes", originHandle) {
   // fill necessary attribute defaults
   setMass(1.0);
   setMargin(0.04);
@@ -55,7 +56,7 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
 }  // PhysicsObjectAttributes ctor
 
 PhysicsSceneAttributes::PhysicsSceneAttributes(const std::string& originHandle)
-    : AbstractPhysicsAttributes(originHandle) {
+    : AbstractPhysicsAttributes("PhysicsSceneAttributes", originHandle) {
   setGravity({0, -9.8, 0});
   // TODO do these defaults need to be maintained here?
   setFrictionCoefficient(0.4);
@@ -64,7 +65,7 @@ PhysicsSceneAttributes::PhysicsSceneAttributes(const std::string& originHandle)
 
 PhysicsManagerAttributes::PhysicsManagerAttributes(
     const std::string& originHandle)
-    : AbstractAttributes(originHandle) {
+    : AbstractAttributes("PhysicsManagerAttributes", originHandle) {
   setSimulator("none");
   setTimestep(0.01);
   setMaxSubsteps(10);

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -24,9 +24,17 @@ namespace assets {
  */
 class AbstractAttributes : public esp::core::Configuration {
  public:
-  AbstractAttributes(const std::string& originHandle = "") : Configuration() {
+  AbstractAttributes(const std::string& classKey,
+                     const std::string& originHandle)
+      : Configuration() {
+    setClassKey(classKey);
     setOriginHandle(originHandle);
   }
+  /**
+   * @brief Get this attributes' class.  Should only be set from constructor.
+   * Used as key in constructor function pointer maps in AttributesManagers.
+   */
+  std::string getClassKey() const { return getString("classKey"); }
 
   /**
    * @brief Set this attributes name/origin.  Some attributes derive their own
@@ -43,6 +51,17 @@ class AbstractAttributes : public esp::core::Configuration {
   }
   int getObjectTemplateID() const { return getInt("objectTemplateID"); }
 
+ protected:
+  /**
+   * @brief Set this attributes' class.  Should only be set from constructor.
+   * Used as key in constructor function pointer maps in AttributesManagers.
+   * @param classKey the string handle corresponding to the constructors used to
+   * make copies of this object in copy constructor map.
+   */
+  void setClassKey(const std::string& classKey) {
+    setString("classKey", classKey);
+  }
+
  public:
   ESP_SMART_POINTERS(AbstractAttributes)
 };  // class AbstractAttributes
@@ -54,7 +73,8 @@ class AbstractAttributes : public esp::core::Configuration {
  */
 class AbstractPhysicsAttributes : public AbstractAttributes {
  public:
-  AbstractPhysicsAttributes(const std::string& originHandle = "");
+  AbstractPhysicsAttributes(const std::string& classKey,
+                            const std::string& originHandle);
   // forcing this class to be abstract - note still needs definition
   // can't do this because of pybind issues, currently
   // virtual ~AbstractPhysAttributes() = 0;
@@ -280,7 +300,7 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   AbstractPrimitiveAttributes(bool isWireframe,
                               int primObjType,
                               const std::string& primObjClassName)
-      : AbstractAttributes("") {
+      : AbstractAttributes(primObjClassName, "") {
     setIsWireframe(isWireframe);
     setPrimObjType(primObjType);
     setPrimObjClassName(primObjClassName);

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -15,10 +15,10 @@ set(assets_SOURCES
   Mp3dInstanceMeshData.cpp
   Mp3dInstanceMeshData.h
   managers/AttributesManagerBase.h
-  # managers/AssetAttributesManager.h
-  # managers/AssetAttributesManager.cpp
-  # managers/ObjectAttributesManager.h
-  # managers/ObjectAttributesManager.cpp
+  managers/AssetAttributesManager.h
+  managers/AssetAttributesManager.cpp
+  managers/ObjectAttributesManager.h
+  managers/ObjectAttributesManager.cpp
   managers/PhysicsAttributesManager.h
   managers/PhysicsAttributesManager.cpp
   managers/SceneAttributesManager.h

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -93,10 +93,10 @@ ResourceManager::ResourceManager()
 
   initDefaultLightSetups();
   initDefaultMaterials();
-  buildMapOfPrimTypeConstructors();
+  buildImportersAndAttributesManagers();
 }  // namespace assets
 
-void ResourceManager::buildMapOfPrimTypeConstructors() {
+void ResourceManager::buildImportersAndAttributesManagers() {
   primTypeConstructorMap_["capsule3DSolid"] =
       &ResourceManager::createPrimitiveAttributes<
           assets::CapsulePrimitiveAttributes, false,
@@ -149,12 +149,18 @@ void ResourceManager::buildMapOfPrimTypeConstructors() {
     addPrimAssetTemplateToLibrary(attr);
   }
 
-  // assetAttributesManager_ = managers::AssetAttributesManager::create();
-  // objectAttributesManager_ = managers::ObjectAttributesManager::create();
-  // objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
+  assetAttributesManager_ = managers::AssetAttributesManager::create();
+  objectAttributesManager_ = managers::ObjectAttributesManager::create();
+  objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create();
   sceneAttributesManager_ = managers::SceneAttributesManager::create();
 
+  LOG(INFO) << "asset attr mgr query : "
+            << assetAttributesManager_->getNumTemplates();
+  LOG(INFO) << "object attr mgr query : "
+            << objectAttributesManager_->getNumTemplates();
+  LOG(INFO) << "physics attr mgr query : "
+            << physicsAttributesManager_->getNumTemplates();
   LOG(INFO) << "Scene attr mgr query : "
             << sceneAttributesManager_->getNumTemplates();
 
@@ -168,7 +174,7 @@ void ResourceManager::buildMapOfPrimTypeConstructors() {
   CORRADE_INTERNAL_ASSERT_OUTPUT(
       fileImporter_ = importerManager_.loadAndInstantiate("AnySceneImporter"));
 
-}  // buildMapOfPrimTypeConstructors
+}  // buildImportersAndAttributesManagers
 
 void ResourceManager::initDefaultPrimAttributes() {
   // by this point, we should have a GL::Context so load the bb primitive.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -99,13 +99,6 @@ class ResourceManager {
   static constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] =
       "per_vertex_object_id";
 
-  /**
-   * @brief Constant Map holding names of all Magnum 3D primitive classes
-   * supported, keyed by @ref PrimObjTypes enum entry.  Note final entry is not
-   * a valid primitive.
-   */
-  static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
-
   /** @brief Constructor */
   explicit ResourceManager();
 
@@ -287,66 +280,28 @@ class ResourceManager {
   /**
    * @brief Return manager for construction and access to asset attributes.
    */
-  managers::AssetAttributesManager::ptr getAssetAttributesManager() {
+  managers::AssetAttributesManager::ptr getAssetAttributesManager() const {
     return assetAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to object attributes.
    */
-  managers::ObjectAttributesManager::ptr getObjectAttributesManager() {
+  managers::ObjectAttributesManager::ptr getObjectAttributesManager() const {
     return objectAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
    */
-  managers::PhysicsAttributesManager::ptr getPhysicsAttributesManager() {
+  managers::PhysicsAttributesManager::ptr getPhysicsAttributesManager() const {
     return physicsAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
-  managers::SceneAttributesManager::ptr getsceneAttributesManager() {
+  managers::SceneAttributesManager::ptr getsceneAttributesManager() const {
     return sceneAttributesManager_;
   }
-
-  /**
-   * @brief Get the key in @ref primitiveAssetTemplateLibrary_ for the passed
-   * object template asset ID.
-   *
-   * @param objectTemplateID The index of the object template in @ref
-   * primitiveAssetTmpltLibByID_.
-   * @return The key referencing the template in @ref
-   * primitiveAssetTmpltLibByID_, or an empty string if does not exist.
-   */
-  std::string getPrimitiveAssetTemplateHandle(const int primTemplateID) const {
-    CORRADE_ASSERT(primitiveAssetTemplateLibByID_.count(primTemplateID) > 0,
-                   "ResourceManager::getPrimitiveAssetTemplateHandle : No "
-                   "primitive asset template with index"
-                       << primTemplateID << "exists. Aborting",
-                   "");
-    return primitiveAssetTemplateLibByID_.at(primTemplateID);
-  }  // getPrimitiveAssetTemplateHandle
-
-  /**
-   * @brief Get a ref to the primitive asset attributes object for the primitive
-   * identified by the string key.
-   * @param primTemplateHandle the string key of the attributes desired - this
-   * key will be synthesized based on attributes values.
-   * @return the desired primitive attributes, or nullptr if does not exist
-   */
-  AbstractPrimitiveAttributes::ptr getPrimitiveAssetTemplateAttributes(
-      const std::string& primTemplateHandle) const {
-    CORRADE_ASSERT(
-        (primitiveAssetTemplateLibrary_.count(primTemplateHandle) > 0),
-        "ResourceManager::getPrimitiveAssetTemplateAttributes : Unknown "
-        "primitive "
-        "asset template handle :"
-            << primTemplateHandle << ". Aborting",
-        nullptr);
-    return primitiveAssetTemplateLibrary_.at(primTemplateHandle);
-  }
-
   /**
    * @brief Get the key in @ref physicsObjTemplateLibrary_ for the object
    * template index.
@@ -677,70 +632,7 @@ class ResourceManager {
    */
   inline void compressTextures(bool newVal) { compressTextures_ = newVal; };
 
-  /**
-   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
-   * with passed class name
-   */
-  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(
-      const std::string& primTypeName) {
-    CORRADE_ASSERT(
-        primTypeConstructorMap_.count(primTypeName) > 0,
-        "ResourceManager::buildPrimitiveAttributes : No primivite of type"
-            << primTypeName << "exists.  Aborting.",
-        nullptr);
-    return (*this.*primTypeConstructorMap_[primTypeName])();
-  }  // buildPrimitiveAttributes
-
-  /**
-   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
-   * with passed enum value, which maps to class name via @ref
-   * PrimitiveNames3DMap
-   */
-  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(
-      PrimObjTypes& primType) {
-    CORRADE_ASSERT(
-        primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
-        "ResourceManager::buildPrimitiveAttributes : Illegal primtitive type "
-        "name sPrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
-        nullptr);
-    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])();
-  }  // buildPrimitiveAttributes
-
-  /**
-   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
-   * with passed enum value, which maps to class name via @ref
-   * PrimitiveNames3DMap
-   */
-  AbstractPrimitiveAttributes::ptr buildPrimitiveAttributes(int primTypeVal) {
-    CORRADE_ASSERT(
-        (primTypeVal >= 0) &&
-            (primTypeVal < static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES)),
-        "ResourceManager::buildPrimitiveAttributes : Unknown PrimObjTypes "
-        "value requested :"
-            << primTypeVal << ". Aborting",
-        nullptr);
-    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
-                       static_cast<PrimObjTypes>(primTypeVal))])();
-  }  // buildPrimitiveAttributes
-
  private:
-  /**
-   * @brief Build a shared pointer to the appropriate attributes for passed
-   * object type as defined in @ref PrimObjTypes, where each entry except @ref
-   * END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
-   */
-  template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
-  std::shared_ptr<AbstractPrimitiveAttributes> createPrimitiveAttributes() {
-    CORRADE_ASSERT(
-        (primitiveType != PrimObjTypes::END_PRIM_OBJ_TYPES),
-        "ResourceManager::createPrimitiveAttributes : Cannot instantiate "
-        "PrimitiveAttributes object for PrimObjTypes::END_PRIM_OBJ_TYPES. "
-        "Aborting.",
-        nullptr);
-    int idx = static_cast<int>(primitiveType);
-    return T::create(isWireFrame, idx, PrimitiveNames3DMap.at(primitiveType));
-  }
-
   /**
    * @brief Load all file-based object templates given string list of object
    * template file locations.
@@ -824,17 +716,6 @@ class ResourceManager {
       PhysicsObjectAttributes::ptr objectTemplate,
       const std::string& objectTemplateHandle,
       std::map<int, std::string>& mapOfNames);
-
-  /**
-   * @brief Add primitive asset template attributes to appropriate template
-   * library map and index list
-   *
-   * @param primTemplate ptr to primitive template attributes to be added to
-   * library
-   * @return the index of added primitive asset template in names map
-   */
-  int addPrimAssetTemplateToLibrary(
-      AbstractPrimitiveAttributes::ptr primTemplate);
 
  protected:
   // ======== Structs and Types only used locally ========
@@ -1265,22 +1146,6 @@ class ResourceManager {
       physicsObjectTemplateLibrary_;
 
   /**
-   * @brief Maps string keys (built from primitive attributes themselves) to
-   * primitive templates.
-   *
-   */
-  std::map<std::string, AbstractPrimitiveAttributes::ptr>
-      primitiveAssetTemplateLibrary_;
-
-  /**
-   * @brief Map of function pointers to instantiate a primitive attributes
-   * object, keyed by the Magnum primitive class name as listed in @ref
-   * PrimitiveNames3D. A primitive attributes object is instanced by accessing
-   * the approrpiate function pointer.
-   */
-  Map_Of_PrimTypes primTypeConstructorMap_;
-
-  /**
    * @brief Primitive meshes available for instancing via @ref
    * addPrimitiveToDrawables for debugging or visualization purposes.
    */
@@ -1309,12 +1174,6 @@ class ResourceManager {
    * appropriate template handles
    */
   std::map<int, std::string> physicsSynthObjTmpltLibByID_;
-  /**
-   * @brief Maps primitive object template IDs to primitive template handles
-   * (composite strings built from specified attributes values for primitive)
-   */
-  std::map<int, std::string> primitiveAssetTemplateLibByID_;
-
   /**
    * @brief Flag to denote the desire to compress textures. TODO: unused?
    */

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -35,8 +35,8 @@
 #include "esp/gfx/configure.h"
 #include "esp/scene/SceneNode.h"
 
-// #include "managers/AssetAttributesManager.h"
-// #include "managers/ObjectAttributesManager.h"
+#include "managers/AssetAttributesManager.h"
+#include "managers/ObjectAttributesManager.h"
 #include "managers/PhysicsAttributesManager.h"
 #include "managers/SceneAttributesManager.h"
 
@@ -64,65 +64,6 @@ namespace nav {
 class PathFinder;
 }
 namespace assets {
-
-/**
- * @brief The kinds of primitive modelled objects supported.  Paired with
- * Magnum::Primitive namespace objects
- */
-enum class PrimObjTypes : uint32_t {
-  /**
-   * Primitive object corresponding to Magnum::Primitives::capsule3DSolid
-   */
-  CAPSULE_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::capsule3DWireframe
-   */
-  CAPSULE_WF,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::coneSolid
-   */
-  CONE_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::coneWireframe
-   */
-  CONE_WF,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::cubeSolid
-   */
-  CUBE_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::cubeWireframe
-   */
-  CUBE_WF,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::cylinderSolid
-   */
-  CYLINDER_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::cylinderWireframe
-   */
-  CYLINDER_WF,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::icosphereSolid
-   */
-  ICOSPHERE_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::icosphereWireframe
-   */
-  ICOSPHERE_WF,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::uvSphereSolid
-   */
-  UVSPHERE_SOLID,
-  /**
-   * Primitive object corresponding to Magnum::Primitives::uvSphereWireframe
-   */
-  UVSPHERE_WF,
-  /**
-   * marker for no more primitive objects - add any new objects above this entry
-   */
-  END_PRIM_OBJ_TYPES
-};
 
 /**
  * @brief Singleton class responsible for
@@ -172,12 +113,11 @@ class ResourceManager {
   ~ResourceManager() {}
 
   /**
-   * @brief This function will assign the appropriately configured function
-   * pointers for @ref createPrimitiveAttributes calls for each type of
-   * supported primitive to the @ref primTypeConstructorMap, keyed by type of
-   * primtive
+   * @brief This function will build the various @ref Importers and @ref
+   * AttributesManagers used by the system.
    */
-  void buildMapOfPrimTypeConstructors();
+  void buildImportersAndAttributesManagers();
+
   /**
    * @brief Build default primitive attribute files and synthesize an object of
    * each type.
@@ -344,18 +284,18 @@ class ResourceManager {
     return collisionMeshGroups_.at(collisionAssetHandle);
   }
 
-  // /**
-  //  * @brief Return manager for construction and access to asset attributes.
-  //  */
-  // managers::AssetAttributesManager::ptr getAssetAttributesManager() {
-  //   return assetAttributesManager_;
-  // }
-  // /**
-  //  * @brief Return manager for construction and access to object attributes.
-  //  */
-  // managers::ObjectAttributesManager::ptr getObjectAttributesManager() {
-  //   return objectAttributesManager_;
-  // }
+  /**
+   * @brief Return manager for construction and access to asset attributes.
+   */
+  managers::AssetAttributesManager::ptr getAssetAttributesManager() {
+    return assetAttributesManager_;
+  }
+  /**
+   * @brief Return manager for construction and access to object attributes.
+   */
+  managers::ObjectAttributesManager::ptr getObjectAttributesManager() {
+    return objectAttributesManager_;
+  }
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
@@ -1296,14 +1236,14 @@ class ResourceManager {
 
   // ======== Physical parameter data ========
 
-  // /**
-  //  * @brief Manages all construction and access to asset attributes.
-  //  */
-  // managers::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
-  // /**
-  //  * @brief Manages all construction and access to object attributes.
-  //  */
-  // managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+  /**
+   * @brief Manages all construction and access to asset attributes.
+   */
+  managers::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
+  /**
+   * @brief Manages all construction and access to object attributes.
+   */
+  managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
   /**
    * @brief Manages all construction and access to physics world attributes.
    */

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -79,41 +79,41 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
 
   // function pointers to asset attributes copy constructors
   this->copyConstructorMap_["capsule3DSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CapsulePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CapsulePrimitiveAttributes>;
   this->copyConstructorMap_["capsule3DWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CapsulePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CapsulePrimitiveAttributes>;
   this->copyConstructorMap_["coneSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::ConePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::ConePrimitiveAttributes>;
   this->copyConstructorMap_["coneWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::ConePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::ConePrimitiveAttributes>;
   this->copyConstructorMap_["cubeSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CubePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CubePrimitiveAttributes>;
   this->copyConstructorMap_["cubeWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CubePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CubePrimitiveAttributes>;
   this->copyConstructorMap_["cylinderSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CylinderPrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CylinderPrimitiveAttributes>;
   this->copyConstructorMap_["cylinderWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::CylinderPrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::CylinderPrimitiveAttributes>;
   this->copyConstructorMap_["icosphereSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::IcospherePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::IcospherePrimitiveAttributes>;
   this->copyConstructorMap_["icosphereWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::IcospherePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::IcospherePrimitiveAttributes>;
   this->copyConstructorMap_["uvSphereSolid"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::UVSpherePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::UVSpherePrimitiveAttributes>;
   this->copyConstructorMap_["uvSphereWireframe"] =
-      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
-          createAttributesCopy<assets::UVSpherePrimitiveAttributes>;
+      &AssetAttributesManager::createAttributesCopy<
+          assets::UVSpherePrimitiveAttributes>;
   // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
 
   // build default AbstractPrimitiveAttributes objects
@@ -130,14 +130,15 @@ int AssetAttributesManager::registerAttributesTemplate(
     const std::string&) {
   std::string primAttributesHandle = primAttributesTemplate->getOriginHandle();
   // verify that attributes has been edited in a legal manner
-  CORRADE_ASSERT(
-      primAttributesTemplate->isValidTemplate(),
-      "AssetAttributesManager::registerAttributesTemplate : Primitive "
-      "asset attributes template named"
-          << primAttributesHandle
-          << "is not configured properly for specified prmitive"
-          << primAttributesTemplate->getPrimObjClassName() << ". Aborting.",
-      ID_UNDEFINED);
+  if (!primAttributesTemplate->isValidTemplate()) {
+    LOG(ERROR)
+        << "AssetAttributesManager::registerAttributesTemplate : Primitive "
+           "asset attributes template named"
+        << primAttributesHandle
+        << "is not configured properly for specified prmitive"
+        << primAttributesTemplate->getPrimObjClassName() << ". Aborting.";
+    return ID_UNDEFINED;
+  }
 
   // return either the ID of the existing template referenced by
   // primAttributesHandle, or the next available ID if not found.

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -125,29 +125,6 @@ void AssetAttributesManager::buildMapOfPrimTypeConstructors() {
   }
 }  // buildMapOfPrimTypeConstructors
 
-std::shared_ptr<AbstractPrimitiveAttributes>
-AssetAttributesManager::createAttributesTemplate(
-    const std::string& primClassName,
-    bool registerTemplate) {
-  auto primAssetAttributes = buildPrimAttributes(primClassName);
-
-  if (registerTemplate) {
-    registerAttributesTemplate(primAssetAttributes, "");
-  }
-  return primAssetAttributes;
-}  // AssetAttributesManager::createAttributesTemplate
-
-std::shared_ptr<AbstractPrimitiveAttributes>
-AssetAttributesManager::createAttributesTemplate(PrimObjTypes primObjType,
-                                                 bool registerTemplate) {
-  auto primAssetAttributes = buildPrimAttributes(primObjType);
-
-  if (registerTemplate) {
-    registerAttributesTemplate(primAssetAttributes, "");
-  }
-  return primAssetAttributes;
-}  // AssetAttributesManager::createAttributesTemplate
-
 int AssetAttributesManager::registerAttributesTemplate(
     std::shared_ptr<AbstractPrimitiveAttributes> primAttributesTemplate,
     const std::string&) {
@@ -165,21 +142,21 @@ int AssetAttributesManager::registerAttributesTemplate(
   // return either the ID of the existing template referenced by
   // primAttributesHandle, or the next available ID if not found.
   int primTemplateID =
-      addTemplateToLibrary(primAttributesTemplate, primAttributesHandle);
+      this->addTemplateToLibrary(primAttributesTemplate, primAttributesHandle);
   return primTemplateID;
 }  // AssetAttributesManager::registerAttributesTemplate
 
 std::shared_ptr<AbstractPrimitiveAttributes>
 AssetAttributesManager::getAttributesTemplateCopy(
     const std::string& primTemplateHandle) {
-  CORRADE_ASSERT((templateLibrary_.count(primTemplateHandle) > 0),
+  CORRADE_ASSERT((this->templateLibrary_.count(primTemplateHandle) > 0),
                  "AssetAttributesManager::getAttributesCopy : Unknown "
                  "template handle :"
                      << primTemplateHandle << ". Aborting",
                  nullptr);
   // need to return copy so that user mods do not modify existing
   // asset template
-  auto orig = templateLibrary_.at(primTemplateHandle);
+  auto orig = this->templateLibrary_.at(primTemplateHandle);
   // build a copy of existing template
   return copyPrimAttributes(orig);
 }  // AssetAttributesManager::getPrimAssetAttributesCopy

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -33,7 +33,7 @@ const std::map<PrimObjTypes, const char*>
         {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
         {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
 
-void AssetAttributesManager::buildMapOfPrimTypeConstructors() {
+void AssetAttributesManager::buildCtorFuncPtrMaps() {
   // function pointers to asset attributes constructors
   primTypeConstructorMap_["capsule3DSolid"] =
       &AssetAttributesManager::createPrimAttributes<
@@ -78,42 +78,42 @@ void AssetAttributesManager::buildMapOfPrimTypeConstructors() {
           assets::UVSpherePrimitiveAttributes, true, PrimObjTypes::UVSPHERE_WF>;
 
   // function pointers to asset attributes copy constructors
-  primTypeCopyConstructorMap_["capsule3DSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CapsulePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["capsule3DWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CapsulePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["coneSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::ConePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["coneWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::ConePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["cubeSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CubePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["cubeWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CubePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["cylinderSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CylinderPrimitiveAttributes>;
-  primTypeCopyConstructorMap_["cylinderWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::CylinderPrimitiveAttributes>;
-  primTypeCopyConstructorMap_["icosphereSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::IcospherePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["icosphereWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::IcospherePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["uvSphereSolid"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::UVSpherePrimitiveAttributes>;
-  primTypeCopyConstructorMap_["uvSphereWireframe"] =
-      &AssetAttributesManager::createPrimAttributesCopy<
-          assets::UVSpherePrimitiveAttributes>;
+  this->copyConstructorMap_["capsule3DSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CapsulePrimitiveAttributes>;
+  this->copyConstructorMap_["capsule3DWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CapsulePrimitiveAttributes>;
+  this->copyConstructorMap_["coneSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::ConePrimitiveAttributes>;
+  this->copyConstructorMap_["coneWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::ConePrimitiveAttributes>;
+  this->copyConstructorMap_["cubeSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CubePrimitiveAttributes>;
+  this->copyConstructorMap_["cubeWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CubePrimitiveAttributes>;
+  this->copyConstructorMap_["cylinderSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CylinderPrimitiveAttributes>;
+  this->copyConstructorMap_["cylinderWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::CylinderPrimitiveAttributes>;
+  this->copyConstructorMap_["icosphereSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::IcospherePrimitiveAttributes>;
+  this->copyConstructorMap_["icosphereWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::IcospherePrimitiveAttributes>;
+  this->copyConstructorMap_["uvSphereSolid"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::UVSpherePrimitiveAttributes>;
+  this->copyConstructorMap_["uvSphereWireframe"] =
+      &AttributesManager<AbstractPrimitiveAttributes::ptr>::
+          createAttributesCopy<assets::UVSpherePrimitiveAttributes>;
   // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
 
   // build default AbstractPrimitiveAttributes objects
@@ -126,7 +126,7 @@ void AssetAttributesManager::buildMapOfPrimTypeConstructors() {
 }  // buildMapOfPrimTypeConstructors
 
 int AssetAttributesManager::registerAttributesTemplate(
-    std::shared_ptr<AbstractPrimitiveAttributes> primAttributesTemplate,
+    const AbstractPrimitiveAttributes::ptr primAttributesTemplate,
     const std::string&) {
   std::string primAttributesHandle = primAttributesTemplate->getOriginHandle();
   // verify that attributes has been edited in a legal manner
@@ -145,21 +145,6 @@ int AssetAttributesManager::registerAttributesTemplate(
       this->addTemplateToLibrary(primAttributesTemplate, primAttributesHandle);
   return primTemplateID;
 }  // AssetAttributesManager::registerAttributesTemplate
-
-std::shared_ptr<AbstractPrimitiveAttributes>
-AssetAttributesManager::getAttributesTemplateCopy(
-    const std::string& primTemplateHandle) {
-  CORRADE_ASSERT((this->templateLibrary_.count(primTemplateHandle) > 0),
-                 "AssetAttributesManager::getAttributesCopy : Unknown "
-                 "template handle :"
-                     << primTemplateHandle << ". Aborting",
-                 nullptr);
-  // need to return copy so that user mods do not modify existing
-  // asset template
-  auto orig = this->templateLibrary_.at(primTemplateHandle);
-  // build a copy of existing template
-  return copyPrimAttributes(orig);
-}  // AssetAttributesManager::getPrimAssetAttributesCopy
 
 }  // namespace managers
 }  // namespace assets

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -69,7 +69,7 @@ enum class PrimObjTypes : uint32_t {
 namespace managers {
 
 class AssetAttributesManager
-    : public AttributesManager<AbstractPrimitiveAttributes> {
+    : public AttributesManager<AbstractPrimitiveAttributes::ptr> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -78,7 +78,8 @@ class AssetAttributesManager
    */
   static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
   AssetAttributesManager()
-      : AttributesManager<AbstractPrimitiveAttributes>::AttributesManager() {
+      : AttributesManager<
+            AbstractPrimitiveAttributes::ptr>::AttributesManager() {
     buildMapOfPrimTypeConstructors();
   }
 
@@ -97,7 +98,13 @@ class AssetAttributesManager
 
   std::shared_ptr<AbstractPrimitiveAttributes> createAttributesTemplate(
       const std::string& primClassName,
-      bool registerTemplate = true);
+      bool registerTemplate = true) {
+    auto primAssetAttributes = buildPrimAttributes(primClassName);
+    if (registerTemplate) {
+      registerAttributesTemplate(primAssetAttributes, "");
+    }
+    return primAssetAttributes;
+  }  // AssetAttributesManager::createAttributesTemplate
 
   /**
    * @brief Creates an instance of a primtive asset attributes template
@@ -112,7 +119,13 @@ class AssetAttributesManager
    */
   std::shared_ptr<AbstractPrimitiveAttributes> createAttributesTemplate(
       PrimObjTypes primObjType,
-      bool registerTemplate = true);
+      bool registerTemplate = true) {
+    auto primAssetAttributes = buildPrimAttributes(primObjType);
+    if (registerTemplate) {
+      registerAttributesTemplate(primAssetAttributes, "");
+    }
+    return primAssetAttributes;
+  }  // AssetAttributesManager::createAttributesTemplate
 
   /**
    * @brief Add an @ref AbstractPrimitiveAttributes object to the @ref
@@ -147,8 +160,8 @@ class AssetAttributesManager
                    "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
                    {});
     std::string subStr = PrimitiveNames3DMap.at(primType);
-    return getTemplateHandlesBySubStringPerType(templateLibKeyByID_, subStr,
-                                                contains);
+    return this->getTemplateHandlesBySubStringPerType(this->templateLibKeyByID_,
+                                                      subStr, contains);
   }  // getTemplateHandlesByPrimType
 
   /**
@@ -164,6 +177,7 @@ class AssetAttributesManager
   std::shared_ptr<AbstractPrimitiveAttributes> getAttributesTemplateCopy(
       const std::string& primTemplateHandle);
 
+ protected:
   /**
    * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
    * with passed class name
@@ -174,7 +188,6 @@ class AssetAttributesManager
     return (*this.*primTypeCopyConstructorMap_[primTypeName])(origAttr);
   }  // buildPrimAttributes
 
- protected:
   /**
    * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
    * with passed class name

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -154,11 +154,12 @@ class AssetAttributesManager
   std::vector<std::string> getTemplateHandlesByPrimType(
       PrimObjTypes primType,
       bool contains = true) const {
-    CORRADE_ASSERT(primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
-                   "AssetAttributesManager::getTemplateHandlesByPrimType : "
-                   "Illegal primtitive type "
-                   "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
-                   {});
+    if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      LOG(ERROR) << "AssetAttributesManager::getTemplateHandlesByPrimType : "
+                    "Illegal primtitive type "
+                    "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.";
+      return {};
+    }
     std::string subStr = PrimitiveNames3DMap.at(primType);
     return this->getTemplateHandlesBySubStringPerType(this->templateLibKeyByID_,
                                                       subStr, contains);
@@ -171,11 +172,12 @@ class AssetAttributesManager
    */
   const AbstractPrimitiveAttributes::ptr buildPrimAttributes(
       const std::string& primTypeName) {
-    CORRADE_ASSERT(
-        primTypeConstructorMap_.count(primTypeName) > 0,
-        "AssetAttributesManager::buildPrimAttributes : No primitive of type"
-            << primTypeName << "exists.  Aborting.",
-        nullptr);
+    if (primTypeConstructorMap_.count(primTypeName) == 0) {
+      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : No "
+                    "primitive of type"
+                 << primTypeName << "exists.  Aborting.";
+      return nullptr;
+    }
     return (*this.*primTypeConstructorMap_[primTypeName])();
   }  // buildPrimAttributes
 
@@ -186,11 +188,12 @@ class AssetAttributesManager
    */
   const AbstractPrimitiveAttributes::ptr buildPrimAttributes(
       PrimObjTypes primType) {
-    CORRADE_ASSERT(
-        primType != PrimObjTypes::END_PRIM_OBJ_TYPES,
-        "AssetAttributesManager::buildPrimAttributes : Illegal primtitive type "
-        "name PrimObjTypes::END_PRIM_OBJ_TYPES.  Aborting.",
-        nullptr);
+    if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : Illegal "
+                    "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES.  "
+                    "Aborting.";
+      return nullptr;
+    }
     return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])();
   }  // buildPrimAttributes
 
@@ -200,13 +203,13 @@ class AssetAttributesManager
    * PrimitiveNames3DMap
    */
   const AbstractPrimitiveAttributes::ptr buildPrimAttributes(int primTypeVal) {
-    CORRADE_ASSERT(
-        (primTypeVal >= 0) &&
-            (primTypeVal < static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES)),
-        "AssetAttributesManager::buildPrimAttributes : Unknown PrimObjTypes "
-        "value requested :"
-            << primTypeVal << ". Aborting",
-        nullptr);
+    if ((primTypeVal < 0) ||
+        (primTypeVal > static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES))) {
+      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : Unknown "
+                    "PrimObjTypes value requested :"
+                 << primTypeVal << ". Aborting";
+      return nullptr;
+    }
     return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
                        static_cast<PrimObjTypes>(primTypeVal))])();
   }  // buildPrimAttributes
@@ -218,13 +221,13 @@ class AssetAttributesManager
    */
   template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
   const AbstractPrimitiveAttributes::ptr createPrimAttributes() {
-    CORRADE_ASSERT(
-        (primitiveType != PrimObjTypes::END_PRIM_OBJ_TYPES),
-        "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
-        "AbstractPrimitiveAttributes object for "
-        "PrimObjTypes::END_PRIM_OBJ_TYPES. "
-        "Aborting.",
-        nullptr);
+    if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      LOG(ERROR)
+          << "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
+             "AbstractPrimitiveAttributes object for "
+             "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
+      return nullptr;
+    }
     int idx = static_cast<int>(primitiveType);
     return T::create(isWireFrame, idx, PrimitiveNames3DMap.at(primitiveType));
   }
@@ -239,8 +242,8 @@ class AssetAttributesManager
 
   /**
    * @brief Define a map type referencing function pointers to @ref
-   * createPrimAttributes() keyed by string names of classes being instanced, as
-   * defined in @ref PrimNames3D
+   * createPrimAttributes() keyed by string names of classes being instanced,
+   * as defined in @ref PrimNames3D
    */
   typedef std::map<std::string,
                    const AbstractPrimitiveAttributes::ptr (

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -196,7 +196,7 @@ class AssetAttributesManager
       const std::string& primTypeName) {
     CORRADE_ASSERT(
         primTypeConstructorMap_.count(primTypeName) > 0,
-        "AssetAttributesManager::buildPrimAttributes : No primivite of type"
+        "AssetAttributesManager::buildPrimAttributes : No primitive of type"
             << primTypeName << "exists.  Aborting.",
         nullptr);
     return (*this.*primTypeConstructorMap_[primTypeName])();

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -11,10 +11,7 @@
 
 #include <map>
 
-#include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/ConfigurationGroup.h>
-#include <Corrade/Utility/Debug.h>
-#include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/String.h>
 
@@ -68,11 +65,12 @@ class AttributesManager {
    */
   const AttribsPtr getTemplateByID(int objectTemplateID) const {
     std::string key = getTemplateHandleByID(objectTemplateID);
-    CORRADE_ASSERT(getTemplateLibHasHandle(key),
-                   "AttributesManager::getTemplateByID : Unknown "
-                   "object template ID:"
-                       << objectTemplateID << ". Aborting",
-                   nullptr);
+    if (!getTemplateLibHasHandle(key)) {
+      LOG(ERROR) << "AttributesManager::getTemplateByID : Unknown "
+                    "object template ID:"
+                 << objectTemplateID << ". Aborting";
+      return nullptr;
+    }
     return templateLibrary_.at(key);
   }  // getTemplateByID
 
@@ -88,11 +86,12 @@ class AttributesManager {
    */
   const AttribsPtr getTemplateByHandle(
       const std::string& templateHandle) const {
-    CORRADE_ASSERT(getTemplateLibHasHandle(templateHandle),
-                   "AttributesManager::getTemplateByHandle : Unknown "
-                   "object template Handle:"
-                       << templateHandle << ". Aborting",
-                   nullptr);
+    if (!getTemplateLibHasHandle(templateHandle)) {
+      LOG(ERROR) << "AttributesManager::getTemplateByHandle : Unknown "
+                    "object template Handle:"
+                 << templateHandle << ". Aborting";
+      return nullptr;
+    }
     return templateLibrary_.at(templateHandle);
   }  // getAttributesTemplate
 
@@ -105,11 +104,12 @@ class AttributesManager {
    * not exist
    */
   AttribsPtr getTemplateCopyByHandle(const std::string& templateHandle) {
-    CORRADE_ASSERT((this->templateLibrary_.count(templateHandle) > 0),
-                   "AssetAttributesManager::getAttributesCopy : Unknown "
-                   "template handle :"
-                       << templateHandle << ". Aborting",
-                   nullptr);
+    if (this->templateLibrary_.count(templateHandle) == 0) {
+      LOG(ERROR) << "AssetAttributesManager::getAttributesCopy : Unknown "
+                    "template handle :"
+                 << templateHandle << ". Aborting";
+      return nullptr;
+    }
     auto orig = this->templateLibrary_.at(templateHandle);
     return this->copyAttributes(orig);
   }  // AssetAttributesManager::getPrimAssetAttributesCopy
@@ -123,11 +123,12 @@ class AttributesManager {
    * templateLibrary_, or an empty string if does not exist.
    */
   std::string getTemplateHandleByID(const int templateID) const {
-    CORRADE_ASSERT(templateLibKeyByID_.count(templateID) > 0,
-                   "AttributesManager::getTemplateHandleByID : Unknown "
-                   "object template ID:"
-                       << templateID << ". Aborting",
-                   nullptr);
+    if (templateLibKeyByID_.count(templateID) == 0) {
+      LOG(ERROR) << "AttributesManager::getTemplateHandleByID : Unknown "
+                    "object template ID:"
+                 << templateID << ". Aborting";
+      return nullptr;
+    }
     return templateLibKeyByID_.at(templateID);
   }  // getTemplateHandleByID
 
@@ -149,11 +150,10 @@ class AttributesManager {
       return templateLibrary_.at(templateHandle)->getObjectTemplateID();
     } else {
       if (!getNext) {
-        CORRADE_ASSERT(false,
-                       "AttributesManager::getTemplateIDByHandle : No template "
-                       " with handle "
-                           << templateHandle << "exists. Aborting",
-                       ID_UNDEFINED);
+        LOG(ERROR) << "AttributesManager::getTemplateIDByHandle : No template "
+                      " with handle "
+                   << templateHandle << "exists. Aborting";
+        return ID_UNDEFINED;
 
       } else {
         // TODO : This needs to return an unused ID number, to support deleting

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -34,7 +34,7 @@ namespace managers {
  * @tparam T the type of attributes object this class references
  */
 
-template <class T>
+template <class AttribsPtr>
 class AttributesManager {
  public:
   //   //======== Accessor functions ========
@@ -67,7 +67,7 @@ class AttributesManager {
    not
    * exist
    */
-  std::shared_ptr<T> getAttributesTemplate(const int objectTemplateID) const {
+  AttribsPtr getAttributesTemplate(const int objectTemplateID) const {
     std::string key = getTemplateHandleByID(objectTemplateID);
     CORRADE_ASSERT(getTemplateLibHasHandle(key),
                    "AttributesManager::getAttributesTemplate : Unknown "
@@ -88,8 +88,7 @@ class AttributesManager {
    not
    * exist
    */
-  std::shared_ptr<T> getAttributesTemplate(
-      const std::string& templateHandle) const {
+  AttribsPtr getAttributesTemplate(const std::string& templateHandle) const {
     CORRADE_ASSERT(getTemplateLibHasHandle(templateHandle),
                    "AttributesManager::getAttributesTemplate : Unknown "
                    "object template Handle:"
@@ -178,7 +177,7 @@ class AttributesManager {
                                                 contains);
   }
 
-  // protected:
+ protected:
   /**
    * @brief add passed template to library, setting objectTemplateID
    * appropriately.  Called internally by registerTemplate.
@@ -189,7 +188,7 @@ class AttributesManager {
    */
 
   int addTemplateToLibrary(
-      std::shared_ptr<T> attributesTemplate,
+      AttribsPtr attributesTemplate,
       const std::string& attributesHandle) {  // return either the ID of the
                                               // existing template referenced by
     // attributesHandle, or the next available ID if not found.
@@ -236,7 +235,7 @@ class AttributesManager {
   /**
    * @brief Maps string keys to attributes templates
    */
-  std::map<std::string, std::shared_ptr<T>> templateLibrary_;
+  std::map<std::string, AttribsPtr> templateLibrary_;
 
   /**
    * @brief Maps all object attribute IDs to the appropriate handles used
@@ -246,7 +245,7 @@ class AttributesManager {
   std::map<int, std::string> templateLibKeyByID_;
 
  public:
-  ESP_SMART_POINTERS(AttributesManager)
+  ESP_SMART_POINTERS(AttributesManager<AttribsPtr>)
 
 };  // class AttributesManager
 

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -177,6 +177,10 @@ class AttributesManager {
                                                 contains);
   }
 
+  std::map<std::string, AttribsPtr> getTemplateLibrary_() const {
+    return templateLibrary_;
+  }
+
  protected:
   /**
    * @brief add passed template to library, setting objectTemplateID

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -195,7 +195,7 @@ class ObjectAttributesManager
    */
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["PhysicsObjectAttributes"] =
-        &AttributesManager<PhysicsObjectAttributes::ptr>::createAttributesCopy<
+        &ObjectAttributesManager::createAttributesCopy<
             assets::PhysicsObjectAttributes>;
   }
   /**

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -19,9 +19,9 @@ namespace managers {
  * @brief single instance class managing templates describing physical objects
  */
 class ObjectAttributesManager
-    : public AttributesManager<PhysicsObjectAttributes> {
+    : public AttributesManager<PhysicsObjectAttributes::ptr> {
  public:
-  using AttributesManager<PhysicsObjectAttributes>::AttributesManager;
+  using AttributesManager<PhysicsObjectAttributes::ptr>::AttributesManager;
   void setAssetAttributesManager(
       AssetAttributesManager::ptr assetAttributesMgr) {
     assetAttributesMgr_ = assetAttributesMgr;

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -21,7 +21,7 @@ namespace assets {
 
 namespace managers {
 
-PhysicsManagerAttributes::ptr
+const PhysicsManagerAttributes::ptr
 PhysicsAttributesManager::createAttributesTemplate(
     const std::string& physicsFilename,
     bool registerTemplate) {

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -25,12 +25,12 @@ const PhysicsManagerAttributes::ptr
 PhysicsAttributesManager::createAttributesTemplate(
     const std::string& physicsFilename,
     bool registerTemplate) {
-  CORRADE_ASSERT(
-      Cr::Utility::Directory::exists(physicsFilename),
-      "PhysicsAttributesManager::createAttributesTemplate : Specified Filename "
-      ":" << physicsFilename
-          << "cannot be found.  Aborting",
-      nullptr);
+  if (!Cr::Utility::Directory::exists(physicsFilename)) {
+    LOG(ERROR) << "PhysicsAttributesManager::createAttributesTemplate : "
+                  "Specified Filename :"
+               << physicsFilename << "cannot be found.  Aborting";
+    return nullptr;
+  }
 
   // Load the global scene config JSON here
   io::JsonDocument scenePhysicsConfig = io::parseJsonFile(physicsFilename);

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -22,9 +22,9 @@ namespace assets {
 namespace managers {
 
 class PhysicsAttributesManager
-    : public AttributesManager<PhysicsManagerAttributes> {
+    : public AttributesManager<PhysicsManagerAttributes::ptr> {
  public:
-  using AttributesManager<PhysicsManagerAttributes>::AttributesManager;
+  using AttributesManager<PhysicsManagerAttributes::ptr>::AttributesManager;
   /**
    * @brief Creates an instance of a physics world template described by passed
    * string. For physics templates, this a file name. Parses global physics
@@ -57,8 +57,8 @@ class PhysicsAttributesManager
       const std::string& physicsAttributesHandle) {
     // return either the ID of the existing template referenced by
     // physicsAttributesHandle, or the next available ID if not found.
-    int physicsTemplateID = addTemplateToLibrary(physicsAttributesTemplate,
-                                                 physicsAttributesHandle);
+    int physicsTemplateID = this->addTemplateToLibrary(
+        physicsAttributesTemplate, physicsAttributesHandle);
     return physicsTemplateID;
   }  // PhysicsAttributesManager::registerAttributesTemplate
 

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -83,7 +83,7 @@ class PhysicsAttributesManager
    */
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["PhysicsManagerAttributes"] =
-        &AttributesManager<PhysicsManagerAttributes::ptr>::createAttributesCopy<
+        &PhysicsAttributesManager::createAttributesCopy<
             assets::PhysicsManagerAttributes>;
   }
   // instance vars

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -24,7 +24,11 @@ namespace managers {
 class PhysicsAttributesManager
     : public AttributesManager<PhysicsManagerAttributes::ptr> {
  public:
-  using AttributesManager<PhysicsManagerAttributes::ptr>::AttributesManager;
+  PhysicsAttributesManager()
+      : AttributesManager<PhysicsManagerAttributes::ptr>::AttributesManager() {
+    buildCtorFuncPtrMaps();
+  }
+
   /**
    * @brief Creates an instance of a physics world template described by passed
    * string. For physics templates, this a file name. Parses global physics
@@ -38,7 +42,7 @@ class PhysicsAttributesManager
    * @return a reference to the physics simulation meta data object parsed from
    * the specified configuration file.
    */
-  PhysicsManagerAttributes::ptr createAttributesTemplate(
+  const PhysicsManagerAttributes::ptr createAttributesTemplate(
       const std::string& physicsFilename = ESP_DEFAULT_PHYS_SCENE_CONFIG,
       bool registerTemplate = true);
 
@@ -53,7 +57,7 @@ class PhysicsAttributesManager
    * template.
    */
   int registerAttributesTemplate(
-      PhysicsManagerAttributes::ptr physicsAttributesTemplate,
+      const PhysicsManagerAttributes::ptr physicsAttributesTemplate,
       const std::string& physicsAttributesHandle) {
     // return either the ID of the existing template referenced by
     // physicsAttributesHandle, or the next available ID if not found.
@@ -72,6 +76,16 @@ class PhysicsAttributesManager
   std::vector<std::string> buildObjectConfigPaths(const std::string& path);
 
  protected:
+  /**
+   * @brief This function will assign the appropriately configured function
+   * pointer for the copy constructor as required by
+   * AttributesManager<PhysicsSceneAttributes::ptr>
+   */
+  void buildCtorFuncPtrMaps() override {
+    this->copyConstructorMap_["PhysicsManagerAttributes"] =
+        &AttributesManager<PhysicsManagerAttributes::ptr>::createAttributesCopy<
+            assets::PhysicsManagerAttributes>;
+  }
   // instance vars
 
  public:

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -22,13 +22,13 @@ SceneAttributesManager::createAttributesTemplate(
     const std::string& sceneAttributesHandle,
     bool registerTemplate) {
   const bool physSceneExists =
-      templateLibrary_.count(sceneAttributesHandle) > 0;
+      this->templateLibrary_.count(sceneAttributesHandle) > 0;
   PhysicsSceneAttributes::ptr sceneAttributesTemplate;
   if (!physSceneExists) {
     sceneAttributesTemplate =
         PhysicsSceneAttributes::create(sceneAttributesHandle);
   } else {
-    sceneAttributesTemplate = templateLibrary_.at(sceneAttributesHandle);
+    sceneAttributesTemplate = this->templateLibrary_.at(sceneAttributesHandle);
   }
   sceneAttributesTemplate->setRenderAssetHandle(sceneAttributesHandle);
   sceneAttributesTemplate->setCollisionAssetHandle(sceneAttributesHandle);

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -17,7 +17,7 @@ namespace assets {
 
 namespace managers {
 
-std::shared_ptr<PhysicsSceneAttributes>
+const PhysicsSceneAttributes::ptr
 SceneAttributesManager::createAttributesTemplate(
     const std::string& sceneAttributesHandle,
     bool registerTemplate) {

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -13,7 +13,10 @@ namespace managers {
 class SceneAttributesManager
     : public AttributesManager<PhysicsSceneAttributes::ptr> {
  public:
-  using AttributesManager<PhysicsSceneAttributes::ptr>::AttributesManager;
+  SceneAttributesManager()
+      : AttributesManager<PhysicsSceneAttributes::ptr>::AttributesManager() {
+    buildCtorFuncPtrMaps();
+  }
   /**
    * @brief Creates an instance of a scene template described by passed
    string.
@@ -26,7 +29,7 @@ class SceneAttributesManager
    * @return a reference to the desired template.
    */
 
-  PhysicsSceneAttributes::ptr createAttributesTemplate(
+  const PhysicsSceneAttributes::ptr createAttributesTemplate(
       const std::string& sceneAttributesHandle,
       bool registerTemplate = true);
   /**
@@ -40,7 +43,7 @@ class SceneAttributesManager
    * template.
    */
   int registerAttributesTemplate(
-      PhysicsSceneAttributes::ptr sceneAttributesTemplate,
+      const PhysicsSceneAttributes::ptr sceneAttributesTemplate,
       const std::string& sceneAttributesHandle) {
     // return either the ID of the existing template referenced by
     // sceneAttributesHandle, or the next available ID if not found.
@@ -57,7 +60,7 @@ class SceneAttributesManager
    * this scene lives in.
    */
   void setSceneValsFromPhysicsAttributes(
-      PhysicsManagerAttributes::ptr physicsManagerAttributes) {
+      const PhysicsManagerAttributes::cptr physicsManagerAttributes) {
     for (auto sceneAttr : this->templateLibrary_) {
       sceneAttr.second->setFrictionCoefficient(
           physicsManagerAttributes->getFrictionCoefficient());
@@ -67,6 +70,17 @@ class SceneAttributesManager
   }  // SceneAttributesManager::setSceneValsFromPhysicsAttributes
 
  protected:
+  /**
+   * @brief This function will assign the appropriately configured function
+   * pointer for the copy constructor as required by
+   * AttributesManager<PhysicsSceneAttributes::ptr>
+   */
+  void buildCtorFuncPtrMaps() override {
+    this->copyConstructorMap_["PhysicsSceneAttributes"] =
+        &AttributesManager<PhysicsSceneAttributes::ptr>::createAttributesCopy<
+            assets::PhysicsSceneAttributes>;
+  }
+
   // instance vars
 
  public:

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -11,9 +11,9 @@ namespace assets {
 
 namespace managers {
 class SceneAttributesManager
-    : public AttributesManager<PhysicsSceneAttributes> {
+    : public AttributesManager<PhysicsSceneAttributes::ptr> {
  public:
-  using AttributesManager<PhysicsSceneAttributes>::AttributesManager;
+  using AttributesManager<PhysicsSceneAttributes::ptr>::AttributesManager;
   /**
    * @brief Creates an instance of a scene template described by passed
    string.
@@ -58,7 +58,7 @@ class SceneAttributesManager
    */
   void setSceneValsFromPhysicsAttributes(
       PhysicsManagerAttributes::ptr physicsManagerAttributes) {
-    for (auto sceneAttr : templateLibrary_) {
+    for (auto sceneAttr : this->templateLibrary_) {
       sceneAttr.second->setFrictionCoefficient(
           physicsManagerAttributes->getFrictionCoefficient());
       sceneAttr.second->setRestitutionCoefficient(

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -77,7 +77,7 @@ class SceneAttributesManager
    */
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["PhysicsSceneAttributes"] =
-        &AttributesManager<PhysicsSceneAttributes::ptr>::createAttributesCopy<
+        &SceneAttributesManager::createAttributesCopy<
             assets::PhysicsSceneAttributes>;
   }
 

--- a/src/esp/bindings/CMakeLists.txt
+++ b/src/esp/bindings/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(MagnumBindings REQUIRED Python)
 pybind11_add_module(habitat_sim_bindings
   bindings.cpp
   attributesBindings.cpp
+  attributesManagersBindings.cpp
   geoBindings.cpp
   GfxBindings.cpp
   OpaqueTypes.h

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -54,11 +54,11 @@ void initSimBindings(py::module& m) {
       .def(py::init<const SimulatorConfiguration&>())
       .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
            R"(PYTHON DOES NOT GET OWNERSHIP)",
-           pybind11::return_value_policy::reference)
+           py::return_value_policy::reference)
       .def("get_active_semantic_scene_graph",
            &Simulator::getActiveSemanticSceneGraph,
            R"(PYTHON DOES NOT GET OWNERSHIP)",
-           pybind11::return_value_policy::reference)
+           py::return_value_policy::reference)
       .def_property_readonly("semantic_scene", &Simulator::getSemanticScene, R"(
         The semantic scene graph
 
@@ -83,7 +83,7 @@ void initSimBindings(py::module& m) {
       .def("get_template_handle_by_ID", &Simulator::getObjectTemplateHandleByID,
            "object_id"_a)
       .def("get_template_handles", &Simulator::getObjectTemplateHandles,
-           "search_str"_a = "")
+           "search_str"_a = "", "contains"_a = true)
       .def("add_object", &Simulator::addObject, "object_lib_index"_a,
            "attachment_node"_a = nullptr,
            "light_setup_key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
@@ -95,7 +95,7 @@ void initSimBindings(py::module& m) {
       .def("get_physics_object_library_size",
            &Simulator::getPhysicsObjectLibrarySize)
       .def("get_object_template", &Simulator::getObjectTemplate,
-           "object_template_id"_a, pybind11::return_value_policy::reference)
+           "object_template_id"_a, py::return_value_policy::reference)
       .def("load_object_configs", &Simulator::loadObjectConfigs, "path"_a)
       .def("load_object_template", &Simulator::registerObjectTemplate,
            "object_template"_a, "object_template_handle"_a)

--- a/src/esp/bindings/attributesBindings.cpp
+++ b/src/esp/bindings/attributesBindings.cpp
@@ -40,7 +40,8 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&AbstractAttributes::create<const std::string&>))
       .def("set_origin_handle", &AbstractAttributes::setOriginHandle,
            "origin_handle"_a)
-      .def("get_origin_handle", &AbstractAttributes::getOriginHandle);
+      .def("get_origin_handle", &AbstractAttributes::getOriginHandle)
+      .def("get_object_template_ID", &AbstractAttributes::getObjectTemplateID);
 
   // ==== AbstractPhysicsAttributes ====
   py::class_<AbstractPhysicsAttributes, AbstractAttributes,
@@ -110,6 +111,8 @@ void initAttributesBindings(py::module& m) {
              AbstractPrimitiveAttributes::ptr>(m, "AbstractPrimitiveAttributes")
       .def(py::init(
           &AbstractPrimitiveAttributes::create<bool, int, const std::string&>))
+      .def("set_origin_handle", &AbstractPrimitiveAttributes::setOriginHandle,
+           "do_not_use"_a)
       .def("get_is_wireframe", &AbstractPrimitiveAttributes::getIsWireframe)
       .def("set_use_texture_coords",
            &AbstractPrimitiveAttributes::setUseTextureCoords,

--- a/src/esp/bindings/attributesBindings.cpp
+++ b/src/esp/bindings/attributesBindings.cpp
@@ -8,7 +8,6 @@
 #include <Magnum/Python.h>
 
 #include "esp/assets/Attributes.h"
-#include "esp/assets/ResourceManager.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;
@@ -17,37 +16,22 @@ namespace esp {
 namespace assets {
 
 void initAttributesBindings(py::module& m) {
-  // ==== PrimObjTypes enum describing types of primitives supported ====
-  py::enum_<assets::PrimObjTypes>(m, "PrimObjTypes")
-      .value("CAPSULE_SOLID", assets::PrimObjTypes::CAPSULE_SOLID)
-      .value("CAPSULE_WF", assets::PrimObjTypes::CAPSULE_WF)
-      .value("CONE_SOLID", assets::PrimObjTypes::CONE_SOLID)
-      .value("CONE_WF", assets::PrimObjTypes::CONE_WF)
-      .value("CUBE_SOLID", assets::PrimObjTypes::CUBE_SOLID)
-      .value("CUBE_WF", assets::PrimObjTypes::CUBE_WF)
-      .value("CYLINDER_SOLID", assets::PrimObjTypes::CYLINDER_SOLID)
-      .value("CYLINDER_WF", assets::PrimObjTypes::CYLINDER_WF)
-      .value("ICOSPHERE_SOLID", assets::PrimObjTypes::ICOSPHERE_SOLID)
-      .value("ICOSPHERE_WF", assets::PrimObjTypes::ICOSPHERE_WF)
-      .value("UVSPHERE_SOLID", assets::PrimObjTypes::UVSPHERE_SOLID)
-      .value("UVSPHERE_WF", assets::PrimObjTypes::UVSPHERE_WF)
-      .value("END_PRIM_OBJ_TYPE", assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
-
   // ==== AbstractAttributes ====
   py::class_<AbstractAttributes, esp::core::Configuration,
              AbstractAttributes::ptr>(m, "AbstractAttributes")
-      .def(py::init(&AbstractAttributes::create<>))
-      .def(py::init(&AbstractAttributes::create<const std::string&>))
+      .def(py::init(
+          &AbstractAttributes::create<const std::string&, const std::string&>))
       .def("set_origin_handle", &AbstractAttributes::setOriginHandle,
            "origin_handle"_a)
       .def("get_origin_handle", &AbstractAttributes::getOriginHandle)
-      .def("get_object_template_ID", &AbstractAttributes::getObjectTemplateID);
+      .def("get_object_template_ID", &AbstractAttributes::getObjectTemplateID)
+      .def("get_template_class", &AbstractAttributes::getClassKey);
 
   // ==== AbstractPhysicsAttributes ====
   py::class_<AbstractPhysicsAttributes, AbstractAttributes,
              AbstractPhysicsAttributes::ptr>(m, "AbstractPhysicsAttributes")
-      .def(py::init(&AbstractPhysicsAttributes::create<>))
-      .def(py::init(&AbstractPhysicsAttributes::create<const std::string&>))
+      .def(py::init(&AbstractPhysicsAttributes::create<const std::string&,
+                                                       const std::string&>))
       .def("set_scale", &AbstractPhysicsAttributes::setScale, "scale"_a)
       .def("get_scale", &AbstractPhysicsAttributes::getScale)
       .def("set_friction_coefficient",

--- a/src/esp/bindings/attributesManagersBindings.cpp
+++ b/src/esp/bindings/attributesManagersBindings.cpp
@@ -1,0 +1,132 @@
+
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "esp/bindings/bindings.h"
+
+#include <Magnum/Magnum.h>
+#include <Magnum/Python.h>
+
+#include "esp/assets/Attributes.h"
+#include "esp/assets/managers/AssetAttributesManager.h"
+#include "esp/assets/managers/ObjectAttributesManager.h"
+#include "esp/assets/managers/PhysicsAttributesManager.h"
+#include "esp/assets/managers/SceneAttributesManager.h"
+
+namespace py = pybind11;
+using py::literals::operator""_a;
+
+namespace esp {
+namespace assets {
+namespace managers {
+void initAttributesManagersBindings(py::module& m) {
+  // ==== PrimObjTypes enum describing types of primitives supported ====
+  py::enum_<assets::PrimObjTypes>(m, "PrimObjTypes")
+      .value("CAPSULE_SOLID", assets::PrimObjTypes::CAPSULE_SOLID)
+      .value("CAPSULE_WF", assets::PrimObjTypes::CAPSULE_WF)
+      .value("CONE_SOLID", assets::PrimObjTypes::CONE_SOLID)
+      .value("CONE_WF", assets::PrimObjTypes::CONE_WF)
+      .value("CUBE_SOLID", assets::PrimObjTypes::CUBE_SOLID)
+      .value("CUBE_WF", assets::PrimObjTypes::CUBE_WF)
+      .value("CYLINDER_SOLID", assets::PrimObjTypes::CYLINDER_SOLID)
+      .value("CYLINDER_WF", assets::PrimObjTypes::CYLINDER_WF)
+      .value("ICOSPHERE_SOLID", assets::PrimObjTypes::ICOSPHERE_SOLID)
+      .value("ICOSPHERE_WF", assets::PrimObjTypes::ICOSPHERE_WF)
+      .value("UVSPHERE_SOLID", assets::PrimObjTypes::UVSPHERE_SOLID)
+      .value("UVSPHERE_WF", assets::PrimObjTypes::UVSPHERE_WF)
+      .value("END_PRIM_OBJ_TYPE", assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
+
+  // ==== Primitive Asset Attributes template manager ====
+  py::class_<AssetAttributesManager, AssetAttributesManager::ptr>(
+      m, "AssetAttributesManager")
+      .def("get_template_handle_by_ID",
+           &AssetAttributesManager::getTemplateHandleByID, "object_id"_a)
+      .def("get_template_ID_by_handle",
+           &AssetAttributesManager::getTemplateIDByHandle, "object_id"_a,
+           "get_next_id"_a = false)
+      .def("get_num_templates", &AssetAttributesManager::getNumTemplates)
+      .def("get_random_template_handle",
+           &AssetAttributesManager::getRandomTemplateHandle)
+      .def("get_template_handles",
+           &AssetAttributesManager::getTemplateHandlesBySubstring,
+           "search_str"_a = "", "contains"_a = true)
+      .def("get_library_has_handle",
+           &AssetAttributesManager::getTemplateLibHasHandle)
+      // only ever return a copy of primitive asset template to user, so
+      // that name used as map key and internal name do not get out of synch
+      .def("get_template_by_handle",
+           &AssetAttributesManager::getTemplateCopyByHandle, "template_name"_a,
+           py::return_value_policy::reference)
+      .def("create_template",
+           py::overload_cast<const std::string&, bool>(
+               &AssetAttributesManager::createAttributesTemplate),
+           "primitive_class_name"_a, "register_template"_a = true,
+           py::return_value_policy::reference)
+      .def("create_template",
+           py::overload_cast<assets::PrimObjTypes, bool>(
+               &AssetAttributesManager::createAttributesTemplate),
+           "primitive_object_type_enum"_a, "register_template"_a = true,
+           py::return_value_policy::reference)
+
+      .def("register_template",
+           &AssetAttributesManager::registerAttributesTemplate, "template"_a,
+           "template_handle"_a)
+
+      ;
+
+  // ==== Primitive Asset Attributes template manager ====
+  py::class_<ObjectAttributesManager, ObjectAttributesManager::ptr>(
+      m, "ObjectAttributesManager")
+      .def("get_template_handle_by_ID",
+           &ObjectAttributesManager::getTemplateHandleByID, "object_id"_a)
+      .def("get_template_ID_by_handle",
+           &ObjectAttributesManager::getTemplateIDByHandle, "object_id"_a,
+           "get_next_id"_a = false)
+      .def("get_num_templates", &ObjectAttributesManager::getNumTemplates)
+      .def("get_random_template_handle",
+           &ObjectAttributesManager::getRandomTemplateHandle)
+      .def("get_template_handles",
+           &ObjectAttributesManager::getTemplateHandlesBySubstring,
+           "search_str"_a = "", "contains"_a = true)
+      .def("get_library_has_handle",
+           &ObjectAttributesManager::getTemplateLibHasHandle)
+      .def("get_template_by_id", &ObjectAttributesManager::getTemplateByID,
+           "template_id"_a, py::return_value_policy::reference)
+      .def("get_template_by_handle",
+           &ObjectAttributesManager::getTemplateByHandle, "template_name"_a,
+           py::return_value_policy::reference)
+
+      .def("create_template",
+           &ObjectAttributesManager::createAttributesTemplate,
+           "primitive_object_type_enum"_a, "register_template"_a = true,
+           py::return_value_policy::reference)
+      .def("register_template",
+           &ObjectAttributesManager::registerAttributesTemplate, "template"_a,
+           "template_handle"_a)
+
+      .def("get_num_file_templates",
+           &ObjectAttributesManager::getNumFileTemplateObjects)
+      .def("get_random_file_template_handle",
+           &ObjectAttributesManager::getRandomFileTemplateHandle)
+      .def("get_file_template_handles",
+           &ObjectAttributesManager::getFileTemplateHandlesBySubstring,
+           "search_str"_a = "", "contains"_a = true)
+      .def("get_num_synth_templates",
+           &ObjectAttributesManager::getNumSynthTemplateObjects)
+      .def("get_random_synth_template_handle",
+           &ObjectAttributesManager::getRandomSynthTemplateHandle)
+      .def("get_synth_template_handles",
+           &ObjectAttributesManager::getSynthTemplateHandlesBySubstring,
+           "search_str"_a = "", "contains"_a = true);
+
+  /**
+   * TODO: Add bindings for PhysicsAttributesManager and SceneAttributesManager?
+   */
+
+}  // initAttributesBindings
+
+}  // namespace managers
+
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -81,6 +81,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   esp::initEspBindings(m);
   esp::core::initCoreBindings(m);
   esp::assets::initAttributesBindings(m);
+  esp::assets::managers::initAttributesManagersBindings(m);
   esp::geo::initGeoBindings(m);
   esp::physics::initPhysicsBindings(m);
   esp::scene::initSceneBindings(m);

--- a/src/esp/bindings/bindings.h
+++ b/src/esp/bindings/bindings.h
@@ -11,7 +11,10 @@ namespace esp {
 
 namespace assets {
 void initAttributesBindings(pybind11::module& m);
-}
+namespace managers {
+void initAttributesManagersBindings(pybind11::module& m);
+}  // namespace managers
+}  // namespace assets
 
 namespace geo {
 void initGeoBindings(pybind11::module& m);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -60,7 +60,9 @@ int PhysicsManager::addObject(const int objectLibIndex,
                               scene::SceneNode* attachmentNode,
                               const Magnum::ResourceKey& lightSetup) {
   const std::string& configHandle =
-      resourceManager_.getPhysicsObjectTemplateHandle(objectLibIndex);
+      resourceManager_.getObjectAttributesManager()->getTemplateHandleByID(
+          objectLibIndex);
+
   return addObject(configHandle, drawables, attachmentNode, lightSetup);
 }
 
@@ -71,7 +73,8 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
   //! Invoke resourceManager to draw object
   //! Test Mesh primitive is valid
   assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
-      resourceManager_.getPhysicsObjectAttributes(configFileHandle);
+      resourceManager_.getObjectAttributesManager()->getTemplateByHandle(
+          configFileHandle);
 
   //! Make rigid object and add it to existingObjects
   int nextObjectID_ = allocateObjectID();
@@ -526,10 +529,10 @@ const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
   return *existingObjects_.at(physObjectID)->visualNode_;
 }
 
-const assets::PhysicsObjectAttributes::ptr
+const assets::PhysicsObjectAttributes::cptr
 PhysicsManager::getInitializationAttributes(const int physObjectID) const {
   assertIDValidity(physObjectID);
-  return std::static_pointer_cast<assets::PhysicsObjectAttributes>(
+  return std::static_pointer_cast<const assets::PhysicsObjectAttributes>(
       existingObjects_.at(physObjectID)->getInitializationAttributes());
 }
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -92,7 +92,7 @@ class PhysicsManager {
    */
   explicit PhysicsManager(
       assets::ResourceManager& _resourceManager,
-      const assets::PhysicsManagerAttributes::ptr _physicsManagerAttributes)
+      const assets::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
       : resourceManager_(_resourceManager),
         physicsManagerAttributes(_physicsManagerAttributes){};
 
@@ -802,7 +802,7 @@ class PhysicsManager {
    * instances of objects.
    * @return The initialization settings of the specified object instance.
    */
-  const assets::PhysicsObjectAttributes::ptr getInitializationAttributes(
+  const assets::PhysicsObjectAttributes::cptr getInitializationAttributes(
       const int physObjectID) const;
 
  protected:
@@ -882,7 +882,7 @@ class PhysicsManager {
 
   /** @brief A pointer to the @ref assets::PhysicsManagerAttributes describing
    * this physics manager */
-  const assets::PhysicsManagerAttributes::ptr physicsManagerAttributes;
+  const assets::PhysicsManagerAttributes::cptr physicsManagerAttributes;
 
   /** @brief The current physics library implementation used by this
    * @ref PhysicsManager. Can be used to correctly cast the @ref PhysicsManager

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -569,7 +569,7 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * instances of objects.
    * @return The initialization settings of this object instance.
    */
-  const assets::AbstractPhysicsAttributes::ptr getInitializationAttributes()
+  const assets::AbstractPhysicsAttributes::cptr getInitializationAttributes()
       const {
     return initializationAttributes_;
   };

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -19,9 +19,9 @@ bool RigidObject::initialize(
   }
 
   // save a copy of the template at initialization time
-  initializationAttributes_ = esp::assets::PhysicsObjectAttributes::create(
-      *(static_cast<esp::assets::PhysicsObjectAttributes*>(
-          physicsAttributes.get())));
+  initializationAttributes_ =
+      resMgr.getObjectAttributesManager()->getTemplateCopyByHandle(
+          physicsAttributes->getOriginHandle());
 
   return initializationFinalize(resMgr);
 }

--- a/src/esp/physics/RigidScene.cpp
+++ b/src/esp/physics/RigidScene.cpp
@@ -18,9 +18,9 @@ bool RigidScene::initialize(
     return false;
   }
   objectMotionType_ = MotionType::STATIC;
-  initializationAttributes_ = esp::assets::PhysicsSceneAttributes::create(
-      *(static_cast<esp::assets::PhysicsSceneAttributes*>(
-          physicsAttributes.get())));
+  initializationAttributes_ =
+      resMgr.getSceneAttributesManager()->getTemplateCopyByHandle(
+          physicsAttributes->getOriginHandle());
 
   return initializationFinalize(resMgr);
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -50,7 +50,7 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   explicit BulletPhysicsManager(
       assets::ResourceManager& _resourceManager,
-      const assets::PhysicsManagerAttributes::ptr _physicsManagerAttributes)
+      const assets::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
       : PhysicsManager(_resourceManager, _physicsManagerAttributes){};
 
   /** @brief Destructor which destructs necessary Bullet physics structures.*/

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -78,7 +78,7 @@ bool BulletRigidObject::initializationFinalize(
     auto primAttrMgr = resMgr.getAssetAttributesManager();
 
     auto primAttributes =
-        primAttrMgr->getAttributesTemplate(collisionAssetHandle);
+        primAttrMgr->getTemplateByHandle(collisionAssetHandle);
     // primitive object pointer construction
     auto primObjPtr = buildPrimitiveCollisionObject(primAttributes);
     bGenericShapes_.clear();

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -75,8 +75,10 @@ bool BulletRigidObject::initializationFinalize(
            ->getUseMeshCollision()) {  // if using prim collider
     // prim stuff here
     // get appropriate bullet collision primitive attributes
+    auto primAttrMgr = resMgr.getAssetAttributesManager();
+
     auto primAttributes =
-        resMgr.getPrimitiveAssetTemplateAttributes(collisionAssetHandle);
+        primAttrMgr->getAttributesTemplate(collisionAssetHandle);
     // primitive object pointer construction
     auto primObjPtr = buildPrimitiveCollisionObject(primAttributes);
     bGenericShapes_.clear();

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -327,26 +327,17 @@ int Simulator::addObjectByHandle(const std::string& objectLibHandle,
 }
 
 std::vector<int> Simulator::loadObjectConfigs(const std::string& path) {
-  std::vector<int> templateIndices;
-  auto physicsAttributesManager =
-      resourceManager_->getPhysicsAttributesManager();
   std::vector<std::string> validConfigPaths =
-      physicsAttributesManager->buildObjectConfigPaths(path);
-  for (auto& validPath : validConfigPaths) {
-    templateIndices.push_back(
-        resourceManager_->parseAndLoadPhysObjTemplate(validPath));
-  }
+      resourceManager_->getPhysicsAttributesManager()->buildObjectConfigPaths(
+          path);
+
+  std::vector<int> templateIndices =
+      resourceManager_->getObjectAttributesManager()->loadAllFileBasedTemplates(
+          validConfigPaths);
   return templateIndices;
-}
+}  // Simulator::loadObjectConfigs
 
-int Simulator::registerObjectTemplate(
-    assets::PhysicsObjectAttributes::ptr objTmplPtr,
-    const std::string& objectTemplateHandle) {
-  return resourceManager_->registerObjectTemplate(objTmplPtr,
-                                                  objectTemplateHandle);
-}
-
-const assets::PhysicsObjectAttributes::ptr
+const assets::PhysicsObjectAttributes::cptr
 Simulator::getObjectInitializationTemplate(int objectId,
                                            const int sceneID) const {
   if (sceneHasPhysics(sceneID)) {
@@ -577,7 +568,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
             Eigen::Transform<float, 3, Eigen::Affine> >(
             physicsManager_->getObjectVisualSceneNode(objectID)
                 .absoluteTransformationMatrix());
-        const assets::PhysicsObjectAttributes::ptr initializationTemplate =
+        const assets::PhysicsObjectAttributes::cptr initializationTemplate =
             physicsManager_->getInitializationAttributes(objectID);
         objectTransform.scale(Magnum::EigenIntegration::cast<vec3f>(
             initializationTemplate->getScale()));

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -112,19 +112,23 @@ class Simulator {
    * @return The string key referencing the asset in @ref ResourceManager.
    */
   std::string getObjectTemplateHandleByID(const int objectTemplateID) const {
-    return resourceManager_->getPhysicsObjectTemplateHandle(objectTemplateID);
+    return resourceManager_->getObjectAttributesManager()
+        ->getTemplateHandleByID(objectTemplateID);
   }
 
   /**
    * @brief Get a list of all templates whose origin handles contain @ref
    * subStr, ignoring subStr's case
    * @param subStr substring to search for within existing object templates
+   * @param contains whether search should be inclusive or exclusive of substr
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
   std::vector<std::string> getObjectTemplateHandles(
-      const std::string& subStr = "") {
-    return resourceManager_->getPhysicsObjectTemplateHandlesBySubstring(subStr);
+      const std::string& subStr = "",
+      bool contains = true) {
+    return resourceManager_->getObjectAttributesManager()
+        ->getTemplateHandlesBySubstring(subStr, contains);
   }
   /**
    * @brief Get a list of all file-based templates whose origin handles contain
@@ -136,7 +140,8 @@ class Simulator {
    */
   std::vector<std::string> getFileBasedObjectTemplateHandles(
       const std::string& subStr = "") {
-    return resourceManager_->getFileTemplateHandlesBySubstring(subStr);
+    return resourceManager_->getObjectAttributesManager()
+        ->getFileTemplateHandlesBySubstring(subStr);
   }
 
   /**
@@ -149,7 +154,8 @@ class Simulator {
    */
   std::vector<std::string> getSynthesizedObjectTemplateHandles(
       const std::string& subStr = "") {
-    return resourceManager_->getSynthTemplateHandlesBySubstring(subStr);
+    return resourceManager_->getObjectAttributesManager()
+        ->getSynthTemplateHandlesBySubstring(subStr);
   }
 
   /**
@@ -203,21 +209,24 @@ class Simulator {
    * esp::assets::ResourceManager::physicsObjectLibrary_.
    */
   int getPhysicsObjectLibrarySize() const {
-    return resourceManager_->getPhysicsObjectLibrarySize();
+    return resourceManager_->getObjectAttributesManager()->getNumTemplates();
   }
 
   /**
    * @brief Get a smart pointer to a physics object template by index.
    */
-  assets::PhysicsObjectAttributes::ptr getObjectTemplate(int templateId) const {
-    return resourceManager_->getPhysicsObjectAttributes(templateId);
+  const assets::PhysicsObjectAttributes::ptr getObjectTemplate(
+      int templateId) const {
+    return resourceManager_->getObjectAttributesManager()->getTemplateByID(
+        templateId);
   }
   /**
    * @brief Get a smart pointer to a physics object template by handle.
    */
-  assets::PhysicsObjectAttributes::ptr getObjectTemplateByName(
+  const assets::PhysicsObjectAttributes::ptr getObjectTemplateByName(
       const std::string& templateHandle) const {
-    return resourceManager_->getPhysicsObjectAttributes(templateHandle);
+    return resourceManager_->getObjectAttributesManager()->getTemplateByHandle(
+        templateHandle);
   }
   /**
    * @brief Load all "*.phys_properties.json" files from the provided file or
@@ -242,16 +251,21 @@ class Simulator {
    * @return A template index for instancing the loaded template or ID_UNDEFINED
    * if failed.
    */
-  int registerObjectTemplate(assets::PhysicsObjectAttributes::ptr objTmplPtr,
-                             const std::string& objectTemplateHandle);
+  int registerObjectTemplate(
+      const assets::PhysicsObjectAttributes::ptr& objTmplPtr,
+      const std::string& objectTemplateHandle) {
+    return resourceManager_->getObjectAttributesManager()
+        ->registerAttributesTemplate(objTmplPtr, objectTemplateHandle);
+  }
 
   /**
    * @brief Get a static view of a physics object's template when the object was
    * instanced.
    *
-   * Use this to query the object's properties when it was initialized.
+   * Use this to query the object's properties when it was initialized.  Object
+   * pointed at by pointer is const, and can not be modified.
    */
-  const assets::PhysicsObjectAttributes::ptr getObjectInitializationTemplate(
+  const assets::PhysicsObjectAttributes::cptr getObjectInitializationTemplate(
       int objectId,
       const int sceneID = 0) const;
 

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -22,6 +22,7 @@
 namespace Cr = Corrade;
 
 using esp::assets::ResourceManager;
+using esp::assets::managers::ObjectAttributesManager;
 using esp::physics::PhysicsManager;
 using esp::scene::SceneManager;
 
@@ -80,12 +81,14 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
     esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
-    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
-                                            objectFile);
+    auto objectAttributesManager =
+        resourceManager_.getObjectAttributesManager();
+    objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                        objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        resourceManager_.getPhysicsObjectAttributes(objectFile);
+        objectAttributesManager->getTemplateByHandle(objectFile);
 
     for (int i = 0; i < 2; i++) {
       // mark the object not joined
@@ -160,12 +163,15 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.0);
     physicsObjectAttributes->setJoinCollisionMeshes(false);
-    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
-                                            objectFile);
+
+    auto objectAttributesManager =
+        resourceManager_.getObjectAttributesManager();
+    objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                        objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        resourceManager_.getPhysicsObjectAttributes(objectFile);
+        objectAttributesManager->getTemplateByHandle(objectFile);
 
     for (int i = 0; i < 2; i++) {
       if (i == 0) {
@@ -231,8 +237,10 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
         esp::assets::PhysicsObjectAttributes::create();
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.0);
-    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
-                                            objectFile);
+    auto objectAttributesManager =
+        resourceManager_.getObjectAttributesManager();
+    objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                        objectFile);
 
     // generate two centered boxes with dimension 2x2x2
     int objectId0 = physicsManager_->addObject(objectFile, nullptr);
@@ -275,12 +283,14 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
     physicsObjectAttributes->setRenderAssetHandle(objectFile);
     physicsObjectAttributes->setMargin(0.1);
 
-    resourceManager_.registerObjectTemplate(physicsObjectAttributes,
-                                            objectFile);
+    auto objectAttributesManager =
+        resourceManager_.getObjectAttributesManager();
+    objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                        objectFile);
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        resourceManager_.getPhysicsObjectAttributes(objectFile);
+        objectAttributesManager->getTemplateByHandle(objectFile);
 
     auto* drawables = &sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
@@ -335,11 +345,13 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
   physicsObjectAttributes->setMargin(0.0);
 
-  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
+  auto objectAttributesManager = resourceManager_.getObjectAttributesManager();
+  objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                      objectFile);
 
   // get a reference to the stored template to edit
   esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-      resourceManager_.getPhysicsObjectAttributes(objectFile);
+      objectAttributesManager->getTemplateByHandle(objectFile);
 
   std::vector<Magnum::Vector3> testScales{
       {1.0, 1.0, 1.0},  {4.0, 3.0, 2.0},    {0.1, 0.2, 0.3},
@@ -399,7 +411,9 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
   physicsObjectAttributes->setMargin(0.0);
-  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
+  auto objectAttributesManager = resourceManager_.getObjectAttributesManager();
+  objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                      objectFile);
 
   auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
@@ -542,7 +556,9 @@ TEST_F(PhysicsManagerTest, TestSceneNodeAttachment) {
   esp::assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
       esp::assets::PhysicsObjectAttributes::create();
   physicsObjectAttributes->setRenderAssetHandle(objectFile);
-  resourceManager_.registerObjectTemplate(physicsObjectAttributes, objectFile);
+  auto objectAttributesManager = resourceManager_.getObjectAttributesManager();
+  objectAttributesManager->registerAttributesTemplate(physicsObjectAttributes,
+                                                      objectFile);
 
   esp::scene::SceneNode& root =
       sceneManager_.getSceneGraph(sceneID_).getRootNode();
@@ -603,8 +619,11 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
     physicsObjectAttributes->setBoundingBoxCollisions(true);
     physicsObjectAttributes->setScale(
         {boxHalfExtent, boxHalfExtent, boxHalfExtent});
-    int boxId = resourceManager_.registerObjectTemplate(physicsObjectAttributes,
-                                                        objectFile);
+    auto objectAttributesManager =
+        resourceManager_.getObjectAttributesManager();
+
+    int boxId = objectAttributesManager->registerAttributesTemplate(
+        physicsObjectAttributes, objectFile);
 
     auto& drawables = sceneManager_.getSceneGraph(sceneID_).getDrawables();
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -310,14 +310,18 @@ Viewer::Viewer(const Arguments& arguments)
 }  // end Viewer::Viewer
 
 void Viewer::addObject(int ID) {
-  if (physicsManager_ == nullptr)
+  if (physicsManager_ == nullptr) {
     return;
-  addObject(resourceManager_.getPhysicsObjectTemplateHandle(ID));
+  }
+  const std::string& configHandle =
+      resourceManager_.getObjectAttributesManager()->getTemplateHandleByID(ID);
+  addObject(configHandle);
 }  // addObject
 
 void Viewer::addObject(const std::string& configFile) {
-  if (physicsManager_ == nullptr)
+  if (physicsManager_ == nullptr) {
     return;
+  }
 
   Mn::Matrix4 T =
       agentBodyNode_
@@ -338,9 +342,11 @@ void Viewer::addObject(const std::string& configFile) {
 // add file-based template derived object from keypress
 void Viewer::addTemplateObject() {
   if (physicsManager_ != nullptr) {
-    int numObjTemplates = resourceManager_.getNumFileTemplateObjects();
+    int numObjTemplates = resourceManager_.getObjectAttributesManager()
+                              ->getNumFileTemplateObjects();
     if (numObjTemplates > 0) {
-      addObject(resourceManager_.getRandomFileTemplateHandle());
+      addObject(resourceManager_.getObjectAttributesManager()
+                    ->getRandomFileTemplateHandle());
     } else
       LOG(WARNING) << "No objects loaded, can't add any";
   } else
@@ -352,9 +358,11 @@ void Viewer::addTemplateObject() {
 void Viewer::addPrimitiveObject() {
   // TODO : use this to implement synthesizing rendered physical objects
   if (physicsManager_ != nullptr) {
-    int numObjPrims = resourceManager_.getNumSynthTemplateObjects();
+    int numObjPrims = resourceManager_.getObjectAttributesManager()
+                          ->getNumSynthTemplateObjects();
     if (numObjPrims > 0) {
-      addObject(resourceManager_.getRandomSynthTemplateHandle());
+      addObject(resourceManager_.getObjectAttributesManager()
+                    ->getRandomSynthTemplateHandle());
     } else
       LOG(WARNING) << "No primitive templates available, can't add any objects";
   } else
@@ -363,15 +371,17 @@ void Viewer::addPrimitiveObject() {
 }  // addPrimitiveObject
 
 void Viewer::removeLastObject() {
-  if (physicsManager_ == nullptr || objectIDs_.size() == 0)
+  if (physicsManager_ == nullptr || objectIDs_.size() == 0) {
     return;
+  }
   physicsManager_->removeObject(objectIDs_.back());
   objectIDs_.pop_back();
 }
 
 void Viewer::invertGravity() {
-  if (physicsManager_ == nullptr)
+  if (physicsManager_ == nullptr) {
     return;
+  }
   const Mn::Vector3& gravity = physicsManager_->getGravity();
   const Mn::Vector3 invGravity = -1 * gravity;
   physicsManager_->setGravity(invGravity);


### PR DESCRIPTION
## Motivation and Context
This PR completes the internal implementation of the attributes managers, migrating the functionality for template management for assets and objects.  Nearly all of the functionality the AttributesManagers introduced was present in the previous PR, so this PR is primarily focused on modifying the existing code base to use the ObjectAttributesManager and AssetAttributesManager instead of ResourceManager.  All the hooks to access attributes template functionality that were previous passing through sim to get to resource manager still do this now (a future PR will change this, which will be a breaking change); however, all the internal code that did reside in ResourceManager has been removed, shrinking both header and implementation files by around 500 lines each.  

The planned use for these objects, from a user's perspective, is to have the user request the manager of the attributes they would like to modify from Simulator, and then modify the attributes directly.  Upon modification, the appropriate steps would be taken internally to process their modifications. Currently, rudimentary bindings have been added, although direct access to the managers from python is not yet available, and will be added in the next PR. 
Existing tests were updated to be compatible with the new configuration, although no new tests were designed to handle the new functionality introduced.  This will also be presented in the next PR.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
existing c++ and python tests passed.  A future PR will introduce tests specifically designed to validate the new functionality that is not directly tested currently.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
