### PR TITLE
Fix building with make in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def in_git():
     try:
         subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"])
         return True
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.SubprocessError):
         return False
 
 
@@ -131,7 +131,7 @@ def has_ninja():
     try:
         subprocess.check_output(["ninja", "--version"])
         return True
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.SubprocessError):
         return False
 
 
@@ -194,7 +194,7 @@ class CMakeBuild(build_ext):
     def run(self):
         try:
             subprocess.check_output(["cmake", "--version"])
-        except OSError:
+        except (OSError, subprocess.SubprocessError):
             raise RuntimeError(
                 "CMake must be installed to build the following extensions: "
                 + ", ".join(e.name for e in self.extensions)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes a bug in setup.py introduced by #757 that prevented setup.py from using make if ninja was not available. Apparently, if the subprocess executable is not found it throws a `FileNotFoundError` instead of a `subprocess Error`. This patch widens the exception catching target to include this as well as other permission related errors.  
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
I was able to build on my machine that doesn't have Ninja installed.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
