### PR TITLE
[bug-fix] Object-attached Agent with Split Semantic Scene

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -427,6 +427,7 @@ class Sensor:
             and self._sim.get_active_scene_graph()
             is not self._sim.get_active_semantic_scene_graph()
         ):
+            agent_node.parent = self._sim.get_active_scene_graph().get_root_node()
             render_flags |= habitat_sim.gfx.Camera.Flags.OBJECTS_ONLY
             self._sim.renderer.draw(
                 self._sensor_object, self._sim.get_active_scene_graph(), render_flags


### PR DESCRIPTION
## Motivation and Context

Python implementation of split SEMANTIC render assigns the agent SceneNode's parent to the semantic SceneGraph root before rendering. Attaching an agent to a simulation object creates all rendering assets for the object under the agent's SceneGraph sub-tree. This results in an error during the secondary SEMANTIC rendering pass over the active SceneGraph added in #679. 

For reference this error displays as: 
```
SceneGraph::Object::transformations(): the objects are not part of the same tree
```
This PR re-assigns the agent SceneNode's parent to the active SceneGraph root before the 2nd pass to fix this bug.

## How Has This Been Tested

Still no separate semantic testing on CI, leading to this bug slipping through. Tested locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
