### PR TITLE
Object Attributes allow for primitives as asset handles

### DIFF
--- a/src/esp/assets/attributes/ObjectAttributes.cpp
+++ b/src/esp/assets/attributes/ObjectAttributes.cpp
@@ -56,6 +56,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setFrictionCoefficient(0.5);
   setRestitutionCoefficient(0.1);
   setScale({1.0, 1.0, 1.0});
+  setCollisionAssetSize({1.0, 1.0, 1.0});
   setMargin(0.04);
   setOrientUp({0, 1, 0});
   setOrientFront({0, 0, -1});

--- a/src/esp/assets/attributes/ObjectAttributes.h
+++ b/src/esp/assets/attributes/ObjectAttributes.h
@@ -38,8 +38,19 @@ class AbstractObjectAttributes : public AbstractAttributes {
                            const std::string& handle);
 
   virtual ~AbstractObjectAttributes() = default;
+
+  /**
+   * @brief Scale of the ojbect
+   */
   void setScale(const Magnum::Vector3& scale) { setVec3("scale", scale); }
   Magnum::Vector3 getScale() const { return getVec3("scale"); }
+
+  void setCollisionAssetSize(const Magnum::Vector3& collisionAssetSize) {
+    setVec3("collisionAssetSize", collisionAssetSize);
+  }
+  Magnum::Vector3 getCollisionAssetSize() const {
+    return getVec3("collisionAssetSize");
+  }
 
   /**
    * @brief collision shape inflation margin

--- a/src/esp/assets/managers/AssetAttributesManager.cpp
+++ b/src/esp/assets/managers/AssetAttributesManager.cpp
@@ -119,7 +119,8 @@ AssetAttributesManager::createAttributesTemplate(
   if (nullptr == primAssetAttributes) {
     return primAssetAttributes;
   }
-  LOG(INFO) << "Asset attributes (" << primClassName << ") created"
+  LOG(INFO) << "Asset attributes (" << primClassName << " : "
+            << primAssetAttributes->getHandle() << ") created"
             << (registerTemplate ? " and registered." : ".");
 
   return this->postCreateRegister(primAssetAttributes, registerTemplate);

--- a/src/esp/assets/managers/AssetAttributesManager.h
+++ b/src/esp/assets/managers/AssetAttributesManager.h
@@ -374,9 +374,19 @@ class AssetAttributesManager
 
  protected:
   /**
+   * @brief Check if currently configured primitive asset template library has
+   * passed handle.
+   * @param handle String name of primitive asset attributes desired
+   * @return whether handle exists or not in asset attributes library
+   */
+  bool isValidPrimitiveAttributes(const std::string& handle) override {
+    return this->getTemplateLibHasHandle(handle);
+  }
+
+  /**
    * @brief Not used by Attrs::AbstractPrimitiveAttributes.
    */
-  void setDefaultFileNameBasedAttributes(
+  void setDefaultAssetNameBasedAttributes(
       CORRADE_UNUSED Attrs::AbstractPrimitiveAttributes::ptr attributes,
       CORRADE_UNUSED bool setFrame,
       CORRADE_UNUSED const std::string& meshHandle,

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -1028,7 +1028,7 @@ bool AttributesManager<T>::setJSONAssetHandleAndType(
       typeVal = static_cast<int>(
           Attrs::AbstractObjectAttributes::AssetTypeNamesMap.at(tmpVal));
     } else {
-      LOG(WARNING) << "AttributesManager::convertJsonStringToAssetType : "
+      LOG(WARNING) << "AttributesManager::setJSONAssetHandleAndType : "
                       "Value in json @ tag : "
                    << jsonMeshTypeTag << " : `" << tmpVal
                    << "` does not map to a valid "

--- a/src/esp/assets/managers/AttributesManagerBase.h
+++ b/src/esp/assets/managers/AttributesManagerBase.h
@@ -937,6 +937,12 @@ auto AttributesManager<T>::createObjectAttributesFromJson(
       jsonDoc, "scale",
       std::bind(&Attrs::AbstractObjectAttributes::setScale, attributes, _1));
 
+  // collision asset size
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonDoc, "collision asset size",
+      std::bind(&Attrs::AbstractObjectAttributes::setCollisionAssetSize,
+                attributes, _1));
+
   // margin
   io::jsonIntoSetter<double>(
       jsonDoc, "margin",

--- a/src/esp/assets/managers/ObjectAttributesManager.cpp
+++ b/src/esp/assets/managers/ObjectAttributesManager.cpp
@@ -25,7 +25,7 @@ ObjectAttributes::ptr ObjectAttributesManager::createAttributesTemplate(
     bool registerTemplate) {
   ObjectAttributes::ptr attrs;
   std::string msg;
-  if (isValidPrimitiveAttributes(attributesTemplateHandle)) {
+  if (this->isValidPrimitiveAttributes(attributesTemplateHandle)) {
     // if attributesTemplateHandle == some existing primitive attributes, then
     // this is a primitive-based object we are building
     attrs = createPrimBasedAttributesTemplate(attributesTemplateHandle,
@@ -74,7 +74,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
     const std::string& primAttrTemplateHandle,
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
-  if (!isValidPrimitiveAttributes(primAttrTemplateHandle)) {
+  if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
     LOG(ERROR)
         << "ObjectAttributesManager::createPrimBasedAttributesTemplate : No "
            "primitive with handle '"
@@ -172,12 +172,12 @@ ObjectAttributes::ptr ObjectAttributesManager::initNewAttribsInternal(
   // set default collision asset handle
   newAttributes->setCollisionAssetHandle(attributesHandle);
   // set defaults for passed render asset handles
-  setDefaultFileNameBasedAttributes(
+  this->setDefaultAssetNameBasedAttributes(
       newAttributes, true, newAttributes->getRenderAssetHandle(),
       std::bind(&AbstractObjectAttributes::setRenderAssetType, newAttributes,
                 _1));
   // set defaults for passed collision asset handles
-  setDefaultFileNameBasedAttributes(
+  this->setDefaultAssetNameBasedAttributes(
       newAttributes, false, newAttributes->getCollisionAssetHandle(),
       std::bind(&AbstractObjectAttributes::setCollisionAssetType, newAttributes,
                 _1));
@@ -187,19 +187,23 @@ ObjectAttributes::ptr ObjectAttributesManager::initNewAttribsInternal(
 
 // Eventually support explicitly configuring desirable defaults/file-name
 // base settings.
-void ObjectAttributesManager::setDefaultFileNameBasedAttributes(
+void ObjectAttributesManager::setDefaultAssetNameBasedAttributes(
     ObjectAttributes::ptr attributes,
     bool setFrame,
-    const std::string&,
-    std::function<void(int)> meshTypeSetter) {
-  // TODO : support future mesh-name specific type setting?
-  meshTypeSetter(static_cast<int>(AssetType::UNKNOWN));
-
+    const std::string& meshHandle,
+    std::function<void(int)> assetTypeSetter) {
+  if (this->isValidPrimitiveAttributes(meshHandle)) {
+    // value is valid primitive, and value is different than existing value
+    assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
+  } else {
+    // use unknown for object mesh types of non-primitives
+    assetTypeSetter(static_cast<int>(AssetType::UNKNOWN));
+  }
   if (setFrame) {
     attributes->setOrientUp({0, 1, 0});
     attributes->setOrientFront({0, 0, -1});
   }
-}  // SceneAttributesManager::setDefaultFileNameBasedAttributes
+}  // SceneAttributesManager::setDefaultAssetNameBasedAttributes
 
 int ObjectAttributesManager::registerAttributesTemplateFinalize(
     ObjectAttributes::ptr objectTemplate,
@@ -218,7 +222,7 @@ int ObjectAttributesManager::registerAttributesTemplateFinalize(
   std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
   std::string collisionAssetHandle = objectTemplate->getCollisionAssetHandle();
 
-  if (isValidPrimitiveAttributes(renderAssetHandle)) {
+  if (this->isValidPrimitiveAttributes(renderAssetHandle)) {
     // If renderAssetHandle corresponds to valid/existing primitive attributes
     // then setRenderAssetIsPrimitive to true and set map of IDs->Names to
     // physicsSynthObjTmpltLibByID_
@@ -244,7 +248,7 @@ int ObjectAttributesManager::registerAttributesTemplateFinalize(
     return ID_UNDEFINED;
   }
 
-  if (isValidPrimitiveAttributes(collisionAssetHandle)) {
+  if (this->isValidPrimitiveAttributes(collisionAssetHandle)) {
     // If collisionAssetHandle corresponds to valid/existing primitive
     // attributes then setCollisionAssetIsPrimitive to true
     objectTemplate->setCollisionAssetIsPrimitive(true);

--- a/src/esp/assets/managers/ObjectAttributesManager.h
+++ b/src/esp/assets/managers/ObjectAttributesManager.h
@@ -128,7 +128,7 @@ class ObjectAttributesManager
    * @param handle String name of primitive asset attributes desired
    * @return whether handle exists or not in asset attributes library
    */
-  bool isValidPrimitiveAttributes(const std::string& handle) {
+  bool isValidPrimitiveAttributes(const std::string& handle) override {
     return assetAttributesMgr_->getTemplateLibHasHandle(handle);
   }
 
@@ -235,13 +235,13 @@ class ObjectAttributesManager
    * @param setFrame whether the frame should be set or not (only for render
    * assets in scenes)
    * @param fileName Mesh Handle to check.
-   * @param meshTypeSetter Setter for mesh type.
+   * @param assetTypeSetter Setter for mesh type.
    */
-  void setDefaultFileNameBasedAttributes(
+  void setDefaultAssetNameBasedAttributes(
       Attrs::ObjectAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
-      std::function<void(int)> meshTypeSetter) override;
+      std::function<void(int)> assetTypeSetter) override;
 
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with

--- a/src/esp/assets/managers/PhysicsAttributesManager.h
+++ b/src/esp/assets/managers/PhysicsAttributesManager.h
@@ -70,9 +70,19 @@ class PhysicsAttributesManager
 
  protected:
   /**
+   * @brief Check if currently configured primitive asset template library has
+   * passed handle.
+   * @param handle String name of primitive asset attributes desired
+   * @return whether handle exists or not in asset attributes library
+   */
+  bool isValidPrimitiveAttributes(const std::string& handle) override {
+    return objectAttributesMgr_->getTemplateLibHasHandle(handle);
+  }
+
+  /**
    * @brief Not used by PhysicsManagerAttributes.
    */
-  void setDefaultFileNameBasedAttributes(
+  void setDefaultAssetNameBasedAttributes(
       CORRADE_UNUSED Attrs::PhysicsManagerAttributes::ptr attributes,
       CORRADE_UNUSED bool setFrame,
       CORRADE_UNUSED const std::string& meshHandle,

--- a/src/esp/assets/managers/StageAttributesManager.cpp
+++ b/src/esp/assets/managers/StageAttributesManager.cpp
@@ -37,8 +37,7 @@ StageAttributes::ptr StageAttributesManager::createAttributesTemplate(
     bool registerTemplate) {
   StageAttributes::ptr attrs;
   std::string msg;
-  if (objectAttributesMgr_->isValidPrimitiveAttributes(
-          attributesTemplateHandle)) {
+  if (this->isValidPrimitiveAttributes(attributesTemplateHandle)) {
     // if attributesTemplateHandle == some existing primitive attributes, then
     // this is a primitive-based stage (i.e. a plane) we are building
     attrs = createPrimBasedAttributesTemplate(attributesTemplateHandle,
@@ -101,7 +100,7 @@ int StageAttributesManager::registerAttributesTemplateFinalize(
   std::string collisionAssetHandle = stageAttributes->getCollisionAssetHandle();
 
   // verify these represent legitimate assets
-  if (objectAttributesMgr_->isValidPrimitiveAttributes(renderAssetHandle)) {
+  if (this->isValidPrimitiveAttributes(renderAssetHandle)) {
     // If renderAssetHandle corresponds to valid/existing primitive attributes
     // then setRenderAssetIsPrimitive to true and set map of IDs->Names to
     // physicsSynthObjTmpltLibByID_
@@ -128,7 +127,7 @@ int StageAttributesManager::registerAttributesTemplateFinalize(
     return ID_UNDEFINED;
   }
 
-  if (objectAttributesMgr_->isValidPrimitiveAttributes(collisionAssetHandle)) {
+  if (this->isValidPrimitiveAttributes(collisionAssetHandle)) {
     // If collisionAssetHandle corresponds to valid/existing primitive
     // attributes then setCollisionAssetIsPrimitive to true
     stageAttributes->setCollisionAssetIsPrimitive(true);
@@ -172,7 +171,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
     const std::string& primAssetHandle,
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
-  if (!objectAttributesMgr_->isValidPrimitiveAttributes(primAssetHandle)) {
+  if (!this->isValidPrimitiveAttributes(primAssetHandle)) {
     LOG(ERROR)
         << "StageAttributesManager::createPrimBasedAttributesTemplate : No "
            "primitive with handle '"
@@ -249,18 +248,18 @@ StageAttributes::ptr StageAttributesManager::initNewAttribsInternal(
   // set default origin and orientation values based on file name
   // from AssetInfo::fromPath
   // set defaults for passed render asset handles
-  setDefaultFileNameBasedAttributes(
+  this->setDefaultAssetNameBasedAttributes(
       newAttributes, true, newAttributes->getRenderAssetHandle(),
       std::bind(&AbstractObjectAttributes::setRenderAssetType, newAttributes,
                 _1));
   // set defaults for passed collision asset handles
-  setDefaultFileNameBasedAttributes(
+  this->setDefaultAssetNameBasedAttributes(
       newAttributes, false, newAttributes->getCollisionAssetHandle(),
       std::bind(&AbstractObjectAttributes::setCollisionAssetType, newAttributes,
                 _1));
 
   // set defaults for passed semantic asset handles
-  setDefaultFileNameBasedAttributes(
+  this->setDefaultAssetNameBasedAttributes(
       newAttributes, false, newAttributes->getSemanticAssetHandle(),
       std::bind(&StageAttributes::setSemanticAssetType, newAttributes, _1));
 
@@ -278,11 +277,11 @@ StageAttributes::ptr StageAttributesManager::initNewAttribsInternal(
   return newAttributes;
 }  // StageAttributesManager::initNewAttribsInternal
 
-void StageAttributesManager::setDefaultFileNameBasedAttributes(
+void StageAttributesManager::setDefaultAssetNameBasedAttributes(
     StageAttributes::ptr attributes,
     bool setFrame,
     const std::string& fileName,
-    std::function<void(int)> meshTypeSetter) {
+    std::function<void(int)> assetTypeSetter) {
   // TODO : support future mesh-name specific type setting?
   using Corrade::Utility::String::endsWith;
 
@@ -294,28 +293,30 @@ void StageAttributesManager::setDefaultFileNameBasedAttributes(
   up = up1;
   fwd = fwd1;
   if (endsWith(fileName, "_semantic.ply")) {
-    meshTypeSetter(static_cast<int>(AssetType::INSTANCE_MESH));
+    assetTypeSetter(static_cast<int>(AssetType::INSTANCE_MESH));
   } else if (endsWith(fileName, "mesh.ply")) {
-    meshTypeSetter(static_cast<int>(AssetType::FRL_PTEX_MESH));
+    assetTypeSetter(static_cast<int>(AssetType::FRL_PTEX_MESH));
     up = up2;
     fwd = fwd2;
   } else if (endsWith(fileName, "house.json")) {
-    meshTypeSetter(static_cast<int>(AssetType::SUNCG_SCENE));
+    assetTypeSetter(static_cast<int>(AssetType::SUNCG_SCENE));
   } else if (endsWith(fileName, ".glb")) {
     // assumes MP3D glb with gravity = -Z
-    meshTypeSetter(static_cast<int>(AssetType::MP3D_MESH));
+    assetTypeSetter(static_cast<int>(AssetType::MP3D_MESH));
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
     up = up2;
     fwd = fwd2;
+  } else if (this->isValidPrimitiveAttributes(fileName)) {
+    assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
   } else {
-    meshTypeSetter(static_cast<int>(AssetType::UNKNOWN));
+    assetTypeSetter(static_cast<int>(AssetType::UNKNOWN));
   }
   if (setFrame) {
     attributes->setOrientUp(up);
     attributes->setOrientFront(fwd);
   }
-}  // StageAttributesManager::setDefaultFileNameBasedAttributes
+}  // StageAttributesManager::setDefaultAssetNameBasedAttributes
 
 StageAttributes::ptr StageAttributesManager::loadAttributesFromJSONDoc(
     const std::string& templateName,

--- a/src/esp/assets/managers/StageAttributesManager.h
+++ b/src/esp/assets/managers/StageAttributesManager.h
@@ -108,6 +108,15 @@ class StageAttributesManager
 
  protected:
   /**
+   * @brief Check if currently configured primitive asset template library has
+   * passed handle.
+   * @param handle String name of primitive asset attributes desired
+   * @return whether handle exists or not in asset attributes library
+   */
+  bool isValidPrimitiveAttributes(const std::string& handle) override {
+    return objectAttributesMgr_->getTemplateLibHasHandle(handle);
+  }
+  /**
    * @brief Perform file-name-based attributes initialization. This is to
    * take the place of the AssetInfo::fromPath functionality, and is only
    * intended to provide default values and other help if certain mistakes
@@ -119,13 +128,13 @@ class StageAttributesManager
    * @param setFrame whether the frame should be set or not (only for render
    * assets in scenes)
    * @param fileName Mesh Handle to check.
-   * @param meshTypeSetter Setter for mesh type.
+   * @param assetTypeSetter Setter for mesh type.
    */
-  void setDefaultFileNameBasedAttributes(
+  void setDefaultAssetNameBasedAttributes(
       Attrs::StageAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
-      std::function<void(int)> meshTypeSetter) override;
+      std::function<void(int)> assetTypeSetter) override;
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with
    * any default values, before any specific values are set.

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -64,8 +64,8 @@ void initAttributesBindings(py::module& m) {
           "collision_asset_size",
           &AbstractObjectAttributes::getCollisionAssetSize,
           &AbstractObjectAttributes::setCollisionAssetSize,
-          R"(Size of collsion assets for constructions built from this template in 
-          x,y,z.  Default is [1.0,1.0,1.0].  This is used to resize a collision asset 
+          R"(Size of collsion assets for constructions built from this template in
+          x,y,z.  Default is [1.0,1.0,1.0].  This is used to resize a collision asset
           to match a render asset if necessary, such as when using a primitive.)")
       .def_property(
           "margin", &AbstractObjectAttributes::getMargin,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -61,6 +61,13 @@ void initAttributesBindings(py::module& m) {
           &AbstractObjectAttributes::setScale,
           R"(Scale multiplier for constructions built from this template in x,y,z)")
       .def_property(
+          "collision_asset_size",
+          &AbstractObjectAttributes::getCollisionAssetSize,
+          &AbstractObjectAttributes::setCollisionAssetSize,
+          R"(Size of collsion assets for constructions built from this template in 
+          x,y,z.  Default is [1.0,1.0,1.0].  This is used to resize a collision asset 
+          to match a render asset if necessary, such as when using a primitive.)")
+      .def_property(
           "margin", &AbstractObjectAttributes::getMargin,
           &AbstractObjectAttributes::setMargin,
           R"(Collision margin for constructions built from this template.)")

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -88,6 +88,7 @@ bool BulletRigidObject::initialization_LibSpecific(
     if (nullptr == primObjPtr) {
       return false;
     }
+    primObjPtr->setLocalScaling(btVector3(tmpAttr->getCollisionAssetSize()));
     bGenericShapes_.clear();
     bGenericShapes_.emplace_back(std::move(primObjPtr));
     bObjectShape_->addChildShape(btTransform::getIdentity(),
@@ -106,6 +107,8 @@ bool BulletRigidObject::initialization_LibSpecific(
 
       // add the final object after joining meshes
       if (joinCollisionMeshes) {
+        bObjectConvexShapes_.back()->setLocalScaling(
+            btVector3(tmpAttr->getCollisionAssetSize()));
         bObjectConvexShapes_.back()->setMargin(0.0);
         bObjectConvexShapes_.back()->recalcLocalAabb();
         bObjectShape_->addChildShape(btTransform::getIdentity(),


### PR DESCRIPTION
## Motivation and Context
This supports using primitive asset attributes tags as collision or render mesh names in object JSON configuration files.
To use this, the exact name of the primitive asset attributes template must be used in the object attributes template as either the render or collision mesh.  

So, for example, to use a sphere primitive as the collision asset, use "uvSphereSolid_rings_8_segments_16_useTexCoords_false_useTangents_false" as the "collision mesh" value in the object's configuration JSON file.

Also, another tag has been added, "collision asset size", which is a 3-vector to enable resizing the primitive to match the render asset.  So if the render asset has is a sphere of radius .1 meters, then this tag should be :
 "collision asset size" : [0.1,0.1,0.1]

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
all c++ and python tests passed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
