### PR TITLE
Fix pip install and shlex in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,6 @@ class CMakeBuild(build_ext):
         )
 
         if self.run_cmake(cmake_args):
-            print(self.build_temp)
             subprocess.check_call(
                 shlex.split(
                     'cmake -H"{}" -B"{}"'.format(ext.sourcedir, self.build_temp)

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,8 @@ class CMakeBuild(build_ext):
             with open(args_cache_file, "w") as f:
                 json.dump(cache, f, indent=4, sort_keys=True)
 
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
         # Save the CMake build directory -- that's where the generated setup.py
         # for magnum-bindings will appear which we need to run later
         global _cmake_build_dir
@@ -263,8 +265,12 @@ class CMakeBuild(build_ext):
         )
 
         if self.run_cmake(cmake_args):
+            print(self.build_temp)
             subprocess.check_call(
-                ["cmake", "-H", ext.sourcedir, "-B", self.build_tmp] + cmake_args,
+                shlex.split(
+                    'cmake -H"{}" -B"{}"'.format(ext.sourcedir, self.build_temp)
+                )
+                + cmake_args,
                 env=env,
             )
 
@@ -369,6 +375,9 @@ if __name__ == "__main__":
         long_description="",
         packages=find_packages(),
         install_requires=requirements,
+        setup_requires=["pytest-runner"],
+        tests_require=["pytest", "pytest-cov"],
+        python_requires=">=3.6",
         # add extension module
         ext_modules=[CMakeExtension("habitat_sim._ext.habitat_sim_bindings", "src")],
         # add custom build_ext command


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It makes sure the pip being called to install magnum is the one that is actually associated with the current python environment. It also removes some unnecessary shlex to make sure paths with quotes, spaces, or other special characters will work.

I also added an automatic way of running pytest tests from setup.py including install pytest and improved some of the features inside of setup.py
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Ran the setup.py with all the options

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
