### PR TITLE
[docs] Fix page linking and remove unused notebooks.rst page

### DIFF
--- a/docs/Doxyfile-mcss
+++ b/docs/Doxyfile-mcss
@@ -16,7 +16,7 @@ XML_PROGRAMLISTING     = NO
 ##! M_CLASS_TREE_EXPAND_LEVELS = 2
 
 ##! M_LINKS_NAVBAR1 = \
-##!  "<a href="pages.html">Pages</a> <a href="new-actions.html">Add new actions</a> <a href="stereo-agent.html">Stereo agent</a> <a href="lighting-setups.html">Lighting Setups</a> <a href="notebooks.html">Notebooks</a> <a href="image-extractor.html">Image extraction</a>" \
+##!  "<a href="pages.html">Pages</a> <a href="new-actions.html">Add new actions</a> <a href="stereo-agent.html">Stereo agent</a> <a href="lighting-setups.html">Lighting Setups</a> <a href="image-extractor.html">Image extraction</a> <a href="rigid-object-tutorial.html">Rigid Object Tutorial</a>" \
 ##!  "<a href="classes.html">Classes</a>"
 ##! M_LINKS_NAVBAR2 = \
 ##!  "<a href="cpp.html">C++ API</a>" \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ INPUT_PAGES = [
     "pages/new-actions.rst",
     "pages/stereo-agent.rst",
     "pages/lighting-setups.rst",
-    "pages/notebooks.rst",
     "pages/image-extractor.rst",
     "pages/rigid-object-tutorial.rst",
 ]
@@ -76,8 +75,8 @@ LINKS_NAVBAR1 = [
             ("Add new actions", "new-actions"),
             ("Stereo agent", "stereo-agent"),
             ("Lighting Setups", "lighting-setups"),
-            ("Notebooks", "notebooks"),
             ("Image extraction", "image-extractor"),
+            ("Rigid Object Tutorial", "rigid-object-tutorial"),
         ],
     ),
     ("Classes", "classes", []),

--- a/docs/pages/image-extractor.rst
+++ b/docs/pages/image-extractor.rst
@@ -5,7 +5,7 @@ Habitat Sim Image Extractor Tutorial
     :class: m-block m-default
 
 
-This notebook will go over how to use the Image Extraction API in Habitat Sim and the different user options available.
+:summary: This tutorial will demonstrate how to use the Image Extraction API in Habitat Sim and the different user options available.
 
 .. code:: py
 

--- a/docs/pages/lighting-setups.rst
+++ b/docs/pages/lighting-setups.rst
@@ -1,12 +1,12 @@
+Working with Lights
+###################
+
 :ref-prefix:
     habitat_sim.gfx
     habitat_sim.simulator
     habitat_sim.sim
     habitat_sim.agent
     habitat_sim.attributes
-
-Working with Lights
-###################
 
 :summary: This tutorial demonstrates lighting of scenes and objects in Habitat -- creation, placement, configuration, and manipulation of light sources and shaders.
 

--- a/docs/pages/notebooks.rst
+++ b/docs/pages/notebooks.rst
@@ -1,6 +1,0 @@
-Notebooks
-#########
-
-We have the following demos in jupyter notebooks
-
--   ``notebooks/habitat-sim-demo.ipynb``

--- a/docs/pages/rigid-object-tutorial.rst
+++ b/docs/pages/rigid-object-tutorial.rst
@@ -1,12 +1,12 @@
+Interactive Rigid Objects
+#########################
+
 :ref-prefix:
     habitat_sim.simulator
     habitat_sim.sim
     habitat_sim.agent
     habitat_sim.attributes
     habitat_sim.scene
-
-Interactive Rigid Objects
-#########################
 
 :summary: This tutorial demonstrates rigid object interactions in Habitat-sim -- instancing, dynamic simulation, and kinematic manipulation.
 


### PR DESCRIPTION
## Motivation and Context

Minor changes to documentation to remove unused notebooks.rst page and fix pages.html linking to some tutorial pages.

## How Has This Been Tested

local build

Fixed pages.html:
![image](https://user-images.githubusercontent.com/1445143/91906657-6a6f1580-ec5d-11ea-8e5b-fa8b23da027c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
