### PR TITLE
--Plug possible loophole in mesh handle/type setting in json;

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -11,6 +11,16 @@ namespace assets {
 //  Derived attribute implementations
 //----------------------------------------//
 
+// All keys must be lowercase
+const std::map<std::string, esp::assets::AssetType>
+    AbstractPhysicsAttributes::AssetTypeNamesMap = {
+        {"mp3d", AssetType::MP3D_MESH},
+        {"navmesh", AssetType::NAVMESH},
+        {"ptex", AssetType::FRL_PTEX_MESH},
+        {"semantic", AssetType::INSTANCE_MESH},
+        {"suncg", AssetType::SUNCG_SCENE},
+};
+
 AbstractPhysicsAttributes::AbstractPhysicsAttributes(
     const std::string& attributesClassKey,
     const std::string& handle)

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "Magnum/Math/Math.h"
 #include "Magnum/Types.h"
+
+#include "esp/assets/Asset.h"
 #include "esp/core/Configuration.h"
 
 namespace esp {
@@ -91,6 +93,12 @@ class AbstractAttributes : public esp::core::Configuration {
  */
 class AbstractPhysicsAttributes : public AbstractAttributes {
  public:
+  /**
+   * @brief Constant static map to provide mappings from string tags to @ref
+   * AssetType values.  This will be used to map values set in json for mesh
+   * type to @ref AssetTypes.  Keys must be lowercase.
+   */
+  static const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
   AbstractPhysicsAttributes(const std::string& classKey,
                             const std::string& handle);
 

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -113,18 +113,13 @@ AssetAttributesManager::createAttributesTemplate(
     const std::string& primClassName,
     bool registerTemplate) {
   auto primAssetAttributes = buildPrimAttributes(primClassName);
-  if (nullptr != primAssetAttributes && registerTemplate) {
-    int attrID = this->registerAttributesTemplate(primAssetAttributes, "");
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
+  if (nullptr == primAssetAttributes) {
+    return primAssetAttributes;
   }
-  if (nullptr != primAssetAttributes) {
-    LOG(INFO) << "Asset attributes (" << primClassName << ") created"
-              << (registerTemplate ? " and registered." : ".");
-  }
-  return primAssetAttributes;
+  LOG(INFO) << "Asset attributes (" << primClassName << ") created"
+            << (registerTemplate ? " and registered." : ".");
+
+  return this->postCreateRegister(primAssetAttributes, registerTemplate);
 }  // AssetAttributesManager::createAttributesTemplate
 
 int AssetAttributesManager::registerAttributesTemplateFinalize(
@@ -134,8 +129,7 @@ int AssetAttributesManager::registerAttributesTemplateFinalize(
   // verify that attributes has been edited in a legal manner
   if (!primAttributesTemplate->isValidTemplate()) {
     LOG(ERROR) << "AssetAttributesManager::registerAttributesTemplateFinalize "
-                  ": Primitive "
-                  "asset attributes template named"
+                  ": Primitive asset attributes template named"
                << primAttributesHandle
                << "is not configured properly for specified prmitive"
                << primAttributesTemplate->getPrimObjClassName()

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -146,15 +146,15 @@ class AssetAttributesManager
   AbstractPrimitiveAttributes::ptr createAttributesTemplate(
       PrimObjTypes primObjType,
       bool registerTemplate = true) {
-    auto primAssetAttributes = buildPrimAttributes(primObjType);
-    if (nullptr != primAssetAttributes && registerTemplate) {
-      int attrID = this->registerAttributesTemplate(primAssetAttributes, "");
-      if (attrID == ID_UNDEFINED) {
-        // some error occurred
-        return nullptr;
-      }
+    if (primObjType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
+      LOG(ERROR)
+          << "AssetAttributesManager::createAttributesTemplate : Illegal "
+             "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
+             "Aborting.";
+      return nullptr;
     }
-    return primAssetAttributes;
+    return createAttributesTemplate(PrimitiveNames3DMap.at(primObjType),
+                                    registerTemplate);
   }  // AssetAttributesManager::createAttributesTemplate
 
   /**
@@ -378,6 +378,15 @@ class AssetAttributesManager
 
  protected:
   /**
+   * @brief Not used by AbstractPrimitiveAttributes.
+   */
+  void setDefaultFileNameBasedAttributes(
+      CORRADE_UNUSED AbstractPrimitiveAttributes::ptr attributes,
+      CORRADE_UNUSED bool setFrame,
+      CORRADE_UNUSED const std::string& meshHandle,
+      CORRADE_UNUSED std::function<void(int)> meshTypeSetter) override {}
+
+  /**
    * @brief This method will perform any necessary updating that is
    * attributesManager-specific upon template removal, such as removing a
    * specific template handle from the list of file-based template handles in
@@ -470,40 +479,6 @@ class AssetAttributesManager
   }  // AssetAttributeManager::buildPrimAttributes
 
   /**
-   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
-   * with passed enum value, which maps to class name via @ref
-   * PrimitiveNames3DMap
-   */
-  AbstractPrimitiveAttributes::ptr buildPrimAttributes(PrimObjTypes primType) {
-    if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : Illegal "
-                    "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
-                    "Aborting.";
-      return nullptr;
-    }
-    return initNewAttribsInternal(
-        (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(primType)])());
-  }  // AssetAttributeManager::buildPrimAttributes
-
-  /**
-   * @brief Build an @ref AbstractPrimtiveAttributes object of type associated
-   * with passed enum value, which maps to class name via @ref
-   * PrimitiveNames3DMap
-   */
-  AbstractPrimitiveAttributes::ptr buildPrimAttributes(int primTypeVal) {
-    if ((primTypeVal < 0) ||
-        (primTypeVal > static_cast<int>(PrimObjTypes::END_PRIM_OBJ_TYPES))) {
-      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : Unknown "
-                    "PrimObjTypes value requested :"
-                 << primTypeVal << ". Aborting";
-      return nullptr;
-    }
-    return initNewAttribsInternal(
-        (*this.*primTypeConstructorMap_[PrimitiveNames3DMap.at(
-                    static_cast<PrimObjTypes>(primTypeVal))])());
-  }  // AssetAttributeManager::buildPrimAttributes
-
-  /**
    * @brief Build a shared pointer to the appropriate attributes for passed
    * object type as defined in @ref PrimObjTypes, where each entry except @ref
    * END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
@@ -579,7 +554,7 @@ class AssetAttributesManager
  public:
   ESP_SMART_POINTERS(AssetAttributesManager)
 
-};  // AssetAttributesManager
+};  // namespace managers
 }  // namespace managers
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -554,7 +554,7 @@ class AssetAttributesManager
  public:
   ESP_SMART_POINTERS(AssetAttributesManager)
 
-};  // namespace managers
+};  // AssetAttributesManager
 }  // namespace managers
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -434,7 +434,71 @@ class AttributesManager {
   AttribsPtr createPhysicsAttributesFromJson(const std::string& filename,
                                              const io::JsonDocument& jsonDoc);
 
+  /**
+   * @brief Only used by @ref AbstractPhysicsAttributes derived-attributes. Set
+   * the asset type and mesh asset filename from json file. If mesh asset
+   * filename has changed in json, but type has not been specified in json,
+   * re-run file-path-driven configuration to get asset type and possibly
+   * orientation frame, if appropriate.
+   *
+   * @param attributes The AbstractPhysicsAttributes object to be populated
+   * @param jsonDoc The json document
+   * @param jsonMeshTypeTag The string tag denoting the desired mesh type in the
+   * json.
+   * @param jsonMeshHandleTag The string for the mesh asset handle.
+   * @param fileName [in/out] On entry this is old mesh file handle, on exit is
+   * new mesh file handle, or empty.
+   * @param meshTypeSetter Function pointer to the appropriate mesh type setter
+   * in the Attributes object.
+   * @return Whether the render asset name was specified in the json and should
+   * be set from fileName variable.
+   */
+  bool setJSONAssetHandleAndType(AttribsPtr attributes,
+                                 const io::JsonDocument& jsonDoc,
+                                 const char* jsonMeshTypeTag,
+                                 const char* jsonMeshHandleTag,
+                                 std::string& fileName,
+                                 std::function<void(int)> meshTypeSetter);
+
   //======== Internally accessed functions ========
+  /**
+   * @brief Perform post creation registration if specified.
+   *
+   * @param attributes Attributes template
+   * @param registerTemplate If template should be registered
+   * @return attributes template, or null ptr if registration failed.
+   */
+  inline AttribsPtr postCreateRegister(AttribsPtr attributes,
+                                       bool registerTemplate) {
+    if (!registerTemplate) {
+      return attributes;
+    }
+    int attrID =
+        registerAttributesTemplate(attributes, attributes->getHandle());
+    // return nullptr if registration error occurs.
+    return (attrID == ID_UNDEFINED) ? nullptr : attributes;
+  }  // postCreateRegister
+
+  /**
+   * @brief Perform file-name-based attributes initialization. This is to
+   * take the place of the AssetInfo::fromPath functionality, and is only
+   * intended to provide default values and other help if certain mistakes
+   * are made by the user, such as specifying an asset handle in json but not
+   * specifying the asset type corresponding to that handle.  These settings
+   * should not restrict anything, only provide defaults.
+   *
+   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param setFrame whether the frame should be set or not (only for render
+   * assets in scenes)
+   * @param fileName Mesh Handle to check.
+   * @param meshTypeSetter Setter for mesh type.
+   */
+  virtual void setDefaultFileNameBasedAttributes(
+      AttribsPtr attributes,
+      bool setFrame,
+      const std::string& fileName,
+      std::function<void(int)> meshTypeSetter) = 0;
+
   /**
    * @brief Get directory component of attributes handle and call @ref
    * attributes->setFileDirectory legitimate directory exists in handle.
@@ -750,17 +814,27 @@ AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
       std::bind(&AbstractPhysicsAttributes::setOrientFront, attributes, _1));
 
   // 4. parse render and collision mesh filepaths
-  std::string propertiesFileDirectory = attributes->getFileDirectory();
   std::string rndrFName = "";
-  std::string colFName = "";
-  if (io::jsonIntoVal<std::string>(jsonDoc, "render mesh", rndrFName)) {
-    rndrFName =
-        Cr::Utility::Directory::join(propertiesFileDirectory, rndrFName);
+  std::string rTmpFName = attributes->getRenderAssetHandle();
+  if (setJSONAssetHandleAndType(
+          attributes, jsonDoc, "render mesh type", "render mesh", rTmpFName,
+          std::bind(&AbstractPhysicsAttributes::setRenderAssetType, attributes,
+                    _1))) {
+    rndrFName = rTmpFName;
   }
 
-  if (io::jsonIntoVal<std::string>(jsonDoc, "collision mesh", colFName)) {
-    colFName = Cr::Utility::Directory::join(propertiesFileDirectory, colFName);
-  }
+  std::string colFName = "";
+  std::string cTmpFName = attributes->getCollisionAssetHandle();
+  if (setJSONAssetHandleAndType(
+          attributes, jsonDoc, "collision mesh type", "collision mesh",
+          cTmpFName,
+          std::bind(&AbstractPhysicsAttributes::setCollisionAssetType,
+                    attributes, _1))) {
+    colFName = cTmpFName;
+    // TODO eventually remove this, but currently collision mesh must be UNKNOWN
+    attributes->setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
+  };
+  // TODO for now force collision mesh types to be
 
   // use non-empty result if either result is empty
   attributes->setRenderAssetHandle(rndrFName.compare("") == 0 ? colFName
@@ -771,6 +845,62 @@ AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
 
   return attributes;
 }  // AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson
+
+template <class T>
+bool AttributesManager<T>::setJSONAssetHandleAndType(
+    T attributes,
+    const io::JsonDocument& jsonDoc,
+    const char* jsonMeshTypeTag,
+    const char* jsonMeshHandleTag,
+    std::string& fileName,
+    std::function<void(int)> meshTypeSetter) {
+  std::string propertiesFileDirectory = attributes->getFileDirectory();
+  // save current file name
+  const std::string oldFName(fileName);
+  // clear var to get new value
+  fileName = "";
+  // Map a json string value to its corresponding AssetType if found and cast to
+  // int, based on @ref AbstractPhysicsAttributes::AssetTypeNamesMap mappings.
+  // Casts an int of the @ref esp::AssetType enum value if found and understood,
+  // 0 (AssetType::UNKNOWN) if found but not understood, and
+  //-1 if tag is not found in json.
+  int typeVal = -1;
+  std::string tmpVal = "";
+  if (io::jsonIntoVal<std::string>(jsonDoc, jsonMeshTypeTag, tmpVal)) {
+    // tag was found, perform check
+    std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
+    if (AbstractPhysicsAttributes::AssetTypeNamesMap.count(tmpVal)) {
+      typeVal = static_cast<int>(
+          AbstractPhysicsAttributes::AssetTypeNamesMap.at(tmpVal));
+    } else {
+      LOG(WARNING) << "AttributesManager::convertJsonStringToAssetType : "
+                      "Value in json @ tag : "
+                   << jsonMeshTypeTag << " : `" << tmpVal
+                   << "` does not map to a valid "
+                      "AbstractPhysicsAttributes::AssetTypeNamesMap value, so "
+                      "defaulting mesh type to AssetType::UNKNOWN.";
+      typeVal = static_cast<int>(AssetType::UNKNOWN);
+    }
+    // value found so override current value, otherwise do not.
+    meshTypeSetter(typeVal);
+  }  // if type is found in json.  If not typeVal is -1
+
+  // Read json for new mesh handle
+  if (io::jsonIntoVal<std::string>(jsonDoc, jsonMeshHandleTag, fileName)) {
+    // value has changed
+    fileName = Cr::Utility::Directory::join(propertiesFileDirectory, fileName);
+    if ((typeVal == -1) && (oldFName.compare(fileName) != 0)) {
+      std::string strToFind(jsonMeshTypeTag);
+      // if file name is different, and type val has not been specified, perform
+      // name-specific mesh type config
+      // do not override orientation - should be specified in json.
+      setDefaultFileNameBasedAttributes(attributes, false, fileName,
+                                        meshTypeSetter);
+    }
+    return true;
+  }
+  return false;
+}  // AttributesManager<AttribsPtr>::setAssetHandleAndType
 
 template <class T>
 T AttributesManager<T>::removeTemplateInternal(

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -101,6 +101,11 @@ class AttributesManager {
   int registerAttributesTemplate(
       AttribsPtr attributesTemplate,
       const std::string& attributesTemplateHandle = "") {
+    if (nullptr == attributesTemplate) {
+      LOG(ERROR) << "AttributesManager::registerAttributesTemplate : Invalid "
+                    "(null) template passed to registration. Aborting.";
+      return ID_UNDEFINED;
+    }
     if ("" != attributesTemplateHandle) {
       return registerAttributesTemplateFinalize(attributesTemplate,
                                                 attributesTemplateHandle);

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -838,8 +838,7 @@ AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
     colFName = cTmpFName;
     // TODO eventually remove this, but currently collision mesh must be UNKNOWN
     attributes->setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
-  };
-  // TODO for now force collision mesh types to be
+  }
 
   // use non-empty result if either result is empty
   attributes->setRenderAssetHandle(rndrFName.compare("") == 0 ? colFName

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -237,6 +237,26 @@ class ObjectAttributesManager
 
  protected:
   /**
+   * @brief Perform file-name-based attributes initialization. This is to
+   * take the place of the AssetInfo::fromPath functionality, and is only
+   * intended to provide default values and other help if certain mistakes
+   * are made by the user, such as specifying an asset handle in json but not
+   * specifying the asset type corresponding to that handle.  These settings
+   * should not restrict anything, only provide defaults.
+   *
+   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param setFrame whether the frame should be set or not (only for render
+   * assets in scenes)
+   * @param fileName Mesh Handle to check.
+   * @param meshTypeSetter Setter for mesh type.
+   */
+  void setDefaultFileNameBasedAttributes(
+      PhysicsObjectAttributes::ptr attributes,
+      bool setFrame,
+      const std::string& meshHandle,
+      std::function<void(int)> meshTypeSetter) override;
+
+  /**
    * @brief Used Internally.  Configure newly-created attributes with any
    * default values, before any specific values are set.
    *

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -48,15 +48,7 @@ PhysicsAttributesManager::createDefaultAttributesTemplate(
   PhysicsManagerAttributes::ptr physicsManagerAttributes =
       initNewAttribsInternal(PhysicsManagerAttributes::create(physicsFilename));
 
-  if (registerTemplate) {
-    int attrID = this->registerAttributesTemplate(physicsManagerAttributes,
-                                                  physicsFilename);
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
-  }
-  return physicsManagerAttributes;
+  return this->postCreateRegister(physicsManagerAttributes, registerTemplate);
 }  // PhysicsAttributesManager::createDefaultAttributesTemplate
 
 PhysicsManagerAttributes::ptr
@@ -130,16 +122,7 @@ PhysicsAttributesManager::createFileBasedAttributesTemplate(
     }
   }  // if load rigid object library metadata
 
-  if (registerTemplate) {
-    int attrID = this->registerAttributesTemplate(physicsManagerAttributes,
-                                                  physicsFilename);
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
-  }
-
-  return physicsManagerAttributes;
+  return this->postCreateRegister(physicsManagerAttributes, registerTemplate);
 }  // PhysicsAttributesManager::createFileBasedAttributesTemplate
 
 }  // namespace managers

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -90,6 +90,15 @@ class PhysicsAttributesManager
 
  protected:
   /**
+   * @brief Not used by PhysicsManagerAttributes.
+   */
+  void setDefaultFileNameBasedAttributes(
+      CORRADE_UNUSED PhysicsManagerAttributes::ptr attributes,
+      CORRADE_UNUSED bool setFrame,
+      CORRADE_UNUSED const std::string& meshHandle,
+      CORRADE_UNUSED std::function<void(int)> meshTypeSetter) override {}
+
+  /**
    * @brief Used Internally.  Configure newly-created attributes with any
    * default values, before any specific values are set.
    *

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -18,15 +18,6 @@ namespace assets {
 
 namespace managers {
 
-const std::map<std::string, esp::assets::AssetType>
-    SceneAttributesManager::AssetTypeNamesMap = {
-        {"mp3d", AssetType::MP3D_MESH},
-        {"navmesh", AssetType::NAVMESH},
-        {"ptex", AssetType::FRL_PTEX_MESH},
-        {"semantic", AssetType::INSTANCE_MESH},
-        {"suncg", AssetType::SUNCG_SCENE},
-};
-
 SceneAttributesManager::SceneAttributesManager(
     assets::ResourceManager& resourceManager,
     ObjectAttributesManager::ptr objectAttributesMgr,
@@ -210,24 +201,17 @@ SceneAttributesManager::createPrimBasedAttributesTemplate(
   sceneAttributes->setMargin(0.0);
 
   // set render mesh handle
-  sceneAttributes->setRenderAssetHandle(primAssetHandle);
+  int primType = static_cast<int>(AssetType::PRIMITIVE);
+  sceneAttributes->setRenderAssetType(primType);
   // set collision mesh/primitive handle and default for primitives to not use
   // mesh collisions
-  sceneAttributes->setCollisionAssetHandle(primAssetHandle);
+  sceneAttributes->setCollisionAssetType(primType);
   sceneAttributes->setUseMeshCollision(false);
   // NOTE to eventually use mesh collisions with primitive objects, a
   // collision primitive mesh needs to be configured and set in MeshMetaData
   // and CollisionMesh
 
-  if (nullptr != sceneAttributes && registerTemplate) {
-    int attrID =
-        this->registerAttributesTemplate(sceneAttributes, primAssetHandle);
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
-  }
-  return sceneAttributes;
+  return this->postCreateRegister(sceneAttributes, registerTemplate);
 }  // SceneAttributesManager::createPrimBasedAttributesTemplate
 
 PhysicsSceneAttributes::ptr
@@ -238,23 +222,13 @@ SceneAttributesManager::createBackCompatAttributesTemplate(
   PhysicsSceneAttributes::ptr sceneAttributes =
       initNewAttribsInternal(PhysicsSceneAttributes::create(sceneFilename));
 
-  if (registerTemplate) {
-    int attrID =
-        this->registerAttributesTemplate(sceneAttributes, sceneFilename);
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
-  }
-
-  return sceneAttributes;
+  return this->postCreateRegister(sceneAttributes, registerTemplate);
 }  // SceneAttributesManager::createBackCompatAttributesTemplate
 
 PhysicsSceneAttributes::ptr SceneAttributesManager::initNewAttribsInternal(
     PhysicsSceneAttributes::ptr newAttributes) {
   this->setFileDirectoryFromHandle(newAttributes);
 
-  using Corrade::Utility::String::endsWith;
   std::string sceneFilename = newAttributes->getHandle();
 
   // set defaults that config files or other constructive processes might
@@ -279,7 +253,7 @@ PhysicsSceneAttributes::ptr SceneAttributesManager::initNewAttribsInternal(
   if (Corrade::Utility::Directory::exists(navmeshFilename)) {
     newAttributes->setNavmeshAssetHandle(navmeshFilename);
   }
-
+  // Build default semantic descriptor file name
   std::string houseFilename = io::changeExtension(sceneFilename, ".house");
   if (cfgFilepaths_.count("house")) {
     houseFilename = cfgFilepaths_.at("house");
@@ -288,42 +262,29 @@ PhysicsSceneAttributes::ptr SceneAttributesManager::initNewAttribsInternal(
     houseFilename = io::changeExtension(sceneFilename, ".scn");
   }
   newAttributes->setHouseFilename(houseFilename);
-
-  if (Corrade::Utility::Directory::exists(houseFilename)) {
-    const std::string semanticMeshFilename =
-        io::removeExtension(houseFilename) + "_semantic.ply";
-    if (Corrade::Utility::Directory::exists(houseFilename)) {
-      newAttributes->setSemanticAssetHandle(semanticMeshFilename);
-    }
-  }
+  // Build default semantic mesh file name
+  const std::string semanticMeshFilename =
+      io::removeExtension(houseFilename) + "_semantic.ply";
+  newAttributes->setSemanticAssetHandle(semanticMeshFilename);
 
   // set default origin and orientation values based on file name
   // from AssetInfo::fromPath
-  newAttributes->setOrientUp({0, 1, 0});
-  newAttributes->setOrientFront({0, 0, -1});
-  if (endsWith(sceneFilename, "_semantic.ply")) {
-    newAttributes->setRenderAssetType(
-        static_cast<int>(AssetType::INSTANCE_MESH));
-  } else if (endsWith(sceneFilename, "mesh.ply")) {
-    newAttributes->setRenderAssetType(
-        static_cast<int>(AssetType::FRL_PTEX_MESH));
-    newAttributes->setOrientUp({0, 0, 1});
-    newAttributes->setOrientFront({0, 1, 0});
-  } else if (endsWith(sceneFilename, "house.json")) {
-    newAttributes->setRenderAssetType(static_cast<int>(AssetType::SUNCG_SCENE));
-  } else if (endsWith(sceneFilename, ".glb")) {
-    // assumes MP3D glb with gravity = -Z
-    newAttributes->setRenderAssetType(static_cast<int>(AssetType::MP3D_MESH));
-    // Create a coordinate for the mesh by rotating the default ESP
-    // coordinate frame to -Z gravity
-    newAttributes->setOrientUp({0, 0, 1});
-    newAttributes->setOrientFront({0, 1, 0});
-  } else {
-    newAttributes->setRenderAssetType(static_cast<int>(AssetType::UNKNOWN));
-  }
-  newAttributes->setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
-  newAttributes->setSemanticAssetType(
-      static_cast<int>(AssetType::INSTANCE_MESH));
+  // set defaults for passed render asset handles
+  setDefaultFileNameBasedAttributes(
+      newAttributes, true, newAttributes->getRenderAssetHandle(),
+      std::bind(&AbstractPhysicsAttributes::setRenderAssetType, newAttributes,
+                _1));
+  // set defaults for passed collision asset handles
+  setDefaultFileNameBasedAttributes(
+      newAttributes, false, newAttributes->getCollisionAssetHandle(),
+      std::bind(&AbstractPhysicsAttributes::setCollisionAssetType,
+                newAttributes, _1));
+
+  // set defaults for passed semantic asset handles
+  setDefaultFileNameBasedAttributes(
+      newAttributes, false, newAttributes->getSemanticAssetHandle(),
+      std::bind(&PhysicsSceneAttributes::setSemanticAssetType, newAttributes,
+                _1));
 
   // set default physical quantities specified in physics manager attributes
   if (physicsAttributesManager_->getTemplateLibHasHandle(
@@ -338,6 +299,45 @@ PhysicsSceneAttributes::ptr SceneAttributesManager::initNewAttribsInternal(
   }
   return newAttributes;
 }  // SceneAttributesManager::initNewAttribsInternal
+
+void SceneAttributesManager::setDefaultFileNameBasedAttributes(
+    PhysicsSceneAttributes::ptr attributes,
+    bool setFrame,
+    const std::string& fileName,
+    std::function<void(int)> meshTypeSetter) {
+  // TODO : support future mesh-name specific type setting?
+  using Corrade::Utility::String::endsWith;
+
+  Magnum::Vector3 up, up1{0, 1, 0}, up2{0, 0, 1};
+  Magnum::Vector3 fwd, fwd1{0, 0, -1}, fwd2{0, 1, 0};
+
+  // set default origin and orientation values based on file name
+  // from AssetInfo::fromPath
+  up = up1;
+  fwd = fwd1;
+  if (endsWith(fileName, "_semantic.ply")) {
+    meshTypeSetter(static_cast<int>(AssetType::INSTANCE_MESH));
+  } else if (endsWith(fileName, "mesh.ply")) {
+    meshTypeSetter(static_cast<int>(AssetType::FRL_PTEX_MESH));
+    up = up2;
+    fwd = fwd2;
+  } else if (endsWith(fileName, "house.json")) {
+    meshTypeSetter(static_cast<int>(AssetType::SUNCG_SCENE));
+  } else if (endsWith(fileName, ".glb")) {
+    // assumes MP3D glb with gravity = -Z
+    meshTypeSetter(static_cast<int>(AssetType::MP3D_MESH));
+    // Create a coordinate for the mesh by rotating the default ESP
+    // coordinate frame to -Z gravity
+    up = up2;
+    fwd = fwd2;
+  } else {
+    meshTypeSetter(static_cast<int>(AssetType::UNKNOWN));
+  }
+  if (setFrame) {
+    attributes->setOrientUp(up);
+    attributes->setOrientFront(fwd);
+  }
+}  // SceneAttributesManager::setDefaultFileNameBasedAttributes
 
 PhysicsSceneAttributes::ptr
 SceneAttributesManager::createFileBasedAttributesTemplate(
@@ -375,36 +375,36 @@ SceneAttributesManager::createFileBasedAttributesTemplate(
 
   // populate specified semantic file name if specified in json - defaults
   // are overridden only if specified in json.
-  std::string semanticFName = "";
+
   std::string navmeshFName = "";
   std::string houseFName = "";
   std::string lightSetup = "";
-  if (io::jsonIntoVal<std::string>(jsonConfig, "semantic mesh",
-                                   semanticFName)) {
-    semanticFName =
-        Cr::Utility::Directory::join(sceneLocFileDir, semanticFName);
-  }
-  if (semanticFName != "") {
+
+  // populate semantic mesh type if present
+  std::string semanticFName = sceneAttributes->getSemanticAssetHandle();
+  if (this->setJSONAssetHandleAndType(
+          sceneAttributes, jsonConfig, "semantic mesh type", "semantic mesh",
+          semanticFName,
+          std::bind(&PhysicsSceneAttributes::setSemanticAssetType,
+                    sceneAttributes, _1))) {
     // if "semantic mesh" is specified in scene json to non-empty value, set
     // value (override default).
     sceneAttributes->setSemanticAssetHandle(semanticFName);
+    // TODO eventually remove this, but currently semantic mesh must be instance
+    sceneAttributes->setSemanticAssetType(
+        static_cast<int>(AssetType::INSTANCE_MESH));
   }
 
   if (io::jsonIntoVal<std::string>(jsonConfig, "nav mesh", navmeshFName)) {
     navmeshFName = Cr::Utility::Directory::join(sceneLocFileDir, navmeshFName);
-  }
-  if (navmeshFName != "") {
-    // if "nav mesh" is specified in scene json to non-empty value, set value
-    // (override default).
+    // if "nav mesh" is specified in scene json set value (override default).
     sceneAttributes->setNavmeshAssetHandle(navmeshFName);
   }
 
   if (io::jsonIntoVal<std::string>(jsonConfig, "house filename", houseFName)) {
     houseFName = Cr::Utility::Directory::join(sceneLocFileDir, houseFName);
-  }
-  if (houseFName != "") {
-    // if "house filename" is specified in scene json to non-empty value, set
-    // value (override default).
+    // if "house filename" is specified in scene json, set value (override
+    // default).
     sceneAttributes->setHouseFilename(houseFName);
   }
 
@@ -414,52 +414,8 @@ SceneAttributesManager::createFileBasedAttributesTemplate(
     sceneAttributes->setLightSetup(lightSetup);
   }
 
-  // populate mesh types if present
-  int val = convertJsonStringToAssetType(jsonConfig, "render mesh type");
-  if (val != -1) {  // if not found do not override current value
-    sceneAttributes->setRenderAssetType(val);
-  }
-  val = convertJsonStringToAssetType(jsonConfig, "collision mesh type");
-  if (val != -1) {  // if not found do not override current value
-    sceneAttributes->setCollisionAssetType(val);
-  }
-  val = convertJsonStringToAssetType(jsonConfig, "semantic mesh type type");
-  if (val != -1) {  // if not found do not override current value
-    sceneAttributes->setSemanticAssetType(val);
-  }
-
-  if (registerTemplate) {
-    int attrID =
-        this->registerAttributesTemplate(sceneAttributes, sceneFilename);
-    if (attrID == ID_UNDEFINED) {
-      // some error occurred
-      return nullptr;
-    }
-  }
-
-  return sceneAttributes;
+  return this->postCreateRegister(sceneAttributes, registerTemplate);
 }  // SceneAttributesManager::createBackCompatAttributesTemplate
-
-int SceneAttributesManager::convertJsonStringToAssetType(
-    io::JsonDocument& jsonDoc,
-    const char* jsonTag) {
-  std::string tmpVal = "";
-  io::jsonIntoVal<std::string>(jsonDoc, jsonTag, tmpVal);
-  if (tmpVal.length() != 0) {
-    std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
-    if (AssetTypeNamesMap.count(tmpVal)) {
-      return static_cast<int>(AssetTypeNamesMap.at(tmpVal));
-    } else {
-      LOG(WARNING) << "SceneAttributesManager::convertJsonStringToAssetType : "
-                      "Value in json : "
-                   << tmpVal
-                   << " does not map to a valid AssetType value, so defaulting "
-                      "to AssetType::UNKNOWN.";
-      return static_cast<int>(AssetType::UNKNOWN);
-    }
-  }
-  return -1;
-}  // SceneAttributesManager::convertJsonStringToAssetType
 
 }  // namespace managers
 }  // namespace assets

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -18,13 +18,6 @@ namespace managers {
 class SceneAttributesManager
     : public AttributesManager<PhysicsSceneAttributes::ptr> {
  public:
-  /**
-   * @brief Constant Map holding names of all Magnum 3D primitive classes
-   * supported, keyed by @ref PrimObjTypes enum entry. Note final entry is not
-   * a valid primitive.
-   */
-  static const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
-
   SceneAttributesManager(
       assets::ResourceManager& resourceManager,
       ObjectAttributesManager::ptr objectAttributesMgr,
@@ -124,6 +117,25 @@ class SceneAttributesManager
 
  protected:
   /**
+   * @brief Perform file-name-based attributes initialization. This is to
+   * take the place of the AssetInfo::fromPath functionality, and is only
+   * intended to provide default values and other help if certain mistakes
+   * are made by the user, such as specifying an asset handle in json but not
+   * specifying the asset type corresponding to that handle.  These settings
+   * should not restrict anything, only provide defaults.
+   *
+   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param setFrame whether the frame should be set or not (only for render
+   * assets in scenes)
+   * @param fileName Mesh Handle to check.
+   * @param meshTypeSetter Setter for mesh type.
+   */
+  void setDefaultFileNameBasedAttributes(
+      PhysicsSceneAttributes::ptr attributes,
+      bool setFrame,
+      const std::string& meshHandle,
+      std::function<void(int)> meshTypeSetter) override;
+  /**
    * @brief Used Internally.  Configure newly-created attributes with any
    * default values, before any specific values are set.
    *
@@ -170,20 +182,6 @@ class SceneAttributesManager
   PhysicsSceneAttributes::ptr createFileBasedAttributesTemplate(
       const std::string& sceneFilename,
       bool registerTemplate = true);
-
-  /**
-   * @brief Convert a json string value to its corresponding AssetType, cast to
-   * int, based on mappings in @ref SceneAttributesManager::AssetTypeNamesMap.
-   * Returns an int cast of the @ref esp::AssetType enum value if found and
-   * understood, 0 (AssetType::UNKNOWN) if found but not understood, and -1 if
-   * tag is not found in json.
-   *
-   * @param jsonDoc json document to query
-   * @param jsonTag the tag containing the data
-   * @return the appropriate value.
-   */
-  int convertJsonStringToAssetType(io::JsonDocument& jsonDoc,
-                                   const char* jsonTag);
 
   /**
    * @brief Add a @ref std::shared_ptr<attributesType> object to the

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -896,7 +896,7 @@ class PhysicsManager {
    * @return The raycast results sorted by distance.
    */
   virtual RaycastResults castRay(const esp::geo::Ray& ray,
-                                 double maxDistance = 100.0) {
+                                 CORRADE_UNUSED double maxDistance = 100.0) {
     RaycastResults results;
     results.ray = ray;
     return results;


### PR DESCRIPTION
Reading json handles and json meshtypes improved -if a mesh handle is changed in json, but no mesh type is specified, rudimentary mesh type setting is performed; Unused methods are removed;

## Motivation and Context
Possibility of changing mesh handle to different type of mesh in json, without specifying new type.  This puts hooks into process that allows for semi-intelligent mesh type setting if needed.  Also a few methods have been removed that were not being used from attributes handlers.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests have passed.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
