### PR TITLE
-Allow for expanded 'read-only' setting for Attributes Templates.

### DIFF
--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -100,7 +100,7 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
     auto tmplt = createAttributesTemplate(elem.second, true);
     std::string tmpltHandle = tmplt->getHandle();
     defaultPrimAttributeHandles_[elem.second] = tmpltHandle;
-    this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
+    this->undeletableTemplateNames_.insert(tmpltHandle);
   }
 
   LOG(INFO) << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -90,7 +90,7 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
       &AssetAttributesManager::createAttributesCopy<
           assets::UVSpherePrimitiveAttributes>;
   // no entry added for PrimObjTypes::END_PRIM_OBJ_TYPES
-  this->defaultTemplateNames_.clear();
+  this->undeletableTemplateNames_.clear();
   // build default AbstractPrimitiveAttributes objects
   for (const std::pair<const PrimObjTypes, const char*>& elem :
        PrimitiveNames3DMap) {
@@ -100,12 +100,12 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
     auto tmplt = createAttributesTemplate(elem.second, true);
     std::string tmpltHandle = tmplt->getHandle();
     defaultPrimAttributeHandles_[elem.second] = tmpltHandle;
-    this->defaultTemplateNames_.push_back(tmpltHandle);
+    this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
   }
 
   LOG(INFO) << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "
                "primitive asset templates : "
-            << std::to_string(this->defaultTemplateNames_.size());
+            << std::to_string(defaultPrimAttributeHandles_.size());
 }  // AssetAttributesManager::buildMapOfPrimTypeConstructors
 
 AbstractPrimitiveAttributes::ptr

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -90,13 +90,13 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
   this->undeletableTemplateNames_.clear();
   // build default primtive object templates corresponding to given default
   // asset templates
-  const std::map<std::string, std::string>& lib =
+  std::vector<std::string> lib =
       assetAttributesMgr_->getUndeletableTemplateHandles();
-  for (const std::pair<std::string, std::string>& elem : lib) {
-    auto tmplt = createPrimBasedAttributesTemplate(elem.first, true);
+  for (const std::string& elem : lib) {
+    auto tmplt = createPrimBasedAttributesTemplate(elem, true);
     // save handles in list of defaults, so they are not removed
     std::string tmpltHandle = tmplt->getHandle();
-    this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
+    this->undeletableTemplateNames_.insert(tmpltHandle);
   }
 }  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
 
@@ -298,7 +298,7 @@ std::vector<int> ObjectAttributesManager::loadAllFileBasedTemplates(
     // save handles in list of defaults, so they are not removed, if desired.
     if (saveAsDefaults) {
       std::string tmpltHandle = tmplt->getHandle();
-      this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
+      this->undeletableTemplateNames_.insert(tmpltHandle);
     }
     resIDs[i] = tmplt->getID();
   }

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -87,16 +87,16 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
 void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
-  this->defaultTemplateNames_.clear();
+  this->undeletableTemplateNames_.clear();
   // build default primtive object templates corresponding to given default
   // asset templates
-  const std::vector<std::string> lib =
-      assetAttributesMgr_->getDefaultTemplateHandles();
-  for (std::string primAssetHandle : lib) {
-    auto tmplt = createPrimBasedAttributesTemplate(primAssetHandle, true);
+  const std::map<std::string, std::string>& lib =
+      assetAttributesMgr_->getUndeletableTemplateHandles();
+  for (const std::pair<std::string, std::string>& elem : lib) {
+    auto tmplt = createPrimBasedAttributesTemplate(elem.first, true);
     // save handles in list of defaults, so they are not removed
     std::string tmpltHandle = tmplt->getHandle();
-    this->defaultTemplateNames_.push_back(tmpltHandle);
+    this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
   }
 }  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
 
@@ -295,10 +295,11 @@ std::vector<int> ObjectAttributesManager::loadAllFileBasedTemplates(
     auto tmplt =
         createFileBasedAttributesTemplate(objPhysPropertiesFilename, true);
 
-    // save handles in list of defaults, so they are not removed
-    std::string tmpltHandle = tmplt->getHandle();
-    this->defaultTemplateNames_.push_back(tmpltHandle);
-
+    // save handles in list of defaults, so they are not removed, if desired.
+    if (saveAsDefaults) {
+      std::string tmpltHandle = tmplt->getHandle();
+      this->undeletableTemplateNames_[tmpltHandle] = tmpltHandle;
+    }
     resIDs[i] = tmplt->getID();
   }
   LOG(INFO) << "Loaded file-based object templates: "

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -87,6 +87,12 @@ void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
              This removes, and returns the template referenced by the passed ID 
              from the library.)",
            "ID"_a)
+      .def("set_template_lock", &AttrClass::setTemplateLock,
+           R"(
+             This sets the lock state for the template that has the passed name.
+             Lock == True makes the template unable to be deleted.
+             Note : Locked templates can still be edited.)",
+           "handle"_a, "lock"_a)
       .def("remove_all_templates", &AttrClass::removeAllTemplates,
            R"( 
              This removes, and returns, a list of all the user-added templates 

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -27,7 +27,7 @@ namespace managers {
 /**
  * @brief instance class template base classes for attributes managers.
  * @tparam The type used to specialize class template for each attributes
- * manager.  Will be a smart pointer to an attributes
+ * manager. Will be a smart pointer to an attributes
  * @param m pybind module reference.
  * @param classStrPrefix string prefix for python class name specification.
  */
@@ -77,26 +77,58 @@ void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
            R"(
              Returns the handle for a random template chosen from the 
              existing templates being managed.)")
+      .def("get_undeletable_handles", &AttrClass::getUndeletableTemplateHandles,
+           R"(
+            Returns a list of template handles for templates that have been marked
+            undeletable by the system. These templates can still be edited.)")
+      .def("get_user_locked_handles", &AttrClass::getUserLockedTemplateHandles,
+           R"(
+            Returns a list of template handles for templates that have been marked
+            locked by the user. These will be undeletable until unlocked by the user.
+            These templates can still be edited.)")
       .def("get_library_has_handle", &AttrClass::getTemplateLibHasHandle,
            R"(
              Returns whether the passed handle describes an existing template 
              in the library.)",
            "handle"_a)
-      .def("remove_template_by_ID", &AttrClass::removeTemplateByID,
-           R"(
-             This removes, and returns the template referenced by the passed ID 
-             from the library.)",
-           "ID"_a)
       .def("set_template_lock", &AttrClass::setTemplateLock,
            R"(
              This sets the lock state for the template that has the passed name.
              Lock == True makes the template unable to be deleted.
              Note : Locked templates can still be edited.)",
            "handle"_a, "lock"_a)
+      .def("set_lock_by_substring", &AttrClass::setTemplatesLockBySubstring,
+           R"(
+             This sets the lock state for all templates whose handles either 
+             contain or explictly do not contain the passed search_str.
+             Returns a list of handles for templates locked by this function 
+             call. Lock == True makes the template unable to be deleted.
+             Note : Locked templates can still be edited.)",
+           "lock"_a, "search_str"_a = "", "contains"_a = true)
+      .def("set_template_list_lock", &AttrClass::setTemplateLockByHandles,
+           R"(
+             This sets the lock state for all templates whose handles
+             are passed in list. Returns a list of handles for templates 
+             locked by this function call. Lock == True makes the template unable 
+             to be deleted. Note : Locked templates can still be edited.)",
+           "handles"_a, "lock"_a)
       .def("remove_all_templates", &AttrClass::removeAllTemplates,
            R"( 
-             This removes, and returns, a list of all the user-added templates 
-             referenced in the library.)")
+             This removes, and returns, a list of all the templates referenced 
+             in the library that have not been marked undeletable by the system 
+             or read-only by the user.)")
+      .def("remove_templates_by_str", &AttrClass::removeTemplatesBySubstring,
+           R"( 
+             This removes, and returns, a list of all the templates referenced 
+             in the library that have not been marked undeletable by the system 
+             or read-only by the user and whose handles either contain or explictly 
+             do not contain the passed search_str.)",
+           "search_str"_a = "", "contains"_a = true)
+      .def("remove_template_by_ID", &AttrClass::removeTemplateByID,
+           R"(
+             This removes, and returns the template referenced by the passed ID 
+             from the library.)",
+           "ID"_a)
       .def("remove_template_by_handle", &AttrClass::removeTemplateByHandle,
            R"(
              This removes, and returns the template referenced by the passed handle 


### PR DESCRIPTION
Certain attributes templates are expected to always be around (such as default primitive asset attribute templates and the object templates built from them.  Furthermore, users may wish to set templates to be locked to prevent accidental deletion, or to unlock them once they decide to delete them.  This PR supports this functionality.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->


## How Has This Been Tested
Existing c++ and python tests passed.
EDIT (JT) : Tests have been added in c++ and python to verify functionality.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
