### PR TITLE
--[BugFix] Add missing header guard; Change pragma once to #-defines

### DIFF
--- a/src/esp/agent/Agent.h
+++ b/src/esp/agent/Agent.h
@@ -1,8 +1,8 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-
-#pragma once
+#ifndef ESP_AGENT_AGENT_H_
+#define ESP_AGENT_AGENT_H_
 
 #include <map>
 #include <set>
@@ -143,3 +143,5 @@ class Agent : public Magnum::SceneGraph::AbstractFeature3D {
 
 }  // namespace agent
 }  // namespace esp
+
+#endif  // ESP_AGENT_AGENT_H_

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_ASSET_H_
+#define ESP_ASSETS_ASSET_H_
 
 #include "esp/core/esp.h"
 #include "esp/geo/CoordinateFrame.h"
@@ -65,3 +66,5 @@ struct Asset {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_ASSET_H_

--- a/src/esp/assets/CollisionMeshData.h
+++ b/src/esp/assets/CollisionMeshData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_COLLISIONMESHDATA_H_
+#define ESP_ASSETS_COLLISIONMESHDATA_H_
 
 /** @file
  * @brief Struct @ref esp::assets::CollisionMeshData
@@ -52,3 +53,5 @@ struct CollisionMeshData {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_COLLISIONMESHDATA_H_

--- a/src/esp/assets/GenericInstanceMeshData.h
+++ b/src/esp/assets/GenericInstanceMeshData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_GENERICINSTANCEMESHDATA_H_
+#define ESP_ASSETS_GENERICINSTANCEMESHDATA_H_
 
 #include <Corrade/Containers/Optional.h>
 #include <Magnum/GL/Buffer.h>
@@ -99,3 +100,5 @@ class GenericInstanceMeshData : public BaseMesh {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_GENERICINSTANCEMESHDATA_H_

--- a/src/esp/assets/GenericMeshData.h
+++ b/src/esp/assets/GenericMeshData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_GENERICMESHDATA_H_
+#define ESP_ASSETS_GENERICMESHDATA_H_
 
 /** @file
  * @brief Class @ref esp::assets::GenericMeshData, Class @ref
@@ -114,3 +115,5 @@ class GenericMeshData : public BaseMesh {
 };
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_GENERICMESHDATA_H_

--- a/src/esp/assets/MeshData.h
+++ b/src/esp/assets/MeshData.h
@@ -1,8 +1,9 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
+// LICENSE file in the root directory of this source tree.\
 
-#pragma once
+#ifndef ESP_ASSETS_MESHDATA_H_
+#define ESP_ASSETS_MESHDATA_H_
 
 #include <vector>
 
@@ -29,3 +30,5 @@ struct MeshData {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_MESHDATA_H_

--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_MESHMETADATA_H_
+#define ESP_ASSETS_MESHMETADATA_H_
 
 /** @file
  * @brief Struct @ref esp::assets::MeshTransformNode, Struct @ref
@@ -141,3 +142,5 @@ struct MeshMetaData {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_MESHMETADATA_H_

--- a/src/esp/assets/Mp3dInstanceMeshData.h
+++ b/src/esp/assets/Mp3dInstanceMeshData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_MP3DINSTANCEDATA_H_
+#define ESP_ASSETS_MP3DINSTANCEDATA_H_
 
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/Mesh.h>
@@ -45,3 +46,5 @@ class Mp3dInstanceMeshData : public GenericInstanceMeshData {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_MP3DINSTANCEDATA_H_

--- a/src/esp/assets/PTexMeshData.h
+++ b/src/esp/assets/PTexMeshData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_PTEXMESHDATA_H_
+#define ESP_ASSETS_PTEXMESHDATA_H_
 
 #include <memory>
 #include <string>
@@ -101,3 +102,5 @@ class PTexMeshData : public BaseMesh {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_ASSETS_PTEXMESHDATA_H_

--- a/src/esp/bindings/bindings.h
+++ b/src/esp/bindings/bindings.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_BINDINGS_BINDINGS_H_
+#define ESP_BINDINGS_BINDINGS_H_
 
 #include <pybind11/pybind11.h>
 #include "esp/bindings/OpaqueTypes.h"
@@ -45,3 +46,5 @@ void initSimBindings(pybind11::module& m);
 }
 
 }  // namespace esp
+
+#endif  // ESP_BINDINGS_BINDINGS_H_

--- a/src/esp/core/Buffer.h
+++ b/src/esp/core/Buffer.h
@@ -2,7 +2,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_BUFFER_H_
+#define ESP_CORE_BUFFER_H_
+
 #include <Corrade/Containers/Array.h>
 
 #include "esp/core/esp.h"
@@ -51,3 +53,5 @@ class Buffer {
 
 }  // namespace core
 }  // namespace esp
+
+#endif  // ESP_CORE_BUFFER_H_

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_CONFIGURATION_H_
+#define ESP_CORE_CONFIGURATION_H_
 
 #include <Corrade/Utility/Configuration.h>
 #include <Magnum/Magnum.h>
@@ -111,3 +112,5 @@ class Configuration {
 
 }  // namespace core
 }  // namespace esp
+
+#endif  // ESP_CORE_CONFIGURATION_H_

--- a/src/esp/core/RigidState.h
+++ b/src/esp/core/RigidState.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_RIGIDSTATE_H_
+#define ESP_CORE_RIGIDSTATE_H_
 
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Quaternion.h>
@@ -28,3 +29,5 @@ struct RigidState {
 };
 }  // namespace core
 }  // namespace esp
+
+#endif  // ESP_CORE_RIGIDSTATE_H_

--- a/src/esp/core/Utility.h
+++ b/src/esp/core/Utility.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_UTILITY_H_
+#define ESP_CORE_UTILITY_H_
 
 /** @file */
 
@@ -34,3 +35,5 @@ Magnum::Quaternion randomRotation() {
 }
 }  // namespace core
 }  // namespace esp
+
+#endif  // ESP_CORE_UTILITY_H_

--- a/src/esp/core/esp.h
+++ b/src/esp/core/esp.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_ESP_H_
+#define ESP_CORE_ESP_H_
 
 /** @file */
 
@@ -173,3 +174,5 @@ inline bool equal(const std::map<K, std::shared_ptr<V>>& a,
 }
 
 }  // namespace esp
+
+#endif  // ESP_CORE_ESP_H_

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_LOGGING_H_
+#define ESP_CORE_LOGGING_H_
 
 #include "esp/core/configure.h"
 
@@ -66,3 +67,5 @@ class LogMessageVoidify {
       exit(-1);                                                     \
     }                                                               \
   } while (false)
+
+#endif  // ESP_CORE_LOGGING_H_

--- a/src/esp/core/random.h
+++ b/src/esp/core/random.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_RANDOM_H_
+#define ESP_CORE_RANDOM_H_
 
 #include <random>
 
@@ -60,3 +61,5 @@ class Random {
 
 }  // namespace core
 }  // namespace esp
+
+#endif  // ESP_CORE_RANDOM_H_

--- a/src/esp/core/spimpl.h
+++ b/src/esp/core/spimpl.h
@@ -25,8 +25,8 @@
         - Released
  */
 
-#ifndef SPIMPL_H_
-#define SPIMPL_H_
+#ifndef ESP_CORE_SPIMPL_H_
+#define ESP_CORE_SPIMPL_H_
 
 #include <cassert>
 #include <memory>
@@ -440,4 +440,4 @@ struct hash<spimpl::impl_ptr<T, D, C>> {
 };
 }  // namespace std
 
-#endif  // SPIMPL_H_
+#endif  // ESP_CORE_SPIMPL_H_

--- a/src/esp/geo/OBB.h
+++ b/src/esp/geo/OBB.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GEO_OBB_H_
+#define ESP_GEO_OBB_H_
 
 #include "esp/core/esp.h"
 #include "esp/geo/geo.h"
@@ -76,3 +77,5 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
 
 }  // namespace geo
 }  // namespace esp
+
+#endif  // ESP_GEO_OBB_H_

--- a/src/esp/geo/geo.h
+++ b/src/esp/geo/geo.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GEO_GEO_H_
+#define ESP_GEO_GEO_H_
 
 #include <vector>
 
@@ -61,3 +62,5 @@ struct Ray {
 
 }  // namespace geo
 }  // namespace esp
+
+#endif  // ESP_GEO_GEO_H_

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_DEPTHUNPROJECT_H_
+#define ESP_GFX_DEPTHUNPROJECT_H_
 
 #include <Corrade/Containers/EnumSet.h>
 #include <Magnum/GL/AbstractShaderProgram.h>
@@ -152,3 +153,5 @@ void unprojectDepth(const Magnum::Vector2& unprojection,
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_DEPTHUNPROJECT_H_

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_GFX_DEPTHUNPROJECT_H_
-#define ESP_GFX_DEPTHUNPROJECT_H_
+#ifndef ESP_GFX_DEPTHUNPROJECTION_H_
+#define ESP_GFX_DEPTHUNPROJECTION_H_
 
 #include <Corrade/Containers/EnumSet.h>
 #include <Magnum/GL/AbstractShaderProgram.h>

--- a/src/esp/gfx/DepthUnprojection.h
+++ b/src/esp/gfx/DepthUnprojection.h
@@ -154,4 +154,4 @@ void unprojectDepth(const Magnum::Vector2& unprojection,
 }  // namespace gfx
 }  // namespace esp
 
-#endif  // ESP_GFX_DEPTHUNPROJECT_H_
+#endif  // ESP_GFX_DEPTHUNPROJECTION_H_

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_DRAWABLE_H_
+#define ESP_GFX_DRAWABLE_H_
 
 #include "esp/core/esp.h"
 #include "magnum.h"
@@ -87,3 +88,5 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_DRAWABLE_H_

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_DRAWABLEGROUP_H_
+#define ESP_GFX_DRAWABLEGROUP_H_
 
 #include <Magnum/SceneGraph/Drawable.h>
 #include <Magnum/SceneGraph/FeatureGroup.h>
@@ -91,3 +92,5 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_DRAWABLEGROUP_H_

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_GENERICDRAWABLE_H_
+#define ESP_GFX_GENERICDRAWABLE_H_
 
 #include <Magnum/Shaders/Phong.h>
 
@@ -49,3 +50,5 @@ class GenericDrawable : public Drawable {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_GENERICDRAWABLE_H_

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_LIGHTINGSETUP_H_
+#define ESP_GFX_LIGHTINGSETUP_H_
 
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Color.h>
@@ -58,3 +59,5 @@ LightSetup getLightsAtBoxCorners(
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_LIGHTINGSETUP_H_

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -60,4 +60,4 @@ LightSetup getLightsAtBoxCorners(
 }  // namespace gfx
 }  // namespace esp
 
-#endif  // ESP_GFX_LIGHTINGSETUP_H_
+#endif  // ESP_GFX_LIGHTSETUP_H_

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_GFX_LIGHTINGSETUP_H_
-#define ESP_GFX_LIGHTINGSETUP_H_
+#ifndef ESP_GFX_LIGHTSETUP_H_
+#define ESP_GFX_LIGHTSETUP_H_
 
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Color.h>

--- a/src/esp/gfx/MaterialData.h
+++ b/src/esp/gfx/MaterialData.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_MATERIALDATA_H_
+#define ESP_GFX_MATERIALDATA_H_
 
 #include <Magnum/GL/Texture.h>
 #include <Magnum/Magnum.h>
@@ -33,3 +34,5 @@ struct PhongMaterialData : public MaterialData {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_MATERIALDATA_H_

--- a/src/esp/gfx/MeshVisualizerDrawable.h
+++ b/src/esp/gfx/MeshVisualizerDrawable.h
@@ -2,7 +2,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_
+#define ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_
+
 #include <Magnum/Shaders/MeshVisualizer.h>
 #include "Drawable.h"
 #include "esp/gfx/Drawable.h"
@@ -41,3 +43,5 @@ class MeshVisualizerDrawable : public Drawable {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_

--- a/src/esp/gfx/MeshVisualizerDrawable.h
+++ b/src/esp/gfx/MeshVisualizerDrawable.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_
-#define ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_
+#ifndef ESP_GFX_MESHVISUALIZERDRAWABLE_H_
+#define ESP_GFX_MESHVISUALIZERDRAWABLE_H_
 
 #include <Magnum/Shaders/MeshVisualizer.h>
 #include "Drawable.h"

--- a/src/esp/gfx/MeshVisualizerDrawable.h
+++ b/src/esp/gfx/MeshVisualizerDrawable.h
@@ -44,4 +44,4 @@ class MeshVisualizerDrawable : public Drawable {
 }  // namespace gfx
 }  // namespace esp
 
-#endif  // ESP_GFX_MESHVISUALIZATIONDRAWABLE_H_
+#endif  // ESP_GFX_MESHVISUALIZERDRAWABLE_H_

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_PTEXMESHDATA_H_
+#define ESP_GFX_PTEXMESHDATA_H_
 
 #include "Drawable.h"
 #include "esp/gfx/ShaderManager.h"
@@ -46,3 +47,5 @@ class PTexMeshDrawable : public Drawable {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_PTEXMESHDATA_H_

--- a/src/esp/gfx/PTexMeshDrawable.h
+++ b/src/esp/gfx/PTexMeshDrawable.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_GFX_PTEXMESHDATA_H_
-#define ESP_GFX_PTEXMESHDATA_H_
+#ifndef ESP_GFX_PTEXMESHDRAWABLE_H_
+#define ESP_GFX_PTEXMESHDRAWABLE_H_
 
 #include "Drawable.h"
 #include "esp/gfx/ShaderManager.h"
@@ -48,4 +48,4 @@ class PTexMeshDrawable : public Drawable {
 }  // namespace gfx
 }  // namespace esp
 
-#endif  // ESP_GFX_PTEXMESHDATA_H_
+#endif  // ESP_GFX_PTEXMESHDRAWABLE_H_

--- a/src/esp/gfx/PTexMeshShader.h
+++ b/src/esp/gfx/PTexMeshShader.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_PTEXMESHSHADER_H_
+#define ESP_GFX_PTEXMESHSHADER_H_
 
 #include <memory>
 #include <vector>
@@ -91,3 +92,5 @@ class PTexMeshShader : public Magnum::GL::AbstractShaderProgram {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_PTEXMESHSHADER_H_

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_RENDERCAMERA_H_
+#define ESP_GFX_RENDERCAMERA_H_
 
 #include "magnum.h"
 
@@ -139,3 +140,5 @@ class RenderCamera : public MagnumCamera {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_RENDERCAMERA_H_

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_RENDERTARGET_H_
+#define ESP_GFX_RENDERTARGET_H_
 
 #include <Magnum/Magnum.h>
 
@@ -157,3 +158,5 @@ class RenderTarget {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_RENDERTARGET_H_

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_RENDERER_H_
+#define ESP_GFX_RENDERER_H_
 
 #include "esp/core/esp.h"
 #include "esp/gfx/RenderCamera.h"
@@ -52,3 +53,5 @@ class Renderer {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_RENDERER_H_

--- a/src/esp/gfx/ShaderManager.h
+++ b/src/esp/gfx/ShaderManager.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_SHADERMANAGER_H_
+#define ESP_GFX_SHADERMANAGER_H_
 
 #include <Magnum/GL/AbstractShaderProgram.h>
 #include <Magnum/ResourceManager.h>
@@ -30,3 +31,5 @@ void setLightSetupForSubTree(scene::SceneNode& root,
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_SHADERMANAGER_H_

--- a/src/esp/gfx/WindowlessContext.h
+++ b/src/esp/gfx/WindowlessContext.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_WINDOWLESSCONTEXT_H_
+#define ESP_GFX_WINDOWLESSCONTEXT_H_
 
 #include "esp/core/esp.h"
 
@@ -24,3 +25,5 @@ class WindowlessContext {
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_WINDOWLESSCONTEXT_H_

--- a/src/esp/gfx/magnum.h
+++ b/src/esp/gfx/magnum.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_MAGNUM_H_
+#define ESP_GFX_MAGNUM_H_
 
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
@@ -28,3 +29,5 @@ typedef Magnum::SceneGraph::Drawable3D MagnumDrawable;
 typedef Magnum::SceneGraph::DrawableGroup3D MagnumDrawableGroup;
 typedef Magnum::GL::AbstractShaderProgram MagnumShaderProgram;
 typedef Magnum::Trade::PhongMaterialData MagnumMaterialData;
+
+#endif  // ESP_GFX_MAGNUM_H_

--- a/src/esp/io/io.h
+++ b/src/esp/io/io.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_IO_IO_H_
+#define ESP_IO_IO_H_
 
 #include <string>
 #include <vector>
@@ -32,3 +33,5 @@ std::vector<std::string> tokenize(const std::string& string,
 
 }  // namespace io
 }  // namespace esp
+
+#endif  // ESP_IO_IO_H_

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_IO_JSON_H_
+#define ESP_IO_JSON_H_
 
 #include <cstdint>
 #define RAPIDJSON_NO_INT64DEFINE
@@ -298,3 +299,5 @@ void toDoubleVector(const GV& value, std::vector<double>* vec) {
 
 }  // namespace io
 }  // namespace esp
+
+#endif  // ESP_IO_JSON_H_

--- a/src/esp/nav/GreedyFollower.h
+++ b/src/esp/nav/GreedyFollower.h
@@ -1,4 +1,9 @@
-#pragma once
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_NAV_GREEDYFOLLOWER_H_
+#define ESP_NAV_GREEDYFOLLOWER_H_
 
 #include "esp/core/RigidState.h"
 #include "esp/core/esp.h"
@@ -159,3 +164,5 @@ class GreedyGeodesicFollowerImpl {
 
 }  // namespace nav
 }  // namespace esp
+
+#endif  // ESP_NAV_GREEDYFOLLOWER_H_

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_NAV_PATHFINDER_H_
+#define ESP_NAV_PATHFINDER_H_
 
 #include <string>
 #include <vector>
@@ -352,3 +353,5 @@ class PathFinder {
 
 }  // namespace nav
 }  // namespace esp
+
+#endif  // ESP_NAV_PATHFINDER_H_

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_PHYSICS_BASE_RIGIDBASE_H_
-#define ESP_PHYSICS_BASE_RIGIDBASE_H_
+#ifndef ESP_PHYSICS_RIGIDBASE_H_
+#define ESP_PHYSICS_RIGIDBASE_H_
 
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Containers/Reference.h>
@@ -643,4 +643,4 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
 
 }  // namespace physics
 }  // namespace esp
-#endif  // ESP_PHYSICS_BASE_RIGIDBASE_H_
+#endif  // ESP_PHYSICS_RIGIDBASE_H_

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_PHYSICS_BULLET_BULLETPHYSICSMANAGER_H_
+#define ESP_PHYSICS_BULLET_BULLETPHYSICSMANAGER_H_
 
 /** @file
  * @brief Class @ref esp::physics::BulletPhysicsManager
@@ -247,3 +248,5 @@ class BulletPhysicsManager : public PhysicsManager {
 };  // end class BulletPhysicsManager
 }  // end namespace physics
 }  // end namespace esp
+
+#endif  // ESP_PHYSICS_BULLET_BULLETPHYSICSMANAGER_H_

--- a/src/esp/scene/GibsonSemanticScene.h
+++ b/src/esp/scene/GibsonSemanticScene.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_GIBSONSEMANTICSCENE_H_
+#define ESP_SCENE_GIBSONSEMANTICSCENE_H_
 
 #include "SemanticScene.h"
 
@@ -34,3 +35,5 @@ struct GibsonObjectCategory : public SemanticCategory {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_GIBSONSEMANTICSCENE_H_

--- a/src/esp/scene/Mp3dSemanticScene.h
+++ b/src/esp/scene/Mp3dSemanticScene.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_MP3DSEMANTICSCENE_H_
+#define ESP_SCENE_MP3DSEMANTICSCENE_H_
 
 #include "SemanticScene.h"
 
@@ -38,3 +39,5 @@ struct Mp3dRegionCategory : public SemanticCategory {
 };
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_MP3DSEMANTICSCENE_H_

--- a/src/esp/scene/ObjectControls.h
+++ b/src/esp/scene/ObjectControls.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_OBJECTCONTROLS_H_
+#define ESP_SCENE_OBJECTCONTROLS_H_
 
 #include <functional>
 #include <map>
@@ -50,3 +51,5 @@ class ObjectControls {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_OBJECTCONTROLS_H_

--- a/src/esp/scene/ReplicaSemanticScene.h
+++ b/src/esp/scene/ReplicaSemanticScene.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_REPLICASEMANTICSCENE_H_
+#define ESP_SCENE_REPLICASEMANTICSCENE_H_
 
 #include "SemanticScene.h"
 
@@ -34,3 +35,5 @@ struct ReplicaObjectCategory : public SemanticCategory {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_REPLICASEMANTICSCENE_H_

--- a/src/esp/scene/SceneConfiguration.h
+++ b/src/esp/scene/SceneConfiguration.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SCENECONFIGURATION_H_
+#define ESP_SCENE_SCENECONFIGURATION_H_
 
 #include <map>
 #include <string>
@@ -32,3 +33,5 @@ bool operator!=(const SceneConfiguration& a, const SceneConfiguration& b);
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SCENECONFIGURATION_H_

--- a/src/esp/scene/SceneGraph.h
+++ b/src/esp/scene/SceneGraph.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SCENEGRAPH_H
+#define ESP_SCENE_SCENEGRAPH_H
 
 #include <unordered_map>
 
@@ -137,3 +138,5 @@ class SceneGraph {
 };
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SCENEGRAPH_H

--- a/src/esp/scene/SceneManager.h
+++ b/src/esp/scene/SceneManager.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SCENEMANAGER_H_
+#define ESP_SCENE_SCENEMANAGER_H_
 
 #include <memory>
 #include <vector>
@@ -39,3 +40,5 @@ class SceneManager {
 };
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SCENEMANAGER_H_

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SCENENODE_H_
+#define ESP_SCENE_SCENENODE_H_
 
 #include <stack>
 
@@ -199,3 +200,5 @@ void preOrderFeatureTraversalWithCallback(SceneNode& node, Callable&& cb) {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SCENENODE_H_

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SEMANTICSCENE_H_
+#define ESP_SCENE_SEMANTICSCENE_H_
 
 #include <map>
 #include <memory>
@@ -216,3 +217,5 @@ class SemanticObject {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SEMANTICSCENE_H_

--- a/src/esp/scene/SuncgObjectCategoryMap.h
+++ b/src/esp/scene/SuncgObjectCategoryMap.h
@@ -2,6 +2,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#ifndef ESP_SCENE_SUNCGOBJECTCATEGORYMAP_H_
+#define ESP_SCENE_SUNCGOBJECTCATEGORYMAP_H_
+
 #include <map>
 #include <string>
 #include <utility>
@@ -2651,3 +2654,5 @@ static const std::map<std::string, std::string> kSuncgObjectCategoryMap = {
 
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SUNCGOBJECTCATEGORYMAP_H_

--- a/src/esp/scene/SuncgSemanticScene.h
+++ b/src/esp/scene/SuncgSemanticScene.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SCENE_SUNCGSEMANTICSCENE_H_
+#define ESP_SCENE_SUNCGSEMANTICSCENE_H_
 
 #include "SemanticScene.h"
 
@@ -63,3 +64,5 @@ struct SuncgRegionCategory : public SemanticCategory {
 };
 }  // namespace scene
 }  // namespace esp
+
+#endif  // ESP_SCENE_SUNCGSEMANTICSCENE_H_

--- a/src/esp/sensor/PinholeCamera.h
+++ b/src/esp/sensor/PinholeCamera.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SENSOR_PINHOLECAMERA_H_
+#define ESP_SENSOR_PINHOLECAMERA_H_
 
 #include "VisualSensor.h"
 #include "esp/core/esp.h"
@@ -81,3 +82,5 @@ class PinholeCamera : public VisualSensor {
 
 }  // namespace sensor
 }  // namespace esp
+
+#endif  // ESP_SENSOR_PINHOLECAMERA_H_

--- a/src/esp/sensor/RedwoodNoiseModel.cuh
+++ b/src/esp/sensor/RedwoodNoiseModel.cuh
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SENSOR_REDWOODNOISEMODEL_CUH_
+#define ESP_SENSOR_REDWOODNOISEMODEL_CUH_
 
 namespace esp {
 namespace sensor {
@@ -32,3 +33,5 @@ void simulateFromGPU(const float* __restrict__ devDepth,
 }  // namespace impl
 }  // namespace sensor
 }  // namespace esp
+
+#endif  // ESP_SENSOR_REDWOODNOISEMODEL_CUH_

--- a/src/esp/sensor/RedwoodNoiseModel.h
+++ b/src/esp/sensor/RedwoodNoiseModel.h
@@ -2,7 +2,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
-#pragma once
+
+#ifndef ESP_SENSOR_REDWOODNOISEMODEL_H_
+#define ESP_SENSOR_REDWOODNOISEMODEL_H_
 
 #include "esp/core/esp.h"
 #include "esp/core/random.h"
@@ -85,3 +87,5 @@ struct RedwoodNoiseModelGPUImpl {
 
 }  // namespace sensor
 }  // namespace esp
+
+#endif  // ESP_SENSOR_REDWOODNOISEMODEL_H_

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SENSOR_SENSOR_H_
+#define ESP_SENSOR_SENSOR_H_
 
 #include "esp/core/esp.h"
 
@@ -138,3 +139,5 @@ class SensorSuite {
 
 }  // namespace sensor
 }  // namespace esp
+
+#endif  // ESP_SENSOR_SENSOR_H_

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_SENSOR_VISUALSENSOR_H_
+#define ESP_SENSOR_VISUALSENSOR_H_
 
 #include <Corrade/Containers/Optional.h>
 
@@ -115,3 +116,5 @@ class VisualSensor : public Sensor {
 
 }  // namespace sensor
 }  // namespace esp
+
+#endif  // ESP_SENSOR_VISUALSENSOR_H_

--- a/src/utils/datatool/SceneLoader.h
+++ b/src/utils/datatool/SceneLoader.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_UTILS_DATATOOL_SCENELOADER_H_
+#define ESP_UTILS_DATATOOL_SCENELOADER_H_
 
 #include <string>
 
@@ -34,3 +35,5 @@ class SceneLoader {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif  // ESP_UTILS_DATATOOL_SCENELOADER_H_

--- a/src/utils/viewer/ObjectPickingHelper.h
+++ b/src/utils/viewer/ObjectPickingHelper.h
@@ -1,4 +1,10 @@
-#pragma once
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_UTILS_VIEWER_OBJECTPICKINGHELPER_H_
+#define ESP_UTILS_VIEWER_OBJECTPICKINGHELPER_H_
+
 #include <Magnum/GL/Framebuffer.h>
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/Magnum.h>
@@ -67,3 +73,5 @@ class ObjectPickingHelper {
   esp::gfx::DrawableGroup pickedObjectDrawbles_;
   ObjectPickingHelper& mapForDraw();
 };
+
+#endif  // ESP_UTILS_VIEWER_OBJECTPICKINGHELPER_H_


### PR DESCRIPTION
## Motivation and Context
SuncgObjectCategoryMap.h lacked a header guard, so this PR adds one.  Also, All existing #pragma once guards have been replaced with #-defines, for consistency and to be in line with google c++ code guidelines [The #define Guard](https://google.github.io/styleguide/cppguide.html#The__define_Guard), [Do not use pragma-once](https://google.github.io/styleguide/cppguide.html#Windows_Code).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
