### PR TITLE
Add recompute_navmesh to demo_runner and examples

### DIFF
--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -7,6 +7,7 @@ import math
 import multiprocessing
 import os
 import random
+import sys
 import time
 from enum import Enum
 
@@ -337,6 +338,14 @@ class DemoRunner:
 
         random.seed(self._sim_settings["seed"])
         self._sim.seed(self._sim_settings["seed"])
+
+        recompute_navmesh = self._sim_settings.get("recompute_navmesh")
+        if recompute_navmesh or not self._sim.pathfinder.is_loaded:
+            if not self._sim_settings["silent"]:
+                print("Recomputing navmesh")
+            navmesh_settings = habitat_sim.NavMeshSettings()
+            navmesh_settings.set_defaults()
+            self._sim.recompute_navmesh(self._sim.pathfinder, navmesh_settings)
 
         # initialize the agent at a random start state
         start_state = self.init_agent_state(self._sim_settings["default_agent"])

--- a/examples/example.py
+++ b/examples/example.py
@@ -24,6 +24,7 @@ parser.add_argument("--print_semantic_scene", action="store_true")
 parser.add_argument("--print_semantic_mask_stats", action="store_true")
 parser.add_argument("--compute_shortest_path", action="store_true")
 parser.add_argument("--compute_action_shortest_path", action="store_true")
+parser.add_argument("--recompute_navmesh", action="store_true")
 parser.add_argument("--seed", type=int, default=1)
 parser.add_argument("--silent", action="store_true")
 parser.add_argument("--test_fps_regression", type=int, default=0)
@@ -57,6 +58,7 @@ def make_settings():
     settings["enable_physics"] = args.enable_physics
     settings["physics_config_file"] = args.physics_config_file
     settings["frustum_culling"] = not args.disable_frustum_culling
+    settings["recompute_navmesh"] = args.recompute_navmesh
 
     return settings
 

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -45,7 +45,8 @@ def make_cfg(settings):
         sim_cfg.enable_physics = settings["enable_physics"]
     if "physics_config_file" in settings:
         sim_cfg.physics_config_file = settings["physics_config_file"]
-    print("sim_cfg.physics_config_file = " + sim_cfg.physics_config_file)
+    if not settings["silent"]:
+        print("sim_cfg.physics_config_file = " + sim_cfg.physics_config_file)
     if "scene_light_setup" in settings:
         sim_cfg.scene_light_setup = settings["scene_light_setup"]
     sim_cfg.gpu_device_id = 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -78,6 +78,7 @@ def test_example_modules(args):
                 "--enable_physics",
                 "--semantic_sensor",
                 "--depth_sensor",
+                "--recompute_navmesh",
             ]
         )
         if not (("--compute_action_shortest_path" in p) and ("--enable_physics" in p))


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It allows benchmark.py and other scripts to run on scenes that don't come with a precomputed navmesh. I also added args to examples/example.py. It automatically runs if a navmesh isn't loaded.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Added additional tests to tests/test_example.py

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
