### PR TITLE
Bug fix: no frustum culling for replica data set.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -188,8 +188,13 @@ bool ResourceManager::loadScene(
   // pass nullptr as physics manager for render mesh, since we are loading
   // collision mesh next
   bool renderMeshSuccess =
-      loadSceneInternal(renderInfo, nullptr, &rootNode, &drawables, true, false,
-                        renderLightSetup);
+      loadSceneInternal(renderInfo,         // AssetInfo
+                        nullptr,            // physics manager
+                        &rootNode,          // parent scene node
+                        &drawables,         //  drawable group
+                        true,               // compute Absolute AABBs or not
+                        false,              // split semantic mesh or not
+                        renderLightSetup);  // light setup
 
   if (!renderMeshSuccess) {
     LOG(ERROR)
@@ -201,8 +206,13 @@ bool ResourceManager::loadScene(
     AssetInfo colInfo = assetInfoMap.at("collision");
     // should this be checked to make sure we do not reload?
     bool collisionMeshSuccess =
-        loadSceneInternal(colInfo, _physicsManager, nullptr, nullptr, false,
-                          false, renderLightSetup);
+        loadSceneInternal(colInfo,            // AssetInfo
+                          _physicsManager,    // physics manager
+                          nullptr,            // parent scene node
+                          nullptr,            // drawable group
+                          false,              // compute absolute AABBs or not
+                          false,              // split semantic mesh or not
+                          renderLightSetup);  // light setup
 
     if (!collisionMeshSuccess) {
       LOG(ERROR)
@@ -277,9 +287,14 @@ bool ResourceManager::loadScene(
       auto& semanticRootNode = semanticSceneGraph.getRootNode();
       auto& semanticDrawables = semanticSceneGraph.getDrawables();
       bool computeSemanticAABBs = splitSemanticMesh;
+
       semanticSceneSuccess = loadSceneInternal(
-          semanticInfo, nullptr, &semanticRootNode, &semanticDrawables,
-          computeSemanticAABBs, splitSemanticMesh);
+          semanticInfo,          // AssetInfo
+          nullptr,               // physics manager
+          &semanticRootNode,     // parent scene node
+          &semanticDrawables,    // drawable group
+          computeSemanticAABBs,  // compute absolute AABBs or not
+          splitSemanticMesh);    // split semantic mesh or not
       // regardless of load failure, original code still changed
       // activeSemanticSceneID_
       activeSceneIDs[1] = activeSemanticSceneID;
@@ -750,29 +765,24 @@ bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
         node.addFeature<gfx::PTexMeshDrawable>(*pTexMeshData, jSubmesh,
                                                shaderManager_, drawables);
 
-        if (computeAbsoluteAABBs_) {
-          staticDrawableInfo.emplace_back(
-              StaticDrawableInfo{node, static_cast<uint32_t>(jSubmesh)});
-        }
+        staticDrawableInfo.emplace_back(
+            StaticDrawableInfo{node, static_cast<uint32_t>(jSubmesh)});
       }
     }
-    if (computeAbsoluteAABBs_) {
-      // compute aabb if appropriate here - always done if parent exists
-      // retrieve the ptex mesh data
-      CORRADE_ASSERT(
-          resourceDict_.count(filename) != 0,
-          "ResourceManager::loadScene: ptex mesh is not loaded. Aborting.",
-          false);
-      const MeshMetaData& metaData = getMeshMetaData(filename);
-      CORRADE_ASSERT(metaData.meshIndex.first == metaData.meshIndex.second,
-                     "ResourceManager::loadScene: ptex mesh is not loaded "
-                     "correctly. Aborting.",
-                     false);
+    // compute aabb if appropriate here - always done if parent exists
+    // retrieve the ptex mesh data
+    CORRADE_ASSERT(
+        resourceDict_.count(filename) != 0,
+        "ResourceManager::loadScene: ptex mesh is not loaded. Aborting.",
+        false);
+    const MeshMetaData& metaData = getMeshMetaData(filename);
+    CORRADE_ASSERT(metaData.meshIndex.first == metaData.meshIndex.second,
+                   "ResourceManager::loadScene: ptex mesh is not loaded "
+                   "correctly. Aborting.",
+                   false);
 
-      computePTexMeshAbsoluteAABBs(*meshes_[metaData.meshIndex.first],
-                                   staticDrawableInfo);
-    }
-
+    computePTexMeshAbsoluteAABBs(*meshes_[metaData.meshIndex.first],
+                                 staticDrawableInfo);
   }  // if parent
 
   return true;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -414,8 +414,7 @@ bool ResourceManager::loadSceneInternal(
         meshSuccess = loadInstanceMeshData(
             info, parent, drawables, computeAbsoluteAABBs, splitSemanticMesh);
       } else if (info.type == AssetType::FRL_PTEX_MESH) {
-        meshSuccess =
-            loadPTexMeshData(info, parent, drawables, computeAbsoluteAABBs);
+        meshSuccess = loadPTexMeshData(info, parent, drawables);
       } else if (info.type == AssetType::SUNCG_SCENE) {
         meshSuccess = loadSUNCGHouseFile(info, parent, drawables);
       } else if (info.type == AssetType::MP3D_MESH) {
@@ -717,8 +716,7 @@ void ResourceManager::buildPrimitiveAssetData(
 
 bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
                                        scene::SceneNode* parent,
-                                       DrawableGroup* drawables,
-                                       bool computeAbsoluteAABBs) {
+                                       DrawableGroup* drawables) {
 #ifdef ESP_BUILD_PTEX_SUPPORT
   // if this is a new file, load it and add it to the dictionary
   const std::string& filename = info.filepath;
@@ -769,8 +767,8 @@ bool ResourceManager::loadPTexMeshData(const AssetInfo& info,
             StaticDrawableInfo{node, static_cast<uint32_t>(jSubmesh)});
       }
     }
-    // compute aabb if appropriate here - always done if parent exists
-    // retrieve the ptex mesh data
+    // always compute absolute aabb for the PTEX mesh if parent exists
+    // because the ptex mesh is for sure a static scene.
     CORRADE_ASSERT(
         resourceDict_.count(filename) != 0,
         "ResourceManager::loadScene: ptex mesh is not loaded. Aborting.",

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -654,6 +654,7 @@ class ResourceManager {
   /**
    * @brief Load a PTex mesh into assets from a file and add it to the scene
    * graph for rendering.
+   * @return True if the mesh is loaded, otherwise false
    *
    * @param info The @ref AssetInfo for the mesh, already parsed from a
    * file.
@@ -661,13 +662,10 @@ class ResourceManager {
    * as a child.
    * @param drawables The @ref DrawableGroup with which the mesh will be
    * rendered.
-   * @param computeAbsoluteAABBs Whether absolute bounding boxes should be
-   * computed
    */
   bool loadPTexMeshData(const AssetInfo& info,
                         scene::SceneNode* parent,
-                        DrawableGroup* drawables,
-                        bool computeAbsoluteAABBs);
+                        DrawableGroup* drawables);
 
   /**
    * @brief Load an instance mesh (e.g. Matterport reconstruction) into assets

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -822,16 +822,6 @@ class ResourceManager {
                              const Mn::ResourceKey& material,
                              DrawableGroup* group = nullptr);
 
-  // ======== Instance Variables ========
-
-  /**
-   * @brief this helper vector contains information of the drawables on which
-   * we will compute the absolute AABB pair
-   *
-   */
-  // std::vector<StaticDrawableInfo> staticDrawableInfo_;
-  bool computeAbsoluteAABBs_ = false;
-
   // ======== General geometry data ========
   // shared_ptr is used here, instead of Corrade::Containers::Optional, or
   // std::optional because shared_ptr is reference type, not value type, and

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -654,7 +654,7 @@ class ResourceManager {
   /**
    * @brief Load a PTex mesh into assets from a file and add it to the scene
    * graph for rendering.
-   * @return True if the mesh is loaded, otherwise false
+   * @return true if the mesh is loaded, otherwise false
    *
    * @param info The @ref AssetInfo for the mesh, already parsed from a
    * file.


### PR DESCRIPTION
## Motivation and Context
As titled.
In this diff, 2 changes:
- compute the absolute AABB for replica mesh by default.
- add some comments to improve the code readability. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
