### PR TITLE
Pathfinder House Keeping

### DIFF
--- a/docs/pages/image-extractor.rst
+++ b/docs/pages/image-extractor.rst
@@ -58,7 +58,7 @@ Optional Args:
 * output (List): A list of the different output image types the user can obtain. The options are any of 'rgba', 'depth', and 'semantic'. Default is rgba.
 * shuffle (Boolean): Whether or not to shuffle the extracted images.
 * use_caching (Boolean): Whether or not to cache (up to capacity) images in memory rather than generating them from the simulator on the fly.
-* pixels_per_meter (Float): Granularity of the topdown view used for setting the camera positions in the pose extractor.
+* meters_per_pixel (Float): Granularity of the topdown view used for setting the camera positions in the pose extractor.
 
 
 Habitat Sim does not currently support multiple instances of extractors, so if you're done using

--- a/habitat_sim/utils/data/data_extractor.py
+++ b/habitat_sim/utils/data/data_extractor.py
@@ -40,7 +40,7 @@ class ImageExtractor:
     :property img_size: Tuple of image output dimensions (height, width)
     :property cfg: configuration for simulator of type SimulatorConfiguration
     :property sim: Simulator object
-    :property pixels_per_meter: Resolution of topdown map. 0.1 means each pixel in the topdown map
+    :property meters_per_pixel: Resolution of topdown map. 0.1 means each pixel in the topdown map
         represents 0.1 x 0.1 meters in the coordinate system of the pathfinder
 
     :property tdv_fp_ref_triples: List of tuples containing (TopdownView Object, scene_filepath, reference point)
@@ -73,7 +73,7 @@ class ImageExtractor:
         shuffle: bool = True,
         split: tuple = (70, 30),
         use_caching: bool = True,
-        pixels_per_meter: float = 0.1,
+        meters_per_pixel: float = 0.1,
     ):
         if sum(split) != 100:
             raise Exception("Train/test split must sum to 100.")
@@ -99,22 +99,22 @@ class ImageExtractor:
             sim.reconfigure(self.cfg)
 
         self.sim = sim
-        self.pixels_per_meter = pixels_per_meter
+        self.meters_per_pixel = meters_per_pixel
         if not sim_provided:
             self.tdv_fp_ref_triples = self._preprocessing(
-                self.sim, self.scene_filepaths, self.pixels_per_meter
+                self.sim, self.scene_filepaths, self.meters_per_pixel
             )
         else:
             ref_point = self._get_pathfinder_reference_point(self.sim.pathfinder)
             self.tdv_fp_ref_triples = [
                 (
-                    TopdownView(self.sim, ref_point[1], pixels_per_meter),
+                    TopdownView(self.sim, ref_point[1], meters_per_pixel),
                     self.sim.config.sim_cfg.scene.id,
                     ref_point,
                 )
             ]
 
-        args = (self.tdv_fp_ref_triples, self.pixels_per_meter)
+        args = (self.tdv_fp_ref_triples, self.meters_per_pixel)
         self.pose_extractor = get_pose_extractor(pose_extractor_name)(*args)
         self.poses = self.pose_extractor.extract_all_poses(labels=self.labels)
 
@@ -213,13 +213,13 @@ class ImageExtractor:
         class_names = list(set(name for name in self.instance_id_to_name.values()))
         return class_names
 
-    def _preprocessing(self, sim, scene_filepaths, pixels_per_meter):
+    def _preprocessing(self, sim, scene_filepaths, meters_per_pixel):
         tdv_fp_ref = []
         for filepath in scene_filepaths:
             cfg = self._config_sim(filepath, self.img_size)
             sim.reconfigure(cfg)
             ref_point = self._get_pathfinder_reference_point(sim.pathfinder)
-            tdv = TopdownView(sim, ref_point[1], pixels_per_meter=pixels_per_meter)
+            tdv = TopdownView(sim, ref_point[1], meters_per_pixel=meters_per_pixel)
             tdv_fp_ref.append((tdv, filepath, ref_point))
 
         return tdv_fp_ref
@@ -313,7 +313,7 @@ class ImageExtractor:
 
 
 class TopdownView(object):
-    def __init__(self, sim, height, pixels_per_meter=0.1):
+    def __init__(self, sim, height, meters_per_pixel=0.1):
         self.topdown_view = sim.pathfinder.get_topdown_view(
-            pixels_per_meter, height
+            meters_per_pixel, height
         ).astype(np.float64)

--- a/habitat_sim/utils/data/pose_extractor.py
+++ b/habitat_sim/utils/data/pose_extractor.py
@@ -20,13 +20,13 @@ class PoseExtractor:
             scene_filepath: The file path to the mesh file. Necessary for scene switches.
             reference point: A reference point from the coordinate system of the scene. Necessary for specifying poses in the scene's coordinate system.
 
-    :property pixels_per_meter: Resolution of topdown map. 0.1 means each pixel in the topdown map
+    :property meters_per_pixel: Resolution of topdown map. 0.1 means each pixel in the topdown map
         represents 0.1 x 0.1 meters in the coordinate system of the scene that the map represents.
     """
 
-    def __init__(self, topdown_views, pixels_per_meter=0.1):
+    def __init__(self, topdown_views, meters_per_pixel=0.1):
         self.tdv_fp_ref_triples = topdown_views
-        self.pixels_per_meter = pixels_per_meter
+        self.meters_per_pixel = meters_per_pixel
 
     def extract_all_poses(self, labels: List[float]) -> np.ndarray:
         r"""Returns a numpy array of camera poses. For each scene, this method extends the list of poses according to the extraction rule defined in extract_poses.
@@ -80,16 +80,16 @@ class PoseExtractor:
             r2, c2 = cpi
             new_pos = np.array(
                 [
-                    startw + c1 * self.pixels_per_meter,
+                    startw + c1 * self.meters_per_pixel,
                     starty,
-                    starth + r1 * self.pixels_per_meter,
+                    starth + r1 * self.meters_per_pixel,
                 ]
             )
             new_cpi = np.array(
                 [
-                    startw + c2 * self.pixels_per_meter,
+                    startw + c2 * self.meters_per_pixel,
                     starty,
-                    starth + r2 * self.pixels_per_meter,
+                    starth + r2 * self.meters_per_pixel,
                 ]
             )
             cam_normal = new_cpi - new_pos
@@ -101,8 +101,8 @@ class PoseExtractor:
 
 @registry.register_pose_extractor(name="closest_point_extractor")
 class ClosestPointExtractor(PoseExtractor):
-    def __init__(self, topdown_views, pixels_per_meter=0.1):
-        super().__init__(topdown_views, pixels_per_meter)
+    def __init__(self, topdown_views, meters_per_pixel=0.1):
+        super().__init__(topdown_views, meters_per_pixel)
 
     def extract_poses(self, labels, view, fp):
         # Determine the physical spacing between each camera position
@@ -187,8 +187,8 @@ class ClosestPointExtractor(PoseExtractor):
 
 @registry.register_pose_extractor(name="panorama_extractor")
 class PanoramaExtractor(PoseExtractor):
-    def __init__(self, topdown_views, pixels_per_meter=0.1):
-        super().__init__(topdown_views, pixels_per_meter)
+    def __init__(self, topdown_views, meters_per_pixel=0.1):
+        super().__init__(topdown_views, meters_per_pixel)
 
     def extract_poses(self, labels, view, fp):
         # Determine the physical spacing between each camera position

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -76,7 +76,7 @@ void initShortestPathBindings(py::module& m) {
       .def("seed", &PathFinder::seed)
       .def("get_topdown_view", &PathFinder::getTopDownView,
            R"(Returns the topdown view of the PathFinder's navmesh.)",
-           "pixelsPerMeter"_a, "height"_a)
+           "meters_per_pixel"_a, "height"_a)
       .def("get_random_navigable_point", &PathFinder::getRandomNavigablePoint)
       .def("find_path", py::overload_cast<ShortestPath&>(&PathFinder::findPath),
            "path"_a)

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -106,7 +106,7 @@ class IslandSystem {
       // Iterate over all polygons in a tile
       for (int jPoly = 0; jPoly < tile->header->polyCount; ++jPoly) {
         // Get the polygon reference from the tile and polygon id
-        dtPolyRef startRef = navMesh->encodePolyId(iTile, tile->salt, jPoly);
+        dtPolyRef startRef = navMesh->encodePolyId(tile->salt, iTile, jPoly);
 
         // If the polygon ref is valid, and we haven't seen it yet,
         // start connected component analysis from this polygon
@@ -259,7 +259,7 @@ struct PathFinder::Impl {
   std::pair<vec3f, vec3f> bounds() const { return bounds_; };
 
   Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> getTopDownView(
-      const float pixelsPerMeter,
+      const float metersPerPixel,
       const float height);
 
   const assets::MeshData::ptr getNavMeshData();
@@ -772,7 +772,7 @@ void PathFinder::Impl::removeZeroAreaPolys() {
     // Iterate over all polygons in a tile
     for (int jPoly = 0; jPoly < tile->header->polyCount; ++jPoly) {
       // Get the polygon reference from the tile and polygon id
-      dtPolyRef polyRef = navMesh_->encodePolyId(iTile, tile->salt, jPoly);
+      dtPolyRef polyRef = navMesh_->encodePolyId(tile->salt, iTile, jPoly);
       const dtPoly* poly = nullptr;
       const dtMeshTile* tmp = nullptr;
       navMesh_->getTileAndPolyByRefUnsafe(polyRef, &tmp, &poly);
@@ -1246,7 +1246,7 @@ bool PathFinder::Impl::isNavigable(const vec3f& pt,
 typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> MatrixXb;
 
 Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic>
-PathFinder::Impl::getTopDownView(const float pixelsPerMeter,
+PathFinder::Impl::getTopDownView(const float metersPerPixel,
                                  const float height) {
   std::pair<vec3f, vec3f> mapBounds = bounds();
   vec3f bound1 = mapBounds.first;
@@ -1254,8 +1254,8 @@ PathFinder::Impl::getTopDownView(const float pixelsPerMeter,
 
   float xspan = std::abs(bound1[0] - bound2[0]);
   float zspan = std::abs(bound1[2] - bound2[2]);
-  int xResolution = xspan / pixelsPerMeter;
-  int zResolution = zspan / pixelsPerMeter;
+  int xResolution = xspan / metersPerPixel;
+  int zResolution = zspan / metersPerPixel;
   float startx = fmin(bound1[0], bound2[0]);
   float startz = fmin(bound1[2], bound2[2]);
   MatrixXb topdownMap(zResolution, xResolution);
@@ -1266,9 +1266,9 @@ PathFinder::Impl::getTopDownView(const float pixelsPerMeter,
     for (int w = 0; w < xResolution; w++) {
       vec3f point = vec3f(curx, height, curz);
       topdownMap(h, w) = isNavigable(point, 0.5);
-      curx = curx + pixelsPerMeter;
+      curx = curx + metersPerPixel;
     }
-    curz = curz + pixelsPerMeter;
+    curz = curz + metersPerPixel;
     curx = startx;
   }
 
@@ -1291,7 +1291,7 @@ const assets::MeshData::ptr PathFinder::Impl::getNavMeshData() {
       // Iterate over all polygons in a tile
       for (int jPoly = 0; jPoly < tile->header->polyCount; ++jPoly) {
         // Get the polygon reference from the tile and polygon id
-        dtPolyRef polyRef = navMesh_->encodePolyId(iTile, tile->salt, jPoly);
+        dtPolyRef polyRef = navMesh_->encodePolyId(tile->salt, iTile, jPoly);
         const dtPoly* poly = nullptr;
         const dtMeshTile* tmp = nullptr;
         navMesh_->getTileAndPolyByRefUnsafe(polyRef, &tmp, &poly);
@@ -1412,9 +1412,9 @@ std::pair<vec3f, vec3f> PathFinder::bounds() const {
 }
 
 Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> PathFinder::getTopDownView(
-    const float pixelsPerMeter,
+    const float metersPerPixel,
     const float height) {
-  return pimpl_->getTopDownView(pixelsPerMeter, height);
+  return pimpl_->getTopDownView(metersPerPixel, height);
 }
 
 const assets::MeshData::ptr PathFinder::getNavMeshData() {

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -332,7 +332,7 @@ class PathFinder {
   std::pair<vec3f, vec3f> bounds() const;
 
   Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> getTopDownView(
-      const float pixelsPerMeter,
+      const float metersPerPixel,
       const float height);
 
   /**

--- a/tests/test_data_extraction.py
+++ b/tests/test_data_extraction.py
@@ -33,7 +33,7 @@ class MyDataset(Dataset):
 
 
 def test_topdown_view(sim):
-    tdv = TopdownView(sim, height=0.0, pixels_per_meter=0.1)
+    tdv = TopdownView(sim, height=0.0, meters_per_pixel=0.1)
     topdown_view = tdv.topdown_view
     assert type(topdown_view) == np.ndarray
 


### PR DESCRIPTION
## Motivation and Context

Fix a bug in the pathfinder code and correct a name.

1. `encodePolyId(iTile, tile->salt, jPoly)` should be `encodePolyId(tile->salt, iTile, jPoly)`.  This bug didn't actually cause any issues since we just have 1 tile, thus `iTile` is `0`, and our tiles are never changed, so `tile->salt` is also always `0`.  But should fix it non-the-less to prevent future issues.

2. `pixels_per_meter` is actually `meters_per_pixel` based on the doc-string and usage.

CC @mpiseno 


## How Has This Been Tested

Tests still pass

## Types of changes

Docs change / refactoring / dependency upgrade
Bug fix (non-breaking change which fixes an issue)