### PR TITLE
To fix broken links in docs excluded std lib to from linking pipeline

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -896,7 +896,7 @@ EXCLUDE_PATTERNS       = */test/*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = std
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
## Motivation and Context
We have around 100+ broken links from the doc page: https://aihabitat.org/docs/habitat-cpp/namespacestd.html.
To fix broken links in docs excluded std lib to from linking pipeline.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Check docs build in CI.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade

