### PR TITLE
--Fix issue with attributes handle remove.

### DIFF
--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -378,6 +378,18 @@ class AssetAttributesManager
 
  protected:
   /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+  void updateTemplateHandleLists(int templateID,
+                                 const std::string& templateHandle) override {}
+
+  /**
    * @brief Verify that passed template handle describes attributes of type
    * specified by passed primtive name (ie "cube", "capsule")
    * @param templateHandle The handle to test.

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -245,9 +245,10 @@ class AttributesManager {
     return removeTemplateInternal(templateHandle,
                                   "AttributesManager::removeTemplateByHandle");
   }
+
   /**
-   * @brief Get the key in @ref templateLibrary_ for the object template with
-   * the given unique ID.
+   * @brief Get the key in @ref templateLibrary_ for the object template
+   * with the given unique ID.
    *
    * @param templateID The unique ID of the desired template.
    * @return The key referencing the template in @ref
@@ -445,6 +446,19 @@ class AttributesManager {
    */
   AttribsPtr removeTemplateInternal(const std::string& templateHandle,
                                     const std::string& src);
+
+  /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes to remove.
+   */
+  virtual void updateTemplateHandleLists(int templateID,
+                                         const std::string& templateHandle) = 0;
+
   /**
    * @brief Used Internally. Get the ID of the template in @ref templateLibrary_
    * for the given template Handle, if exists. If the template is not in the
@@ -747,6 +761,9 @@ T AttributesManager<T>::removeTemplateInternal(
   templateLibKeyByID_.erase(templateID);
   templateLibrary_.erase(templateHandle);
   availableTemplateIDs_.emplace_front(templateID);
+  // call instance-specific update to remove template handle from any local
+  // lists
+  updateTemplateHandleLists(templateID, templateHandle);
   return attribsTemplate;
 }  // AttributesManager::removeTemplateByHandle
 

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -237,6 +237,21 @@ class ObjectAttributesManager
 
  protected:
   /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+  void updateTemplateHandleLists(int templateID,
+                                 const std::string& templateHandle) override {
+    physicsFileObjTmpltLibByID_.erase(templateID);
+    physicsSynthObjTmpltLibByID_.erase(templateID);
+  }
+
+  /**
    * @brief Add a copy of @ref AbstractAttributes object to the @ref
    * templateLibrary_. Verify that render and collision handles have been
    * set properly.  We are doing this since these values can be modified by the

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -90,6 +90,18 @@ class PhysicsAttributesManager
 
  protected:
   /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+  void updateTemplateHandleLists(int templateID,
+                                 const std::string& templateHandle) override {}
+
+  /**
    * @brief Add a @ref PhysicsManagerAttributes::ptr object to the @ref
    * templateLibrary_.
    *

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -104,6 +104,18 @@ class SceneAttributesManager
 
  protected:
   /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+  void updateTemplateHandleLists(int templateID,
+                                 const std::string& templateHandle) override {}
+
+  /**
    * @brief Scene is file-based lacking a descriptive .json, described by @ref
    * sceneFilename; populate a returned scene attributes with appropriate data.
    * This method's intended use is to support backwards compatibility for when

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -272,11 +272,25 @@ TEST_F(AttributesManagersTest, AttributesManagersCreate) {
   LOG(INFO) << "Start Test : Create, Edit, Remove Attributes for "
                "ObjectAttributesManager @ "
             << objectFile;
+  int origNumFileBased = objectAttributesManager_->getNumFileTemplateObjects();
+  int origNumPrimBased = objectAttributesManager_->getNumSynthTemplateObjects();
   // object attributes manager attributes verifcation
   testCreateAndRemove<AttrMgrs::ObjectAttributesManager>(
       objectAttributesManager_, objectFile);
+  // verify that no new file-based and no new synth based template objects
+  // remain
+  int newNumFileBased1 = objectAttributesManager_->getNumFileTemplateObjects();
+  int newNumPrimBased1 = objectAttributesManager_->getNumSynthTemplateObjects();
+  ASSERT_EQ(origNumFileBased, newNumFileBased1);
+  ASSERT_EQ(origNumPrimBased, newNumPrimBased1);
   testCreateAndRemoveDefault<AttrMgrs::ObjectAttributesManager>(
       objectAttributesManager_, objectFile, true);
+  // verify that no new file-based and no new synth based template objects
+  // remain
+  int newNumFileBased2 = objectAttributesManager_->getNumFileTemplateObjects();
+  int newNumPrimBased2 = objectAttributesManager_->getNumSynthTemplateObjects();
+  ASSERT_EQ(origNumFileBased, newNumFileBased2);
+  ASSERT_EQ(origNumPrimBased, newNumPrimBased2);
 
 }  // AttributesManagersTest::AttributesManagersCreate test
 


### PR DESCRIPTION
The removal functionality within the attributes handler did not remove the handle from any specialization-specific handle lists.  Currently this is only an issue with ObjectAttributesManager, where file based and synthesized/prim-based attributes are partitioned.
This PR introduces a fix for this issue, and also includes c++ tests to verify this works.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Added c++ test functionality, and all c++/python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
