### PR TITLE
Don't load textures if you don't need them

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -83,6 +83,18 @@ class Simulator(SimulatorBackend):
             )
         )
 
+        config.sim_cfg.requires_textures = any(
+            map(
+                lambda cfg: any(
+                    map(
+                        lambda sens_spec: sens_spec.sensor_type == SensorType.COLOR,
+                        cfg.sensor_specifications,
+                    )
+                ),
+                config.agents,
+            )
+        )
+
     def __attrs_post_init__(self):
         self._sanitize_config(self.config)
         self.__set_from_config(self.config)

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -419,10 +419,10 @@ class ResourceManager {
       const Magnum::Vector3& origin);
 
   /**
-   * @brief Set whether textures should be compressed.
-   * @param newVal New texture compression setting.
+   * @brief Sets whether or not the current agent sensor suite requires textures
+   * for rendering. Textures will not be loaded if this is false.
    */
-  inline void compressTextures(bool newVal) { compressTextures_ = newVal; };
+  inline void setRequiresTextures(bool newVal) { requiresTextures_ = newVal; }
 
  private:
   /**
@@ -921,9 +921,9 @@ class ResourceManager {
   std::map<std::string, std::vector<CollisionMeshData>> collisionMeshGroups_;
 
   /**
-   * @brief Flag to denote the desire to compress textures. TODO: unused?
+   * @brief Flag to load textures of meshes
    */
-  bool compressTextures_ = false;
+  bool requiresTextures_ = true;
 };
 
 }  // namespace assets

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -16,6 +16,7 @@
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/LightSetup.h"
 #include "esp/gfx/RenderCamera.h"
+#include "esp/gfx/RenderTarget.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/scene/SemanticScene.h"
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -34,8 +34,6 @@ void initSimBindings(py::module& m) {
       .def_readwrite("default_camera_uuid",
                      &SimulatorConfiguration::defaultCameraUuid)
       .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId)
-      .def_readwrite("compress_textures",
-                     &SimulatorConfiguration::compressTextures)
       .def_readwrite("allow_sliding", &SimulatorConfiguration::allowSliding)
       .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
       .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling)
@@ -46,6 +44,8 @@ void initSimBindings(py::module& m) {
                      &SimulatorConfiguration::sceneLightSetup)
       .def_readwrite("load_semantic_mesh",
                      &SimulatorConfiguration::loadSemanticMesh)
+      .def_readwrite("requires_textures",
+                     &SimulatorConfiguration::requiresTextures)
       .def(py::self == py::self)
       .def(py::self != py::self);
 

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -45,7 +45,7 @@ struct RenderTarget::Impl {
   Impl(const Mn::Vector2i& size,
        const Mn::Vector2& depthUnprojection,
        DepthShader* depthShader,
-       bool hasTextures)
+       Renderer::Flags flags)
       : colorBuffer_{},
         objectIdBuffer_{},
         depthRenderTexture_{},
@@ -55,7 +55,7 @@ struct RenderTarget::Impl {
         unprojectedDepth_{Mn::NoCreate},
         depthUnprojectionMesh_{Mn::NoCreate},
         depthUnprojectionFrameBuffer_{Mn::NoCreate},
-        hasTextures_{hasTextures} {
+        rendererFlags_{flags} {
     if (depthShader_) {
       CORRADE_INTERNAL_ASSERT(depthShader_->flags() &
                               DepthShader::Flag::UnprojectExistingDepth);
@@ -122,7 +122,7 @@ struct RenderTarget::Impl {
   void renderExit() {}
 
   void blitRgbaToDefault() {
-    if (!hasTextures_)
+    if (rendererFlags_ & Renderer::Flag::NoTextures)
       throw std::runtime_error(
           "Simulator was initialized with requiresTextures = false");
 
@@ -136,7 +136,7 @@ struct RenderTarget::Impl {
   }
 
   void readFrameRgba(const Mn::MutableImageView2D& view) {
-    if (!hasTextures_)
+    if (rendererFlags_ & Renderer::Flag::NoTextures)
       throw std::runtime_error(
           "Simulator was initialized with requiresTextures = false");
 
@@ -172,7 +172,7 @@ struct RenderTarget::Impl {
     // See discussion here:
     // https://github.com/facebookresearch/habitat-sim/pull/114#discussion_r312718502
 
-    if (!hasTextures_)
+    if (rendererFlags_ & Renderer::Flag::NoTextures)
       throw std::runtime_error(
           "Simulator was initialized with requiresTextures = false");
 
@@ -258,7 +258,7 @@ struct RenderTarget::Impl {
   Mn::GL::Mesh depthUnprojectionMesh_;
   Mn::GL::Framebuffer depthUnprojectionFrameBuffer_;
 
-  const bool hasTextures_;
+  const Renderer::Flags rendererFlags_;
 
 #ifdef ESP_BUILD_WITH_CUDA
   cudaGraphicsResource_t colorBufferCugl_ = nullptr;
@@ -270,11 +270,11 @@ struct RenderTarget::Impl {
 RenderTarget::RenderTarget(const Mn::Vector2i& size,
                            const Mn::Vector2& depthUnprojection,
                            DepthShader* depthShader,
-                           bool hasTextures)
+                           Renderer::Flags flags)
     : pimpl_(spimpl::make_unique_impl<Impl>(size,
                                             depthUnprojection,
                                             depthShader,
-                                            hasTextures)) {}
+                                            flags)) {}
 
 void RenderTarget::renderEnter() {
   pimpl_->renderEnter();

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -44,7 +44,8 @@ const Mn::GL::Framebuffer::ColorAttachment UnprojectedDepthBuffer =
 struct RenderTarget::Impl {
   Impl(const Mn::Vector2i& size,
        const Mn::Vector2& depthUnprojection,
-       DepthShader* depthShader)
+       DepthShader* depthShader,
+       bool hasTextures)
       : colorBuffer_{},
         objectIdBuffer_{},
         depthRenderTexture_{},
@@ -53,7 +54,8 @@ struct RenderTarget::Impl {
         depthShader_{depthShader},
         unprojectedDepth_{Mn::NoCreate},
         depthUnprojectionMesh_{Mn::NoCreate},
-        depthUnprojectionFrameBuffer_{Mn::NoCreate} {
+        depthUnprojectionFrameBuffer_{Mn::NoCreate},
+        hasTextures_{hasTextures} {
     if (depthShader_) {
       CORRADE_INTERNAL_ASSERT(depthShader_->flags() &
                               DepthShader::Flag::UnprojectExistingDepth);
@@ -120,6 +122,10 @@ struct RenderTarget::Impl {
   void renderExit() {}
 
   void blitRgbaToDefault() {
+    if (!hasTextures_)
+      throw std::runtime_error(
+          "Simulator was initialized with requiresTextures = false");
+
     framebuffer_.mapForRead(RgbaBuffer);
     ASSERT(framebuffer_.viewport() == Mn::GL::defaultFramebuffer.viewport());
 
@@ -130,6 +136,10 @@ struct RenderTarget::Impl {
   }
 
   void readFrameRgba(const Mn::MutableImageView2D& view) {
+    if (!hasTextures_)
+      throw std::runtime_error(
+          "Simulator was initialized with requiresTextures = false");
+
     framebuffer_.mapForRead(RgbaBuffer).read(framebuffer_.viewport(), view);
   }
 
@@ -161,6 +171,10 @@ struct RenderTarget::Impl {
     // TODO: Consider implementing the GPU read functions with EGLImage
     // See discussion here:
     // https://github.com/facebookresearch/habitat-sim/pull/114#discussion_r312718502
+
+    if (!hasTextures_)
+      throw std::runtime_error(
+          "Simulator was initialized with requiresTextures = false");
 
     if (colorBufferCugl_ == nullptr)
       checkCudaErrors(cudaGraphicsGLRegisterImage(
@@ -244,6 +258,8 @@ struct RenderTarget::Impl {
   Mn::GL::Mesh depthUnprojectionMesh_;
   Mn::GL::Framebuffer depthUnprojectionFrameBuffer_;
 
+  const bool hasTextures_;
+
 #ifdef ESP_BUILD_WITH_CUDA
   cudaGraphicsResource_t colorBufferCugl_ = nullptr;
   cudaGraphicsResource_t objecIdBufferCugl_ = nullptr;
@@ -253,10 +269,12 @@ struct RenderTarget::Impl {
 
 RenderTarget::RenderTarget(const Mn::Vector2i& size,
                            const Mn::Vector2& depthUnprojection,
-                           DepthShader* depthShader)
+                           DepthShader* depthShader,
+                           bool hasTextures)
     : pimpl_(spimpl::make_unique_impl<Impl>(size,
                                             depthUnprojection,
-                                            depthShader)) {}
+                                            depthShader,
+                                            hasTextures)) {}
 
 void RenderTarget::renderEnter() {
   pimpl_->renderEnter();

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -31,10 +31,14 @@ class RenderTarget {
    *                           Unprojects the depth on the CPU if nullptr.
    *                           Must be not nullptr to use @ref
    *                           readFrameDepthGPU()
+   * @param hasTextures        Tracks whether or not textures where loaded
+   *                           so that we can throw an error if readFrameRgba
+   *                           is called if this is false.
    */
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
-               DepthShader* depthShader);
+               DepthShader* depthShader,
+               bool hasTextures);
 
   /**
    * @brief Constructor
@@ -45,8 +49,9 @@ class RenderTarget {
    * Equivalent to calling @ref RenderTarget(size, depthUnprojection, nullptr)
    */
   RenderTarget(const Magnum::Vector2i& size,
-               const Magnum::Vector2& depthUnprojection)
-      : RenderTarget{size, depthUnprojection, nullptr} {};
+               const Magnum::Vector2& depthUnprojection,
+               bool hasTextures)
+      : RenderTarget{size, depthUnprojection, nullptr, hasTextures} {};
 
   ~RenderTarget() {}
 

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -9,6 +9,7 @@
 #include "esp/core/esp.h"
 
 #include "esp/gfx/DepthUnprojection.h"
+#include "esp/gfx/Renderer.h"
 
 namespace esp {
 namespace gfx {
@@ -31,14 +32,16 @@ class RenderTarget {
    *                           Unprojects the depth on the CPU if nullptr.
    *                           Must be not nullptr to use @ref
    *                           readFrameDepthGPU()
-   * @param hasTextures        Tracks whether or not textures where loaded
-   *                           so that we can throw an error if readFrameRgba
-   *                           is called if this is false.
+   * @param flags              The flags of the renderer that constructed this
+   *                           render target.  Currently just used to track
+   *                           whether or not @ref readFrameRgba,
+   *                           @ref blitRgbaToDefault, and @readFrameRgbaGPU
+   *                           are valid calls.
    */
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
                DepthShader* depthShader,
-               bool hasTextures);
+               Renderer::Flags flags);
 
   /**
    * @brief Constructor
@@ -46,12 +49,12 @@ class RenderTarget {
    * @param depthUnprojection  Depth unrpojection parameters.  See @ref
    *                           calculateDepthUnprojection()
    *
-   * Equivalent to calling @ref RenderTarget(size, depthUnprojection, nullptr)
+   * Equivalent to calling
+   * @ref RenderTarget(size, depthUnprojection, nullptr, {})
    */
   RenderTarget(const Magnum::Vector2i& size,
-               const Magnum::Vector2& depthUnprojection,
-               bool hasTextures)
-      : RenderTarget{size, depthUnprojection, nullptr, hasTextures} {};
+               const Magnum::Vector2& depthUnprojection)
+      : RenderTarget{size, depthUnprojection, nullptr, {}} {}
 
   ~RenderTarget() {}
 

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -26,7 +26,7 @@ namespace esp {
 namespace gfx {
 
 struct Renderer::Impl {
-  Impl() {
+  Impl(bool hasTextures) : depthShader_{nullptr}, hasTextures_{hasTextures} {
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::FaceCulling);
   }
@@ -67,14 +67,19 @@ struct Renderer::Impl {
     }
 
     sensor.bindRenderTarget(RenderTarget::create_unique(
-        sensor.framebufferSize(), *depthUnprojection, depthShader_.get()));
+        sensor.framebufferSize(), *depthUnprojection, depthShader_.get(),
+        hasTextures_));
   }
 
  private:
-  std::unique_ptr<DepthShader> depthShader_ = nullptr;
+  std::unique_ptr<DepthShader> depthShader_;
+  const bool hasTextures_;
 };
 
-Renderer::Renderer() : pimpl_(spimpl::make_unique_impl<Impl>()) {}
+Renderer::Renderer(bool hasTextures)
+    : pimpl_(spimpl::make_unique_impl<Impl>(hasTextures)) {}
+
+Renderer::Renderer() : Renderer{true} {}
 
 void Renderer::draw(RenderCamera& camera,
                     scene::SceneGraph& sceneGraph,

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -18,6 +18,7 @@
 #include <Magnum/PixelFormat.h>
 
 #include "esp/gfx/DepthUnprojection.h"
+#include "esp/gfx/RenderTarget.h"
 #include "esp/gfx/magnum.h"
 
 namespace Mn = Magnum;
@@ -26,8 +27,7 @@ namespace esp {
 namespace gfx {
 
 struct Renderer::Impl {
-  explicit Impl(bool hasTextures)
-      : depthShader_{nullptr}, hasTextures_{hasTextures} {
+  explicit Impl(Flags flags) : depthShader_{nullptr}, flags_{flags} {
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::FaceCulling);
   }
@@ -69,18 +69,16 @@ struct Renderer::Impl {
 
     sensor.bindRenderTarget(RenderTarget::create_unique(
         sensor.framebufferSize(), *depthUnprojection, depthShader_.get(),
-        hasTextures_));
+        flags_));
   }
 
  private:
   std::unique_ptr<DepthShader> depthShader_;
-  const bool hasTextures_;
+  const Flags flags_;
 };
 
-Renderer::Renderer(bool hasTextures)
-    : pimpl_(spimpl::make_unique_impl<Impl>(hasTextures)) {}
-
-Renderer::Renderer() : Renderer{true} {}
+Renderer::Renderer(Flags flags)
+    : pimpl_(spimpl::make_unique_impl<Impl>(flags)) {}
 
 void Renderer::draw(RenderCamera& camera,
                     scene::SceneGraph& sceneGraph,

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -26,7 +26,8 @@ namespace esp {
 namespace gfx {
 
 struct Renderer::Impl {
-  Impl(bool hasTextures) : depthShader_{nullptr}, hasTextures_{hasTextures} {
+  explicit Impl(bool hasTextures)
+      : depthShader_{nullptr}, hasTextures_{hasTextures} {
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::FaceCulling);
   }

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -14,8 +14,17 @@ namespace gfx {
 
 class Renderer {
  public:
-  Renderer();
-  explicit Renderer(bool hasTextures);
+  enum class Flag {
+    NoTextures = 1 << 0,
+  };
+
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+  CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
+
+  /**
+   * @brief Constructor
+   */
+  explicit Renderer(Flags flags = {});
 
   // draw the scene graph with the camera specified by user
   void draw(RenderCamera& camera,

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -15,6 +15,7 @@ namespace gfx {
 class Renderer {
  public:
   Renderer();
+  explicit Renderer(bool hasTextures);
 
   // draw the scene graph with the camera specified by user
   void draw(RenderCamera& camera,

--- a/src/esp/sensor/CMakeLists.txt
+++ b/src/esp/sensor/CMakeLists.txt
@@ -1,4 +1,12 @@
-set(sensor_SOURCES PinholeCamera.cpp PinholeCamera.h Sensor.cpp Sensor.h VisualSensor.h)
+set(
+  sensor_SOURCES
+  PinholeCamera.cpp
+  PinholeCamera.h
+  Sensor.cpp
+  Sensor.h
+  VisualSensor.cpp
+  VisualSensor.h
+)
 
 if(BUILD_WITH_CUDA)
   list(APPEND sensor_SOURCES RedwoodNoiseModel.cpp RedwoodNoiseModel.h)

--- a/src/esp/sensor/VisualSensor.cpp
+++ b/src/esp/sensor/VisualSensor.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "VisualSensor.h"
+#include "esp/gfx/RenderTarget.h"
+
+namespace esp {
+namespace sensor {
+VisualSensor::VisualSensor(scene::SceneNode& node, SensorSpec::ptr spec)
+    : Sensor{node, spec}, tgt_{nullptr} {}
+
+VisualSensor::~VisualSensor() = default;
+
+void VisualSensor::bindRenderTarget(gfx::RenderTarget::uptr&& tgt) {
+  if (tgt->framebufferSize() != framebufferSize())
+    throw std::runtime_error("RenderTarget is not the correct size");
+
+  tgt_ = std::move(tgt);
+}
+
+}  // namespace sensor
+}  // namespace esp

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -9,18 +9,21 @@
 #include "esp/core/esp.h"
 
 #include "esp/gfx/RenderCamera.h"
-#include "esp/gfx/RenderTarget.h"
 #include "esp/sensor/Sensor.h"
 
 namespace esp {
+namespace gfx {
+class RenderTarget;
+}
+
 namespace sensor {
 
 // Represents a sensor that provides visual data from the environment to an
 // agent
 class VisualSensor : public Sensor {
  public:
-  using Sensor::Sensor;
-  virtual ~VisualSensor() {}
+  explicit VisualSensor(scene::SceneNode& node, SensorSpec::ptr spec);
+  virtual ~VisualSensor();
 
   /**
    * @brief Return the size of the framebuffer corresponding to the sensor's
@@ -83,11 +86,7 @@ class VisualSensor : public Sensor {
    * @brief Binds the given given RenderTarget to the sensor.  The sensor takes
    * ownership of the RenderTarget
    */
-  void bindRenderTarget(gfx::RenderTarget::uptr&& tgt) {
-    if (tgt->framebufferSize() != framebufferSize())
-      throw std::runtime_error("RenderTarget is not the correct size");
-    tgt_ = std::move(tgt);
-  }
+  void bindRenderTarget(std::unique_ptr<gfx::RenderTarget>&& tgt);
 
   /**
    * @brief Returns a reference to the sensors render target
@@ -109,7 +108,7 @@ class VisualSensor : public Sensor {
   }
 
  protected:
-  gfx::RenderTarget::uptr tgt_ = nullptr;
+  std::unique_ptr<gfx::RenderTarget> tgt_;
 
   ESP_SMART_POINTERS(VisualSensor)
 };

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -95,10 +95,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   } else if (requiresTextures_ == 0 && config_.requiresTextures) {
     throw std::runtime_error(
         "requiresTextures was changed to True from False.  Must call close() "
-        "before changing "
-        "value.\n Got " +
-        std::to_string(config_.requiresTextures) + " expected " +
-        std::to_string(requiresTextures_));
+        "before changing this value.");
   } else if (requiresTextures_ == 1 && !config_.requiresTextures) {
     LOG(WARNING) << "Not changing requiresTextures as the simulator was "
                     "initialized with True.  Call close() to change this.";

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -778,7 +778,7 @@ class Simulator {
    * to load textures.  Because we cache mesh loading, this should
    * *not* be changed without calling close() first
    */
-  int requiresTextures_ = -1;
+  Corrade::Containers::Optional<bool> requiresTextures_;
 
   ESP_SMART_POINTERS(Simulator)
 };

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -60,7 +60,15 @@ struct SimulatorConfiguration {
    * simulation, if a suitable library (i.e. Bullet) has been installed.
    */
   bool enablePhysics = false;
+  /**
+   * @brief Whether or not to load the semantic mesh
+   */
   bool loadSemanticMesh = true;
+  /**
+   * @brief Whether or not to load textures for the meshes. This MUST be true
+   * for RGB rendering
+   */
+  bool requiresTextures = true;
   std::string physicsConfigFile =
       ESP_DEFAULT_PHYS_SCENE_CONFIG_REL_PATH;  // should we instead link a
                                                // PhysicsManagerConfiguration
@@ -764,6 +772,13 @@ class Simulator {
   //! NavMesh visualization variables
   int navMeshVisPrimID_ = esp::ID_UNDEFINED;
   esp::scene::SceneNode* navMeshVisNode_ = nullptr;
+
+  /**
+   * @brief Tracks whether or not the simulator was initialized
+   * to load textures.  Because we cache mesh loading, this should
+   * *not* be changed without calling close() first
+   */
+  int requiresTextures_ = -1;
 
   ESP_SMART_POINTERS(Simulator)
 };

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -263,6 +263,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig.scene.id = sceneFileName;
   simConfig.enablePhysics = useBullet;
   simConfig.frustumCulling = true;
+  simConfig.requiresTextures = true;
   if (args.isSet("stage-requires-lighting")) {
     Mn::Debug{} << "Stage using DEFAULT_LIGHTING_KEY";
     simConfig.sceneLightSetup =

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -83,20 +83,14 @@ _test_scenes = [
     ),
 ]
 
+sensor_types = ["color_sensor", "depth_sensor", "semantic_sensor"]
+
 
 @pytest.mark.gfxtest
 @pytest.mark.parametrize(
-    "scene,has_sem,sensor_type",
-    list(
-        itertools.product(
-            _test_scenes[0:2],
-            [True],
-            ["color_sensor", "depth_sensor", "semantic_sensor"],
-        )
-    )
-    + list(
-        itertools.product(_test_scenes[2:], [False], ["color_sensor", "depth_sensor"])
-    ),
+    "scene,sensor_type",
+    list(itertools.product(_test_scenes[0:2], sensor_types))
+    + list(itertools.product(_test_scenes[2:], sensor_types[0:2])),
 )
 @pytest.mark.parametrize("gpu2gpu", [True, False])
 # NB: This should go last, we have to force a close on the simulator when
@@ -104,7 +98,6 @@ _test_scenes = [
 @pytest.mark.parametrize("frustum_culling", [True, False])
 def test_sensors(
     scene,
-    has_sem,
     sensor_type,
     gpu2gpu,
     frustum_culling,
@@ -120,7 +113,10 @@ def test_sensors(
     sim.close()
 
     make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
-    make_cfg_settings["semantic_sensor"] = has_sem and sensor_type == "semantic_sensor"
+    for k in sensor_types:
+        make_cfg_settings[k] = False
+
+    make_cfg_settings[sensor_type] = True
     make_cfg_settings["scene"] = scene
     make_cfg_settings["frustum_culling"] = frustum_culling
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -117,6 +117,8 @@ def test_sensors(
     if not habitat_sim.cuda_enabled and gpu2gpu:
         pytest.skip("Skipping GPU->GPU test")
 
+    sim.close()
+
     make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
     make_cfg_settings["semantic_sensor"] = has_sem and sensor_type == "semantic_sensor"
     make_cfg_settings["scene"] = scene
@@ -125,11 +127,6 @@ def test_sensors(
     cfg = make_cfg(make_cfg_settings)
     for sensor_spec in cfg.agents[0].sensor_specifications:
         sensor_spec.gpu2gpu_transfer = gpu2gpu
-
-    # The scene loading may be done differently with/without frustum culling,
-    # thus we need to force a reload when frustum culling gets swapped
-    if cfg.sim_cfg.frustum_culling != sim.config.sim_cfg.frustum_culling:
-        sim.close()
 
     sim.reconfigure(cfg)
 
@@ -141,6 +138,8 @@ def test_sensors(
     assert np.linalg.norm(
         obs[sensor_type].astype(np.float) - gt.astype(np.float)
     ) < 9.0e-2 * np.linalg.norm(gt.astype(np.float)), f"Incorrect {sensor_type} output"
+
+    sim.close()
 
 
 # Tests to make sure that no sensors is supported and doesn't crash
@@ -171,6 +170,8 @@ def test_smoke_redwood_noise(scene, gpu2gpu, sim, make_cfg_settings):
     if not habitat_sim.cuda_enabled and gpu2gpu:
         pytest.skip("Skipping GPU->GPU test")
 
+    sim.close()
+
     make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
     make_cfg_settings["depth_sensor"] = True
     make_cfg_settings["color_sensor"] = False
@@ -188,6 +189,8 @@ def test_smoke_redwood_noise(scene, gpu2gpu, sim, make_cfg_settings):
     assert np.linalg.norm(
         obs["depth_sensor"].astype(np.float) - gt.astype(np.float)
     ) > 1.5e-2 * np.linalg.norm(gt.astype(np.float)), "Incorrect depth_sensor output"
+
+    sim.close()
 
 
 @pytest.mark.gfxtest


### PR DESCRIPTION
## Motivation and Context

Textures take a lot of GPU memory but we don't need them unless we are doing RGB rendering.  So don't load them if we aren't!

I also removed the compressTextures_ flag while I was poking around.  That is certainly deprecated as it was subsumed by basis and it never worked on Gibson (those textures are too big).

One thing this has revealed is that is likely time to get rid of the hack of sharing the simulator between tests to make them run faster.  That will make tests right slightly slower but at least it will put pressure on us to make spin-up time as fast as possible?

## How Has This Been Tested

Tests pass.  You can tell it is not loading textures by GPU memory usage and just pure load time :)

## Types of changes

New feature (non-breaking change which adds functionality)

