### PR TITLE
Enable typeguard pytest plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-parallel
+                pip install pytest-parallel typeguard
               fi
       - run:
           name: Install emscripten
@@ -397,12 +397,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest --workers 4 --cov-report=xml --cov=./
+              pytest --workers 4 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --workers 4 --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
+              pytest --workers 4 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten

--- a/habitat_sim/agent/controls/object_controls.py
+++ b/habitat_sim/agent/controls/object_controls.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable
+from typing import Callable
 
 import attr
 import numpy as np
@@ -30,7 +30,9 @@ class ObjectControls(object):
         handle collisions
     """
 
-    move_filter_fn: Callable[..., Any] = attr.ib(default=_noop_filter)
+    move_filter_fn: Callable[[np.ndarray, np.ndarray], np.ndarray] = attr.ib(
+        default=_noop_filter
+    )
 
     @staticmethod
     def is_body_action(action_name: str):

--- a/habitat_sim/agent/controls/object_controls.py
+++ b/habitat_sim/agent/controls/object_controls.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable
+from typing import Any, Callable
 
 import attr
 import numpy as np
@@ -18,7 +18,7 @@ from habitat_sim.registry import registry
 EPS = 1e-5
 
 
-def _noop_filter(start: np.array, end: np.array) -> np.array:
+def _noop_filter(start: np.ndarray, end: np.ndarray) -> np.ndarray:
     return end
 
 
@@ -30,7 +30,7 @@ class ObjectControls(object):
         handle collisions
     """
 
-    move_filter_fn: Callable = attr.ib(default=_noop_filter)
+    move_filter_fn: Callable[..., Any] = attr.ib(default=_noop_filter)
 
     @staticmethod
     def is_body_action(action_name: str):

--- a/habitat_sim/agent/controls/object_controls.py
+++ b/habitat_sim/agent/controls/object_controls.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable
+from typing import Callable, Tuple, Union
 
 import attr
+import magnum as mn
 import numpy as np
 import quaternion  # noqa: F401
 
@@ -16,9 +17,10 @@ from habitat_sim.registry import registry
 
 # epislon used to deal with machine precision
 EPS = 1e-5
+_3d_point = Union[np.ndarray, mn.Vector3, Tuple[float, float, float]]
 
 
-def _noop_filter(start: np.ndarray, end: np.ndarray) -> np.ndarray:
+def _noop_filter(start: _3d_point, end: _3d_point) -> _3d_point:
     return end
 
 
@@ -30,7 +32,7 @@ class ObjectControls(object):
         handle collisions
     """
 
-    move_filter_fn: Callable[[np.ndarray, np.ndarray], np.ndarray] = attr.ib(
+    move_filter_fn: Callable[[_3d_point, _3d_point], _3d_point] = attr.ib(
         default=_noop_filter
     )
 

--- a/habitat_sim/agent/controls/pyrobot_noisy_controls.py
+++ b/habitat_sim/agent/controls/pyrobot_noisy_controls.py
@@ -12,7 +12,7 @@ https://github.com/facebookresearch/pyrobot
 Please cite PyRobot if you use this noise model
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union, cast
 
 import attr
 import magnum as mn
@@ -28,8 +28,8 @@ from habitat_sim.registry import registry
 
 @attr.s(auto_attribs=True)
 class _TruncatedMultivariateGaussian:
-    mean: np.array
-    cov: np.array
+    mean: Union[np.ndarray, Sequence[float]]
+    cov: Union[np.ndarray, Sequence[float]]
 
     def __attrs_post_init__(self):
         self.mean = np.array(self.mean)
@@ -52,7 +52,7 @@ class _TruncatedMultivariateGaussian:
 
         sample = np.zeros_like(self.mean)
         for i in range(len(self.mean)):
-            stdev = np.sqrt(self.cov[i, i])
+            stdev = np.sqrt(cast(np.ndarray, self.cov)[i, i])
             mean = self.mean[i]
             # Always truncate to 3 standard deviations
             a, b = -3, 3

--- a/habitat_sim/logging.py
+++ b/habitat_sim/logging.py
@@ -134,17 +134,17 @@ def check_failed(message):
         raise FailedCheckException(message)
     except FailedCheckException:
         log_record = logger.makeRecord(
-            "CRITICAL", 50, filename, line_num, message, None, None
+            "CRITICAL", 50, filename, line_num, message, None, None  # type: ignore
         )
         handler.handle(log_record)
 
         log_record = logger.makeRecord(
-            "DEBUG", 10, filename, line_num, "Check failed here:", None, None
+            "DEBUG", 10, filename, line_num, "Check failed here:", None, None  # type: ignore
         )
         handler.handle(log_record)
         for line in stacktrace_lines:
             log_record = logger.makeRecord(
-                "DEBUG", 10, filename, line_num, line, None, None
+                "DEBUG", 10, filename, line_num, line, None, None  # type: ignore
             )
             handler.handle(log_record)
         raise

--- a/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/habitat_sim/nav/greedy_geodesic_follower.py
@@ -6,7 +6,11 @@ import numpy as np
 from habitat_sim import errors, scene
 from habitat_sim.agent.agent import Agent
 from habitat_sim.agent.controls.controls import ActuationSpec
-from habitat_sim.nav import GreedyFollowerCodes, GreedyGeodesicFollowerImpl, PathFinder
+from habitat_sim.nav import (  # type: ignore
+    GreedyFollowerCodes,
+    GreedyGeodesicFollowerImpl,
+    PathFinder,
+)
 from habitat_sim.utils.common import quat_to_magnum
 
 

--- a/habitat_sim/registry.py
+++ b/habitat_sim/registry.py
@@ -69,7 +69,9 @@ class _Registry:
 
             cls._mapping["move_fn"][
                 _camel_to_snake(controller.__name__) if name is None else name
-            ] = controller(body_action)
+            ] = controller(
+                body_action
+            )  # type : ignore
 
             return controller
 

--- a/habitat_sim/registry.py
+++ b/habitat_sim/registry.py
@@ -38,7 +38,7 @@ class _Registry:
         controller: Optional[Type] = None,
         *,
         name: Optional[str] = None,
-        body_action: bool = None,
+        body_action: Optional[bool] = None,
     ):
         r"""Registers a new control with Habitat-Sim. Registered controls can
         then be retrieved via `get_move_fn()`
@@ -70,8 +70,8 @@ class _Registry:
             cls._mapping["move_fn"][
                 _camel_to_snake(controller.__name__) if name is None else name
             ] = controller(
-                body_action
-            )  # type : ignore
+                body_action  # type: ignore
+            )
 
             return controller
 

--- a/habitat_sim/sensors/noise_models/no_noise_model.py
+++ b/habitat_sim/sensors/noise_models/no_noise_model.py
@@ -6,6 +6,7 @@
 
 from typing import Union
 
+import attr
 import numpy as np
 from numpy import ndarray
 from torch import Tensor
@@ -21,7 +22,8 @@ except ImportError:
 
 
 @registry.register_noise_model(name="None")
-class NoSensorNoiseModel(SensorNoiseModel):
+@attr.s(auto_attribs=True)
+class NoSensorNoiseModel(SensorNoiseModel):  # type: ignore
     @staticmethod
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:
         return True

--- a/habitat_sim/sensors/noise_models/no_noise_model.py
+++ b/habitat_sim/sensors/noise_models/no_noise_model.py
@@ -23,7 +23,7 @@ except ImportError:
 
 @registry.register_noise_model(name="None")
 @attr.s(auto_attribs=True)
-class NoSensorNoiseModel(SensorNoiseModel):  # type: ignore
+class NoSensorNoiseModel(SensorNoiseModel):
     @staticmethod
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:
         return True

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -128,7 +128,7 @@ class Simulator(SimulatorBackend):
     def __enter__(self) -> "Simulator":
         return self
 
-    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
     def seed(self, new_seed: int) -> None:

--- a/habitat_sim/utils/common.py
+++ b/habitat_sim/utils/common.py
@@ -6,7 +6,7 @@
 
 import math
 from io import BytesIO
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -15,7 +15,7 @@ import numpy as np
 import quaternion
 
 
-def quat_from_coeffs(coeffs: np.ndarray) -> np.quaternion:
+def quat_from_coeffs(coeffs: Sequence[float]) -> np.quaternion:
     r"""Creates a quaternion from the coeffs returned by the simulator backend
 
     :param coeffs: Coefficients of a quaternion in :py:`[b, c, d, a]` format,

--- a/habitat_sim/utils/compare_profiles.py
+++ b/habitat_sim/utils/compare_profiles.py
@@ -47,7 +47,7 @@ import sqlite3
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from sqlite3 import Connection
-from typing import Any, DefaultDict, Dict, List, Set, Union
+from typing import Any, DefaultDict, Dict, List, Optional, Set, Union
 
 import attr
 
@@ -169,7 +169,7 @@ def _display_time_ms(time: int, args: Namespace, show_sign: bool = False) -> str
 def print_summaries(
     summaries: Union[List[DefaultDict[str, SummaryItem]], List[DefaultDict[Any, Any]]],
     args: Namespace,
-    labels: None = None,
+    labels: Optional[List[str]] = None,
 ) -> None:
     """Print a dictionary of summaries to stdout. See create_arg_parser for
     formatting options available in the args object. See also

--- a/habitat_sim/utils/data/pose_extractor.py
+++ b/habitat_sim/utils/data/pose_extractor.py
@@ -85,7 +85,7 @@ class PoseExtractor:
         self,
         poses: List[Tuple[Tuple[int, int], Tuple[int, int], str]],
         ref_point: Tuple[float32, float32, float32],
-    ) -> List[Tuple[ndarray, quaternion, str]]:
+    ) -> List[Tuple[Union[np.ndarray, Tuple[int, int]], quaternion, str]]:
         # Convert from topdown map coordinate system to that of the scene
         startw, starty, starth = ref_point
         for i, pose in enumerate(poses):

--- a/habitat_sim/utils/viz_utils.py
+++ b/habitat_sim/utils/viz_utils.py
@@ -95,7 +95,7 @@ def display_video(video_file: str, height: int = 400):
         )
     else:
         if sys.platform == "win32":
-            os.startfile(video_file)
+            os.startfile(video_file)  # type: ignore
         else:
             opener = "open" if sys.platform == "darwin" else "xdg-open"
             subprocess.call([opener, video_file])


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We have static type guarding, now we can use pytest to do runtime typeguarding too (only when pytest is run). 
It also caught a few minor typing bugs (with lists/ndarrays) used interchangably that have now been fixed.

This will only check if any existing typehints are used incorrectly. (Ex passing a list when it expects a numpy array etc).
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Typeguard and pytest
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
