### PR TITLE
Disabled running version_conda_release on every master commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,8 +591,6 @@ workflows:
       - install_and_test_ubuntu
       - pre-commit
   nightly:
-    AIHABITAT_CONDA_CHN: aihabitat-nightly
-    AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
 #    triggers:
 #      - schedule:
 #          cron: "0 7 * * *"
@@ -605,12 +603,14 @@ workflows:
       - update_docs:
           requires:
             - install_and_test_ubuntu
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
       - build_conda_binaries:
+          AIHABITAT_CONDA_CHN: aihabitat-nightly
+          AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
           requires:
             - install_and_test_ubuntu
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,7 +622,7 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
             branches:
-              only: master
+              ignore: /.*/
       - update_docs:
           requires:
             - install_and_test_ubuntu
@@ -630,7 +630,7 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
             branches:
-              only: master
+              ignore: /.*/
       - build_conda_binaries:
           requires:
             - install_and_test_ubuntu
@@ -638,4 +638,4 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
             branches:
-              only: master
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,13 @@ jobs:
 
   build_conda_binaries:
     <<: *gpu
+    parameters:
+      AIHABITAT_CONDA_CHN:
+        type: string
+        default: "aihabitat"
+      AIHABITAT_CONDA_CHN_PWD_VAR:
+        type: string
+        default: "AIHABITAT_CONDA_PWD"
     steps:
       - checkout:
           path: ./habitat-sim
@@ -527,7 +534,7 @@ jobs:
               apt-cache policy docker-ce
               sudo apt-get install -y docker-ce
 
-              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_NIGHTLY_CONDA_PWD=$AIHABITAT_NIGHTLY_CONDA_PWD
+              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_CONDA_CHN_PWD=$<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>,AIHABITAT_CONDA_CHN=$<< parameters.AIHABITAT_CONDA_CHN >>
               docker run -it --ipc=host --rm -v $(pwd)/../../:/remote hsim_condabuild_dcontainer /bin/bash -c "source ~/.bashrc && conda activate py36 && cd /remote/habitat-sim/conda-build && python linux_matrix_builder.py --conda_upload"
 
   update_docs:
@@ -584,13 +591,15 @@ workflows:
       - install_and_test_ubuntu
       - pre-commit
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    AIHABITAT_CONDA_CHN: aihabitat-nightly
+    AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
+#    triggers:
+#      - schedule:
+#          cron: "0 7 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
     jobs:
       - install_and_test_ubuntu
       - update_docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
               apt-cache policy docker-ce
               sudo apt-get install -y docker-ce
 
-              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_CONDA_CHN_PWD=$<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>,AIHABITAT_CONDA_CHN=$<< parameters.AIHABITAT_CONDA_CHN >>
+              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_CONDA_CHN_PWD=$<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>,AIHABITAT_CONDA_CHN=<< parameters.AIHABITAT_CONDA_CHN >>
               docker run -it --ipc=host --rm -v $(pwd)/../../:/remote hsim_condabuild_dcontainer /bin/bash -c "source ~/.bashrc && conda activate py36 && cd /remote/habitat-sim/conda-build && python linux_matrix_builder.py --conda_upload"
 
   update_docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ workflows:
 
   version_conda_release:
     jobs:
-      - install_and_test_ubuntu
+      - install_and_test_ubuntu:
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,29 +591,29 @@ workflows:
       - install_and_test_ubuntu
       - pre-commit
   nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 7 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - master
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - install_and_test_ubuntu
       - update_docs:
           requires:
             - install_and_test_ubuntu
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
       - build_conda_binaries:
           AIHABITAT_CONDA_CHN: aihabitat-nightly
           AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
           requires:
             - install_and_test_ubuntu
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
 
   version_conda_release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
               apt-cache policy docker-ce
               sudo apt-get install -y docker-ce
 
-              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_CONDA_CHN_PWD=$<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>,AIHABITAT_CONDA_CHN=<< parameters.AIHABITAT_CONDA_CHN >>
+              docker build -t hsim_condabuild_dcontainer -f Dockerfile . --build-arg AIHABITAT_CONDA_CHN_PWD=$<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >> --build-arg AIHABITAT_CONDA_CHN=<< parameters.AIHABITAT_CONDA_CHN >>
               docker run -it --ipc=host --rm -v $(pwd)/../../:/remote hsim_condabuild_dcontainer /bin/bash -c "source ~/.bashrc && conda activate py36 && cd /remote/habitat-sim/conda-build && python linux_matrix_builder.py --conda_upload"
 
   update_docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,3 +614,28 @@ workflows:
 #          filters:
 #            branches:
 #              only: master
+
+  version_conda_release:
+    jobs:
+      - install_and_test_ubuntu
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
+            branches:
+              only: master
+      - update_docs:
+          requires:
+            - install_and_test_ubuntu
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
+            branches:
+              only: master
+      - build_conda_binaries:
+          requires:
+            - install_and_test_ubuntu
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
+            branches:
+              only: master

--- a/conda-build/Dockerfile
+++ b/conda-build/Dockerfile
@@ -3,7 +3,8 @@ FROM nvidia/cudagl:10.0-devel-centos7
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ARG AIHABITAT_NIGHTLY_CONDA_PWD
+ARG AIHABITAT_CONDA_CHN
+ARG AIHABITAT_CONDA_CHN_PWD
 
 RUN yum install -y wget curl perl cmake util-linux xz bzip2 git patch which unzip
 RUN yum install -y yum-utils centos-release-scl
@@ -32,7 +33,7 @@ ENV PATH /opt/conda/bin:$PATH
 ADD ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
 
-RUN anaconda login --username aihabitat-nightly --password $AIHABITAT_NIGHTLY_CONDA_PWD
+RUN anaconda login --username $AIHABITAT_CONDA_CHN --password $AIHABITAT_CONDA_CHN_PWD
 RUN conda create --name py36 python=3.6 -y && conda init bash
 RUN source ~/.bashrc && conda activate py36 && conda install -y anaconda-client git gitpython ninja conda-build=3.18.9 # last version that works with our setup
 RUN conda config --set anaconda_upload yes


### PR DESCRIPTION
## Motivation and Context
After latest change we noticed that Conda build step was triggered both for tagged commit and for the one merged into master:
<img width="1397" alt="Screen Shot 2020-09-14 at 6 50 46 PM" src="https://user-images.githubusercontent.com/877440/93155542-35ca7780-f6bb-11ea-9b05-0d2b67525ab1.png">

 Based on [CircelCI documentation](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag) that's the right way to disabled running version_conda_release on every master commit as `filters` section is union not intersection of branch and tag filters.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Hard to tests without landing.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
