### PR TITLE
Refactor NavMesh visualization to Simulator property

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -73,6 +73,10 @@ void initSimBindings(py::module& m) {
       .def("close", &Simulator::close)
       .def_property("pathfinder", &Simulator::getPathFinder,
                     &Simulator::setPathFinder)
+      .def_property(
+          "navmesh_visualization", &Simulator::isNavMeshVisualizationActive,
+          &Simulator::setNavMeshVisualization,
+          R"(Enable or disable wireframe visualization of current pathfinder's NavMesh.)")
       .def_property_readonly("gpu_device", &Simulator::gpuDevice)
       .def_property_readonly("random", &Simulator::random)
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
@@ -161,8 +165,6 @@ void initSimBindings(py::module& m) {
            "semantic_id"_a, "object_id"_a, "scene_id"_a = 0)
       .def("recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
            "navmesh_settings"_a, "include_static_objects"_a = false)
-      .def("toggle_navmesh_visualization",
-           &Simulator::toggleNavMeshVisualization)
       .def("get_light_setup", &Simulator::getLightSetup,
            "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY)
       .def("set_light_setup", &Simulator::setLightSetup, "light_setup"_a,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -167,6 +167,15 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
       // Pass the error to the python through pybind11 allowing graceful exit
       throw std::invalid_argument("Cannot load: " + sceneFilename);
     }
+
+    // refresh the NavMesh visualization if necessary after loading a new
+    // SceneGraph
+    if (isNavMeshVisualizationActive()) {
+      // if updating pathfinder_ instance, refresh the visualization.
+      setNavMeshVisualization(false);  // first clear the old instance
+      setNavMeshVisualization(true);
+    }
+
     const Magnum::Range3D& sceneBB = rootNode.computeCumulativeBB();
     resourceManager_->setLightSetup(gfx::getLightsAtBoxCorners(sceneBB));
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -529,9 +529,18 @@ class Simulator {
                         bool includeStaticObjects = false);
 
   /**
-   * @brief Toggle visualization of the current NavMesh @ref pathfinder_.
+   * @brief Set visualization of the current NavMesh @ref pathfinder_ on or off.
+   *
+   * @param visualize Whether or not to visualize the navmesh.
+   * @return Whether or not the NavMesh visualization is active.
    */
-  void toggleNavMeshVisualization();
+  bool setNavMeshVisualization(bool visualize);
+
+  /**
+   * @brief Query active state of the current NavMesh @ref pathfinder_
+   * visualization.
+   */
+  bool isNavMeshVisualizationActive();
 
   agent::Agent::ptr getAgent(int agentId);
 

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -44,7 +44,10 @@ def test_recompute_navmesh(test_scene, sim):
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     sim.reconfigure(hab_cfg)
 
-    sim.toggle_navmesh_visualization()
+    sim.navmesh_visualization = True
+    assert sim.navmesh_visualization
+    sim.navmesh_visualization = False
+    assert not sim.navmesh_visualization
 
     # generate random point pairs
     num_samples = 100


### PR DESCRIPTION
## Motivation and Context
Previous implementation (#683) enabled toggling the NavMesh visualization in Simulator. Would rather have a way to query/set the state of the visualization explicitly. This PR refactors the `Simulator.toggle_navmesh_visualization` function to a `Simulator.navmesh_visualization` property.

## How Has This Been Tested

Local testing and small pytest check.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
