### PR TITLE
No shared sim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,7 +470,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat; cd habitat-lab
               python setup.py develop --all
-              python setup.py test
+              pytest --workers 4 --verbose -rsxX -q
       - save_cache:
           key: habitat-lab-{{ checksum "./hablab_sha" }}
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
+                pip install pytest-parallel
               fi
       - run:
           name: Install emscripten
@@ -396,12 +397,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest --cov-report=xml --cov=./
+              pytest --workers 4 --cov-report=xml --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
+              pytest --workers 4 --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,7 +470,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat; cd habitat-lab
               python setup.py develop --all
-              pytest --workers 4 --verbose -rsxX -q
+              python setup.py test
       - save_cache:
           key: habitat-lab-{{ checksum "./hablab_sha" }}
           background: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,6 @@ from os import path as osp
 
 import pytest
 
-import habitat_sim
-from examples.settings import make_cfg
-
 _test_scene = osp.abspath(
     osp.join(
         osp.dirname(__file__),
@@ -13,7 +10,7 @@ _test_scene = osp.abspath(
 )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def make_cfg_settings():
     return dict(
         height=480,
@@ -26,10 +23,3 @@ def make_cfg_settings():
         scene=_test_scene,
         frustum_culling=True,
     )
-
-
-# Any test globally can take `sim` as an arguement and will get
-# the single instance of the Simulator
-@pytest.fixture(scope="session")
-def sim(make_cfg_settings):
-    return habitat_sim.Simulator(make_cfg(make_cfg_settings))

--- a/tests/test_attributes_managers.py
+++ b/tests/test_attributes_managers.py
@@ -3,6 +3,7 @@
 import magnum as mn
 
 import examples.settings
+import habitat_sim
 
 
 def perform_general_tests(attr_mgr, search_string):
@@ -169,69 +170,66 @@ def perform_add_blank_template_test(attr_mgr, valid_render_handle=None):
     assert curr_num_templates == orig_num_templates
 
 
-def test_physics_attributes_managers(sim):
+def test_physics_attributes_managers():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # get attribute managers
+        phys_attr_mgr = sim.get_physics_template_manager()
 
-    # get attribute managers
-    phys_attr_mgr = sim.get_physics_template_manager()
+        # perform general tests for this attributes manager
+        template0, _ = perform_general_tests(
+            phys_attr_mgr, cfg_settings["physics_config_file"]
+        )
 
-    # perform general tests for this attributes manager
-    template0, _ = perform_general_tests(
-        phys_attr_mgr, cfg_settings["physics_config_file"]
-    )
+        # verify that physics template matches expected values in file
+        assert template0.timestep == 0.008
+        assert template0.simulator == "bullet"
 
-    # verify that physics template matches expected values in file
-    assert template0.timestep == 0.008
-    assert template0.simulator == "bullet"
-
-    # verify creating new template
-    perform_add_blank_template_test(phys_attr_mgr)
+        # verify creating new template
+        perform_add_blank_template_test(phys_attr_mgr)
 
 
-def test_stage_attributes_managers(sim):
+def test_stage_attributes_managers():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        stage_name = cfg_settings["scene"]
 
-    stage_name = cfg_settings["scene"]
+        # get attribute managers
+        stage_mgr = sim.get_stage_template_manager()
 
-    # get attribute managers
-    stage_mgr = sim.get_stage_template_manager()
+        # perform general tests for this attributes manager
+        template0, _ = perform_general_tests(stage_mgr, stage_name)
 
-    # perform general tests for this attributes manager
-    template0, _ = perform_general_tests(stage_mgr, stage_name)
+        # verify gravity in template is as expected
+        assert template0.gravity == mn.Vector3(0.0, -9.8, 0.0)
 
-    # verify gravity in template is as expected
-    assert template0.gravity == mn.Vector3(0.0, -9.8, 0.0)
-
-    # verify creating new template
-    perform_add_blank_template_test(stage_mgr, template0.render_asset_handle)
+        # verify creating new template
+        perform_add_blank_template_test(stage_mgr, template0.render_asset_handle)
 
 
-def test_object_attributes_managers(sim):
+def test_object_attributes_managers():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # get object attribute managers
+        obj_mgr = sim.get_object_template_manager()
 
-    # get object attribute managers
-    obj_mgr = sim.get_object_template_manager()
+        # get object template random handle
+        rand_obj_handle = obj_mgr.get_random_template_handle()
 
-    # get object template random handle
-    rand_obj_handle = obj_mgr.get_random_template_handle()
+        # perform general tests for object attribute manager
+        template0, _ = perform_general_tests(obj_mgr, rand_obj_handle)
 
-    # perform general tests for object attribute manager
-    template0, _ = perform_general_tests(obj_mgr, rand_obj_handle)
-
-    # verify creating new template
-    perform_add_blank_template_test(obj_mgr, template0.render_asset_handle)
+        # verify creating new template
+        perform_add_blank_template_test(obj_mgr, template0.render_asset_handle)
 
 
 def perform_asset_attrib_mgr_tests(
@@ -292,70 +290,73 @@ def perform_asset_attrib_mgr_tests(
     assert orig_num_templates == attr_mgr.get_num_templates()
 
 
-def test_asset_attributes_managers(sim):
+def test_asset_attributes_managers():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # legal and illegal vals for primitives based on wireframe or solid
+        legal_mod_val_wf = 64
+        illegal_mod_val_wf = 25
+        legal_mod_val_solid = 5
+        illegal_mod_val_solid = 0
 
-    # legal and illegal vals for primitives based on wireframe or solid
-    legal_mod_val_wf = 64
-    illegal_mod_val_wf = 25
-    legal_mod_val_solid = 5
-    illegal_mod_val_solid = 0
+        # get object attribute managers
+        attr_mgr = sim.get_asset_template_manager()
 
-    # get object attribute managers
-    attr_mgr = sim.get_asset_template_manager()
+        # capsule
+        print("Test Capsule attributes construction, modification, saving and removal.")
+        dflt_solid_attribs = attr_mgr.get_default_capsule_template(False)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr,
+            dflt_solid_attribs,
+            "segments",
+            legal_mod_val_solid,
+            illegal_mod_val_solid,
+        )
+        dflt_wf_attribs = attr_mgr.get_default_capsule_template(True)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
+        )
 
-    # capsule
-    print("Test Capsule attributes construction, modification, saving and removal.")
-    dflt_solid_attribs = attr_mgr.get_default_capsule_template(False)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr,
-        dflt_solid_attribs,
-        "segments",
-        legal_mod_val_solid,
-        illegal_mod_val_solid,
-    )
-    dflt_wf_attribs = attr_mgr.get_default_capsule_template(True)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
-    )
+        # cone
+        print("Test Cone attributes construction, modification, saving and removal.")
+        dflt_solid_attribs = attr_mgr.get_default_cone_template(False)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr,
+            dflt_solid_attribs,
+            "segments",
+            legal_mod_val_solid,
+            illegal_mod_val_solid,
+        )
+        dflt_wf_attribs = attr_mgr.get_default_cone_template(True)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
+        )
 
-    # cone
-    print("Test Cone attributes construction, modification, saving and removal.")
-    dflt_solid_attribs = attr_mgr.get_default_cone_template(False)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr,
-        dflt_solid_attribs,
-        "segments",
-        legal_mod_val_solid,
-        illegal_mod_val_solid,
-    )
-    dflt_wf_attribs = attr_mgr.get_default_cone_template(True)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
-    )
+        # cylinder
+        print(
+            "Test Cylinder attributes construction, modification, saving and removal."
+        )
+        dflt_solid_attribs = attr_mgr.get_default_cylinder_template(False)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_solid_attribs, "segments", 5, illegal_mod_val_solid
+        )
+        dflt_wf_attribs = attr_mgr.get_default_cylinder_template(True)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
+        )
 
-    # cylinder
-    print("Test Cylinder attributes construction, modification, saving and removal.")
-    dflt_solid_attribs = attr_mgr.get_default_cylinder_template(False)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_solid_attribs, "segments", 5, illegal_mod_val_solid
-    )
-    dflt_wf_attribs = attr_mgr.get_default_cylinder_template(True)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
-    )
-
-    # UVSphere
-    print("Test UVSphere attributes construction, modification, saving and removal.")
-    dflt_solid_attribs = attr_mgr.get_default_UVsphere_template(False)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_solid_attribs, "segments", 5, illegal_mod_val_solid
-    )
-    dflt_wf_attribs = attr_mgr.get_default_UVsphere_template(True)
-    perform_asset_attrib_mgr_tests(
-        attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
-    )
+        # UVSphere
+        print(
+            "Test UVSphere attributes construction, modification, saving and removal."
+        )
+        dflt_solid_attribs = attr_mgr.get_default_UVsphere_template(False)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_solid_attribs, "segments", 5, illegal_mod_val_solid
+        )
+        dflt_wf_attribs = attr_mgr.get_default_UVsphere_template(True)
+        perform_asset_attrib_mgr_tests(
+            attr_mgr, dflt_wf_attribs, "segments", legal_mod_val_wf, illegal_mod_val_wf
+        )

--- a/tests/test_data_extraction.py
+++ b/tests/test_data_extraction.py
@@ -6,6 +6,8 @@ from torch import nn as nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, Dataset
 
+import habitat_sim
+from examples.settings import make_cfg
 from habitat_sim.utils.data.data_extractor import ImageExtractor, TopdownView
 from habitat_sim.utils.data.data_structures import ExtractorLRUCache
 
@@ -30,25 +32,29 @@ class MyDataset(Dataset):
         return self.extractor[idx]
 
 
-def test_topdown_view(sim):
-    tdv = TopdownView(sim, height=0.0, meters_per_pixel=0.1)
-    topdown_view = tdv.topdown_view
-    assert type(topdown_view) == np.ndarray
+def test_topdown_view(make_cfg_settings):
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        tdv = TopdownView(sim, height=0.0, meters_per_pixel=0.1)
+        topdown_view = tdv.topdown_view
+        assert type(topdown_view) == np.ndarray
 
 
-def test_data_extractor_end_to_end(sim):
+def test_data_extractor_end_to_end(make_cfg_settings):
     # Path is relative to simulator.py
-    scene_filepath = ""
-    extractor = ImageExtractor(scene_filepath, labels=[0.0], img_size=(32, 32), sim=sim)
-    dataset = MyDataset(extractor)
-    dataloader = DataLoader(dataset, batch_size=3)
-    net = TrivialNet()
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        scene_filepath = ""
+        extractor = ImageExtractor(
+            scene_filepath, labels=[0.0], img_size=(32, 32), sim=sim
+        )
+        dataset = MyDataset(extractor)
+        dataloader = DataLoader(dataset, batch_size=3)
+        net = TrivialNet()
 
-    # Run data through network
-    for sample_batch in dataloader:
-        img, _ = sample_batch["rgba"], sample_batch["label"]
-        img = img.permute(0, 3, 2, 1).float()
-        net(img)
+        # Run data through network
+        for sample_batch in dataloader:
+            img, _ = sample_batch["rgba"], sample_batch["label"]
+            img = img.permute(0, 3, 2, 1).float()
+            net(img)
 
 
 def test_extractor_cache():
@@ -63,11 +69,12 @@ def test_extractor_cache():
     assert 1 not in cache
 
 
-def test_pose_extractors(sim):
-    scene_filepath = ""
-    pose_extractor_names = ["closest_point_extractor", "panorama_extractor"]
-    for name in pose_extractor_names:
-        extractor = ImageExtractor(
-            scene_filepath, img_size=(32, 32), sim=sim, pose_extractor_name=name
-        )
-        assert len(extractor) > 1
+def test_pose_extractors(make_cfg_settings):
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        scene_filepath = ""
+        pose_extractor_names = ["closest_point_extractor", "panorama_extractor"]
+        for name in pose_extractor_names:
+            extractor = ImageExtractor(
+                scene_filepath, img_size=(32, 32), sim=sim, pose_extractor_name=name
+            )
+            assert len(extractor) > 1

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -12,13 +12,14 @@ import pytest
 import quaternion  # noqa: F401
 
 import examples.settings
+import habitat_sim
 
 
 @pytest.mark.skipif(
     not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),
     reason="Requires the habitat-test-scenes",
 )
-def test_unproject(sim):
+def test_unproject():
     cfg_settings = examples.settings.default_sim_settings.copy()
 
     # configure some settings in case defaults change
@@ -30,26 +31,27 @@ def test_unproject(sim):
 
     # loading the scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # position agent
+        sim.agents[0].scene_node.rotation = mn.Quaternion()
+        sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
 
-    # position agent
-    sim.agents[0].scene_node.rotation = mn.Quaternion()
-    sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
+        # setup camera
+        visual_sensor = sim._sensors["color_sensor"]
+        scene_graph = sim.get_active_scene_graph()
+        scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
+        render_camera = scene_graph.get_default_render_camera()
 
-    # setup camera
-    visual_sensor = sim._sensors["color_sensor"]
-    scene_graph = sim.get_active_scene_graph()
-    scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
-    render_camera = scene_graph.get_default_render_camera()
+        # test unproject
+        center_ray = render_camera.unproject(
+            mn.Vector2i(50, 50)
+        )  # middle of the viewport
+        assert np.allclose(center_ray.origin, np.array([0.5, 0, 0]), atol=0.07)
+        assert np.allclose(center_ray.direction, np.array([0, 0, -1.0]), atol=0.02)
 
-    # test unproject
-    center_ray = render_camera.unproject(mn.Vector2i(50, 50))  # middle of the viewport
-    assert np.allclose(center_ray.origin, np.array([0.5, 0, 0]), atol=0.07)
-    assert np.allclose(center_ray.direction, np.array([0, 0, -1.0]), atol=0.02)
-
-    test_ray_2 = render_camera.unproject(
-        mn.Vector2i(100, 100)
-    )  # bottom right of the viewport
-    assert np.allclose(
-        test_ray_2.direction, np.array([0.569653, -0.581161, -0.581161]), atol=0.07
-    )
+        test_ray_2 = render_camera.unproject(
+            mn.Vector2i(100, 100)
+        )  # bottom right of the viewport
+        assert np.allclose(
+            test_ray_2.direction, np.array([0.569653, -0.581161, -0.581161]), atol=0.07
+        )

--- a/tests/test_light_setup.py
+++ b/tests/test_light_setup.py
@@ -1,3 +1,5 @@
+import habitat_sim
+from examples.settings import make_cfg
 from habitat_sim.gfx import (
     DEFAULT_LIGHTING_KEY,
     NO_LIGHT_KEY,
@@ -6,32 +8,35 @@ from habitat_sim.gfx import (
 )
 
 
-def test_get_no_light_setup(sim):
-    assert len(sim.get_light_setup(NO_LIGHT_KEY)) == 0
+def test_get_no_light_setup(make_cfg_settings):
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        assert len(sim.get_light_setup(NO_LIGHT_KEY)) == 0
 
 
-def test_set_default_light_setup(sim):
-    light_setup = [LightInfo(position=[1.0, 1.0, 1.0])]
+def test_set_default_light_setup(make_cfg_settings):
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        light_setup = [LightInfo(position=[1.0, 1.0, 1.0])]
 
-    sim.set_light_setup(light_setup)
-    assert sim.get_light_setup() == light_setup
+        sim.set_light_setup(light_setup)
+        assert sim.get_light_setup() == light_setup
 
-    # ensure modifications to local light setup variable are not reflected in sim
-    light_setup[0].model = LightPositionModel.CAMERA
-    assert sim.get_light_setup() != light_setup
+        # ensure modifications to local light setup variable are not reflected in sim
+        light_setup[0].model = LightPositionModel.CAMERA
+        assert sim.get_light_setup() != light_setup
 
-    sim.set_light_setup(light_setup, DEFAULT_LIGHTING_KEY)
-    assert sim.get_light_setup() == light_setup
+        sim.set_light_setup(light_setup, DEFAULT_LIGHTING_KEY)
+        assert sim.get_light_setup() == light_setup
 
 
-def test_set_custom_light_setup(sim):
-    custom_setup_key = "custom_setup_key"
+def test_set_custom_light_setup(make_cfg_settings):
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        custom_setup_key = "custom_setup_key"
 
-    light_setup = sim.get_light_setup(custom_setup_key)
-    assert len(light_setup) == 0
+        light_setup = sim.get_light_setup(custom_setup_key)
+        assert len(light_setup) == 0
 
-    light_setup.append(LightInfo(position=[1.0, 1.0, 1.0]))
-    assert sim.get_light_setup() != light_setup
+        light_setup.append(LightInfo(position=[1.0, 1.0, 1.0]))
+        assert sim.get_light_setup() != light_setup
 
-    sim.set_light_setup(light_setup, custom_setup_key)
-    assert sim.get_light_setup(custom_setup_key) == light_setup
+        sim.set_light_setup(light_setup, custom_setup_key)
+        assert sim.get_light_setup(custom_setup_key) == light_setup

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -31,113 +31,115 @@ def get_shortest_path(sim, samples):
 
 
 @pytest.mark.parametrize("test_scene", test_scenes)
-def test_recompute_navmesh(test_scene, sim):
+def test_recompute_navmesh(test_scene):
     if not osp.exists(test_scene):
         pytest.skip(f"{test_scene} not found")
 
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = test_scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
 
-    sim.navmesh_visualization = True
-    assert sim.navmesh_visualization
-    sim.navmesh_visualization = False
-    assert not sim.navmesh_visualization
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        sim.navmesh_visualization = True
+        assert sim.navmesh_visualization
+        sim.navmesh_visualization = False
+        assert not sim.navmesh_visualization
 
-    # generate random point pairs
-    num_samples = 100
-    samples = []
-    for _ in range(num_samples):
-        samples.append(
-            (
-                sim.pathfinder.get_random_navigable_point(),
-                sim.pathfinder.get_random_navigable_point(),
-            )
-        )
-
-    # compute shortest paths between these points on the loaded navmesh
-    loaded_navmesh_path_results = get_shortest_path(sim, samples)
-
-    hab_cfg = examples.settings.make_cfg(cfg_settings)
-    agent_config = hab_cfg.agents[hab_cfg.sim_cfg.default_agent_id]
-    agent_config.radius *= 2.0
-    sim.reconfigure(hab_cfg)
-    # compute shortest paths between these points on the loaded navmesh with twice radius
-    loaded_navmesh_2rad_path_results = get_shortest_path(sim, samples)
-
-    navmesh_settings = habitat_sim.NavMeshSettings()
-    navmesh_settings.set_defaults()
-    assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
-    assert sim.pathfinder.is_loaded
-
-    recomputed_navmesh_results = get_shortest_path(sim, samples)
-
-    navmesh_settings.agent_radius *= 2.0
-    assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
-    assert sim.pathfinder.is_loaded  # this may not always be viable...
-
-    recomputed_2rad_navmesh_results = get_shortest_path(sim, samples)
-
-    some_diff = False
-    for i in range(num_samples):
-        assert loaded_navmesh_path_results[i][0] == recomputed_navmesh_results[i][0]
-        assert (
-            loaded_navmesh_2rad_path_results[i][0]
-            == recomputed_2rad_navmesh_results[i][0]
-        )
-        if loaded_navmesh_path_results[i][0]:
-            assert (
-                abs(
-                    loaded_navmesh_path_results[i][1] - recomputed_navmesh_results[i][1]
+        # generate random point pairs
+        num_samples = 100
+        samples = []
+        for _ in range(num_samples):
+            samples.append(
+                (
+                    sim.pathfinder.get_random_navigable_point(),
+                    sim.pathfinder.get_random_navigable_point(),
                 )
-                < EPS
             )
 
-        if recomputed_2rad_navmesh_results[i][0]:
+        # compute shortest paths between these points on the loaded navmesh
+        loaded_navmesh_path_results = get_shortest_path(sim, samples)
+
+        hab_cfg = examples.settings.make_cfg(cfg_settings)
+        agent_config = hab_cfg.agents[hab_cfg.sim_cfg.default_agent_id]
+        agent_config.radius *= 2.0
+        sim.reconfigure(hab_cfg)
+        # compute shortest paths between these points on the loaded navmesh with twice radius
+        loaded_navmesh_2rad_path_results = get_shortest_path(sim, samples)
+
+        navmesh_settings = habitat_sim.NavMeshSettings()
+        navmesh_settings.set_defaults()
+        assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
+        assert sim.pathfinder.is_loaded
+
+        recomputed_navmesh_results = get_shortest_path(sim, samples)
+
+        navmesh_settings.agent_radius *= 2.0
+        assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
+        assert sim.pathfinder.is_loaded  # this may not always be viable...
+
+        recomputed_2rad_navmesh_results = get_shortest_path(sim, samples)
+
+        some_diff = False
+        for i in range(num_samples):
+            assert loaded_navmesh_path_results[i][0] == recomputed_navmesh_results[i][0]
             assert (
-                abs(
-                    loaded_navmesh_2rad_path_results[i][1]
-                    - recomputed_2rad_navmesh_results[i][1]
-                )
-                < EPS
+                loaded_navmesh_2rad_path_results[i][0]
+                == recomputed_2rad_navmesh_results[i][0]
             )
+            if loaded_navmesh_path_results[i][0]:
+                assert (
+                    abs(
+                        loaded_navmesh_path_results[i][1]
+                        - recomputed_navmesh_results[i][1]
+                    )
+                    < EPS
+                )
 
-        if (
-            loaded_navmesh_path_results[i][0] != recomputed_2rad_navmesh_results[i][0]
-            or loaded_navmesh_path_results[i][1] - recomputed_2rad_navmesh_results[i][1]
-            > EPS
-        ):
-            some_diff = True
+            if recomputed_2rad_navmesh_results[i][0]:
+                assert (
+                    abs(
+                        loaded_navmesh_2rad_path_results[i][1]
+                        - recomputed_2rad_navmesh_results[i][1]
+                    )
+                    < EPS
+                )
 
-    assert some_diff
+            if (
+                loaded_navmesh_path_results[i][0]
+                != recomputed_2rad_navmesh_results[i][0]
+                or loaded_navmesh_path_results[i][1]
+                - recomputed_2rad_navmesh_results[i][1]
+                > EPS
+            ):
+                some_diff = True
+
+        assert some_diff
 
 
 @pytest.mark.parametrize("test_scene", test_scenes)
-def test_navmesh_area(test_scene, sim):
+def test_navmesh_area(test_scene):
     if not osp.exists(test_scene):
         pytest.skip(f"{test_scene} not found")
 
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = test_scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # get the initial navmesh area. This test assumes default navmesh assets.
+        loadedNavMeshArea = sim.pathfinder.navigable_area
+        if test_scene.endswith("skokloster-castle.glb"):
+            assert math.isclose(loadedNavMeshArea, 226.65673828125)
+        elif test_scene.endswith("van-gogh-room.glb"):
+            assert math.isclose(loadedNavMeshArea, 9.17772102355957)
 
-    # get the initial navmesh area. This test assumes default navmesh assets.
-    loadedNavMeshArea = sim.pathfinder.navigable_area
-    if test_scene.endswith("skokloster-castle.glb"):
-        assert math.isclose(loadedNavMeshArea, 226.65673828125)
-    elif test_scene.endswith("van-gogh-room.glb"):
-        assert math.isclose(loadedNavMeshArea, 9.17772102355957)
+        navmesh_settings = habitat_sim.NavMeshSettings()
+        navmesh_settings.set_defaults()
+        assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
+        assert sim.pathfinder.is_loaded
 
-    navmesh_settings = habitat_sim.NavMeshSettings()
-    navmesh_settings.set_defaults()
-    assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
-    assert sim.pathfinder.is_loaded
-
-    # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
-    recomputedNavMeshArea1 = sim.pathfinder.navigable_area
-    if test_scene.endswith("skokloster-castle.glb"):
-        assert math.isclose(recomputedNavMeshArea1, 565.1781616210938)
-    elif test_scene.endswith("van-gogh-room.glb"):
-        assert math.isclose(recomputedNavMeshArea1, 9.17772102355957)
+        # get the re-computed navmesh area. This test assumes NavMeshSettings default values.
+        recomputedNavMeshArea1 = sim.pathfinder.navigable_area
+        if test_scene.endswith("skokloster-castle.glb"):
+            assert math.isclose(recomputedNavMeshArea1, 565.1781616210938)
+        elif test_scene.endswith("van-gogh-room.glb"):
+            assert math.isclose(recomputedNavMeshArea1, 9.17772102355957)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -14,6 +14,7 @@ import pytest
 import quaternion
 
 import examples.settings
+import habitat_sim
 import habitat_sim.physics
 from habitat_sim.utils.common import (
     quat_from_angle_axis,
@@ -27,7 +28,7 @@ from habitat_sim.utils.common import (
     or not osp.exists("data/objects/"),
     reason="Requires the habitat-test-scenes and habitat test objects",
 )
-def test_kinematics(sim):
+def test_kinematics():
     cfg_settings = examples.settings.default_sim_settings.copy()
 
     cfg_settings[
@@ -39,94 +40,97 @@ def test_kinematics(sim):
 
     # test loading the physical scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
-    obj_mgr = sim.get_object_template_manager()
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        obj_mgr = sim.get_object_template_manager()
 
-    assert obj_mgr.get_num_templates() > 0
+        assert obj_mgr.get_num_templates() > 0
 
-    # test adding an object to the world
-    # get handle for object 0, used to test
-    obj_handle_list = obj_mgr.get_template_handles("cheezit")
-    object_id = sim.add_object_by_handle(obj_handle_list[0])
-    assert len(sim.get_existing_object_ids()) > 0
+        # test adding an object to the world
+        # get handle for object 0, used to test
+        obj_handle_list = obj_mgr.get_template_handles("cheezit")
+        object_id = sim.add_object_by_handle(obj_handle_list[0])
+        assert len(sim.get_existing_object_ids()) > 0
 
-    # test setting the motion type
+        # test setting the motion type
 
-    assert sim.set_object_motion_type(habitat_sim.physics.MotionType.STATIC, object_id)
-    assert (
-        sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.STATIC
-    )
-    assert sim.set_object_motion_type(
-        habitat_sim.physics.MotionType.KINEMATIC, object_id
-    )
-    assert (
-        sim.get_object_motion_type(object_id)
-        == habitat_sim.physics.MotionType.KINEMATIC
-    )
+        assert sim.set_object_motion_type(
+            habitat_sim.physics.MotionType.STATIC, object_id
+        )
+        assert (
+            sim.get_object_motion_type(object_id)
+            == habitat_sim.physics.MotionType.STATIC
+        )
+        assert sim.set_object_motion_type(
+            habitat_sim.physics.MotionType.KINEMATIC, object_id
+        )
+        assert (
+            sim.get_object_motion_type(object_id)
+            == habitat_sim.physics.MotionType.KINEMATIC
+        )
 
-    # test kinematics
-    I = np.identity(4)
+        # test kinematics
+        I = np.identity(4)
 
-    # test get and set translation
-    sim.set_translation(np.array([0, 1.0, 0]), object_id)
-    assert np.allclose(sim.get_translation(object_id), np.array([0, 1.0, 0]))
+        # test get and set translation
+        sim.set_translation(np.array([0, 1.0, 0]), object_id)
+        assert np.allclose(sim.get_translation(object_id), np.array([0, 1.0, 0]))
 
-    # test object SceneNode
-    object_node = sim.get_object_scene_node(object_id)
-    assert np.allclose(sim.get_translation(object_id), object_node.translation)
+        # test object SceneNode
+        object_node = sim.get_object_scene_node(object_id)
+        assert np.allclose(sim.get_translation(object_id), object_node.translation)
 
-    # test get and set transform
-    sim.set_transformation(I, object_id)
-    assert np.allclose(sim.get_transformation(object_id), I)
+        # test get and set transform
+        sim.set_transformation(I, object_id)
+        assert np.allclose(sim.get_transformation(object_id), I)
 
-    # test get and set rotation
-    Q = quat_from_angle_axis(np.pi, np.array([0, 1.0, 0]))
-    expected = np.eye(4)
-    expected[0:3, 0:3] = quaternion.as_rotation_matrix(Q)
-    sim.set_rotation(quat_to_magnum(Q), object_id)
-    assert np.allclose(sim.get_transformation(object_id), expected)
-    assert np.allclose(quat_from_magnum(sim.get_rotation(object_id)), Q)
+        # test get and set rotation
+        Q = quat_from_angle_axis(np.pi, np.array([0, 1.0, 0]))
+        expected = np.eye(4)
+        expected[0:3, 0:3] = quaternion.as_rotation_matrix(Q)
+        sim.set_rotation(quat_to_magnum(Q), object_id)
+        assert np.allclose(sim.get_transformation(object_id), expected)
+        assert np.allclose(quat_from_magnum(sim.get_rotation(object_id)), Q)
 
-    # test object removal
-    sim.remove_object(object_id)
-    assert len(sim.get_existing_object_ids()) == 0
+        # test object removal
+        sim.remove_object(object_id)
+        assert len(sim.get_existing_object_ids()) == 0
 
-    obj_handle_list = obj_mgr.get_template_handles("cheezit")
-    object_id = sim.add_object_by_handle(obj_handle_list[0])
+        obj_handle_list = obj_mgr.get_template_handles("cheezit")
+        object_id = sim.add_object_by_handle(obj_handle_list[0])
 
-    prev_time = 0.0
-    for _ in range(2):
-        # do some kinematics here (todo: translating or rotating instead of absolute)
+        prev_time = 0.0
+        for _ in range(2):
+            # do some kinematics here (todo: translating or rotating instead of absolute)
+            sim.set_translation(np.random.rand(3), object_id)
+            T = sim.get_transformation(object_id)  # noqa : F841
+
+            # test getting observation
+            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+
+            # check that time is increasing in the world
+            assert sim.get_world_time() > prev_time
+            prev_time = sim.get_world_time()
+
+        sim.remove_object(object_id)
+
+        # test attaching/dettaching an Agent to/from physics simulation
+        agent_node = sim.agents[0].scene_node
+        obj_handle_list = obj_mgr.get_template_handles("cheezit")
+        object_id = sim.add_object_by_handle(obj_handle_list[0], agent_node)
         sim.set_translation(np.random.rand(3), object_id)
-        T = sim.get_transformation(object_id)  # noqa : F841
+        assert np.allclose(agent_node.translation, sim.get_translation(object_id))
+        sim.remove_object(object_id, False)  # don't delete the agent's node
+        assert agent_node.translation
 
-        # test getting observation
-        sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
-
-        # check that time is increasing in the world
-        assert sim.get_world_time() > prev_time
-        prev_time = sim.get_world_time()
-
-    sim.remove_object(object_id)
-
-    # test attaching/dettaching an Agent to/from physics simulation
-    agent_node = sim.agents[0].scene_node
-    obj_handle_list = obj_mgr.get_template_handles("cheezit")
-    object_id = sim.add_object_by_handle(obj_handle_list[0], agent_node)
-    sim.set_translation(np.random.rand(3), object_id)
-    assert np.allclose(agent_node.translation, sim.get_translation(object_id))
-    sim.remove_object(object_id, False)  # don't delete the agent's node
-    assert agent_node.translation
-
-    # test get/set RigidState
-    object_id = sim.add_object_by_handle(obj_handle_list[0])
-    targetRigidState = habitat_sim.bindings.RigidState(
-        mn.Quaternion(), np.array([1.0, 2.0, 3.0])
-    )
-    sim.set_rigid_state(targetRigidState, object_id)
-    objectRigidState = sim.get_rigid_state(object_id)
-    assert np.allclose(objectRigidState.translation, targetRigidState.translation)
-    assert objectRigidState.rotation == targetRigidState.rotation
+        # test get/set RigidState
+        object_id = sim.add_object_by_handle(obj_handle_list[0])
+        targetRigidState = habitat_sim.bindings.RigidState(
+            mn.Quaternion(), np.array([1.0, 2.0, 3.0])
+        )
+        sim.set_rigid_state(targetRigidState, object_id)
+        objectRigidState = sim.get_rigid_state(object_id)
+        assert np.allclose(objectRigidState.translation, targetRigidState.translation)
+        assert objectRigidState.rotation == targetRigidState.rotation
 
 
 @pytest.mark.skipif(
@@ -134,7 +138,7 @@ def test_kinematics(sim):
     or not osp.exists("data/objects/"),
     reason="Requires the habitat-test-scenes and habitat test objects",
 )
-def test_dynamics(sim):
+def test_dynamics():
     # This test assumes that default.phys_scene_config.json contains "physics simulator": "bullet".
     # TODO: enable dynamic override of this setting in simulation config structure
 
@@ -149,196 +153,203 @@ def test_dynamics(sim):
 
     # test loading the physical scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
-    obj_mgr = sim.get_object_template_manager()
-    # make the simulation deterministic (C++ seed is set in reconfigure)
-    np.random.seed(cfg_settings["seed"])
-    assert obj_mgr.get_num_templates() > 0
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        obj_mgr = sim.get_object_template_manager()
+        # make the simulation deterministic (C++ seed is set in reconfigure)
+        np.random.seed(cfg_settings["seed"])
+        assert obj_mgr.get_num_templates() > 0
 
-    # test adding an object to the world
-    obj_handle_list = obj_mgr.get_template_handles("cheezit")
-    object_id = sim.add_object_by_handle(obj_handle_list[0])
-    object2_id = sim.add_object_by_handle(obj_handle_list[0])
-    # object_id = sim.add_object(1)
-    # object2_id = sim.add_object(1)
-    assert len(sim.get_existing_object_ids()) > 0
+        # test adding an object to the world
+        obj_handle_list = obj_mgr.get_template_handles("cheezit")
+        object_id = sim.add_object_by_handle(obj_handle_list[0])
+        object2_id = sim.add_object_by_handle(obj_handle_list[0])
+        # object_id = sim.add_object(1)
+        # object2_id = sim.add_object(1)
+        assert len(sim.get_existing_object_ids()) > 0
 
-    # place the objects over the table in room
-    sim.set_translation(np.array([-0.569043, 2.04804, 13.6156]), object_id)
-    sim.set_translation(np.array([-0.569043, 2.04804, 12.6156]), object2_id)
+        # place the objects over the table in room
+        sim.set_translation(np.array([-0.569043, 2.04804, 13.6156]), object_id)
+        sim.set_translation(np.array([-0.569043, 2.04804, 12.6156]), object2_id)
 
-    # get object MotionType and continue testing if MotionType::DYNAMIC (implies a physics implementation is active)
-    if sim.get_object_motion_type(object_id) == habitat_sim.physics.MotionType.DYNAMIC:
-        object1_init_template = sim.get_object_initialization_template(object_id)
-        object1_mass = object1_init_template.mass
-        grav = sim.get_gravity()
-        previous_object_states = [
-            [sim.get_translation(object_id), sim.get_rotation(object_id)],
-            [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
-        ]
-        prev_time = sim.get_world_time()
-        for _ in range(50):
-            # force application at a location other than the origin should always cause angular and linear motion
-            sim.apply_force(np.random.rand(3), np.random.rand(3), object2_id)
-
-            # TODO: expose object properties (such as mass) to python
-            # Counter the force of gravity on the object (it should not translate)
-            sim.apply_force(-grav * object1_mass, np.zeros(3), object_id)
-
-            # apply torque to the "floating" object. It should rotate, but not translate
-            sim.apply_torque(np.random.rand(3), object_id)
-
-            # TODO: test other physics functions
-
-            # test getting observation
-            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
-
-            # check that time is increasing in the world
-            assert sim.get_world_time() > prev_time
-            prev_time = sim.get_world_time()
-
-            # check the object states
-            # 1st object should rotate, but not translate
-            assert np.allclose(
-                previous_object_states[0][0], sim.get_translation(object_id)
-            )
-            assert previous_object_states[0][1] != sim.get_rotation(object_id)
-
-            # 2nd object should rotate and translate
-            assert not np.allclose(
-                previous_object_states[1][0], sim.get_translation(object2_id)
-            )
-            assert previous_object_states[1][1] != sim.get_rotation(object2_id)
-
+        # get object MotionType and continue testing if MotionType::DYNAMIC (implies a physics implementation is active)
+        if (
+            sim.get_object_motion_type(object_id)
+            == habitat_sim.physics.MotionType.DYNAMIC
+        ):
+            object1_init_template = sim.get_object_initialization_template(object_id)
+            object1_mass = object1_init_template.mass
+            grav = sim.get_gravity()
             previous_object_states = [
                 [sim.get_translation(object_id), sim.get_rotation(object_id)],
                 [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
             ]
+            prev_time = sim.get_world_time()
+            for _ in range(50):
+                # force application at a location other than the origin should always cause angular and linear motion
+                sim.apply_force(np.random.rand(3), np.random.rand(3), object2_id)
 
-        # test setting DYNAMIC object to KINEMATIC
-        assert sim.set_object_motion_type(
-            habitat_sim.physics.MotionType.KINEMATIC, object2_id
-        )
-        assert (
-            sim.get_object_motion_type(object2_id)
-            == habitat_sim.physics.MotionType.KINEMATIC
-        )
+                # TODO: expose object properties (such as mass) to python
+                # Counter the force of gravity on the object (it should not translate)
+                sim.apply_force(-grav * object1_mass, np.zeros(3), object_id)
 
-        sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+                # apply torque to the "floating" object. It should rotate, but not translate
+                sim.apply_torque(np.random.rand(3), object_id)
 
-        # 2nd object should no longer rotate or translate
-        assert np.allclose(
-            previous_object_states[1][0], sim.get_translation(object2_id)
-        )
-        assert previous_object_states[1][1] == sim.get_rotation(object2_id)
+                # TODO: test other physics functions
 
-        sim.step_physics(0.1)
+                # test getting observation
+                sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
 
-        # test velocity get/set
-        test_lin_vel = np.array([1.0, 0.0, 0.0])
-        test_ang_vel = np.array([0.0, 1.0, 0.0])
+                # check that time is increasing in the world
+                assert sim.get_world_time() > prev_time
+                prev_time = sim.get_world_time()
 
-        # no velocity setting for KINEMATIC objects
-        sim.set_linear_velocity(test_lin_vel, object2_id)
-        assert sim.get_linear_velocity(object2_id) == np.array([0.0, 0.0, 0.0])
+                # check the object states
+                # 1st object should rotate, but not translate
+                assert np.allclose(
+                    previous_object_states[0][0], sim.get_translation(object_id)
+                )
+                assert previous_object_states[0][1] != sim.get_rotation(object_id)
 
-        sim.set_object_motion_type(habitat_sim.physics.MotionType.DYNAMIC, object2_id)
-        sim.set_linear_velocity(test_lin_vel, object2_id)
-        sim.set_angular_velocity(test_ang_vel, object2_id)
-        assert sim.get_linear_velocity(object2_id) == test_lin_vel
-        assert sim.get_angular_velocity(object2_id) == test_ang_vel
+                # 2nd object should rotate and translate
+                assert not np.allclose(
+                    previous_object_states[1][0], sim.get_translation(object2_id)
+                )
+                assert previous_object_states[1][1] != sim.get_rotation(object2_id)
 
-        # test modifying gravity
-        new_object_start = np.array([100.0, 0, 0])
-        sim.set_translation(new_object_start, object_id)
-        new_grav = np.array([10.0, 0, 0])
-        sim.set_gravity(new_grav)
-        assert np.allclose(sim.get_gravity(), new_grav)
-        assert np.allclose(sim.get_translation(object_id), new_object_start)
-        sim.step_physics(0.1)
-        assert sim.get_translation(object_id)[0] > new_object_start[0]
+                previous_object_states = [
+                    [sim.get_translation(object_id), sim.get_rotation(object_id)],
+                    [sim.get_translation(object2_id), sim.get_rotation(object2_id)],
+                ]
+
+            # test setting DYNAMIC object to KINEMATIC
+            assert sim.set_object_motion_type(
+                habitat_sim.physics.MotionType.KINEMATIC, object2_id
+            )
+            assert (
+                sim.get_object_motion_type(object2_id)
+                == habitat_sim.physics.MotionType.KINEMATIC
+            )
+
+            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+
+            # 2nd object should no longer rotate or translate
+            assert np.allclose(
+                previous_object_states[1][0], sim.get_translation(object2_id)
+            )
+            assert previous_object_states[1][1] == sim.get_rotation(object2_id)
+
+            sim.step_physics(0.1)
+
+            # test velocity get/set
+            test_lin_vel = np.array([1.0, 0.0, 0.0])
+            test_ang_vel = np.array([0.0, 1.0, 0.0])
+
+            # no velocity setting for KINEMATIC objects
+            sim.set_linear_velocity(test_lin_vel, object2_id)
+            assert sim.get_linear_velocity(object2_id) == np.array([0.0, 0.0, 0.0])
+
+            sim.set_object_motion_type(
+                habitat_sim.physics.MotionType.DYNAMIC, object2_id
+            )
+            sim.set_linear_velocity(test_lin_vel, object2_id)
+            sim.set_angular_velocity(test_ang_vel, object2_id)
+            assert sim.get_linear_velocity(object2_id) == test_lin_vel
+            assert sim.get_angular_velocity(object2_id) == test_ang_vel
+
+            # test modifying gravity
+            new_object_start = np.array([100.0, 0, 0])
+            sim.set_translation(new_object_start, object_id)
+            new_grav = np.array([10.0, 0, 0])
+            sim.set_gravity(new_grav)
+            assert np.allclose(sim.get_gravity(), new_grav)
+            assert np.allclose(sim.get_translation(object_id), new_object_start)
+            sim.step_physics(0.1)
+            assert sim.get_translation(object_id)[0] > new_object_start[0]
 
 
-def test_velocity_control(sim):
+def test_velocity_control():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "NONE"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
-    sim.set_gravity(np.array([0, 0, 0.0]))
-    obj_mgr = sim.get_object_template_manager()
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        sim.set_gravity(np.array([0, 0, 0.0]))
+        obj_mgr = sim.get_object_template_manager()
 
-    template_path = osp.abspath("data/test_assets/objects/nested_box")
-    template_ids = obj_mgr.load_object_configs(template_path)
-    object_template = obj_mgr.get_template_by_ID(template_ids[0])
-    object_template.linear_damping = 0.0
-    object_template.angular_damping = 0.0
-    obj_mgr.register_template(object_template)
+        template_path = osp.abspath("data/test_assets/objects/nested_box")
+        template_ids = obj_mgr.load_object_configs(template_path)
+        object_template = obj_mgr.get_template_by_ID(template_ids[0])
+        object_template.linear_damping = 0.0
+        object_template.angular_damping = 0.0
+        obj_mgr.register_template(object_template)
 
-    obj_handle = obj_mgr.get_template_handle_by_ID(template_ids[0])
+        obj_handle = obj_mgr.get_template_handle_by_ID(template_ids[0])
 
-    for iteration in range(2):
-        sim.reset()
-        object_id = sim.add_object_by_handle(obj_handle)
-        vel_control = sim.get_object_velocity_control(object_id)
+        for iteration in range(2):
+            sim.reset()
+            object_id = sim.add_object_by_handle(obj_handle)
+            vel_control = sim.get_object_velocity_control(object_id)
 
-        if iteration == 0:
-            if (
-                sim.get_object_motion_type(object_id)
-                != habitat_sim.physics.MotionType.DYNAMIC
-            ):
-                # Non-dynamic simulator in use. Skip 1st pass.
-                sim.remove_object(object_id)
-                continue
-        elif iteration == 1:
-            # test KINEMATIC
-            sim.set_object_motion_type(
-                habitat_sim.physics.MotionType.KINEMATIC, object_id
+            if iteration == 0:
+                if (
+                    sim.get_object_motion_type(object_id)
+                    != habitat_sim.physics.MotionType.DYNAMIC
+                ):
+                    # Non-dynamic simulator in use. Skip 1st pass.
+                    sim.remove_object(object_id)
+                    continue
+            elif iteration == 1:
+                # test KINEMATIC
+                sim.set_object_motion_type(
+                    habitat_sim.physics.MotionType.KINEMATIC, object_id
+                )
+
+            # test global velocities
+            vel_control.linear_velocity = np.array([1.0, 0, 0])
+            vel_control.angular_velocity = np.array([0, 1.0, 0])
+            vel_control.controlling_lin_vel = True
+            vel_control.controlling_ang_vel = True
+
+            while sim.get_world_time() < 1.0:
+                # NOTE: stepping close to default timestep to get near-constant velocity control of DYNAMIC bodies.
+                sim.step_physics(0.00416)
+
+            ground_truth_pos = sim.get_world_time() * vel_control.linear_velocity
+            assert np.allclose(
+                sim.get_translation(object_id), ground_truth_pos, atol=0.01
             )
+            ground_truth_q = mn.Quaternion([[0, 0.480551, 0], 0.876967])
+            angle_error = mn.math.angle(ground_truth_q, sim.get_rotation(object_id))
+            assert angle_error < mn.Rad(0.005)
 
-        # test global velocities
-        vel_control.linear_velocity = np.array([1.0, 0, 0])
-        vel_control.angular_velocity = np.array([0, 1.0, 0])
-        vel_control.controlling_lin_vel = True
-        vel_control.controlling_ang_vel = True
+            sim.reset()
 
-        while sim.get_world_time() < 1.0:
-            # NOTE: stepping close to default timestep to get near-constant velocity control of DYNAMIC bodies.
-            sim.step_physics(0.00416)
+            # test local velocities (turn in a half circle)
+            vel_control.lin_vel_is_local = True
+            vel_control.ang_vel_is_local = True
+            vel_control.linear_velocity = np.array([0, 0, -math.pi])
+            vel_control.angular_velocity = np.array([math.pi * 2.0, 0, 0])
 
-        ground_truth_pos = sim.get_world_time() * vel_control.linear_velocity
-        assert np.allclose(sim.get_translation(object_id), ground_truth_pos, atol=0.01)
-        ground_truth_q = mn.Quaternion([[0, 0.480551, 0], 0.876967])
-        angle_error = mn.math.angle(ground_truth_q, sim.get_rotation(object_id))
-        assert angle_error < mn.Rad(0.005)
+            sim.set_translation(np.array([0, 0, 0.0]), object_id)
+            sim.set_rotation(mn.Quaternion(), object_id)
 
-        sim.reset()
+            while sim.get_world_time() < 0.5:
+                # NOTE: stepping close to default timestep to get near-constant velocity control of DYNAMIC bodies.
+                sim.step_physics(0.008)
 
-        # test local velocities (turn in a half circle)
-        vel_control.lin_vel_is_local = True
-        vel_control.ang_vel_is_local = True
-        vel_control.linear_velocity = np.array([0, 0, -math.pi])
-        vel_control.angular_velocity = np.array([math.pi * 2.0, 0, 0])
+            print(sim.get_world_time())
 
-        sim.set_translation(np.array([0, 0, 0.0]), object_id)
-        sim.set_rotation(mn.Quaternion(), object_id)
+            # NOTE: explicit integration, so expect some error
+            ground_truth_q = mn.Quaternion([[1.0, 0, 0], 0])
+            print(sim.get_translation(object_id))
+            assert np.allclose(
+                sim.get_translation(object_id), np.array([0, 1.0, 0.0]), atol=0.07
+            )
+            angle_error = mn.math.angle(ground_truth_q, sim.get_rotation(object_id))
+            assert angle_error < mn.Rad(0.05)
 
-        while sim.get_world_time() < 0.5:
-            # NOTE: stepping close to default timestep to get near-constant velocity control of DYNAMIC bodies.
-            sim.step_physics(0.008)
-
-        print(sim.get_world_time())
-
-        # NOTE: explicit integration, so expect some error
-        ground_truth_q = mn.Quaternion([[1.0, 0, 0], 0])
-        print(sim.get_translation(object_id))
-        assert np.allclose(
-            sim.get_translation(object_id), np.array([0, 1.0, 0.0]), atol=0.07
-        )
-        angle_error = mn.math.angle(ground_truth_q, sim.get_rotation(object_id))
-        assert angle_error < mn.Rad(0.05)
-
-        sim.remove_object(object_id)
+            sim.remove_object(object_id)
 
 
 @pytest.mark.skipif(
@@ -356,47 +367,47 @@ def test_raycast(sim):
 
     # loading the physical scene
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
-    obj_mgr = sim.get_object_template_manager()
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        obj_mgr = sim.get_object_template_manager()
 
-    if (
-        sim.get_physics_simulation_library()
-        != habitat_sim.physics.PhysicsSimulationLibrary.NONE
-    ):
-        # only test this if we have a physics simulator and therefore a collision world
-        test_ray_1 = habitat_sim.geo.Ray()
-        test_ray_1.direction = mn.Vector3(1.0, 0, 0)
-        raycast_results = sim.cast_ray(test_ray_1)
-        assert raycast_results.ray.direction == test_ray_1.direction
-        assert raycast_results.has_hits()
-        assert len(raycast_results.hits) == 1
-        assert np.allclose(
-            raycast_results.hits[0].point, np.array([6.83063, 0, 0]), atol=0.07
-        )
-        assert np.allclose(
-            raycast_results.hits[0].normal,
-            np.array([-0.999587, 0.0222882, -0.0181424]),
-            atol=0.07,
-        )
-        assert abs(raycast_results.hits[0].ray_distance - 6.831) < 0.001
-        assert raycast_results.hits[0].object_id == -1
+        if (
+            sim.get_physics_simulation_library()
+            != habitat_sim.physics.PhysicsSimulationLibrary.NONE
+        ):
+            # only test this if we have a physics simulator and therefore a collision world
+            test_ray_1 = habitat_sim.geo.Ray()
+            test_ray_1.direction = mn.Vector3(1.0, 0, 0)
+            raycast_results = sim.cast_ray(test_ray_1)
+            assert raycast_results.ray.direction == test_ray_1.direction
+            assert raycast_results.has_hits()
+            assert len(raycast_results.hits) == 1
+            assert np.allclose(
+                raycast_results.hits[0].point, np.array([6.83063, 0, 0]), atol=0.07
+            )
+            assert np.allclose(
+                raycast_results.hits[0].normal,
+                np.array([-0.999587, 0.0222882, -0.0181424]),
+                atol=0.07,
+            )
+            assert abs(raycast_results.hits[0].ray_distance - 6.831) < 0.001
+            assert raycast_results.hits[0].object_id == -1
 
-        # add a primitive object to the world
-        cube_prim_handle = obj_mgr.get_template_handles("cube")[0]
-        cube_obj_id = sim.add_object_by_handle(cube_prim_handle)
-        sim.set_translation(mn.Vector3(3.0, 0, 0), cube_obj_id)
+            # add a primitive object to the world
+            cube_prim_handle = obj_mgr.get_template_handles("cube")[0]
+            cube_obj_id = sim.add_object_by_handle(cube_prim_handle)
+            sim.set_translation(mn.Vector3(3.0, 0, 0), cube_obj_id)
 
-        raycast_results = sim.cast_ray(test_ray_1)
+            raycast_results = sim.cast_ray(test_ray_1)
 
-        assert raycast_results.has_hits()
-        assert len(raycast_results.hits) == 2
-        assert np.allclose(
-            raycast_results.hits[0].point, np.array([2.89355, 0, 0]), atol=0.07
-        )
-        assert np.allclose(
-            raycast_results.hits[0].normal,
-            np.array([-0.998961, -0.0322245, -0.0322245]),
-            atol=0.07,
-        )
-        assert abs(raycast_results.hits[0].ray_distance - 2.8935) < 0.001
-        assert raycast_results.hits[0].object_id == 0
+            assert raycast_results.has_hits()
+            assert len(raycast_results.hits) == 2
+            assert np.allclose(
+                raycast_results.hits[0].point, np.array([2.89355, 0, 0]), atol=0.07
+            )
+            assert np.allclose(
+                raycast_results.hits[0].normal,
+                np.array([-0.998961, -0.0322245, -0.0322245]),
+                atol=0.07,
+            )
+            assert abs(raycast_results.hits[0].ray_distance - 2.8935) < 0.001
+            assert raycast_results.hits[0].object_id == 0

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -356,7 +356,7 @@ def test_velocity_control():
     not osp.exists("data/scene_datasets/habitat-test-scenes/apartment_1.glb"),
     reason="Requires the habitat-test-scenes",
 )
-def test_raycast(sim):
+def test_raycast():
     cfg_settings = examples.settings.default_sim_settings.copy()
 
     # configure some settings in case defaults change

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,28 +1,28 @@
 import examples.settings
+import habitat_sim
 
 
-def test_random_seed(sim):
+def test_random_seed():
     # reconfigure to ensure pathfinder exists
     cfg_settings = examples.settings.default_sim_settings.copy()
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # Test that the same seed gives the same point
+        sim.seed(1)
+        point1 = sim.pathfinder.get_random_navigable_point()
+        sim.seed(1)
+        point2 = sim.pathfinder.get_random_navigable_point()
+        assert all(point1 == point2)
 
-    # Test that the same seed gives the same point
-    sim.seed(1)
-    point1 = sim.pathfinder.get_random_navigable_point()
-    sim.seed(1)
-    point2 = sim.pathfinder.get_random_navigable_point()
-    assert all(point1 == point2)
+        # Test that different seeds give different points
+        sim.seed(2)
+        point1 = sim.pathfinder.get_random_navigable_point()
+        sim.seed(3)
+        point2 = sim.pathfinder.get_random_navigable_point()
+        assert any(point1 != point2)
 
-    # Test that different seeds give different points
-    sim.seed(2)
-    point1 = sim.pathfinder.get_random_navigable_point()
-    sim.seed(3)
-    point2 = sim.pathfinder.get_random_navigable_point()
-    assert any(point1 != point2)
-
-    # Test that the same seed gives different points when sampled twice
-    sim.seed(4)
-    point1 = sim.pathfinder.get_random_navigable_point()
-    point2 = sim.pathfinder.get_random_navigable_point()
-    assert any(point1 != point2)
+        # Test that the same seed gives different points when sampled twice
+        sim.seed(4)
+        point1 = sim.pathfinder.get_random_navigable_point()
+        point2 = sim.pathfinder.get_random_navigable_point()
+        assert any(point1 != point2)

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -153,6 +153,8 @@ def test_reconfigure_render(
     cfg = make_cfg(make_cfg_settings)
 
     with habitat_sim.Simulator(cfg) as sim:
+        make_cfg_settings["scene"] = scene
+        sim.reconfigure(make_cfg(make_cfg_settings))
         for sensor_type in ["color_sensor", "depth_sensor"]:
             obs, gt = _render_and_load_gt(sim, scene, sensor_type, False)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,16 +1,14 @@
-import multiprocessing
 import random
 from os import path as osp
 
 import magnum as mn
 import numpy as np
-import pytest
 
 import examples.settings
 import habitat_sim
 
 
-def test_no_navmesh_smoke(sim):
+def test_no_navmesh_smoke():
     sim_cfg = habitat_sim.SimulatorConfiguration()
     agent_config = habitat_sim.AgentConfiguration()
     # No sensors as we are only testing to see if things work
@@ -21,18 +19,19 @@ def test_no_navmesh_smoke(sim):
     # Make it try to load a navmesh that doesn't exists
     sim_cfg.scene.filepaths["navmesh"] = "/tmp/dne.navmesh"
 
-    sim.reconfigure(habitat_sim.Configuration(sim_cfg, [agent_config]))
+    with habitat_sim.Simulator(
+        habitat_sim.Configuration(sim_cfg, [agent_config])
+    ) as sim:
+        sim.initialize_agent(0)
 
-    sim.initialize_agent(0)
-
-    random.seed(0)
-    for _ in range(50):
-        obs = sim.step(random.choice(list(agent_config.action_space.keys())))
-        # Can't collide with no navmesh
-        assert not obs["collided"]
+        random.seed(0)
+        for _ in range(50):
+            obs = sim.step(random.choice(list(agent_config.action_space.keys())))
+            # Can't collide with no navmesh
+            assert not obs["collided"]
 
 
-def test_empty_scene(sim):
+def test_empty_scene():
     cfg_settings = examples.settings.default_sim_settings.copy()
 
     # keyword "NONE" initializes a scene with no scene mesh
@@ -41,35 +40,35 @@ def test_empty_scene(sim):
     cfg_settings["depth_sensor"] = True
 
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        assert sim.get_stage_initialization_template() == None
 
-    assert sim.get_stage_initialization_template() == None
-
-    # test that empty frames can be rendered without a scene mesh
-    for _ in range(2):
-        sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+        # test that empty frames can be rendered without a scene mesh
+        for _ in range(2):
+            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
 
 
-def test_sim_reset(sim):
-    agent_config = sim.config.agents[0]
-    sim.initialize_agent(0)
-    initial_state = sim.agents[0].initial_state
-    # Take random steps in the environment
-    for _ in range(10):
-        action = random.choice(list(agent_config.action_space.keys()))
-        sim.step(action)
+def test_sim_reset(make_cfg_settings):
+    with habitat_sim.Simulator(examples.settings.make_cfg(make_cfg_settings)) as sim:
+        agent_config = sim.config.agents[0]
+        sim.initialize_agent(0)
+        initial_state = sim.agents[0].initial_state
+        # Take random steps in the environment
+        for _ in range(10):
+            action = random.choice(list(agent_config.action_space.keys()))
+            sim.step(action)
 
-    sim.reset()
-    new_state = sim.agents[0].get_state()
-    same_position = all(initial_state.position == new_state.position)
-    same_rotation = np.isclose(
-        initial_state.rotation, new_state.rotation, rtol=1e-4
-    )  # Numerical error can cause slight deviations
-    assert same_position and same_rotation
+        sim.reset()
+        new_state = sim.agents[0].get_state()
+        same_position = all(initial_state.position == new_state.position)
+        same_rotation = np.isclose(
+            initial_state.rotation, new_state.rotation, rtol=1e-4
+        )  # Numerical error can cause slight deviations
+        assert same_position and same_rotation
 
 
 # Make sure you can keep a reference to an agent alive without crashing
-def _test_keep_agent_tgt():
+def test_keep_agent():
     sim_cfg = habitat_sim.SimulatorConfiguration()
     agent_config = habitat_sim.AgentConfiguration()
 
@@ -84,7 +83,7 @@ def _test_keep_agent_tgt():
 
 
 # Make sure you can construct and destruct the simulator multiple times
-def _test_multiple_construct_destroy_tgt():
+def test_multiple_construct_destroy():
     sim_cfg = habitat_sim.SimulatorConfiguration()
     agent_config = habitat_sim.AgentConfiguration()
 
@@ -95,79 +94,63 @@ def _test_multiple_construct_destroy_tgt():
             pass
 
 
-@pytest.mark.parametrize(
-    "test_fn", [_test_keep_agent_tgt, _test_multiple_construct_destroy_tgt]
-)
-def test_subproc_fns(test_fn):
-    mp_ctx = multiprocessing.get_context("spawn")
-
-    # Run this test in a subprocess as things with OpenGL
-    # contexts get messy
-    p = mp_ctx.Process(target=test_fn)
-
-    p.start()
-    p.join()
-
-    assert p.exitcode == 0
-
-
-def test_scene_bounding_boxes(sim):
+def test_scene_bounding_boxes():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
-    scene_graph = sim.get_active_scene_graph()
-    root_node = scene_graph.get_root_node()
-    root_node.compute_cumulative_bb()
-    scene_bb = root_node.cumulative_bb
-    ground_truth = mn.Range3D.from_size(
-        mn.Vector3(-0.775869, -0.0233012, -1.6706), mn.Vector3(6.76937, 3.86304, 3.5359)
-    )
-    assert ground_truth == scene_bb
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        scene_graph = sim.get_active_scene_graph()
+        root_node = scene_graph.get_root_node()
+        root_node.compute_cumulative_bb()
+        scene_bb = root_node.cumulative_bb
+        ground_truth = mn.Range3D.from_size(
+            mn.Vector3(-0.775869, -0.0233012, -1.6706),
+            mn.Vector3(6.76937, 3.86304, 3.5359),
+        )
+        assert ground_truth == scene_bb
 
 
-def test_object_template_editing(sim):
+def test_object_template_editing():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    sim.reconfigure(hab_cfg)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # test creating a new template with a test asset
+        transform_box_path = osp.abspath("data/test_assets/objects/transform_box.glb")
+        transform_box_template = habitat_sim.attributes.ObjectAttributes()
+        transform_box_template.render_asset_handle = transform_box_path
+        obj_mgr = sim.get_object_template_manager()
+        old_library_size = obj_mgr.get_num_templates()
+        transform_box_template_id = obj_mgr.register_template(
+            transform_box_template, "transform_box_template"
+        )
+        assert obj_mgr.get_num_templates() > old_library_size
+        assert transform_box_template_id != -1
 
-    # test creating a new template with a test asset
-    transform_box_path = osp.abspath("data/test_assets/objects/transform_box.glb")
-    transform_box_template = habitat_sim.attributes.ObjectAttributes()
-    transform_box_template.render_asset_handle = transform_box_path
-    obj_mgr = sim.get_object_template_manager()
-    old_library_size = obj_mgr.get_num_templates()
-    transform_box_template_id = obj_mgr.register_template(
-        transform_box_template, "transform_box_template"
-    )
-    assert obj_mgr.get_num_templates() > old_library_size
-    assert transform_box_template_id != -1
+        # test loading a test asset template from file
+        sphere_path = osp.abspath("data/test_assets/objects/sphere")
+        old_library_size = obj_mgr.get_num_templates()
+        template_ids = obj_mgr.load_object_configs(sphere_path)
+        assert len(template_ids) > 0
+        assert obj_mgr.get_num_templates() > old_library_size
 
-    # test loading a test asset template from file
-    sphere_path = osp.abspath("data/test_assets/objects/sphere")
-    old_library_size = obj_mgr.get_num_templates()
-    template_ids = obj_mgr.load_object_configs(sphere_path)
-    assert len(template_ids) > 0
-    assert obj_mgr.get_num_templates() > old_library_size
+        # test getting and editing template reference - changes underlying template
+        sphere_template = obj_mgr.get_template_by_ID(template_ids[0])
+        assert sphere_template.render_asset_handle.endswith("sphere.glb")
+        sphere_scale = np.array([2.0, 2.0, 2.0])
+        sphere_template.scale = sphere_scale
+        obj_mgr.register_template(sphere_template, sphere_template.handle)
+        sphere_template2 = obj_mgr.get_template_by_ID(template_ids[0])
+        assert sphere_template2.scale == sphere_scale
 
-    # test getting and editing template reference - changes underlying template
-    sphere_template = obj_mgr.get_template_by_ID(template_ids[0])
-    assert sphere_template.render_asset_handle.endswith("sphere.glb")
-    sphere_scale = np.array([2.0, 2.0, 2.0])
-    sphere_template.scale = sphere_scale
-    obj_mgr.register_template(sphere_template, sphere_template.handle)
-    sphere_template2 = obj_mgr.get_template_by_ID(template_ids[0])
-    assert sphere_template2.scale == sphere_scale
+        # test adding a new object
+        object_id = sim.add_object(template_ids[0])
+        assert object_id != -1
 
-    # test adding a new object
-    object_id = sim.add_object(template_ids[0])
-    assert object_id != -1
+        # test getting initialization templates
+        stage_init_template = sim.get_stage_initialization_template()
+        assert stage_init_template.render_asset_handle == cfg_settings["scene"]
 
-    # test getting initialization templates
-    stage_init_template = sim.get_stage_initialization_template()
-    assert stage_init_template.render_asset_handle == cfg_settings["scene"]
-
-    obj_init_template = sim.get_object_initialization_template(object_id)
-    assert obj_init_template.render_asset_handle.endswith("sphere.glb")
+        obj_init_template = sim.get_object_initialization_template(object_id)
+        assert obj_init_template.render_asset_handle.endswith("sphere.glb")


### PR DESCRIPTION
## Motivation and Context

It's time to get rid of the sharing the instance of the simulator among all the tests hack.  I also added an explicit test that the current test_sensors was implicitly testing -- making sure reconfigure actually swaps the scene correctly.

This also allows us to enable parallel testing through https://github.com/browsertron/pytest-parallel so total test time is actually reduced!

## How Has This Been Tested

Via the tests

## Types of changes

 Docs change / refactoring / dependency upgrade
