### PR TITLE
fix for BulletRigidObject convex shapes

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -239,13 +239,17 @@ void BulletRigidObject::constructBulletCompoundFromMeshes(
             btVector3(transformFromLocalToWorld.transformPoint(v)), false);
       }
     } else {
-      bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>(
-          static_cast<const btScalar*>(mesh.positions.data()->data()),
-          mesh.positions.size(), sizeof(Magnum::Vector3)));
+      bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>());
+      // transform points into world space, including any scale/shear in
+      // transformFromLocalToWorld.
+      for (auto& v : mesh.positions) {
+        bObjectConvexShapes_.back()->addPoint(
+            btVector3(transformFromLocalToWorld.transformPoint(v)), false);
+      }
       bObjectConvexShapes_.back()->setMargin(0.0);
       bObjectConvexShapes_.back()->recalcLocalAabb();
       //! Add to compound shape stucture
-      bObjectShape_->addChildShape(btTransform{transformFromLocalToWorld},
+      bObjectShape_->addChildShape(btTransform::getIdentity(),
                                    bObjectConvexShapes_.back().get());
     }
   }


### PR DESCRIPTION
## Motivation and Context

We looked at some physics videos recently that showed books falling through the bookcase and objects not resting properly on the sofa. As a result, we were concerned about the long-term usability of convex shapes.

I tracked this down to a bug in how we're constructing the convex shapes. Specifically, while GLB nodes/meshes often contain *scale*, the Bullet `btTransform` class does *not* support scale/shear. And sadly, Bullet doesn't assert or warn about this when you construct btTransforms.

My fix here is to give Bullet world-space vertices (already transformed) instead of local-space.

## How Has This Been Tested

Ad hoc testing in viewer with our sofa object (composed of multiple convex parts). See screenshot.
![sofa_test](https://user-images.githubusercontent.com/6557808/94979156-15315880-04d6-11eb-8058-8c9692f65edb.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
