### PR TITLE
Scene Import setup/initialization of newly-created attributes

### DIFF
--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -17,6 +17,7 @@ AssetInfo AssetInfo::fromPath(const std::string& path) {
     info.type = AssetType::INSTANCE_MESH;
   } else if (endsWith(path, "mesh.ply")) {
     info.type = AssetType::FRL_PTEX_MESH;
+    // below is same as {geo::ESP_BACK, geo::ESP_UP};
     info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
   } else if (endsWith(path, "house.json")) {
     info.type = AssetType::SUNCG_SCENE;
@@ -25,7 +26,7 @@ AssetInfo AssetInfo::fromPath(const std::string& path) {
     info.type = AssetType::MP3D_MESH;
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
-    info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
+    info.frame = {geo::ESP_BACK, geo::ESP_UP};
   }
 
   return info;

--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -17,8 +17,7 @@ AssetInfo AssetInfo::fromPath(const std::string& path) {
     info.type = AssetType::INSTANCE_MESH;
   } else if (endsWith(path, "mesh.ply")) {
     info.type = AssetType::FRL_PTEX_MESH;
-    // below is same as {geo::ESP_BACK, geo::ESP_UP};
-    info.frame = {quatf::FromTwoVectors(geo::ESP_GRAVITY, -vec3f::UnitZ())};
+    info.frame = {geo::ESP_BACK, geo::ESP_UP};
   } else if (endsWith(path, "house.json")) {
     info.type = AssetType::SUNCG_SCENE;
   } else if (endsWith(path, ".glb")) {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -88,8 +88,8 @@ void ResourceManager::buildImportersAndAttributesManagers() {
   objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create(
       *this, objectAttributesManager_);
-  sceneAttributesManager_ =
-      managers::SceneAttributesManager::create(*this, objectAttributesManager_);
+  sceneAttributesManager_ = managers::SceneAttributesManager::create(
+      *this, objectAttributesManager_, physicsAttributesManager_);
 
   // instantiate a primitive importer
   CORRADE_INTERNAL_ASSERT_OUTPUT(
@@ -176,6 +176,9 @@ bool ResourceManager::loadScene(
   // add a scene attributes for this filename or modify the existing one
   sceneAttributesManager_->createAttributesTemplate(info.filepath, true);
 
+  // create AssetInfos here for each potential mesh file for the scene, if they
+  // are unique.
+
   // we only compute absolute AABB for every mesh component when loading ptex
   // mesh, or general mesh (e.g., MP3D)
   staticDrawableInfo_.clear();
@@ -253,10 +256,6 @@ bool ResourceManager::loadScene(
   // old loadPhysicsScene code
   if (_physicsManager) {
     const std::string& filename = info.filepath;
-    // TODO: enable loading of multiple scenes from file and storing individual
-    // parameters instead of scene properties in manager global config
-    sceneAttributesManager_->setSceneValsFromPhysicsAttributes(
-        _physicsManager->getInitializationAttributes());
 
     //! CONSTRUCT SCENE
 

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -386,8 +386,9 @@ class AssetAttributesManager
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.
    */
-  void updateTemplateHandleLists(int templateID,
-                                 const std::string& templateHandle) override {}
+  void updateTemplateHandleLists(
+      CORRADE_UNUSED int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {}
 
   /**
    * @brief Verify that passed template handle describes attributes of type

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -441,6 +441,17 @@ class AssetAttributesManager
   };
 
   /**
+   * @brief Used Internally.  Configure newly-created attributes with any
+   * default values, before any specific values are set.
+   *
+   * @param newAttributes Newly created attributes.
+   */
+  AbstractPrimitiveAttributes::ptr initNewAttribsInternal(
+      AbstractPrimitiveAttributes::ptr newAttributes) override {
+    return newAttributes;
+  }
+
+  /**
    * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
    * with passed class name
    * @param primClassName Magnum::Primitives class name of primitive being
@@ -454,7 +465,8 @@ class AssetAttributesManager
                  << primClassName << "exists in Magnum::Primitives. Aborting.";
       return nullptr;
     }
-    return (*this.*primTypeConstructorMap_[primClassName])();
+    return initNewAttribsInternal(
+        (*this.*primTypeConstructorMap_[primClassName])());
   }  // AssetAttributeManager::buildPrimAttributes
 
   /**
@@ -469,7 +481,8 @@ class AssetAttributesManager
                     "Aborting.";
       return nullptr;
     }
-    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])();
+    return initNewAttribsInternal(
+        (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])());
   }  // AssetAttributeManager::buildPrimAttributes
 
   /**
@@ -485,8 +498,9 @@ class AssetAttributesManager
                  << primTypeVal << ". Aborting";
       return nullptr;
     }
-    return (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
-                       static_cast<PrimObjTypes>(primTypeVal))])();
+    return initNewAttribsInternal(
+        (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
+                    static_cast<PrimObjTypes>(primTypeVal))])());
   }  // AssetAttributeManager::buildPrimAttributes
 
   /**

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -435,6 +435,15 @@ class AttributesManager {
                                              const io::JsonDocument& jsonDoc);
 
   //======== Internally accessed functions ========
+
+  /**
+   * @brief Used Internally.  Configure newly-created attributes with any
+   * default values, before any specific values are set.
+   *
+   * @param newAttributes Newly created attributes.
+   */
+  virtual AttribsPtr initNewAttribsInternal(AttribsPtr newAttributes) = 0;
+
   /**
    * @brief Used Internally. Remove the template referenced by the passed
    * string handle. Will emplace template ID within deque of usable IDs and
@@ -545,6 +554,7 @@ class AttributesManager {
    */
   template <typename U>
   AttribsPtr createAttributesCopy(AttribsPtr& orig) {
+    // don't call init on copy - assume copy is already properly initialized.
     return U::create(*(static_cast<U*>(orig.get())));
   }  // AttributesManager::
 
@@ -679,7 +689,8 @@ template <class U>
 AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
     const std::string& configFilename,
     const io::JsonDocument& jsonDoc) {
-  auto attributes = U::create(configFilename);
+  auto attributes = initNewAttribsInternal(U::create(configFilename));
+
   using std::placeholders::_1;
 
   // scale

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -64,8 +64,8 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   }
 
   // construct a PhysicsObjectAttributes
-  auto primObjectAttributes =
-      PhysicsObjectAttributes::create(primAttrTemplateHandle);
+  auto primObjectAttributes = initNewAttribsInternal(
+      PhysicsObjectAttributes::create(primAttrTemplateHandle));
   // set margin to be 0
   primObjectAttributes->setMargin(0.0);
   // make smaller as default size - prims are approx meter in size
@@ -159,7 +159,7 @@ ObjectAttributesManager::createDefaultAttributesTemplate(
     bool registerTemplate) {
   // construct a PhysicsObjectAttributes
   PhysicsObjectAttributes::ptr objAttributes =
-      PhysicsObjectAttributes::create(templateName);
+      initNewAttribsInternal(PhysicsObjectAttributes::create(templateName));
   // set render mesh handle as a default
   objAttributes->setRenderAssetHandle(templateName);
   if (registerTemplate) {

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -245,8 +245,9 @@ class ObjectAttributesManager
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.
    */
-  void updateTemplateHandleLists(int templateID,
-                                 const std::string& templateHandle) override {
+  void updateTemplateHandleLists(
+      int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {
     physicsFileObjTmpltLibByID_.erase(templateID);
     physicsSynthObjTmpltLibByID_.erase(templateID);
   }

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -237,6 +237,17 @@ class ObjectAttributesManager
 
  protected:
   /**
+   * @brief Used Internally.  Configure newly-created attributes with any
+   * default values, before any specific values are set.
+   *
+   * @param newAttributes Newly created attributes.
+   */
+  PhysicsObjectAttributes::ptr initNewAttribsInternal(
+      PhysicsObjectAttributes::ptr newAttributes) override {
+    return newAttributes;
+  }
+
+  /**
    * @brief This method will perform any necessary updating that is
    * attributesManager-specific upon template removal, such as removing a
    * specific template handle from the list of file-based template handles in

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -46,7 +46,7 @@ PhysicsAttributesManager::createDefaultAttributesTemplate(
     bool registerTemplate) {
   // Attributes descriptor for physics world
   PhysicsManagerAttributes::ptr physicsManagerAttributes =
-      PhysicsManagerAttributes::create(physicsFilename);
+      initNewAttribsInternal(PhysicsManagerAttributes::create(physicsFilename));
 
   if (registerTemplate) {
     int attrID = this->registerAttributesTemplate(physicsManagerAttributes,
@@ -65,7 +65,7 @@ PhysicsAttributesManager::createFileBasedAttributesTemplate(
     bool registerTemplate) {
   // Attributes descriptor for physics world
   PhysicsManagerAttributes::ptr physicsManagerAttributes =
-      PhysicsManagerAttributes::create(physicsFilename);
+      initNewAttribsInternal(PhysicsManagerAttributes::create(physicsFilename));
 
   // Load the global physics manager config JSON here
   io::JsonDocument jsonConfig;

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -98,8 +98,9 @@ class PhysicsAttributesManager
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.
    */
-  void updateTemplateHandleLists(int templateID,
-                                 const std::string& templateHandle) override {}
+  void updateTemplateHandleLists(
+      CORRADE_UNUSED int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {}
 
   /**
    * @brief Add a @ref PhysicsManagerAttributes::ptr object to the @ref

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -90,6 +90,16 @@ class PhysicsAttributesManager
 
  protected:
   /**
+   * @brief Used Internally.  Configure newly-created attributes with any
+   * default values, before any specific values are set.
+   *
+   * @param newAttributes Newly created attributes.
+   */
+  PhysicsManagerAttributes::ptr initNewAttribsInternal(
+      PhysicsManagerAttributes::ptr newAttributes) override {
+    return newAttributes;
+  }
+  /**
    * @brief This method will perform any necessary updating that is
    * attributesManager-specific upon template removal, such as removing a
    * specific template handle from the list of file-based template handles in

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -223,6 +223,21 @@ SceneAttributesManager::createBackCompatAttributesTemplate(
   return sceneAttributes;
 }  // SceneAttributesManager::createBackCompatAttributesTemplate
 
+PhysicsSceneAttributes::ptr SceneAttributesManager::initNewAttribsInternal(
+    PhysicsSceneAttributes::ptr newAttributes) {
+  if (physicsAttributesManager_->getTemplateLibHasHandle(
+          physicsManagerAttributesHandle_)) {
+    auto physMgrAttributes = physicsAttributesManager_->getTemplateByHandle(
+        physicsManagerAttributesHandle_);
+    newAttributes->setGravity(physMgrAttributes->getGravity());
+    newAttributes->setFrictionCoefficient(
+        physMgrAttributes->getFrictionCoefficient());
+    newAttributes->setRestitutionCoefficient(
+        physMgrAttributes->getRestitutionCoefficient());
+  }
+  return newAttributes;
+}  // SceneAttributesManager::initNewAttribsInternal
+
 PhysicsSceneAttributes::ptr
 SceneAttributesManager::createFileBasedAttributesTemplate(
     const std::string& sceneFilename,

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -112,8 +112,9 @@ class SceneAttributesManager
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.
    */
-  void updateTemplateHandleLists(int templateID,
-                                 const std::string& templateHandle) override {}
+  void updateTemplateHandleLists(
+      CORRADE_UNUSED int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {}
 
   /**
    * @brief Scene is file-based lacking a descriptive .json, described by @ref


### PR DESCRIPTION
## Motivation and Context
This PR is an incremental change for scene Import support that adds the ability to initialize newly created attributes with defaults before any file-based or otherwise specified values are set.  This also addresses some warnings related to unused arguments in certain method calls.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ any python tests passed.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
