### PR TITLE
Fix for Bullet static objects/stage and add get_num_active_contact_points, 

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -250,7 +250,13 @@ void initSimBindings(py::module& m) {
       .def(
           "set_object_light_setup", &Simulator::setObjectLightSetup,
           "object_id"_a, "light_setup_key"_a, "scene_id"_a = 0,
-          R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)");
+          R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)")
+
+      .def(
+          "get_num_active_contact_points",
+          &Simulator::getNumActiveContactPoints,
+          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)");
+  ;
 }
 
 }  // namespace sim

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -912,6 +912,8 @@ class PhysicsManager {
     return results;
   }
 
+  virtual int getNumActiveContactPoints() { return -1; }
+
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an
    * existing object). Terminate the program and report an error if not. This

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -98,10 +98,9 @@ class BulletBase {
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
   /** @brief Static data: All components of a @ref RigidObjectType::SCENE are
-   * stored here. See @ref btCollisionObject.  Also, all objects set to STATIC
-   * are stored here.
+   * stored here. Also, all objects set to STATIC are stored here.
    */
-  std::vector<std::unique_ptr<btCollisionObject>> bStaticCollisionObjects_;
+  std::vector<std::unique_ptr<btRigidBody>> bStaticCollisionObjects_;
 
   //! keep a map of collision objects to object ids for quick lookups from
   //! Bullet collision checking.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -257,5 +257,25 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
   return results;
 }
 
+int BulletPhysicsManager::getNumActiveContactPoints() {
+  int pointCount = 0;
+  auto* dispatcher = bWorld_->getDispatcher();
+  for (int i = 0; i < dispatcher->getNumManifolds(); i++) {
+    auto* manifold = dispatcher->getManifoldByIndexInternal(i);
+    const btCollisionObject* colObj0 =
+        static_cast<const btCollisionObject*>(manifold->getBody0());
+    const btCollisionObject* colObj1 =
+        static_cast<const btCollisionObject*>(manifold->getBody1());
+
+    // logic copied from btSimulationIslandManager::buildIslands. We want to
+    // count manifold points only if related to non-sleeping bodies.
+    if (((colObj0) && colObj0->getActivationState() != ISLAND_SLEEPING) ||
+        ((colObj1) && colObj1->getActivationState() != ISLAND_SLEEPING)) {
+      pointCount += manifold->getNumContacts();
+    }
+  }
+  return pointCount;
+}
+
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -183,6 +183,13 @@ class BulletPhysicsManager : public PhysicsManager {
   virtual RaycastResults castRay(const esp::geo::Ray& ray,
                                  double maxDistance = 100.0) override;
 
+  // The number of contact points that were active during the last step. An
+  // object resting on another object will involve several active contact
+  // points. Once both objects are asleep, the contact points are inactive. This
+  // count can be used as a metric for the complexity/cost of collision-handling
+  // in the current scene.
+  int getNumActiveContactPoints() override;
+
  protected:
   //============ Initialization =============
   /**

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -52,7 +52,7 @@ BulletRigidObject::~BulletRigidObject() {
   } else if (objectMotionType_ == MotionType::STATIC) {
     // remove collision objects from the world
     for (auto& co : bStaticCollisionObjects_) {
-      bWorld_->removeCollisionObject(co.get());
+      bWorld_->removeRigidBody(co.get());
       collisionObjToObjIds_->erase(co.get());
     }
   }
@@ -287,7 +287,7 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
 
   // remove the existing object from the world to change its type
   if (objectMotionType_ == MotionType::STATIC) {
-    bWorld_->removeCollisionObject(bStaticCollisionObjects_.back().get());
+    bWorld_->removeRigidBody(bStaticCollisionObjects_.back().get());
     collisionObjToObjIds_->erase(bStaticCollisionObjects_.back().get());
     bStaticCollisionObjects_.clear();
   } else {
@@ -307,13 +307,16 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
   } else if (mt == MotionType::STATIC) {
     objectMotionType_ = MotionType::STATIC;
 
-    // create a static collision object at the current transform
-    std::unique_ptr<btCollisionObject> staticCollisionObject =
-        std::make_unique<btCollisionObject>();
-    staticCollisionObject->setCollisionShape(bObjectShape_.get());
-    staticCollisionObject->setWorldTransform(
-        bObjectRigidBody_->getWorldTransform());
-    bWorld_->addCollisionObject(
+    // mass == 0 to indicate static. See isStaticObject assert below. See also
+    // examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
+    btVector3 localInertia(0, 0, 0);
+    btRigidBody::btRigidBodyConstructionInfo cInfo(
+        /*mass*/ 0.0, nullptr, bObjectShape_.get(), localInertia);
+    cInfo.m_startWorldTransform = bObjectRigidBody_->getWorldTransform();
+    std::unique_ptr<btRigidBody> staticCollisionObject =
+        std::make_unique<btRigidBody>(cInfo);
+    ASSERT(staticCollisionObject->isStaticObject());
+    bWorld_->addRigidBody(
         staticCollisionObject.get(),
         2,       // collisionFilterGroup (2 == StaticFilter)
         1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -25,7 +25,7 @@ BulletRigidStage::BulletRigidStage(
 BulletRigidStage::~BulletRigidStage() {
   // remove collision objects from the world
   for (auto& co : bStaticCollisionObjects_) {
-    bWorld_->removeCollisionObject(co.get());
+    bWorld_->removeRigidBody(co.get());
     collisionObjToObjIds_->erase(co.get());
   }
 }
@@ -45,7 +45,10 @@ bool BulletRigidStage::initialization_LibSpecific(
     object->setFriction(initializationAttributes_->getFrictionCoefficient());
     object->setRestitution(
         initializationAttributes_->getRestitutionCoefficient());
-    bWorld_->addCollisionObject(object.get());
+    bWorld_->addRigidBody(
+        object.get(),
+        2,       // collisionFilterGroup (2 == StaticFilter)
+        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
     collisionObjToObjIds_->emplace(object.get(), objectId_);
   }
 
@@ -97,14 +100,17 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
 
     // re-build the bvh after setting margin
     meshShape->buildOptimizedBvh();
-    std::unique_ptr<btCollisionObject> sceneCollisionObject =
-        std::make_unique<btCollisionObject>();
-    sceneCollisionObject->setCollisionShape(meshShape.get());
-    // rotation|translation are properties of the object
-    sceneCollisionObject->setWorldTransform(
+    // mass == 0 to indicate static. See isStaticObject assert below. See also
+    // examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
+    btVector3 localInertia(0, 0, 0);
+    btRigidBody::btRigidBodyConstructionInfo cInfo(
+        /*mass*/ 0.0, nullptr, meshShape.get(), localInertia);
+    cInfo.m_startWorldTransform =
         btTransform{btMatrix3x3{transformFromLocalToWorld.rotation()},
-                    btVector3{transformFromLocalToWorld.translation()}});
-
+                    btVector3{transformFromLocalToWorld.translation()}};
+    std::unique_ptr<btRigidBody> sceneCollisionObject =
+        std::make_unique<btRigidBody>(cInfo);
+    ASSERT(sceneCollisionObject->isStaticObject());
     bStageArrays_.emplace_back(std::move(indexedVertexArray));
     bStageShapes_.emplace_back(std::move(meshShape));
     bStaticCollisionObjects_.emplace_back(std::move(sceneCollisionObject));

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -719,6 +719,10 @@ class Simulator {
    */
   core::Random::ptr random() { return random_; }
 
+  int getNumActiveContactPoints() {
+    return physicsManager_->getNumActiveContactPoints();
+  }
+
  protected:
   Simulator(){};
 


### PR DESCRIPTION
## Motivation and Context

This is a change to how we create Bullet static objects (including the stage). The previous approach caused an issue where the static object would never go to sleep, thus causing a potential runtime perf hit. The new approach is more consistent with Bullet example code and fixes the non-sleeping issue.

I've also added `get_num_active_contact_points`, which is generally useful as a proxy for Bullet collision cost/complexity and also helps diagnose/test the specific issue with static objects.

## How Has This Been Tested

`SimTest` unit test. Ad hoc testing in viewer with stage, dynamic objects, and static objects.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
