### PR TITLE
--Refactor load configs call.

### DIFF
--- a/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
@@ -499,6 +499,7 @@
     "    sim = habitat_sim.Simulator(cfg)\n",
     "    # Managers of various Attributes templates\n",
     "    obj_attr_mgr = sim.get_object_template_manager()\n",
+    "    obj_attr_mgr.load_configs(str(os.path.join(data_path, \"objects\")))\n",
     "    prim_attr_mgr = sim.get_asset_template_manager()\n",
     "    stage_attr_mgr = sim.get_stage_template_manager()\n",
     "    # UI-populated handles used in various cells.  Need to initialize to valid\n",

--- a/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
@@ -200,6 +200,7 @@
     "    sim = habitat_sim.Simulator(cfg)\n",
     "    # Managers of various Attributes templates\n",
     "    obj_attr_mgr = sim.get_object_template_manager()\n",
+    "    obj_attr_mgr.load_configs(str(os.path.join(data_path, \"objects\")))\n",
     "    prim_attr_mgr = sim.get_asset_template_manager()\n",
     "    stage_attr_mgr = sim.get_stage_template_manager()"
    ]

--- a/examples/tutorials/colabs/rigid_object_tutorial.ipynb
+++ b/examples/tutorials/colabs/rigid_object_tutorial.ipynb
@@ -205,6 +205,7 @@
     "    # [dynamic_control]\n",
     "\n",
     "    observations = []\n",
+    "    obj_templates_mgr.load_configs(str(os.path.join(data_path, \"objects\")))\n",
     "    # search for an object template by key sub-string\n",
     "    cheezit_template_handle = obj_templates_mgr.get_template_handles(\n",
     "        \"data/objects/cheezit\"\n",

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -490,6 +490,7 @@ def make_simulator_from_settings(sim_settings):
     sim = habitat_sim.Simulator(cfg)
     # Managers of various Attributes templates
     obj_attr_mgr = sim.get_object_template_manager()
+    obj_attr_mgr.load_configs(str(os.path.join(data_path, "objects")))
     prim_attr_mgr = sim.get_asset_template_manager()
     stage_attr_mgr = sim.get_stage_template_manager()
     # UI-populated handles used in various cells.  Need to initialize to valid

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -191,6 +191,7 @@ def make_simulator_from_settings(sim_settings):
     sim = habitat_sim.Simulator(cfg)
     # Managers of various Attributes templates
     obj_attr_mgr = sim.get_object_template_manager()
+    obj_attr_mgr.load_configs(str(os.path.join(data_path, "objects")))
     prim_attr_mgr = sim.get_asset_template_manager()
     stage_attr_mgr = sim.get_stage_template_manager()
 

--- a/examples/tutorials/nb_python/rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/rigid_object_tutorial.py
@@ -189,6 +189,7 @@ if __name__ == "__main__":
     # [dynamic_control]
 
     observations = []
+    obj_templates_mgr.load_configs(str(os.path.join(data_path, "objects")))
     # search for an object template by key sub-string
     cheezit_template_handle = obj_templates_mgr.get_template_handles(
         "data/objects/cheezit"

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -48,6 +48,10 @@ template <class T>
 void declareBaseAttributesManager(py::module& m, std::string classStrPrefix) {
   using MgrClass = AttributesManager<T>;
   using AttribsPtr = std::shared_ptr<T>;
+  // Most, but not all, of these methods are from ManagedContainer class
+  // template.  However, we use AttributesManager as the base class because we
+  // wish to have appropriate (attributes-related) argument nomenclature and
+  // documentation.
   std::string pyclass_name = classStrPrefix + std::string("AttributesManager");
   py::class_<MgrClass, std::shared_ptr<MgrClass>>(m, pyclass_name.c_str())
       .def(
@@ -261,13 +265,19 @@ void initAttributesManagersBindings(py::module& m) {
              ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
-      .def(
-          "load_object_configs", &ObjectAttributesManager::loadObjectConfigs,
-          R"(Build templates for all files with ".phys_properties.json" extension
+      .def("load_configs", &ObjectAttributesManager::loadObjectConfigs,
+           R"(Build templates for all JSON files with appropriate extension
             that exist in the provided file or directory path. If save_as_defaults
             is true, then these templates will be unable to be deleted)"
-          "path"_a,
-          "save_as_defaults"_a = false)
+           "path"_a,
+           "save_as_defaults"_a = false)
+      .def("load_object_configs", &ObjectAttributesManager::loadObjectConfigs,
+           R"(DEPRECATED : use "load_configs" instead.
+            Build templates for all files with ".phys_properties.json" extension
+            that exist in the provided file or directory path. If save_as_defaults
+            is true, then these templates will be unable to be deleted)"
+           "path"_a,
+           "save_as_defaults"_a = false)
 
       // manage file-based templates access
       .def(

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -42,7 +42,7 @@ def test_kinematics():
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     with habitat_sim.Simulator(hab_cfg) as sim:
         obj_mgr = sim.get_object_template_manager()
-
+        obj_mgr.load_configs("data/objects/", True)
         assert obj_mgr.get_num_templates() > 0
 
         # test adding an object to the world
@@ -155,6 +155,7 @@ def test_dynamics():
     hab_cfg = examples.settings.make_cfg(cfg_settings)
     with habitat_sim.Simulator(hab_cfg) as sim:
         obj_mgr = sim.get_object_template_manager()
+        obj_mgr.load_configs("data/objects/", True)
         # make the simulation deterministic (C++ seed is set in reconfigure)
         np.random.seed(cfg_settings["seed"])
         assert obj_mgr.get_num_templates() > 0
@@ -278,7 +279,7 @@ def test_velocity_control():
         obj_mgr = sim.get_object_template_manager()
 
         template_path = osp.abspath("data/test_assets/objects/nested_box")
-        template_ids = obj_mgr.load_object_configs(template_path)
+        template_ids = obj_mgr.load_configs(template_path)
         object_template = obj_mgr.get_template_by_ID(template_ids[0])
         object_template.linear_damping = 0.0
         object_template.angular_damping = 0.0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -131,7 +131,7 @@ def test_object_template_editing():
         # test loading a test asset template from file
         sphere_path = osp.abspath("data/test_assets/objects/sphere")
         old_library_size = obj_mgr.get_num_templates()
-        template_ids = obj_mgr.load_object_configs(sphere_path)
+        template_ids = obj_mgr.load_configs(sphere_path)
         assert len(template_ids) > 0
         assert obj_mgr.get_num_templates() > old_library_size
 


### PR DESCRIPTION
## Motivation and Context
This adds an additional python binding to load objects, and deprecates, but does not remove, the existing binding.  This is in preparation for MetadataMediator/Dataset config handling.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
