### PR TITLE
Fix habitat-api + habitat_baselines global install

### DIFF
--- a/examples/colab_utils/colab_install.sh
+++ b/examples/colab_utils/colab_install.sh
@@ -7,11 +7,12 @@ catch() {
 }
 set -e
 shopt -s extglob
+shopt -s globstar
 
 #Checks if in Google Colab and does not run installation if it is not
-python -c 'import google.colab' 2>/dev/null || (echo "Google Colab not detected: skipping installation" >&2  &&  exit)
+python -c 'import google.colab' 2>/dev/null || exit
 #Don't run again if it's already installed
-[ -f /content/habitat_sim_installed ] && exit
+[ -f /content/habitat_sim_installed ] && echo "Habitat is already installed. Aborting..." >&2 && exit
 #Install Miniconda
 cd /content/
 wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -bfp /usr/local
@@ -22,24 +23,26 @@ ln -s /usr/local/lib/python3.6/dist-packages /usr/local/lib/python3.6/site-packa
 ##Install Habitat-Sim and Magnum binaries
 conda config --set default_threads 4 #Enables multithread conda installation
 NIGHTLY="${NIGHTLY:-false}" #setting the ENV $NIGHTLY to true will install the nightly version from conda
-if [ "$NIGHTLY" = true ]; then
-  conda install -y --prefix /usr/local -c aihabitat-nightly -c conda-forge habitat-sim headless withbullet python=3.6
-else
-  conda install -y --prefix /usr/local -c aihabitat -c conda-forge habitat-sim headless withbullet python=3.6
+CHANNEL="${CHANNEL:-aihabitat}"
+if ${NIGHTLY}; then
+  CHANNEL="${CHANNEL}-nightly"
 fi
+conda install -y --prefix /usr/local -c "${CHANNEL}" -c conda-forge habitat-sim headless withbullet python=3.6
 
 #Shallow GIT clone for speed
 git clone https://github.com/facebookresearch/habitat-api --depth 1
 git clone https://github.com/facebookresearch/habitat-sim --depth 1
 
 #Install Requirements.
+source /usr/local/bin/activate #Activate Conda Environment in Bash
 cd /content/habitat-api/
 set +e
-python3.6 -m pip install -r /content/habitat-api/requirements.txt
+pip install -r /content/habitat-api/requirements.txt
 reqs=(/content/habitat-api/habitat_baselines/**/requirements.txt)
-python3.6 -m pip install "${reqs[@]/#/-r}"
-python3.6 setup.py develop --all
+pip install "${reqs[@]/#/-r}"
 set -e
+python setup.py develop --all
+pip install . #Reinstall to trigger sys.path update
 cd /content/habitat-sim/
 rm -rf habitat_sim/ # Deletes the habitat_sim folder so it doesn't interfere with import path
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Fixes the Habitat-API and Habitat_baseline global installs so that they don't need to be added to the colab path.
* Fixes bug with aborting if not in Colab
* Fixes bug that prevented ifcfg from being installed
* Adds stderr message to let it know it's aborting the install script due to prior install
* Refactor nightly build command to be more concise
* Add CHANNEL env variable for changing the install channel
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
In Colab. You can test yourself by changing the colab download URL
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
