### PR TITLE
Add make_video utility to viz_utils

### DIFF
--- a/habitat_sim/utils/__init__.py
+++ b/habitat_sim/utils/__init__.py
@@ -10,7 +10,7 @@
 # fixed
 
 
-from habitat_sim.utils import common
+from habitat_sim.utils import common, viz_utils
 from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
 
-__all__ = ["quat_from_angle_axis", "quat_rotate_vector", "common"]
+__all__ = ["quat_from_angle_axis", "quat_rotate_vector", "common", "viz_utils"]

--- a/habitat_sim/utils/viz_utils.py
+++ b/habitat_sim/utils/viz_utils.py
@@ -7,8 +7,13 @@ import sys
 if "google.colab" in sys.modules:
     os.environ["IMAGEIO_FFMPEG_EXE"] = "/usr/bin/ffmpeg"
 
+from typing import Dict, List, Optional, Tuple
+
 import imageio
+import numpy as np
 from tqdm.auto import tqdm
+
+from habitat_sim.utils.common import d3_40_colors_rgb
 
 
 def is_notebook():
@@ -94,3 +99,161 @@ def display_video(video_file: str, height: int = 400):
         else:
             opener = "open" if sys.platform == "darwin" else "xdg-open"
             subprocess.call([opener, video_file])
+
+
+def make_video(
+    observations: List[np.ndarray],
+    primary_obs: str,
+    primary_obs_type: str,
+    video_file: str,
+    fps: int = 60,
+    open_vid: bool = True,
+    video_dims: Optional[Tuple[int]] = None,
+    overlay_settings=None,
+    depth_clip: Optional[float] = 10.0,
+):
+    """Build a video from a passed observations array, with some images optionally overlayed.
+
+    :param observations: List of observations from which the video should be constructed.
+    :param primary_obs: Sensor name in observations to be used for primary video images.
+    :param primary_obs_type: Primary image observation type ("color", "depth", "semantic" supported).
+    :param video_file: File to save resultant .mp4 video.
+    :param fps: Desired video frames per second.
+    :param open_vid: Whether or not to open video upon creation.
+    :param video_dims: Height by Width of video if different than observation dimensions. Applied after overlays.
+    :param overlay_settings: List of settings Dicts, optional.
+    :param depth_clip: Defines default depth clip normalization for all depth images.
+
+    With **overlay_settings** dicts specifying per-entry: \n
+        "type": observation type ("color", "depth", "semantic" supported)\n
+        "dims": overlay dimensions (Tuple : (width, height))\n
+        "pos": overlay position (top left) (Tuple : (width, height))\n
+        "border": overlay image border thickness (int)\n
+        "border_color": overlay image border color [0-255] (3d: array, list, or tuple). Defaults to gray [150]\n
+        "obs": observation key (string)\n
+    """
+    videodims = observations[0][primary_obs].shape
+    videodims = (videodims[1], videodims[0])  # flip to w,h order
+    if not video_file.endswith(".mp4"):
+        video_file = video_file + ".mp4"
+    print("Encoding the video: %s " % video_file)
+    writer = get_fast_video_writer(video_file, fps=fps)
+
+    # build the border frames for the overlays and validate settings
+    border_frames = []
+    if overlay_settings is not None:
+        for overlay in overlay_settings:
+            border_image = np.zeros(
+                (
+                    overlay["dims"][1] + overlay["border"] * 2,
+                    overlay["dims"][0] + overlay["border"] * 2,
+                    3,
+                ),
+                np.uint8,
+            )
+            border_color = np.ones(3) * 150
+            if "border_color" in overlay:
+                border_color = np.asarray(overlay["border_color"])
+            border_image[:, :] = border_color
+            border_frames.append(observation_to_image(border_image, "color"))
+
+    for ob in observations:
+        # primary image processing
+        image_frame = observation_to_image(ob[primary_obs], primary_obs_type)
+        if image_frame is None:
+            print("make_video_new : Aborting, primary image processing failed.")
+            return
+
+        # overlay images from provided settings
+        if overlay_settings is not None:
+            for ov_ix, overlay in enumerate(overlay_settings):
+                overlay_rgb_img = observation_to_image(
+                    ob[overlay["obs"]], overlay["type"], depth_clip
+                )
+                if overlay_rgb_img is None:
+                    print(
+                        'make_video_new : Aborting, overlay image processing failed on "'
+                        + overlay["obs"]
+                        + '".'
+                    )
+                    return
+            overlay_rgb_img = overlay_rgb_img.resize(overlay["dims"])
+            image_frame.paste(
+                border_frames[ov_ix],
+                box=(
+                    overlay["pos"][0] - overlay["border"],
+                    overlay["pos"][1] - overlay["border"],
+                ),
+            )
+            image_frame.paste(overlay_rgb_img, box=overlay["pos"])
+
+        if video_dims is not None:
+            image_frame = image_frame.resize(video_dims)
+
+        # write the desired image to video
+        writer.append_data(np.array(image_frame))
+
+    writer.close()
+    if open_vid:
+        print("Displaying video")
+        display_video(video_file)
+
+
+def depth_to_rgb(depth_image: np.ndarray, clip_max: float = 10.0) -> np.ndarray:
+    """Normalize depth image into [0, 1] and convert to grayscale rgb
+
+    :param depth_image: Raw depth observation image from sensor output.
+    :param clip_max: Max depth distance for clipping and normalization.
+
+    :return: Clipped grayscale depth image data.
+    """
+    d_im = np.clip(depth_image, 0, clip_max)
+    d_im /= clip_max
+    rgb_d_im = (d_im * 255).astype(np.uint8)
+    return rgb_d_im
+
+
+def semantic_to_rgb(semantic_image: np.ndarray) -> np.ndarray:
+    """Map semantic ids to colors and genereate an rgb image
+
+    :param semantic_image: Raw semantic observation image from sensor output.
+
+    :return: rgb semantic image data.
+    """
+    semantic_image_rgb = Image.new(
+        "P", (semantic_image.shape[1], semantic_image.shape[0])
+    )
+    semantic_image_rgb.putpalette(d3_40_colors_rgb.flatten())
+    semantic_image_rgb.putdata((semantic_image.flatten() % 40).astype(np.uint8))
+    semantic_image_rgb = semantic_image_rgb.convert("RGBA")
+    return semantic_image_rgb
+
+
+def observation_to_image(
+    observation_image: np.ndarray,
+    observation_type: str,
+    depth_clip: Optional[float] = 10.0,
+):
+    """Generate an rgb image from a sensor observation. Supported types are: "color", "depth", "semantic"
+
+    :param observation_image: Raw observation image from sensor output.
+    :param observation_type: Observation type ("color", "depth", "semantic" supported)
+    :param depth_clip: Defines default depth clip normalization for all depth images.
+
+    :return: PIL Image object or None if fails.
+    """
+    rgb_image = None
+    if observation_type == "color":
+        rgb_image = Image.fromarray(np.uint8(observation_image))
+    elif observation_type == "depth":
+        rgb_image = Image.fromarray(
+            depth_to_rgb(observation_image, clip_max=depth_clip)
+        )
+    elif observation_type == "semantic":
+        rgb_image = semantic_to_rgb(observation_image)
+    else:
+        print(
+            "semantic_to_rgb : Aborting, unsupported observation type: "
+            + primary_obs_type
+        )
+    return rgb_image

--- a/habitat_sim/utils/viz_utils.py
+++ b/habitat_sim/utils/viz_utils.py
@@ -195,7 +195,6 @@ def make_video(
 
     writer.close()
     if open_vid:
-        print("Displaying video")
         display_video(video_file)
 
 
@@ -253,7 +252,7 @@ def observation_to_image(
         rgb_image = semantic_to_rgb(observation_image)
     else:
         print(
-            "semantic_to_rgb : Aborting, unsupported observation type: "
+            "semantic_to_rgb : Failed, unsupported observation type: "
             + primary_obs_type
         )
     return rgb_image


### PR DESCRIPTION
## Motivation and Context

Instead of duplicating the process of making a video from sensor observations with overlays we'll provide a fairly general utility.

Based on #706 

## How Has This Been Tested

Local in Colab.
E.g.
```
    overlay_dims = (int(sim_settings["width"]/5), int(sim_settings["height"]/5))
    overlay_settings = [
      {
        "obs": "color_sensor_1st_person",
        "type": "color",
        "dims": overlay_dims,
        "pos": (10,10),
        "border": 2
      },
      {
        "obs": "depth_sensor_1st_person",
        "type": "depth",
        "dims": overlay_dims,
        "pos": (10,30+overlay_dims[1]),
        "border": 2
      },
      {
        "obs": "semantic_sensor_1st_person",
        "type": "semantic",
        "dims": overlay_dims,
        "pos": (10,50+overlay_dims[1]*2),
        "border": 2
      }
    ]

    make_video(
      observations = observations,
      primary_obs = "color_sensor_3rd_person",
      primary_obs_type = "color",
      video_file= "test_new_video",
      fps= int(1.0 / time_step), 
      open_vid=True,
      overlay_settings = overlay_settings,
      depth_clip=1.0
    )
```

Produces a video (note this is choppy due to gif conversion):
![overlay_example](https://user-images.githubusercontent.com/1445143/90072110-ab51bb00-dcab-11ea-8a08-f14619bd870f.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
