### PR TITLE
--[Bug Fix] Verify AttributesManager template type is valid

### DIFF
--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -76,7 +76,7 @@ enum class PrimObjTypes : uint32_t {
 };
 namespace managers {
 class AssetAttributesManager
-    : public AttributesManager<Attrs::AbstractPrimitiveAttributes::ptr> {
+    : public AttributesManager<Attrs::AbstractPrimitiveAttributes> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -86,7 +86,7 @@ class AssetAttributesManager
   static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
 
   AssetAttributesManager(assets::ResourceManager& resourceManager)
-      : AttributesManager<Attrs::AbstractPrimitiveAttributes::ptr>::
+      : AttributesManager<Attrs::AbstractPrimitiveAttributes>::
             AttributesManager(resourceManager, "Primitive Asset") {
     buildCtorFuncPtrMaps();
   }  // AssetAttributesManager::ctor

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -45,7 +45,7 @@ template <class T>
 class AttributesManager {
  public:
   static_assert(std::is_base_of<Attrs::AbstractAttributes, T>::value,
-                "Managed typedd must be derived from AbstractAttributes");
+                "Managed type must be derived from AbstractAttributes");
 
   typedef std::shared_ptr<T> AttribsPtr;
 
@@ -917,8 +917,7 @@ class AttributesManager {
 // Class Template Method Definitions
 
 template <class T>
-typename AttributesManager<T>::AttribsPtr
-AttributesManager<T>::createObjectAttributesFromJson(
+std::shared_ptr<T> AttributesManager<T>::createObjectAttributesFromJson(
     const std::string& configFilename,
     const io::JsonDocument& jsonDoc) {
   auto attributes = this->initNewAttribsInternal(configFilename);
@@ -1004,7 +1003,7 @@ AttributesManager<T>::createObjectAttributesFromJson(
 
 template <class T>
 bool AttributesManager<T>::setJSONAssetHandleAndType(
-    typename AttributesManager<T>::AttribsPtr attributes,
+    AttribsPtr attributes,
     const io::JsonDocument& jsonDoc,
     const char* jsonMeshTypeTag,
     const char* jsonMeshHandleTag,
@@ -1078,7 +1077,7 @@ bool AttributesManager<T>::setTemplateLock(const std::string& templateHandle,
 }  // AttributesManager::setTemplateLock
 
 template <class T>
-std::vector<typename AttributesManager<T>::AttribsPtr>
+std::vector<std::shared_ptr<T>>
 AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
                                                  bool contains) {
   std::vector<AttribsPtr> res;
@@ -1096,9 +1095,9 @@ AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
 }  // removeAllTemplates
 
 template <class T>
-typename AttributesManager<T>::AttribsPtr
-AttributesManager<T>::removeTemplateInternal(const std::string& templateHandle,
-                                             const std::string& sourceStr) {
+std::shared_ptr<T> AttributesManager<T>::removeTemplateInternal(
+    const std::string& templateHandle,
+    const std::string& sourceStr) {
   if (!checkExistsWithMessage(templateHandle, sourceStr)) {
     LOG(INFO) << sourceStr << " : Unable to remove " << attrType_
               << " template " << templateHandle << " : Does not exist.";

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -917,10 +917,10 @@ class AttributesManager {
 // Class Template Method Definitions
 
 template <class T>
-std::shared_ptr<T> AttributesManager<T>::createObjectAttributesFromJson(
+auto AttributesManager<T>::createObjectAttributesFromJson(
     const std::string& configFilename,
-    const io::JsonDocument& jsonDoc) {
-  auto attributes = this->initNewAttribsInternal(configFilename);
+    const io::JsonDocument& jsonDoc) -> AttribsPtr {
+  AttribsPtr attributes = this->initNewAttribsInternal(configFilename);
 
   using std::placeholders::_1;
 
@@ -1077,9 +1077,9 @@ bool AttributesManager<T>::setTemplateLock(const std::string& templateHandle,
 }  // AttributesManager::setTemplateLock
 
 template <class T>
-std::vector<std::shared_ptr<T>>
-AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
-                                                 bool contains) {
+auto AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
+                                                      bool contains)
+    -> std::vector<AttribsPtr> {
   std::vector<AttribsPtr> res;
   // get all handles that match query elements first
   std::vector<std::string> handles =
@@ -1095,9 +1095,9 @@ AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
 }  // removeAllTemplates
 
 template <class T>
-std::shared_ptr<T> AttributesManager<T>::removeTemplateInternal(
+auto AttributesManager<T>::removeTemplateInternal(
     const std::string& templateHandle,
-    const std::string& sourceStr) {
+    const std::string& sourceStr) -> AttribsPtr {
   if (!checkExistsWithMessage(templateHandle, sourceStr)) {
     LOG(INFO) << sourceStr << " : Unable to remove " << attrType_
               << " template " << templateHandle << " : Does not exist.";

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -41,9 +41,14 @@ namespace Attrs = esp::assets::attributes;
  * references
  */
 
-template <class AttribsPtr>
+template <class T>
 class AttributesManager {
  public:
+  static_assert(std::is_base_of<Attrs::AbstractAttributes, T>::value,
+                "Managed typedd must be derived from AbstractAttributes");
+
+  typedef std::shared_ptr<T> AttribsPtr;
+
   AttributesManager(assets::ResourceManager& resourceManager,
                     const std::string& attrType)
       : resourceManager_(resourceManager), attrType_(attrType) {}
@@ -854,7 +859,7 @@ class AttributesManager {
    * defined in @ref AssetAttributesManager::PrimNames3D.)
    */
   typedef std::map<std::string,
-                   AttribsPtr (AttributesManager<AttribsPtr>::*)(AttribsPtr&)>
+                   AttribsPtr (AttributesManager<T>::*)(AttribsPtr&)>
       Map_Of_CopyCtors;
 
   /**
@@ -911,8 +916,9 @@ class AttributesManager {
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class AttribsPtr>
-AttribsPtr AttributesManager<AttribsPtr>::createObjectAttributesFromJson(
+template <class T>
+typename AttributesManager<T>::AttribsPtr
+AttributesManager<T>::createObjectAttributesFromJson(
     const std::string& configFilename,
     const io::JsonDocument& jsonDoc) {
   auto attributes = this->initNewAttribsInternal(configFilename);
@@ -998,7 +1004,7 @@ AttribsPtr AttributesManager<AttribsPtr>::createObjectAttributesFromJson(
 
 template <class T>
 bool AttributesManager<T>::setJSONAssetHandleAndType(
-    T attributes,
+    typename AttributesManager<T>::AttribsPtr attributes,
     const io::JsonDocument& jsonDoc,
     const char* jsonMeshTypeTag,
     const char* jsonMeshHandleTag,
@@ -1052,10 +1058,9 @@ bool AttributesManager<T>::setJSONAssetHandleAndType(
   return false;
 }  // AttributesManager<AttribsPtr>::setAssetHandleAndType
 
-template <class AttribsPtr>
-bool AttributesManager<AttribsPtr>::setTemplateLock(
-    const std::string& templateHandle,
-    bool lock) {
+template <class T>
+bool AttributesManager<T>::setTemplateLock(const std::string& templateHandle,
+                                           bool lock) {
   // if template does not currently exist then do not attempt to modify its
   // lock state
   if (!checkExistsWithMessage(templateHandle,
@@ -1072,11 +1077,10 @@ bool AttributesManager<AttribsPtr>::setTemplateLock(
   return true;
 }  // AttributesManager::setTemplateLock
 
-template <class AttribsPtr>
-std::vector<AttribsPtr>
-AttributesManager<AttribsPtr>::removeTemplatesBySubstring(
-    const std::string& subStr,
-    bool contains) {
+template <class T>
+std::vector<typename AttributesManager<T>::AttribsPtr>
+AttributesManager<T>::removeTemplatesBySubstring(const std::string& subStr,
+                                                 bool contains) {
   std::vector<AttribsPtr> res;
   // get all handles that match query elements first
   std::vector<std::string> handles =
@@ -1092,16 +1096,16 @@ AttributesManager<AttribsPtr>::removeTemplatesBySubstring(
 }  // removeAllTemplates
 
 template <class T>
-T AttributesManager<T>::removeTemplateInternal(
-    const std::string& templateHandle,
-    const std::string& sourceStr) {
+typename AttributesManager<T>::AttribsPtr
+AttributesManager<T>::removeTemplateInternal(const std::string& templateHandle,
+                                             const std::string& sourceStr) {
   if (!checkExistsWithMessage(templateHandle, sourceStr)) {
     LOG(INFO) << sourceStr << " : Unable to remove " << attrType_
               << " template " << templateHandle << " : Does not exist.";
     return nullptr;
   }
 
-  T attribsTemplate = getTemplateCopyByHandle(templateHandle);
+  auto attribsTemplate = getTemplateCopyByHandle(templateHandle);
   std::string msg;
   if (this->undeletableTemplateNames_.count(templateHandle) > 0) {
     msg = "Required Undeletable Template";

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -17,10 +17,10 @@ namespace managers {
  * @brief single instance class managing templates describing physical objects
  */
 class ObjectAttributesManager
-    : public AttributesManager<Attrs::ObjectAttributes::ptr> {
+    : public AttributesManager<Attrs::ObjectAttributes> {
  public:
   ObjectAttributesManager(assets::ResourceManager& resourceManager)
-      : AttributesManager<Attrs::ObjectAttributes::ptr>::AttributesManager(
+      : AttributesManager<Attrs::ObjectAttributes>::AttributesManager(
             resourceManager,
             "Object") {
     buildCtorFuncPtrMaps();

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -19,12 +19,13 @@ namespace assets {
 
 namespace managers {
 class PhysicsAttributesManager
-    : public AttributesManager<Attrs::PhysicsManagerAttributes::ptr> {
+    : public AttributesManager<Attrs::PhysicsManagerAttributes> {
  public:
   PhysicsAttributesManager(assets::ResourceManager& resourceManager,
                            ObjectAttributesManager::ptr objectAttributesMgr)
-      : AttributesManager<Attrs::PhysicsManagerAttributes::ptr>::
-            AttributesManager(resourceManager, "Physics Manager"),
+      : AttributesManager<Attrs::PhysicsManagerAttributes>::AttributesManager(
+            resourceManager,
+            "Physics Manager"),
         objectAttributesMgr_(objectAttributesMgr) {
     buildCtorFuncPtrMaps();
   }

--- a/src/esp/assets/managers/StageAttributesManager.cpp
+++ b/src/esp/assets/managers/StageAttributesManager.cpp
@@ -24,9 +24,8 @@ StageAttributesManager::StageAttributesManager(
     assets::ResourceManager& resourceManager,
     ObjectAttributesManager::ptr objectAttributesMgr,
     PhysicsAttributesManager::ptr physicsAttributesManager)
-    : AttributesManager<StageAttributes::ptr>::AttributesManager(
-          resourceManager,
-          "Stage"),
+    : AttributesManager<StageAttributes>::AttributesManager(resourceManager,
+                                                            "Stage"),
       objectAttributesMgr_(objectAttributesMgr),
       physicsAttributesManager_(physicsAttributesManager),
       cfgLightSetup_(assets::ResourceManager::NO_LIGHT_KEY) {

--- a/src/esp/assets/managers/StageAttributesManager.h
+++ b/src/esp/assets/managers/StageAttributesManager.h
@@ -16,7 +16,7 @@ enum class AssetType;
 
 namespace managers {
 class StageAttributesManager
-    : public AttributesManager<Attrs::StageAttributes::ptr> {
+    : public AttributesManager<Attrs::StageAttributes> {
  public:
   StageAttributesManager(
       assets::ResourceManager& resourceManager,

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -44,6 +44,7 @@ using attributes::UVSpherePrimitiveAttributes;
 template <class T>
 void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
   using AttrClass = AttributesManager<T>;
+  using AttribsPtr = std::shared_ptr<T>;
   std::string pyclass_name = classStrPrefix + std::string("AttributesManager");
   py::class_<AttrClass, std::shared_ptr<AttrClass>>(m, pyclass_name.c_str())
       .def(
@@ -64,13 +65,13 @@ void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
             contain the passed search_str, based on the value of boolean contains.)",
           "search_str"_a = "", "contains"_a = true)
       .def("create_template",
-           static_cast<T (AttrClass::*)(const std::string&, bool)>(
+           static_cast<AttribsPtr (AttrClass::*)(const std::string&, bool)>(
                &AttrClass::createAttributesTemplate),
            R"(Creates a template based on passed handle, and registers it in
             the library if register_template is True.)",
            "handle"_a, "register_template"_a = true)
       .def("create_new_template",
-           static_cast<T (AttrClass::*)(const std::string&, bool)>(
+           static_cast<AttribsPtr (AttrClass::*)(const std::string&, bool)>(
                &AttrClass::createDefaultAttributesTemplate),
            R"(Creates a template built with default values, and registers it in
             the library if register_template is True.)",
@@ -139,12 +140,13 @@ void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
              returns the template's integer ID.)",
            "template"_a, "specified_handle"_a = "")
       .def("get_template_by_ID",
-           static_cast<T (AttrClass::*)(int)>(&AttrClass::getTemplateCopyByID),
+           static_cast<AttribsPtr (AttrClass::*)(int)>(
+               &AttrClass::getTemplateCopyByID),
            R"(This returns a copy of the template specified by the passed
              ID if it exists, and NULL if it does not.)",
            "ID"_a)
       .def("get_template_by_handle",
-           static_cast<T (AttrClass::*)(const std::string&)>(
+           static_cast<AttribsPtr (AttrClass::*)(const std::string&)>(
                &AttrClass::getTemplateCopyByHandle),
            R"(This returns a copy of the template specified by the passed
              handle if it exists, and NULL if it does not.)",
@@ -169,10 +171,9 @@ void initAttributesManagersBindings(py::module& m) {
       .value("END_PRIM_OBJ_TYPE", assets::PrimObjTypes::END_PRIM_OBJ_TYPES);
 
   // ==== Primitive Asset Attributes Template manager ====
-  declareBaseAttributesManager<AbstractPrimitiveAttributes::ptr>(m,
-                                                                 "BaseAsset");
+  declareBaseAttributesManager<AbstractPrimitiveAttributes>(m, "BaseAsset");
   py::class_<AssetAttributesManager,
-             AttributesManager<AbstractPrimitiveAttributes::ptr>,
+             AttributesManager<AbstractPrimitiveAttributes>,
              AssetAttributesManager::ptr>(m, "AssetAttributesManager")
       // AssetAttributesMangaer-specific bindings
       // return appropriately cast capsule templates
@@ -252,8 +253,8 @@ void initAttributesManagersBindings(py::module& m) {
            "handle"_a);
 
   // ==== Physical Object Attributes Template manager ====
-  declareBaseAttributesManager<ObjectAttributes::ptr>(m, "BaseObject");
-  py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes::ptr>,
+  declareBaseAttributesManager<ObjectAttributes>(m, "BaseObject");
+  py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes>,
              ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
@@ -303,15 +304,15 @@ void initAttributesManagersBindings(py::module& m) {
              existing templates being managed.)");
 
   // ==== Stage Attributes Template manager ====
-  declareBaseAttributesManager<StageAttributes::ptr>(m, "BaseStage");
-  py::class_<StageAttributesManager, AttributesManager<StageAttributes::ptr>,
+  declareBaseAttributesManager<StageAttributes>(m, "BaseStage");
+  py::class_<StageAttributesManager, AttributesManager<StageAttributes>,
              StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
-  declareBaseAttributesManager<PhysicsManagerAttributes::ptr>(m, "BasePhysics");
+  declareBaseAttributesManager<PhysicsManagerAttributes>(m, "BasePhysics");
   py::class_<PhysicsAttributesManager,
-             AttributesManager<PhysicsManagerAttributes::ptr>,
+             AttributesManager<PhysicsManagerAttributes>,
              PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
 
 }  // namespace managers


### PR DESCRIPTION
Previously, the attributes managers specialized the class template by specifying a smart pointer to an attributes class as the class template type parameter.  This relied on the implementer knowing what was required by the class template, method -wise, in order for the manager to properly function.  If an inappropriate class was specified, the class template functionality would fail.

This PR introduces a verification process to make sure the class template type parameter references a class that has the required methods for the manager to function.  This is accomplished by sending the actual attributes class as the template type to specialize the class template.  This allows us to verify that the specified template class is derived from the desired base class (so we can be sure that the objects we wish to manage with a particular manager implement the necessary functions for the attributes managers to work correctly).  If an illegal class is passed now as a template parameter, the code will not compile.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests have passed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
