### PR TITLE
Compute/query navigable area in Pathfinder

### DIFF
--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -94,8 +94,7 @@ void initShortestPathBindings(py::module& m) {
       .def("snap_point", &PathFinder::snapPoint<vec3f>)
       .def("island_radius", &PathFinder::islandRadius, "pt"_a)
       .def_property_readonly("is_loaded", &PathFinder::isLoaded)
-      .def_property_readonly("navigable_area",
-                             &PathFinder::computeNavigableArea)
+      .def_property_readonly("navigable_area", &PathFinder::getNavigableArea)
       .def("load_nav_mesh", &PathFinder::loadNavMesh)
       .def("save_nav_mesh", &PathFinder::saveNavMesh, "path"_a)
       .def("distance_to_closest_obstacle",

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -94,6 +94,8 @@ void initShortestPathBindings(py::module& m) {
       .def("snap_point", &PathFinder::snapPoint<vec3f>)
       .def("island_radius", &PathFinder::islandRadius, "pt"_a)
       .def_property_readonly("is_loaded", &PathFinder::isLoaded)
+      .def_property_readonly("navigable_area",
+                             &PathFinder::computeNavigableArea)
       .def("load_nav_mesh", &PathFinder::loadNavMesh)
       .def("save_nav_mesh", &PathFinder::saveNavMesh, "path"_a)
       .def("distance_to_closest_obstacle",

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -783,7 +783,7 @@ void PathFinder::Impl::removeZeroAreaPolys() {
       float polygonArea = polyArea(poly, tile);
       if (polygonArea < 1e-5) {
         navMesh_->setPolyFlags(polyRef, POLYFLAGS_DISABLED);
-      } else {
+      } else if (poly->flags & POLYFLAGS_WALK) {
         navMeshArea_ += polygonArea;
       }
     }

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -242,6 +242,8 @@ struct PathFinder::Impl {
 
   bool isLoaded() const { return navMesh_ != nullptr; };
 
+  float getNavigableArea() const { return navMeshArea_; };
+
   void seed(uint32_t newSeed);
 
   float islandRadius(const vec3f& pt) const;
@@ -253,8 +255,6 @@ struct PathFinder::Impl {
       const float maxSearchRadius = 2.0) const;
 
   bool isNavigable(const vec3f& pt, const float maxYDelta = 0.5) const;
-
-  float computeNavigableArea();
 
   std::pair<vec3f, vec3f> bounds() const { return bounds_; };
 
@@ -280,6 +280,10 @@ struct PathFinder::Impl {
   //! Holds triangulated geom/topo. Generated when queried. Reset with
   //! navQuery_.
   assets::MeshData::ptr meshData_ = nullptr;
+
+  //! Sum of all NavMesh polygons. Computed on NavMesh load/recompute. See
+  //! removeZeroAreaPolys.
+  float navMeshArea_ = 0;
 
   std::pair<vec3f, vec3f> bounds_;
 
@@ -752,36 +756,12 @@ float polyArea(const dtPoly* poly, const dtMeshTile* tile) {
 }
 }  // namespace
 
-float PathFinder::Impl::computeNavigableArea() {
-  float navigableArea = 0;
-  // Iterate over all tiles
-  for (int iTile = 0; iTile < navMesh_->getMaxTiles(); ++iTile) {
-    const dtMeshTile* tile =
-        const_cast<const dtNavMesh*>(navMesh_.get())->getTile(iTile);
-    if (!tile)
-      continue;
-
-    // Iterate over all polygons in a tile
-    for (int jPoly = 0; jPoly < tile->header->polyCount; ++jPoly) {
-      // Get the polygon reference from the tile and polygon id
-      dtPolyRef polyRef = navMesh_->encodePolyId(iTile, tile->salt, jPoly);
-      const dtPoly* poly = nullptr;
-      const dtMeshTile* tmp = nullptr;
-      navMesh_->getTileAndPolyByRefUnsafe(polyRef, &tmp, &poly);
-
-      CORRADE_INTERNAL_ASSERT(poly != nullptr);
-      CORRADE_INTERNAL_ASSERT(tmp != nullptr);
-
-      navigableArea += polyArea(poly, tile);
-    }
-  }
-  return navigableArea;
-}
-
 // Some polygons have zero area for some reason.  When we navigate into a zero
 // area polygon, things crash.  So we find all zero area polygons and mark
 // them as disabled/not navigable.
+// Also compute the total NavMesh area for later query.
 void PathFinder::Impl::removeZeroAreaPolys() {
+  navMeshArea_ = 0;
   // Iterate over all tiles
   for (int iTile = 0; iTile < navMesh_->getMaxTiles(); ++iTile) {
     const dtMeshTile* tile =
@@ -800,8 +780,11 @@ void PathFinder::Impl::removeZeroAreaPolys() {
       CORRADE_INTERNAL_ASSERT(poly != nullptr);
       CORRADE_INTERNAL_ASSERT(tmp != nullptr);
 
-      if (polyArea(poly, tile) < 1e-5) {
+      float polygonArea = polyArea(poly, tile);
+      if (polygonArea < 1e-5) {
         navMesh_->setPolyFlags(polyRef, POLYFLAGS_DISABLED);
+      } else {
+        navMeshArea_ += polygonArea;
       }
     }
   }
@@ -1420,8 +1403,8 @@ bool PathFinder::isNavigable(const vec3f& pt, const float maxYDelta) const {
   return pimpl_->isNavigable(pt);
 }
 
-float PathFinder::computeNavigableArea() const {
-  return pimpl_->computeNavigableArea();
+float PathFinder::getNavigableArea() const {
+  return pimpl_->getNavigableArea();
 }
 
 std::pair<vec3f, vec3f> PathFinder::bounds() const {

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -322,6 +322,11 @@ class PathFinder {
   bool isNavigable(const vec3f& pt, const float maxYDelta = 0.5) const;
 
   /**
+   * Compute and return the total area of all NavMesh polygons
+   */
+  float computeNavigableArea() const;
+
+  /**
    * @return The axis aligned bounding box containing the navigation mesh.
    */
   std::pair<vec3f, vec3f> bounds() const;

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -324,7 +324,7 @@ class PathFinder {
   /**
    * Compute and return the total area of all NavMesh polygons
    */
-  float computeNavigableArea() const;
+  float getNavigableArea() const;
 
   /**
    * @return The axis aligned bounding box containing the navigation mesh.

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -43,13 +43,6 @@ def test_recompute_navmesh(test_scene, sim):
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     sim.reconfigure(hab_cfg)
 
-    # get the initial navmesh area. This test assumes default navmesh assets.
-    loadedNavMeshArea = sim.pathfinder.navigable_area
-    if test_scene.endswith("skokloster-castle.glb"):
-        assert loadedNavMeshArea == 226.65673828125
-    elif test_scene.endswith("van-gogh-room.glb"):
-        assert loadedNavMeshArea == 9.17772102355957
-
     # generate random point pairs
     num_samples = 100
     samples = []
@@ -75,13 +68,6 @@ def test_recompute_navmesh(test_scene, sim):
     navmesh_settings.set_defaults()
     assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
     assert sim.pathfinder.is_loaded
-
-    # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
-    recomputedNavMeshArea1 = sim.pathfinder.navigable_area
-    if test_scene.endswith("skokloster-castle.glb"):
-        assert recomputedNavMeshArea1 == 565.1781616210938
-    elif test_scene.endswith("van-gogh-room.glb"):
-        assert recomputedNavMeshArea1 == 9.17772102355957
 
     recomputed_navmesh_results = get_shortest_path(sim, samples)
 
@@ -123,3 +109,33 @@ def test_recompute_navmesh(test_scene, sim):
             some_diff = True
 
     assert some_diff
+
+
+@pytest.mark.parametrize("test_scene", test_scenes)
+def test_navmesh_area(test_scene, sim):
+    if not osp.exists(test_scene):
+        pytest.skip(f"{test_scene} not found")
+
+    cfg_settings = examples.settings.default_sim_settings.copy()
+    cfg_settings["scene"] = test_scene
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim.reconfigure(hab_cfg)
+
+    # get the initial navmesh area. This test assumes default navmesh assets.
+    loadedNavMeshArea = sim.pathfinder.navigable_area
+    if test_scene.endswith("skokloster-castle.glb"):
+        assert loadedNavMeshArea == 226.65673828125
+    elif test_scene.endswith("van-gogh-room.glb"):
+        assert loadedNavMeshArea == 9.17772102355957
+
+    navmesh_settings = habitat_sim.NavMeshSettings()
+    navmesh_settings.set_defaults()
+    assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
+    assert sim.pathfinder.is_loaded
+
+    # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
+    recomputedNavMeshArea1 = sim.pathfinder.navigable_area
+    if test_scene.endswith("skokloster-castle.glb"):
+        assert recomputedNavMeshArea1 == 565.1781616210938
+    elif test_scene.endswith("van-gogh-room.glb"):
+        assert recomputedNavMeshArea1 == 9.17772102355957

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -1,4 +1,5 @@
 import glob
+import math
 import os
 import os.path as osp
 
@@ -124,9 +125,9 @@ def test_navmesh_area(test_scene, sim):
     # get the initial navmesh area. This test assumes default navmesh assets.
     loadedNavMeshArea = sim.pathfinder.navigable_area
     if test_scene.endswith("skokloster-castle.glb"):
-        assert loadedNavMeshArea == 226.65673828125
+        assert math.isclose(loadedNavMeshArea, 226.65673828125)
     elif test_scene.endswith("van-gogh-room.glb"):
-        assert loadedNavMeshArea == 9.17772102355957
+        assert math.isclose(loadedNavMeshArea, 9.17772102355957)
 
     navmesh_settings = habitat_sim.NavMeshSettings()
     navmesh_settings.set_defaults()
@@ -136,6 +137,6 @@ def test_navmesh_area(test_scene, sim):
     # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
     recomputedNavMeshArea1 = sim.pathfinder.navigable_area
     if test_scene.endswith("skokloster-castle.glb"):
-        assert recomputedNavMeshArea1 == 565.1781616210938
+        assert math.isclose(recomputedNavMeshArea1, 565.1781616210938)
     elif test_scene.endswith("van-gogh-room.glb"):
-        assert recomputedNavMeshArea1 == 9.17772102355957
+        assert math.isclose(recomputedNavMeshArea1, 9.17772102355957)

--- a/tests/test_recompute_navmesh.py
+++ b/tests/test_recompute_navmesh.py
@@ -43,6 +43,9 @@ def test_recompute_navmesh(test_scene, sim):
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     sim.reconfigure(hab_cfg)
 
+    # get the initial navmesh area
+    loadedNavMeshArea = sim.pathfinder.navigable_area
+
     # generate random point pairs
     num_samples = 100
     samples = []
@@ -69,11 +72,19 @@ def test_recompute_navmesh(test_scene, sim):
     assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
     assert sim.pathfinder.is_loaded
 
+    # get the re-computed navmesh area
+    recomputedNavMeshArea1 = sim.pathfinder.navigable_area
+    assert loadedNavMeshArea == recomputedNavMeshArea1
+
     recomputed_navmesh_results = get_shortest_path(sim, samples)
 
     navmesh_settings.agent_radius *= 2.0
     assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
     assert sim.pathfinder.is_loaded  # this may not always be viable...
+
+    # get the re-computed navmesh area with radius 2
+    recomputedNavMeshArea2 = sim.pathfinder.navigable_area
+    assert loadedNavMeshArea != recomputedNavMeshArea2
 
     recomputed_2rad_navmesh_results = get_shortest_path(sim, samples)
 
@@ -81,19 +92,23 @@ def test_recompute_navmesh(test_scene, sim):
     for i in range(num_samples):
         assert loaded_navmesh_path_results[i][0] == recomputed_navmesh_results[i][0]
         assert (
-            recomputed_2rad_navmesh_results[i][0]
+            loaded_navmesh_2rad_path_results[i][0]
             == recomputed_2rad_navmesh_results[i][0]
         )
         if loaded_navmesh_path_results[i][0]:
             assert (
-                loaded_navmesh_path_results[i][1] - recomputed_navmesh_results[i][1]
+                abs(
+                    loaded_navmesh_path_results[i][1] - recomputed_navmesh_results[i][1]
+                )
                 < EPS
             )
 
         if recomputed_2rad_navmesh_results[i][0]:
             assert (
-                recomputed_2rad_navmesh_results[i][1]
-                - recomputed_2rad_navmesh_results[i][1]
+                abs(
+                    loaded_navmesh_2rad_path_results[i][1]
+                    - recomputed_2rad_navmesh_results[i][1]
+                )
                 < EPS
             )
 

--- a/tests/test_recompute_navmesh.py
+++ b/tests/test_recompute_navmesh.py
@@ -43,8 +43,12 @@ def test_recompute_navmesh(test_scene, sim):
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     sim.reconfigure(hab_cfg)
 
-    # get the initial navmesh area
+    # get the initial navmesh area. This test assumes default navmesh assets.
     loadedNavMeshArea = sim.pathfinder.navigable_area
+    if test_scene.endswith("skokloster-castle.glb"):
+        assert loadedNavMeshArea == 226.65673828125
+    elif test_scene.endswith("van-gogh-room.glb"):
+        assert loadedNavMeshArea == 9.17772102355957
 
     # generate random point pairs
     num_samples = 100
@@ -72,19 +76,18 @@ def test_recompute_navmesh(test_scene, sim):
     assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
     assert sim.pathfinder.is_loaded
 
-    # get the re-computed navmesh area
+    # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
     recomputedNavMeshArea1 = sim.pathfinder.navigable_area
-    assert loadedNavMeshArea == recomputedNavMeshArea1
+    if test_scene.endswith("skokloster-castle.glb"):
+        assert recomputedNavMeshArea1 == 565.1781616210938
+    elif test_scene.endswith("van-gogh-room.glb"):
+        assert recomputedNavMeshArea1 == 9.17772102355957
 
     recomputed_navmesh_results = get_shortest_path(sim, samples)
 
     navmesh_settings.agent_radius *= 2.0
     assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
     assert sim.pathfinder.is_loaded  # this may not always be viable...
-
-    # get the re-computed navmesh area with radius 2
-    recomputedNavMeshArea2 = sim.pathfinder.navigable_area
-    assert loadedNavMeshArea != recomputedNavMeshArea2
 
     recomputed_2rad_navmesh_results = get_shortest_path(sim, samples)
 


### PR DESCRIPTION
## Motivation and Context

In response to [this issue](https://github.com/facebookresearch/habitat-api/issues/420) this PR adds NavMesh area computation/query to Pathfinder. This computes the sum of all NavMesh polygon areas including all floors and isolated islands.

**Query the navigable area in python with:** `pathfinder.navigable_area`

## How Has This Been Tested

Validated area locally on a 1.1m radius cylinder and 0.1m radius agent resulting in ~`π` area.
Added golden number test to pytest for `skokloster-castle` and `van-gogh-room`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
