### PR TITLE
add profiling_utils.configure and on_start_step

### DIFF
--- a/habitat_sim/utils/profiling_utils.py
+++ b/habitat_sim/utils/profiling_utils.py
@@ -30,9 +30,33 @@ export HABITAT_PROFILING=1
 path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=cuda,nvtx
 --trace-fork-before-exec=true --output=my_profile python my_program.py
 # look for my_profile.qdrep in working directory
+
+Example usage for capturing a certain range of train steps (from step 200 to
+step 300):
+
+@profiling_utils.RangeContext("train")
+def train():
+    profiling_utils.configure(capture_start_step=200, num_steps_to_capture=100)
+    initialize_training()
+    for _ in range(10000)):
+        profiling_utils.on_start_step()
+        with profiling_utils.RangeContext("collect_rollout_steps"):
+            collect_rollout_steps()
+        with profiling_utils.RangeContext("update_agent"):
+            update_agent()
+
+Example of capturing an Nsight Systems profile using your capture range:
+export HABITAT_PROFILING=1
+export NSYS_NVTX_PROFILER_REGISTER_ONLY=0  # required when using capture range
+path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=cuda,nvtx
+--trace-fork-before-exec=true ---trace=nvtx --capture-range=nvtx -p
+"habitat_capture_range" --output=my_profile python my_program.py
+# look for my_profile.qdrep in working directory
 """
 import os
 from contextlib import ContextDecorator
+
+import attr
 
 from habitat_sim.logging import logger
 
@@ -44,6 +68,69 @@ if enable_profiling:
     from torch.cuda import nvtx
 
 
+@attr.s(auto_attribs=True)
+class _ProfilingHelper:
+    step_count: int = -1
+    capture_start_step: int = -1
+    capture_end_step: int = -1
+    range_depth: int = 0
+
+
+_helper = _ProfilingHelper()
+
+
+def configure(capture_start_step=-1, num_steps_to_capture=-1):
+    r"""Configures profiling_utils to push a "habitat_capture_range" range to
+    span the desired train steps. See also on_start_step(). See
+    profiling_utils.py file-level documentation for example usage with Nvidia
+    Nsight.
+
+    Your program can have many processes that call range_push/range_pop, but
+    only your main process (the one executing your train loop) should call
+    configure() and on_start_step().
+
+    If capture_start_step == 0, then capturing starts at the start of step 0
+    (after initialization code). If capture_start_step == -1, then capturing
+    starts immediately after your call to configure() and includes any
+    initialization code that runs prior to step 0. If num_steps_to_capture ==
+    -1, the range won't be popped and capture will continue until your program
+    terminates.
+    """
+
+    if not enable_profiling:
+        return
+
+    assert _helper.step_count == -1  # must call configure before on_start_step
+    _helper.capture_start_step = capture_start_step
+
+    if _helper.capture_start_step == -1:
+        range_push("habitat_capture_range")
+
+    assert num_steps_to_capture == -1 or num_steps_to_capture > 0
+    if num_steps_to_capture == -1:
+        _helper.capture_end_step = -1
+    elif _helper.capture_start_step == -1:
+        _helper.capture_end_step = num_steps_to_capture
+    else:
+        _helper.capture_end_step = capture_start_step + num_steps_to_capture
+
+
+def on_start_step():
+    r"""Marks the start of a train step. This is required for profiling_utils
+    internal bookkeeping. See also configure().
+    """
+
+    if not enable_profiling:
+        return
+
+    _helper.step_count += 1
+
+    if _helper.step_count == _helper.capture_start_step:
+        range_push("habitat_capture_range")
+    elif _helper.step_count == _helper.capture_end_step:
+        range_pop()
+
+
 def range_push(msg: str) -> None:
     r"""Annotates the start of a range for profiling. Requires HABITAT_PROFILING
     environment variable to be set, otherwise the function is a no-op. Pushes a
@@ -51,14 +138,26 @@ def range_push(msg: str) -> None:
     corresponding range_pop. Attached profilers can capture the time spent in
     ranges."
     """
-    if enable_profiling:
-        nvtx.range_push(msg)
+    if not enable_profiling:
+        return
+
+    nvtx.range_push(msg)
+    _helper.range_depth += 1
+    max_depth = 64
+    # In practice, there is little need to go deeper than 5 or 10. By asserting
+    # here, we'll catch improper range_push/range_pop usage. Specifically,
+    # we'll (eventually) catch an unmatched range_push.
+    assert _helper.range_depth < max_depth
 
 
 def range_pop() -> None:
     r"""Annotates the end of a range for profiling. See also range_push."""
-    if enable_profiling:
-        nvtx.range_pop()
+    if not enable_profiling:
+        return
+
+    assert _helper.range_depth > 0
+    nvtx.range_pop()
+    _helper.range_depth -= 1
 
 
 class RangeContext(ContextDecorator):

--- a/habitat_sim/utils/profiling_utils.py
+++ b/habitat_sim/utils/profiling_utils.py
@@ -60,10 +60,10 @@ import attr
 
 from habitat_sim.logging import logger
 
-env_var = os.environ.get("HABITAT_PROFILING", "0")
-enable_profiling = env_var != "0"
-if enable_profiling:
-    logger.info("HABITAT_PROFILING={}".format(env_var))
+_env_var = os.environ.get("HABITAT_PROFILING", "0")
+_enable_profiling = _env_var != "0"
+if _enable_profiling:
+    logger.info("HABITAT_PROFILING={}".format(_env_var))
     logger.info("profiling_utils.py range_push/range_pop annotation is enabled")
     from torch.cuda import nvtx
 
@@ -97,7 +97,7 @@ def configure(capture_start_step=-1, num_steps_to_capture=-1):
     terminates.
     """
 
-    if not enable_profiling:
+    if not _enable_profiling:
         return
 
     assert _helper.step_count == -1  # must call configure before on_start_step
@@ -120,7 +120,7 @@ def on_start_step():
     internal bookkeeping. See also configure().
     """
 
-    if not enable_profiling:
+    if not _enable_profiling:
         return
 
     _helper.step_count += 1
@@ -138,7 +138,7 @@ def range_push(msg: str) -> None:
     corresponding range_pop. Attached profilers can capture the time spent in
     ranges."
     """
-    if not enable_profiling:
+    if not _enable_profiling:
         return
 
     nvtx.range_push(msg)
@@ -152,7 +152,7 @@ def range_push(msg: str) -> None:
 
 def range_pop() -> None:
     r"""Annotates the end of a range for profiling. See also range_push."""
-    if not enable_profiling:
+    if not _enable_profiling:
         return
 
     assert _helper.range_depth > 0

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -7,6 +7,8 @@
 
 import importlib
 import os
+from io import StringIO
+from unittest.mock import patch
 
 from habitat_sim.utils import profiling_utils
 
@@ -22,6 +24,7 @@ def test_env_var_enable():
     assert not profiling_utils.enable_profiling
     # We also call range_push/range_pop to verify they run without error.
     profiling_utils.range_push("test, env var not set")
+    assert profiling_utils._helper.range_depth == 0
     profiling_utils.range_pop()
 
     # test with env var set to "0". This is equivalent to
@@ -30,6 +33,7 @@ def test_env_var_enable():
     importlib.reload(profiling_utils)
     assert not profiling_utils.enable_profiling
     profiling_utils.range_push("test, HABITAT_PROFILING='0'")
+    assert profiling_utils._helper.range_depth == 0
     profiling_utils.range_pop()
 
     # test with env var set to "1"
@@ -37,26 +41,25 @@ def test_env_var_enable():
     importlib.reload(profiling_utils)
     assert profiling_utils.enable_profiling
     profiling_utils.range_push("test, HABITAT_PROFILING=True")
+    assert profiling_utils._helper.range_depth == 1
     profiling_utils.range_pop()
 
 
 # Create nested ranges and verify the code runs without error.
 def test_nested_range_push_pop():
-    # Unfortunately, there isn't a way to verify correct behavior here. Ranges
-    # get recorded in the Nvidia driver/profiler. Documentation for
-    # torch.cuda.nvtx.range_push claims that it returns range stack depth, so I
-    # hoped to use it as a behavior checker, but it seems to just return -1 or
-    # -2 in practice.
 
     os.environ[env_var_name] = "1"
     importlib.reload(profiling_utils)
 
+    assert profiling_utils._helper.range_depth == 0
     profiling_utils.range_push("A")
     profiling_utils.range_push("B")
     profiling_utils.range_push("C")
+    assert profiling_utils._helper.range_depth == 3
     profiling_utils.range_pop()
     profiling_utils.range_pop()
     profiling_utils.range_pop()
+    assert profiling_utils._helper.range_depth == 0
 
 
 # Create ranges via RangeContext and verify the code runs without error.
@@ -66,15 +69,47 @@ def test_range_context():
     importlib.reload(profiling_utils)
 
     with profiling_utils.RangeContext("A"):
-        pass
+        assert profiling_utils._helper.range_depth == 1
+    assert profiling_utils._helper.range_depth == 0
 
     @profiling_utils.RangeContext("B")
     def my_example_profiled_function():
         pass
 
     my_example_profiled_function()
+    assert profiling_utils._helper.range_depth == 0
 
     with profiling_utils.RangeContext("C"):
+        assert profiling_utils._helper.range_depth == 1
         my_example_profiled_function()
+        assert profiling_utils._helper.range_depth == 1
         with profiling_utils.RangeContext("D"):
+            assert profiling_utils._helper.range_depth == 2
             my_example_profiled_function()
+        assert profiling_utils._helper.range_depth == 1
+    assert profiling_utils._helper.range_depth == 0
+
+
+# Use configure() to capture a desired range of train steps.
+def test_configure_and_on_start_step():
+
+    # Use mock range_push/range_pop. This test only looks to confirm that these
+    # functions get called at the right time.
+    def fake_range_push(msg):
+        print("range_push " + msg)
+
+    def fake_range_pop():
+        print("range_pop")
+
+    with patch("sys.stdout", new=StringIO()) as fake_out, patch(
+        "habitat_sim.utils.profiling_utils.range_push", new=fake_range_push
+    ), patch("habitat_sim.utils.profiling_utils.range_pop", new=fake_range_pop):
+        # Capture train steps 2 through 6.
+        profiling_utils.configure(capture_start_step=2, num_steps_to_capture=5)
+        for step in range(8):
+            profiling_utils.on_start_step()  # Mark start of train step
+            print("step {}".format(step))
+
+        # Expect the capture range to span steps 2 through 6.
+        expected_out = "step 0\nstep 1\nrange_push habitat_capture_range\nstep 2\nstep 3\nstep 4\nstep 5\nstep 6\nrange_pop\nstep 7\n"
+        assert fake_out.getvalue() == expected_out

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -12,16 +12,16 @@ from unittest.mock import patch
 
 from habitat_sim.utils import profiling_utils
 
-env_var_name = "HABITAT_PROFILING"
+_ENV_VAR_NAME = "HABITAT_PROFILING"
 
 # Based on the env var, reloading the profiling_utils module should set
-# profiling_utils.enable_profiling to True or False.
+# profiling_utils._enable_profiling to True or False.
 def test_env_var_enable():
 
     # test with env var not set
-    os.environ.pop(env_var_name, None)
+    os.environ.pop(_ENV_VAR_NAME, None)
     importlib.reload(profiling_utils)
-    assert not profiling_utils.enable_profiling
+    assert not profiling_utils._enable_profiling
     # We also call range_push/range_pop to verify they run without error.
     profiling_utils.range_push("test, env var not set")
     assert profiling_utils._helper.range_depth == 0
@@ -29,17 +29,17 @@ def test_env_var_enable():
 
     # test with env var set to "0". This is equivalent to
     # `export HABITAT_PROFILING=0` on the command line.
-    os.environ[env_var_name] = "0"
+    os.environ[_ENV_VAR_NAME] = "0"
     importlib.reload(profiling_utils)
-    assert not profiling_utils.enable_profiling
+    assert not profiling_utils._enable_profiling
     profiling_utils.range_push("test, HABITAT_PROFILING='0'")
     assert profiling_utils._helper.range_depth == 0
     profiling_utils.range_pop()
 
     # test with env var set to "1"
-    os.environ[env_var_name] = "1"
+    os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
-    assert profiling_utils.enable_profiling
+    assert profiling_utils._enable_profiling
     profiling_utils.range_push("test, HABITAT_PROFILING=True")
     assert profiling_utils._helper.range_depth == 1
     profiling_utils.range_pop()
@@ -48,7 +48,7 @@ def test_env_var_enable():
 # Create nested ranges and verify the code runs without error.
 def test_nested_range_push_pop():
 
-    os.environ[env_var_name] = "1"
+    os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
 
     assert profiling_utils._helper.range_depth == 0
@@ -65,7 +65,7 @@ def test_nested_range_push_pop():
 # Create ranges via RangeContext and verify the code runs without error.
 def test_range_context():
 
-    os.environ[env_var_name] = "1"
+    os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
 
     with profiling_utils.RangeContext("A"):


### PR DESCRIPTION
## Motivation and Context

We want to control the range of train steps that we capture for profiling.

Example usage for capturing a certain range of train steps (from step 200 to
step 300):
```
@profiling_utils.RangeContext("train")
def train():
    profiling_utils.configure(capture_start_step=200, num_steps_to_capture=100)
    initialize_training()
    for _ in range(10000)):
        profiling_utils.on_start_step()
        with profiling_utils.RangeContext("collect_rollout_steps"):
            collect_rollout_steps()
        with profiling_utils.RangeContext("update_agent"):
            update_agent()
```

## How Has This Been Tested

Added a unit test. Also some ad hoc testing with DDPPO training.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Hab-sim code freeze lifted
