### PR TITLE
--Remove unnecessary namespace alias

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -136,7 +136,8 @@ void ResourceManager::initPhysicsManager(
     std::shared_ptr<physics::PhysicsManager>& physicsManager,
     bool isEnabled,
     scene::SceneNode* parent,
-    const Attrs::PhysicsManagerAttributes::ptr& physicsManagerAttributes) {
+    const metadata::attributes::PhysicsManagerAttributes::ptr&
+        physicsManagerAttributes) {
   //! PHYSICS INIT: Use the passed attributes to initialize physics engine
   bool defaultToNoneSimulator = true;
   if (isEnabled) {

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -53,9 +53,6 @@ class PhongMaterialData;
 
 namespace Mn = Magnum;
 
-namespace Attrs = esp::metadata::attributes;
-namespace AttrMgrs = esp::metadata::managers;
-
 namespace esp {
 namespace gfx {
 class Drawable;
@@ -147,7 +144,8 @@ class ResourceManager {
       std::shared_ptr<physics::PhysicsManager>& physicsManager,
       bool isEnabled,
       scene::SceneNode* parent,
-      const Attrs::PhysicsManagerAttributes::ptr& physicsManagerAttributes);
+      const metadata::attributes::PhysicsManagerAttributes::ptr&
+          physicsManagerAttributes);
 
   /**
    * @brief Load a scene mesh and add it to the specified @ref DrawableGroup as
@@ -167,11 +165,12 @@ class ResourceManager {
    * @ref SimulatorConfiguration
    * @return Whether or not the scene load succeeded.
    */
-  bool loadStage(const Attrs::StageAttributes::ptr& sceneAttributes,
-                 std::shared_ptr<physics::PhysicsManager> _physicsManager,
-                 esp::scene::SceneManager* sceneManagerPtr,
-                 std::vector<int>& activeSceneIDs,
-                 bool createSemanticMesh);
+  bool loadStage(
+      const metadata::attributes::StageAttributes::ptr& sceneAttributes,
+      std::shared_ptr<physics::PhysicsManager> _physicsManager,
+      esp::scene::SceneManager* sceneManagerPtr,
+      std::vector<int>& activeSceneIDs,
+      bool createSemanticMesh);
 
   /**
    * @brief Construct scene collision mesh group based on name and type of
@@ -218,30 +217,30 @@ class ResourceManager {
   /**
    * @brief Return manager for construction and access to asset attributes.
    */
-  const AttrMgrs::AssetAttributesManager::ptr getAssetAttributesManager()
-      const {
+  const metadata::managers::AssetAttributesManager::ptr
+  getAssetAttributesManager() const {
     return assetAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to object attributes.
    */
-  const AttrMgrs::ObjectAttributesManager::ptr getObjectAttributesManager()
-      const {
+  const metadata::managers::ObjectAttributesManager::ptr
+  getObjectAttributesManager() const {
     return objectAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
    */
-  const AttrMgrs::PhysicsAttributesManager::ptr getPhysicsAttributesManager()
-      const {
+  const metadata::managers::PhysicsAttributesManager::ptr
+  getPhysicsAttributesManager() const {
     return physicsAttributesManager_;
   }
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
-  const AttrMgrs::StageAttributesManager::ptr getStageAttributesManager()
-      const {
+  const metadata::managers::StageAttributesManager::ptr
+  getStageAttributesManager() const {
     return stageAttributesManager_;
   }
 
@@ -420,7 +419,7 @@ class ResourceManager {
    * @return the coordinate frame of the assets the passed attributes describes.
    */
   esp::geo::CoordinateFrame buildFrameFromAttributes(
-      const Attrs::AbstractObjectAttributes::ptr& attribs,
+      const metadata::attributes::AbstractObjectAttributes::ptr& attribs,
       const Magnum::Vector3& origin);
 
   /**
@@ -653,7 +652,7 @@ class ResourceManager {
    * created
    */
   std::map<std::string, AssetInfo> createStageAssetInfosFromAttributes(
-      const Attrs::StageAttributes::ptr& stageAttributes,
+      const metadata::attributes::StageAttributes::ptr& stageAttributes,
       bool createCollisionInfo,
       bool createSemanticInfo);
 
@@ -884,22 +883,26 @@ class ResourceManager {
   /**
    * @brief Manages all construction and access to asset attributes.
    */
-  AttrMgrs::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
+  metadata::managers::AssetAttributesManager::ptr assetAttributesManager_ =
+      nullptr;
 
   /**
    * @brief Manages all construction and access to object attributes.
    */
-  AttrMgrs::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+  metadata::managers::ObjectAttributesManager::ptr objectAttributesManager_ =
+      nullptr;
 
   /**
    * @brief Manages all construction and access to physics world attributes.
    */
-  AttrMgrs::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
+  metadata::managers::PhysicsAttributesManager::ptr physicsAttributesManager_ =
+      nullptr;
 
   /**
    * @brief Manages all construction and access to scene attributes.
    */
-  AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
+  metadata::managers::StageAttributesManager::ptr stageAttributesManager_ =
+      nullptr;
 
   //! tracks primitive mesh ids
   int nextPrimitiveMeshId = 0;

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -30,7 +30,7 @@ namespace managers {
 template <class T>
 class AbstractObjectAttributesManager : public AttributesManager<T> {
  public:
-  static_assert(std::is_base_of<Attrs::AbstractObjectAttributes, T>::value,
+  static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
                 "AbstractObjectAttributesManager :: Managed object type must "
                 "be derived from AbstractObjectAttributes");
 

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -161,7 +161,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
                   "primitive class type : "
                << primClassName
                << " so returning default attributes for solid uvSphere.";
-    return this->getObjectCopyByHandle<Attrs::UVSpherePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         defaultPrimAttributeHandles_.at("uvSphereSolid"));
   }
 
@@ -173,7 +173,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
            "create default primitive asset attributes from primClassName "
         << primClassName
         << " so returning default attributes for solid uvSphere.";
-    return this->getObjectCopyByHandle<Attrs::UVSpherePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         defaultPrimAttributeHandles_.at("uvSphereSolid"));
   }
   this->setValsFromJSONDoc(primAssetAttributes, jsonDoc);

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -76,7 +76,7 @@ enum class PrimObjTypes : uint32_t {
 };
 namespace managers {
 class AssetAttributesManager
-    : public AttributesManager<Attrs::AbstractPrimitiveAttributes> {
+    : public AttributesManager<attributes::AbstractPrimitiveAttributes> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -86,7 +86,7 @@ class AssetAttributesManager
   static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
 
   AssetAttributesManager()
-      : AttributesManager<Attrs::AbstractPrimitiveAttributes>::
+      : AttributesManager<attributes::AbstractPrimitiveAttributes>::
             AttributesManager("Primitive Asset", "prim_config.json") {
     buildCtorFuncPtrMaps();
   }  // AssetAttributesManager::ctor
@@ -107,7 +107,7 @@ class AssetAttributesManager
    * @return a reference to the desired template.
    */
 
-  Attrs::AbstractPrimitiveAttributes::ptr createObject(
+  attributes::AbstractPrimitiveAttributes::ptr createObject(
       const std::string& primClassName,
       bool registerTemplate = true) override;
 
@@ -124,7 +124,7 @@ class AssetAttributesManager
    * @param jsonConfig json document to parse
    * @return a reference to the desired template.
    */
-  Attrs::AbstractPrimitiveAttributes::ptr buildObjectFromJSONDoc(
+  attributes::AbstractPrimitiveAttributes::ptr buildObjectFromJSONDoc(
       const std::string& filename,
       const io::JsonGenericValue& jsonConfig) override;
 
@@ -148,7 +148,7 @@ class AssetAttributesManager
    * not. If the user is going to edit this template, this should be false.
    * @return a reference to the desired template.
    */
-  Attrs::AbstractPrimitiveAttributes::ptr createObject(
+  attributes::AbstractPrimitiveAttributes::ptr createObject(
       PrimObjTypes primObjType,
       bool registerTemplate = true) {
     if (primObjType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
@@ -190,7 +190,7 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::CapsulePrimitiveAttributes::ptr getDefaultCapsuleTemplate(
+  attributes::CapsulePrimitiveAttributes::ptr getDefaultCapsuleTemplate(
       bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
@@ -198,7 +198,7 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("capsule3DSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::CapsulePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CapsulePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getDefaultCapsuleTemplate
 
@@ -209,12 +209,12 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::CapsulePrimitiveAttributes::ptr getCapsuleTemplate(
+  attributes::CapsulePrimitiveAttributes::ptr getCapsuleTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "capsule")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::CapsulePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CapsulePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getCapsuleTemplate
 
@@ -223,14 +223,15 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::ConePrimitiveAttributes::ptr getDefaultConeTemplate(bool isWireFrame) {
+  attributes::ConePrimitiveAttributes::ptr getDefaultConeTemplate(
+      bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
       templateHndle = defaultPrimAttributeHandles_.at("coneWireframe");
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("coneSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::ConePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::ConePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getDefaultConeTemplate
 
@@ -241,12 +242,12 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::ConePrimitiveAttributes::ptr getConeTemplate(
+  attributes::ConePrimitiveAttributes::ptr getConeTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "cone")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::ConePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::ConePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getConeTemplate
 
@@ -255,14 +256,15 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::CubePrimitiveAttributes::ptr getDefaultCubeTemplate(bool isWireFrame) {
+  attributes::CubePrimitiveAttributes::ptr getDefaultCubeTemplate(
+      bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
       templateHndle = defaultPrimAttributeHandles_.at("cubeWireframe");
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("cubeSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::CubePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CubePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getDefaultCubeTemplate
 
@@ -273,12 +275,12 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::CubePrimitiveAttributes::ptr getCubeTemplate(
+  attributes::CubePrimitiveAttributes::ptr getCubeTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "cube")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::CubePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CubePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getCubeTemplate
 
@@ -287,7 +289,7 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::CylinderPrimitiveAttributes::ptr getDefaultCylinderTemplate(
+  attributes::CylinderPrimitiveAttributes::ptr getDefaultCylinderTemplate(
       bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
@@ -295,7 +297,7 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("cylinderSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::CylinderPrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CylinderPrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getDefaultCylinderTemplate
 
@@ -306,12 +308,12 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::CylinderPrimitiveAttributes::ptr getCylinderTemplate(
+  attributes::CylinderPrimitiveAttributes::ptr getCylinderTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "cylinder")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::CylinderPrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::CylinderPrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getCylinderTemplate
 
@@ -320,7 +322,7 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::IcospherePrimitiveAttributes::ptr getDefaultIcosphereTemplate(
+  attributes::IcospherePrimitiveAttributes::ptr getDefaultIcosphereTemplate(
       bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
@@ -328,8 +330,9 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("icosphereSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::IcospherePrimitiveAttributes>(
-        templateHndle);
+    return this
+        ->getObjectCopyByHandle<attributes::IcospherePrimitiveAttributes>(
+            templateHndle);
   }  // AssetAttributeManager::getDefaultIcosphereTemplate
 
   /**
@@ -339,13 +342,14 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::IcospherePrimitiveAttributes::ptr getIcosphereTemplate(
+  attributes::IcospherePrimitiveAttributes::ptr getIcosphereTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "icosphere")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::IcospherePrimitiveAttributes>(
-        templateHndle);
+    return this
+        ->getObjectCopyByHandle<attributes::IcospherePrimitiveAttributes>(
+            templateHndle);
   }  // AssetAttributeManager::getIcosphereTemplate
 
   /**
@@ -353,7 +357,7 @@ class AssetAttributesManager
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */
-  Attrs::UVSpherePrimitiveAttributes::ptr getDefaultUVSphereTemplate(
+  attributes::UVSpherePrimitiveAttributes::ptr getDefaultUVSphereTemplate(
       bool isWireFrame) {
     std::string templateHndle;
     if (isWireFrame) {
@@ -361,7 +365,7 @@ class AssetAttributesManager
     } else {
       templateHndle = defaultPrimAttributeHandles_.at("uvSphereSolid");
     }
-    return this->getObjectCopyByHandle<Attrs::UVSpherePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getDefaultUVSphereTemplate
 
@@ -372,12 +376,12 @@ class AssetAttributesManager
    * @return appropriately cast template, or nullptr if template handle
    * incorrectly specified.
    */
-  Attrs::UVSpherePrimitiveAttributes::ptr getUVSphereTemplate(
+  attributes::UVSpherePrimitiveAttributes::ptr getUVSphereTemplate(
       const std::string& templateHndle) {
     if (!verifyTemplateHandle(templateHndle, "uvSphere")) {
       return nullptr;
     }
-    return this->getObjectCopyByHandle<Attrs::UVSpherePrimitiveAttributes>(
+    return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         templateHndle);
   }  // AssetAttributeManager::getUVSphereTemplate
 
@@ -387,8 +391,9 @@ class AssetAttributesManager
    * defaults.  Currently not supported for AbstractPrimitiveAttributes.
    * @param _defaultObj the object to use for defaults;
    */
-  void setDefaultObject(CORRADE_UNUSED Attrs::AbstractPrimitiveAttributes::ptr&
-                            _defaultObj) override {
+  void setDefaultObject(
+      CORRADE_UNUSED attributes::AbstractPrimitiveAttributes::ptr& _defaultObj)
+      override {
     LOG(WARNING) << "AssetAttributesManager::setDefaultObject : Overriding "
                     "defualt objects for PrimitiveAssetAttributes not "
                     "currently supported.  Aborting.";
@@ -450,7 +455,7 @@ class AssetAttributesManager
    * template.
    */
   int registerObjectFinalize(
-      Attrs::AbstractPrimitiveAttributes::ptr attributesTemplate,
+      attributes::AbstractPrimitiveAttributes::ptr attributesTemplate,
       const std::string& ignored = "") override;
 
   /**
@@ -459,7 +464,7 @@ class AssetAttributesManager
    * @param primClassName Primitive Magnum class name.
    * @return newAttributes Newly created attributes.
    */
-  Attrs::AbstractPrimitiveAttributes::ptr initNewObjectInternal(
+  attributes::AbstractPrimitiveAttributes::ptr initNewObjectInternal(
       const std::string& primClassName) override {
     if (primTypeConstructorMap_.count(primClassName) == 0) {
       LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : No "
@@ -478,11 +483,11 @@ class AssetAttributesManager
    * PrimObjTypes::END_PRIM_OBJ_TYPES corresponds to a Magnum Primitive type
    */
   template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
-  Attrs::AbstractPrimitiveAttributes::ptr createPrimAttributes() {
+  attributes::AbstractPrimitiveAttributes::ptr createPrimAttributes() {
     if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
       LOG(ERROR)
           << "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
-             "Attrs::AbstractPrimitiveAttributes object for "
+             "attributes::AbstractPrimitiveAttributes object for "
              "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return nullptr;
     }
@@ -495,8 +500,8 @@ class AssetAttributesManager
    * reset.
    */
   void resetFinalize() override {
-    // build default Attrs::AbstractPrimitiveAttributes objects - reset does not
-    // remove constructor mappings;
+    // build default attributes::AbstractPrimitiveAttributes objects - reset
+    // does not remove constructor mappings;
     for (const std::pair<PrimObjTypes, const char*>& elem :
          PrimitiveNames3DMap) {
       if (elem.first == PrimObjTypes::END_PRIM_OBJ_TYPES) {
@@ -522,7 +527,7 @@ class AssetAttributesManager
    * instanced, as defined in @ref PrimitiveNames3DMap
    */
   typedef std::map<std::string,
-                   Attrs::AbstractPrimitiveAttributes::ptr (
+                   attributes::AbstractPrimitiveAttributes::ptr (
                        AssetAttributesManager::*)()>
       Map_Of_PrimTypeCtors;
 

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -22,7 +22,7 @@ class ManagedContainerBase;
 }
 namespace metadata {
 namespace managers {
-namespace Attrs = esp::metadata::attributes;
+
 /**
  * @brief Class template defining responsibilities and functionality for
  * managing @ref esp::metadata::attributes::AbstractAttributes constructs.
@@ -33,7 +33,7 @@ namespace Attrs = esp::metadata::attributes;
 template <class T>
 class AttributesManager : public esp::core::ManagedContainer<T> {
  public:
-  static_assert(std::is_base_of<Attrs::AbstractAttributes, T>::value,
+  static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
                 "AttributesManager :: Managed object type must be derived from "
                 "AbstractAttributes");
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -74,7 +74,7 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
 }  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
 
 void ObjectAttributesManager::setValsFromJSONDoc(
-    Attrs::ObjectAttributes::ptr objAttributes,
+    attributes::ObjectAttributes::ptr objAttributes,
     const io::JsonGenericValue& jsonConfig) {
   this->loadAbstractObjectAttributesFromJson(objAttributes, jsonConfig);
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -17,10 +17,10 @@ namespace managers {
  * @brief single instance class managing templates describing physical objects
  */
 class ObjectAttributesManager
-    : public AbstractObjectAttributesManager<Attrs::ObjectAttributes> {
+    : public AbstractObjectAttributesManager<attributes::ObjectAttributes> {
  public:
   ObjectAttributesManager()
-      : AbstractObjectAttributesManager<Attrs::ObjectAttributes>::
+      : AbstractObjectAttributesManager<attributes::ObjectAttributes>::
             AbstractObjectAttributesManager("Object", "phys_properties.json") {
     buildCtorFuncPtrMaps();
   }
@@ -45,7 +45,7 @@ class ObjectAttributesManager
    * subsequent editing will require re-registration. Defaults to true.
    * @return a reference to the desired template, or nullptr if fails.
    */
-  Attrs::ObjectAttributes::ptr createPrimBasedAttributesTemplate(
+  attributes::ObjectAttributes::ptr createPrimBasedAttributesTemplate(
       const std::string& primAttrTemplateHandle,
       bool registerTemplate = true) override;
 
@@ -55,7 +55,7 @@ class ObjectAttributesManager
    * @param attribs (out) an existing attributes to be modified.
    * @param jsonConfig json document to parse
    */
-  void setValsFromJSONDoc(Attrs::ObjectAttributes::ptr attribs,
+  void setValsFromJSONDoc(attributes::ObjectAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
   /**
@@ -174,7 +174,7 @@ class ObjectAttributesManager
    * @param assetTypeSetter Setter for mesh type.
    */
   void setDefaultAssetNameBasedAttributes(
-      Attrs::ObjectAttributes::ptr attributes,
+      attributes::ObjectAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
       std::function<void(int)> assetTypeSetter) override;
@@ -185,7 +185,7 @@ class ObjectAttributesManager
    *
    * @param handleName handle name to be assigned to attributes
    */
-  Attrs::ObjectAttributes::ptr initNewObjectInternal(
+  attributes::ObjectAttributes::ptr initNewObjectInternal(
       const std::string& handleName) override;
 
   /**
@@ -217,7 +217,7 @@ class ObjectAttributesManager
    * template.
    */
   int registerObjectFinalize(
-      Attrs::ObjectAttributes::ptr attributesTemplate,
+      attributes::ObjectAttributes::ptr attributesTemplate,
       const std::string& attributesTemplateHandle) override;
 
   /**
@@ -236,7 +236,8 @@ class ObjectAttributesManager
    */
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["ObjectAttributes"] =
-        &ObjectAttributesManager::createObjectCopy<Attrs::ObjectAttributes>;
+        &ObjectAttributesManager::createObjectCopy<
+            attributes::ObjectAttributes>;
   }  // ObjectAttributesManager::buildCtorFuncPtrMaps()
 
   // ======== Typedefs and Instance Variables ========

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -31,7 +31,7 @@ PhysicsManagerAttributes::ptr PhysicsAttributesManager::createObject(
 }  // PhysicsAttributesManager::createObject
 
 void PhysicsAttributesManager::setValsFromJSONDoc(
-    Attrs::PhysicsManagerAttributes::ptr physicsManagerAttributes,
+    attributes::PhysicsManagerAttributes::ptr physicsManagerAttributes,
     const io::JsonGenericValue&
         jsonConfig) {  // load the simulator preference - default is "none"
                        // simulator, set in

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -18,12 +18,11 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class PhysicsAttributesManager
-    : public AttributesManager<Attrs::PhysicsManagerAttributes> {
+    : public AttributesManager<attributes::PhysicsManagerAttributes> {
  public:
   PhysicsAttributesManager(ObjectAttributesManager::ptr objectAttributesMgr)
-      : AttributesManager<Attrs::PhysicsManagerAttributes>::AttributesManager(
-            "Physics Manager",
-            "phys_scene_config.json"),
+      : AttributesManager<attributes::PhysicsManagerAttributes>::
+            AttributesManager("Physics Manager", "phys_scene_config.json"),
         objectAttributesMgr_(objectAttributesMgr) {
     buildCtorFuncPtrMaps();
   }
@@ -47,7 +46,7 @@ class PhysicsAttributesManager
    * @return a reference to the physics simulation meta data object parsed from
    * the specified configuration file.
    */
-  Attrs::PhysicsManagerAttributes::ptr createObject(
+  attributes::PhysicsManagerAttributes::ptr createObject(
       const std::string& physicsFilename =
           ESP_DEFAULT_PHYS_SCENE_CONFIG_REL_PATH,
       bool registerTemplate = true) override;
@@ -58,7 +57,7 @@ class PhysicsAttributesManager
    * @param attribs (out) an existing attributes to be modified.
    * @param jsonConfig json document to parse
    */
-  void setValsFromJSONDoc(Attrs::PhysicsManagerAttributes::ptr attribs,
+  void setValsFromJSONDoc(attributes::PhysicsManagerAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
  protected:
@@ -78,12 +77,12 @@ class PhysicsAttributesManager
    *
    * @param handleName handle name to be assigned to attributes
    */
-  Attrs::PhysicsManagerAttributes::ptr initNewObjectInternal(
+  attributes::PhysicsManagerAttributes::ptr initNewObjectInternal(
       const std::string& handleName) override {
-    Attrs::PhysicsManagerAttributes::ptr newAttributes =
+    attributes::PhysicsManagerAttributes::ptr newAttributes =
         this->constructFromDefault();
     if (nullptr == newAttributes) {
-      newAttributes = Attrs::PhysicsManagerAttributes::create(handleName);
+      newAttributes = attributes::PhysicsManagerAttributes::create(handleName);
     }
     this->setFileDirectoryFromHandle(newAttributes);
     return newAttributes;
@@ -113,7 +112,7 @@ class PhysicsAttributesManager
    * template.
    */
   int registerObjectFinalize(
-      Attrs::PhysicsManagerAttributes::ptr physicsAttributesTemplate,
+      attributes::PhysicsManagerAttributes::ptr physicsAttributesTemplate,
       const std::string& physicsAttributesHandle) override {
     // adds template to library, and returns either the ID of the existing
     // template referenced by physicsAttributesHandle, or the next available ID
@@ -137,7 +136,7 @@ class PhysicsAttributesManager
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["PhysicsManagerAttributes"] =
         &PhysicsAttributesManager::createObjectCopy<
-            Attrs::PhysicsManagerAttributes>;
+            attributes::PhysicsManagerAttributes>;
   }  // PhysicsAttributesManager::buildCtorFuncPtrMaps
 
   // instance vars

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -270,7 +270,7 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
 }  // StageAttributesManager::setDefaultAssetNameBasedAttributes
 
 void StageAttributesManager::setValsFromJSONDoc(
-    Attrs::StageAttributes::ptr stageAttributes,
+    attributes::StageAttributes::ptr stageAttributes,
     const io::JsonGenericValue& jsonConfig) {
   this->loadAbstractObjectAttributesFromJson(stageAttributes, jsonConfig);
 

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -17,7 +17,7 @@ enum class AssetType;
 namespace metadata {
 namespace managers {
 class StageAttributesManager
-    : public AbstractObjectAttributesManager<Attrs::StageAttributes> {
+    : public AbstractObjectAttributesManager<attributes::StageAttributes> {
  public:
   StageAttributesManager(
       ObjectAttributesManager::ptr objectAttributesMgr,
@@ -71,7 +71,7 @@ class StageAttributesManager
    * subsequent editing will require re-registration. Defaults to true.
    * @return a reference to the desired stage template, or nullptr if fails.
    */
-  Attrs::StageAttributes::ptr createPrimBasedAttributesTemplate(
+  attributes::StageAttributes::ptr createPrimBasedAttributesTemplate(
       const std::string& primAttrTemplateHandle,
       bool registerTemplate = true) override;
 
@@ -81,7 +81,7 @@ class StageAttributesManager
    * @param attribs (out) an existing attributes to be modified.
    * @param jsonConfig json document to parse
    */
-  void setValsFromJSONDoc(Attrs::StageAttributes::ptr attribs,
+  void setValsFromJSONDoc(attributes::StageAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
  protected:
@@ -109,7 +109,7 @@ class StageAttributesManager
    * @param assetTypeSetter Setter for mesh type.
    */
   void setDefaultAssetNameBasedAttributes(
-      Attrs::StageAttributes::ptr attributes,
+      attributes::StageAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
       std::function<void(int)> assetTypeSetter) override;
@@ -119,7 +119,7 @@ class StageAttributesManager
    *
    * @param handleName handle name to be assigned to attributes
    */
-  Attrs::StageAttributes::ptr initNewObjectInternal(
+  attributes::StageAttributes::ptr initNewObjectInternal(
       const std::string& handleName) override;
 
   /**
@@ -149,7 +149,7 @@ class StageAttributesManager
    */
 
   int registerObjectFinalize(
-      Attrs::StageAttributes::ptr StageAttributesTemplate,
+      attributes::StageAttributes::ptr StageAttributesTemplate,
       const std::string& StageAttributesHandle) override;
 
   /**
@@ -165,7 +165,7 @@ class StageAttributesManager
    */
   void buildCtorFuncPtrMaps() override {
     this->copyConstructorMap_["StageAttributes"] =
-        &StageAttributesManager::createObjectCopy<Attrs::StageAttributes>;
+        &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
   }  // StageAttributesManager::buildCtorFuncPtrMaps
 
   // instance vars

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -33,7 +33,6 @@ namespace esp {
 //! core physics simulation namespace
 namespace physics {
 
-namespace Attrs = esp::metadata::attributes;
 //! Holds information about one ray hit instance.
 struct RayHitInfo {
   //! The id of the object hit by this ray. Stage hits are -1.
@@ -124,7 +123,8 @@ class PhysicsManager {
    */
   explicit PhysicsManager(
       assets::ResourceManager& _resourceManager,
-      const Attrs::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
+      const metadata::attributes::PhysicsManagerAttributes::cptr
+          _physicsManagerAttributes)
       : resourceManager_(_resourceManager),
         physicsManagerAttributes_(_physicsManagerAttributes){};
 
@@ -866,7 +866,7 @@ class PhysicsManager {
    *
    * @return The initialization settings of the specified object instance.
    */
-  Attrs::ObjectAttributes::ptr getObjectInitAttributes(
+  metadata::attributes::ObjectAttributes::ptr getObjectInitAttributes(
       const int physObjectID) const {
     assertIDValidity(physObjectID);
     return existingObjects_.at(physObjectID)->getInitializationAttributes();
@@ -878,7 +878,7 @@ class PhysicsManager {
    * @return The initialization settings of the stage or nullptr if the stage is
    * not initialized.
    */
-  Attrs::StageAttributes::ptr getStageInitAttributes() const {
+  metadata::attributes::StageAttributes::ptr getStageInitAttributes() const {
     return staticStageObject_->getInitializationAttributes();
   }
 
@@ -887,8 +887,9 @@ class PhysicsManager {
    *
    * @return The initialization settings for this physics manager
    */
-  Attrs::PhysicsManagerAttributes::ptr getInitializationAttributes() const {
-    return Attrs::PhysicsManagerAttributes::create(
+  metadata::attributes::PhysicsManagerAttributes::ptr
+  getInitializationAttributes() const {
+    return metadata::attributes::PhysicsManagerAttributes::create(
         *physicsManagerAttributes_.get());
   }
 
@@ -987,7 +988,8 @@ class PhysicsManager {
   /** @brief A pointer to the @ref
    * esp::metadata::attributes::PhysicsManagerAttributes describing
    * this physics manager */
-  const Attrs::PhysicsManagerAttributes::cptr physicsManagerAttributes_;
+  const metadata::attributes::PhysicsManagerAttributes::cptr
+      physicsManagerAttributes_;
 
   /** @brief The current physics library implementation used by this
    * @ref PhysicsManager. Can be used to correctly cast the @ref PhysicsManager

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -33,7 +33,6 @@ class AbstractObjectAttributes;
 
 namespace physics {
 
-namespace Attrs = esp::metadata::attributes;
 /**
 @brief Motion type of a @ref RigidObject.
 Defines its treatment by the simulator and operations which can be performed on
@@ -635,7 +634,8 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Saved attributes when the object was initialized.
    */
-  Attrs::AbstractObjectAttributes::ptr initializationAttributes_ = nullptr;
+  metadata::attributes::AbstractObjectAttributes::ptr
+      initializationAttributes_ = nullptr;
 
   //! Access for the object to its own PhysicsManager id. Scene will keep -1.
   int objectId_ = -1;

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -30,8 +30,8 @@ bool RigidObject::finalizeObject() {
   node().computeCumulativeBB();
 
   // cast initialization attributes
-  Attrs::ObjectAttributes::cptr ObjectAttributes =
-      std::dynamic_pointer_cast<const Attrs::ObjectAttributes>(
+  metadata::attributes::ObjectAttributes::cptr ObjectAttributes =
+      std::dynamic_pointer_cast<const metadata::attributes::ObjectAttributes>(
           initializationAttributes_);
 
   if (!ObjectAttributes->getComputeCOMFromShape()) {

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -125,8 +125,10 @@ class RigidObject : public RigidBase {
    * @return A copy of the @ref esp::metadata::attributes::ObjectAttributes
    * template used to create this object.
    */
-  std::shared_ptr<Attrs::ObjectAttributes> getInitializationAttributes() const {
-    return RigidBase::getInitializationAttributes<Attrs::ObjectAttributes>();
+  std::shared_ptr<metadata::attributes::ObjectAttributes>
+  getInitializationAttributes() const {
+    return RigidBase::getInitializationAttributes<
+        metadata::attributes::ObjectAttributes>();
   };
 
  private:

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -38,8 +38,10 @@ class RigidStage : public RigidBase {
    * @return A copy of the @ref esp::metadata::attributes::StageAttributes
    * template used to create this stage object.
    */
-  std::shared_ptr<Attrs::StageAttributes> getInitializationAttributes() const {
-    return RigidBase::getInitializationAttributes<Attrs::StageAttributes>();
+  std::shared_ptr<metadata::attributes::StageAttributes>
+  getInitializationAttributes() const {
+    return RigidBase::getInitializationAttributes<
+        metadata::attributes::StageAttributes>();
   };
   /**
    * @brief Finalize the creation of this @ref RigidStage

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -51,7 +51,8 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   explicit BulletPhysicsManager(
       assets::ResourceManager& _resourceManager,
-      const Attrs::PhysicsManagerAttributes::cptr _physicsManagerAttributes)
+      const metadata::attributes::PhysicsManagerAttributes::cptr
+          _physicsManagerAttributes)
       : PhysicsManager(_resourceManager, _physicsManagerAttributes) {
     collisionObjToObjIds_ =
         std::make_shared<std::map<const btCollisionObject*, int>>();

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -30,8 +30,8 @@ namespace Cr = Corrade;
 namespace esp {
 namespace sim {
 
-using Attrs::PhysicsManagerAttributes;
-using Attrs::StageAttributes;
+using metadata::attributes::PhysicsManagerAttributes;
+using metadata::attributes::StageAttributes;
 
 Simulator::Simulator(const SimulatorConfiguration& cfg)
     : random_{core::Random::create(cfg.randomSeed)},
@@ -333,17 +333,17 @@ int Simulator::addObjectByHandle(const std::string& objectLibHandle,
   return ID_UNDEFINED;
 }
 
-const Attrs::ObjectAttributes::cptr Simulator::getObjectInitializationTemplate(
-    const int objectId,
-    const int sceneID) const {
+const metadata::attributes::ObjectAttributes::cptr
+Simulator::getObjectInitializationTemplate(const int objectId,
+                                           const int sceneID) const {
   if (sceneHasPhysics(sceneID)) {
     return physicsManager_->getObjectInitAttributes(objectId);
   }
   return nullptr;
 }
 
-const Attrs::StageAttributes::cptr Simulator::getStageInitializationTemplate(
-    const int sceneID) const {
+const metadata::attributes::StageAttributes::cptr
+Simulator::getStageInitializationTemplate(const int sceneID) const {
   if (sceneHasPhysics(sceneID)) {
     return physicsManager_->getStageInitAttributes();
   }
@@ -628,8 +628,9 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
             Eigen::Transform<float, 3, Eigen::Affine> >(
             physicsManager_->getObjectVisualSceneNode(objectID)
                 .absoluteTransformationMatrix());
-        const Attrs::ObjectAttributes::cptr initializationTemplate =
-            physicsManager_->getObjectInitAttributes(objectID);
+        const metadata::attributes::ObjectAttributes::cptr
+            initializationTemplate =
+                physicsManager_->getObjectInitAttributes(objectID);
         objectTransform.scale(Magnum::EigenIntegration::cast<vec3f>(
             initializationTemplate->getScale()));
         std::string meshHandle =

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -37,9 +37,6 @@ class Renderer;
 
 namespace esp {
 namespace sim {
-namespace AttrMgrs = esp::metadata::managers;
-namespace Attrs = esp::metadata::attributes;
-
 class Simulator {
  public:
   explicit Simulator(const SimulatorConfiguration& cfg);
@@ -90,30 +87,30 @@ class Simulator {
   /**
    * @brief Return manager for construction and access to asset attributes.
    */
-  const AttrMgrs::AssetAttributesManager::ptr getAssetAttributesManager()
-      const {
+  const metadata::managers::AssetAttributesManager::ptr
+  getAssetAttributesManager() const {
     return resourceManager_->getAssetAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to object attributes.
    */
-  const AttrMgrs::ObjectAttributesManager::ptr getObjectAttributesManager()
-      const {
+  const metadata::managers::ObjectAttributesManager::ptr
+  getObjectAttributesManager() const {
     return resourceManager_->getObjectAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
    */
-  const AttrMgrs::PhysicsAttributesManager::ptr getPhysicsAttributesManager()
-      const {
+  const metadata::managers::PhysicsAttributesManager::ptr
+  getPhysicsAttributesManager() const {
     return resourceManager_->getPhysicsAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
-  const AttrMgrs::StageAttributesManager::ptr getStageAttributesManager()
-      const {
+  const metadata::managers::StageAttributesManager::ptr
+  getStageAttributesManager() const {
     return resourceManager_->getStageAttributesManager();
   }
 
@@ -187,17 +184,16 @@ class Simulator {
    * Use this to query the object's properties when it was initialized.  Object
    * pointed at by pointer is const, and can not be modified.
    */
-  const Attrs::ObjectAttributes::cptr getObjectInitializationTemplate(
-      int objectId,
-      int sceneID = 0) const;
+  const metadata::attributes::ObjectAttributes::cptr
+  getObjectInitializationTemplate(int objectId, int sceneID = 0) const;
 
   /**
    * @brief Get a copy of a stage's template when the stage was instanced.
    *
    * Use this to query the stage's properties when it was initialized.
    */
-  const Attrs::StageAttributes::cptr getStageInitializationTemplate(
-      int sceneID = 0) const;
+  const metadata::attributes::StageAttributes::cptr
+  getStageInitializationTemplate(int sceneID = 0) const;
 
   /**
    * @brief Remove an instanced object by ID. See @ref


### PR DESCRIPTION
## Motivation and Context
This removes namespace aliases into the metadata attributes and metadata managers that were unnecessary.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
