### PR TITLE
[bugfix] Activate island when removing sleeping objects

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -40,6 +40,12 @@ BulletRigidObject::BulletRigidObject(
       MotionState(*rigidBodyNode) {}
 
 BulletRigidObject::~BulletRigidObject() {
+  if (!isActive()) {
+    // This object may be supporting other sleeping objects, so wake them before
+    // removing.
+    activateCollisionIsland();
+  }
+
   if (objectMotionType_ != MotionType::STATIC) {
     // remove rigid body from the world
     bWorld_->removeRigidBody(bObjectRigidBody_.get());
@@ -377,6 +383,21 @@ void BulletRigidObject::syncPose() {
   bObjectRigidBody_->setWorldTransform(
       btTransform(node().transformationMatrix()));
 }  // syncPose
+
+void BulletRigidObject::activateCollisionIsland() {
+  // activate nearby objects in the simulation island as computed on the
+  // previous collision detection pass
+  btCollisionObject* thisColObj = bObjectRigidBody_.get();
+  if (getMotionType() == MotionType::STATIC) {
+    thisColObj = bStaticCollisionObjects_.back().get();
+  }
+  auto& colObjs = bWorld_->getCollisionWorld()->getCollisionObjectArray();
+  for (auto objIx = 0; objIx < colObjs.size(); ++objIx) {
+    if (colObjs[objIx]->getIslandTag() == thisColObj->getIslandTag()) {
+      colObjs[objIx]->activate();
+    }
+  }
+}
 
 void BulletRigidObject::setCOM(const Magnum::Vector3&) {
   // Current not supported

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -439,6 +439,12 @@ class BulletRigidObject : public BulletBase,
    * updates. See @ref btRigidBody::setWorldTransform. */
   void syncPose() override;
 
+  /**
+   * @brief Iterate through all collision objects and active all objects sharing
+   * a collision island tag with this object's collision shape.
+   */
+  void activateCollisionIsland();
+
  private:
   // === Physical object ===
   //! If true, the object's bounding box will be used for collision once


### PR DESCRIPTION
## Motivation and Context

An issue was identified where removing a sleeping object supporting other objects would not activate the supported objects, causing them to float instead of falling as expected. This PR fixes the issue by activating a sleeping object's collision island upon removal.

## How Has This Been Tested

Added `TestRemoveSleepingSupport ` to `PhysicsTest.cpp`.

Testing in viewer:
Green outline denotes sleeping object.
**Before**:
![stacking_before](https://user-images.githubusercontent.com/1445143/93260930-e9347a00-f756-11ea-8a63-c3dcca23f856.gif)


**After**:
![stacking](https://user-images.githubusercontent.com/1445143/93260417-35cb8580-f756-11ea-9495-4e170ae6fa95.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
