### PR TITLE
Conda build for head/headless x with bullet/without bullet, CI test, issues fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,17 +260,6 @@ jobs:
               cd habitat-sim
               pip install -r requirements.txt --progress-bar off
               python setup.py install --headless
-    # Will be moved to nightly runs
-      - run:
-          name: Build conda Linux packages
-          command: |
-              export PATH=$HOME/miniconda/bin:$PATH
-              . activate habitat;
-              cd habitat-sim
-              conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
-              rm -rf build
-              cd conda-build
-              python linux_matrix_builder.py
       - run:
           name: run clang-tidy
           command: |
@@ -450,6 +439,17 @@ jobs:
           background: true
           paths:
             - ./habitat-sim/build/docs-public
+    # Will be moved to nightly runs
+      - run:
+          name: Build conda Linux packages
+          command: |
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat;
+              cd habitat-sim
+              conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
+              rm -rf build
+              cd conda-build
+              python linux_matrix_builder.py
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,6 @@ workflows:
       - cpp_lint
       - js_lint
       - install_and_test_ubuntu
-      - build_conda_binaries
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
                   lsb-release \
                   xdg-utils \
                   wget
-      - run: &install_conda
+      - run:
           name: Install cuda
           no_output_timeout: 20m
           background: true
@@ -177,7 +177,7 @@ jobs:
       - restore_cache:
           keys:
             - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
-      - run:
+      - run: &install_conda
           name: Install conda and dependencies
           no_output_timeout: 20m
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,9 +470,10 @@ jobs:
               rm -rf build
               cd conda-build
               conda install -y anaconda-client git gitpython ninja conda-build=3.18.9 # last version that works with our setup
-              python linux_matrix_builder.py
+              anaconda login --username aihabitat-nightly --password $AIHABITAT_NIGHTLY_CONDA_PWD
+              python linux_matrix_builder.py --conda_upload
       - store_artifacts:
-          path: .habitat-sim/conda-build/hsim-linux/linux-64
+          path: habitat-sim/conda-build/hsim-linux/linux-64
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,6 +471,8 @@ jobs:
               cd conda-build
               conda install -y anaconda-client git gitpython ninja conda-build=3.18.9 # last version that works with our setup
               python linux_matrix_builder.py
+      - store_artifacts:
+          path: .habitat-sim/conda-build/hsim-linux/linux-64
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,9 @@ jobs:
               . activate habitat;
               cd habitat-sim
               conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
-              python conda-build/linux_matrix_builder.py
+              rm -rf build
+              cd conda-build
+              python linux_matrix_builder.py
       - run:
           name: run clang-tidy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,6 +471,7 @@ jobs:
               cd conda-build
               conda install -y anaconda-client git gitpython ninja conda-build=3.18.9 # last version that works with our setup
               anaconda login --username aihabitat-nightly --password $AIHABITAT_NIGHTLY_CONDA_PWD
+              conda config --set anaconda_upload yes
               python linux_matrix_builder.py --conda_upload
       - store_artifacts:
           path: habitat-sim/conda-build/hsim-linux/linux-64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,11 +114,6 @@ jobs:
                   libbullet-dev\
                   lcov\
                   unzip || true
-              sudo apt install --allow-change-held-packages \
-                  texlive-base \
-                  texlive-latex-extra \
-                  texlive-fonts-extra \
-                  texlive-fonts-recommended
       - run:
           name: Install Headless Chrome dependencies
           command: |
@@ -383,6 +378,12 @@ jobs:
       - run:
           name: Build sim documentation
           command: |
+              sudo apt install --allow-change-held-packages \
+                  texlive-base \
+                  texlive-latex-extra \
+                  texlive-fonts-extra \
+                  texlive-fonts-recommended
+
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
               cd habitat-sim
@@ -473,8 +474,6 @@ jobs:
               anaconda login --username aihabitat-nightly --password $AIHABITAT_NIGHTLY_CONDA_PWD
               conda config --set anaconda_upload yes
               python linux_matrix_builder.py --conda_upload
-      - store_artifacts:
-          path: habitat-sim/conda-build/hsim-linux/linux-64
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
               sudo mkdir /opt/cmake
               sudo sh ./cmake-3.10.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
               sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-      - run:
+      - run: &install_deps
           name: Install dependencies
           no_output_timeout: 20m
           command: |
@@ -163,7 +163,7 @@ jobs:
                   lsb-release \
                   xdg-utils \
                   wget
-      - run:
+      - run: &install_conda
           name: Install cuda
           no_output_timeout: 20m
           background: true
@@ -458,21 +458,8 @@ jobs:
       - restore_cache:
           keys:
             - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
-      - run:
-          name: Install conda and dependencies
-          no_output_timeout: 20m
-          command: |
-              if [ ! -d ~/miniconda ]
-              then
-                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-                chmod +x ~/miniconda.sh
-                ~/miniconda.sh -b -p $HOME/miniconda
-                rm ~/miniconda.sh
-                export PATH=$HOME/miniconda/bin:$PATH
-                conda create -y -n habitat python=3.6
-                . activate habitat
-                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-              fi
+      - <<: *install_conda
+      - <<: *install_deps
       - run:
           name: Build conda Linux packages
           command: |
@@ -482,8 +469,8 @@ jobs:
 
               rm -rf build
               cd conda-build
-              sudo sh common/install_conda.sh
-              python linux_matrix_builder.py --ci_test
+              conda install -y anaconda-client git gitpython ninja conda-build=3.18.9 # last version that works with our setup
+              python linux_matrix_builder.py
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,15 @@ jobs:
               cd habitat-sim
               pip install -r requirements.txt --progress-bar off
               python setup.py install --headless
+    # Will be moved to nightly runs
+      - run:
+          name: Build conda Linux packages
+          command: |
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat;
+              cd habitat-sim
+              conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
+              python conda-build/linux_matrix_builder.py
       - run:
           name: run clang-tidy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,9 +439,8 @@ jobs:
           background: true
           paths:
             - ./habitat-sim/build/docs-public
-    # Will be moved to nightly runs
       - run:
-          name: Build conda Linux packages
+          name: Build conda Linux packages for CI
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
@@ -449,7 +448,42 @@ jobs:
               conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
               rm -rf build
               cd conda-build
-              python linux_matrix_builder.py
+              python linux_matrix_builder.py --ci_test
+
+  build_conda_binaries:
+    <<: *gpu
+    steps:
+      - checkout:
+          path: ./habitat-sim
+      - restore_cache:
+          keys:
+            - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
+      - run:
+          name: Install conda and dependencies
+          no_output_timeout: 20m
+          command: |
+              if [ ! -d ~/miniconda ]
+              then
+                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                chmod +x ~/miniconda.sh
+                ~/miniconda.sh -b -p $HOME/miniconda
+                rm ~/miniconda.sh
+                export PATH=$HOME/miniconda/bin:$PATH
+                conda create -y -n habitat python=3.6
+                . activate habitat
+                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
+              fi
+      - run:
+          name: Build conda Linux packages
+          command: |
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat;
+              cd habitat-sim
+
+              rm -rf build
+              cd conda-build
+              sudo sh common/install_conda.sh
+              python linux_matrix_builder.py --ci_test
 
   update_docs:
     docker:
@@ -503,6 +537,7 @@ workflows:
       - cpp_lint
       - js_lint
       - install_and_test_ubuntu
+      - build_conda_binaries
   nightly:
     triggers:
       - schedule:
@@ -514,6 +549,12 @@ workflows:
     jobs:
       - install_and_test_ubuntu
       - update_docs:
+          requires:
+            - install_and_test_ubuntu
+          filters:
+            branches:
+              only: master
+      - build_conda_binaries:
           requires:
             - install_and_test_ubuntu
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,8 +458,8 @@ jobs:
       - restore_cache:
           keys:
             - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
-      - <<: *install_conda
-      - <<: *install_deps
+      - run: *install_conda
+      - run: *install_deps
       - run:
           name: Build conda Linux packages
           command: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![CircleCI](https://circleci.com/gh/facebookresearch/habitat-sim.svg?style=shield)](https://circleci.com/gh/facebookresearch/habitat-sim)
 [![codecov](https://codecov.io/gh/facebookresearch/habitat-sim/branch/master/graph/badge.svg)](https://codecov.io/gh/facebookresearch/habitat-sim)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookresearch/habitat-sim/blob/master/LICENSE)
+[![Anaconda-Server Badge](https://anaconda.org/aihabitat/habitat-sim/badges/version.svg)](https://anaconda.org/aihabitat/habitat-sim)
+[![Anaconda-Server Badge](https://anaconda.org/aihabitat/habitat-sim/badges/platforms.svg)](https://anaconda.org/aihabitat/habitat-sim)
 
 # Habitat-Sim
 
@@ -303,9 +305,9 @@ We highly recommend installing a [miniconda](https://docs.conda.io/en/latest/min
 
 ## Documentation
 
-Browse the online [Habitat-Sim documentation](https://aihabitat.org/docs/habitat-sim/index.html). 
+Browse the online [Habitat-Sim documentation](https://aihabitat.org/docs/habitat-sim/index.html).
 
-To get you started, see the [Lighting Setup tutorial](https://aihabitat.org/docs/habitat-sim/lighting-setups.html) for adding new objects to existing scenes and relighting the scene & objects. The [Image Extractor tutorial](https://aihabitat.org/docs/habitat-sim/image-extractor.html) shows how to get images from scenes loaded in Habitat-Sim. 
+To get you started, see the [Lighting Setup tutorial](https://aihabitat.org/docs/habitat-sim/lighting-setups.html) for adding new objects to existing scenes and relighting the scene & objects. The [Image Extractor tutorial](https://aihabitat.org/docs/habitat-sim/image-extractor.html) shows how to get images from scenes loaded in Habitat-Sim.
 
 ## Rendering to GPU Tensors
 

--- a/conda-build/README.md
+++ b/conda-build/README.md
@@ -22,7 +22,7 @@ From there you will have a shell within your linux container. Now, navigate to `
 
 To download the package, run ```conda install -c aihabitat -c conda-forge habitat-sim headless ```. 
 
-Our linux conda builds currently only support ```{head/headless} x {with bullet/without bullet}``` binaries. In the command above, we are telling conda to use a feature called ```headless```.  
+Our linux conda builds currently only support ```{head / headless} x {with bullet / without bullet}``` binaries. In the command above, we are telling conda to use a feature called ```headless```.  
 
 
 

--- a/conda-build/README.md
+++ b/conda-build/README.md
@@ -10,7 +10,7 @@ To then download the package, run ```conda install -c aihabitat -c conda-forge h
 
 ### Building for Linux
 
-The process is almost the same for linux; there is a corresponding python script for starting things off. You can use Ubuntu 16.04 or  a docker container to do the builds. There is a dockerfile in this directory that you can use to create a container.
+The process is almost the same for linux; there is a corresponding python script for starting things off, however we use a docker container to do the builds. There is a dockerfile in this directory that you can use to create a container.
 
 ```docker build -t hsim_condabuild_dcontainer -f Dockerfile .```
 

--- a/conda-build/README.md
+++ b/conda-build/README.md
@@ -1,5 +1,6 @@
 ### Building for macOS
 
+Install conda packages as decribed here ```conda-build/common/install_conda.sh``` and run ```conda create --name py36 python=3.6;conda activate py36```.
 Running ```python macos_matrix_builder.py``` with python >= 3.6 will start the build process by setting all the environment variables and making a call to conda build. Make sure the meta.yaml file in conda-build/habitat-sim/ is configured correctly accoridng to https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
 
 Once the package is built, make sure you're logged in to anaconda cloud and then run ```anaconda upload <path to the tarball file that conda build created>```. For exmaple ```anaconda upload hsim-macos/osx-64/habitat-sim-1.3.2-py3.6_osx.tar.bz2```. This will upload the package to anaconda cloud for everyone to download.
@@ -9,7 +10,7 @@ To then download the package, run ```conda install -c aihabitat -c conda-forge h
 
 ### Building for Linux
 
-The process is almost the same for linux; there is a corresponding python script for starting things off, however we use a docker container to do the builds. There is a dockerfile in this directory that you can use to create a container.
+The process is almost the same for linux; there is a corresponding python script for starting things off. You can use Ubuntu 16.04 or  a docker container to do the builds. There is a dockerfile in this directory that you can use to create a container.
 
 ```docker build -t hsim_condabuild_dcontainer -f Dockerfile .```
 
@@ -17,11 +18,11 @@ That will create your docker container. Now run
 
 ```docker run -it --ipc=host --rm -v $(pwd)/../:/remote hsim_condabuild_dcontainer bash```
 
-From there you will have a shell within your linux container. Now, navigate to ```cd /remote/conda-build``` where habitat-sim has been mounted. Create a conda environment within the linux container with python>=3.6 (identical to that needed by habitat-sim build). And then run ```python linux_matrix_build.py```, which will kick off the build process. After this has finished, upload it to anaconda cloud in the same way described in the macOS section.
+From there you will have a shell within your linux container. Now, navigate to ```cd /remote/conda-build``` where habitat-sim has been mounted. Create a conda environment within the linux container with python>=3.6 (identical to that needed by habitat-sim build): ```conda create --name py36 python=3.6;conda activate py36```. And then run ```python linux_matrix_builder.py```, which will kick off the build process. After this has finished, upload it to anaconda cloud in the same way described in the macOS section.
 
 To download the package, run ```conda install -c aihabitat -c conda-forge habitat-sim headless ```. 
 
-Our linux conda builds currently only support ```headless``` binaries. In the command above, we are telling conda to use a feature called ```headless```. The first time you install habitat-sim in a conda env, you have to specify what features to use.  Otherwise, it throws uninterpretable errors. 
+Our linux conda builds currently only support ```{head/headless} x {with bullet/without bullet}``` binaries. In the command above, we are telling conda to use a feature called ```headless```.  
 
 
 

--- a/conda-build/common/install_conda.sh
+++ b/conda-build/common/install_conda.sh
@@ -8,5 +8,5 @@ chmod +x  Miniconda2-latest-Linux-x86_64.sh
 ./Miniconda2-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda2-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
-conda install -y conda-build anaconda-client git ninja
+conda install -y anaconda-client git ninja conda-build=3.18.9 # last version that works with our setup
 conda remove -y --force patchelf

--- a/conda-build/habitat-sim/meta.yaml
+++ b/conda-build/habitat-sim/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - attrs>=19.1.0
     - numba
     - numpy>=1.13
+    - gitpython
     - quaternion
     - pillow
     - scipy>=1.3.0
@@ -41,6 +42,7 @@ requirements:
 
   run:
     - python x.x
+    - gitpython
     - attrs>=19.1.0
     - numba
     - numpy>=1.13

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -40,8 +40,8 @@ def build_parser():
 def main():
     args = build_parser().parse_args()
     py_vers = ["3.6"]
-    bullet_modes = [True, False][1:]
-    headless_modes = [True, False][0:1]
+    bullet_modes = [True, False]
+    headless_modes = [True, False]
     cuda_vers = [None, "9.2", "10.0"][0:1]
 
     for py_ver, use_bullet, headless, cuda_ver in itertools.product(
@@ -65,9 +65,8 @@ def main():
         if use_bullet:
             build_string += "bullet_"
             env["CONDA_BULLET"] = "- bullet"
+            env["CONDA_BULLET_FEATURE"] = "- withbullet"
             env["WITH_BULLET"] = "1"
-        else:
-            env["CONDA_BULLET"] = ""
 
         if cuda_ver is not None:
             build_string += f"cuda{cuda_ver}_"

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -91,6 +91,7 @@ def main():
         build_string += "_" + sha
 
         env["HSIM_BUILD_STRING"] = build_string
+        print(f"ENVIRONMENT VARIABLES: {env}")
 
         call(
             build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux"),

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -16,6 +16,7 @@ sys.path.append("../")
 import habitat_sim
 
 build_cmd_template = """
+{PREFIX} \
 conda build \
   --python {PY_VER} \
   --channel conda-forge \
@@ -101,7 +102,8 @@ def main():
         env["HSIM_BUILD_STRING"] = build_string
 
         call(
-            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux", ANACONDA_UPLOAD_MODE="--no-anaconda-upload" if args.conda_upload else ""),
+            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux", ANACONDA_UPLOAD_MODE="--no-anaconda-upload" if args.conda_upload else "",
+                                      PREFIX="conda config --set anaconda_upload yes;" if args.conda_upload else ""),
             env=env,
         )
 

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -67,6 +67,8 @@ def main():
             env["CONDA_BULLET"] = "- bullet"
             env["CONDA_BULLET_FEATURE"] = "- withbullet"
             env["WITH_BULLET"] = "1"
+        else:
+            env["CONDA_BULLET"] = ""
 
         if cuda_ver is not None:
             build_string += f"cuda{cuda_ver}_"

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -33,7 +33,7 @@ def call(cmd, env=None):
 
 def build_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--ci_test', help="Test package conda build during continues integration test.", action='store_false')
+    parser.add_argument('--ci_test', help="Test package conda build during continues integration test.", action='store_true')
 
     return parser
 

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -16,7 +16,6 @@ sys.path.append("../")
 import habitat_sim
 
 build_cmd_template = """
-{PREFIX} \
 conda build \
   --python {PY_VER} \
   --channel conda-forge \
@@ -102,8 +101,7 @@ def main():
         env["HSIM_BUILD_STRING"] = build_string
 
         call(
-            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux", ANACONDA_UPLOAD_MODE="--no-anaconda-upload" if args.conda_upload else "",
-                                      PREFIX="conda config --set anaconda_upload yes;" if args.conda_upload else ""),
+            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux", ANACONDA_UPLOAD_MODE="" if args.conda_upload else "--no-anaconda-upload"),
             env=env,
         )
 

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -33,6 +33,7 @@ def call(cmd, env=None):
 
 def build_parser():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--ci_test', help="Test package conda build during continues integration test.", action='store_false')
 
     return parser
 
@@ -43,6 +44,11 @@ def main():
     bullet_modes = [True, False]
     headless_modes = [True, False]
     cuda_vers = [None, "9.2", "10.0"][0:1]
+
+    # For CI test only one package build for test speed interest
+    if args.ci_test:
+        bullet_modes = [True]
+        headless_modes = [True]
 
     for py_ver, use_bullet, headless, cuda_ver in itertools.product(
         py_vers, bullet_modes, headless_modes, cuda_vers
@@ -91,7 +97,6 @@ def main():
         build_string += "_" + sha
 
         env["HSIM_BUILD_STRING"] = build_string
-        print(f"ENVIRONMENT VARIABLES: {env}")
 
         call(
             build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux"),

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -20,7 +20,7 @@ conda build \
   --python {PY_VER} \
   --channel conda-forge \
   --no-test \
-  --no-anaconda-upload \
+  {ANACONDA_UPLOAD_MODE} \
   --output-folder {OUTPUT_FOLDER} \
   habitat-sim
 """
@@ -34,6 +34,8 @@ def call(cmd, env=None):
 def build_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--ci_test', help="Test package conda build during continues integration test.", action='store_true')
+    parser.add_argument('--conda_upload', help="Upload conda binaries as package to authenticated Anaconda cloud account.",
+                        action='store_true')
 
     return parser
 
@@ -99,7 +101,7 @@ def main():
         env["HSIM_BUILD_STRING"] = build_string
 
         call(
-            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux"),
+            build_cmd_template.format(PY_VER=py_ver, OUTPUT_FOLDER="hsim-linux", ANACONDA_UPLOAD_MODE="--no-anaconda-upload" if args.conda_upload else ""),
             env=env,
         )
 

--- a/conda-build/macos_matrix_builder.py
+++ b/conda-build/macos_matrix_builder.py
@@ -47,7 +47,7 @@ def main():
 
         # including a timestamp in anticipation of nightly builds
         env["VERSION"] = habitat_sim.__version__ + time.strftime(".%Y.%m.%d")
-        env["WITH_BULLET"] = "1" if use_bullet else "0"
+        env["WITH_BULLET"] = "0"
         env["WITH_CUDA"] = "0"
         env["HEADLESS"] = "0"
         env["HSIM_SOURCE_PATH"] = osp.abspath(osp.join(osp.dirname(__file__), ".."))
@@ -55,11 +55,9 @@ def main():
         build_string = f"py{py_ver}_"
         if use_bullet:
             build_string += "bullet_"
+            env["WITH_BULLET"] = "1"
             env["CONDA_BULLET"] = "- bullet"
             env["CONDA_BULLET_FEATURE"] = "- withbullet"
-        else:
-            env["CONDA_BULLET"] = ""
-            env["CONDA_BULLET_FEATURE"] = ""
 
         build_string += "osx"
 


### PR DESCRIPTION
#  Motivation and Context
- Made Linux binaries build for head / headless x with bullet / without bullet
- Improved Conda build readme
- Use Frozen `conda-build` lib version that works with current setup
- Added conda binaries build step to CI without upload to Anaconda upload for testing purposes. 
- Next Conda workflows are supported now:
<img width="1405" alt="Screenshot 2020-07-01 22 57 29" src="https://user-images.githubusercontent.com/877440/86321816-96830180-bbee-11ea-8b19-3f4ee27e09eb.png">

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
- Built v0.1.5 binaries.
- Added CI build step
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
