### PR TITLE
Configurable Semantic id

### DIFF
--- a/data/default.phys_scene_config.json
+++ b/data/default.phys_scene_config.json
@@ -1,5 +1,5 @@
 {
-    "physics simulator": "bullet",
+    "physics simulator": "none",
     "timestep": 0.008,
     "gravity": [0,-9.8,0],
     "friction coefficient": 0.4,

--- a/data/default.phys_scene_config.json
+++ b/data/default.phys_scene_config.json
@@ -1,5 +1,5 @@
 {
-    "physics simulator": "none",
+    "physics simulator": "bullet",
     "timestep": 0.008,
     "gravity": [0,-9.8,0],
     "friction coefficient": 0.4,

--- a/examples/tutorials/semantic_id_tutorial.py
+++ b/examples/tutorials/semantic_id_tutorial.py
@@ -98,25 +98,6 @@ def make_configuration(scene_file):
     return habitat_sim.Configuration(backend_cfg, [agent_cfg])
 
 
-def add_chairs(sim):
-    # load some chair object template from configuration file
-    chair_template_id = sim.load_object_configs(
-        str(os.path.join(data_path, "test_assets/objects/chair"))
-    )[0]
-
-    # add 2 chairs and arrange them
-    ids = []
-    ids.append(sim.add_object(chair_template_id))
-    ids.append(sim.add_object(chair_template_id))
-
-    sim.set_rotation(mn.Quaternion.rotation(mn.Deg(-115), mn.Vector3.y_axis()), ids[0])
-    sim.set_translation([2.0, 0.47, 0.9], ids[0])
-
-    sim.set_translation([2.9, 0.47, 0.0], ids[1])
-
-    return ids
-
-
 # [/setup]
 
 # This is wrapped such that it can be added to a unit test
@@ -141,19 +122,56 @@ def main(show_imgs=True, save_imgs=False):
         cfg = make_configuration(scene_file=scene)
         sim.reconfigure(cfg)
         agent_transform = place_agent(sim)
-        get_obs(sim, show_imgs, save_imgs)
+        # get_obs(sim, show_imgs, save_imgs)
 
-        # add new chair objects to the scene with default semanticId == 0
-        chair_ids = add_chairs(sim)
-        get_obs(sim, show_imgs, save_imgs)
+        # load some chair object template from configuration file
+        chair_template_id = sim.load_object_configs(
+            str(os.path.join(data_path, "test_assets/objects/chair"))
+        )[0]
+
+        # add 2 chairs with default semanticId == 0 and arrange them
+        chair_ids = []
+        chair_ids.append(sim.add_object(chair_template_id))
+        chair_ids.append(sim.add_object(chair_template_id))
+
+        sim.set_rotation(
+            mn.Quaternion.rotation(mn.Deg(-115), mn.Vector3.y_axis()), chair_ids[0]
+        )
+        sim.set_translation([2.0, 0.47, 0.9], chair_ids[0])
+
+        sim.set_translation([2.9, 0.47, 0.0], chair_ids[1])
+        # get_obs(sim, show_imgs, save_imgs)
 
         # set the semanticId for both chairs
-        sim.set_object_semantic_id(20, chair_ids[0])
-        sim.set_object_semantic_id(20, chair_ids[1])
-        get_obs(sim, show_imgs, save_imgs)
+        sim.set_object_semantic_id(2, chair_ids[0])
+        sim.set_object_semantic_id(2, chair_ids[1])
+        # get_obs(sim, show_imgs, save_imgs)
 
         # set the semanticId for one chair
-        sim.set_object_semantic_id(10, chair_ids[1])
+        sim.set_object_semantic_id(1, chair_ids[1])
+        # get_obs(sim, show_imgs, save_imgs)
+
+        # add a box with default semanticId configured in the template
+        box_template = habitat_sim.attributes.PhysicsObjectAttributes()
+        box_template.set_render_asset_handle(
+            str(os.path.join(data_path, "test_assets/objects/transform_box.glb"))
+        )
+        box_template.set_scale(np.array([0.2, 0.2, 0.2]))
+        # set the default semantic id for this object template
+        box_template.semantic_id = 10
+        box_template_id = sim.load_object_template(box_template, "box")
+        box_id = sim.add_object(box_template_id)
+        sim.set_translation([3.5, 0.47, 0.9], box_id)
+        sim.set_rotation(
+            mn.Quaternion.rotation(mn.Deg(-30), mn.Vector3.y_axis()), box_id
+        )
+
+        get_obs(sim, show_imgs, save_imgs)
+
+        # set semantic id for specific SceneNode components of the box object
+        box_visual_nodes = sim.get_object_visual_scene_nodes(box_id)
+        box_visual_nodes[6].semantic_id = 3
+        box_visual_nodes[7].semantic_id = 4
         get_obs(sim, show_imgs, save_imgs)
 
     # [/semantic id]

--- a/examples/tutorials/semantic_id_tutorial.py
+++ b/examples/tutorials/semantic_id_tutorial.py
@@ -18,6 +18,7 @@ save_index = 0
 
 
 def show_img(data, save):
+    # display rgb and semantic images side-by-side
     fig = plt.figure(figsize=(12, 12))
     ax1 = fig.add_subplot(1, 2, 1)
     ax1.axis("off")
@@ -40,6 +41,7 @@ def show_img(data, save):
 
 
 def get_obs(sim, show, save):
+    # render sensor ouputs and optionally show them
     rgb_obs = sim.get_sensor_observations()["rgba_camera"]
     semantic_obs = sim.get_sensor_observations()["semantic_camera"]
     if show:
@@ -65,7 +67,7 @@ def make_configuration(scene_file):
 
     # sensor configurations
     # Note: all sensors must have the same resolution
-    # setup rgb and depth sensors with slight offset
+    # setup rgb and semantic sensors
     camera_resolution = [1080, 960]
     sensors = {
         "rgba_camera": {
@@ -97,11 +99,12 @@ def make_configuration(scene_file):
 
 
 def add_chairs(sim):
-    # load some object templates from configuration files
+    # load some chair object template from configuration file
     chair_template_id = sim.load_object_configs(
         str(os.path.join(data_path, "test_assets/objects/chair"))
     )[0]
 
+    # add 2 chairs and arrange them
     ids = []
     ids.append(sim.add_object(chair_template_id))
     ids.append(sim.add_object(chair_template_id))

--- a/examples/tutorials/semantic_id_tutorial.py
+++ b/examples/tutorials/semantic_id_tutorial.py
@@ -1,0 +1,160 @@
+# [setup]
+import math
+import os
+
+import magnum as mn
+import numpy as np
+from matplotlib import pyplot as plt
+
+import habitat_sim
+from habitat_sim.gfx import LightInfo, LightPositionModel
+from habitat_sim.utils.common import quat_from_angle_axis, quat_to_magnum
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+data_path = os.path.join(dir_path, "../../data")
+output_path = os.path.join(dir_path, "semantic_object_tutorial_output/")
+
+save_index = 0
+
+
+def show_img(data, save):
+    fig = plt.figure(figsize=(12, 12))
+    ax1 = fig.add_subplot(1, 2, 1)
+    ax1.axis("off")
+    ax1.imshow(data[0], interpolation="nearest")
+    ax2 = fig.add_subplot(1, 2, 2)
+    ax2.axis("off")
+    ax2.imshow(data[1], interpolation="nearest")
+    plt.axis("off")
+    plt.show(block=False)
+    if save:
+        global save_index
+        plt.savefig(
+            output_path + str(save_index) + ".jpg",
+            bbox_inches="tight",
+            pad_inches=0,
+            quality=50,
+        )
+        save_index += 1
+    plt.pause(1)
+
+
+def get_obs(sim, show, save):
+    rgb_obs = sim.get_sensor_observations()["rgba_camera"]
+    semantic_obs = sim.get_sensor_observations()["semantic_camera"]
+    if show:
+        show_img((rgb_obs, semantic_obs), save)
+
+
+def place_agent(sim):
+    # place our agent in the scene
+    agent_state = habitat_sim.AgentState()
+    agent_state.position = [5.0, 0.0, 1.0]
+    agent_state.rotation = quat_from_angle_axis(
+        math.radians(70), np.array([0, 1.0, 0])
+    ) * quat_from_angle_axis(math.radians(-20), np.array([1.0, 0, 0]))
+    agent = sim.initialize_agent(0, agent_state)
+    return agent.scene_node.transformation_matrix()
+
+
+def make_configuration(scene_file):
+    # simulator configuration
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.scene.id = scene_file
+    backend_cfg.enable_physics = True
+
+    # sensor configurations
+    # Note: all sensors must have the same resolution
+    # setup rgb and depth sensors with slight offset
+    camera_resolution = [1080, 960]
+    sensors = {
+        "rgba_camera": {
+            "sensor_type": habitat_sim.SensorType.COLOR,
+            "resolution": camera_resolution,
+            "position": [0.0, 1.5, 0.0],  #::: fix y to be 0 later
+        },
+        "semantic_camera": {
+            "sensor_type": habitat_sim.SensorType.SEMANTIC,
+            "resolution": camera_resolution,
+            "position": [0.0, 1.5, 0.0],
+        },
+    }
+
+    sensor_specs = []
+    for sensor_uuid, sensor_params in sensors.items():
+        sensor_spec = habitat_sim.SensorSpec()
+        sensor_spec.uuid = sensor_uuid
+        sensor_spec.sensor_type = sensor_params["sensor_type"]
+        sensor_spec.resolution = sensor_params["resolution"]
+        sensor_spec.position = sensor_params["position"]
+        sensor_specs.append(sensor_spec)
+
+    # agent configuration
+    agent_cfg = habitat_sim.agent.AgentConfiguration()
+    agent_cfg.sensor_specifications = sensor_specs
+
+    return habitat_sim.Configuration(backend_cfg, [agent_cfg])
+
+
+def add_chairs(sim):
+    # load some object templates from configuration files
+    chair_template_id = sim.load_object_configs(
+        str(os.path.join(data_path, "test_assets/objects/chair"))
+    )[0]
+
+    ids = []
+    ids.append(sim.add_object(chair_template_id))
+    ids.append(sim.add_object(chair_template_id))
+
+    sim.set_rotation(mn.Quaternion.rotation(mn.Deg(-115), mn.Vector3.y_axis()), ids[0])
+    sim.set_translation([2.0, 0.47, 0.9], ids[0])
+
+    sim.set_translation([2.9, 0.47, 0.0], ids[1])
+
+    return ids
+
+
+# [/setup]
+
+# This is wrapped such that it can be added to a unit test
+def main(show_imgs=True, save_imgs=False):
+    if save_imgs:
+        if not os.path.exists(output_path):
+            os.mkdir(output_path)
+
+    # [semantic id]
+
+    # create the simulator and render flat shaded scene
+    cfg = make_configuration(scene_file="NONE")
+    sim = habitat_sim.Simulator(cfg)
+
+    test_scenes = [
+        "data/scene_datasets/habitat-test-scenes/apartment_1.glb",
+        "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb",
+    ]
+
+    for scene in test_scenes:
+        # reconfigure the simulator with a new scene asset
+        cfg = make_configuration(scene_file=scene)
+        sim.reconfigure(cfg)
+        agent_transform = place_agent(sim)
+        get_obs(sim, show_imgs, save_imgs)
+
+        # add new chair objects to the scene with default semanticId == 0
+        chair_ids = add_chairs(sim)
+        get_obs(sim, show_imgs, save_imgs)
+
+        # set the semanticId for both chairs
+        sim.set_object_semantic_id(20, chair_ids[0])
+        sim.set_object_semantic_id(20, chair_ids[1])
+        get_obs(sim, show_imgs, save_imgs)
+
+        # set the semanticId for one chair
+        sim.set_object_semantic_id(10, chair_ids[1])
+        get_obs(sim, show_imgs, save_imgs)
+
+    # [/semantic id]
+
+
+if __name__ == "__main__":
+    main(show_imgs=True, save_imgs=True)

--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -53,6 +53,7 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(
   setJoinCollisionMeshes(true);
   setRequiresLighting(true);
   setIsVisible(true);
+  setSemanticId(0);
   setIsCollidable(true);
 }  // PhysicsObjectAttributes ctor
 

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -244,6 +244,10 @@ class PhysicsObjectAttributes : public AbstractPhysicsAttributes {
   void setIsVisible(bool isVisible) { setBool("isVisible", isVisible); }
   bool getIsVisible() const { return getBool("isVisible"); }
 
+  void setSemanticId(uint32_t semanticId) { setInt("semanticId", semanticId); }
+
+  uint32_t getSemanticId() const { return getInt("semanticId"); }
+
   // if object should be checked for collisions - if other objects can collide
   // with this object
   void setIsCollidable(bool isCollidable) {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1307,9 +1307,8 @@ std::vector<scene::SceneNode*> ResourceManager::addObjectToDrawables(
         addComponent(loadedAssetData.meshMetaData, scalingNode, lightSetup,
                      drawables, loadedAssetData.meshMetaData.root);
 
-    for (auto node : componentNodes) {
-      newNodes.push_back(node);
-    }
+    newNodes.insert(newNodes.end(), componentNodes.begin(),
+                    componentNodes.end());
   }  // should always be specified, otherwise won't do anything
   return newNodes;
 }  // addObjectToDrawables
@@ -1346,9 +1345,7 @@ std::vector<scene::SceneNode*> ResourceManager::addComponent(
   for (auto& child : meshTransformNode.children) {
     std::vector<scene::SceneNode*> childNodes =
         addComponent(metaData, node, lightSetup, drawables, child);
-    for (auto node : childNodes) {
-      newNodes.push_back(node);
-    }
+    newNodes.insert(newNodes.end(), childNodes.begin(), childNodes.end());
   }
   return newNodes;
 }  // addComponent

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -314,6 +314,7 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
+   * @return Pointers to all nodes created as the result of this process.
    */
   std::vector<scene::SceneNode*> addObjectToDrawables(
       int objTemplateLibID,
@@ -348,6 +349,7 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
+   * @return Pointers to all nodes created as the result of this process.
    */
   std::vector<scene::SceneNode*> addObjectToDrawables(
       const std::string& objTemplateHandle,
@@ -488,6 +490,8 @@ class ResourceManager {
    * rendered.
    * @param meshTransformNode The @ref MeshTransformNode for component
    * identifying its mesh, material, transformation, and children.
+   * @return Pointers to all nodes created as the result of this recursive
+   * process.
    */
   std::vector<scene::SceneNode*> addComponent(
       const MeshMetaData& metaData,

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -315,19 +315,21 @@ class ResourceManager {
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
    */
-  void addObjectToDrawables(int objTemplateLibID,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            const Magnum::ResourceKey& lightSetup =
-                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY}) {
+  std::vector<scene::SceneNode*> addObjectToDrawables(
+      int objTemplateLibID,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
+          DEFAULT_LIGHTING_KEY}) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           objectAttributesManager_->getTemplateHandleByID(objTemplateLibID);
 
-      addObjectToDrawables(objTemplateHandleName, parent, drawables,
-                           lightSetup);
+      return addObjectToDrawables(objTemplateHandleName, parent, drawables,
+                                  lightSetup);
     }  // else objTemplateID does not exist - shouldn't happen
-  }    // addObjectToDrawables
+    return std::vector<scene::SceneNode*>();
+  }  // addObjectToDrawables
 
   /**
    * @brief Add an object from a specified object template handle to the
@@ -347,11 +349,12 @@ class ResourceManager {
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
    */
-  void addObjectToDrawables(const std::string& objTemplateHandle,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            const Magnum::ResourceKey& lightSetup =
-                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
+  std::vector<scene::SceneNode*> addObjectToDrawables(
+      const std::string& objTemplateHandle,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
+          DEFAULT_LIGHTING_KEY});
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref
@@ -486,11 +489,12 @@ class ResourceManager {
    * @param meshTransformNode The @ref MeshTransformNode for component
    * identifying its mesh, material, transformation, and children.
    */
-  void addComponent(const MeshMetaData& metaData,
-                    scene::SceneNode& parent,
-                    const Magnum::ResourceKey& lightSetup,
-                    DrawableGroup* drawables,
-                    const MeshTransformNode& meshTransformNode);
+  std::vector<scene::SceneNode*> addComponent(
+      const MeshMetaData& metaData,
+      scene::SceneNode& parent,
+      const Magnum::ResourceKey& lightSetup,
+      DrawableGroup* drawables,
+      const MeshTransformNode& meshTransformNode);
 
   /**
    * @brief Load textures from importer into assets, and update metaData for

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -314,23 +314,23 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
-   * @return Pointers to all nodes created as the result of this process.
+   * @param visNodeCache Cache for pointers to all nodes created as the result
+   * of this process.
    */
-  std::vector<scene::SceneNode*> addObjectToDrawables(
-      int objTemplateLibID,
-      scene::SceneNode* parent,
-      DrawableGroup* drawables,
-      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-          DEFAULT_LIGHTING_KEY}) {
+  void addObjectToDrawables(int objTemplateLibID,
+                            scene::SceneNode* parent,
+                            DrawableGroup* drawables,
+                            std::vector<scene::SceneNode*>& visNodeCache,
+                            const Magnum::ResourceKey& lightSetup =
+                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY}) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           objectAttributesManager_->getTemplateHandleByID(objTemplateLibID);
 
-      return addObjectToDrawables(objTemplateHandleName, parent, drawables,
-                                  lightSetup);
+      addObjectToDrawables(objTemplateHandleName, parent, drawables,
+                           visNodeCache, lightSetup);
     }  // else objTemplateID does not exist - shouldn't happen
-    return std::vector<scene::SceneNode*>();
-  }  // addObjectToDrawables
+  }    // addObjectToDrawables
 
   /**
    * @brief Add an object from a specified object template handle to the
@@ -349,14 +349,15 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
-   * @return Pointers to all nodes created as the result of this process.
+   * @param visNodeCache Cache for pointers to all nodes created as the result
+   * of this process.
    */
-  std::vector<scene::SceneNode*> addObjectToDrawables(
-      const std::string& objTemplateHandle,
-      scene::SceneNode* parent,
-      DrawableGroup* drawables,
-      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-          DEFAULT_LIGHTING_KEY});
+  void addObjectToDrawables(const std::string& objTemplateHandle,
+                            scene::SceneNode* parent,
+                            DrawableGroup* drawables,
+                            std::vector<scene::SceneNode*>& visNodeCache,
+                            const Magnum::ResourceKey& lightSetup =
+                                Magnum::ResourceKey{DEFAULT_LIGHTING_KEY});
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref
@@ -490,15 +491,15 @@ class ResourceManager {
    * rendered.
    * @param meshTransformNode The @ref MeshTransformNode for component
    * identifying its mesh, material, transformation, and children.
-   * @return Pointers to all nodes created as the result of this recursive
-   * process.
+   * @param visNodeCache Cache for pointers to all nodes created as the result
+   * of this recursive process.
    */
-  std::vector<scene::SceneNode*> addComponent(
-      const MeshMetaData& metaData,
-      scene::SceneNode& parent,
-      const Magnum::ResourceKey& lightSetup,
-      DrawableGroup* drawables,
-      const MeshTransformNode& meshTransformNode);
+  void addComponent(const MeshMetaData& metaData,
+                    scene::SceneNode& parent,
+                    const Magnum::ResourceKey& lightSetup,
+                    DrawableGroup* drawables,
+                    const MeshTransformNode& meshTransformNode,
+                    std::vector<scene::SceneNode*>& visNodeCache);
 
   /**
    * @brief Load textures from importer into assets, and update metaData for

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -314,8 +314,8 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
-   * @param visNodeCache Cache for pointers to all nodes created as the result
-   * of this process.
+   * @param[out] visNodeCache Cache for pointers to all nodes created as the
+   * result of this process.
    */
   void addObjectToDrawables(int objTemplateLibID,
                             scene::SceneNode* parent,
@@ -349,8 +349,8 @@ class ResourceManager {
    * gfx::Drawable will be rendered.
    * @param lightSetup The @ref LightSetup key that will be used
    * for the added component.
-   * @param visNodeCache Cache for pointers to all nodes created as the result
-   * of this process.
+   * @param[out] visNodeCache Cache for pointers to all nodes created as the
+   * result of this process.
    */
   void addObjectToDrawables(const std::string& objTemplateHandle,
                             scene::SceneNode* parent,
@@ -491,8 +491,8 @@ class ResourceManager {
    * rendered.
    * @param meshTransformNode The @ref MeshTransformNode for component
    * identifying its mesh, material, transformation, and children.
-   * @param visNodeCache Cache for pointers to all nodes created as the result
-   * of this recursive process.
+   * @param[out] visNodeCache Cache for pointers to all nodes created as the
+   * result of this recursive process.
    */
   void addComponent(const MeshMetaData& metaData,
                     scene::SceneNode& parent,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -88,7 +88,9 @@ void initAttributesBindings(py::module& m) {
       .def("set_requires_lighting",
            &PhysicsObjectAttributes::setRequiresLighting, "requires_lighting"_a)
       .def("get_requires_lighting",
-           &PhysicsObjectAttributes::getRequiresLighting);
+           &PhysicsObjectAttributes::getRequiresLighting)
+      .def_property("semantic_id", &PhysicsObjectAttributes::getSemanticId,
+                    &PhysicsObjectAttributes::setSemanticId);
 
   // ==== AbstractPrimitiveAttributes ====
   py::class_<AbstractPrimitiveAttributes, AbstractAttributes,

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -72,6 +72,8 @@ void initSceneBindings(py::module& m) {
       .def(py::init_alias<std::reference_wrapper<SceneNode>>(),
            R"(Constructor: creates a scene node, and sets its parent.)")
       .def_property("type", &SceneNode::getType, &SceneNode::setType)
+      .def_property("semantic_id", &SceneNode::getSemanticId,
+                    &SceneNode::setSemanticId)
       .def(
           "create_child", [](SceneNode& self) { return &self.createChild(); },
           R"(Creates a child node, and sets its parent to the current node.)")

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -136,6 +136,9 @@ void initSimBindings(py::module& m) {
       .def("set_gravity", &Simulator::setGravity, "gravity"_a, "scene_id"_a = 0)
       .def("get_object_scene_node", &Simulator::getObjectSceneNode,
            "object_id"_a, "scene_id"_a = 0)
+      .def("get_object_visual_scene_nodes",
+           &Simulator::getObjectVisualSceneNodes, "object_id"_a,
+           "scene_id"_a = 0)
       .def("set_transformation", &Simulator::setTransformation, "transform"_a,
            "object_id"_a, "scene_id"_a = 0)
       .def("get_transformation", &Simulator::getTransformation, "object_id"_a,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -170,6 +170,8 @@ void initSimBindings(py::module& m) {
            "scene_id"_a = 0)
       .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
            "object_id"_a, "scene_id"_a = 0)
+      .def("set_object_semantic_id", &Simulator::setObjectSemanticId,
+           "semantic_id"_a, "object_id"_a, "scene_id"_a = 0)
       .def("recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
            "navmesh_settings"_a, "include_static_objects"_a = false)
       .def("get_light_setup", &Simulator::getLightSetup,

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -61,7 +61,8 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       .setShininess(materialData_->shininess)
       .setLightPositions(lightPositions)
       .setLightColors(lightColors)
-      .setObjectId(materialData_->perVertexObjectId ? 0 : node_.getId())
+      //.setObjectId(materialData_->perVertexObjectId ? 0 : node_.getId())
+      .setObjectId(materialData_->perVertexObjectId ? 0 : node_.getSemanticId())
       .setTransformationMatrix(transformationMatrix)
       .setProjectionMatrix(camera.projectionMatrix())
       .setNormalMatrix(transformationMatrix.rotationScaling());

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -61,7 +61,6 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       .setShininess(materialData_->shininess)
       .setLightPositions(lightPositions)
       .setLightColors(lightColors)
-      //.setObjectId(materialData_->perVertexObjectId ? 0 : node_.getId())
       .setObjectId(materialData_->perVertexObjectId ? 0 : node_.getSemanticId())
       .setTransformationMatrix(transformationMatrix)
       .setProjectionMatrix(camera.projectionMatrix())

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -110,9 +110,10 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
 
   existingObjects_.at(nextObjectID_)
       ->visualNodes_.push_back(existingObjects_.at(nextObjectID_)->visualNode_);
-  for (auto node : newNodes) {
-    existingObjects_.at(nextObjectID_)->visualNodes_.push_back(node);
-  }
+  existingObjects_.at(nextObjectID_)
+      ->visualNodes_.insert(
+          existingObjects_.at(nextObjectID_)->visualNodes_.end(),
+          newNodes.begin(), newNodes.end());
 
   // finalize rigid object creation
   objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -103,9 +103,16 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
 
   //! Draw object via resource manager
   //! Render node as child of physics node
-  resourceManager_.addObjectToDrawables(
-      configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
-      drawables, lightSetup);
+  std::vector<scene::SceneNode*> newNodes =
+      resourceManager_.addObjectToDrawables(
+          configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
+          drawables, lightSetup);
+
+  existingObjects_.at(nextObjectID_)
+      ->visualNodes_.push_back(existingObjects_.at(nextObjectID_)->visualNode_);
+  for (auto node : newNodes) {
+    existingObjects_.at(nextObjectID_)->visualNodes_.push_back(node);
+  }
 
   // finalize rigid object creation
   objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();
@@ -535,6 +542,12 @@ const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
     int physObjectID) const {
   assertIDValidity(physObjectID);
   return *existingObjects_.at(physObjectID)->visualNode_;
+}
+
+void PhysicsManager::setSemanticId(const int physObjectID,
+                                   uint32_t semanticId) {
+  assertIDValidity(physObjectID);
+  existingObjects_.at(physObjectID)->setSemanticId(semanticId);
 }
 
 const assets::PhysicsObjectAttributes::cptr

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -101,19 +101,14 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     return ID_UNDEFINED;
   }
 
-  //! Draw object via resource manager
-  //! Render node as child of physics node
-  std::vector<scene::SceneNode*> newNodes =
-      resourceManager_.addObjectToDrawables(
-          configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
-          drawables, lightSetup);
-
   existingObjects_.at(nextObjectID_)
       ->visualNodes_.push_back(existingObjects_.at(nextObjectID_)->visualNode_);
-  existingObjects_.at(nextObjectID_)
-      ->visualNodes_.insert(
-          existingObjects_.at(nextObjectID_)->visualNodes_.end(),
-          newNodes.begin(), newNodes.end());
+
+  //! Draw object via resource manager
+  //! Render node as child of physics node
+  resourceManager_.addObjectToDrawables(
+      configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
+      drawables, existingObjects_.at(nextObjectID_)->visualNodes_, lightSetup);
 
   // finalize rigid object creation
   objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -540,6 +540,12 @@ const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
   return *existingObjects_.at(physObjectID)->visualNode_;
 }
 
+std::vector<scene::SceneNode*> PhysicsManager::getObjectVisualSceneNodes(
+    const int physObjectID) const {
+  assertIDValidity(physObjectID);
+  return existingObjects_.at(physObjectID)->visualNodes_;
+}
+
 void PhysicsManager::setSemanticId(const int physObjectID,
                                    uint32_t semanticId) {
   assertIDValidity(physObjectID);

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -811,6 +811,8 @@ class PhysicsManager {
     return activePhysSimLib_;
   };
 
+  void setSemanticId(const int physObjectID, uint32_t semanticId);
+
   /**
    * @brief Get the template used to initialize an object.
    *

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -779,6 +779,16 @@ class PhysicsManager {
    */
   const scene::SceneNode& getObjectVisualSceneNode(int physObjectID) const;
 
+  /**
+   * @brief Get pointers to an object's visual SceneNodes.
+   *
+   * @param physObjectID The object ID and key identifying the object in @ref
+   * PhysicsManager::existingObjects_.
+   * @return pointers to the object's visual scene nodes.
+   */
+  std::vector<scene::SceneNode*> getObjectVisualSceneNodes(
+      const int objectID) const;
+
   /** @brief Render any debugging visualizations provided by the underlying
    * physics simulator implementation. By default does nothing. See @ref
    * BulletPhysicsManager::debugDraw.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -819,7 +819,7 @@ class PhysicsManager {
    * existingObjects_.
    * @param semanticId The desired semantic id for the object.
    */
-  void setSemanticId(const int physObjectID, uint32_t semanticId);
+  void setSemanticId(int physObjectID, uint32_t semanticId);
 
   /**
    * @brief Get the template used to initialize an object.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -811,6 +811,14 @@ class PhysicsManager {
     return activePhysSimLib_;
   };
 
+  /**
+   * @brief Set the @ref esp::scene:SceneNode::semanticId_ for all visual nodes
+   * belonging to an object.
+   *
+   * @param objectID The object ID and key identifying the object in @ref
+   * existingObjects_.
+   * @param semanticId The desired semantic id for the object.
+   */
   void setSemanticId(const int physObjectID, uint32_t semanticId);
 
   /**

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -571,6 +571,12 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual void setAngularDamping(CORRADE_UNUSED const double angDamping) {}
 
+  /**
+   * @brief Set the @ref esp::scene:SceneNode::semanticId_ for all visual nodes
+   * belonging to the object.
+   *
+   * @param semanticId The desired semantic id for the object.
+   */
   void setSemanticId(uint32_t semanticId) {
     for (auto node : visualNodes_) {
       node->setSemanticId(semanticId);

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -571,6 +571,12 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual void setAngularDamping(CORRADE_UNUSED const double angDamping) {}
 
+  void setSemanticId(uint32_t semanticId) {
+    for (auto node : visualNodes_) {
+      node->setSemanticId(semanticId);
+    }
+  }
+
   /**
    * @brief Get the template used to initialize this object or scene.
    *
@@ -597,6 +603,10 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * translation as scaling is applied to a child of this node.
    */
   scene::SceneNode* visualNode_ = nullptr;
+
+  //! all nodes created when this object's render asset was added to the
+  //! SceneGraph
+  std::vector<esp::scene::SceneNode*> visualNodes_;
 
  protected:
   /** @brief Used to synchronize other simulator's notion of the object state

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -42,6 +42,10 @@ bool RigidObject::finalizeObject() {
     // otherwise use the bounding box center
     shiftOriginToBBCenter();
   }
+
+  // set the visualization semantic id
+  setSemanticId(physicsObjectAttributes->getSemanticId());
+
   // finish object by instancing any dynamics library-specific code required
   return finalizeObject_LibSpecific();
 }  // RigidObject::finalizeObject

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -108,6 +108,9 @@ class SceneNode : public MagnumObject {
   // the type of the attached object (e.g., sensor, agent etc.)
   SceneNodeType type_ = SceneNodeType::EMPTY;
   int id_ = ID_UNDEFINED;
+
+  //! The semantic category of this node. Used to render attached Drawables with
+  //! SEMANTIC sensor when no perVertexObjectIds are present.
   uint32_t semanticId_ = 0;
 
   //! the local bounding box for meshes stored at this node

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -61,6 +61,12 @@ class SceneNode : public MagnumObject {
   //! Sets node id
   virtual void setId(int id) { id_ = id; }
 
+  //! Returns node semanticId
+  virtual int getSemanticId() const { return semanticId_; }
+
+  //! Sets node semanticId
+  virtual void setSemanticId(int semanticId) { semanticId_ = semanticId; }
+
   Magnum::Vector3 absoluteTranslation() const {
     return this->absoluteTransformation().translation();
   }
@@ -102,6 +108,7 @@ class SceneNode : public MagnumObject {
   // the type of the attached object (e.g., sensor, agent etc.)
   SceneNodeType type_ = SceneNodeType::EMPTY;
   int id_ = ID_UNDEFINED;
+  uint32_t semanticId_ = 0;
 
   //! the local bounding box for meshes stored at this node
   Magnum::Range3D meshBB_;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -428,6 +428,15 @@ scene::SceneNode* Simulator::getObjectSceneNode(const int objectID,
   return nullptr;
 }
 
+std::vector<scene::SceneNode*> Simulator::getObjectVisualSceneNodes(
+    const int objectID,
+    const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    return physicsManager_->getObjectVisualSceneNodes(objectID);
+  }
+  return std::vector<scene::SceneNode*>();
+}
+
 // set object transform (kinemmatic control)
 void Simulator::setTransformation(const Magnum::Matrix4& transform,
                                   const int objectID,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -546,6 +546,14 @@ void Simulator::setObjectBBDraw(bool drawBB,
   }
 }
 
+void Simulator::setObjectSemanticId(uint32_t semanticId,
+                                    const int objectID,
+                                    const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    physicsManager_->setSemanticId(objectID, semanticId);
+  }
+}
+
 double Simulator::stepWorld(const double dt) {
   if (physicsManager_ != nullptr) {
     physicsManager_->stepPhysics(dt);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -565,9 +565,7 @@ class Simulator {
    * @param sceneID !! Not used currently !! Specifies which physical scene of
    * the object.
    */
-  void setObjectSemanticId(uint32_t semanticId,
-                           int objectID,
-                           int sceneID);
+  void setObjectSemanticId(uint32_t semanticId, int objectID, int sceneID);
 
   /**
    * @brief Discrete collision check for contact between an object and the

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -555,6 +555,11 @@ class Simulator {
    */
   void setObjectBBDraw(bool drawBB, const int objectID, const int sceneID = 0);
 
+  //! set semanticId for all nodes belonging to an object
+  void setObjectSemanticId(uint32_t semanticId,
+                           const int objectID,
+                           const int sceneID);
+
   /**
    * @brief Discrete collision check for contact between an object and the
    * collision world.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -566,8 +566,8 @@ class Simulator {
    * the object.
    */
   void setObjectSemanticId(uint32_t semanticId,
-                           const int objectID,
-                           const int sceneID);
+                           int objectID,
+                           int sceneID);
 
   /**
    * @brief Discrete collision check for contact between an object and the

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -555,7 +555,16 @@ class Simulator {
    */
   void setObjectBBDraw(bool drawBB, const int objectID, const int sceneID = 0);
 
-  //! set semanticId for all nodes belonging to an object
+  /**
+   * @brief Set the @ref esp::scene:SceneNode::semanticId_ for all visual nodes
+   * belonging to an object.
+   *
+   * @param semanticId The desired semantic id for the object.
+   * @param objectID The object ID and key identifying the object in @ref
+   * esp::physics::PhysicsManager::existingObjects_.
+   * @param sceneID !! Not used currently !! Specifies which physical scene of
+   * the object.
+   */
   void setObjectSemanticId(uint32_t semanticId,
                            const int objectID,
                            const int sceneID);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -398,6 +398,14 @@ class Simulator {
                                        const int sceneID = 0);
 
   /**
+   * @brief Get references to the object's visual scene nodes or empty if
+   * failed.
+   */
+  std::vector<scene::SceneNode*> getObjectVisualSceneNodes(
+      const int objectID,
+      const int sceneID = 0);
+
+  /**
    * @brief Get the current 4x4 transformation matrix of an object.
    * See @ref esp::physics::PhysicsManager::getTransformation.
    * @param objectID The object ID and key identifying the object in @ref
@@ -565,7 +573,7 @@ class Simulator {
    * @param sceneID !! Not used currently !! Specifies which physical scene of
    * the object.
    */
-  void setObjectSemanticId(uint32_t semanticId, int objectID, int sceneID);
+  void setObjectSemanticId(uint32_t semanticId, int objectID, int sceneID = 0);
 
   /**
    * @brief Discrete collision check for contact between an object and the

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,6 +8,7 @@ import pytest
 import examples.tutorials.lighting_tutorial
 import examples.tutorials.new_actions
 import examples.tutorials.rigid_object_tutorial
+import examples.tutorials.semantic_id_tutorial
 import examples.tutorials.stereo_agent
 
 
@@ -24,6 +25,7 @@ import examples.tutorials.stereo_agent
         (examples.tutorials.new_actions, ()),
         (examples.tutorials.lighting_tutorial, (False,)),
         (examples.tutorials.rigid_object_tutorial, (False,)),
+        (examples.tutorials.semantic_id_tutorial, (False,)),
     ],
 )
 def test_example_modules(example_module, args):


### PR DESCRIPTION
## Motivation and Context

Many use cases require the ability to set semantic id for objects introduced to the scene via the physics pipeline. This PR aims to address that need.

Currently, `SEMANTIC` sensor observations include per-vertex object ids imported from some datasets (e.g. MP3D and Replica). All other objects are rendered through this sensor by `SceneNode::id_` which defaults to -1 (not ideal as it is converted to unsigned int). This PR introduces a new `SceneNode::semanticId_` variable for this purpose with default 0 and necessary getters/setters + python property. 

A single object will have multiple SceneNodes which can have Drawables attached. This PR adds a function to assist users with setting the semantic id for all object nodes, an object template field for default semantic id, and a function to query visual SceneNodes cached on object creation.

A tutorial script is added for this feature (tutorial page pending).

Previous, outdated iteration of this feature: #341 

## How Has This Been Tested

New tutorial script (also run with pytest): `python <path-to-habitat>/examples/tutorials/semantic_id_tutorial.py`

**Note: no per-vertex semantic scenes exist for testing yet. This would be an ideal use case for that.**
(Tested locally on Replica)

**Example output:**
Empty room (no per-vertex ids, so default semanticId_ == 0)
<img width="50%" height="50%" src="https://user-images.githubusercontent.com/1445143/86286952-3f544100-bb9c-11ea-8282-e1c588b891ee.jpg">

Chairs added with default semanticId_ == 0.
<img width="50%" height="50%" src="https://user-images.githubusercontent.com/1445143/86286955-3fecd780-bb9c-11ea-9bf7-4f15cab7ba93.jpg">

Set semanticId_ = 20 for both chairs.
<img width="50%" height="50%" src="https://user-images.githubusercontent.com/1445143/86286957-3fecd780-bb9c-11ea-82fa-7a0a67b8b58a.jpg">

Set semanticId_ = 10 for one chair.
<img width="50%" height="50%" src="https://user-images.githubusercontent.com/1445143/86286958-40856e00-bb9c-11ea-881a-cd8c5293d7da.jpg">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
