### PR TITLE
[object picking] Step 1: remove object id from GenericDrawable

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -856,7 +856,7 @@ bool ResourceManager::loadGeneralMeshData(
                meshes_[meshMetaData.meshIndex.first]) {
       // no default scene --- standalone OBJ/PLY files, for example
       // take a wild guess and load the first mesh with the first material
-      // addMeshToDrawables(metaData, *parent, drawables, ID_UNDEFINED, 0, 0);
+      // addMeshToDrawables(metaData, *parent, drawables, 0, 0);
       loadMeshHierarchy(*fileImporter_, meshMetaData.root, 0);
     } else {
       LOG(ERROR) << "No default scene available and no meshes found, exiting";
@@ -1347,8 +1347,7 @@ void ResourceManager::addComponent(const MeshMetaData& metaData,
   // Add a drawable if the object has a mesh and the mesh is loaded
   if (meshIDLocal != ID_UNDEFINED) {
     const int materialIDLocal = meshTransformNode.materialIDLocal;
-    addMeshToDrawables(metaData, node, lightSetup, drawables,
-                       meshTransformNode.componentID, meshIDLocal,
+    addMeshToDrawables(metaData, node, lightSetup, drawables, meshIDLocal,
                        materialIDLocal);
 
     // compute the bounding box for the mesh we are adding
@@ -1367,7 +1366,6 @@ void ResourceManager::addMeshToDrawables(const MeshMetaData& metaData,
                                          scene::SceneNode& node,
                                          const Mn::ResourceKey& lightSetup,
                                          DrawableGroup* drawables,
-                                         int objectID,
                                          int meshIDLocal,
                                          int materialIDLocal) {
   const int meshStart = metaData.meshIndex.first;
@@ -1383,8 +1381,7 @@ void ResourceManager::addMeshToDrawables(const MeshMetaData& metaData,
         std::to_string(metaData.materialIndex.first + materialIDLocal);
   }
 
-  createGenericDrawable(mesh, node, lightSetup, materialKey, drawables,
-                        objectID);
+  createGenericDrawable(mesh, node, lightSetup, materialKey, drawables);
 
   if (computeAbsoluteAABBs_) {
     staticDrawableInfo_.emplace_back(StaticDrawableInfo{node, meshID});
@@ -1404,11 +1401,10 @@ void ResourceManager::createGenericDrawable(
     scene::SceneNode& node,
     const Mn::ResourceKey& lightSetup,
     const Mn::ResourceKey& material,
-    DrawableGroup* group /* = nullptr */,
-    int objectId /* = ID_UNDEFINED */) {
+    DrawableGroup* group /* = nullptr */) {
   node.addFeature<gfx::GenericDrawable>(mesh, shaderManager_, lightSetup,
-                                        material, group, objectId);
-}
+                                        material, group);
+}  // namespace assets
 
 bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,
                                          scene::SceneNode* parent,

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -755,8 +755,6 @@ class ResourceManager {
    * for the added mesh.
    * @param drawables The @ref DrawableGroup with which the new @ref
    * gfx::Drawable will be rendered.
-   * @param objectID The object type identifier or semantic group (e.g.
-   * 1->chair, 2->table, etc..) for semantic rendering of the mesh.
    * @param meshIDLocal The index of the mesh within the mesh group linked to
    * the asset via the @ref MeshMetaData.
    * @param materialIDLocal The index of the material within the material
@@ -766,7 +764,6 @@ class ResourceManager {
                           scene::SceneNode& node,
                           const Magnum::ResourceKey& lightSetup,
                           DrawableGroup* drawables,
-                          int objectID,
                           int meshIDLocal,
                           int materialIDLocal);
 
@@ -790,8 +787,6 @@ class ResourceManager {
    * @param group Optional @ref DrawableGroup with which the render the @ref
    * gfx::Drawable.
    * @param texture Optional texture for the mesh.
-   * @param objectId Optional object type indentifier or semantic type for the
-   * mesh (e.g. 1->table, 2->chair, etc...).
    * @param color Optional color parameter for the shader program. Defaults to
    * white.
    */
@@ -799,8 +794,7 @@ class ResourceManager {
                              scene::SceneNode& node,
                              const Magnum::ResourceKey& lightSetup,
                              const Magnum::ResourceKey& material,
-                             DrawableGroup* group = nullptr,
-                             int objectId = ID_UNDEFINED);
+                             DrawableGroup* group = nullptr);
 
   // ======== Instance Variables ========
 

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -19,14 +19,12 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
                                  ShaderManager& shaderManager,
                                  const Mn::ResourceKey& lightSetup,
                                  const Mn::ResourceKey& materialData,
-                                 DrawableGroup* group /* = nullptr */,
-                                 int objectId /* = ID_UNDEFINED */)
+                                 DrawableGroup* group /* = nullptr */)
     : Drawable{node, mesh, group},
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetup)},
       materialData_{
-          shaderManager.get<MaterialData, PhongMaterialData>(materialData)},
-      objectId_(objectId) {
+          shaderManager.get<MaterialData, PhongMaterialData>(materialData)} {
   // update the shader early here to to avoid doing it during the render loop
   updateShader();
 }

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -15,15 +15,14 @@ namespace gfx {
 class GenericDrawable : public Drawable {
  public:
   //! Create a GenericDrawable for the given object using shader and mesh.
-  //! Adds drawable to given group and uses provided texture, objectId, and
-  //! color for textured, object id buffer and color shader output respectively
+  //! Adds drawable to given group and uses provided texture, and
+  //! color for textured buffer and color shader output respectively
   explicit GenericDrawable(scene::SceneNode& node,
                            Magnum::GL::Mesh& mesh,
                            ShaderManager& shaderManager,
                            const Magnum::ResourceKey& lightSetup,
                            const Magnum::ResourceKey& materialData,
-                           DrawableGroup* group = nullptr,
-                           int objectId = ID_UNDEFINED);
+                           DrawableGroup* group = nullptr);
 
   void setLightSetup(const Magnum::ResourceKey& lightSetup) override;
 
@@ -39,7 +38,6 @@ class GenericDrawable : public Drawable {
                                    Magnum::Shaders::Phong::Flags flags) const;
 
   Magnum::GL::Texture2D* texture_;
-  int objectId_;
   Magnum::Color4 color_;
 
   // shader parameters


### PR DESCRIPTION
## Motivation and Context
I am working on a new functionality in viewer -- object picking. This is a rather useful function that we would like to have for quite a long time.

This is 1st diff that is to address this problem.
We did not use the object id anywhere in our simulator, and it confuses the developers and users. The solution is to deprecate it, and introduce a drawableID in the Drawable class (parent class of GenericaDrawable) to address this problem (in the coming diff). So each drawable (NOT just the GenericDrawable) would have a unique id to identify itself.



<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
