### PR TITLE
-- Expand Attributes' JSON-loading tests

### DIFF
--- a/src/esp/assets/attributes/AttributesBase.h
+++ b/src/esp/assets/attributes/AttributesBase.h
@@ -5,14 +5,6 @@
 #ifndef ESP_ASSETS_ATTRIBUTES_ATTRIBUTES_H_
 #define ESP_ASSETS_ATTRIBUTES_ATTRIBUTES_H_
 
-#include <Magnum/Magnum.h>
-#include <map>
-#include <string>
-#include <vector>
-#include "Magnum/Math/Math.h"
-#include "Magnum/Types.h"
-
-#include "esp/assets/Asset.h"
 #include "esp/core/Configuration.h"
 
 namespace esp {

--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -17,7 +17,7 @@ const std::map<std::string, esp::assets::AssetType>
         {"suncg", AssetType::SUNCG_SCENE},
 };
 
-const std::string AbstractObjectAttributes::JSONConfigExample =
+const std::string AbstractObjectAttributes::JSONConfigTestString =
     R"({
       "scale":[2,3,4],
       "margin": 0.9,
@@ -30,8 +30,8 @@ const std::string AbstractObjectAttributes::JSONConfigExample =
       "render mesh": "testJSONRenderAsset.glb",
       "collision mesh": "testJSONCollisionAsset.glb")";
 
-const std::string ObjectAttributes::JSONConfigExample =
-    AbstractObjectAttributes::JSONConfigExample +
+const std::string ObjectAttributes::JSONConfigTestString =
+    AbstractObjectAttributes::JSONConfigTestString +
     R"(,
       "mass": 9,
       "use bounding box for collision": true,
@@ -40,8 +40,8 @@ const std::string ObjectAttributes::JSONConfigExample =
       "COM": [0.1,0.2,0.3]
     })";
 
-const std::string StageAttributes::JSONConfigExample =
-    AbstractObjectAttributes::JSONConfigExample +
+const std::string StageAttributes::JSONConfigTestString =
+    AbstractObjectAttributes::JSONConfigTestString +
     R"(,
       "gravity": [9,8,7],
       "origin":[1,2,3],

--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -17,11 +17,11 @@ const std::map<std::string, esp::assets::AssetType>
         {"suncg", AssetType::SUNCG_SCENE},
 };
 
-const std::string AbstractObjectAttributes::JSONConfigTemplate =
+const std::string AbstractObjectAttributes::JSONConfigExample =
     R"({
       "scale":[2,3,4],
       "margin": 0.9,
-      "friction coefficient": 0.321,
+      "friction coefficient": 0.321, 
       "restitution coefficient": 0.456,
       "requires lighting": false,
       "units to meters": 1.1,
@@ -30,8 +30,8 @@ const std::string AbstractObjectAttributes::JSONConfigTemplate =
       "render mesh": "testJSONRenderAsset.glb",
       "collision mesh": "testJSONCollisionAsset.glb")";
 
-const std::string ObjectAttributes::JSONConfigTemplate =
-    AbstractObjectAttributes::JSONConfigTemplate +
+const std::string ObjectAttributes::JSONConfigExample =
+    AbstractObjectAttributes::JSONConfigExample +
     R"(,
       "mass": 9,
       "use bounding box for collision": true,
@@ -40,8 +40,8 @@ const std::string ObjectAttributes::JSONConfigTemplate =
       "COM": [0.1,0.2,0.3]
     })";
 
-const std::string StageAttributes::JSONConfigTemplate =
-    AbstractObjectAttributes::JSONConfigTemplate +
+const std::string StageAttributes::JSONConfigExample =
+    AbstractObjectAttributes::JSONConfigExample +
     R"(,
       "gravity": [9,8,7],
       "origin":[1,2,3],

--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -17,6 +17,38 @@ const std::map<std::string, esp::assets::AssetType>
         {"suncg", AssetType::SUNCG_SCENE},
 };
 
+const std::string AbstractObjectAttributes::JSONConfigTemplate =
+    R"({
+      "scale":[2,3,4],
+      "margin": 0.9,
+      "friction coefficient": 0.321,
+      "restitution coefficient": 0.456,
+      "requires lighting": false,
+      "units to meters": 1.1,
+      "up":[2.1,0,0],
+      "front":[0,2.1,0],
+      "render mesh": "testJSONRenderAsset.glb",
+      "collision mesh": "testJSONCollisionAsset.glb")";
+
+const std::string ObjectAttributes::JSONConfigTemplate =
+    AbstractObjectAttributes::JSONConfigTemplate +
+    R"(,
+      "mass": 9,
+      "use bounding box for collision": true,
+      "join collision meshes":true,
+      "inertia": [1.1, 0.9, 0.3],
+      "COM": [0.1,0.2,0.3]
+    })";
+
+const std::string StageAttributes::JSONConfigTemplate =
+    AbstractObjectAttributes::JSONConfigTemplate +
+    R"(,
+      "gravity": [9,8,7],
+      "origin":[1,2,3],
+      "semantic mesh":"testJSONSemanticAsset.glb",
+      "nav mesh":"testJSONNavMeshAsset.glb",
+      "house filename":"testJSONHouseFileName.glb"
+    })";
 AbstractObjectAttributes::AbstractObjectAttributes(
     const std::string& attributesClassKey,
     const std::string& handle)

--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -37,7 +37,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setUnitsToMeters(1.0);
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
-}  // AbstractPhysicsAttributes ctor
+}  // AbstractObjectAttributes ctor
 
 ObjectAttributes::ObjectAttributes(const std::string& handle)
     : AbstractObjectAttributes("ObjectAttributes", handle) {

--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -21,7 +21,7 @@ const std::string AbstractObjectAttributes::JSONConfigExample =
     R"({
       "scale":[2,3,4],
       "margin": 0.9,
-      "friction coefficient": 0.321, 
+      "friction coefficient": 0.321,
       "restitution coefficient": 0.456,
       "requires lighting": false,
       "units to meters": 1.1,

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -7,6 +7,8 @@
 
 #include "AttributesBase.h"
 
+#include "esp/assets/Asset.h"
+
 namespace esp {
 namespace assets {
 namespace attributes {

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -23,10 +23,10 @@ class AbstractObjectAttributes : public AbstractAttributes {
   /**
    * @brief This defines an example JSON descriptor for @ref
    * AbstractObjectAttributes Has values that are different than defaults so
-   * this can be used to test JSON loading. These values may break the code, so
-   * should not be used.
+   * this can be used to test JSON loading. These values are set to be
+   * purposefully invalid, for testing purposes, and so should not be used.
    */
-  static const std::string JSONConfigTemplate;
+  static const std::string JSONConfigExample;
 
   /**
    * @brief Constant static map to provide mappings from string tags to @ref
@@ -177,9 +177,10 @@ class ObjectAttributes : public AbstractObjectAttributes {
   /**
    * @brief This defines an example JSON descriptor for @ref ObjectAttributes.
    * Has values that are different than defaults so this can be used to test
-   * JSON loading. These values may break the code, so should not be used.
+   * JSON loading. These values are set to be purposefully invalid, for testing
+   * purposes, and so should not be used.
    */
-  static const std::string JSONConfigTemplate;
+  static const std::string JSONConfigExample;
 
   ObjectAttributes(const std::string& handle = "");
   // center of mass (COM)
@@ -251,17 +252,18 @@ class ObjectAttributes : public AbstractObjectAttributes {
 };  // class ObjectAttributes
 
 ///////////////////////////////////////
-// stage and physics manager attributes
+// stage attributes
 
-//! attributes for a single physical scene
+//! attributes for a single stage
 class StageAttributes : public AbstractObjectAttributes {
  public:
   /**
    * @brief This defines an example JSON descriptor for @ref StageAttributes
    * Has values that are different than defaults so this can be used to test
-   * JSON loading. These values may break the code, so should not be used.
+   * JSON loading. These values are set to be purposefully invalid, for testing
+   * purposes, and so should not be used.
    */
-  static const std::string JSONConfigTemplate;
+  static const std::string JSONConfigExample;
   StageAttributes(const std::string& handle = "");
 
   void setOrigin(const Magnum::Vector3& origin) { setVec3("origin", origin); }

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -21,12 +21,12 @@ namespace attributes {
 class AbstractObjectAttributes : public AbstractAttributes {
  public:
   /**
-   * @brief This defines an example JSON descriptor for @ref
+   * @brief This defines an example json descriptor for @ref
    * AbstractObjectAttributes Has values that are different than defaults so
-   * this can be used to test JSON loading. These values are set to be
+   * this can be used to test json loading. These values are set to be
    * purposefully invalid, for testing purposes, and so should not be used.
    */
-  static const std::string JSONConfigExample;
+  static const std::string JSONConfigTestString;
 
   /**
    * @brief Constant static map to provide mappings from string tags to @ref
@@ -175,12 +175,12 @@ class AbstractObjectAttributes : public AbstractAttributes {
 class ObjectAttributes : public AbstractObjectAttributes {
  public:
   /**
-   * @brief This defines an example JSON descriptor for @ref ObjectAttributes.
+   * @brief This defines an example json descriptor for @ref ObjectAttributes.
    * Has values that are different than defaults so this can be used to test
-   * JSON loading. These values are set to be purposefully invalid, for testing
+   * json loading. These values are set to be purposefully invalid, for testing
    * purposes, and so should not be used.
    */
-  static const std::string JSONConfigExample;
+  static const std::string JSONConfigTestString;
 
   ObjectAttributes(const std::string& handle = "");
   // center of mass (COM)
@@ -258,12 +258,12 @@ class ObjectAttributes : public AbstractObjectAttributes {
 class StageAttributes : public AbstractObjectAttributes {
  public:
   /**
-   * @brief This defines an example JSON descriptor for @ref StageAttributes
+   * @brief This defines an example json descriptor for @ref StageAttributes
    * Has values that are different than defaults so this can be used to test
-   * JSON loading. These values are set to be purposefully invalid, for testing
+   * json loading. These values are set to be purposefully invalid, for testing
    * purposes, and so should not be used.
    */
-  static const std::string JSONConfigExample;
+  static const std::string JSONConfigTestString;
   StageAttributes(const std::string& handle = "");
 
   void setOrigin(const Magnum::Vector3& origin) { setVec3("origin", origin); }

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -156,7 +156,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
  public:
   ESP_SMART_POINTERS(AbstractObjectAttributes)
 
-};  // class AbstractPhysicsAttributes
+};  // class AbstractObjectAttributes
 
 /**
  * @brief Specific Attributes instance which is constructed with a base set of

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -21,6 +21,14 @@ namespace attributes {
 class AbstractObjectAttributes : public AbstractAttributes {
  public:
   /**
+   * @brief This defines an example JSON descriptor for @ref
+   * AbstractObjectAttributes Has values that are different than defaults so
+   * this can be used to test JSON loading. These values may break the code, so
+   * should not be used.
+   */
+  static const std::string JSONConfigTemplate;
+
+  /**
    * @brief Constant static map to provide mappings from string tags to @ref
    * AssetType values.  This will be used to map values set in json for mesh
    * type to @ref AssetTypes.  Keys must be lowercase.
@@ -166,6 +174,13 @@ class AbstractObjectAttributes : public AbstractAttributes {
  */
 class ObjectAttributes : public AbstractObjectAttributes {
  public:
+  /**
+   * @brief This defines an example JSON descriptor for @ref ObjectAttributes.
+   * Has values that are different than defaults so this can be used to test
+   * JSON loading. These values may break the code, so should not be used.
+   */
+  static const std::string JSONConfigTemplate;
+
   ObjectAttributes(const std::string& handle = "");
   // center of mass (COM)
   void setCOM(const Magnum::Vector3& com) { setVec3("COM", com); }
@@ -241,6 +256,12 @@ class ObjectAttributes : public AbstractObjectAttributes {
 //! attributes for a single physical scene
 class StageAttributes : public AbstractObjectAttributes {
  public:
+  /**
+   * @brief This defines an example JSON descriptor for @ref StageAttributes
+   * Has values that are different than defaults so this can be used to test
+   * JSON loading. These values may break the code, so should not be used.
+   */
+  static const std::string JSONConfigTemplate;
   StageAttributes(const std::string& handle = "");
 
   void setOrigin(const Magnum::Vector3& origin) { setVec3("origin", origin); }

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
@@ -8,6 +8,15 @@ namespace esp {
 namespace assets {
 namespace attributes {
 
+const std::string PhysicsManagerAttributes::JSONConfigTemplate =
+    R"({
+      "physics simulator": "bullet_test",
+      "timestep": 1.0,
+      "gravity": [1,2,3],
+      "friction coefficient": 1.4,
+      "restitution coefficient": 1.1
+    })";
+
 PhysicsManagerAttributes::PhysicsManagerAttributes(const std::string& handle)
     : AbstractAttributes("PhysicsManagerAttributes", handle) {
   setSimulator("none");

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
@@ -8,7 +8,7 @@ namespace esp {
 namespace assets {
 namespace attributes {
 
-const std::string PhysicsManagerAttributes::JSONConfigTemplate =
+const std::string PhysicsManagerAttributes::JSONConfigExample =
     R"({
       "physics simulator": "bullet_test",
       "timestep": 1.0,

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.cpp
@@ -8,7 +8,7 @@ namespace esp {
 namespace assets {
 namespace attributes {
 
-const std::string PhysicsManagerAttributes::JSONConfigExample =
+const std::string PhysicsManagerAttributes::JSONConfigTestString =
     R"({
       "physics simulator": "bullet_test",
       "timestep": 1.0,

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.h
@@ -17,10 +17,10 @@ class PhysicsManagerAttributes : public AbstractAttributes {
   /**
    * @brief This defines an example JSON descriptor for @ref
    * PhysicsManagerAttributes. Has values that are different than defaults so
-   * this can be used to test JSON loading.  These values may break the code, so
-   * should not be used.
+   * this can be used to test JSON loading. These values are set to be
+   * purposefully invalid, for testing purposes, and so should not be used.
    */
-  static const std::string JSONConfigTemplate;
+  static const std::string JSONConfigExample;
   PhysicsManagerAttributes(const std::string& handle = "");
 
   void setSimulator(const std::string& simulator) {

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.h
@@ -14,6 +14,13 @@ namespace attributes {
 //! attributes for a single physics manager
 class PhysicsManagerAttributes : public AbstractAttributes {
  public:
+  /**
+   * @brief This defines an example JSON descriptor for @ref
+   * PhysicsManagerAttributes. Has values that are different than defaults so
+   * this can be used to test JSON loading.  These values may break the code, so
+   * should not be used.
+   */
+  static const std::string JSONConfigTemplate;
   PhysicsManagerAttributes(const std::string& handle = "");
 
   void setSimulator(const std::string& simulator) {

--- a/src/esp/assets/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/assets/attributes/PhysicsManagerAttributes.h
@@ -15,12 +15,12 @@ namespace attributes {
 class PhysicsManagerAttributes : public AbstractAttributes {
  public:
   /**
-   * @brief This defines an example JSON descriptor for @ref
+   * @brief This defines an example json descriptor for @ref
    * PhysicsManagerAttributes. Has values that are different than defaults so
-   * this can be used to test JSON loading. These values are set to be
+   * this can be used to test json loading. These values are set to be
    * purposefully invalid, for testing purposes, and so should not be used.
    */
-  static const std::string JSONConfigExample;
+  static const std::string JSONConfigTestString;
   PhysicsManagerAttributes(const std::string& handle = "");
 
   void setSimulator(const std::string& simulator) {

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -132,6 +132,22 @@ class AssetAttributesManager
   }  // Attrs::AbstractPrimitiveAttributes::ptr createDefaultAttributesTemplate
 
   /**
+   * @brief Parse passed JSON Document specifically for @ref
+   * AbstractPrimitiveAttributes object. It always returns a valid @ref
+   * AbstractPrimitiveAttributes::ptr object.
+   *
+   * TODO : currently do not support file-based Primitive Assets, so no actual
+   * JSON parsing.
+   * @param filename the name of the file describing the asset attributes, used
+   * to determine type of attributes template.
+   * @param jsonConfig json document to parse
+   * @return a reference to the desired template.
+   */
+  Attrs::AbstractPrimitiveAttributes::ptr loadAttributesFromJSONDoc(
+      const std::string& filename,
+      const io::JsonDocument& jsonConfig) override;
+
+  /**
    * @brief Should only be called internally. Creates an instance of a
    * primtive asset attributes template described by passed enum value. For
    * primitive assets this mapes to the Magnum primitive class name

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -514,13 +514,13 @@ class AttributesManager {
   /**
    * @brief Create either an object or a scene attributes from a json config.
    * Since both object attributes and scene attributes inherit from @ref
-   * AbstractPhysicsAttributes, the functionality to populate these fields from
+   * AbstractObjectAttributes, the functionality to populate these fields from
    * json can be shared.  Also will will populate render mesh and collision mesh
    * handles in object and scene attributes with value(s) specified in json.  If
    * one is blank will use other for both.
    *
    * @tparam type of attributes to create : MUST INHERIT FROM @ref
-   * AbstractPhysicsAttributes
+   * AbstractObjectAttributes
    * @param filename name of json descriptor file
    * @param jsonDoc json document to parse
    * @return an appropriately cast attributes pointer with base class fields
@@ -531,13 +531,13 @@ class AttributesManager {
                                              const io::JsonDocument& jsonDoc);
 
   /**
-   * @brief Only used by @ref AbstractPhysicsAttributes derived-attributes. Set
+   * @brief Only used by @ref AbstractObjectAttributes derived-attributes. Set
    * the asset type and mesh asset filename from json file. If mesh asset
    * filename has changed in json, but type has not been specified in json,
    * re-run file-path-driven configuration to get asset type and possibly
    * orientation frame, if appropriate.
    *
-   * @param attributes The AbstractPhysicsAttributes object to be populated
+   * @param attributes The AbstractObjectAttributes object to be populated
    * @param jsonDoc The json document
    * @param jsonMeshTypeTag The string tag denoting the desired mesh type in the
    * json.
@@ -583,7 +583,7 @@ class AttributesManager {
    * specifying the asset type corresponding to that handle.  These settings
    * should not restrict anything, only provide defaults.
    *
-   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param attributes The AbstractObjectAttributes object to be configured
    * @param setFrame whether the frame should be set or not (only for render
    * assets in scenes)
    * @param fileName Mesh Handle to check.
@@ -960,7 +960,7 @@ bool AttributesManager<T>::setJSONAssetHandleAndType(
   // clear var to get new value
   fileName = "";
   // Map a json string value to its corresponding AssetType if found and cast to
-  // int, based on @ref AbstractPhysicsAttributes::AssetTypeNamesMap mappings.
+  // int, based on @ref AbstractObjectAttributes::AssetTypeNamesMap mappings.
   // Casts an int of the @ref esp::AssetType enum value if found and understood,
   // 0 (AssetType::UNKNOWN) if found but not understood, and
   //-1 if tag is not found in json.
@@ -977,7 +977,7 @@ bool AttributesManager<T>::setJSONAssetHandleAndType(
                       "Value in json @ tag : "
                    << jsonMeshTypeTag << " : `" << tmpVal
                    << "` does not map to a valid "
-                      "AbstractPhysicsAttributes::AssetTypeNamesMap value, so "
+                      "AbstractObjectAttributes::AssetTypeNamesMap value, so "
                       "defaulting mesh type to AssetType::UNKNOWN.";
       typeVal = static_cast<int>(AssetType::UNKNOWN);
     }

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -123,7 +123,7 @@ class AttributesManager {
 
   /**
    * @brief Parse passed JSON Document specifically for @ref AttribsPtr object.
-   * It always returns a  @ref AttribsPtr object.
+   * It always returns a @ref AttribsPtr object.
    * @param filename Can be the name of the file describing the @ref AttribsPtr,
    * used for attributes handle on create and, for some attributes such as @ref
    * PrimAssetAttributes, to determine type of actual instanced attributes

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -500,7 +500,7 @@ class AttributesManager {
       try {
         jsonDoc = io::parseJsonFile(filename);
       } catch (...) {
-        LOG(ERROR) << "Failed to parse " << filename << "as JSON.";
+        LOG(ERROR) << "Failed to parse " << filename << " as JSON.";
         return false;
       }
       return true;

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -575,8 +575,8 @@ class AttributesManager {
    * filled in.
    */
   template <typename U>
-  AttribsPtr createPhysicsAttributesFromJson(const std::string& filename,
-                                             const io::JsonDocument& jsonDoc);
+  AttribsPtr createObjectAttributesFromJson(const std::string& filename,
+                                            const io::JsonDocument& jsonDoc);
 
   /**
    * @brief Only used by @ref AbstractObjectAttributes derived-attributes. Set
@@ -910,7 +910,7 @@ class AttributesManager {
 
 template <class AttribsPtr>
 template <class U>
-AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
+AttribsPtr AttributesManager<AttribsPtr>::createObjectAttributesFromJson(
     const std::string& configFilename,
     const io::JsonDocument& jsonDoc) {
   auto attributes = initNewAttribsInternal(U::create(configFilename));
@@ -992,7 +992,7 @@ AttribsPtr AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson(
   attributes->setUseMeshCollision(true);
 
   return attributes;
-}  // AttributesManager<AttribsPtr>::createPhysicsAttributesFromJson
+}  // AttributesManager<AttribsPtr>::createObjectAttributesFromJson
 
 template <class T>
 bool AttributesManager<T>::setJSONAssetHandleAndType(

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -107,7 +107,7 @@ ObjectAttributes::ptr ObjectAttributesManager::loadAttributesFromJSONDoc(
     const io::JsonDocument& jsonConfig) {
   // Construct a ObjectAttributes and populate with any AbstractObjectAttributes
   // fields found in json.
-  auto objAttributes = this->createPhysicsAttributesFromJson<ObjectAttributes>(
+  auto objAttributes = this->createObjectAttributesFromJson<ObjectAttributes>(
       templateName, jsonConfig);
 
   // Populate with object-specific fields found in json, if any are there.

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -118,7 +118,7 @@ ObjectAttributesManager::createFileBasedAttributesTemplate(
   }
 
   // Construct a ObjectAttributes and populate with any
-  // AbstractPhysicsAttributes fields found in json.
+  // AbstractObjectAttributes fields found in json.
   auto objAttributes = this->createPhysicsAttributesFromJson<ObjectAttributes>(
       objPhysConfigFilename, jsonConfig);
 

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -8,7 +8,6 @@
 #include <Corrade/Utility/String.h>
 
 #include "esp/assets/Asset.h"
-#include "esp/io/io.h"
 #include "esp/io/json.h"
 
 using std::placeholders::_1;
@@ -34,8 +33,9 @@ ObjectAttributes::ptr ObjectAttributesManager::createAttributesTemplate(
   } else if (this->isValidFileName(attributesTemplateHandle)) {
     // if attributesTemplateHandle == some existing file then
     // assume this is a file-based object template we are building.
-    attrs = createFileBasedAttributesTemplate(attributesTemplateHandle,
-                                              registerTemplate);
+    // this method lives in class template.
+    attrs = this->createFileBasedAttributesTemplate(attributesTemplateHandle,
+                                                    registerTemplate);
     msg = "File (" + attributesTemplateHandle + ") Based";
   } else {
     // if neither of these is true, then build an empty template and assign the
@@ -102,49 +102,37 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
   }
 }  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
 
-ObjectAttributes::ptr
-ObjectAttributesManager::createFileBasedAttributesTemplate(
-    const std::string& objPhysConfigFilename,
-    bool registerTemplate) {
-  // Load JSON config file
-  io::JsonDocument jsonConfig;
-  bool success = this->verifyLoadJson(objPhysConfigFilename, jsonConfig);
-  if (!success) {
-    LOG(ERROR)
-        << "ObjectAttributesManager::createFileBasedAttributesTemplate : "
-           "Failure reading json : "
-        << objPhysConfigFilename << ". Aborting.";
-    return nullptr;
-  }
-
-  // Construct a ObjectAttributes and populate with any
-  // AbstractObjectAttributes fields found in json.
+ObjectAttributes::ptr ObjectAttributesManager::loadAttributesFromJSONDoc(
+    const std::string& templateName,
+    const io::JsonDocument& jsonConfig) {
+  // Construct a ObjectAttributes and populate with any AbstractObjectAttributes
+  // fields found in json.
   auto objAttributes = this->createPhysicsAttributesFromJson<ObjectAttributes>(
-      objPhysConfigFilename, jsonConfig);
+      templateName, jsonConfig);
 
-  // Populate with object-specific fields found in json, if any are there
+  // Populate with object-specific fields found in json, if any are there.
   // object mass
   io::jsonIntoSetter<double>(
       jsonConfig, "mass",
       std::bind(&ObjectAttributes::setMass, objAttributes, _1));
 
-  // optional set bounding box as collision object
+  // Use bounding box as collision object
   io::jsonIntoSetter<bool>(
       jsonConfig, "use bounding box for collision",
       std::bind(&ObjectAttributes::setBoundingBoxCollisions, objAttributes,
                 _1));
 
-  //! Get collision configuration options if specified
+  // Join collision meshes if specified
   io::jsonIntoSetter<bool>(
       jsonConfig, "join collision meshes",
       std::bind(&ObjectAttributes::setJoinCollisionMeshes, objAttributes, _1));
 
-  // object's interia matrix diag
+  // The object's interia matrix diagonal
   io::jsonIntoConstSetter<Magnum::Vector3>(
       jsonConfig, "inertia",
       std::bind(&ObjectAttributes::setInertia, objAttributes, _1));
 
-  // the center of mass (in the local frame of the object)
+  // The center of mass (in the local frame of the object)
   // if COM is provided, use it for mesh shift
   bool comIsSet = io::jsonIntoConstSetter<Magnum::Vector3>(
       jsonConfig, "COM",
@@ -152,7 +140,7 @@ ObjectAttributesManager::createFileBasedAttributesTemplate(
   // if com is set from json, don't compute from shape, and vice versa
   objAttributes->setComputeCOMFromShape(!comIsSet);
 
-  return this->postCreateRegister(objAttributes, registerTemplate);
+  return objAttributes;
 }  // ObjectAttributesManager::createFileBasedAttributesTemplate
 
 ObjectAttributes::ptr ObjectAttributesManager::createDefaultAttributesTemplate(

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -257,7 +257,7 @@ class ObjectAttributesManager
    * specifying the asset type corresponding to that handle.  These settings
    * should not restrict anything, only provide defaults.
    *
-   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param attributes The AbstractObjectAttributes object to be configured
    * @param setFrame whether the frame should be set or not (only for render
    * assets in scenes)
    * @param fileName Mesh Handle to check.

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -22,7 +22,7 @@ class ObjectAttributesManager
   ObjectAttributesManager(assets::ResourceManager& resourceManager)
       : AttributesManager<Attrs::ObjectAttributes::ptr>::AttributesManager(
             resourceManager,
-            "Physical Object") {
+            "Object") {
     buildCtorFuncPtrMaps();
   }
 
@@ -98,21 +98,17 @@ class ObjectAttributesManager
       bool registerTemplate = true);
 
   /**
-   * @brief Creates an instance of a template from a JSON file using passed
-   * filename by loading and parsing the loaded JSON and generating a @ref
-   * ObjectAttributes object. It returns created instance if successful,
-   * and nullptr if fails.
+   * @brief Parse passed JSON Document specifically for @ref ObjectAttributes
+   * object. It always returns a valid @ref ObjectAttributes::ptr object.
    *
-   * @param filename the name of the file describing the object attributes.
-   * Assumes it exists and fails if it does not.
-   * @param registerTemplate whether to add this template to the library.
-   * If the user is going to edit this template, this should be false - any
-   * subsequent editing will require re-registration. Defaults to true.
-   * @return a reference to the desired template, or nullptr if fails.
+   * @param templateName The desired name for this @ref ObjectAttributes
+   * template.
+   * @param jsonConfig json document to parse
+   * @return a reference to the desired template.
    */
-  Attrs::ObjectAttributes::ptr createFileBasedAttributesTemplate(
-      const std::string& filename,
-      bool registerTemplate = true);
+  Attrs::ObjectAttributes::ptr loadAttributesFromJSONDoc(
+      const std::string& templateName,
+      const io::JsonDocument& jsonConfig) override;
 
   /**
    * @brief Load file-based object templates for all "*.phys_properties.json"

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -76,17 +76,18 @@ class PhysicsAttributesManager
       bool registerTemplate = false) override;
 
   /**
-   * @brief Read and parse the json file @ref physicsFileName and populate a
-   * returned physics manager attributes with appropriate data.
+   * @brief Parse passed JSON Document specifically for @ref
+   * PhysicsManagerAttributes object. It always returns a valid @ref
+   * PhysicsManagerAttributes::ptr object.
    *
-   * @param physicsFilename The configuration file to parse.
-   * @param registerTemplate whether to add this template to the library.
-   * @return a reference to the physics simulation meta data object parsed from
-   * the specified configuration file, or nullptr if fails.
+   * @param templateName the desired handle of the @ref
+   * PhysicsManagerAttributes.
+   * @param jsonConfig json document to parse
+   * @return a reference to the desired template.
    */
-  Attrs::PhysicsManagerAttributes::ptr createFileBasedAttributesTemplate(
-      const std::string& physicsFilename,
-      bool registerTemplate);
+  Attrs::PhysicsManagerAttributes::ptr loadAttributesFromJSONDoc(
+      const std::string& templateName,
+      const io::JsonDocument& jsonConfig) override;
 
  protected:
   /**

--- a/src/esp/assets/managers/StageAttributesManager.cpp
+++ b/src/esp/assets/managers/StageAttributesManager.cpp
@@ -348,7 +348,7 @@ StageAttributes::ptr StageAttributesManager::createFileBasedAttributesTemplate(
   }
 
   // construct a StageAttributes and populate with any
-  // AbstractPhysicsAttributes fields found in json.
+  // AbstractObjectAttributes fields found in json.
   auto stageAttributes = this->createPhysicsAttributesFromJson<StageAttributes>(
       stageFilename, jsonConfig);
 

--- a/src/esp/assets/managers/StageAttributesManager.cpp
+++ b/src/esp/assets/managers/StageAttributesManager.cpp
@@ -26,12 +26,12 @@ StageAttributesManager::StageAttributesManager(
     PhysicsAttributesManager::ptr physicsAttributesManager)
     : AttributesManager<StageAttributes::ptr>::AttributesManager(
           resourceManager,
-          "Physical Stage"),
+          "Stage"),
       objectAttributesMgr_(objectAttributesMgr),
       physicsAttributesManager_(physicsAttributesManager),
       cfgLightSetup_(assets::ResourceManager::NO_LIGHT_KEY) {
   buildCtorFuncPtrMaps();
-}
+}  // StageAttributesManager ctor
 
 StageAttributes::ptr StageAttributesManager::createAttributesTemplate(
     const std::string& stageAttributesHandle,
@@ -52,8 +52,9 @@ StageAttributes::ptr StageAttributesManager::createAttributesTemplate(
         fileExists) {
       // check if stageAttributesHandle corresponds to an actual, existing
       // json stage file descriptor.
-      attrs = createFileBasedAttributesTemplate(stageAttributesHandle,
-                                                registerTemplate);
+      // this method lives in class template.
+      attrs = this->createFileBasedAttributesTemplate(stageAttributesHandle,
+                                                      registerTemplate);
       msg = "JSON File (" + stageAttributesHandle + ") Based";
     } else {
       // if name is not json file descriptor but still appropriate file
@@ -334,28 +335,18 @@ void StageAttributesManager::setDefaultFileNameBasedAttributes(
   }
 }  // StageAttributesManager::setDefaultFileNameBasedAttributes
 
-StageAttributes::ptr StageAttributesManager::createFileBasedAttributesTemplate(
-    const std::string& stageFilename,
-    bool registerTemplate) {
-  // Load the stage config JSON here
-  io::JsonDocument jsonConfig;
-  bool success = this->verifyLoadJson(stageFilename, jsonConfig);
-  if (!success) {
-    LOG(ERROR) << "StageAttributesManager::createFileBasedAttributesTemplate : "
-                  "Failure reading json "
-               << stageFilename << ". Aborting.";
-    return nullptr;
-  }
-
-  // construct a StageAttributes and populate with any
-  // AbstractObjectAttributes fields found in json.
+StageAttributes::ptr StageAttributesManager::loadAttributesFromJSONDoc(
+    const std::string& templateName,
+    const io::JsonDocument& jsonConfig) {
+  // construct a StageAttributes and populate with any AbstractObjectAttributes
+  // fields found in json.
   auto stageAttributes = this->createPhysicsAttributesFromJson<StageAttributes>(
-      stageFilename, jsonConfig);
+      templateName, jsonConfig);
 
   // directory location where stage files are found
   std::string stageLocFileDir = stageAttributes->getFileDirectory();
 
-  // now parse stage-specific fields
+  // now parse stage-specific fields.
   // load stage specific gravity
   io::jsonIntoConstSetter<Magnum::Vector3>(
       jsonConfig, "gravity",
@@ -410,14 +401,12 @@ StageAttributes::ptr StageAttributesManager::createFileBasedAttributesTemplate(
   // load the rigid object library metadata (no physics init yet...)
   if (jsonConfig.HasMember("rigid object paths") &&
       jsonConfig["rigid object paths"].IsArray()) {
-    std::string configDirectory =
-        stageFilename.substr(0, stageFilename.find_last_of("/"));
-
+    std::string configDirectory = stageAttributes->getFileDirectory();
     const auto& paths = jsonConfig["rigid object paths"];
     for (rapidjson::SizeType i = 0; i < paths.Size(); i++) {
       if (!paths[i].IsString()) {
         LOG(ERROR)
-            << "StageAttributesManager::createAttributesTemplate "
+            << "StageAttributesManager::loadAttributesFromJSONDoc "
                ":Invalid value in stage config 'rigid object paths'- array "
             << i;
         continue;
@@ -430,8 +419,8 @@ StageAttributes::ptr StageAttributesManager::createFileBasedAttributesTemplate(
     }
   }  // if load rigid object library metadata
 
-  return this->postCreateRegister(stageAttributes, registerTemplate);
-}  // StageAttributesManager::createFileBasedAttributesTemplate
+  return stageAttributes;
+}  // StageAttributesManager::loadAttributesFromJSONDoc
 
 }  // namespace managers
 }  // namespace assets

--- a/src/esp/assets/managers/StageAttributesManager.cpp
+++ b/src/esp/assets/managers/StageAttributesManager.cpp
@@ -340,7 +340,7 @@ StageAttributes::ptr StageAttributesManager::loadAttributesFromJSONDoc(
     const io::JsonDocument& jsonConfig) {
   // construct a StageAttributes and populate with any AbstractObjectAttributes
   // fields found in json.
-  auto stageAttributes = this->createPhysicsAttributesFromJson<StageAttributes>(
+  auto stageAttributes = this->createObjectAttributesFromJson<StageAttributes>(
       templateName, jsonConfig);
 
   // directory location where stage files are found

--- a/src/esp/assets/managers/StageAttributesManager.h
+++ b/src/esp/assets/managers/StageAttributesManager.h
@@ -124,7 +124,7 @@ class StageAttributesManager
    * specifying the asset type corresponding to that handle.  These settings
    * should not restrict anything, only provide defaults.
    *
-   * @param attributes The AbstractPhysicsAttributes object to be configured
+   * @param attributes The AbstractObjectAttributes object to be configured
    * @param setFrame whether the frame should be set or not (only for render
    * assets in scenes)
    * @param fileName Mesh Handle to check.

--- a/src/esp/assets/managers/StageAttributesManager.h
+++ b/src/esp/assets/managers/StageAttributesManager.h
@@ -115,6 +115,19 @@ class StageAttributesManager
       const std::string& primAttrTemplateHandle,
       bool registerTemplate = true);
 
+  /**
+   * @brief Parse passed JSON Document specifically for @ref StageAttributes
+   * object. It always returns a valid @ref StageAttributes::ptr object.
+   *
+   * @param templateName the desired handle of the @ref StageAttributes
+   * attributes.
+   * @param jsonConfig json document to parse
+   * @return a reference to the desired template.
+   */
+  Attrs::StageAttributes::ptr loadAttributesFromJSONDoc(
+      const std::string& templateName,
+      const io::JsonDocument& jsonConfig) override;
+
  protected:
   /**
    * @brief Perform file-name-based attributes initialization. This is to
@@ -168,18 +181,6 @@ class StageAttributesManager
    * @return a reference to the desired stage template, or nullptr if fails.
    */
   Attrs::StageAttributes::ptr createBackCompatAttributesTemplate(
-      const std::string& stageFilename,
-      bool registerTemplate = true);
-
-  /**
-   * @brief Read and parse the json file @ref stageFilename and populate a
-   * returned stage attributes with appropriate data.
-   *
-   * @param stageFilename The configuration file to parse.
-   * @param registerTemplate whether to add this template to the library or not.
-   * @return a reference to the desired stage template, or nullptr if fails.
-   */
-  Attrs::StageAttributes::ptr createFileBasedAttributesTemplate(
       const std::string& stageFilename,
       bool registerTemplate = true);
 

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -221,7 +221,7 @@ void initAttributesBindings(py::module& m) {
       .def_property(
           "house_filename", &StageAttributes::getHouseFilename,
           &StageAttributes::setHouseFilename,
-          R"(Handle for file containing semantic type maps and hierarchy for 
+          R"(Handle for file containing semantic type maps and hierarchy for
           constructions built from this template.)")
       .def_property(
           "light_setup", &StageAttributes::getLightSetup,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -144,7 +144,7 @@ void initAttributesBindings(py::module& m) {
       .def_property_readonly_static(
           "JSON_config_example",
           [](py::object) { return ObjectAttributes::JSONConfigTemplate; },
-          R"(A JSON example illustrating the possible user-modifiable 
+          R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for ObjectAttributes)")
       .def_property(
           "com", &ObjectAttributes::getCOM, &ObjectAttributes::setCOM,
@@ -203,7 +203,7 @@ void initAttributesBindings(py::module& m) {
       .def_property_readonly_static(
           "JSON_config_example",
           [](py::object) { return StageAttributes::JSONConfigTemplate; },
-          R"(A JSON example illustrating the possible user-modifiable 
+          R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for StageAttributes)")
       .def_property(
           "gravity", &StageAttributes::getGravity, &StageAttributes::setGravity,
@@ -252,7 +252,7 @@ void initAttributesBindings(py::module& m) {
           [](py::object) {
             return PhysicsManagerAttributes::JSONConfigTemplate;
           },
-          R"(A JSON example illustrating the possible user-modifiable 
+          R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for PhysicsManagerAttributes)")
       .def_property_readonly(
           "simulator", &PhysicsManagerAttributes::getSimulator,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -143,7 +143,7 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&ObjectAttributes::create<const std::string&>))
       .def_property_readonly_static(
           "JSON_config_example",
-          [](py::object) { return ObjectAttributes::JSONConfigTemplate; },
+          [](py::object) { return ObjectAttributes::JSONConfigExample; },
           R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for ObjectAttributes)")
       .def_property(
@@ -202,7 +202,7 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&StageAttributes::create<const std::string&>))
       .def_property_readonly_static(
           "JSON_config_example",
-          [](py::object) { return StageAttributes::JSONConfigTemplate; },
+          [](py::object) { return StageAttributes::JSONConfigExample; },
           R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for StageAttributes)")
       .def_property(
@@ -250,7 +250,7 @@ void initAttributesBindings(py::module& m) {
       .def_property_readonly_static(
           "JSON_config_example",
           [](py::object) {
-            return PhysicsManagerAttributes::JSONConfigTemplate;
+            return PhysicsManagerAttributes::JSONConfigExample;
           },
           R"(A JSON example illustrating the possible user-modifiable
           fields (via JSON) for PhysicsManagerAttributes)")

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -141,6 +141,11 @@ void initAttributesBindings(py::module& m) {
       m, "ObjectAttributes")
       .def(py::init(&ObjectAttributes::create<>))
       .def(py::init(&ObjectAttributes::create<const std::string&>))
+      .def_property_readonly_static(
+          "JSON_config_example",
+          [](py::object) { return ObjectAttributes::JSONConfigTemplate; },
+          R"(A JSON example illustrating the possible user-modifiable 
+          fields (via JSON) for ObjectAttributes)")
       .def_property(
           "com", &ObjectAttributes::getCOM, &ObjectAttributes::setCOM,
           R"(The Center of Mass for objects built from this template.)")
@@ -195,6 +200,11 @@ void initAttributesBindings(py::module& m) {
       m, "StageAttributes")
       .def(py::init(&StageAttributes::create<>))
       .def(py::init(&StageAttributes::create<const std::string&>))
+      .def_property_readonly_static(
+          "JSON_config_example",
+          [](py::object) { return StageAttributes::JSONConfigTemplate; },
+          R"(A JSON example illustrating the possible user-modifiable 
+          fields (via JSON) for StageAttributes)")
       .def_property(
           "gravity", &StageAttributes::getGravity, &StageAttributes::setGravity,
           R"(The 3-vector representation of gravity to use for physically-based
@@ -237,6 +247,13 @@ void initAttributesBindings(py::module& m) {
              PhysicsManagerAttributes::ptr>(m, "PhysicsManagerAttributes")
       .def(py::init(&PhysicsManagerAttributes::create<>))
       .def(py::init(&PhysicsManagerAttributes::create<const std::string&>))
+      .def_property_readonly_static(
+          "JSON_config_example",
+          [](py::object) {
+            return PhysicsManagerAttributes::JSONConfigTemplate;
+          },
+          R"(A JSON example illustrating the possible user-modifiable 
+          fields (via JSON) for PhysicsManagerAttributes)")
       .def_property_readonly(
           "simulator", &PhysicsManagerAttributes::getSimulator,
           R"(The simulator being used for dynamic simulation.  If none then only kinematic

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -141,11 +141,6 @@ void initAttributesBindings(py::module& m) {
       m, "ObjectAttributes")
       .def(py::init(&ObjectAttributes::create<>))
       .def(py::init(&ObjectAttributes::create<const std::string&>))
-      .def_property_readonly_static(
-          "JSON_config_example",
-          [](py::object) { return ObjectAttributes::JSONConfigExample; },
-          R"(A JSON example illustrating the possible user-modifiable
-          fields (via JSON) for ObjectAttributes)")
       .def_property(
           "com", &ObjectAttributes::getCOM, &ObjectAttributes::setCOM,
           R"(The Center of Mass for objects built from this template.)")
@@ -200,11 +195,6 @@ void initAttributesBindings(py::module& m) {
       m, "StageAttributes")
       .def(py::init(&StageAttributes::create<>))
       .def(py::init(&StageAttributes::create<const std::string&>))
-      .def_property_readonly_static(
-          "JSON_config_example",
-          [](py::object) { return StageAttributes::JSONConfigExample; },
-          R"(A JSON example illustrating the possible user-modifiable
-          fields (via JSON) for StageAttributes)")
       .def_property(
           "gravity", &StageAttributes::getGravity, &StageAttributes::setGravity,
           R"(The 3-vector representation of gravity to use for physically-based
@@ -231,7 +221,7 @@ void initAttributesBindings(py::module& m) {
       .def_property(
           "house_filename", &StageAttributes::getHouseFilename,
           &StageAttributes::setHouseFilename,
-          R"(Handle for file containing semantic type maps and hierarchy for
+          R"(Handle for file containing semantic type maps and hierarchy for 
           constructions built from this template.)")
       .def_property(
           "light_setup", &StageAttributes::getLightSetup,
@@ -247,13 +237,6 @@ void initAttributesBindings(py::module& m) {
              PhysicsManagerAttributes::ptr>(m, "PhysicsManagerAttributes")
       .def(py::init(&PhysicsManagerAttributes::create<>))
       .def(py::init(&PhysicsManagerAttributes::create<const std::string&>))
-      .def_property_readonly_static(
-          "JSON_config_example",
-          [](py::object) {
-            return PhysicsManagerAttributes::JSONConfigExample;
-          },
-          R"(A JSON example illustrating the possible user-modifiable
-          fields (via JSON) for PhysicsManagerAttributes)")
       .def_property_readonly(
           "simulator", &PhysicsManagerAttributes::getSimulator,
           R"(The simulator being used for dynamic simulation.  If none then only kinematic

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -56,9 +56,9 @@ bool jsonIntoVal(CORRADE_UNUSED const JsonDocument& d,
 
 /**
  * @brief Check passed json doc for existence of passed @ref tag as
- * float. If present, populate passed @ref val with
- * value. Returns whether tag is found and successfully populated, or not. Logs
- * an error if tag is found but is inappropriate type.
+ * float. If present, populate passed @ref val with value. Returns whether tag
+ * is found and successfully populated, or not. Logs an error if tag is found
+ * but is inappropriate type.
  *
  * @param d json document to parse
  * @param tag string tag to look for in json doc
@@ -79,9 +79,9 @@ inline bool jsonIntoVal(const JsonDocument& d, const char* tag, float& val) {
 
 /**
  * @brief Check passed json doc for existence of passed @ref tag as
- * double. If present, populate passed @ref val with
- * value. Returns whether tag is found and successfully populated, or not. Logs
- * an error if tag is found but is inappropriate type.
+ * double. If present, populate passed @ref val with value. Returns whether tag
+ * is found and successfully populated, or not. Logs an error if tag is found
+ * but is inappropriate type.
  *
  * @param d json document to parse
  * @param tag string tag to look for in json doc
@@ -103,9 +103,33 @@ inline bool jsonIntoVal(const JsonDocument& d, const char* tag, double& val) {
 
 /**
  * @brief Check passed json doc for existence of passed @ref tag as
- * double. If present, populate passed @ref val with
- * value. Returns whether tag is found and successfully populated, or not. Logs
- * an error if tag is found but is inappropriate type.
+ * int. If present, populate passed @ref val with value. Returns whether tag
+ * is found and successfully populated, or not. Logs an error if tag is found
+ * but is inappropriate type.
+ *
+ * @param d json document to parse
+ * @param tag string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+
+template <>
+inline bool jsonIntoVal(const JsonDocument& d, const char* tag, int& val) {
+  if (d.HasMember(tag)) {
+    if (d[tag].IsNumber()) {
+      val = d[tag].GetInt();
+      return true;
+    }
+    LOG(ERROR) << "Invalid int value specified in JSON config at " << tag;
+  }
+  return false;
+}  // jsonIntoInt
+
+/**
+ * @brief Check passed json doc for existence of passed @ref tag as
+ * boolean. If present, populate passed @ref val with value. Returns whether tag
+ * is found and successfully populated, or not. Logs an error if tag is found
+ * but is inappropriate type.
  *
  * @param d json document to parse
  * @param tag string tag to look for in json doc

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -55,7 +55,7 @@ class AttributesManagersTest : public testing::Test {
   template <typename T, typename U>
   std::shared_ptr<U> testBuildAttributesFromJSONString(std::shared_ptr<T> mgr) {
     // get JSON sample config from static Attributes string
-    const std::string& jsonString = U::JSONConfigTemplate;
+    const std::string& jsonString = U::JSONConfigExample;
     // create JSON document
     try {
       const auto& jsonDoc = esp::io::parseJsonString(jsonString);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -51,7 +51,7 @@ class AttributesManagersTest : public testing::Test {
    * @param mgr the Attributes Manager being tested,
    * @param handle the handle of the desired attributes template to work with
    */
-  template <class T>
+  template <typename T>
   void testCreateAndRemove(std::shared_ptr<T> mgr, const std::string& handle) {
     // meaningless key to modify attributes for verifcation of behavior
     std::string keyStr = "tempKey";
@@ -136,7 +136,7 @@ class AttributesManagersTest : public testing::Test {
    * @param renderHandle a legal render handle to set for the new template so
    * that registration won't fail.
    */
-  template <class T>
+  template <typename T>
   void testRemoveAllButDefault(std::shared_ptr<T> mgr,
                                const std::string& handle,
                                bool setRenderHandle) {
@@ -208,7 +208,7 @@ class AttributesManagersTest : public testing::Test {
    * @param renderHandle a legal render handle to set for the new template so
    * that registration won't fail.
    */
-  template <class T>
+  template <typename T>
   void testCreateAndRemoveDefault(std::shared_ptr<T> mgr,
                                   const std::string& handle,
                                   bool setRenderHandle) {
@@ -263,7 +263,7 @@ class AttributesManagersTest : public testing::Test {
    * @param illegalVal a legal value of ctorModField.  If null ptr then no
    * illegal values possible.
    */
-  template <class T>
+  template <typename T>
   void testAssetAttributesModRegRemove(std::shared_ptr<T> defaultAttribs,
                                        const std::string& ctorModField,
                                        int legalVal,
@@ -332,12 +332,24 @@ class AttributesManagersTest : public testing::Test {
   AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
 };  // class AttributesManagersTest
 
+TEST_F(AttributesManagersTest, AttributesManagers_JSONLoadTest) {}
+
+/**
+ * @brief This test will test creating, modifying, registering and deleting
+ * Attributes via Attributes Mangers for all existing attributes
+ * (PhysicsManagerAttributes, StageAttributes, ObjectAttributes, etc). These
+ * tests should be consistent with most types of future attributes managers
+ * specializing the AttributesManager class template that follow the same
+ * expected behavior paths as extent attributes/attributesManagers.  Note :
+ * PrimitiveAssetAttributes exhibit slightly different behavior and need their
+ * own tests.
+ */
 TEST_F(AttributesManagersTest, AttributesManagersCreate) {
   LOG(INFO) << "Starting AttributesManagersTest::AttributesManagersCreate";
-  std::string stageFile = Cr::Utility::Directory::join(
+  std::string stageConfigFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/scenes/simple_room.glb");
 
-  std::string objectFile = Cr::Utility::Directory::join(
+  std::string objectConfigFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/chair.phys_properties.json");
 
   LOG(INFO) << "Start Test : Create, Edit, Remove Attributes for "
@@ -348,28 +360,28 @@ TEST_F(AttributesManagersTest, AttributesManagersCreate) {
   testCreateAndRemove<AttrMgrs::PhysicsAttributesManager>(
       physicsAttributesManager_, physicsConfigFile);
   testCreateAndRemoveDefault<AttrMgrs::PhysicsAttributesManager>(
-      physicsAttributesManager_, stageFile, false);
+      physicsAttributesManager_, stageConfigFile, false);
 
   LOG(INFO) << "Start Test : Create, Edit, Remove Attributes for "
                "StageAttributesManager @ "
-            << stageFile;
+            << stageConfigFile;
 
   // scene attributes manager attributes verifcation
   testCreateAndRemove<AttrMgrs::StageAttributesManager>(stageAttributesManager_,
-                                                        stageFile);
+                                                        stageConfigFile);
   testCreateAndRemoveDefault<AttrMgrs::StageAttributesManager>(
-      stageAttributesManager_, stageFile, true);
+      stageAttributesManager_, stageConfigFile, true);
 
   LOG(INFO) << "Start Test : Create, Edit, Remove Attributes for "
                "ObjectAttributesManager @ "
-            << objectFile;
+            << objectConfigFile;
 
   int origNumFileBased = objectAttributesManager_->getNumFileTemplateObjects();
   int origNumPrimBased = objectAttributesManager_->getNumSynthTemplateObjects();
 
   // object attributes manager attributes verifcation
   testCreateAndRemove<AttrMgrs::ObjectAttributesManager>(
-      objectAttributesManager_, objectFile);
+      objectAttributesManager_, objectConfigFile);
   // verify that no new file-based and no new synth based template objects
   // remain
   int newNumFileBased1 = objectAttributesManager_->getNumFileTemplateObjects();
@@ -377,7 +389,7 @@ TEST_F(AttributesManagersTest, AttributesManagersCreate) {
   ASSERT_EQ(origNumFileBased, newNumFileBased1);
   ASSERT_EQ(origNumPrimBased, newNumPrimBased1);
   testCreateAndRemoveDefault<AttrMgrs::ObjectAttributesManager>(
-      objectAttributesManager_, objectFile, true);
+      objectAttributesManager_, objectConfigFile, true);
   // verify that no new file-based and no new synth based template objects
   // remain
   int newNumFileBased2 = objectAttributesManager_->getNumFileTemplateObjects();
@@ -387,7 +399,7 @@ TEST_F(AttributesManagersTest, AttributesManagersCreate) {
 
   // test adding many and removing all but defaults
   testRemoveAllButDefault<AttrMgrs::ObjectAttributesManager>(
-      objectAttributesManager_, objectFile, true);
+      objectAttributesManager_, objectConfigFile, true);
   // verify that no new file-based and no new synth based template objects
   // remain
   int newNumFileBased3 = objectAttributesManager_->getNumFileTemplateObjects();
@@ -396,15 +408,21 @@ TEST_F(AttributesManagersTest, AttributesManagersCreate) {
   ASSERT_EQ(origNumPrimBased, newNumPrimBased3);
 }  // AttributesManagersTest::AttributesManagersCreate test
 
+/**
+ * @brief test primitive asset attributes functionality in attirbutes managers.
+ * This includes testing handle auto-gen when relevant fields in asset
+ * attributes are changed.
+ */
 TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   LOG(INFO) << "Starting "
                "AttributesManagersTest::PrimitiveAssetAttributesTest";
   /**
-   * primitive asset attributes require slightly different testing since a
-   * default set of attributes are created on program load and are always
-   * present.  User modification of asset attributes always starts by
-   * modifying an existing default template - users will never create an
-   * attributes template from scratch.
+   * Primitive asset attributes require slightly different testing since a
+   * default set of attributes (matching the default Magnum::Primitive
+   * parameters) are created on program load and are always present.  User
+   * modification of asset attributes always starts by modifying an existing
+   * default template - users will never create an attributes template from
+   * scratch.
    */
   int legalModValWF = 64;
   int illegalModValWF = 25;

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -55,7 +55,7 @@ class AttributesManagersTest : public testing::Test {
   template <typename T, typename U>
   std::shared_ptr<U> testBuildAttributesFromJSONString(std::shared_ptr<T> mgr) {
     // get JSON sample config from static Attributes string
-    const std::string& jsonString = U::JSONConfigExample;
+    const std::string& jsonString = U::JSONConfigTestString;
     // create JSON document
     try {
       const auto& jsonDoc = esp::io::parseJsonString(jsonString);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,12 +18,12 @@ configure_file(
 test(AttributesManagersTest assets)
 target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(CoreTest io assets)
+TEST(CoreTest io)
 
 test(NavTest nav assets)
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(IOTest io)
+TEST(IOTest io assets)
 target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(Mp3dTest scene)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,12 +18,12 @@ configure_file(
 test(AttributesManagersTest assets)
 target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-TEST(CoreTest io)
+test(CoreTest io)
 
 test(NavTest nav assets)
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-TEST(IOTest io assets)
+test(IOTest io assets)
 target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(Mp3dTest scene)

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -4,14 +4,10 @@
 
 #include <gtest/gtest.h>
 
-#include "esp/assets/attributes/ObjectAttributes.h"
 #include "esp/core/Configuration.h"
 #include "esp/core/esp.h"
-#include "esp/io/json.h"
 
 using namespace esp::core;
-using esp::assets::attributes::AbstractObjectAttributes;
-using esp::assets::attributes::ObjectAttributes;
 
 TEST(CoreTest, ConfigurationTest) {
   Configuration cfg;
@@ -21,55 +17,4 @@ TEST(CoreTest, ConfigurationTest) {
   EXPECT_TRUE(cfg.hasValue("myString"));
   EXPECT_EQ(cfg.get<int>("myInt"), 10);
   EXPECT_EQ(cfg.get<std::string>("myString"), "test");
-}
-
-TEST(CoreTest, JsonTest) {
-  std::string s = "{\"test\":[1, 2, 3, 4]}";
-  const auto& json = esp::io::parseJsonString(s);
-  std::vector<int> t;
-  esp::io::toIntVector(json["test"], &t);
-  EXPECT_EQ(t[1], 2);
-  EXPECT_EQ(esp::io::jsonToString(json), "{\"test\":[1,2,3,4]}");
-
-  // test attributes populating
-
-  std::string attr_str =
-      "{\"render mesh\": \"banana.glb\",\"join collision "
-      "meshes\":false,\"mass\": 0.066,\"scale\": [2.0,2.0,2]}";
-
-  const auto& jsonDoc = esp::io::parseJsonString(attr_str);
-
-  // for function ptr placeholder
-  using std::placeholders::_1;
-  ObjectAttributes::ptr attributes = ObjectAttributes::create("temp");
-
-  bool success = false;
-  // test vector
-  success = esp::io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonDoc, "scale",
-      std::bind(&AbstractObjectAttributes::setScale, attributes, _1));
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getScale()[1], 2);
-
-  // test double
-  success = esp::io::jsonIntoSetter<double>(
-      jsonDoc, "mass", std::bind(&ObjectAttributes::setMass, attributes, _1));
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getMass(), 0.066);
-
-  // test bool
-  success = esp::io::jsonIntoSetter<bool>(
-      jsonDoc, "join collision meshes",
-      std::bind(&ObjectAttributes::setJoinCollisionMeshes, attributes, _1));
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getJoinCollisionMeshes(), false);
-
-  // test string
-  success = esp::io::jsonIntoSetter<std::string>(
-      jsonDoc, "render mesh",
-      std::bind(&ObjectAttributes::setRenderAssetHandle, attributes, _1));
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getRenderAssetHandle(), "banana.glb");
-
-  // test string
 }

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -3,12 +3,17 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <gtest/gtest.h>
+#include "esp/assets/attributes/ObjectAttributes.h"
 #include "esp/core/esp.h"
 #include "esp/io/io.h"
+#include "esp/io/json.h"
 
 #include "configure.h"
 
 using namespace esp::io;
+
+using esp::assets::attributes::AbstractObjectAttributes;
+using esp::assets::attributes::ObjectAttributes;
 
 TEST(IOTest, fileExistTest) {
   std::string file = FILE_THAT_EXISTS;
@@ -93,4 +98,55 @@ TEST(IOTest, tokenizeTest) {
   EXPECT_EQ((std::vector<std::string>{",a,", ",bb", "c"}), t2);
   const auto& t3 = tokenize(file, ",|", 0, true);
   EXPECT_EQ((std::vector<std::string>{"", "a", "bb", "c"}), t3);
+}
+
+/**
+ * @brief Test basic JSON file processing
+ */
+TEST(IOTest, JsonTest) {
+  std::string s = "{\"test\":[1, 2, 3, 4]}";
+  const auto& json = esp::io::parseJsonString(s);
+  std::vector<int> t;
+  esp::io::toIntVector(json["test"], &t);
+  EXPECT_EQ(t[1], 2);
+  EXPECT_EQ(esp::io::jsonToString(json), "{\"test\":[1,2,3,4]}");
+
+  // test basic attributes populating
+
+  std::string attr_str =
+      "{\"render mesh\": \"banana.glb\",\"join collision "
+      "meshes\":false,\"mass\": 0.066,\"scale\": [2.0,2.0,2]}";
+
+  const auto& jsonDoc = esp::io::parseJsonString(attr_str);
+
+  // for function ptr placeholder
+  using std::placeholders::_1;
+  ObjectAttributes::ptr attributes = ObjectAttributes::create("temp");
+
+  bool success = false;
+  // test vector
+  success = esp::io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonDoc, "scale", std::bind(&ObjectAttributes::setScale, attributes, _1));
+  EXPECT_EQ(success, true);
+  EXPECT_EQ(attributes->getScale()[1], 2);
+
+  // test double
+  success = esp::io::jsonIntoSetter<double>(
+      jsonDoc, "mass", std::bind(&ObjectAttributes::setMass, attributes, _1));
+  EXPECT_EQ(success, true);
+  EXPECT_EQ(attributes->getMass(), 0.066);
+
+  // test bool
+  success = esp::io::jsonIntoSetter<bool>(
+      jsonDoc, "join collision meshes",
+      std::bind(&ObjectAttributes::setJoinCollisionMeshes, attributes, _1));
+  EXPECT_EQ(success, true);
+  EXPECT_EQ(attributes->getJoinCollisionMeshes(), false);
+
+  // test string
+  success = esp::io::jsonIntoSetter<std::string>(
+      jsonDoc, "render mesh",
+      std::bind(&ObjectAttributes::setRenderAssetHandle, attributes, _1));
+  EXPECT_EQ(success, true);
+  EXPECT_EQ(attributes->getRenderAssetHandle(), "banana.glb");
 }


### PR DESCRIPTION
## Motivation and Context
We needed more tests for attributes setting via JSON.  This PR adds the following : 
1. The ability to parse a JSON doc directly into an attributes template.  The JSON did not have to originate from a file.
2. Example JSON strings for each type attributes that can be built from a JSON file.  These illustrate tags being used, with non-default values so that they can be used to test the JSON parsing functionality.
3. Test JSON loading and parsing for PhysicsManager, Object and Stage Attributes
4.  JSON tests were also moved from core to IO. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests have passed; Test added to verify all expected JSON fields are correctly populated. 

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
