### PR TITLE
--Update sphere test asset to use primitive sphere implicit collider.

### DIFF
--- a/data/test_assets/objects/sphere.phys_properties.json
+++ b/data/test_assets/objects/sphere.phys_properties.json
@@ -1,3 +1,5 @@
 {
-    "render mesh": "sphere.glb"
+    "render mesh": "sphere.glb",
+	"collision mesh": "icosphereSolid_subdivs_1",
+	"collision asset size":[0.25,0.25,0.25]
 }


### PR DESCRIPTION
## Motivation and Context
The existing test asset "sphere.glb" was using its render mesh (1.5k polys) as a collision mesh, which resulted in overly expensive collision calcs.  This PR has a change to the configuration so the sphere will use a properly sized primitive for implicit collision calculation.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
