### PR TITLE
--Configuration for SceneImport and Default Kinematics

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -17,6 +17,14 @@ AbstractPhysicsAttributes::AbstractPhysicsAttributes(
     : AbstractAttributes(attributesClassKey, handle) {
   setFrictionCoefficient(0.5);
   setRestitutionCoefficient(0.1);
+  // default rendering and collisions will be mesh for physics objects and
+  // scenes. Primitive-based objects do not currently support mesh collisions,
+  // however, due to issues with how non-triangle meshes (i.e. wireframes) are
+  // handled in @ref GenericMeshData::setMeshData
+  setRenderAssetIsPrimitive(false);
+  setCollisionAssetIsPrimitive(false);
+  setUseMeshCollision(true);
+
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
 }  // AbstractPhysicsAttributes ctor
@@ -39,13 +47,7 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(const std::string& handle)
   setInertia({0, 0, 0});
   setLinearDamping(0.2);
   setAngularDamping(0.2);
-  // default rendering and collisions will be mesh for physics objects
-  // primitive-based objects do not currently support mesh collisions, however,
-  // due to issues with how non-triangle meshes (i.e. wireframes) are handled in
-  // @ref GenericMeshData::setMeshData
-  setRenderAssetIsPrimitive(false);
-  setCollisionAssetIsPrimitive(false);
-  setUseMeshCollision(true);
+
   setComputeCOMFromShape(true);
 
   setBoundingBoxCollisions(false);
@@ -62,6 +64,8 @@ PhysicsSceneAttributes::PhysicsSceneAttributes(const std::string& handle)
   // TODO do these defaults need to be maintained here?
   setFrictionCoefficient(0.4);
   setRestitutionCoefficient(0.05);
+
+  setRequiresLighting(false);
 }  // PhysicsSceneAttributes ctor
 
 PhysicsManagerAttributes::PhysicsManagerAttributes(const std::string& handle)

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -87,7 +87,6 @@ class AbstractPhysicsAttributes : public AbstractAttributes {
                             const std::string& handle);
 
   virtual ~AbstractPhysicsAttributes() = default;
-
   void setScale(const Magnum::Vector3& scale) { setVec3("scale", scale); }
   Magnum::Vector3 getScale() const { return getVec3("scale"); }
 
@@ -163,6 +162,12 @@ class AbstractPhysicsAttributes : public AbstractAttributes {
 
   bool getUseMeshCollision() const { return getBool("useMeshCollision"); }
 
+  // if true use phong illumination model instead of flat shading
+  void setRequiresLighting(bool requiresLighting) {
+    setBool("requiresLighting", requiresLighting);
+  }
+  bool getRequiresLighting() const { return getBool("requiresLighting"); }
+
   bool getIsDirty() const { return getBool("__isDirty"); }
   void setIsClean() { setBool("__isDirty", false); }
 
@@ -229,13 +234,10 @@ class PhysicsObjectAttributes : public AbstractPhysicsAttributes {
   }
   bool getJoinCollisionMeshes() const { return getBool("joinCollisionMeshes"); }
 
-  // if true use phong illumination model instead of flat shading
-  void setRequiresLighting(bool requiresLighting) {
-    setBool("requiresLighting", requiresLighting);
-  }
-  bool getRequiresLighting() const { return getBool("requiresLighting"); }
-
-  // if object is visible
+  /**
+   * @brief If not visible can add dynamic non-rendered object into a scene
+   * object.  If is not visible then should not add object to drawables.
+   */
   void setIsVisible(bool isVisible) { setBool("isVisible", isVisible); }
   bool getIsVisible() const { return getBool("isVisible"); }
 
@@ -267,6 +269,14 @@ class PhysicsSceneAttributes : public AbstractPhysicsAttributes {
     setVec3("gravity", gravity);
   }
   Magnum::Vector3 getGravity() const { return getVec3("gravity"); }
+
+  void setSemanticAssetHandle(const std::string& semanticAssetHandle) {
+    setString("semanticAssetHandle", semanticAssetHandle);
+    setIsDirty();
+  }
+  std::string getSemanticAssetHandle() const {
+    return getString("semanticAssetHandle");
+  }
 
  public:
   ESP_SMART_POINTERS(PhysicsSceneAttributes)

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -133,18 +133,21 @@ void ResourceManager::initPhysicsManager(
     const PhysicsManagerAttributes::ptr& physicsManagerAttributes) {
   //! PHYSICS INIT: Use the passed attributes to initialize physics engine
   bool defaultToNoneSimulator = true;
-  if (physicsManagerAttributes->getSimulator().compare("bullet") == 0) {
+  if (isEnabled) {
+    if (physicsManagerAttributes->getSimulator().compare("bullet") == 0) {
 #ifdef ESP_BUILD_WITH_BULLET
-    physicsManager.reset(
-        new physics::BulletPhysicsManager(*this, physicsManagerAttributes));
-    defaultToNoneSimulator = false;
+      physicsManager.reset(
+          new physics::BulletPhysicsManager(*this, physicsManagerAttributes));
+      defaultToNoneSimulator = false;
 #else
-    LOG(WARNING)
-        << ":\n---\nPhysics was enabled and Bullet physics engine was "
-           "specified, but the project is built without Bullet support. "
-           "Objects added to the scene will be restricted to kinematic updates "
-           "only. Reinstall with --bullet to enable Bullet dynamics.\n---";
+      LOG(WARNING)
+          << ":\n---\nPhysics was enabled and Bullet physics engine was "
+             "specified, but the project is built without Bullet support. "
+             "Objects added to the scene will be restricted to kinematic "
+             "updates "
+             "only. Reinstall with --bullet to enable Bullet dynamics.\n---";
 #endif
+    }
   }
   // reset to base PhysicsManager to override previous as default behavior
   // if the desired simulator is not supported reset to "none" in metaData
@@ -154,10 +157,6 @@ void ResourceManager::initPhysicsManager(
         new physics::PhysicsManager(*this, physicsManagerAttributes));
   }
 
-  physicsManager->setIsEnabled(isEnabled);
-  if (!isEnabled) {
-    return;
-  }
   // build default primitive asset templates, and default primitive object
   // templates
   initDefaultPrimAttributes();
@@ -251,7 +250,7 @@ bool ResourceManager::loadScene(
   }
 
   // old loadPhysicsScene code
-  if ((_physicsManager) && _physicsManager->isEnabled()) {
+  if (_physicsManager) {
     const std::string& filename = info.filepath;
     // TODO: enable loading of multiple scenes from file and storing individual
     // parameters instead of scene properties in manager global config

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -253,10 +253,6 @@ bool ResourceManager::loadScene(
   // old loadPhysicsScene code
   if ((_physicsManager) && _physicsManager->isEnabled()) {
     const std::string& filename = info.filepath;
-
-    // Done already in load scene
-    // PhysicsSceneAttributes::ptr physSceneLib =
-    //     sceneAttributesManager_->createAttributesTemplate(filename, true);
     // TODO: enable loading of multiple scenes from file and storing individual
     // parameters instead of scene properties in manager global config
     sceneAttributesManager_->setSceneValsFromPhysicsAttributes(

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -124,6 +124,25 @@ class ResourceManager {
   void initDefaultPrimAttributes();
 
   /**
+   * @brief Instantiate, or reinstantiate, PhysicsManager defined by passed
+   * attributes
+   * @param physicsManager The currently defined @ref physics::PhysicsManager.
+   * Will be reseated to the specified physics implementation.
+   * @param isEnabled Whether this PhysicsManager is enabled or not.  Takes the
+   * place of old checks for nullptr.
+   * @param parent The @ref scene::SceneNode of which the scene mesh will be
+   * added as a child. Typically near the root of the scene. Expected to be
+   * static.
+   * @param physicsManagerAttributes A smart pointer to meta data structure
+   * storing configured physics simulation parameters.
+   */
+  void initPhysicsManager(
+      std::shared_ptr<physics::PhysicsManager>& physicsManager,
+      bool isEnabled,
+      scene::SceneNode* parent,
+      const PhysicsManagerAttributes::ptr& physicsManagerAttributes);
+
+  /**
    * @brief Load a scene mesh and add it to the specified @ref DrawableGroup as
    * a child of the specified @ref scene::SceneNode.
    *
@@ -131,6 +150,8 @@ class ResourceManager {
    * new @ref gfx::Drawable is added for the scene (i.e. it will not be
    * rendered).
    * @param info The loaded @ref AssetInfo for the scene mesh.
+   * @param _physicsManager The currently defined @ref physics::PhysicsManager.
+   * @param buildCollisionMesh Whether to build collision meshes for the scene.
    * @param parent The @ref scene::SceneNode of which the scene mesh will be
    * added as a child. Typically near the root of the scene. Expected to be
    * static.
@@ -143,42 +164,11 @@ class ResourceManager {
    */
   bool loadScene(
       const AssetInfo& info,
+      std::shared_ptr<physics::PhysicsManager> _physicsManager,
       scene::SceneNode* parent = nullptr,
       DrawableGroup* drawables = nullptr,
       const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{NO_LIGHT_KEY},
       bool splitSemanticMesh = true);
-
-  /**
-   * @brief Load and instantiate a scene including physics simulation.
-   *
-   * Loads a physics simulator for the world from the parameters defined in the
-   * @ref PhysicsManagerAttributes and reseats the @ref physics::PhysicsManager
-   * based on the configured simulator implementation. Loads the scene mesh and
-   * adds it to the specified @ref DrawableGroup as a child of the specified
-   * @ref scene::SceneNode. If these are not specified, the assets are loaded,
-   * but no new @ref gfx::Drawable is added for the scene (i.e. it will not be
-   * rendered).
-   * @param info The loaded @ref AssetInfo for the scene mesh.
-   * @param _physicsManager The currently defined @ref physics::PhysicsManager.
-   * Will be reseated to the configured physics implementation.
-   * @param physicsManagerAttributes A smart pointer to meta data structure
-   * storing configured physics simulation parameters.
-   * @param parent The @ref scene::SceneNode of which the scene mesh will be
-   * added as a child. Typically near the root of the scene. Expected to be
-   * static.
-   * @param drawables The @ref DrawableGroup with which the scene mesh will be
-   * rendered.
-   * @param lightSetup The @ref LightSetup key that will be used.
-   * @return Whether or not the scene load succeeded.
-   */
-  bool loadPhysicsScene(
-      const AssetInfo& info,
-      std::shared_ptr<physics::PhysicsManager>& _physicsManager,
-      const PhysicsManagerAttributes::ptr physicsManagerAttributes,
-      scene::SceneNode* parent = nullptr,
-      DrawableGroup* drawables = nullptr,
-      const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-          NO_LIGHT_KEY});
 
   /**
    * @brief Construct scene collision mesh group based on name and type of
@@ -422,18 +412,6 @@ class ResourceManager {
   inline void compressTextures(bool newVal) { compressTextures_ = newVal; };
 
  private:
-  /**
-   * @brief Instantiate, or reinstatiate, PhysicsManager defined by passed
-   * attributes
-   * @param physicsManager The currently defined @ref physics::PhysicsManager.
-   * Will be reseated to the configured physics implementation.
-   * @param physicsManagerAttributes A smart pointer to meta data structure
-   * storing configured physics simulation parameters.
-   */
-  void initPhysicsManager(
-      std::shared_ptr<physics::PhysicsManager>& physicsManager,
-      const PhysicsManagerAttributes::ptr& physicsManagerAttributes);
-
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
    * specified @ref meshType used by @ref objectTemplateHandle

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -28,7 +28,7 @@ PhysicsAttributesManager::createAttributesTemplate(
   } else {
     // if name is not file descriptor, return default attributes.
     attrs = createDefaultAttributesTemplate(physicsFilename, registerTemplate);
-    msg = "New default";
+    msg = "File (" + physicsFilename + ") not found so new, default";
   }
 
   if (nullptr != attrs) {

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -216,8 +216,6 @@ SceneAttributesManager::createFileBasedAttributesTemplate(
 
   // TODO : any specific non-json file-based parsing required
 
-  //
-
   if (registerTemplate) {
     int attrID = this->registerAttributesTemplate(sceneAttributesTemplate,
                                                   sceneFilename);

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -216,6 +216,8 @@ SceneAttributesManager::createFileBasedAttributesTemplate(
 
   // TODO : any specific non-json file-based parsing required
 
+  //
+
   if (registerTemplate) {
     int attrID = this->registerAttributesTemplate(sceneAttributesTemplate,
                                                   sceneFilename);

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -47,7 +47,20 @@ void initAttributesBindings(py::module& m) {
                     &AbstractPhysicsAttributes::setRenderAssetHandle)
       .def_property("collision_asset_handle",
                     &AbstractPhysicsAttributes::getCollisionAssetHandle,
-                    &AbstractPhysicsAttributes::setCollisionAssetHandle);
+                    &AbstractPhysicsAttributes::setCollisionAssetHandle)
+      .def_property("requires_lighting",
+                    &AbstractPhysicsAttributes::getRequiresLighting,
+                    &AbstractPhysicsAttributes::setRequiresLighting)
+      .def_property_readonly(
+          "render_asset_is_primitive",
+          &AbstractPhysicsAttributes::getRenderAssetIsPrimitive)
+      .def_property_readonly(
+          "collision_asset_is_primitive",
+          &AbstractPhysicsAttributes::getCollisionAssetIsPrimitive)
+      .def_property_readonly("use_mesh_for_collision",
+                             &AbstractPhysicsAttributes::getUseMeshCollision)
+      .def_property_readonly("is_dirty",
+                             &AbstractPhysicsAttributes::getIsDirty);
 
   // ==== PhysicsObjectAttributes ====
   py::class_<PhysicsObjectAttributes, AbstractPhysicsAttributes,
@@ -69,21 +82,16 @@ void initAttributesBindings(py::module& m) {
       .def_property("angular_damping",
                     &PhysicsObjectAttributes::getAngularDamping,
                     &PhysicsObjectAttributes::setAngularDamping)
-      .def_property("render_asset_handle",
-                    &PhysicsObjectAttributes::getRenderAssetHandle,
-                    &PhysicsObjectAttributes::setRenderAssetHandle)
-      .def_property("collision_asset_handle",
-                    &PhysicsObjectAttributes::getCollisionAssetHandle,
-                    &PhysicsObjectAttributes::setCollisionAssetHandle)
       .def_property("bounding_box_collisions",
                     &PhysicsObjectAttributes::getBoundingBoxCollisions,
                     &PhysicsObjectAttributes::setBoundingBoxCollisions)
       .def_property("join_collision_meshes",
                     &PhysicsObjectAttributes::getJoinCollisionMeshes,
                     &PhysicsObjectAttributes::setJoinCollisionMeshes)
-      .def_property("requires_lighting",
-                    &PhysicsObjectAttributes::getRequiresLighting,
-                    &PhysicsObjectAttributes::setRequiresLighting)
+      .def_property("is_visibile", &PhysicsObjectAttributes::getIsVisible,
+                    &PhysicsObjectAttributes::setIsVisible)
+      .def_property("is_collidable", &PhysicsObjectAttributes::getIsCollidable,
+                    &PhysicsObjectAttributes::setIsCollidable)
       .def_property("semantic_id", &PhysicsObjectAttributes::getSemanticId,
                     &PhysicsObjectAttributes::setSemanticId);
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -14,7 +14,7 @@ bool PhysicsManager::initPhysics(scene::SceneNode* node) {
   physicsNode_ = node;
 
   // Copy over relevant configuration
-  fixedTimeStep_ = physicsManagerAttributes->getTimestep();
+  fixedTimeStep_ = physicsManagerAttributes_->getTimestep();
 
   //! Create new scene node and set up any physics-related variables
   // Overridden by specific physics-library-based class
@@ -104,9 +104,15 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
 
   //! Draw object via resource manager
   //! Render node as child of physics node
-  resourceManager_.addObjectToDrawables(
-      configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
-      drawables, existingObjects_.at(nextObjectID_)->visualNodes_, lightSetup);
+  //! Verify we should make the object drawable
+  if (existingObjects_.at(nextObjectID_)
+          ->getInitializationAttributes()
+          ->getIsVisible()) {
+    resourceManager_.addObjectToDrawables(
+        configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
+        drawables, existingObjects_.at(nextObjectID_)->visualNodes_,
+        lightSetup);
+  }
 
   // finalize rigid object creation
   objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -850,15 +850,6 @@ class PhysicsManager {
         *physicsManagerAttributes_.get());
   }
 
-  /**@brief whether this physics manager is supporting any kind of
-   * object/collision handling
-   */
-  bool isEnabled() { return enabled_; }
-  /**@brief whether this physics manager is supporting any kind of
-   * object/collision handling
-   */
-  void setIsEnabled(bool _enabled) { enabled_ = _enabled; }
-
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an
    * existing object). Terminate the program and report an error if not. This
@@ -975,12 +966,6 @@ class PhysicsManager {
   std::vector<int> recycledObjectIDs_;
 
   //! Utilities
-
-  /**
-   * @brief Whether this physicsManager is enabled or not.  If not enabled then
-   * should not support adding objects or collision calcs.
-   */
-  bool enabled_ = false;
 
   /** @brief Tracks whether or not this @ref PhysicsManager has already been
    * initialized with @ref initPhysics. */

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -857,9 +857,7 @@ class PhysicsManager {
   /**@brief whether this physics manager is supporting any kind of
    * object/collision handling
    */
-  void setIsEnabled(bool _enabled) {
-    enabled_ = _enabled;
-  }
+  void setIsEnabled(bool _enabled) { enabled_ = _enabled; }
 
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -94,7 +94,7 @@ class PhysicsManager {
       assets::ResourceManager& _resourceManager,
       const assets::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
       : resourceManager_(_resourceManager),
-        physicsManagerAttributes(_physicsManagerAttributes){};
+        physicsManagerAttributes_(_physicsManagerAttributes){};
 
   /** @brief Destructor*/
   virtual ~PhysicsManager();
@@ -105,8 +105,6 @@ class PhysicsManager {
    *
    * @param node    The scene graph node which will act as the parent of all
    * physical scene and object nodes.
-   * @param physicsManagerAttributes A structure containing values for physical
-   * parameters necessary to initialize the physical scene and simulator.
    */
   bool initPhysics(scene::SceneNode* node);
 
@@ -117,7 +115,7 @@ class PhysicsManager {
   virtual void reset() {
     /* TODO: reset object states or clear them? Other? */
     worldTime_ = 0.0;
-  };
+  }
 
   /** @brief Stores references to a set of drawable elements. */
   using DrawableGroup = gfx::DrawableGroup;
@@ -842,6 +840,27 @@ class PhysicsManager {
     return existingObjects_.at(physObjectID)->getInitializationAttributes();
   }
 
+  /**
+   * @brief Get a copy of the template used to initialize this physics manager
+   *
+   * @return The initialization settings for this physics manager
+   */
+  assets::PhysicsManagerAttributes::ptr getInitializationAttributes() const {
+    return assets::PhysicsManagerAttributes::create(
+        *physicsManagerAttributes_.get());
+  }
+
+  /**@brief whether this physics manager is supporting any kind of
+   * object/collision handling
+   */
+  bool isEnabled() { return enabled_; }
+  /**@brief whether this physics manager is supporting any kind of
+   * object/collision handling
+   */
+  void setIsEnabled(bool _enabled) {
+    enabled_ = _enabled;
+  }
+
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an
    * existing object). Terminate the program and report an error if not. This
@@ -880,8 +899,6 @@ class PhysicsManager {
    * @brief Finalize physics initialization. Setup staticSceneObject_ and
    * initialize any other physics-related values for physics-based scenes.
    * Overidden by instancing class if physics is supported.
-   * @param physicsManagerAttributes A structure containing values for physical
-   * parameters necessary to initialize the physical scene and simulator.
    */
   virtual bool initPhysicsFinalize();
 
@@ -917,7 +934,7 @@ class PhysicsManager {
 
   /** @brief A pointer to the @ref assets::PhysicsManagerAttributes describing
    * this physics manager */
-  const assets::PhysicsManagerAttributes::cptr physicsManagerAttributes;
+  const assets::PhysicsManagerAttributes::cptr physicsManagerAttributes_;
 
   /** @brief The current physics library implementation used by this
    * @ref PhysicsManager. Can be used to correctly cast the @ref PhysicsManager
@@ -960,6 +977,12 @@ class PhysicsManager {
   std::vector<int> recycledObjectIDs_;
 
   //! Utilities
+
+  /**
+   * @brief Whether this physicsManager is enabled or not.  If not enabled then
+   * should not support adding objects or collision calcs.
+   */
+  bool enabled_ = false;
 
   /** @brief Tracks whether or not this @ref PhysicsManager has already been
    * initialized with @ref initPhysics. */

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -34,7 +34,7 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
   bWorld_->setDebugDrawer(&debugDrawer_);
 
   // currently GLB meshes are y-up
-  bWorld_->setGravity(btVector3(physicsManagerAttributes->getVec3("gravity")));
+  bWorld_->setGravity(btVector3(physicsManagerAttributes_->getVec3("gravity")));
 
   //! Create new scene node
   staticSceneObject_ = physics::BulletRigidScene::create_unique(

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -171,8 +171,6 @@ class BulletPhysicsManager : public PhysicsManager {
   /**
    * @brief Finalize physics initialization: Setup staticSceneObject_ and
    * initialize any other physics-related values.
-   * @param physicsManagerAttributes A structure containing values for physical
-   * parameters necessary to initialize the physical scene and simulator.
    */
   bool initPhysicsFinalize() override;
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -89,11 +89,11 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   }
 
   // create pathfinder and load navmesh if available
-  pathfinder_ = nav::PathFinder::create();
   std::string navmeshFilename = io::changeExtension(sceneFilename, ".navmesh");
   if (cfg.scene.filepaths.count("navmesh")) {
     navmeshFilename = cfg.scene.filepaths.at("navmesh");
   }
+  pathfinder_ = nav::PathFinder::create();
   if (io::exists(navmeshFilename)) {
     LOG(INFO) << "Loading navmesh from " << navmeshFilename;
     pathfinder_->loadNavMesh(navmeshFilename);
@@ -106,9 +106,6 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   seed(config_.randomSeed);
 
   std::string houseFilename = io::changeExtension(sceneFilename, ".house");
-  if (!io::exists(houseFilename)) {
-    houseFilename = io::changeExtension(sceneFilename, ".scn");
-  }
   if (cfg.scene.filepaths.count("house")) {
     houseFilename = cfg.scene.filepaths.at("house");
   }
@@ -117,6 +114,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     houseFilename = io::changeExtension(sceneFilename, ".scn");
   }
 
+  // TODO : replace with PhysicsSceneAttributes?
   assets::AssetInfo sceneInfo = assets::AssetInfo::fromPath(sceneFilename);
   sceneInfo.requiresLighting =
       cfg.sceneLightSetup != assets::ResourceManager::NO_LIGHT_KEY;
@@ -149,28 +147,23 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     resourceManager_->compressTextures(cfg.compressTextures);
 
     bool loadSuccess = false;
-    if (config_.enablePhysics) {
-      // use physics world attributes manager to get physics manager attributes
-      // described by config file
-      auto physicsManagerAttributes =
-          resourceManager_->getPhysicsAttributesManager()
-              ->createAttributesTemplate(cfg.physicsConfigFile, true);
 
-      CORRADE_ASSERT(
-          physicsManagerAttributes != nullptr,
-          "Simulator::reconfigure : Error attempting to load world described by"
-              << cfg.physicsConfigFile << ". Aborting", );
+    // use physics world attributes manager to get physics manager attributes
+    // described by config file
+    auto physicsManagerAttributes =
+        resourceManager_->getPhysicsAttributesManager()
+            ->createAttributesTemplate(cfg.physicsConfigFile, true);
 
-      loadSuccess = resourceManager_->loadPhysicsScene(
-          sceneInfo, physicsManager_, physicsManagerAttributes, &rootNode,
-          &drawables, cfg.sceneLightSetup);
+    // (re)init physics manager
+    resourceManager_->initPhysicsManager(physicsManager_, config_.enablePhysics,
+                                         &rootNode, physicsManagerAttributes);
 
-    } else {
-      loadSuccess = resourceManager_->loadScene(
-          sceneInfo, &rootNode, &drawables, cfg.sceneLightSetup);
-    }
+    // Load scene
+    loadSuccess = resourceManager_->loadScene(
+        sceneInfo, physicsManager_, &rootNode, &drawables, cfg.sceneLightSetup);
+
     if (!loadSuccess) {
-      LOG(ERROR) << "cannot load " << sceneFilename;
+      LOG(ERROR) << "Cannot load " << sceneFilename;
       // Pass the error to the python through pybind11 allowing graceful exit
       throw std::invalid_argument("Cannot load: " + sceneFilename);
     }
@@ -194,7 +187,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
         const assets::AssetInfo semanticSceneInfo =
             assets::AssetInfo::fromPath(semanticMeshFilename);
         resourceManager_->loadScene(
-            semanticSceneInfo, &semanticRootNode, &semanticDrawables,
+            semanticSceneInfo, nullptr, &semanticRootNode, &semanticDrawables,
             assets::ResourceManager::NO_LIGHT_KEY, cfg.frustumCulling);
         LOG(INFO) << "Loaded.";
       } else {
@@ -214,7 +207,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
                         "annotations. \n---";
       }
     }
-  }
+  }  // if (cfg.createRenderer)
 
   semanticScene_ = nullptr;
   semanticScene_ = scene::SemanticScene::create();
@@ -245,10 +238,53 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   }
 
   reset();
-}
+}  // Simulator::reconfigure
+
+void Simulator::rebuildPathFinder(const std::string& navmeshFilename) {
+  pathfinder_ = nav::PathFinder::create();
+  if (io::exists(navmeshFilename)) {
+    LOG(INFO) << "Loading navmesh from " << navmeshFilename;
+    pathfinder_->loadNavMesh(navmeshFilename);
+    LOG(INFO) << "Loaded.";
+  } else {
+    LOG(WARNING) << "Navmesh file not found, checked at " << navmeshFilename;
+  }
+}  // Simulator::rebuildPathFinder
+
+void Simulator::rebuildSemanticScene(const assets::AssetType sceneType,
+                                     const std::string& sceneFilename,
+                                     std::string& houseFilename) {
+  semanticScene_ = nullptr;
+  semanticScene_ = scene::SemanticScene::create();
+  switch (sceneType) {
+    case assets::AssetType::INSTANCE_MESH:
+      houseFilename = Cr::Utility::Directory::join(
+          Cr::Utility::Directory::path(houseFilename), "info_semantic.json");
+      if (io::exists(houseFilename)) {
+        scene::SemanticScene::loadReplicaHouse(houseFilename, *semanticScene_);
+      }
+      break;
+    case assets::AssetType::MP3D_MESH:
+      // TODO(msb) Fix AssetType determination logic.
+      if (io::exists(houseFilename)) {
+        using Corrade::Utility::String::endsWith;
+        if (endsWith(houseFilename, ".house")) {
+          scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
+        } else if (endsWith(houseFilename, ".scn")) {
+          scene::SemanticScene::loadGibsonHouse(houseFilename, *semanticScene_);
+        }
+      }
+      break;
+    case assets::AssetType::SUNCG_SCENE:
+      scene::SemanticScene::loadSuncgHouse(sceneFilename, *semanticScene_);
+      break;
+    default:
+      break;
+  }
+}  // Simulator::reloadSemanticScene
 
 void Simulator::reset() {
-  if (physicsManager_ != nullptr) {
+  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
     // Note: only resets time to 0 by default.
     physicsManager_->reset();
   }
@@ -259,7 +295,7 @@ void Simulator::reset() {
   const Magnum::Range3D& sceneBB =
       getActiveSceneGraph().getRootNode().computeCumulativeBB();
   resourceManager_->setLightSetup(gfx::getLightsAtBoxCorners(sceneBB));
-}
+}  // Simulator::reset()
 
 void Simulator::seed(uint32_t newSeed) {
   random_->seed(newSeed);
@@ -543,7 +579,7 @@ void Simulator::setObjectSemanticId(uint32_t semanticId,
 }
 
 double Simulator::stepWorld(const double dt) {
-  if (physicsManager_ != nullptr) {
+  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
     physicsManager_->stepPhysics(dt);
   }
   return getWorldTime();
@@ -551,7 +587,7 @@ double Simulator::stepWorld(const double dt) {
 
 // get the simulated world time (0 if no physics enabled)
 double Simulator::getWorldTime() {
-  if (physicsManager_ != nullptr) {
+  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
     return physicsManager_->getWorldTime();
   }
   return NO_TIME;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -241,7 +241,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 }  // Simulator::reconfigure
 
 void Simulator::reset() {
-  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
+  if (physicsManager_ != nullptr) {
     // Note: only resets time to 0 by default.
     physicsManager_->reset();
   }
@@ -536,7 +536,7 @@ void Simulator::setObjectSemanticId(uint32_t semanticId,
 }
 
 double Simulator::stepWorld(const double dt) {
-  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
+  if (physicsManager_ != nullptr) {
     physicsManager_->stepPhysics(dt);
   }
   return getWorldTime();
@@ -544,7 +544,7 @@ double Simulator::stepWorld(const double dt) {
 
 // get the simulated world time (0 if no physics enabled)
 double Simulator::getWorldTime() {
-  if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
+  if (physicsManager_ != nullptr) {
     return physicsManager_->getWorldTime();
   }
   return NO_TIME;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -240,49 +240,6 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   reset();
 }  // Simulator::reconfigure
 
-void Simulator::rebuildPathFinder(const std::string& navmeshFilename) {
-  pathfinder_ = nav::PathFinder::create();
-  if (io::exists(navmeshFilename)) {
-    LOG(INFO) << "Loading navmesh from " << navmeshFilename;
-    pathfinder_->loadNavMesh(navmeshFilename);
-    LOG(INFO) << "Loaded.";
-  } else {
-    LOG(WARNING) << "Navmesh file not found, checked at " << navmeshFilename;
-  }
-}  // Simulator::rebuildPathFinder
-
-void Simulator::rebuildSemanticScene(const assets::AssetType sceneType,
-                                     const std::string& sceneFilename,
-                                     std::string& houseFilename) {
-  semanticScene_ = nullptr;
-  semanticScene_ = scene::SemanticScene::create();
-  switch (sceneType) {
-    case assets::AssetType::INSTANCE_MESH:
-      houseFilename = Cr::Utility::Directory::join(
-          Cr::Utility::Directory::path(houseFilename), "info_semantic.json");
-      if (io::exists(houseFilename)) {
-        scene::SemanticScene::loadReplicaHouse(houseFilename, *semanticScene_);
-      }
-      break;
-    case assets::AssetType::MP3D_MESH:
-      // TODO(msb) Fix AssetType determination logic.
-      if (io::exists(houseFilename)) {
-        using Corrade::Utility::String::endsWith;
-        if (endsWith(houseFilename, ".house")) {
-          scene::SemanticScene::loadMp3dHouse(houseFilename, *semanticScene_);
-        } else if (endsWith(houseFilename, ".scn")) {
-          scene::SemanticScene::loadGibsonHouse(houseFilename, *semanticScene_);
-        }
-      }
-      break;
-    case assets::AssetType::SUNCG_SCENE:
-      scene::SemanticScene::loadSuncgHouse(sceneFilename, *semanticScene_);
-      break;
-    default:
-      break;
-  }
-}  // Simulator::reloadSemanticScene
-
 void Simulator::reset() {
   if (physicsManager_ != nullptr && physicsManager_->isEnabled()) {
     // Note: only resets time to 0 by default.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -56,6 +56,10 @@ struct SimulatorConfiguration {
   bool allowSliding = true;
   // enable or disable the frustum culling
   bool frustumCulling = true;
+  /**
+   * @brief This flags specifies whether or not dynamics is supported by the
+   * simulation, if a suitable library (i.e. Bullet) has been installed.
+   */
   bool enablePhysics = false;
   bool loadSemanticMesh = true;
   std::string physicsConfigFile =
@@ -627,8 +631,7 @@ class Simulator {
   }
 
   bool sceneHasPhysics(int sceneID) const {
-    return isValidScene(sceneID) && physicsManager_ != nullptr &&
-           physicsManager_->isEnabled();
+    return isValidScene(sceneID) && physicsManager_ != nullptr;
   }
 
   gfx::WindowlessContext::uptr context_ = nullptr;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -16,6 +16,7 @@
 #include "esp/gfx/RenderTarget.h"
 #include "esp/gfx/WindowlessContext.h"
 #include "esp/nav/PathFinder.h"
+#include "esp/physics/PhysicsManager.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/scene/SceneConfiguration.h"
 #include "esp/scene/SceneManager.h"
@@ -24,6 +25,9 @@
 namespace AttrMgrs = esp::assets::managers;
 
 namespace esp {
+// namespace physics {
+// class PhysicsManager;
+// }
 namespace nav {
 class PathFinder;
 class NavMeshSettings;
@@ -88,6 +92,25 @@ class Simulator {
 
   virtual void reset();
 
+ protected:
+  /**
+   * @brief (Re)builds @ref semanticScene_ upon reconfigure.
+   *
+   * @param sceneType The type of the scene mesh.
+   * @param sceneFileName The file name of the scene mesh
+   */
+  void rebuildSemanticScene(const assets::AssetType sceneType,
+                            const std::string& sceneFilename,
+                            std::string& houseFilename);
+
+  /**
+   * @brief (Re)builds @ref pathfinder_ upon reconfigure.
+   *
+   * @param navmeshFilename The file name of the navmesh
+   */
+  void rebuildPathFinder(const std::string& navmeshFilename);
+
+ public:
   virtual void seed(uint32_t newSeed);
 
   std::shared_ptr<gfx::Renderer> getRenderer() { return renderer_; }
@@ -622,7 +645,7 @@ class Simulator {
   }
 
   bool sceneHasPhysics(int sceneID) const {
-    return isValidScene(sceneID) && physicsManager_ != nullptr;
+    return isValidScene(sceneID) && physicsManager_ != nullptr && physicsManager_->isEnabled();
   }
 
   gfx::WindowlessContext::uptr context_ = nullptr;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -25,9 +25,6 @@
 namespace AttrMgrs = esp::assets::managers;
 
 namespace esp {
-// namespace physics {
-// class PhysicsManager;
-// }
 namespace nav {
 class PathFinder;
 class NavMeshSettings;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -92,24 +92,6 @@ class Simulator {
 
   virtual void reset();
 
- protected:
-  /**
-   * @brief (Re)builds @ref semanticScene_ upon reconfigure.
-   *
-   * @param sceneType The type of the scene mesh.
-   * @param sceneFileName The file name of the scene mesh
-   */
-  void rebuildSemanticScene(const assets::AssetType sceneType,
-                            const std::string& sceneFilename,
-                            std::string& houseFilename);
-
-  /**
-   * @brief (Re)builds @ref pathfinder_ upon reconfigure.
-   *
-   * @param navmeshFilename The file name of the navmesh
-   */
-  void rebuildPathFinder(const std::string& navmeshFilename);
-
  public:
   virtual void seed(uint32_t newSeed);
 
@@ -645,7 +627,8 @@ class Simulator {
   }
 
   bool sceneHasPhysics(int sceneID) const {
-    return isValidScene(sceneID) && physicsManager_ != nullptr && physicsManager_->isEnabled();
+    return isValidScene(sceneID) && physicsManager_ != nullptr &&
+           physicsManager_->isEnabled();
   }
 
   gfx::WindowlessContext::uptr context_ = nullptr;

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -64,7 +64,8 @@ void CullingTest::computeAbsoluteAABB() {
   auto& drawables = sceneGraph.getDrawables();
   const esp::assets::AssetInfo info =
       esp::assets::AssetInfo::fromPath(sceneFile);
-  CORRADE_VERIFY(resourceManager.loadScene(info, &sceneRootNode, &drawables));
+  CORRADE_VERIFY(
+      resourceManager.loadScene(info, nullptr, &sceneRootNode, &drawables));
 
   std::vector<Mn::Range3D> aabbs;
   for (unsigned int iDrawable = 0; iDrawable < drawables.size(); ++iDrawable) {
@@ -136,7 +137,8 @@ void CullingTest::frustumCulling() {
   auto& drawables = sceneGraph.getDrawables();
   const esp::assets::AssetInfo info =
       esp::assets::AssetInfo::fromPath(sceneFile);
-  CORRADE_VERIFY(resourceManager.loadScene(info, &sceneRootNode, &drawables));
+  CORRADE_VERIFY(
+      resourceManager.loadScene(info, nullptr, &sceneRootNode, &drawables));
 
   // set the camera
   esp::gfx::RenderCamera& renderCamera = sceneGraph.getDefaultRenderCamera();

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -63,7 +63,8 @@ DrawableTest::DrawableTest() {
   esp::scene::SceneNode& sceneRootNode = sceneGraph.getRootNode();
   const esp::assets::AssetInfo info =
       esp::assets::AssetInfo::fromPath(sceneFile);
-  resourceManager_.loadScene(info, &sceneRootNode, drawableGroup_);
+
+  resourceManager_.loadScene(info, nullptr, &sceneRootNode, drawableGroup_);
 }
 
 void DrawableTest::addRemoveDrawables() {

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -55,9 +55,11 @@ class PhysicsManagerTest : public testing::Test {
     auto physicsManagerAttributes =
         physicsAttributesManager_->createAttributesTemplate(physicsConfigFile,
                                                             true);
-    resourceManager_.loadPhysicsScene(info, physicsManager_,
-                                      physicsManagerAttributes, navSceneNode,
-                                      &drawables);
+    // construct physics manager based on specifications in attributes
+    resourceManager_.initPhysicsManager(physicsManager_, true, navSceneNode,
+                                        physicsManagerAttributes);
+    // load scene
+    resourceManager_.loadScene(info, physicsManager_, navSceneNode, &drawables);
   }
 
   // must declare these in this order due to avoid deallocation errors

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -39,7 +39,7 @@ TEST(ResourceManagerTest, createJoinedCollisionMesh) {
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
   esp::scene::SceneNode* navSceneNode = &sceneGraph.getRootNode().createChild();
   const esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
-  resourceManager.loadScene(info, navSceneNode, nullptr);
+  resourceManager.loadScene(info, nullptr, navSceneNode, nullptr);
 
   esp::assets::MeshData::uptr joinedBox =
       resourceManager.createJoinedCollisionMesh(boxFile);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -240,7 +240,7 @@ Viewer::Viewer(const Arguments& arguments)
   if (useCollisions && (args.isSet("debug-bullet"))) {
     debugBullet_ = true;
   }
-  
+
   const Mn::Range3D& sceneBB = rootNode_->computeCumulativeBB();
   resourceManager_.setLightSetup(esp::gfx::getLightsAtBoxCorners(sceneBB));
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -230,8 +230,8 @@ Viewer::Viewer(const Arguments& arguments)
 
   bool useBullet = args.isSet("enable-physics");
   // construct physics manager based on specifications in attributes
-  resourceManager_.initPhysicsManager(physicsManager_, useCollisions,
-                                      navSceneNode_, physicsManagerAttributes);
+  resourceManager_.initPhysicsManager(physicsManager_, useBullet, navSceneNode_,
+                                      physicsManagerAttributes);
 
   if (!resourceManager_.loadScene(info, physicsManager_, navSceneNode_,
                                   &drawables, sceneLightSetup)) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -233,38 +233,6 @@ Viewer::Viewer(const Arguments& arguments)
   resourceManager_.initPhysicsManager(physicsManager_, useCollisions,
                                       navSceneNode_, physicsManagerAttributes);
 
-  // if (args.isSet("enable-physics")) {
-  // std::string physicsConfigFilename = args.value("physics-config");
-  // if (!Cr::Utility::Directory::exists(physicsConfigFilename)) {
-  //   LOG(FATAL)
-  //       << physicsConfigFilename
-  //       << " was not found, specify an existing file in --physics-config";
-  // }
-  // // // use physics world attributes manager to get physics manager
-  // attributes
-  // // described by config file
-  // auto physicsManagerAttributes =
-  //     resourceManager_.getPhysicsAttributesManager()
-  //         ->createAttributesTemplate(physicsConfigFilename, true);
-  // CORRADE_ASSERT(physicsManagerAttributes != nullptr,
-  //                "Viewer::ctor : Error attempting to load world described
-  //                by"
-  //                    << physicsConfigFilename << ". Aborting", );
-
-  // // construct physics manager based on specifications in attributes
-  // resourceManager_.initPhysicsManager(physicsManager_, navSceneNode_,
-  //                                     physicsManagerAttributes);
-
-  // bool loadSuccess = resourceManager_.loadPhysicsScene(
-  //     info, physicsManager_, navSceneNode_, &drawables, sceneLightSetup);
-
-  // if (!loadSuccess) {
-  //   LOG(FATAL) << "cannot load " << sceneFileName;
-  // }
-  // if (args.isSet("debug-bullet")) {
-  //   debugBullet_ = true;
-  // }
-  //} else {
   if (!resourceManager_.loadScene(info, physicsManager_, navSceneNode_,
                                   &drawables, sceneLightSetup)) {
     LOG(FATAL) << "cannot load " << sceneFileName;
@@ -272,8 +240,7 @@ Viewer::Viewer(const Arguments& arguments)
   if (useCollisions && (args.isSet("debug-bullet"))) {
     debugBullet_ = true;
   }
-  //}
-
+  
   const Mn::Range3D& sceneBB = rootNode_->computeCumulativeBB();
   resourceManager_.setLightSetup(esp::gfx::getLightsAtBoxCorners(sceneBB));
 


### PR DESCRIPTION
This PR introduces some changes to how the PhysicsManager object is maintained, and how scenes are loaded, in preparation for upcoming Scene Importing, to help generalize loading functionality and facilitate backwards compatibility with current scene loading/importing, as well as always giving the user access to default (primitive) objects.  The primary changes in this PR are : 

1. Configure physicsManager to always be constructed in some state in simulator/viewer so long as a renderer is created.
2. ResourceManager is changed to have only a single loadScene method.
3. The meaning of the --enable-physics flag has been changed to denote whether a BulletPhysicsManager is instantiated (if it has been installed).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ tests were modified slightly to load scenes in the appropriate manner;  All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. 
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
