### PR TITLE
Attributes managers object sim tests

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -47,6 +47,7 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
   setRenderAssetIsPrimitive(false);
   setCollisionAssetIsPrimitive(false);
   setUseMeshCollision(true);
+  setComputeCOMFromShape(true);
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -190,10 +190,10 @@ class PhysicsObjectAttributes : public AbstractPhysicsAttributes {
   Magnum::Vector3 getCOM() const { return getVec3("COM"); }
 
   // whether com is provided or not
-  void setCOMIsProvided(bool COMIsProvided) {
-    setBool("COMIsProvided", COMIsProvided);
+  void setComputeCOMFromShape(bool computeCOMFromShape) {
+    setBool("computeCOMFromShape", computeCOMFromShape);
   }
-  bool getCOMIsProvided() const { return getBool("COMIsProvided"); }
+  bool getComputeCOMFromShape() const { return getBool("computeCOMFromShape"); }
 
   // collision shape inflation margin
   void setMargin(double margin) { setDouble("margin", margin); }

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -189,6 +189,12 @@ class PhysicsObjectAttributes : public AbstractPhysicsAttributes {
   void setCOM(const Magnum::Vector3& com) { setVec3("COM", com); }
   Magnum::Vector3 getCOM() const { return getVec3("COM"); }
 
+  // whether com is provided or not
+  void setCOMIsProvided(bool COMIsProvided) {
+    setBool("COMIsProvided", COMIsProvided);
+  }
+  bool getCOMIsProvided() const { return getBool("COMIsProvided"); }
+
   // collision shape inflation margin
   void setMargin(double margin) { setDouble("margin", margin); }
   double getMargin() const { return getDouble("margin"); }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -105,7 +105,8 @@ void ResourceManager::initDefaultPrimAttributes() {
   // wireframe cube no differently than other primivite-based rendered
   // objects)
   auto cubeMeshName =
-      assetAttributesManager_->getTemplateByHandle("cubeWireframe")
+      assetAttributesManager_
+          ->getTemplateCopyByHandle<CubePrimitiveAttributes>("cubeWireframe")
           ->getPrimObjClassName();
 
   auto wfCube = primitiveImporter_->mesh(cubeMeshName);

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -317,7 +317,7 @@ bool ResourceManager::loadPhysicsScene(
     //! Add scene meshgroup to collision mesh groups
     collisionMeshGroups_.emplace(filename, meshGroup);
     //! Initialize collision mesh
-    bool sceneSuccess = _physicsManager->addScene(physSceneLib, meshGroup);
+    bool sceneSuccess = _physicsManager->addScene(filename, meshGroup);
     if (!sceneSuccess) {
       return false;
     }
@@ -1187,9 +1187,13 @@ bool ResourceManager::instantiateAssetsOnDemand(
   PhysicsObjectAttributes::ptr physicsObjectAttributes =
       objectAttributesManager_->getTemplateByHandle(objectTemplateHandle);
 
-  // if attributes are "dirty" (values have changed since last registered)
-  // then re-register.  Should never return ID_UNDEFINED - this would mean
-  // something has corrupted the library.
+  // if attributes are "dirty" (important values have changed since last
+  // registered) then re-register.  Should never return ID_UNDEFINED - this
+  // would mean something has corrupted the library.
+  // NOTE : this is called when an new object is being made, but before the
+  // object has acquired a copy of its parent attributes.  No object should ever
+  // have a copy of attributes with isDirty == true - any editing of attributes
+  // for objects requires object rebuilding.
   if (physicsObjectAttributes->getIsDirty()) {
     CORRADE_ASSERT(
         (ID_UNDEFINED != objectAttributesManager_->registerAttributesTemplate(

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -323,7 +323,6 @@ class ResourceManager {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           objectAttributesManager_->getTemplateHandleByID(objTemplateLibID);
-      // physicsObjectTemplateLibByID_.at(objTemplateLibID);
 
       addObjectToDrawables(objTemplateHandleName, parent, drawables,
                            lightSetup);

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -163,7 +163,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("capsule3DSolid");
     }
-    return getTemplateCopyByHandle<CapsulePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CapsulePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultCapsuleTemplate
 
   /**
@@ -178,7 +179,8 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "capsule")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<CapsulePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CapsulePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getCapsuleTemplate
 
   /**
@@ -193,7 +195,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("coneSolid");
     }
-    return getTemplateCopyByHandle<ConePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<ConePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultConeTemplate
 
   /**
@@ -208,7 +211,8 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "cone")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<ConePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<ConePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getConeTemplate
 
   /**
@@ -223,7 +227,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("cubeSolid");
     }
-    return getTemplateCopyByHandle<CubePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CubePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultCubeTemplate
 
   /**
@@ -238,7 +243,8 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "cube")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<CubePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CubePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getCubeTemplate
 
   /**
@@ -254,7 +260,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("cylinderSolid");
     }
-    return getTemplateCopyByHandle<CylinderPrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CylinderPrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultCylinderTemplate
 
   /**
@@ -269,7 +276,8 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "cylinder")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<CylinderPrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<CylinderPrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getCylinderTemplate
 
   /**
@@ -285,7 +293,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("icosphereSolid");
     }
-    return getTemplateCopyByHandle<IcospherePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<IcospherePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultIcosphereTemplate
 
   /**
@@ -300,7 +309,8 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "icosphere")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<IcospherePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<IcospherePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getIcosphereTemplate
 
   /**
@@ -316,7 +326,8 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("uvSphereSolid");
     }
-    return getTemplateCopyByHandle<UVSpherePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<UVSpherePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getDefaultUVSphereTemplate
 
   /**
@@ -331,49 +342,9 @@ class AssetAttributesManager
     if (!verifyTemplateHandle(templateHndle, "uvSphere")) {
       return nullptr;
     }
-    return getTemplateCopyByHandle<UVSpherePrimitiveAttributes>(templateHndle);
+    return this->getTemplateCopyByHandle<UVSpherePrimitiveAttributes>(
+        templateHndle);
   }  // AssetAttributeManager::getUVSphereTemplate
-
-  /**
-   * @brief Get a copy of the attributes template identified by the
-   * attributesTemplateID, casted to the appropriate derived asset attributes
-   * class
-   *
-   * Can be used to manipulate a template before instancing new objects.
-   * @param attributesTemplateID The ID of the template.  Is mapped to the key
-   * referencing the asset in @ref templateLibrary_ by @ref templateLibKeyByID_.
-   * @return A mutable reference to the object template, or nullptr if does not
-   * exist
-   */
-  template <class U>
-  std::shared_ptr<U> getTemplateCopyByID(int attributesTemplateID) {
-    std::string templateHandle = getTemplateHandleByID(attributesTemplateID);
-    auto res = AttributesManager<AbstractPrimitiveAttributes::ptr>::
-        getTemplateCopyByID(attributesTemplateID);
-    if (nullptr == res) {
-      return nullptr;
-    }
-    return std::dynamic_pointer_cast<U>(res);
-  }  // AttributesManager::getTemplateCopyByID
-
-  /**
-   * @brief Return a reference to a copy of the object specified
-   * by passed handle, casted to the appropriate derived asset attributes class
-   * This is the version that should be accessed by the user
-   * @param templateHandle the string key of the attributes desired.
-   * @return a copy of the desired attributes, or nullptr if does
-   * not exist
-   */
-  template <class U>
-  std::shared_ptr<U> getTemplateCopyByHandle(
-      const std::string& templateHandle) {
-    auto res = AttributesManager<AbstractPrimitiveAttributes::ptr>::
-        getTemplateCopyByHandle(templateHandle);
-    if (nullptr == res) {
-      return nullptr;
-    }
-    return std::dynamic_pointer_cast<U>(res);
-  }  // AttributesManager::getTemplateCopyByHandle
 
  protected:
   /**

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -36,6 +36,8 @@ namespace managers {
 template <class AttribsPtr>
 class AttributesManager {
  public:
+  virtual ~AttributesManager() = default;
+
   /**
    * @brief Creates an instance of a template described by passed string. For
    * physical objects, this is either a file name or a reference to a primitive
@@ -182,6 +184,45 @@ class AttributesManager {
     }
     auto orig = this->templateLibrary_.at(templateHandle);
     return this->copyAttributes(orig);
+  }  // AttributesManager::getTemplateCopyByHandle
+
+  /**
+   * @brief Get a copy of the attributes template identified by the
+   * attributesTemplateID, casted to the appropriate derived asset attributes
+   * class
+   *
+   * Can be used to manipulate a template before instancing new objects.
+   * @param attributesTemplateID The ID of the template.  Is mapped to the key
+   * referencing the asset in @ref templateLibrary_ by @ref templateLibKeyByID_.
+   * @return A mutable reference to the object template, or nullptr if does not
+   * exist
+   */
+  template <class U>
+  std::shared_ptr<U> getTemplateCopyByID(int attributesTemplateID) {
+    std::string templateHandle = getTemplateHandleByID(attributesTemplateID);
+    auto res = getTemplateCopyByID(attributesTemplateID);
+    if (nullptr == res) {
+      return nullptr;
+    }
+    return std::dynamic_pointer_cast<U>(res);
+  }  // AttributesManager::getTemplateCopyByID
+
+  /**
+   * @brief Return a reference to a copy of the object specified
+   * by passed handle, casted to the appropriate derived asset attributes class
+   * This is the version that should be accessed by the user
+   * @param templateHandle the string key of the attributes desired.
+   * @return a copy of the desired attributes, or nullptr if does
+   * not exist
+   */
+  template <class U>
+  std::shared_ptr<U> getTemplateCopyByHandle(
+      const std::string& templateHandle) {
+    auto res = getTemplateCopyByHandle(templateHandle);
+    if (nullptr == res) {
+      return nullptr;
+    }
+    return std::dynamic_pointer_cast<U>(res);
   }  // AttributesManager::getTemplateCopyByHandle
 
   /**

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -241,7 +241,7 @@ ObjectAttributesManager::parseAndLoadPhysObjTemplate(
       physicsObjectAttributes->setCOM(COM);
       // set a flag which we can find later so we don't override the desired
       // COM with BB center.
-      physicsObjectAttributes->setCOMIsProvided(true);
+      physicsObjectAttributes->setComputeCOMFromShape(false);
     }
   }
 

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -241,7 +241,7 @@ ObjectAttributesManager::parseAndLoadPhysObjTemplate(
       physicsObjectAttributes->setCOM(COM);
       // set a flag which we can find later so we don't override the desired
       // COM with BB center.
-      physicsObjectAttributes->setBool("COM_provided", true);
+      physicsObjectAttributes->setCOMIsProvided(true);
     }
   }
 

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -16,6 +16,10 @@ namespace core {
 
 class Configuration {
  public:
+  // virtual destructor set to that pybind11 recognizes attributes inheritance
+  // from configuration to be polymorphic
+  virtual ~Configuration() = default;
+
   template <typename T>
   bool set(const std::string& key, const T& value) {
     return cfg.setValue(key, value);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -33,7 +33,7 @@ PhysicsManager::~PhysicsManager() {
 }
 
 bool PhysicsManager::addScene(
-    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
+    const std::string& handle,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
   for (const assets::CollisionMeshData& meshData : meshGroup) {
@@ -43,15 +43,13 @@ bool PhysicsManager::addScene(
   }
 
   //! Initialize scene
-  bool sceneSuccess = addSceneFinalize(physicsSceneAttributes);
+  bool sceneSuccess = addSceneFinalize(handle);
   return sceneSuccess;
 }
 
-bool PhysicsManager::addSceneFinalize(
-    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes) {
+bool PhysicsManager::addSceneFinalize(const std::string& handle) {
   //! Initialize scene
-  bool sceneSuccess =
-      staticSceneObject_->initialize(resourceManager_, physicsSceneAttributes);
+  bool sceneSuccess = staticSceneObject_->initialize(resourceManager_, handle);
   return sceneSuccess;
 }
 
@@ -72,9 +70,6 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
                               const Magnum::ResourceKey& lightSetup) {
   //! Invoke resourceManager to draw object
   //! Test Mesh primitive is valid
-  assets::PhysicsObjectAttributes::ptr physicsObjectAttributes =
-      resourceManager_.getObjectAttributesManager()->getTemplateByHandle(
-          configFileHandle);
 
   //! Make rigid object and add it to existingObjects
   int nextObjectID_ = allocateObjectID();
@@ -85,15 +80,24 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
   // verify whether necessary assets exist, and if not, instantiate them
   // only make object if asset instantiation succeeds (short circuit)
   bool objectSuccess =
-      resourceManager_.instantiateAssetsOnDemand(configFileHandle) &&
-      makeAndAddRigidObject(nextObjectID_, physicsObjectAttributes, objectNode);
+      resourceManager_.instantiateAssetsOnDemand(configFileHandle);
+  if (!objectSuccess) {
+    LOG(ERROR) << "PhysicsManager::addObject : "
+                  "ResourceManager::instantiateAssetsOnDemand unsuccessful. "
+                  "Aborting.";
+    return ID_UNDEFINED;
+  }
+
+  objectSuccess =
+      makeAndAddRigidObject(nextObjectID_, configFileHandle, objectNode);
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
-    LOG(ERROR) << "makeRigidObject unsuccessful";
+    LOG(ERROR) << "PhysicsManager::addObject : PhysicsManager::makeRigidObject "
+                  "unsuccessful.  Aborting.";
     return ID_UNDEFINED;
   }
 
@@ -102,20 +106,8 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
   resourceManager_.addObjectToDrawables(
       configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
       drawables, lightSetup);
-  existingObjects_.at(nextObjectID_)->node().computeCumulativeBB();
 
-  if (physicsObjectAttributes->hasValue("COM_provided")) {
-    // if the COM is provided, shift by that
-    Magnum::Vector3 comShift = -physicsObjectAttributes->getCOM();
-    // first apply scale
-    comShift = physicsObjectAttributes->getScale() * comShift;
-    existingObjects_.at(nextObjectID_)->shiftOrigin(comShift);
-  } else {
-    // otherwise use the bounding box center
-    existingObjects_.at(nextObjectID_)->shiftOriginToBBCenter();
-  }
-
-  // finalize rigid object creation
+  // // finalize rigid object creation
   existingObjects_.at(nextObjectID_)->finalizeObject();
 
   return nextObjectID_;
@@ -162,12 +154,11 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
   return physObjectID;
 }
 
-bool PhysicsManager::makeAndAddRigidObject(
-    int newObjectID,
-    assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-    scene::SceneNode* objectNode) {
+bool PhysicsManager::makeAndAddRigidObject(int newObjectID,
+                                           const std::string& handle,
+                                           scene::SceneNode* objectNode) {
   auto ptr = physics::RigidObject::create_unique(objectNode);
-  bool objSuccess = ptr->initialize(resourceManager_, physicsObjectAttributes);
+  bool objSuccess = ptr->initialize(resourceManager_, handle);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }
@@ -543,8 +534,7 @@ const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
 const assets::PhysicsObjectAttributes::cptr
 PhysicsManager::getInitializationAttributes(const int physObjectID) const {
   assertIDValidity(physObjectID);
-  return std::static_pointer_cast<const assets::PhysicsObjectAttributes>(
-      existingObjects_.at(physObjectID)->getInitializationAttributes());
+  return existingObjects_.at(physObjectID)->getInitializationAttributes();
 }
 
 }  // namespace physics

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -107,8 +107,14 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
       configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
       drawables, lightSetup);
 
-  // // finalize rigid object creation
-  existingObjects_.at(nextObjectID_)->finalizeObject();
+  // finalize rigid object creation
+  objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();
+  if (!objectSuccess) {
+    removeObject(nextObjectID_, true, true);
+    LOG(ERROR) << "PhysicsManager::addObject : PhysicsManager::finalizeObject "
+                  "unsuccessful.  Aborting.";
+    return ID_UNDEFINED;
+  }
 
   return nextObjectID_;
 }

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -127,14 +127,13 @@ class PhysicsManager {
    * Only one 'scene' may be initialized per simulated world, but this scene may
    * contain several components (e.g. GLB heirarchy).
    *
-   * @param physicsSceneAttributes a pointer to the structure defining physical
+   * @param handle The handle to the attributes structure defining physical
    * properties of the scene.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
-  bool addScene(
-      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes,
-      const std::vector<assets::CollisionMeshData>& meshGroup);
+  bool addScene(const std::string& handle,
+                const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::assets::ResourceManager::physicsObjectLibrary_.
@@ -869,29 +868,27 @@ class PhysicsManager {
    * @brief Finalize scene initialization for kinematic scenes.  Overidden by
    * instancing class if physics is supported.
    *
-   * @param physicsSceneAttributes a pointer to the structure defining physical
+   * @param handle the handle to the attributes structure defining physical
    * properties of the scene.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
 
-  virtual bool addSceneFinalize(
-      const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes);
+  virtual bool addSceneFinalize(const std::string& handle);
 
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
    * @param meshGroup The object's mesh.
-   * @param physicsObjectAttributes The physical object's template defining its
+   * @param handle The handle to the physical object's template defining its
    * physical parameters.
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  virtual bool makeAndAddRigidObject(
-      int newObjectID,
-      assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      scene::SceneNode* objectNode);
+  virtual bool makeAndAddRigidObject(int newObjectID,
+                                     const std::string& handle,
+                                     scene::SceneNode* objectNode);
 
   /** @brief A reference to a @ref esp::assets::ResourceManager which holds
    * assets that can be accessed by this @ref PhysicsManager*/

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -101,8 +101,9 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that
    * inherits from this class.
+   * @return whether successful finalization.
    */
-  virtual void finalizeObject() = 0;
+  virtual bool finalizeObject() = 0;
 
  private:
   /**
@@ -117,8 +118,9 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
    * after @ref RigidObject or @ref RigidScene is created.
+   * @return whether successful finalization.
    */
-  virtual void finalizeObject_LibSpecifc() = 0;
+  virtual bool finalizeObject_LibSpecific() = 0;
 
  public:
   /**

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -24,7 +24,7 @@ bool RigidObject::initialize(const assets::ResourceManager& resMgr,
   return initialization_LibSpecific(resMgr);
 }  // RigidObject::initialize
 
-void RigidObject::finalizeObject() {
+bool RigidObject::finalizeObject() {
   node().computeCumulativeBB();
 
   // cast initialization attributes
@@ -32,8 +32,8 @@ void RigidObject::finalizeObject() {
       std::dynamic_pointer_cast<const assets::PhysicsObjectAttributes>(
           initializationAttributes_);
 
-  if (physicsObjectAttributes->getCOMIsProvided()) {
-    // if the COM is provided, shift by that
+  if (!physicsObjectAttributes->getComputeCOMFromShape()) {
+    // will be false if the COM is provided; shift by that COM
     Magnum::Vector3 comShift = -physicsObjectAttributes->getCOM();
     // first apply scale
     comShift = physicsObjectAttributes->getScale() * comShift;
@@ -43,7 +43,7 @@ void RigidObject::finalizeObject() {
     shiftOriginToBBCenter();
   }
   // finish object by instancing any dynamics library-specific code required
-  finalizeObject_LibSpecifc();
+  return finalizeObject_LibSpecific();
 }  // RigidObject::finalizeObject
 
 bool RigidObject::initialization_LibSpecific(const assets::ResourceManager&) {

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -10,9 +10,8 @@ namespace physics {
 RigidObject::RigidObject(scene::SceneNode* rigidBodyNode)
     : RigidBase(rigidBodyNode), velControl_(VelocityControl::create()) {}
 
-bool RigidObject::initialize(
-    const assets::ResourceManager& resMgr,
-    const assets::AbstractPhysicsAttributes::ptr physicsAttributes) {
+bool RigidObject::initialize(const assets::ResourceManager& resMgr,
+                             const std::string& handle) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidObject more than once";
     return false;
@@ -20,17 +19,38 @@ bool RigidObject::initialize(
 
   // save a copy of the template at initialization time
   initializationAttributes_ =
-      resMgr.getObjectAttributesManager()->getTemplateCopyByHandle(
-          physicsAttributes->getOriginHandle());
+      resMgr.getObjectAttributesManager()->getTemplateCopyByHandle(handle);
 
-  return initializationFinalize(resMgr);
-}
+  return initialization_LibSpecific(resMgr);
+}  // RigidObject::initialize
 
-bool RigidObject::initializationFinalize(const assets::ResourceManager&) {
+void RigidObject::finalizeObject() {
+  node().computeCumulativeBB();
+
+  // cast initialization attributes
+  assets::PhysicsObjectAttributes::cptr physicsObjectAttributes =
+      std::dynamic_pointer_cast<const assets::PhysicsObjectAttributes>(
+          initializationAttributes_);
+
+  if (physicsObjectAttributes->getCOMIsProvided()) {
+    // if the COM is provided, shift by that
+    Magnum::Vector3 comShift = -physicsObjectAttributes->getCOM();
+    // first apply scale
+    comShift = physicsObjectAttributes->getScale() * comShift;
+    shiftOrigin(comShift);
+  } else {
+    // otherwise use the bounding box center
+    shiftOriginToBBCenter();
+  }
+  // finish object by instancing any dynamics library-specific code required
+  finalizeObject_LibSpecifc();
+}  // RigidObject::finalizeObject
+
+bool RigidObject::initialization_LibSpecific(const assets::ResourceManager&) {
   // default kineamtic unless a simulator is initialized...
   objectMotionType_ = MotionType::KINEMATIC;
   return true;
-}
+}  // RigidObject::initialization_LibSpecific
 
 bool RigidObject::setMotionType(MotionType mt) {
   if (mt != MotionType::DYNAMIC) {

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -45,8 +45,8 @@ struct VelocityControl {
   Magnum::Vector3 angVel;
   /**@brief Whether or not to set linear control velocity before stepping. */
   bool controllingLinVel = false;
-  /**@brief Whether or not to set linear control velocity in local space.
-   *
+  /**
+   * @brief Whether or not to set linear control velocity in local space.
    * Useful for commanding actions such as "forward", or "strafe".
    */
   bool linVelIsLocal = false;
@@ -54,8 +54,8 @@ struct VelocityControl {
   /**@brief Whether or not to set angular control velocity before stepping. */
   bool controllingAngVel = false;
 
-  /**@brief Whether or not to set angular control velocity in local space.
-   *
+  /**
+   * @brief Whether or not to set angular control velocity in local space.
    * Useful for commanding actions such as "roll" and "yaw".
    */
   bool angVelIsLocal = false;
@@ -81,14 +81,14 @@ struct VelocityControl {
 };
 
 /**
-@brief An AbstractFeature3D representing an individual rigid object instance
-attached to a SceneNode, updating its state through simulation. This may be a
-@ref MotionType::STATIC scene collision geometry or an object of any @ref
-MotionType which can interact with other members of a physical world. Must have
-a collision mesh. By default, a RigidObject is @ref MotionType::KINEMATIC
-without an underlying simulator implementation. Derived classes can be used to
-introduce specific implementations of dynamics.
-*/
+ * @brief An AbstractFeature3D representing an individual rigid object instance
+ * attached to a SceneNode, updating its state through simulation. This may be a
+ * @ref MotionType::STATIC scene collision geometry or an object of any @ref
+ * MotionType which can interact with other members of a physical world. Must
+ * have a collision mesh. By default, a RigidObject is @ref
+ * MotionType::KINEMATIC without an underlying simulator implementation. Derived
+ * classes can be used to introduce specific implementations of dynamics.
+ */
 class RigidObject : public RigidBase {
  public:
   /**
@@ -104,7 +104,7 @@ class RigidObject : public RigidBase {
   virtual ~RigidObject() {}
 
   /**
-   * @brief Initializes the @ref RigidObject that inheritsfrom this class
+   * @brief Initializes the @ref RigidObject that inherits from this class
    * @param resMgr a reference to ResourceManager object
    * @param handle The handle for the template structure defining relevant
    * phyiscal parameters for this object
@@ -116,8 +116,9 @@ class RigidObject : public RigidBase {
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that
    * inherits from this class.
+   * @return whether successful finalization.
    */
-  void finalizeObject() override;
+  bool finalizeObject() override;
 
   /**
    * @brief Get the template used to initialize this object or scene.
@@ -135,8 +136,8 @@ class RigidObject : public RigidBase {
  private:
   /**
    * @brief Finalize the initialization of this @ref RigidScene
-   * geometry.  This is overridden by inheriting class specific to certain
-   * physics libraries.  Necessary to support kinematic objects without any
+   * geometry. This is overridden by inheriting class specific to certain
+   * physics libraries. Necessary to support kinematic objects without any
    * dynamics support.
    * @param resMgr Reference to resource manager, to access relevant
    * components pertaining to the scene object
@@ -147,27 +148,27 @@ class RigidObject : public RigidBase {
 
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
-   * after @ref RigidObject is created.Overridden
-   * by inheriting class specific to certain physics libraries.Necessary to
-   * support kinematic objects without any dynamics support.
+   * after @ref RigidObject is created. Overridden by inheriting class specific
+   * to certain physics libraries. Necessary to support kinematic objects
+   * without any dynamics support.
+   * @return whether successful finalization.
    */
-  void finalizeObject_LibSpecifc() override {}
+  bool finalizeObject_LibSpecific() override { return true; }
 
  public:
   /**
    * @brief Set the @ref MotionType of the object. If the object is @ref
-   * ObjectType::SCENE it can only be @ref MotionType::STATIC. If the object
-   * is
-   * @ref ObjectType::OBJECT is can also be set to @ref
-   * MotionType::KINEMATIC. Only if a dervied @ref PhysicsManager
-   * implementing dynamics is in use can the object be set to @ref
-   * MotionType::DYNAMIC.
+   * ObjectType::SCENE it can only be @ref MotionType::STATIC. If the object is
+   * @ref ObjectType::OBJECT is can also be set to @ref MotionType::KINEMATIC.
+   * Only if a dervied @ref PhysicsManager implementing dynamics is in use can
+   * the object be set to @ref MotionType::DYNAMIC.
    * @param mt The desirved @ref MotionType.
    * @return true if successfully set, false otherwise.
    */
   bool setMotionType(MotionType mt) override;
 
-  /**@brief Retrieves a reference to the VelocityControl struct for this object.
+  /**
+   * @brief Retrieves a reference to the VelocityControl struct for this object.
    */
   VelocityControl::ptr getVelocityControl() { return velControl_; };
 
@@ -180,7 +181,7 @@ class RigidObject : public RigidBase {
 
  public:
   ESP_SMART_POINTERS(RigidObject)
-};  // namespace physics
+};  // class RigidObject
 
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -101,29 +101,57 @@ class RigidObject : public RigidBase {
   /**
    * @brief Virtual destructor for a @ref RigidObject.
    */
-  virtual ~RigidObject(){};
+  virtual ~RigidObject() {}
 
   /**
-   * @brief Initializes the @ref RigidObject or @ref RigidScene that inherits
-   * from this class
-   * @param physicsAttributes The template structure defining relevant
+   * @brief Initializes the @ref RigidObject that inheritsfrom this class
+   * @param resMgr a reference to ResourceManager object
+   * @param handle The handle for the template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialize(
-      const assets::ResourceManager& resMgr,
-      const assets::AbstractPhysicsAttributes::ptr physicsAttributes) override;
+  bool initialize(const assets::ResourceManager& resMgr,
+                  const std::string& handle) override;
+
+  /**
+   * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that
+   * inherits from this class.
+   */
+  void finalizeObject() override;
+
+  /**
+   * @brief Get the template used to initialize this object or scene.
+   *
+   * AbstractPhysicsAttributes templates are expected to be changed between
+   * instances of objects.
+   * @return The initialization settings of this object instance.
+   */
+  const std::shared_ptr<const assets::PhysicsObjectAttributes>
+  getInitializationAttributes() const {
+    return RigidBase::getInitializationAttributes<
+        assets::PhysicsObjectAttributes>();
+  };
 
  private:
   /**
    * @brief Finalize the initialization of this @ref RigidScene
-   * geometry.  This is overridden by inheriting objects
-   * @param resMgr Reference to resource manager, to access relevant components
-   * pertaining to the scene object
+   * geometry.  This is overridden by inheriting class specific to certain
+   * physics libraries.  Necessary to support kinematic objects without any
+   * dynamics support.
+   * @param resMgr Reference to resource manager, to access relevant
+   * components pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initializationFinalize(
+  bool initialization_LibSpecific(
       const assets::ResourceManager& resMgr) override;
+
+  /**
+   * @brief any physics-lib-specific finalization code that needs to be run
+   * after @ref RigidObject is created.Overridden
+   * by inheriting class specific to certain physics libraries.Necessary to
+   * support kinematic objects without any dynamics support.
+   */
+  void finalizeObject_LibSpecifc() override {}
 
  public:
   /**
@@ -137,7 +165,7 @@ class RigidObject : public RigidBase {
    * @param mt The desirved @ref MotionType.
    * @return true if successfully set, false otherwise.
    */
-  virtual bool setMotionType(MotionType mt) override;
+  bool setMotionType(MotionType mt) override;
 
   /**@brief Retrieves a reference to the VelocityControl struct for this object.
    */
@@ -152,7 +180,7 @@ class RigidObject : public RigidBase {
 
  public:
   ESP_SMART_POINTERS(RigidObject)
-};
+};  // namespace physics
 
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/RigidScene.cpp
+++ b/src/esp/physics/RigidScene.cpp
@@ -10,19 +10,17 @@ namespace physics {
 RigidScene::RigidScene(scene::SceneNode* rigidBodyNode)
     : RigidBase(rigidBodyNode) {}
 
-bool RigidScene::initialize(
-    const assets::ResourceManager& resMgr,
-    const assets::AbstractPhysicsAttributes::ptr physicsAttributes) {
+bool RigidScene::initialize(const assets::ResourceManager& resMgr,
+                            const std::string& handle) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidScene more than once";
     return false;
   }
   objectMotionType_ = MotionType::STATIC;
   initializationAttributes_ =
-      resMgr.getSceneAttributesManager()->getTemplateCopyByHandle(
-          physicsAttributes->getOriginHandle());
+      resMgr.getSceneAttributesManager()->getTemplateCopyByHandle(handle);
 
-  return initializationFinalize(resMgr);
+  return initialization_LibSpecific(resMgr);
 }
 
 }  // namespace physics

--- a/src/esp/physics/RigidScene.h
+++ b/src/esp/physics/RigidScene.h
@@ -47,8 +47,9 @@ class RigidScene : public RigidBase {
   };
   /**
    * @brief Finalize the creation of this @ref RigidScene
+   * @return whether successful finalization.
    */
-  void finalizeObject() override { finalizeObject_LibSpecifc(); }
+  bool finalizeObject() override { return finalizeObject_LibSpecific(); }
 
  private:
   /**
@@ -69,8 +70,9 @@ class RigidScene : public RigidBase {
    * after@ref RigidScene is created.  Called from finalizeObject.  Overridden
    * by inheriting class specific to certain physics libraries. Necessary to
    * support kinematic objects without any dynamics support.
+   * @return whether successful finalization.
    */
-  void finalizeObject_LibSpecifc() override {}
+  bool finalizeObject_LibSpecific() override { return true; }
 
  public:
   /**

--- a/src/esp/physics/RigidScene.h
+++ b/src/esp/physics/RigidScene.h
@@ -19,31 +19,58 @@ class RigidScene : public RigidBase {
   /**
    * @brief Virtual destructor for a @ref RigidScene.
    */
-  virtual ~RigidScene(){};
+  virtual ~RigidScene() {}
 
   /**
-   * @brief Initializes the @ref RigidObject or @ref RigidScene that inherits
+   * @brief Initializes the @ref RigidScene that inherits
    * from this class
-   * @param physicsAttributes The template structure defining relevant
+   * @param resMgr a reference to ResourceManager object
+   * @param handle The handle for the template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialize(
-      const assets::ResourceManager& resMgr,
-      const assets::AbstractPhysicsAttributes::ptr physicsAttributes) override;
+  bool initialize(const assets::ResourceManager& resMgr,
+                  const std::string& handle) override;
+
+  /**
+   * @brief Get the template used to initialize this object or scene.
+   *
+   * AbstractPhysicsAttributes templates are able to be changed between
+   * instances of objects.
+   * @return The initialization settings of this object instance, casted to the
+   * appropriate value.
+   */
+  const std::shared_ptr<const assets::PhysicsSceneAttributes>
+  getInitializationAttributes() const {
+    return RigidBase::getInitializationAttributes<
+        assets::PhysicsSceneAttributes>();
+  };
+  /**
+   * @brief Finalize the creation of this @ref RigidScene
+   */
+  void finalizeObject() override { finalizeObject_LibSpecifc(); }
 
  private:
   /**
    * @brief Finalize the initialization of this @ref RigidScene
-   * geometry.  This is overridden by inheriting objects
+   * geometry.  This is overridden by inheriting class specific to certain
+   * physics libraries.Necessary to support kinematic objects without any
+   * dynamics support.
    * @param resMgr Reference to resource manager, to access relevant components
    * pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initializationFinalize(
+  bool initialization_LibSpecific(
       CORRADE_UNUSED const assets::ResourceManager& resMgr) override {
     return true;
   }
+  /**
+   * @brief any physics-lib-specific finalization code that needs to be run
+   * after@ref RigidScene is created.  Called from finalizeObject.  Overridden
+   * by inheriting class specific to certain physics libraries. Necessary to
+   * support kinematic objects without any dynamics support.
+   */
+  void finalizeObject_LibSpecifc() override {}
 
  public:
   /**
@@ -55,7 +82,7 @@ class RigidScene : public RigidBase {
    * @param mt The desirved @ref MotionType.
    * @return true if successfully set, false otherwise.
    */
-  virtual bool setMotionType(MotionType mt) override {
+  bool setMotionType(MotionType mt) override {
     return mt == MotionType::STATIC;  // only option and default option
   }
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -45,21 +45,18 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
 
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
-bool BulletPhysicsManager::addSceneFinalize(
-    const assets::PhysicsSceneAttributes::ptr physicsSceneAttributes) {
+bool BulletPhysicsManager::addSceneFinalize(const std::string& handle) {
   //! Initialize scene
-  bool sceneSuccess =
-      staticSceneObject_->initialize(resourceManager_, physicsSceneAttributes);
+  bool sceneSuccess = staticSceneObject_->initialize(resourceManager_, handle);
 
   return sceneSuccess;
 }
 
-bool BulletPhysicsManager::makeAndAddRigidObject(
-    int newObjectID,
-    assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-    scene::SceneNode* objectNode) {
+bool BulletPhysicsManager::makeAndAddRigidObject(int newObjectID,
+                                                 const std::string& handle,
+                                                 scene::SceneNode* objectNode) {
   auto ptr = physics::BulletRigidObject::create_unique(objectNode, bWorld_);
-  bool objSuccess = ptr->initialize(resourceManager_, physicsObjectAttributes);
+  bool objSuccess = ptr->initialize(resourceManager_, handle);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -182,27 +182,25 @@ class BulletPhysicsManager : public PhysicsManager {
    * mesh can be used by Bullet. See @ref BulletRigidObject::initializeScene.
    * Bullet mesh conversion adapted from:
    * https://github.com/mosra/magnum-integration/issues/20
-   * @param physicsSceneAttributes a pointer to the structure defining physical
+   * @param handle The handle of the attributes structure defining physical
    * properties of the scene.
    * @return true if successful and false otherwise
    */
-  bool addSceneFinalize(const assets::PhysicsSceneAttributes::ptr
-                            physicsSceneAttributes) override;
+  bool addSceneFinalize(const std::string& handle) override;
 
   /** @brief Create and initialize an @ref RigidObject and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
    * @param meshGroup The object's mesh.
-   * @param physicsObjectAttributes The physical object's template defining its
+   * @param handle The handle to the physical object's template defining its
    * physical parameters.
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  bool makeAndAddRigidObject(
-      int newObjectID,
-      assets::PhysicsObjectAttributes::ptr physicsObjectAttributes,
-      scene::SceneNode* objectNode) override;
+  bool makeAndAddRigidObject(int newObjectID,
+                             const std::string& handle,
+                             scene::SceneNode* objectNode) override;
 
   btDbvtBroadphase bBroadphase_;
   btDefaultCollisionConfiguration bCollisionConfig_;

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -143,10 +143,11 @@ bool BulletRigidObject::initialization_LibSpecific(
   return true;
 }  // initialization_LibSpecific
 
-void BulletRigidObject::finalizeObject_LibSpecifc() {
+bool BulletRigidObject::finalizeObject_LibSpecific() {
   if (usingBBCollisionShape_) {
     setCollisionFromBB();
   }
+  return true;
 }  // finalizeObject_LibSpecifc
 
 std::unique_ptr<btCollisionShape>

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -48,16 +48,15 @@ BulletRigidObject::~BulletRigidObject() {
   }
 }  //~BulletRigidObject
 
-bool BulletRigidObject::initializationFinalize(
+bool BulletRigidObject::initialization_LibSpecific(
     const assets::ResourceManager& resMgr) {
   objectMotionType_ = MotionType::DYNAMIC;
-  auto tmpAttr = static_cast<esp::assets::PhysicsObjectAttributes*>(
-      initializationAttributes_.get());
+  // get this object's creation template, appropriately cast
+  auto tmpAttr = getInitializationAttributes();
+
   //! Physical parameters
   double margin = tmpAttr->getMargin();
-
   bool joinCollisionMeshes = tmpAttr->getJoinCollisionMeshes();
-
   usingBBCollisionShape_ = tmpAttr->getBoundingBoxCollisions();
 
   // TODO(alexanderwclegg): should provide the option for joinCollisionMeshes
@@ -71,22 +70,25 @@ bool BulletRigidObject::initializationFinalize(
   const std::string collisionAssetHandle =
       initializationAttributes_->getCollisionAssetHandle();
 
-  if (!initializationAttributes_
-           ->getUseMeshCollision()) {  // if using prim collider
-    // prim stuff here
-    // get appropriate bullet collision primitive attributes
-    auto primAttrMgr = resMgr.getAssetAttributesManager();
-
+  if (!initializationAttributes_->getUseMeshCollision()) {
+    // if using prim collider get appropriate bullet collision primitive
+    // attributes and build bullet collision shape
     auto primAttributes =
-        primAttrMgr->getTemplateByHandle(collisionAssetHandle);
+        resMgr.getAssetAttributesManager()->getTemplateCopyByHandle(
+            collisionAssetHandle);
     // primitive object pointer construction
-    auto primObjPtr = buildPrimitiveCollisionObject(*primAttributes.get());
+    auto primObjPtr = buildPrimitiveCollisionObject(
+        primAttributes->getPrimObjType(), primAttributes->getHalfLength());
+    if (nullptr == primObjPtr) {
+      return false;
+    }
     bGenericShapes_.clear();
     bGenericShapes_.emplace_back(std::move(primObjPtr));
     bObjectShape_->addChildShape(btTransform::getIdentity(),
                                  bGenericShapes_.back().get());
     bObjectShape_->recalculateLocalAabb();
   } else {
+    // mesh collider
     const std::vector<assets::CollisionMeshData>& meshGroup =
         resMgr.getCollisionMesh(collisionAssetHandle);
     const assets::MeshMetaData& metaData =
@@ -104,7 +106,7 @@ bool BulletRigidObject::initializationFinalize(
                                      bObjectConvexShapes_.back().get());
       }
     }
-  }  // if using mesh collider
+  }  // if using prim collider else use mesh collider
 
   //! Set properties
   bObjectShape_->setMargin(margin);
@@ -139,18 +141,18 @@ bool BulletRigidObject::initializationFinalize(
   //! Sync render pose with physics
   syncPose();
   return true;
-}  // initializeObjectFinalize
+}  // initialization_LibSpecific
 
-void BulletRigidObject::finalizeObject() {
+void BulletRigidObject::finalizeObject_LibSpecifc() {
   if (usingBBCollisionShape_) {
     setCollisionFromBB();
   }
-}  // finalizeObject
+}  // finalizeObject_LibSpecifc
 
 std::unique_ptr<btCollisionShape>
-BulletRigidObject::buildPrimitiveCollisionObject(
-    const assets::AbstractPrimitiveAttributes& primAttributes) {
-  int primTypeVal = primAttributes.getPrimObjType();
+BulletRigidObject::buildPrimitiveCollisionObject(int primTypeVal,
+                                                 double halfLength) {
+  // int primTypeVal = primAttributes.getPrimObjType();
   CORRADE_ASSERT(
       (primTypeVal >= 0) &&
           (primTypeVal <
@@ -168,7 +170,7 @@ BulletRigidObject::buildPrimitiveCollisionObject(
     case assets::PrimObjTypes::CAPSULE_WF: {
       // use bullet capsule :  btCapsuleShape(btScalar radius,btScalar height);
       btScalar radius = 1.0f;
-      btScalar height = 2.0 * primAttributes.getHalfLength();
+      btScalar height = 2.0 * halfLength;
       obj = std::make_unique<btCapsuleShape>(radius, height);
       break;
     }
@@ -176,7 +178,7 @@ BulletRigidObject::buildPrimitiveCollisionObject(
     case assets::PrimObjTypes::CONE_WF: {
       // use bullet cone : btConeShape(btScalar radius,btScalar height);
       btScalar radius = 1.0f;
-      btScalar height = 2.0 * primAttributes.getHalfLength();
+      btScalar height = 2.0 * halfLength;
       obj = std::make_unique<btConeShape>(radius, height);
       break;
     }

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -53,8 +53,9 @@ class BulletRigidObject : public BulletBase,
 
   /**
    * @brief Finalize this object with any necessary post-creation processes.
+   * @return whether successful finalization.
    */
-  void finalizeObject_LibSpecifc() override;
+  bool finalizeObject_LibSpecific() override;
 
   /**
    * @brief Instantiate a bullet primtive appropriate for the passed

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -17,9 +17,7 @@
 #include <btBulletDynamicsCommon.h>
 
 #include "BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.h"
-//#include "esp/assets/Asset.h"
-//#include "esp/assets/BaseMesh.h"
-//#include "esp/assets/MeshMetaData.h"
+
 #include "esp/core/esp.h"
 
 #include "esp/physics/RigidObject.h"
@@ -56,17 +54,20 @@ class BulletRigidObject : public BulletBase,
   /**
    * @brief Finalize this object with any necessary post-creation processes.
    */
-  virtual void finalizeObject() override;
+  void finalizeObject_LibSpecifc() override;
 
   /**
    * @brief Instantiate a bullet primtive appropriate for the passed
    * AbstractPrimitiveAttributes object
-   * @param primAttributes the AbstractPrimitiveAttributes describing the
-   * desired object
+   * @param primTypeVal int value corresponding to assets::PrimObjTypes enum
+   * describing primitive collision shape.
+   * @param halfLength half length of object, for primitives using this value
    * @return a unique pointer to the bullet primitive object
    */
   std::unique_ptr<btCollisionShape> buildPrimitiveCollisionObject(
-      const assets::AbstractPrimitiveAttributes& primAttributes);
+      int primTypeVal,
+      double halfLength);
+  // const assets::AbstractPrimitiveAttributes& primAttributes);
 
   /**
    * @brief Recursively construct a @ref btCompoundShape for collision from
@@ -109,7 +110,7 @@ class BulletRigidObject : public BulletBase,
    * @param mt The desirved @ref MotionType.
    * @return true if successfully set, false otherwise.
    */
-  virtual bool setMotionType(MotionType mt) override;
+  bool setMotionType(MotionType mt) override;
 
   /**
    * @brief Shift the object's local origin by translating all children of this
@@ -418,13 +419,13 @@ class BulletRigidObject : public BulletBase,
  private:
   /**
    * @brief Finalize initialization of this @ref BulletRigidObject as a @ref
-   * MotionType::DYNAMIC object. See @ref btRigidBody.
+   * MotionType::DYNAMIC object. See @ref btRigidBody. This holds
+   * bullet-specific functionality for objects.
    * @param resMgr Reference to resource manager, to access relevant components
    * pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
-
-  virtual bool initializationFinalize(
+  bool initialization_LibSpecific(
       const assets::ResourceManager& resMgr) override;
 
  protected:

--- a/src/esp/physics/bullet/BulletRigidScene.cpp
+++ b/src/esp/physics/bullet/BulletRigidScene.cpp
@@ -26,7 +26,7 @@ BulletRigidScene::~BulletRigidScene() {
     bWorld_->removeCollisionObject(co.get());
   }
 }
-bool BulletRigidScene::initializationFinalize(
+bool BulletRigidScene::initialization_LibSpecific(
     const assets::ResourceManager& resMgr) {
   const auto collisionAssetHandle =
       initializationAttributes_->getCollisionAssetHandle();
@@ -47,7 +47,7 @@ bool BulletRigidScene::initializationFinalize(
 
   return true;
 
-}  // initializationFinalize
+}  // initialization_LibSpecific
 
 void BulletRigidScene::constructBulletSceneFromMeshes(
     const Magnum::Matrix4& transformFromParentToWorld,

--- a/src/esp/physics/bullet/BulletRigidScene.h
+++ b/src/esp/physics/bullet/BulletRigidScene.h
@@ -32,12 +32,12 @@ class BulletRigidScene : public BulletBase, public RigidScene {
  private:
   /**
    * @brief Finalize the initialization of this @ref RigidScene
-   * geometry.  This is overridden by inheriting objects
+   * geometry.  This holds bullet-specific functionality for scenes.
    * @param resMgr Reference to resource manager, to access relevant components
    * pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initializationFinalize(
+  bool initialization_LibSpecific(
       const assets::ResourceManager& resMgr) override;
 
   /**

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -97,7 +97,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        objectAttributesManager->getTemplateByHandle(objectFile);
+        objectAttributesManager->getTemplateCopyByHandle(objectFile);
 
     for (int i = 0; i < 2; i++) {
       // mark the object not joined
@@ -106,7 +106,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
       } else {
         objectTemplate->setJoinCollisionMeshes(true);
       }
-
+      objectAttributesManager->registerAttributesTemplate(objectTemplate);
       physicsManager_->reset();
 
       std::vector<int> objectIds;
@@ -180,7 +180,7 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        objectAttributesManager->getTemplateByHandle(objectFile);
+        objectAttributesManager->getTemplateCopyByHandle(objectFile);
 
     for (int i = 0; i < 2; i++) {
       if (i == 0) {
@@ -188,7 +188,7 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
       } else {
         objectTemplate->setBoundingBoxCollisions(true);
       }
-
+      objectAttributesManager->registerAttributesTemplate(objectTemplate);
       physicsManager_->reset();
 
       int objectId = physicsManager_->addObject(
@@ -299,20 +299,23 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
 
     // get a reference to the stored template to edit
     esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-        objectAttributesManager->getTemplateByHandle(objectFile);
+        objectAttributesManager->getTemplateCopyByHandle(objectFile);
 
     auto* drawables = &sceneManager_.getSceneGraph(sceneID_).getDrawables();
 
     // add the unjoined object
     objectTemplate->setJoinCollisionMeshes(false);
+    objectAttributesManager->registerAttributesTemplate(objectTemplate);
     int objectId0 = physicsManager_->addObject(objectFile, drawables);
 
     // add the joined object
     objectTemplate->setJoinCollisionMeshes(true);
+    objectAttributesManager->registerAttributesTemplate(objectTemplate);
     int objectId1 = physicsManager_->addObject(objectFile, drawables);
 
     // add bounding box object
     objectTemplate->setBoundingBoxCollisions(true);
+    objectAttributesManager->registerAttributesTemplate(objectTemplate);
     int objectId2 = physicsManager_->addObject(objectFile, drawables);
 
     esp::physics::BulletPhysicsManager* bPhysManager =
@@ -360,7 +363,7 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
 
   // get a reference to the stored template to edit
   esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-      objectAttributesManager->getTemplateByHandle(objectFile);
+      objectAttributesManager->getTemplateCopyByHandle(objectFile);
 
   std::vector<Magnum::Vector3> testScales{
       {1.0, 1.0, 1.0},  {4.0, 3.0, 2.0},    {0.1, 0.2, 0.3},
@@ -372,6 +375,7 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   std::vector<int> objectIDs;
   for (auto& testScale : testScales) {
     objectTemplate->setScale(testScale);
+    objectAttributesManager->registerAttributesTemplate(objectTemplate);
 
     Magnum::Range3D boundsGroundTruth(-abs(testScale), abs(testScale));
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -92,6 +92,7 @@ struct SimTest : Cr::TestSuite::Tester {
   void multipleLightingSetupsRGBAObservation();
   void recomputeNavmeshWithStaticObjects();
   void loadingObjectTemplates();
+  void buildingPrimAssetObjectTemplates();
 
   // TODO: remove outlier pixels from image and lower maxThreshold
   const Magnum::Float maxThreshold = 255.f;
@@ -115,7 +116,8 @@ SimTest::SimTest() {
             &SimTest::updateObjectLightSetupRGBAObservation,
             &SimTest::multipleLightingSetupsRGBAObservation,
             &SimTest::recomputeNavmeshWithStaticObjects,
-            &SimTest::loadingObjectTemplates});
+            &SimTest::loadingObjectTemplates, 
+            &SimTest::buildingPrimAssetObjectTemplates});
   // clang-format on
 }
 
@@ -226,7 +228,9 @@ void SimTest::getSceneWithLightingRGBAObservation() {
 
 void SimTest::getDefaultLightingRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
@@ -237,7 +241,9 @@ void SimTest::getDefaultLightingRGBAObservation() {
 
 void SimTest::getCustomLightingRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
@@ -249,9 +255,10 @@ void SimTest::getCustomLightingRGBAObservation() {
 
 void SimTest::updateLightSetupRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
   // update default lighting
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
@@ -280,7 +287,9 @@ void SimTest::updateLightSetupRGBAObservation() {
 
 void SimTest::updateObjectLightSetupRGBAObservation() {
   auto simulator = getSimulator(vangogh);
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
@@ -300,9 +309,10 @@ void SimTest::updateObjectLightSetupRGBAObservation() {
 
 void SimTest::multipleLightingSetupsRGBAObservation() {
   auto simulator = getSimulator(planeScene);
-
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
   // make sure updates apply to all objects using the light setup
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
@@ -329,6 +339,8 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
 
 void SimTest::recomputeNavmeshWithStaticObjects() {
   auto simulator = getSimulator(skokloster);
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
 
   // compute the initial navmesh
   esp::nav::NavMeshSettings navMeshSettings;
@@ -345,7 +357,7 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
   }
 
   // add static object at a known navigable point
-  auto objs = simulator->getObjectTemplateHandles("nested_box");
+  auto objs = objectAttribsMgr->getTemplateHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
   simulator->setTranslation(Magnum::Vector3{randomNavPoint}, objectID);
   simulator->setObjectMotionType(esp::physics::MotionType::STATIC, objectID);
@@ -366,8 +378,10 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
 
   // test scaling
   esp::assets::PhysicsObjectAttributes::ptr objectTemplate =
-      simulator->getObjectTemplate(0);
+      objectAttribsMgr->getTemplateCopyByID(0);
   objectTemplate->setScale({0.5, 0.5, 0.5});
+  int tmplateID = objectAttribsMgr->registerAttributesTemplate(objectTemplate);
+
   objectID = simulator->addObjectByHandle(objs[0]);
   simulator->setTranslation(Magnum::Vector3{randomNavPoint}, objectID);
   simulator->setTranslation(
@@ -388,6 +402,8 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
 
 void SimTest::loadingObjectTemplates() {
   auto simulator = getSimulator(planeScene);
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
 
   // test directory of templates
   std::vector<int> templateIndices = simulator->loadObjectConfigs(
@@ -406,7 +422,7 @@ void SimTest::loadingObjectTemplates() {
   // verify that getting the template handles with empty string returns all
   int numLoadedTemplates = templateIndices2.size();
   std::vector<std::string> templateHandles =
-      simulator->getFileBasedObjectTemplateHandles();
+      objectAttribsMgr->getFileTemplateHandlesBySubstring();
   CORRADE_VERIFY(numLoadedTemplates == templateHandles.size());
 
   // verify that querying with sub string returns template handle corresponding
@@ -419,29 +435,174 @@ void SimTest::loadingObjectTemplates() {
   std::string tmpHndl = fullTmpHndl.substr(len.quot);
   // get all handles that match 2nd half of known handle
   std::vector<std::string> matchTmpltHandles =
-      simulator->getObjectTemplateHandles(tmpHndl);
+      objectAttribsMgr->getTemplateHandlesBySubstring(tmpHndl);
   CORRADE_VERIFY(matchTmpltHandles[0] == fullTmpHndl);
 
   // test fresh template as smart pointer
   esp::assets::PhysicsObjectAttributes::ptr newTemplate =
-      esp::assets::PhysicsObjectAttributes::create();
+      objectAttribsMgr->createAttributesTemplate("new template", false);
   std::string boxPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
   newTemplate->setRenderAssetHandle(boxPath);
-  int templateIndex = simulator->registerObjectTemplate(newTemplate, boxPath);
+  int templateIndex =
+      objectAttribsMgr->registerAttributesTemplate(newTemplate, boxPath);
+
   CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
   // change render asset for object template named boxPath
   std::string chairPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/chair.glb");
   newTemplate->setRenderAssetHandle(chairPath);
-  int templateIndex2 = simulator->registerObjectTemplate(newTemplate, boxPath);
+  int templateIndex2 =
+      objectAttribsMgr->registerAttributesTemplate(newTemplate, boxPath);
 
   CORRADE_VERIFY(templateIndex2 != esp::ID_UNDEFINED);
   CORRADE_VERIFY(templateIndex2 == templateIndex);
   esp::assets::PhysicsObjectAttributes::ptr newTemplate2 =
-      simulator->getObjectTemplateByName(boxPath);
+      objectAttribsMgr->getTemplateCopyByHandle(boxPath);
   CORRADE_VERIFY(newTemplate2->getRenderAssetHandle() == chairPath);
 }
+
+void SimTest::buildingPrimAssetObjectTemplates() {
+  Corrade::Utility::Debug()
+      << "Starting Test : buildingPrimAssetObjectTemplates ";
+  auto simulator = getSimulator(planeScene);
+
+  // test that the correct number of default primitive assets are available as
+  // render/collision targets
+  // manager of asset attributes
+  auto assetAttribsMgr = simulator->getAssetAttributesManager();
+  // manager of object attributes
+  auto objectAttribsMgr = simulator->getObjectAttributesManager();
+
+  // get all handles of templates for primitive-based render objects
+  std::vector<std::string> primObjAssetHandles =
+      objectAttribsMgr->getSynthTemplateHandlesBySubstring("");
+
+  // there should be 1 prim template per default primitive asset template
+  int numPrimsExpected =
+      static_cast<int>(esp::assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
+  // verify the number of primitive templates
+  CORRADE_VERIFY(numPrimsExpected == primObjAssetHandles.size());
+
+  esp::assets::AbstractPrimitiveAttributes::ptr primAttr;
+  {
+    // test that there are existing templates for each key, and that they have
+    // valid values to be used to construct magnum primitives
+    for (int i = 0; i < numPrimsExpected; ++i) {
+      std::string handle = primObjAssetHandles[i];
+      CORRADE_VERIFY(handle != "");
+      primAttr = assetAttribsMgr->getTemplateCopyByHandle(handle);
+      CORRADE_VERIFY(primAttr != nullptr);
+      CORRADE_VERIFY(primAttr->isValidTemplate());
+      // verify that the attributes contains the handle, and the handle contains
+      // the expected class name
+      std::string className =
+          esp::assets::managers::AssetAttributesManager::PrimitiveNames3DMap.at(
+              static_cast<esp::assets::PrimObjTypes>(i));
+      CORRADE_VERIFY((primAttr->getOriginHandle() == handle) &&
+                     (handle.find(className) != std::string::npos));
+    }
+  }
+  // empty vector of handles
+  primObjAssetHandles.clear();
+  {
+    // test that existing template handles can be accessed via name string.
+    // This access is case insensitive
+    primObjAssetHandles =
+        objectAttribsMgr->getSynthTemplateHandlesBySubstring("CONESOLID");
+    // should only be one handle in this vector
+    CORRADE_VERIFY(1 == primObjAssetHandles.size());
+    // handle should not be empty and be long enough to hold class name prefix
+    CORRADE_VERIFY(9 < primObjAssetHandles[0].length());
+    // coneSolid should appear in handle
+    std::string checkStr("coneSolid");
+    CORRADE_VERIFY(primObjAssetHandles[0].find(checkStr) != std::string::npos);
+    // empty vector of handles
+    primObjAssetHandles.clear();
+
+    // test that existing template handles can be accessed through exclusion -
+    // all but certain string.  This access is case insensitive
+    primObjAssetHandles = objectAttribsMgr->getSynthTemplateHandlesBySubstring(
+        "CONESOLID", false);
+    // should be all handles but coneSolid handle here
+    CORRADE_VERIFY((numPrimsExpected - 1) == primObjAssetHandles.size());
+    for (auto primObjAssetHandle : primObjAssetHandles) {
+      CORRADE_VERIFY(primObjAssetHandle.find(checkStr) == std::string::npos);
+    }
+  }
+  // empty vector of handles
+  primObjAssetHandles.clear();
+
+  // test that primitive asset attributes are able to be modified and saved and
+  // the changes persist, while the old templates are not removed
+  {
+    // get existing default cylinder handle
+    primObjAssetHandles = assetAttribsMgr->getTemplateHandlesByPrimType(
+        esp::assets::PrimObjTypes::CYLINDER_SOLID);
+    // should only be one handle in this vector
+    CORRADE_VERIFY(1 == primObjAssetHandles.size());
+    // primitive render object uses primitive render asset as handle
+    std::string origCylinderHandle = primObjAssetHandles[0];
+    primAttr = assetAttribsMgr->getTemplateCopyByHandle(origCylinderHandle);
+    // verify that the origin handle matches what is expected
+    CORRADE_VERIFY(primAttr->getOriginHandle() == origCylinderHandle);
+    // get original number of rings for this cylinder
+    int origNumRings = primAttr->getNumRings();
+    // modify attributes - this will change handle
+    primAttr->setNumRings(2 * origNumRings);
+    // verify that internal name of attributes has changed due to essential
+    // quantity being modified
+    std::string newHandle = primAttr->getOriginHandle();
+    CORRADE_VERIFY(newHandle != origCylinderHandle);
+    // set test label, to validate that copy is reggistered
+    primAttr->setString("test", "test0");
+    // register new attributes
+    int idx = assetAttribsMgr->registerAttributesTemplate(primAttr);
+    CORRADE_VERIFY(idx != esp::ID_UNDEFINED);
+    // set new test label, to validate against retrieved copy
+    primAttr->setString("test", "test1");
+    // retrieve registered attributes copy
+    esp::assets::AbstractPrimitiveAttributes::ptr primAttr2 =
+        assetAttribsMgr->getTemplateCopyByHandle(newHandle);
+    // verify pre-reg and post-reg are named the same
+    CORRADE_VERIFY(primAttr->getOriginHandle() == primAttr2->getOriginHandle());
+    // verify retrieved attributes is copy, not original
+    CORRADE_VERIFY(primAttr->getString("test") != primAttr2->getString("test"));
+    // remove modified attributes
+    esp::assets::AbstractPrimitiveAttributes::ptr primAttr3 =
+        assetAttribsMgr->removeTemplateByHandle(newHandle);
+    CORRADE_VERIFY(nullptr != primAttr3);
+  }
+  // empty vector of handles
+  primObjAssetHandles.clear();
+  {
+    // test creation off new object, using edited attributes
+    // get existing default cylinder handle
+    primObjAssetHandles = assetAttribsMgr->getTemplateHandlesByPrimType(
+        esp::assets::PrimObjTypes::CYLINDER_SOLID);
+    // primitive render object uses primitive render asset as handle
+    std::string origCylinderHandle = primObjAssetHandles[0];
+    primAttr = assetAttribsMgr->getTemplateCopyByHandle(origCylinderHandle);
+    // modify attributes - this will change handle
+    primAttr->setNumRings(2 * primAttr->getNumRings());
+    // verify that internal name of attributes has changed due to essential
+    // quantity being modified
+    std::string newHandle = primAttr->getOriginHandle();
+    // register new attributes
+    int idx = assetAttribsMgr->registerAttributesTemplate(primAttr);
+
+    // create object template with modified primitive asset attributes, by
+    // passing handle.  defaults to register object template
+    auto newCylObjAttr = objectAttribsMgr->createAttributesTemplate(newHandle);
+    CORRADE_VERIFY(nullptr != newCylObjAttr);
+    // create object with new attributes
+    int objectID = simulator->addObjectByHandle(newHandle);
+    CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  }
+  // empty vector of handles
+  primObjAssetHandles.clear();
+
+}  // SimTest::buildingPrimAssetObjectTemplates
 
 }  // namespace
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -576,7 +576,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
   // empty vector of handles
   primObjAssetHandles.clear();
   {
-    // test creation off new object, using edited attributes
+    // test creation of new object, using edited attributes
     // get existing default cylinder handle
     primObjAssetHandles = assetAttribsMgr->getTemplateHandlesByPrimType(
         esp::assets::PrimObjTypes::CYLINDER_SOLID);


### PR DESCRIPTION
## Motivation and Context
This PR presents the final C++ code to support and test the attributes managers implementations.  Included in this PR are : 
1. Added testing to SimTest to test the creation of objects based on primitive assets.
2. Removed simulator access to individual attribute templates for most cases.  All attributes should be accessed via attribute managers.
3. Most attributes access has been changed to provide a copy of the attributes being stored by the manager, instead of the actual attributes.  The goal is to have all such access be via copies, but this will be a breaking change, and will be introduced with the next PR, which will also introduce a tutorial on the proper usage of the attributes.
4. Cleaned up rigid object and rigid scene attributes access, and made object creation more efficient.
5. Overrides of virtual methods are virtual by default, and so do not need to be specified as such (it is recommended not to do so, in fact) so these keywords have been removed where appropriate.

The next, and final PR, will introduce python tests and tutorials about consuming the attributes managers and creating primitive-asset-based objects.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All cpp and python tests pass, including added test for primitive asset-based object creation.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
