### PR TITLE
--[Bug fix] Address stage load w/"none" physicsManager

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -627,14 +627,23 @@ class ResourceManager {
    * @param lightSetup The @ref LightSetup key that will be used
    * for the loaded asset.
    */
-  bool loadStageInternal(
-      const AssetInfo& info,
-      std::shared_ptr<physics::PhysicsManager> _physicsManager,
-      scene::SceneNode* parent = nullptr,
-      DrawableGroup* drawables = nullptr,
-      bool computeAbsoluteAABBs = false,
-      bool splitSemanticMesh = true,
-      const Mn::ResourceKey& lightSetup = Mn::ResourceKey{NO_LIGHT_KEY});
+  bool loadStageInternal(const AssetInfo& info,
+                         scene::SceneNode* parent = nullptr,
+                         DrawableGroup* drawables = nullptr,
+                         bool computeAbsoluteAABBs = false,
+                         bool splitSemanticMesh = true,
+                         const Mn::ResourceKey& lightSetup = Mn::ResourceKey{
+                             NO_LIGHT_KEY});
+
+  /**
+   * @brief Builds the appropriate collision mesh groups for the passed
+   * assetInfo, and adds it to the @ref collisionMeshGroup map.
+   * @param info The @ref AssetInfo for the mesh, already parsed from a file.
+   * @param meshGroup The constructed @ref meshGroup
+   * @return Whether the meshgroup was successfully built or not
+   */
+  bool buildMeshGroups(const AssetInfo& info,
+                       std::vector<CollisionMeshData>& meshGroup);
 
   /**
    * @brief Creates a map of appropriate asset infos for sceneries.  Will always

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -948,7 +948,6 @@ class PhysicsManager {
    *
    * @param handle the handle to the attributes structure defining physical
    * properties of the scene.
-   * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
 

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -104,7 +104,9 @@ class VisualSensor : public Sensor {
    * @param[in] sim Instance of Simulator class for which the observation needs
    *                to be drawn
    */
-  virtual bool drawObservation(sim::Simulator& sim) { return false; }
+  virtual bool drawObservation(CORRADE_UNUSED sim::Simulator& sim) {
+    return false;
+  }
 
  protected:
   gfx::RenderTarget::uptr tgt_ = nullptr;

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -43,7 +43,7 @@ class PhysicsManagerTest : public testing::Test {
     physicsAttributesManager_ = resourceManager_.getPhysicsAttributesManager();
   };
 
-  void initScene(const std::string stageFile) {
+  void initStage(const std::string stageFile) {
     // const esp::assets::AssetInfo info =
     //     esp::assets::AssetInfo::fromPath(stageFile);
 
@@ -92,7 +92,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
   std::string objectFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/nested_box.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
@@ -171,7 +171,7 @@ TEST_F(PhysicsManagerTest, CollisionBoundingBox) {
   std::string objectFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/objects/sphere.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
@@ -248,7 +248,7 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
   std::string objectFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/transform_box.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   if (physicsManager_->getPhysicsSimulationLibrary() !=
       PhysicsManager::PhysicsSimulationLibrary::NONE) {
@@ -291,7 +291,7 @@ TEST_F(PhysicsManagerTest, BulletCompoundShapeMargins) {
   std::string objectFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/transform_box.glb");
 
-  initScene(objectFile);
+  initStage(objectFile);
 
   if (physicsManager_->getPhysicsSimulationLibrary() ==
       PhysicsManager::PhysicsSimulationLibrary::BULLET) {
@@ -354,10 +354,13 @@ TEST_F(PhysicsManagerTest, ConfigurableScaling) {
   // test scaling of objects via template configuration (visual and collision)
   LOG(INFO) << "Starting physics test: ConfigurableScaling";
 
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+
   std::string objectFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/transform_box.glb");
 
-  initScene("NONE");
+  initStage(stageFile);
 
   // test joined vs. unjoined
   ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
@@ -425,7 +428,7 @@ TEST_F(PhysicsManagerTest, TestVelocityControl) {
   std::string stageFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
   ObjectAttributes->setRenderAssetHandle(objectFile);
@@ -570,7 +573,7 @@ TEST_F(PhysicsManagerTest, TestSceneNodeAttachment) {
   std::string stageFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
   ObjectAttributes->setRenderAssetHandle(objectFile);
@@ -621,7 +624,7 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
   std::string stageFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
 
-  initScene(stageFile);
+  initStage(stageFile);
 
   // ensure that changing default timestep does not affect results
   physicsManager_->setTimestep(0.0041666666);


### PR DESCRIPTION
RigidStage objects were not being made if there was no collision asset being constructed.  This would only happen if physicsManager was nullptr (which only happens during certain tests) or if none-type physicsManager is specified.  
This makes RigidStage objects if collision assets are not requested, and will attempt to build collisionMeshGroups out of render mesh if no valid collision mesh is specified. 

A warning for an unused argument in VisualSensor is also addressed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and Python tests have passed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
