### PR TITLE
--Handle setting a default object for Attributes Managers

### DIFF
--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -535,6 +535,21 @@ class ManagedContainer {
     return res;
   }  // ManagedContainer::getUserLockedObjectHandles
 
+  /**
+   * @brief Set the object to provide default values upon construction of @ref
+   * esp::core::AbstractManagedObject.  Override if object should not have
+   * defaults
+   * @param _defaultObj the object to use for defaults;
+   */
+  virtual void setDefaultObject(ManagedPtr& _defaultObj) {
+    defaultObj_ = _defaultObj;
+  }
+
+  /**
+   * @brief Clear any default objects used for construction.
+   */
+  void clearDefaultObject() { defaultObj_ = nullptr; }
+
  protected:
   //======== Common JSON import functions ========
 
@@ -726,6 +741,18 @@ class ManagedContainer {
   }  // ManagedContainer::copyObject
 
   /**
+   * @brief Create a new object as a copy of @ref defaultObject_  if it exists,
+   * otherwise return nullptr.
+   * @return New object or nullptr
+   */
+  ManagedPtr constructFromDefault() {
+    if (defaultObj_ == nullptr) {
+      return nullptr;
+    }
+    return this->copyObject(defaultObj_);
+  }  // ManagedContainer::constructFromDefault
+
+  /**
    * @brief add passed managed object to library, setting managedObjectID
    * appropriately. Called internally by registerObject.
    *
@@ -838,6 +865,12 @@ class ManagedContainer {
    * unlocks them.
    */
   std::set<std::string> userLockedObjectNames_;
+
+  /**
+   * @brief An object to provide default values, to be used upon
+   * AbstractManagedObject construction
+   */
+  ManagedPtr defaultObj_ = nullptr;
 
  public:
   ESP_SMART_POINTERS(ManagedContainer<ManagedPtr>)

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -357,8 +357,8 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultUVSphereTemplate
 
   /**
-   * @brief Return the spedified cube template.
-   * @param templateHndle The handle of the desired cube template. Verifies
+   * @brief Return the spedified UVSphere template.
+   * @param templateHndle The handle of the desired UVSphere template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
@@ -371,6 +371,20 @@ class AssetAttributesManager
     return this->getObjectCopyByHandle<Attrs::UVSpherePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getUVSphereTemplate
+
+  /**
+   * @brief Set the object to provide default values upon construction of @ref
+   * esp::core::AbstractManagedObject.  Override if object should not have
+   * defaults.  Currently not supported for AbstractPrimitiveAttributes.
+   * @param _defaultObj the object to use for defaults;
+   */
+  void setDefaultObject(CORRADE_UNUSED Attrs::AbstractPrimitiveAttributes::ptr&
+                            _defaultObj) override {
+    LOG(WARNING) << "AssetAttributesManager::setDefaultObject : Overriding "
+                    "defualt objects for PrimitiveAssetAttributes not "
+                    "currently supported.  Aborting.";
+    this->defaultObj_ = nullptr;
+  }  // AssetAttributesManager::setDefaultObject
 
  protected:
   /**
@@ -444,6 +458,7 @@ class AssetAttributesManager
                  << primClassName << "exists in Magnum::Primitives. Aborting.";
       return nullptr;
     }
+    // these attributes ignore any default setttings.
     auto newAttributes = (*this.*primTypeConstructorMap_[primClassName])();
     return newAttributes;
   }

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -194,7 +194,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultCapsuleTemplate
 
   /**
-   * @brief Return the spedified capsule template.
+   * @brief Return the specified capsule template.
    * @param templateHndle The handle of the desired capsule template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
@@ -226,7 +226,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultConeTemplate
 
   /**
-   * @brief Return the spedified cone template, either solid or wireframe.
+   * @brief Return the specified cone template, either solid or wireframe.
    * @param templateHndle The handle of the desired cone template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
@@ -258,7 +258,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultCubeTemplate
 
   /**
-   * @brief Return the spedified cube template.
+   * @brief Return the specified cube template.
    * @param templateHndle The handle of the desired cube template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
@@ -291,7 +291,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultCylinderTemplate
 
   /**
-   * @brief Return the spedified cylinder template.
+   * @brief Return the specified cylinder template.
    * @param templateHndle The handle of the desired cylinder template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
@@ -324,7 +324,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultIcosphereTemplate
 
   /**
-   * @brief Return the spedified icosphere template.
+   * @brief Return the specified icosphere template.
    * @param templateHndle The handle of the desired icosphere template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle
@@ -357,7 +357,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getDefaultUVSphereTemplate
 
   /**
-   * @brief Return the spedified UVSphere template.
+   * @brief Return the specified UVSphere template.
    * @param templateHndle The handle of the desired UVSphere template. Verifies
    * that handle is to specified template type
    * @return appropriately cast template, or nullptr if template handle

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -163,10 +163,10 @@ ObjectAttributes::ptr ObjectAttributesManager::loadFromJSONDoc(
 
 ObjectAttributes::ptr ObjectAttributesManager::initNewObjectInternal(
     const std::string& attributesHandle) {
-  // TODO if default template exists from some source, create this template as a
-  // copy
-  auto newAttributes = ObjectAttributes::create(attributesHandle);
-
+  ObjectAttributes::ptr newAttributes = this->constructFromDefault();
+  if (nullptr == newAttributes) {
+    newAttributes = ObjectAttributes::create(attributesHandle);
+  }
   this->setFileDirectoryFromHandle(newAttributes);
   // set default render asset handle
   newAttributes->setRenderAssetHandle(attributesHandle);

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -88,7 +88,11 @@ class PhysicsAttributesManager
    */
   Attrs::PhysicsManagerAttributes::ptr initNewObjectInternal(
       const std::string& handleName) override {
-    auto newAttributes = Attrs::PhysicsManagerAttributes::create(handleName);
+    Attrs::PhysicsManagerAttributes::ptr newAttributes =
+        this->constructFromDefault();
+    if (nullptr == newAttributes) {
+      newAttributes = Attrs::PhysicsManagerAttributes::create(handleName);
+    }
     this->setFileDirectoryFromHandle(newAttributes);
     return newAttributes;
   }

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -204,8 +204,10 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
     const std::string& stageFilename) {
   // TODO if default template exists from some source, create this template as a
   // copy
-  auto newAttributes = StageAttributes::create(stageFilename);
-
+  StageAttributes::ptr newAttributes = this->constructFromDefault();
+  if (nullptr == newAttributes) {
+    newAttributes = StageAttributes::create(stageFilename);
+  }
   // attempt to set source directory if exists
   this->setFileDirectoryFromHandle(newAttributes);
 


### PR DESCRIPTION
## Motivation and Context
This allows for the AttributesManagers to accept a default attributes object to be used to construct all future objects. If one is not provided, construction proceeds as before.  This is in preparation for MetadataMediator.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
c++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
