### PR TITLE
add getDefaultLights

### DIFF
--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -54,6 +54,11 @@ LightSetup getLightsAtBoxCorners(const Magnum::Range3D& box,
                     {{box.backBottomRight(), w}, lightColor}};
 }
 
+LightSetup getDefaultLights() {
+  return LightSetup{{{1.0, 1.0, 0.0, 0.0}, {0.75, 0.75, 0.75}},
+                    {{-0.5, 0.0, 1.0, 0.0}, {0.4, 0.4, 0.4}}};
+}
+
 Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
   if (lightSetup.size() == 0) {
     // We assume an empty light setup means the user wants "flat" shading,

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -63,6 +63,12 @@ LightSetup getLightsAtBoxCorners(
     const Magnum::Color3& lightColor = Magnum::Color3{10.0f});
 
 /**
+ * @brief Get a @ref LightSetup with some directional lights approximating
+ * daylight
+ */
+LightSetup getDefaultLights();
+
+/**
  * @brief Get get a single, combined ambient light color for use with the Phong
  * lighting model.
  */

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -209,7 +209,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     }
 
     const Magnum::Range3D& sceneBB = rootNode.computeCumulativeBB();
-    resourceManager_->setLightSetup(gfx::getLightsAtBoxCorners(sceneBB));
+    resourceManager_->setLightSetup(gfx::getDefaultLights());
 
     // set activeSemanticSceneID_ values and push onto sceneID vector if
     // appropriate - tempIDs[1] will either be old activeSemanticSceneID_ (if
@@ -280,7 +280,7 @@ void Simulator::reset() {
   }
   const Magnum::Range3D& sceneBB =
       getActiveSceneGraph().getRootNode().computeCumulativeBB();
-  resourceManager_->setLightSetup(gfx::getLightsAtBoxCorners(sceneBB));
+  resourceManager_->setLightSetup(gfx::getDefaultLights());
 }  // Simulator::reset()
 
 void Simulator::seed(uint32_t newSeed) {


### PR DESCRIPTION
## Motivation and Context

Better default lighting. The previous set of point lights was too dark for large scenes.
![better_default_lighting](https://user-images.githubusercontent.com/6557808/95107842-4d5fb380-06ef-11eb-964c-89f741cd5e1d.png)

## How Has This Been Tested

Ad hoc testing in viewer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
