### PR TITLE
Fix the depth buffer issue in PR752

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -154,6 +154,8 @@ struct RenderTarget::Impl {
     return framebuffer_.viewport().size();
   }
 
+  Mn::GL::Framebuffer& getFramebuffer() { return framebuffer_; }
+
 #ifdef ESP_BUILD_WITH_CUDA
   void readFrameRgbaGPU(uint8_t* devPtr) {
     // TODO: Consider implementing the GPU read functions with EGLImage
@@ -282,6 +284,10 @@ void RenderTarget::blitRgbaToDefault() {
 
 Mn::Vector2i RenderTarget::framebufferSize() const {
   return pimpl_->framebufferSize();
+}
+
+Mn::GL::Framebuffer& RenderTarget::getFramebuffer() {
+  return pimpl_->getFramebuffer();
 }
 
 #ifdef ESP_BUILD_WITH_CUDA

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -115,6 +115,8 @@ struct RenderTarget::Impl {
     framebuffer_.bind();
   }
 
+  void renderReEnter() { framebuffer_.bind(); }
+
   void renderExit() {}
 
   void blitRgbaToDefault() {
@@ -153,8 +155,6 @@ struct RenderTarget::Impl {
   Mn::Vector2i framebufferSize() const {
     return framebuffer_.viewport().size();
   }
-
-  Mn::GL::Framebuffer& getFramebuffer() { return framebuffer_; }
 
 #ifdef ESP_BUILD_WITH_CUDA
   void readFrameRgbaGPU(uint8_t* devPtr) {
@@ -262,6 +262,10 @@ void RenderTarget::renderEnter() {
   pimpl_->renderEnter();
 }
 
+void RenderTarget::renderReEnter() {
+  pimpl_->renderReEnter();
+}
+
 void RenderTarget::renderExit() {
   pimpl_->renderExit();
 }
@@ -284,10 +288,6 @@ void RenderTarget::blitRgbaToDefault() {
 
 Mn::Vector2i RenderTarget::framebufferSize() const {
   return pimpl_->framebufferSize();
-}
-
-Mn::GL::Framebuffer& RenderTarget::getFramebuffer() {
-  return pimpl_->getFramebuffer();
 }
 
 #ifdef ESP_BUILD_WITH_CUDA

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -57,6 +57,12 @@ class RenderTarget {
   void renderEnter();
 
   /**
+   * @brief Prepare for another render pass (e.g., to bind the framebuffer).
+   * Compared to @renderEnter, it will NOT clear the framebuffer.
+   */
+  void renderReEnter();
+
+  /**
    * @brief Called after any draw calls that target this RenderTarget
    */
   void renderExit();
@@ -65,11 +71,6 @@ class RenderTarget {
    * @brief The size of the framebuffer in WxH
    */
   Magnum::Vector2i framebufferSize() const;
-
-  /**
-   * @brief get the framebuffer
-   */
-  Magnum::GL::Framebuffer& getFramebuffer();
 
   /**
    * @brief Retrieve the RGBA rendering results.

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -67,6 +67,11 @@ class RenderTarget {
   Magnum::Vector2i framebufferSize() const;
 
   /**
+   * @brief get the framebuffer
+   */
+  Magnum::GL::Framebuffer& getFramebuffer();
+
+  /**
    * @brief Retrieve the RGBA rendering results.
    *
    * @param[in, out] view Preallocated memory that will be populated with the

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -96,13 +96,13 @@ bool PinholeCamera::getObservation(sim::Simulator& sim, Observation& obs) {
   if (!hasRenderTarget())
     return false;
 
-  drawObservationToFramebuffer(sim);
+  drawObservation(sim);
   readObservation(obs);
 
   return true;
 }
 
-bool PinholeCamera::drawObservationToFramebuffer(sim::Simulator& sim) {
+bool PinholeCamera::drawObservation(sim::Simulator& sim) {
   if (!hasRenderTarget()) {
     return false;
   }
@@ -163,7 +163,7 @@ bool PinholeCamera::displayObservation(sim::Simulator& sim) {
     return false;
   }
 
-  drawObservationToFramebuffer(sim);
+  drawObservation(sim);
   renderTarget().blitRgbaToDefault();
 
   return true;

--- a/src/esp/sensor/PinholeCamera.cpp
+++ b/src/esp/sensor/PinholeCamera.cpp
@@ -96,13 +96,17 @@ bool PinholeCamera::getObservation(sim::Simulator& sim, Observation& obs) {
   if (!hasRenderTarget())
     return false;
 
-  drawObservation(sim);
+  drawObservationToFramebuffer(sim);
   readObservation(obs);
 
   return true;
 }
 
-void PinholeCamera::drawObservation(sim::Simulator& sim) {
+bool PinholeCamera::drawObservationToFramebuffer(sim::Simulator& sim) {
+  if (!hasRenderTarget()) {
+    return false;
+  }
+
   renderTarget().renderEnter();
 
   gfx::RenderCamera::Flags flags;
@@ -123,6 +127,8 @@ void PinholeCamera::drawObservation(sim::Simulator& sim) {
   }
 
   renderTarget().renderExit();
+
+  return true;
 }
 
 void PinholeCamera::readObservation(Observation& obs) {
@@ -157,7 +163,7 @@ bool PinholeCamera::displayObservation(sim::Simulator& sim) {
     return false;
   }
 
-  drawObservation(sim);
+  drawObservationToFramebuffer(sim);
   renderTarget().blitRgbaToDefault();
 
   return true;

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -53,6 +53,14 @@ class PinholeCamera : public VisualSensor {
   virtual Corrade::Containers::Optional<Magnum::Vector2> depthUnprojection()
       const override;
 
+  /**
+   * @brief Draw an observation to the frame buffer using simulator's renderer
+   * @return true if success, otherwise false (e.g., frame buffer is not set)
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be drawn
+   */
+  virtual bool drawObservationToFramebuffer(sim::Simulator& sim) override;
+
  protected:
   // projection parameters
   int width_ = 640;      // canvas width
@@ -62,13 +70,6 @@ class PinholeCamera : public VisualSensor {
   float hfov_ = 35.0f;   // field of vision (in degrees)
 
   ESP_SMART_POINTERS(PinholeCamera)
-
-  /**
-   * @brief Draw an observation using simulator's renderer
-   * @param[in] sim Instance of Simulator class for which the observation needs
-   *                to be drawn
-   */
-  void drawObservation(sim::Simulator& sim);
 
   /**
    * @brief Read the observation that was rendered by the simulator

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -59,7 +59,7 @@ class PinholeCamera : public VisualSensor {
    * @param[in] sim Instance of Simulator class for which the observation needs
    *                to be drawn
    */
-  virtual bool drawObservationToFramebuffer(sim::Simulator& sim) override;
+  virtual bool drawObservation(sim::Simulator& sim) override;
 
  protected:
   // projection parameters

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -104,9 +104,7 @@ class VisualSensor : public Sensor {
    * @param[in] sim Instance of Simulator class for which the observation needs
    *                to be drawn
    */
-  virtual bool drawObservationToFramebuffer(sim::Simulator& sim) {
-    return false;
-  }
+  virtual bool drawObservation(sim::Simulator& sim) { return false; }
 
  protected:
   gfx::RenderTarget::uptr tgt_ = nullptr;

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -98,6 +98,16 @@ class VisualSensor : public Sensor {
     return *tgt_;
   }
 
+  /**
+   * @brief Draw an observation to the frame buffer using simulator's renderer
+   * @return true if success, otherwise false (e.g., frame buffer is not set)
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be drawn
+   */
+  virtual bool drawObservationToFramebuffer(sim::Simulator& sim) {
+    return false;
+  }
+
  protected:
   gfx::RenderTarget::uptr tgt_ = nullptr;
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -786,15 +786,15 @@ bool Simulator::displayObservation(const int agentId,
   return false;
 }
 
-bool Simulator::drawObservationToFramebuffer(const int agentId,
-                                             const std::string& sensorId) {
+bool Simulator::drawObservation(const int agentId,
+                                const std::string& sensorId) {
   agent::Agent::ptr ag = getAgent(agentId);
 
   if (ag != nullptr) {
     sensor::Sensor::ptr sensor = ag->getSensorSuite().get(sensorId);
     if (sensor != nullptr) {
       return std::static_pointer_cast<sensor::VisualSensor>(sensor)
-          ->drawObservationToFramebuffer(*this);
+          ->drawObservation(*this);
     }
   }
   return false;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -610,6 +610,30 @@ class Simulator {
    *                   be returned
    */
   bool displayObservation(int agentId, const std::string& sensorId);
+
+  /**
+   * @brief
+   * get the render target of a particular sensor of an agent
+   * @return pointer to the render target if it is a valid visual sensor,
+   * otherwise nullptr
+   * @param agentId    Id of the agent for which the observation is to
+   *                   be returned
+   * @param sensorId   Id of the sensor for which the observation is to
+   *                   be returned
+   */
+  gfx::RenderTarget* getRenderTarget(int agentId, const std::string& sensorId);
+
+  /**
+   * @brief draw observations to the frame buffer stored in that
+   * particular sensor of an agent. Unlike the @displayObservation, it will not
+   * display the observation on the default frame buffer
+   * @param agentId    Id of the agent for which the observation is to
+   *                   be returned
+   * @param sensorId   Id of the sensor for which the observation is to
+   *                   be returned
+   */
+  bool drawObservationToFramebuffer(int agentId, const std::string& sensorId);
+
   bool getAgentObservation(int agentId,
                            const std::string& sensorId,
                            sensor::Observation& observation);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -632,7 +632,7 @@ class Simulator {
    * @param sensorId   Id of the sensor for which the observation is to
    *                   be returned
    */
-  bool drawObservationToFramebuffer(int agentId, const std::string& sensorId);
+  bool drawObservation(int agentId, const std::string& sensorId);
 
   bool getAgentObservation(int agentId,
                            const std::string& sensorId,


### PR DESCRIPTION
## Motivation and Context
Tested the PR752 and found a couple of issues:
- In Linux: "imgui" did not display run-time info;
- In Linux: object picking functionality is broken;
- In Mac OSX: The rendering of the picked object is wrong. Occluded triangles would be displayed suggesting the depth buffer was broken.

This PR is to fix this problem.
Root cause:

For the broken object picking:
Now we display the observation via the sensor. A sensor will draw the observation to a framebuffer other than the default main buffer, and then blit the RGB result to the default buffer (NOTE: ONLY color info, NO depth info). However, we need the depth info in rendering the picked object.

For imgui:
The problem was that we did not re-bind the default framebuffer after we displayed the observation of the sensor.

Solution:
When an object is picked, we render the scene via the sensor first, to its framebuffer, the same as before. However, we deferred the blitting. Then we render the highlighted, picked object to the SAME framebuffer, and blit the results to the default main buffer to display.

This is also an alternative solution I can think of:
render the scene via the sensor and blit the RGB result to the screen. Also blit the depth texture from the RenderTarget to the default main buffer so that we can have the depth info. Compared to the current method, this will do one extra pass to copy the depth info, and thus potentially affect the performance.
(Improvement: map the depth texture to a quad which covers the whole screen, render this quad to the depth buffer of the default main buffer. But I found this will cause a lot of code changes if I am correct.)

@mosra : Thoughts? Do you think the current trade-off solution is good to go?

Before on linux: (no imgui, cannot select anything)
![1](https://user-images.githubusercontent.com/931093/91824438-a10e4700-ebef-11ea-9288-51456ae46155.png)

Before on Mac OSX (pay attention to the sofa as part of the wall is displayed on top of the sofa)
![bad](https://user-images.githubusercontent.com/931093/91824901-56d99580-ebf0-11ea-8286-43600cc7961a.png)


Now on linux (with the fix):
![good-2](https://user-images.githubusercontent.com/931093/91824450-a8cdeb80-ebef-11ea-880e-c767ed5cd0b6.png)

Now on Mac OSX (with the fix):
<img width="799" alt="Screen Shot 2020-09-01 at 1 10 03 AM" src="https://user-images.githubusercontent.com/931093/91824916-5b9e4980-ebf0-11ea-9b74-49ffa7c87838.png">




<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
