### PR TITLE
RenderCamera::unproject and Simulator::castRay via Bullet physics

### DIFF
--- a/habitat_sim/geo.py
+++ b/habitat_sim/geo.py
@@ -2,7 +2,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from habitat_sim._ext.habitat_sim_bindings import OBB, BBox
+from habitat_sim._ext.habitat_sim_bindings import OBB, BBox, Ray
 from habitat_sim._ext.habitat_sim_bindings.geo import (
     BACK,
     FRONT,
@@ -25,4 +25,5 @@ __all__ = [
     "RIGHT",
     "compute_gravity_aligned_MOBB",
     "get_transformed_bb",
+    "Ray",
 ]

--- a/habitat_sim/physics.py
+++ b/habitat_sim/physics.py
@@ -2,6 +2,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from habitat_sim._ext.habitat_sim_bindings import MotionType, VelocityControl
+from habitat_sim._ext.habitat_sim_bindings import (
+    MotionType,
+    PhysicsSimulationLibrary,
+    RaycastResults,
+    RayHitInfo,
+    VelocityControl,
+)
 
-__all__ = ["MotionType", "VelocityControl"]
+__all__ = [
+    "PhysicsSimulationLibrary",
+    "MotionType",
+    "VelocityControl",
+    "RayHitInfo",
+    "RaycastResults",
+]

--- a/src/esp/bindings/GeoBindings.cpp
+++ b/src/esp/bindings/GeoBindings.cpp
@@ -44,6 +44,13 @@ void initGeoBindings(py::module& m) {
 
   geo.def("compute_gravity_aligned_MOBB", &geo::computeGravityAlignedMOBB);
   geo.def("get_transformed_bb", &geo::getTransformedBB, "range"_a, "xform"_a);
+
+  // ==== Ray ====
+  py::class_<Ray>(m, "Ray")
+      .def(py::init<Magnum::Vector3, Magnum::Vector3>())
+      .def(py::init<>())
+      .def_readwrite("origin", &Ray::origin)
+      .def_readwrite("direction", &Ray::direction);
 }
 
 }  // namespace geo

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -60,6 +60,10 @@ void initGfxBindings(py::module& m) {
         Set this `Camera`'s projection matrix.
       )",
            "width"_a, "height"_a, "znear"_a, "zfar"_a, "hfov"_a)
+      .def(
+          "unproject", &RenderCamera::unproject,
+          R"(Unproject a 2D viewport point to a 3D ray with its origin at the camera position.)",
+          "viewport_point"_a)
       .def_property_readonly("node", nodeGetter<RenderCamera>,
                              "Node this object is attached to")
       .def_property_readonly("object", nodeGetter<RenderCamera>,

--- a/src/esp/bindings/PhysicsBindings.cpp
+++ b/src/esp/bindings/PhysicsBindings.cpp
@@ -9,6 +9,12 @@ namespace esp {
 namespace physics {
 
 void initPhysicsBindings(py::module& m) {
+  // ==== enum object PhysicsSimulationLibrary ====
+  py::enum_<PhysicsManager::PhysicsSimulationLibrary>(
+      m, "PhysicsSimulationLibrary")
+      .value("NONE", PhysicsManager::PhysicsSimulationLibrary::NONE)
+      .value("BULLET", PhysicsManager::PhysicsSimulationLibrary::BULLET);
+
   // ==== enum object MotionType ====
   py::enum_<MotionType>(m, "MotionType")
       .value("ERROR_MOTIONTYPE", MotionType::ERROR_MOTIONTYPE)
@@ -27,6 +33,21 @@ void initPhysicsBindings(py::module& m) {
       .def_readwrite("ang_vel_is_local", &VelocityControl::angVelIsLocal)
       .def("integrate_transform", &VelocityControl::integrateTransform, "dt"_a,
            "rigid_state"_a);
+
+  // ==== struct object RayHitInfo ====
+  py::class_<RayHitInfo, RayHitInfo::ptr>(m, "RayHitInfo")
+      .def(py::init(&RayHitInfo::create<>))
+      .def_readonly("object_id", &RayHitInfo::objectId)
+      .def_readonly("point", &RayHitInfo::point)
+      .def_readonly("normal", &RayHitInfo::normal)
+      .def_readonly("ray_distance", &RayHitInfo::rayDistance);
+
+  // ==== struct object RaycastResults ====
+  py::class_<RaycastResults, RaycastResults::ptr>(m, "RaycastResults")
+      .def(py::init(&RaycastResults::create<>))
+      .def_readonly("hits", &RaycastResults::hits)
+      .def_readonly("ray", &RaycastResults::ray)
+      .def("has_hits", &RaycastResults::hasHits);
 }
 
 }  // namespace physics

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -95,6 +95,8 @@ void initSimBindings(py::module& m) {
       .def("get_scene_template_manager", &Simulator::getSceneAttributesManager,
            pybind11::return_value_policy::reference)
 
+      .def("get_physics_simulation_library",
+           &Simulator::getPhysicsSimulationLibrary)
       /* --- Object instancing and access --- */
       .def("add_object", &Simulator::addObject, "object_lib_index"_a,
            "attachment_node"_a = nullptr,
@@ -158,6 +160,8 @@ void initSimBindings(py::module& m) {
       .def("apply_torque", &Simulator::applyTorque, "torque"_a, "object_id"_a,
            "scene_id"_a = 0)
       .def("contact_test", &Simulator::contactTest, "object_id"_a,
+           "scene_id"_a = 0)
+      .def("cast_ray", &Simulator::castRay, "ray"_a, "max_distance"_a = 100.0,
            "scene_id"_a = 0)
       .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
            "object_id"_a, "scene_id"_a = 0)

--- a/src/esp/geo/geo.h
+++ b/src/esp/geo/geo.h
@@ -10,6 +10,7 @@
 
 #include <Magnum/Math/Range.h>
 #include "esp/gfx/magnum.h"
+namespace Mn = Magnum;
 
 namespace esp {
 namespace geo {
@@ -43,6 +44,20 @@ template <typename T>
 T clamp(const T& n, const T& low, const T& high) {
   return std::max(low, std::min(n, high));
 }
+
+//! A simple 3D ray defined by an origin point and direction (not necessarily
+//! unit length)
+struct Ray {
+  Mn::Vector3 origin;
+  Mn::Vector3 direction;
+
+  Ray(){};
+
+  Ray(Mn::Vector3 _origin, Mn::Vector3 _direction)
+      : origin(_origin), direction(_direction){};
+
+  ESP_SMART_POINTERS(Ray)
+};
 
 }  // namespace geo
 }  // namespace esp

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -158,11 +158,6 @@ uint32_t RenderCamera::draw(MagnumDrawableGroup& drawables, Flags flags) {
 esp::geo::Ray RenderCamera::unproject(const Mn::Vector2i& viewportPosition) {
   esp::geo::Ray ray;
   ray.origin = object().absoluteTranslation();
-  if (viewportPosition.min() < 0 || (viewport() - viewportPosition).min() < 0) {
-    LOG(WARNING) << "RenderCamera::unproject : viewportPosition outside of "
-                    "viewport, aborting.";
-    return ray;  // ray with 0 direction
-  }
 
   const Magnum::Vector2i viewPos{viewportPosition.x(),
                                  viewport().y() - viewportPosition.y() - 1};

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -7,6 +7,7 @@
 #include "magnum.h"
 
 #include "esp/core/esp.h"
+#include "esp/geo/geo.h"
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -93,6 +94,17 @@ class RenderCamera : public MagnumCamera {
       std::vector<
           std::pair<std::reference_wrapper<Magnum::SceneGraph::Drawable3D>,
                     Magnum::Matrix4>>& drawableTransforms);
+
+  /**
+   * @brief Unproject a 2D viewport point to a 3D ray with origin at camera
+   * position.
+   *
+   * @param viewportPosition The 2D point on the viewport to unproject
+   * ([0,width], [0,height]).
+   * @return a @ref esp::geo::Ray with unit length direction or zero direction
+   * if failed.
+   */
+  esp::geo::Ray unproject(const Mn::Vector2i& viewportPosition);
 
  protected:
   ESP_SMART_POINTERS(RenderCamera)

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -170,7 +170,7 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
 bool PhysicsManager::makeAndAddRigidObject(int newObjectID,
                                            const std::string& handle,
                                            scene::SceneNode* objectNode) {
-  auto ptr = physics::RigidObject::create_unique(objectNode);
+  auto ptr = physics::RigidObject::create_unique(objectNode, newObjectID);
   bool objSuccess = ptr->initialize(resourceManager_, handle);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -34,6 +34,38 @@ namespace esp {
 //! core physics simulation namespace
 namespace physics {
 
+//! Holds information about one ray hit instance.
+struct RayHitInfo {
+  //! The id of the object hit by this ray. Scene hits are -1.
+  int objectId;
+  //! The first impact point of the ray in world space.
+  Magnum::Vector3 point;
+  //! The collision object normal at the point of impact.
+  Magnum::Vector3 normal;
+  //! Distance along the ray direction from the ray origin (in units of ray
+  //! length).
+  double rayDistance;
+
+  ESP_SMART_POINTERS(RayHitInfo)
+};
+
+//! Holds information about all ray hit instances from a ray cast.
+struct RaycastResults {
+  std::vector<RayHitInfo> hits;
+  esp::geo::Ray ray;
+
+  bool hasHits() { return hits.size() > 0; }
+
+  void sortByDistance() {
+    std::sort(hits.begin(), hits.end(),
+              [](const RayHitInfo& A, const RayHitInfo& B) {
+                return A.rayDistance < B.rayDistance;
+              });
+  }
+
+  ESP_SMART_POINTERS(RaycastResults)
+};
+
 // TODO: repurpose to manage multiple physical worlds. Currently represents
 // exactly one world.
 
@@ -848,6 +880,26 @@ class PhysicsManager {
   assets::PhysicsManagerAttributes::ptr getInitializationAttributes() const {
     return assets::PhysicsManagerAttributes::create(
         *physicsManagerAttributes_.get());
+  }
+
+  /**
+   * @brief Cast a ray into the collision world and return a @ref RaycastResults
+   * with hit information.
+   *
+   * Note: not implemented here in default PhysicsManager as there are no
+   * collision objects without a simulation implementation.
+   *
+   * @param ray The ray to cast. Need not be unit length, but returned hit
+   * distances will be in units of ray length.
+   * @param maxDistance The maximum distance along the ray direction to search.
+   * In units of ray length.
+   * @return The raycast results sorted by distance.
+   */
+  virtual RaycastResults castRay(const esp::geo::Ray& ray,
+                                 double maxDistance = 100.0) {
+    RaycastResults results;
+    results.ray = ray;
+    return results;
   }
 
  protected:

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -628,6 +628,9 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   assets::AbstractPhysicsAttributes::ptr initializationAttributes_ = nullptr;
 
+  //! Access for the object to its own PhysicsManager id. Scene will keep -1.
+  int objectId_ = -1;
+
  public:
   ESP_SMART_POINTERS(RigidBase)
 };  // class RigidBase

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -7,8 +7,10 @@
 namespace esp {
 namespace physics {
 
-RigidObject::RigidObject(scene::SceneNode* rigidBodyNode)
-    : RigidBase(rigidBodyNode), velControl_(VelocityControl::create()) {}
+RigidObject::RigidObject(scene::SceneNode* rigidBodyNode, int objectId)
+    : RigidBase(rigidBodyNode), velControl_(VelocityControl::create()) {
+  objectId_ = objectId;
+}
 
 bool RigidObject::initialize(const assets::ResourceManager& resMgr,
                              const std::string& handle) {

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -96,7 +96,7 @@ class RigidObject : public RigidBase {
    * @param rigidBodyNode The @ref scene::SceneNode this feature will be
    * attached to.
    */
-  RigidObject(scene::SceneNode* rigidBodyNode);
+  RigidObject(scene::SceneNode* rigidBodyNode, int objectId);
 
   /**
    * @brief Virtual destructor for a @ref RigidObject.

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -63,8 +63,10 @@ struct SimulationContactResultCallback
 
 class BulletBase {
  public:
-  BulletBase(std::shared_ptr<btMultiBodyDynamicsWorld> bWorld)
-      : bWorld_(bWorld) {}
+  BulletBase(std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
+             std::shared_ptr<std::map<const btCollisionObject*, int>>
+                 collisionObjToObjIds)
+      : bWorld_(bWorld), collisionObjToObjIds_(collisionObjToObjIds) {}
 
   /**
    * @brief Destructor cleans up simulation structures for the object.
@@ -100,6 +102,11 @@ class BulletBase {
    * are stored here.
    */
   std::vector<std::unique_ptr<btCollisionObject>> bStaticCollisionObjects_;
+
+  //! keep a map of collision objects to object ids for quick lookups from
+  //! Bullet collision checking.
+  std::shared_ptr<std::map<const btCollisionObject*, int>>
+      collisionObjToObjIds_;
 
  public:
   ESP_SMART_POINTERS(BulletBase)

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -51,7 +51,10 @@ class BulletPhysicsManager : public PhysicsManager {
   explicit BulletPhysicsManager(
       assets::ResourceManager& _resourceManager,
       const assets::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
-      : PhysicsManager(_resourceManager, _physicsManagerAttributes){};
+      : PhysicsManager(_resourceManager, _physicsManagerAttributes) {
+    collisionObjToObjIds_ =
+        std::make_shared<std::map<const btCollisionObject*, int>>();
+  };
 
   /** @brief Destructor which destructs necessary Bullet physics structures.*/
   virtual ~BulletPhysicsManager();
@@ -166,6 +169,19 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   bool contactTest(const int physObjectID) override;
 
+  /**
+   * @brief Cast a ray into the collision world and return a @ref RaycastResults
+   * with hit information.
+   *
+   * @param ray The ray to cast. Need not be unit length, but returned hit
+   * distances will be in units of ray length.
+   * @param maxDistance The maximum distance along the ray direction to search.
+   * In units of ray length.
+   * @return The raycast results sorted by distance.
+   */
+  virtual RaycastResults castRay(const esp::geo::Ray& ray,
+                                 double maxDistance = 100.0) override;
+
  protected:
   //============ Initialization =============
   /**
@@ -210,6 +226,11 @@ class BulletPhysicsManager : public PhysicsManager {
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
   mutable Magnum::BulletIntegration::DebugDraw debugDrawer_;
+
+  //! keep a map of collision objects to object ids for quick lookups from
+  //! Bullet collision checking.
+  std::shared_ptr<std::map<const btCollisionObject*, int>>
+      collisionObjToObjIds_;
 
  private:
   /** @brief Check if a particular mesh can be used as a collision mesh for

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -44,7 +44,10 @@ class BulletRigidObject : public BulletBase,
    * attached to.
    */
   BulletRigidObject(scene::SceneNode* rigidBodyNode,
-                    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld);
+                    int objectId,
+                    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
+                    std::shared_ptr<std::map<const btCollisionObject*, int>>
+                        collisionObjToObjIds);
 
   /**
    * @brief Destructor cleans up simulation structures for the object.

--- a/src/esp/physics/bullet/BulletRigidScene.cpp
+++ b/src/esp/physics/bullet/BulletRigidScene.cpp
@@ -17,13 +17,16 @@ namespace physics {
 
 BulletRigidScene::BulletRigidScene(
     scene::SceneNode* rigidBodyNode,
-    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld)
-    : BulletBase(bWorld), RigidScene{rigidBodyNode} {}
+    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
+    std::shared_ptr<std::map<const btCollisionObject*, int> >
+        collisionObjToObjIds)
+    : BulletBase(bWorld, collisionObjToObjIds), RigidScene{rigidBodyNode} {}
 
 BulletRigidScene::~BulletRigidScene() {
   // remove collision objects from the world
   for (auto& co : bStaticCollisionObjects_) {
     bWorld_->removeCollisionObject(co.get());
+    collisionObjToObjIds_->erase(co.get());
   }
 }
 bool BulletRigidScene::initialization_LibSpecific(
@@ -43,6 +46,7 @@ bool BulletRigidScene::initialization_LibSpecific(
     object->setRestitution(
         initializationAttributes_->getRestitutionCoefficient());
     bWorld_->addCollisionObject(object.get());
+    collisionObjToObjIds_->emplace(object.get(), objectId_);
   }
 
   return true;

--- a/src/esp/physics/bullet/BulletRigidScene.h
+++ b/src/esp/physics/bullet/BulletRigidScene.h
@@ -22,7 +22,9 @@ namespace physics {
 class BulletRigidScene : public BulletBase, public RigidScene {
  public:
   BulletRigidScene(scene::SceneNode* rigidBodyNode,
-                   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld);
+                   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
+                   std::shared_ptr<std::map<const btCollisionObject*, int>>
+                       collisionObjToObjIds);
 
   /**
    * @brief Destructor cleans up simulation structures for the object.

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -523,6 +523,15 @@ bool Simulator::contactTest(const int objectID, const int sceneID) {
   return false;
 }
 
+esp::physics::RaycastResults Simulator::castRay(const esp::geo::Ray& ray,
+                                                float maxDistance,
+                                                const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    return physicsManager_->castRay(ray, maxDistance);
+  }
+  return esp::physics::RaycastResults();
+}
+
 void Simulator::setObjectBBDraw(bool drawBB,
                                 const int objectID,
                                 const int sceneID) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -146,6 +146,15 @@ class Simulator {
     return resourceManager_->getSceneAttributesManager();
   }
 
+  /** @brief Return the library implementation type for the simulator currently
+   * in use. Use to check for a particular implementation.
+   * @return The implementation type of this simulator.
+   */
+  const esp::physics::PhysicsManager::PhysicsSimulationLibrary&
+  getPhysicsSimulationLibrary() const {
+    return physicsManager_->getPhysicsSimulationLibrary();
+  };
+
   /**
    * @brief Instance an object from a template index in @ref
    * esp::assets::ResourceManager::physicsObjectLibrary_. See @ref
@@ -482,6 +491,24 @@ class Simulator {
    * enabled objects.
    */
   bool contactTest(const int objectID, const int sceneID = 0);
+
+  /**
+   * @brief Raycast into the collision world of a scene.
+   *
+   * Note: A default @ref physics::PhysicsManager has no collision world, so
+   * physics must be enabled for this feature.
+   *
+   * @param ray The ray to cast. Need not be unit length, but returned hit
+   * distances will be in units of ray length.
+   * @param maxDistance The maximum distance along the ray direction to search.
+   * In units of ray length.
+   * @param sceneID !! Not used currently !! Specifies which physical scene of
+   * the object.
+   * @return Raycast results sorted by distance.
+   */
+  esp::physics::RaycastResults castRay(const esp::geo::Ray& ray,
+                                       float maxDistance = 100.0,
+                                       const int sceneID = 0);
 
   /**
    * @brief the physical world has a notion of time which passes during

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import random
+from os import path as osp
+
+import magnum as mn
+import numpy as np
+import pytest
+import quaternion
+
+import examples.settings
+import habitat_sim.physics
+from habitat_sim.utils.common import (
+    quat_from_angle_axis,
+    quat_from_magnum,
+    quat_to_magnum,
+)
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
+    reason="Requires the habitat-test-scenes",
+)
+def test_unproject(sim):
+    cfg_settings = examples.settings.default_sim_settings.copy()
+
+    # configure some settings in case defaults change
+    cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/apartment_1.glb"
+    cfg_settings["width"] = 101
+    cfg_settings["height"] = 101
+    cfg_settings["sensor_height"] = 0
+    cfg_settings["color_sensor"] = True
+
+    # loading the scene
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim.reconfigure(hab_cfg)
+
+    # position agent
+    sim.agents[0].scene_node.rotation = mn.Quaternion()
+    sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
+
+    # setup camera
+    visual_sensor = sim._sensors["color_sensor"]
+    scene_graph = sim.get_active_scene_graph()
+    scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
+    render_camera = scene_graph.get_default_render_camera()
+
+    # test unproject
+    center_ray = render_camera.unproject(mn.Vector2i(50, 50))  # middle of the viewport
+    assert np.allclose(center_ray.origin, np.array([0.5, 0, 0]), atol=0.07)
+    assert np.allclose(center_ray.direction, np.array([0, 0, -1.0]), atol=0.02)
+
+    test_ray_2 = render_camera.unproject(
+        mn.Vector2i(100, 100)
+    )  # bottom right of the viewport
+    assert np.allclose(
+        test_ray_2.direction, np.array([0.569653, -0.581161, -0.581161]), atol=0.07
+    )

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -342,7 +342,7 @@ def test_velocity_control(sim):
 
 
 @pytest.mark.skipif(
-    not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
+    not osp.exists("data/scene_datasets/habitat-test-scenes/apartment_1.glb"),
     reason="Requires the habitat-test-scenes",
 )
 def test_raycast(sim):

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -350,13 +350,6 @@ def test_raycast(sim):
 
     # configure some settings in case defaults change
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/apartment_1.glb"
-    cfg_settings["width"] = 101
-    cfg_settings["height"] = 101
-    cfg_settings["default_agent"] = 0
-    cfg_settings["sensor_height"] = 0
-    cfg_settings["color_sensor"] = True
-    cfg_settings["semantic_sensor"] = False
-    cfg_settings["depth_sensor"] = False
 
     # enable the physics simulator
     cfg_settings["enable_physics"] = True
@@ -407,49 +400,3 @@ def test_raycast(sim):
         )
         assert abs(raycast_results.hits[0].ray_distance - 2.8935) < 0.001
         assert raycast_results.hits[0].object_id == 0
-
-        # test unprojection here since it is related
-        sim.agents[0].scene_node.rotation = mn.Quaternion()
-        sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
-        visual_sensor = sim._sensors["color_sensor"]
-        scene_graph = sim.get_active_scene_graph()
-        scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
-        render_camera = scene_graph.get_default_render_camera()
-        center_ray = render_camera.unproject(
-            mn.Vector2i(50, 50)
-        )  # middle of the viewport
-        assert np.allclose(center_ray.origin, np.array([0.5, 0, 0]), atol=0.07)
-        assert np.allclose(center_ray.direction, np.array([0, 0, -1.0]), atol=0.02)
-
-        test_bad_ray = render_camera.unproject(mn.Vector2i(-1, -1))  # out of viewport
-        # out of bounds ray returns 0 direction and camera origin
-        assert np.allclose(test_bad_ray.origin, np.array([0.5, 0, 0]), atol=0.07)
-        assert np.allclose(test_bad_ray.direction, np.zeros(3), atol=0.07)
-
-        test_ray_2 = render_camera.unproject(
-            mn.Vector2i(100, 100)
-        )  # bottom right of the viewport
-        assert np.allclose(
-            test_ray_2.direction, np.array([0.569653, -0.581161, -0.581161]), atol=0.07
-        )
-
-        raycast_results = sim.cast_ray(test_ray_2)
-
-        assert raycast_results.has_hits()
-        assert len(raycast_results.hits) == 3
-        # verify sorted
-        for hix, hit in enumerate(raycast_results.hits):
-            if hix > 0:
-                assert hit.ray_distance > raycast_results.hits[hix - 1].ray_distance
-        assert np.allclose(
-            raycast_results.hits[0].point,
-            np.array([1.57961, -1.10142, -1.10142]),
-            atol=0.07,
-        )
-        assert np.allclose(
-            raycast_results.hits[0].normal,
-            np.array([-0.864284, 0.376244, -0.333846]),
-            atol=0.07,
-        )
-        assert abs(raycast_results.hits[0].ray_distance - 1.895) < 0.001
-        assert raycast_results.hits[0].object_id == -1


### PR DESCRIPTION
## Motivation and Context

Several existing use cases (e.g. #717, #699) require ray-casting in the simulation's collision world and viewport to ray un-projection. This PR adds support for these features and includes the following changes:
- `esp::geo::Ray` struct and python bindings
- `RenderCamera::unproject` function for 2D viewport -> 3D Ray
- PhysicsManager API for ray-casting: `castRay` function as well as `RayHitInfo` and `RaycastResults` structs.
- BulletPhysicsManager implementation of ray-casting including map of `btCollisionObjects` to object ids for faster identification of objects hit by rays.

## How Has This Been Tested

New python test: `test_physics.test_raycast`.
and
Demo viewer implementation (**will be removed before merge**):
![unproject_and_raycast_pr](https://user-images.githubusercontent.com/1445143/89480530-7644e600-d74a-11ea-80d4-fac3e70b506d.gif)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
