### PR TITLE
[bugfix] Better handling for MotionType::KINEMATIC

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -439,6 +439,12 @@ class BulletRigidObject : public BulletBase,
    * updates. See @ref btRigidBody::setWorldTransform. */
   void syncPose() override;
 
+  /**
+   * @brief construct a @ref btRigidBody for this object configured for either
+   * kinematics or dynamics.
+   */
+  void constructRigidBody(bool kinematic = false);
+
  private:
   // === Physical object ===
   //! If true, the object's bounding box will be used for collision once

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -724,7 +724,7 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
                         .length(),
                     1.0e-4);
           ASSERT_LE((physicsManager_->getTranslation(instancedObjects[1]) -
-                     Magnum::Vector3{0.556, boxHalfExtent * 4, 0.0})
+                     Magnum::Vector3{0.578, boxHalfExtent * 4, 0.0})
                         .length(),
                     2.0e-2);
         } break;


### PR DESCRIPTION
## Motivation and Context

Noticed that `MotionType::KINEMATIC` objects were not responding correctly in many cases. Investigation led to this refactor. We need to create a new `btRigidObject` with different properties when swapping between `KINEMATIC` and `DYNAMIC` `MotionTypes`.

## How Has This Been Tested

Current tests pass.
Local testing in viewer for identified edge case:

**Before:**
Notice the sleeping object's collision shape is out of sync after set to kinematic.
Notice the skating of dynamic objects when stacking on a kinematic object.
![before_kinematic_fix](https://user-images.githubusercontent.com/1445143/93272318-0fafe080-f76a-11ea-838d-c6676bde708d.gif)


**After:**
These issues are fixed. Notice objects in contact with kinematic objects will not sleep.
![after_kinematic_fix](https://user-images.githubusercontent.com/1445143/93272329-163e5800-f76a-11ea-8d6e-12c5abc5bdd0.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
