### PR TITLE
--Make default attributes templates read-only.

### DIFF
--- a/src/esp/assets/Attributes.cpp
+++ b/src/esp/assets/Attributes.cpp
@@ -27,6 +27,10 @@ AbstractPhysicsAttributes::AbstractPhysicsAttributes(
     : AbstractAttributes(attributesClassKey, handle) {
   setFrictionCoefficient(0.5);
   setRestitutionCoefficient(0.1);
+  setScale({1.0, 1.0, 1.0});
+  setMargin(0.04);
+  setOrientUp({0, 1, 0});
+  setOrientFront({0, 0, -1});
   // default rendering and collisions will be mesh for physics objects and
   // scenes. Primitive-based objects do not currently support mesh collisions,
   // however, due to issues with how non-triangle meshes (i.e. wireframes) are
@@ -43,8 +47,6 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(const std::string& handle)
     : AbstractPhysicsAttributes("PhysicsObjectAttributes", handle) {
   // fill necessary attribute defaults
   setMass(1.0);
-  setMargin(0.04);
-  setScale({1.0, 1.0, 1.0});
   setCOM({0, 0, 0});
   setInertia({0, 0, 0});
   setLinearDamping(0.2);
@@ -63,19 +65,13 @@ PhysicsObjectAttributes::PhysicsObjectAttributes(const std::string& handle)
 PhysicsSceneAttributes::PhysicsSceneAttributes(const std::string& handle)
     : AbstractPhysicsAttributes("PhysicsSceneAttributes", handle) {
   setGravity({0, -9.8, 0});
-  // TODO do these defaults need to be maintained here?
-  setFrictionCoefficient(0.4);
-  setRestitutionCoefficient(0.05);
   setOrigin({0, 0, 0});
-  setOrientUp({0, 1, 0});
-  setOrientFront({0, 0, -1});
 
   setRequiresLighting(false);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh
   setCollisionAssetType(0);
   // 4 corresponds to esp::assets::AssetType::INSTANCE_MESH
   setSemanticAssetType(4);
-
 }  // PhysicsSceneAttributes ctor
 
 PhysicsManagerAttributes::PhysicsManagerAttributes(const std::string& handle)

--- a/src/esp/assets/Attributes.h
+++ b/src/esp/assets/Attributes.h
@@ -482,7 +482,10 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   }
   int getNumSegments() const { return getInt("segments"); }
   // capsule, cone and cylinder use halfLength
-  void setHalfLength(double halfLength) { setDouble("halfLength", halfLength); }
+  void setHalfLength(double halfLength) {
+    setDouble("halfLength", halfLength);
+    buildHandle();
+  }
   double getHalfLength() const { return getDouble("halfLength"); }
 
   std::string getPrimObjClassName() const {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -117,14 +117,6 @@ void ResourceManager::initDefaultPrimAttributes() {
   primitive_meshes_[nextPrimitiveMeshId++] =
       std::make_unique<Magnum::GL::Mesh>(Magnum::MeshTools::compile(*wfCube));
 
-  // build default primtive object templates corresponding to given default
-  // asset templates
-  auto lib = assetAttributesManager_->getTemplateLibrary();
-  for (auto primAsset : lib) {
-    objectAttributesManager_->createPrimBasedAttributesTemplate(primAsset.first,
-                                                                true);
-  }
-
 }  // initDefaultPrimAttributes
 
 void ResourceManager::initPhysicsManager(

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -90,7 +90,7 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
       &AssetAttributesManager::createAttributesCopy<
           assets::UVSpherePrimitiveAttributes>;
   // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
-  defaultTemplateNames_.clear();
+  this->defaultTemplateNames_.clear();
   // build default AbstractPrimitiveAttributes objects
   for (const std::pair<const PrimObjTypes, const char*>& elem :
        PrimitiveNames3DMap) {
@@ -100,12 +100,12 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
     auto tmplt = createAttributesTemplate(elem.second, true);
     std::string tmpltHandle = tmplt->getHandle();
     defaultPrimAttributeHandles_[elem.second] = tmpltHandle;
-    defaultTemplateNames_.push_back(tmpltHandle);
+    this->defaultTemplateNames_.push_back(tmpltHandle);
   }
 
   LOG(INFO) << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "
                "primitive asset templates : "
-            << std::to_string(defaultTemplateNames_.size());
+            << std::to_string(this->defaultTemplateNames_.size());
 }  // AssetAttributesManager::buildMapOfPrimTypeConstructors
 
 AbstractPrimitiveAttributes::ptr

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -434,22 +434,6 @@ class AssetAttributesManager
       const std::string& ignored = "") override;
 
   /**
-   * @brief Whether template described by passed handle is read only, or can be
-   * deleted. Default primitive asset templates should not be removed.
-   * @param templateHandle the handle to the template to verify removability.
-   * Assumes template exists.
-   * @return Whether the template is read-only or not
-   */
-  bool isTemplateReadOnly(const std::string& templateHandle) override {
-    for (auto handle : defaultTemplateNames_) {
-      if (handle.compare(templateHandle) == 0) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  /**
    * @brief Used Internally.  Configure newly-created attributes with any
    * default values, before any specific values are set.
    *
@@ -540,11 +524,6 @@ class AssetAttributesManager
    */
   Map_Of_PrimTypeCtors primTypeConstructorMap_;
 
-  /**
-   * @brief vector holding string template handles of all default primitive
-   * asset templates, to make sure they are never deleted.
-   */
-  std::vector<std::string> defaultTemplateNames_;
   /**
    * @brief Map relating primitive class name to default attributes template
    * handle. There should always be a template for each of these handles.

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -86,6 +86,20 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   return this->postCreateRegister(primObjectAttributes, registerTemplate);
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
+void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
+  this->defaultTemplateNames_.clear();
+  // build default primtive object templates corresponding to given default
+  // asset templates
+  const std::vector<std::string> lib =
+      assetAttributesMgr_->getDefaultTemplateHandles();
+  for (std::string primAssetHandle : lib) {
+    auto tmplt = createPrimBasedAttributesTemplate(primAssetHandle, true);
+    // save handles in list of defaults, so they are not removed
+    std::string tmpltHandle = tmplt->getHandle();
+    this->defaultTemplateNames_.push_back(tmpltHandle);
+  }
+}  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
+
 PhysicsObjectAttributes::ptr
 ObjectAttributesManager::createFileBasedAttributesTemplate(
     const std::string& objPhysConfigFilename,
@@ -271,7 +285,8 @@ int ObjectAttributesManager::registerAttributesTemplateFinalize(
 }  // ObjectAttributesManager::registerAttributesTemplateFinalize
 
 std::vector<int> ObjectAttributesManager::loadAllFileBasedTemplates(
-    const std::vector<std::string>& tmpltFilenames) {
+    const std::vector<std::string>& tmpltFilenames,
+    bool saveAsDefaults) {
   std::vector<int> resIDs(tmpltFilenames.size(), ID_UNDEFINED);
   for (int i = 0; i < tmpltFilenames.size(); ++i) {
     auto objPhysPropertiesFilename = tmpltFilenames[i];
@@ -279,6 +294,11 @@ std::vector<int> ObjectAttributesManager::loadAllFileBasedTemplates(
               << objPhysPropertiesFilename;
     auto tmplt =
         createFileBasedAttributesTemplate(objPhysPropertiesFilename, true);
+
+    // save handles in list of defaults, so they are not removed
+    std::string tmpltHandle = tmplt->getHandle();
+    this->defaultTemplateNames_.push_back(tmpltHandle);
+
     resIDs[i] = tmplt->getID();
   }
   LOG(INFO) << "Loaded file-based object templates: "
@@ -287,7 +307,8 @@ std::vector<int> ObjectAttributesManager::loadAllFileBasedTemplates(
 }  // ObjectAttributesManager::loadAllObjectTemplates
 
 std::vector<int> ObjectAttributesManager::loadObjectConfigs(
-    const std::string& path) {
+    const std::string& path,
+    bool saveAsDefaults) {
   std::vector<std::string> paths;
   std::vector<int> templateIndices;
   namespace Directory = Cr::Utility::Directory;
@@ -320,7 +341,7 @@ std::vector<int> ObjectAttributesManager::loadObjectConfigs(
     }
   }
   // build templates from aggregated paths
-  templateIndices = loadAllFileBasedTemplates(paths);
+  templateIndices = loadAllFileBasedTemplates(paths, saveAsDefaults);
 
   return templateIndices;
 }  // ObjectAttributesManager::buildObjectConfigPaths

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -29,6 +29,8 @@ class ObjectAttributesManager
   void setAssetAttributesManager(
       AssetAttributesManager::cptr assetAttributesMgr) {
     assetAttributesMgr_ = assetAttributesMgr;
+    // Create default primitive-based object attributess
+    createDefaultPrimBasedAttributesTemplates();
   }
 
   /**
@@ -125,9 +127,12 @@ class ObjectAttributesManager
    *
    * @param path A global path to a physics property file or directory
    * containing such files.
+   * @param saveAsDefaults Set the templates loaded as undeleteable default
+   * templates.
    * @return A list of template indices for loaded valid object configs
    */
-  std::vector<int> loadObjectConfigs(const std::string& path);
+  std::vector<int> loadObjectConfigs(const std::string& path,
+                                     bool saveAsDefaults = false);
 
   /**
    * @brief Load all file-based object templates given string list of object
@@ -136,10 +141,12 @@ class ObjectAttributesManager
    * This will take the list of file names currently specified in
    * physicsManagerAttributes and load the referenced object templates.
    * @param tmpltFilenames list of file names of object templates
+   * @param saveAsDefaults Set these templates as un-deletable from library.
    * @return vector holding IDs of templates that have been added
    */
   std::vector<int> loadAllFileBasedTemplates(
-      const std::vector<std::string>& tmpltFilenames);
+      const std::vector<std::string>& tmpltFilenames,
+      bool saveAsDefaults);
 
   /**
    * @brief Check if currently configured primitive asset template library has
@@ -237,6 +244,12 @@ class ObjectAttributesManager
 
  protected:
   /**
+   * @brief Create and save default primitive asset-based object templates,
+   * saving their handles as non-deletable default handles.
+   */
+  void createDefaultPrimBasedAttributesTemplates();
+
+  /**
    * @brief Perform file-name-based attributes initialization. This is to
    * take the place of the AssetInfo::fromPath functionality, and is only
    * intended to provide default values and other help if certain mistakes
@@ -298,11 +311,6 @@ class ObjectAttributesManager
       const std::string& attributesTemplateHandle) override;
 
   /**
-   * @brief Whether template described by passed handle is read only, or can be
-   * deleted. All objectAttributes templates are removable, by default
-   */
-  bool isTemplateReadOnly(const std::string&) override { return false; };
-  /**
    * @brief Any object-attributes-specific resetting that needs to happen on
    * reset.
    */
@@ -321,6 +329,8 @@ class ObjectAttributesManager
         &ObjectAttributesManager::createAttributesCopy<
             assets::PhysicsObjectAttributes>;
   }  // ObjectAttributesManager::buildCtorFuncPtrMaps()
+
+  // ======== Typedefs and Instance Variables ========
 
   /**
    * @brief Reference to AssetAttributesManager to give access to primitive

--- a/src/esp/assets/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/assets/managers/PhysicsAttributesManager.cpp
@@ -118,7 +118,7 @@ PhysicsAttributesManager::createFileBasedAttributesTemplate(
       std::string absolutePath =
           Cr::Utility::Directory::join(configDirectory, paths[i].GetString());
       // load all object templates available as configs in absolutePath
-      objectAttributesMgr_->loadObjectConfigs(absolutePath);
+      objectAttributesMgr_->loadObjectConfigs(absolutePath, true);
     }
   }  // if load rigid object library metadata
 

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -144,12 +144,6 @@ class PhysicsAttributesManager
   }  // PhysicsAttributesManager::registerAttributesTemplate
 
   /**
-   * @brief Whether template described by passed handle is read only, or can be
-   * deleted. All PhysicsAttributes templates are removable, by default
-   */
-  bool isTemplateReadOnly(const std::string&) override { return false; }
-
-  /**
    * @brief Any physics-attributes-specific resetting that needs to happen on
    * reset.
    */

--- a/src/esp/assets/managers/SceneAttributesManager.cpp
+++ b/src/esp/assets/managers/SceneAttributesManager.cpp
@@ -433,7 +433,7 @@ SceneAttributesManager::createFileBasedAttributesTemplate(
       std::string absolutePath =
           Cr::Utility::Directory::join(configDirectory, paths[i].GetString());
       // load all object templates available as configs in absolutePath
-      objectAttributesMgr_->loadObjectConfigs(absolutePath);
+      objectAttributesMgr_->loadObjectConfigs(absolutePath, true);
     }
   }  // if load rigid object library metadata
 

--- a/src/esp/assets/managers/SceneAttributesManager.h
+++ b/src/esp/assets/managers/SceneAttributesManager.h
@@ -201,12 +201,6 @@ class SceneAttributesManager
       const std::string& sceneAttributesHandle) override;
 
   /**
-   * @brief Whether template described by passed handle is read only, or can be
-   * deleted. All SceneAttributes templates are removable, by default
-   */
-  bool isTemplateReadOnly(const std::string&) override { return false; };
-
-  /**
    * @brief Any scene-attributes-specific resetting that needs to happen on
    * reset.
    */

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -87,6 +87,10 @@ void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
              This removes, and returns the template referenced by the passed ID 
              from the library.)",
            "ID"_a)
+      .def("remove_all_templates", &AttrClass::removeAllTemplates,
+           R"( 
+             This removes, and returns, a list of all the user-added templates 
+             referenced in the library.)")
       .def("remove_template_by_handle", &AttrClass::removeTemplateByHandle,
            R"(
              This removes, and returns the template referenced by the passed handle 
@@ -231,8 +235,10 @@ void initAttributesManagersBindings(py::module& m) {
       .def("load_object_configs", &ObjectAttributesManager::loadObjectConfigs,
            R"(
          Build templates for all "*.phys_properties.json" files that exist in 
-         the provided file or directory path.)"
-           "path"_a)
+         the provided file or directory path. If save_as_defaults is true, then
+         these templates will be unable to be deleted)"
+           "path"_a,
+           "save_as_defaults"_a = false)
 
       // manage file-based templates access
       .def("get_num_file_templates",


### PR DESCRIPTION
Expand default attributes handling to be available to all attributes managers.  Makes object templates specified by physics world attributes or scene attributes, as well as those associated with primitive assets, to be unable to be removed by the user.  Adds a single function and python binding to be able to remove all removable templates in one command.  Adds tests to verify functionality.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ tests added to verify functionality.  All c++ and python tests passed.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
