### PR TITLE
--Retrieve Copy of object creation attributes

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -550,11 +550,5 @@ void PhysicsManager::setSemanticId(const int physObjectID,
   existingObjects_.at(physObjectID)->setSemanticId(semanticId);
 }
 
-const assets::PhysicsObjectAttributes::cptr
-PhysicsManager::getInitializationAttributes(const int physObjectID) const {
-  assertIDValidity(physObjectID);
-  return existingObjects_.at(physObjectID)->getInitializationAttributes();
-}
-
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -832,14 +832,15 @@ class PhysicsManager {
   void setSemanticId(int physObjectID, uint32_t semanticId);
 
   /**
-   * @brief Get the template used to initialize an object.
+   * @brief Get a copy of the template used to initialize an object.
    *
-   * PhysicsObjectAttributes templates are expected to be changed between
-   * instances of objects.
    * @return The initialization settings of the specified object instance.
    */
-  const assets::PhysicsObjectAttributes::cptr getInitializationAttributes(
-      const int physObjectID) const;
+  assets::PhysicsObjectAttributes::ptr getObjectInitAttributes(
+      const int physObjectID) const {
+    assertIDValidity(physObjectID);
+    return existingObjects_.at(physObjectID)->getInitializationAttributes();
+  }
 
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -584,15 +584,14 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   }
 
   /**
-   * @brief Get the template used to initialize this object or scene.
-   *
-   * AbstractPhysicsAttributes templates are expected to be changed between
-   * instances of objects.
-   * @return The initialization settings of this object instance.
+   * @brief Get a copy of the template used to initialize this object
+   * or scene.
+   * @return A copy of the initialization template used to create this object
+   * instance.
    */
   template <class T>
-  const std::shared_ptr<const T> getInitializationAttributes() const {
-    return std::dynamic_pointer_cast<T>(initializationAttributes_);
+  std::shared_ptr<T> getInitializationAttributes() const {
+    return T::create(*(static_cast<T*>(initializationAttributes_.get())));
   }
 
   /** @brief Store whatever object attributes you want here! */

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -121,14 +121,13 @@ class RigidObject : public RigidBase {
   bool finalizeObject() override;
 
   /**
-   * @brief Get the template used to initialize this object or scene.
+   * @brief Get a copy of the template used to initialize this object.
    *
-   * AbstractPhysicsAttributes templates are expected to be changed between
-   * instances of objects.
-   * @return The initialization settings of this object instance.
+   * @return A copy of the @ref PhysicsObjectAttributes template used to create
+   * this object.
    */
-  const std::shared_ptr<const assets::PhysicsObjectAttributes>
-  getInitializationAttributes() const {
+  std::shared_ptr<assets::PhysicsObjectAttributes> getInitializationAttributes()
+      const {
     return RigidBase::getInitializationAttributes<
         assets::PhysicsObjectAttributes>();
   };

--- a/src/esp/physics/RigidScene.h
+++ b/src/esp/physics/RigidScene.h
@@ -33,15 +33,13 @@ class RigidScene : public RigidBase {
                   const std::string& handle) override;
 
   /**
-   * @brief Get the template used to initialize this object or scene.
+   * @brief Get a copy of the template used to initialize this scene object.
    *
-   * AbstractPhysicsAttributes templates are able to be changed between
-   * instances of objects.
-   * @return The initialization settings of this object instance, casted to the
-   * appropriate value.
+   * @return A copy of the @ref PhysicsSceneAttributes template used to create
+   * this scene object.
    */
-  const std::shared_ptr<const assets::PhysicsSceneAttributes>
-  getInitializationAttributes() const {
+  std::shared_ptr<assets::PhysicsSceneAttributes> getInitializationAttributes()
+      const {
     return RigidBase::getInitializationAttributes<
         assets::PhysicsSceneAttributes>();
   };

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -332,7 +332,7 @@ const assets::PhysicsObjectAttributes::cptr
 Simulator::getObjectInitializationTemplate(int objectId,
                                            const int sceneID) const {
   if (sceneHasPhysics(sceneID)) {
-    return physicsManager_->getInitializationAttributes(objectId);
+    return physicsManager_->getObjectInitAttributes(objectId);
   }
   return nullptr;
 }
@@ -593,7 +593,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
             physicsManager_->getObjectVisualSceneNode(objectID)
                 .absoluteTransformationMatrix());
         const assets::PhysicsObjectAttributes::cptr initializationTemplate =
-            physicsManager_->getInitializationAttributes(objectID);
+            physicsManager_->getObjectInitAttributes(objectID);
         objectTransform.scale(Magnum::EigenIntegration::cast<vec3f>(
             initializationTemplate->getScale()));
         std::string meshHandle =


### PR DESCRIPTION
Retrieve a copy of the attributes template owned by an object that was used to create it.

This PR modifies the process to retrieve an object/scene's initialization attributes by returning a copy instead of const cptr of the attributes themselves.  The purpose of this was to allow users to modify the attributes to make modified copies of the object.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All existing c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
