### PR TITLE
Fallback to CPU-only depth unprojection if needed

### DIFF
--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -50,8 +50,7 @@ class DepthShader : public Magnum::GL::AbstractShaderProgram {
 
   /** @brief  Attempt to construct the shader.  Will return nullptr if the
    * maximum supported GL version is too low
-   *
-   **/
+   */
   static std::unique_ptr<DepthShader> TryCreate(Flags flags = {});
 
   /**
@@ -90,6 +89,8 @@ class DepthShader : public Magnum::GL::AbstractShaderProgram {
  private:
   explicit DepthShader(Flags flags, Magnum::GL::Version version);
 
+  /** @brief Get the OpenGL version required by the shader
+   */
   static Magnum::GL::Version getVersion();
 
   const Flags flags_;

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <Corrade/Containers/EnumSet.h>
 #include <Magnum/GL/AbstractShaderProgram.h>
 #include <Magnum/GL/Version.h>

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -6,6 +6,7 @@
 
 #include <Corrade/Containers/EnumSet.h>
 #include <Magnum/GL/AbstractShaderProgram.h>
+#include <Magnum/GL/Version.h>
 
 namespace esp {
 namespace gfx {
@@ -45,6 +46,12 @@ class DepthShader : public Magnum::GL::AbstractShaderProgram {
   /** @brief Constructor */
   explicit DepthShader(Flags flags = {});
 
+  /** @brief  Attempt to construct the shader.  Will return nullptr if the
+   * maximum supported GL version is too low
+   *
+   **/
+  static std::unique_ptr<DepthShader> TryCreate(Flags flags = {});
+
   /**
    * @brief Set transformation and projection matrix
    * @return Reference to self (for method chaining)
@@ -79,6 +86,10 @@ class DepthShader : public Magnum::GL::AbstractShaderProgram {
   Flags flags() const { return flags_; }
 
  private:
+  explicit DepthShader(Flags flags, Magnum::GL::Version version);
+
+  static Magnum::GL::Version getVersion();
+
   const Flags flags_;
   int transformationMatrixUniform_, projectionMatrixOrDepthUnprojectionUniform_;
 };

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -62,8 +62,8 @@ struct Renderer::Impl {
     }
 
     if (!depthShader_) {
-      depthShader_ = std::make_unique<DepthShader>(
-          DepthShader::Flag::UnprojectExistingDepth);
+      depthShader_ =
+          DepthShader::TryCreate(DepthShader::Flag::UnprojectExistingDepth);
     }
 
     sensor.bindRenderTarget(RenderTarget::create_unique(


### PR DESCRIPTION
## Motivation and Context

Use the CPU implementation of depth unprojection if the GL version isn't high enough.

Closes #710 

## How Has This Been Tested

Forced a return of nullptr and tests still passed.

## Types of changes

  Bug fix (non-breaking change which fixes an issue)
