### PR TITLE
Added changes supporting renaming of habitat-api to habitat-lab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,8 @@ jobs:
                 git clone -q https://github.com/facebookresearch/habitat-lab.git # --depth 1
               fi
               cd habitat-lab
-              git checkout lab_rename # debug delete
+              git fetch origin
+              git checkout -b "lab_rename" "origin/lab_rename" # debug delete
               pip install -r requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
               then
                 export PATH=$HOME/miniconda/bin:$PATH
                 . activate habitat;
-                git clone -q https://github.com/emscripten-core/emsdk.git ~/emsdk
+                git clone -q --depth 1 https://github.com/emscripten-core/emsdk.git ~/emsdk
                 cd ~/emsdk
                 git checkout 6a4c0f98
                 # Use 1.38.42 that has the following integrated:
@@ -404,7 +404,7 @@ jobs:
               . activate habitat;
               if [ ! -d ./habitat-lab ]
               then
-                git clone -q https://github.com/facebookresearch/habitat-lab.git
+                git clone -q --depth 1 https://github.com/facebookresearch/habitat-lab.git
               fi
               cd habitat-lab
               git checkout lab_rename # debug delete
@@ -498,7 +498,7 @@ jobs:
           no_output_timeout: 30m
           command: |
               # Update website
-              git clone git@github.com:facebookmicrosites/habitat-website.git
+              git clone --depth 1 git@github.com:facebookmicrosites/habitat-website.git
               cd habitat-website
               git submodule update --init
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,9 @@ workflows:
       - cpp_lint
       - js_lint
       - install_and_test_ubuntu
-      - update_docs # need to be removed
+      - update_docs: # need to be removed
+          requires:
+            - install_and_test_ubuntu
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,7 @@ workflows:
       - cpp_lint
       - js_lint
       - install_and_test_ubuntu
+      - update_docs # need to be removed
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
               then
                 export PATH=$HOME/miniconda/bin:$PATH
                 . activate habitat;
-                git clone -q --depth 1 https://github.com/emscripten-core/emsdk.git ~/emsdk
+                git clone -q https://github.com/emscripten-core/emsdk.git ~/emsdk
                 cd ~/emsdk
                 git checkout 6a4c0f98
                 # Use 1.38.42 that has the following integrated:
@@ -404,7 +404,7 @@ jobs:
               . activate habitat;
               if [ ! -d ./habitat-lab ]
               then
-                git clone -q --depth 1 https://github.com/facebookresearch/habitat-lab.git
+                git clone -q https://github.com/facebookresearch/habitat-lab.git # --depth 1
               fi
               cd habitat-lab
               git checkout lab_rename # debug delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,11 +404,9 @@ jobs:
               . activate habitat;
               if [ ! -d ./habitat-lab ]
               then
-                git clone -q https://github.com/facebookresearch/habitat-lab.git # --depth 1
+                git clone -q --depth 1 https://github.com/facebookresearch/habitat-lab.git
               fi
               cd habitat-lab
-              git fetch origin
-              git checkout -b "lab_rename" "origin/lab_rename" # debug delete
               pip install -r requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed
@@ -536,9 +534,6 @@ workflows:
       - cpp_lint
       - js_lint
       - install_and_test_ubuntu
-      - update_docs: # need to be removed
-          requires:
-            - install_and_test_ubuntu
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
           no_output_timeout: 30m
           command: |
               # Update website
-              git clone --depth 1 git@github.com:facebookmicrosites/habitat-website.git
+              git clone git@github.com:facebookmicrosites/habitat-website.git
               cd habitat-website
               git submodule update --init
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ jobs:
           # has 3.5, so once tinyply is removed, we could go lower (well, if
           # anybody actually needs that)
           command: |
-              echo $(git ls-remote https://github.com/facebookresearch/habitat-lab.git HEAD | awk '{ print $1}') > ./hapi_sha
-              cat ./hapi_sha
+              echo $(git ls-remote https://github.com/facebookresearch/habitat-lab.git HEAD | awk '{ print $1}') > ./hablab_sha
+              cat ./hablab_sha
               wget https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh
               sudo mkdir /opt/cmake
               sudo sh ./cmake-3.10.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
@@ -233,7 +233,7 @@ jobs:
               fi
       - restore_cache:
           keys:
-            - habitat-lab-{{ checksum "./hapi_sha" }}
+            - habitat-lab-{{ checksum "./hablab_sha" }}
       - restore_cache:
           keys:
             - ccache-{{ arch }}-master
@@ -398,7 +398,7 @@ jobs:
               git submodule update --init
               ./build-public.sh
       - run:
-          name: Install api
+          name: Install Habitat Lab
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
@@ -416,19 +416,19 @@ jobs:
           paths:
             - ~/miniconda
       - run:
-          name: Run api tests
+          name: Run Habitat Lab tests
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat; cd habitat-lab
               python setup.py develop --all
               python setup.py test
       - save_cache:
-          key: habitat-lab-{{ checksum "./hapi_sha" }}
+          key: habitat-lab-{{ checksum "./hablab_sha" }}
           background: true
           paths:
             - ./habitat-lab
       - run:
-          name: Build api documentation
+          name: Build Habitat Lab documentation
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-lab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,7 @@ jobs:
                 git clone -q https://github.com/facebookresearch/habitat-lab.git
               fi
               cd habitat-lab
+              git checkout lab_rename # debug delete
               pip install -r requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           # has 3.5, so once tinyply is removed, we could go lower (well, if
           # anybody actually needs that)
           command: |
-              echo $(git ls-remote https://github.com/facebookresearch/habitat-api.git HEAD | awk '{ print $1}') > ./hapi_sha
+              echo $(git ls-remote https://github.com/facebookresearch/habitat-lab.git HEAD | awk '{ print $1}') > ./hapi_sha
               cat ./hapi_sha
               wget https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh
               sudo mkdir /opt/cmake
@@ -233,7 +233,7 @@ jobs:
               fi
       - restore_cache:
           keys:
-            - habitat-api-{{ checksum "./hapi_sha" }}
+            - habitat-lab-{{ checksum "./hapi_sha" }}
       - restore_cache:
           keys:
             - ccache-{{ arch }}-master
@@ -402,11 +402,11 @@ jobs:
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
-              if [ ! -d ./habitat-api ]
+              if [ ! -d ./habitat-lab ]
               then
-                git clone -q https://github.com/facebookresearch/habitat-api.git
+                git clone -q https://github.com/facebookresearch/habitat-lab.git
               fi
-              cd habitat-api
+              cd habitat-lab
               pip install -r requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed
@@ -419,19 +419,19 @@ jobs:
           name: Run api tests
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
-              . activate habitat; cd habitat-api
+              . activate habitat; cd habitat-lab
               python setup.py develop --all
               python setup.py test
       - save_cache:
-          key: habitat-api-{{ checksum "./hapi_sha" }}
+          key: habitat-lab-{{ checksum "./hapi_sha" }}
           background: true
           paths:
-            - ./habitat-api
+            - ./habitat-lab
       - run:
           name: Build api documentation
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-api
+              . activate habitat; cd habitat-lab
               python setup.py develop --all
 
               cd docs
@@ -501,7 +501,7 @@ jobs:
               cd habitat-website
               git submodule update --init
 
-              for dir in habitat-sim habitat-cpp habitat-api
+              for dir in habitat-sim habitat-cpp habitat-lab
               do
                   rm -rf published/docs/${dir}
                   cp -r ../habitat-sim/build/docs-public/${dir} published/docs/.
@@ -511,7 +511,7 @@ jobs:
               git config --global user.email habitat@fb.com
               NOW=$(date +"%m-%d-%Y")
               git add .
-              git diff-index --quiet HEAD || git commit -m "Build habitat-sim and habitat-api ${NOW}"
+              git diff-index --quiet HEAD || git commit -m "Build habitat-sim and habitat-lab ${NOW}"
               git push origin master
 
               # Deploy to public
@@ -523,7 +523,7 @@ jobs:
               rsync -a published/ ./.
               rm -rf published
               git add .
-              git diff-index --quiet HEAD || git commit -m "Build habitat-sim and habitat-api ${NOW}"
+              git diff-index --quiet HEAD || git commit -m "Build habitat-sim and habitat-lab ${NOW}"
               git push origin gh-pages
 
 workflows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We use [semantic versioning](https://semver.org/). To prepare a release:
 Stable versions are regularly assigned by Habitat core team after rigorous testing.
 
 ## Issues
-We use [GitHub issues](../../issues) to track public bugs. Please ensure your description is
+We use [GitHub issues](https://github.com/facebookresearch/habitat-sim/issues) to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
 
@@ -38,7 +38,7 @@ clear and has sufficient instructions to be able to reproduce the issue.
 
 - C++
   - In general, we follow [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) and [Google C++ guidelines](https://google.github.io/styleguide/cppguide.html)
-  - Use `clang-format`(clang-format-8) for style enforcement and linting. Install clang-format through `brew install clang-format` on MacOS, or using `apt-get install -y clang-format-8` as we do for [the testing environment setup](./.circleci/config.yml) or by downloading [binaries or sources](http://releases.llvm.org/download.html) for Ubuntu etc.
+  - Use `clang-format`(clang-format-8) for style enforcement and linting. Install clang-format through `brew install clang-format` on MacOS, or using `apt-get install -y clang-format-8` as we do for [the testing environment setup](https://github.com/facebookresearch/habitat-sim/blob/master/.circleci/config.yml) or by downloading [binaries or sources](http://releases.llvm.org/download.html) for Ubuntu etc.
 - Python
   - We follow PEP8 and use [typing](https://docs.python.org/3/library/typing.html).
   - Use `black` for style enforcement and linting. Install black through `pip install black`.
@@ -57,4 +57,4 @@ We also use pre-commit hooks to ensure linting and style enforcement. Install th
 
 ## License
 By contributing to habitat-sim, you agree that your contributions will be licensed
-under [the LICENSE file](/LICENSE).
+under [the LICENSE file](https://github.com/facebookresearch/habitat-sim/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To run the above benchmarks on your machine, see instructions in the [examples](
 
 ### Docker Image
 
-We provide a pre-built docker container for habitat-api and habitat-sim, refer to [habitat-docker-setup](https://github.com/facebookresearch/habitat-api#docker-setup).
+We provide a pre-built docker container for habitat-lab and habitat-sim, refer to [habitat-docker-setup](https://github.com/facebookresearch/habitat-lab#docker-setup).
 
 ### From Source
 
@@ -231,7 +231,7 @@ We highly recommend installing a [miniconda](https://docs.conda.io/en/latest/min
    Note3: for active development in Habitat, you might find `./build.sh` instead of `python setup.py install` more useful.
 
 
-1. [Only if using `build.sh`] For use with [Habitat-API](https://github.com/facebookresearch/habitat-api) and your own python code, add habitat-sim to your `PYTHONPATH`. For example modify your `.bashrc` (or `.bash_profile` in Mac OS X) file by adding the line:
+1. [Only if using `build.sh`] For use with [Habitat Lab](https://github.com/facebookresearch/habitat-lab) and your own python code, add habitat-sim to your `PYTHONPATH`. For example modify your `.bashrc` (or `.bash_profile` in Mac OS X) file by adding the line:
    ```bash
    export PYTHONPATH=$PYTHONPATH:/path/to/habitat-sim/
    ```
@@ -281,7 +281,7 @@ We highly recommend installing a [miniconda](https://docs.conda.io/en/latest/min
   `640 x 480, total time: 3.208 sec. FPS: 311.7`.
   Note that the test scenes do not provide semantic meshes.
   If you would like to test the semantic sensors via `example.py`, please use the data from the Matterport3D dataset (see [Datasets](#Datasets)).
-  We have also provided an [example demo](https://aihabitat.org/docs/habitat-api/habitat-api-demo.html) for reference.
+  We have also provided an [example demo](https://aihabitat.org/docs/habitat-lab/habitat-lab-demo.html) for reference.
 
     To run a physics example in python (after building with "Physics simulation via Bullet"):
     ```bash

--- a/docs/Doxyfile-mcss
+++ b/docs/Doxyfile-mcss
@@ -21,7 +21,7 @@ XML_PROGRAMLISTING     = NO
 ##!  "files"
 ##! M_LINKS_NAVBAR2 = \
 ##!  "<a href="../habitat-sim/index.html">Python Docs</a>" \
-##!  "<a href="../habitat-lab/index.html">Habitat API Docs</a>"
+##!  "<a href="../habitat-lab/index.html">Habitat Lab Docs</a>"
 ##! M_PAGE_FINE_PRINT = \
 ##!   "<p>Habitat Sim C++ Docs. Copyright © 2019 Facebook AI Research.<br/>Created with <a href="https://doxygen.org/">Doxygen</a> {doxygen_version} and <a href="https://mcss.mosra.cz/">m.css</a>."
 

--- a/docs/Doxyfile-mcss
+++ b/docs/Doxyfile-mcss
@@ -21,7 +21,7 @@ XML_PROGRAMLISTING     = NO
 ##!  "files"
 ##! M_LINKS_NAVBAR2 = \
 ##!  "<a href="../habitat-sim/index.html">Python Docs</a>" \
-##!  "<a href="../habitat-api/index.html">Habitat API Docs</a>"
+##!  "<a href="../habitat-lab/index.html">Habitat API Docs</a>"
 ##! M_PAGE_FINE_PRINT = \
 ##!   "<p>Habitat Sim C++ Docs. Copyright © 2019 Facebook AI Research.<br/>Created with <a href="https://doxygen.org/">Doxygen</a> {doxygen_version} and <a href="https://mcss.mosra.cz/">m.css</a>."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ LINKS_NAVBAR1 = [
 ]
 LINKS_NAVBAR2 = [
     ("C++ Docs", "../habitat-cpp/index.html", []),
-    ("Habitat API Docs", "../habitat-lab/index.html", []),
+    ("Habitat Lab Docs", "../habitat-lab/index.html", []),
 ]
 
 FINE_PRINT = f"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ LINKS_NAVBAR1 = [
 ]
 LINKS_NAVBAR2 = [
     ("C++ Docs", "../habitat-cpp/index.html", []),
-    ("Habitat API Docs", "../habitat-api/index.html", []),
+    ("Habitat API Docs", "../habitat-lab/index.html", []),
 ]
 
 FINE_PRINT = f"""

--- a/habitat_sim/utils/__init__.py
+++ b/habitat_sim/utils/__init__.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # quat_from_angle_axis and quat_rotate_vector imports
-# added for backward compatibility with Habitat-API
-# TODO @maksymets: remove after habitat-api/examples/new_actions.py will be
+# added for backward compatibility with Habitat Lab
+# TODO @maksymets: remove after habitat-lab/examples/new_actions.py will be
 # fixed
 
 


### PR DESCRIPTION
## Motivation and Context
We changed the name of `Habitat-API` to `Habitat Lab` to make less confusing and stress the purpose of the repo to propose Tasks, Metrics, Baselines to the community. Mirroring https://github.com/facebookresearch/habitat-lab/pull/448 for Habitat Lab.

- Fixed the referenced links that become broken on the website
- Added `--depth 1` option to speed up Hab Lab clone step

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Breaking change (fix or feature that would cause existing functionality to change)