### PR TITLE
--Move SimulatorConfiguration to separate file.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -15,6 +15,7 @@
 #include "esp/gfx/Renderer.h"
 #include "esp/scene/SemanticScene.h"
 #include "esp/sim/Simulator.h"
+#include "esp/sim/SimulatorConfiguration.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;

--- a/src/esp/sim/CMakeLists.txt
+++ b/src/esp/sim/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
   sim STATIC
-  Simulator.cpp Simulator.h
+  Simulator.cpp Simulator.h SimulatorConfiguration.cpp SimulatorConfiguration.h
 )
 
 target_link_libraries(

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -301,23 +301,6 @@ scene::SceneGraph& Simulator::getActiveSemanticSceneGraph() {
   return sceneManager_->getSceneGraph(activeSemanticSceneID_);
 }
 
-bool operator==(const SimulatorConfiguration& a,
-                const SimulatorConfiguration& b) {
-  return a.scene == b.scene && a.defaultAgentId == b.defaultAgentId &&
-         a.defaultCameraUuid == b.defaultCameraUuid &&
-         a.compressTextures == b.compressTextures &&
-         a.createRenderer == b.createRenderer &&
-         a.enablePhysics == b.enablePhysics &&
-         a.physicsConfigFile.compare(b.physicsConfigFile) == 0 &&
-         a.loadSemanticMesh == b.loadSemanticMesh &&
-         a.sceneLightSetup.compare(b.sceneLightSetup) == 0;
-}
-
-bool operator!=(const SimulatorConfiguration& a,
-                const SimulatorConfiguration& b) {
-  return !(a == b);
-}
-
 // === Physics Simulator Functions ===
 
 int Simulator::addObject(const int objectLibId,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -12,16 +12,14 @@
 #include "esp/core/random.h"
 #include "esp/gfx/RenderTarget.h"
 #include "esp/gfx/WindowlessContext.h"
-#include "esp/metadata/managers/AssetAttributesManager.h"
-#include "esp/metadata/managers/ObjectAttributesManager.h"
-#include "esp/metadata/managers/PhysicsAttributesManager.h"
-#include "esp/metadata/managers/StageAttributesManager.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/physics/PhysicsManager.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/scene/SceneConfiguration.h"
 #include "esp/scene/SceneManager.h"
 #include "esp/scene/SceneNode.h"
+
+#include "SimulatorConfiguration.h"
 
 namespace esp {
 namespace nav {
@@ -41,46 +39,6 @@ namespace esp {
 namespace sim {
 namespace AttrMgrs = esp::metadata::managers;
 namespace Attrs = esp::metadata::attributes;
-
-struct SimulatorConfiguration {
-  scene::SceneConfiguration scene;
-  int defaultAgentId = 0;
-  int gpuDeviceId = 0;
-  unsigned int randomSeed = 0;
-  std::string defaultCameraUuid = "rgba_camera";
-  bool compressTextures = false;
-  bool createRenderer = true;
-  // Whether or not the agent can slide on collisions
-  bool allowSliding = true;
-  // enable or disable the frustum culling
-  bool frustumCulling = true;
-  /**
-   * @brief This flags specifies whether or not dynamics is supported by the
-   * simulation, if a suitable library (i.e. Bullet) has been installed.
-   */
-  bool enablePhysics = false;
-  /**
-   * @brief Whether or not to load the semantic mesh
-   */
-  bool loadSemanticMesh = true;
-  /**
-   * @brief Whether or not to load textures for the meshes. This MUST be true
-   * for RGB rendering
-   */
-  bool requiresTextures = true;
-  std::string physicsConfigFile =
-      ESP_DEFAULT_PHYS_SCENE_CONFIG_REL_PATH;  // should we instead link a
-                                               // PhysicsManagerConfiguration
-                                               // object here?
-  /** @brief Light setup key for scene */
-  std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
-
-  ESP_SMART_POINTERS(SimulatorConfiguration)
-};
-bool operator==(const SimulatorConfiguration& a,
-                const SimulatorConfiguration& b);
-bool operator!=(const SimulatorConfiguration& a,
-                const SimulatorConfiguration& b);
 
 class Simulator {
  public:

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "SimulatorConfiguration.h"
+
+namespace esp {
+namespace sim {
+bool operator==(const SimulatorConfiguration& a,
+                const SimulatorConfiguration& b) {
+  return a.scene == b.scene && a.defaultAgentId == b.defaultAgentId &&
+         a.defaultCameraUuid == b.defaultCameraUuid &&
+         a.compressTextures == b.compressTextures &&
+         a.createRenderer == b.createRenderer &&
+         a.enablePhysics == b.enablePhysics &&
+         a.physicsConfigFile.compare(b.physicsConfigFile) == 0 &&
+         a.loadSemanticMesh == b.loadSemanticMesh &&
+         a.sceneLightSetup.compare(b.sceneLightSetup) == 0;
+}
+
+bool operator!=(const SimulatorConfiguration& a,
+                const SimulatorConfiguration& b) {
+  return !(a == b);
+}
+
+}  // namespace sim
+}  // namespace esp

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -1,0 +1,59 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_SIM_SIMULATORCONFIGURATION_H_
+#define ESP_SIM_SIMULATORCONFIGURATION_H_
+
+#include "esp/assets/ResourceManager.h"
+#include "esp/physics/configure.h"
+#include "esp/scene/SceneConfiguration.h"
+
+namespace esp {
+namespace sim {
+
+struct SimulatorConfiguration {
+  scene::SceneConfiguration scene;
+  int defaultAgentId = 0;
+  int gpuDeviceId = 0;
+  unsigned int randomSeed = 0;
+  std::string defaultCameraUuid = "rgba_camera";
+  bool compressTextures = false;
+  bool createRenderer = true;
+  // Whether or not the agent can slide on collisions
+  bool allowSliding = true;
+  // enable or disable the frustum culling
+  bool frustumCulling = true;
+  /**
+   * @brief This flags specifies whether or not dynamics is supported by the
+   * simulation, if a suitable library (i.e. Bullet) has been installed.
+   */
+  bool enablePhysics = false;
+  /**
+   * @brief Whether or not to load the semantic mesh
+   */
+  bool loadSemanticMesh = true;
+  /**
+   * @brief Whether or not to load textures for the meshes. This MUST be true
+   * for RGB rendering
+   */
+  bool requiresTextures = true;
+  std::string physicsConfigFile =
+      ESP_DEFAULT_PHYS_SCENE_CONFIG_REL_PATH;  // should we instead link a
+                                               // PhysicsManagerConfiguration
+                                               // object here?
+  /** @brief Light setup key for scene */
+  std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
+
+  ESP_SMART_POINTERS(SimulatorConfiguration)
+};
+bool operator==(const SimulatorConfiguration& a,
+                const SimulatorConfiguration& b);
+
+bool operator!=(const SimulatorConfiguration& a,
+                const SimulatorConfiguration& b);
+
+}  // namespace sim
+}  // namespace esp
+
+#endif  // ESP_SIM_SIMULATORCONFIGURATION_H_


### PR DESCRIPTION
## Motivation and Context
This PR moves the SimulatorConfiguration class to its own file, so that it can be consumed by other classes without importing all of Simulator.h.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
