### PR TITLE
[bug fix][PBR 1] Ignore normal maps with a warning for meshes without tangents

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1599,13 +1599,15 @@ void ResourceManager::addComponent(
 
     gfx::Drawable::Flags meshAttributeFlags{};
     const auto& meshData = meshes_[meshID]->getMeshData();
-    if (meshData != Cr::Containers::NullOpt &&
-        meshData->hasAttribute(Mn::Trade::MeshAttribute::Tangent)) {
-      meshAttributeFlags |= gfx::Drawable::Flag::HasTangent;
-    }
-    if (meshData != Cr::Containers::NullOpt &&
-        meshData->hasAttribute(Mn::Trade::MeshAttribute::Bitangent)) {
-      meshAttributeFlags |= gfx::Drawable::Flag::HasSeparateBitangent;
+    if (meshData != Cr::Containers::NullOpt) {
+      if (meshData->hasAttribute(Mn::Trade::MeshAttribute::Tangent)) {
+        meshAttributeFlags |= gfx::Drawable::Flag::HasTangent;
+
+        // if it has tangent, then check if it has bitangent
+        if (meshData->hasAttribute(Mn::Trade::MeshAttribute::Bitangent)) {
+          meshAttributeFlags |= gfx::Drawable::Flag::HasSeparateBitangent;
+        }
+      }
     }
     createGenericDrawable(mesh,                // render mesh
                           meshAttributeFlags,  // mesh attribute flags

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1660,9 +1660,13 @@ void ResourceManager::createGenericDrawable(
     const Mn::ResourceKey& lightSetupKey,
     const Mn::ResourceKey& materialKey,
     DrawableGroup* group /* = nullptr */) {
-  node.addFeature<gfx::GenericDrawable>(mesh, meshAttributeFlags,
-                                        shaderManager_, lightSetupKey,
-                                        materialKey, group);
+  node.addFeature<gfx::GenericDrawable>(
+      mesh,                // render mesh
+      meshAttributeFlags,  // mesh attribute flags
+      shaderManager_,      // shader manager
+      lightSetupKey,       // kightSetup key
+      materialKey,         // material key
+      group);              // drawable group
 }
 
 bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1090,9 +1090,15 @@ bool ResourceManager::loadGeneralMeshData(
      // TODO: cache visual nodes added by this process
   std::vector<scene::SceneNode*> visNodeCache;
   std::vector<StaticDrawableInfo> staticDrawableInfo;
-  addComponent(meshMetaData, newNode, lightSetupKey, drawables,
-               meshMetaData.root, visNodeCache, computeAbsoluteAABBs,
-               staticDrawableInfo);
+
+  addComponent(meshMetaData,       // mesh metadata
+               newNode,            // parent scene node
+               lightSetupKey,      // lightSetup key
+               drawables,          // drawble group
+               meshMetaData.root,  // mesh transform node
+               visNodeCache,       // a vector of scene nodes, the visNodeCache
+               computeAbsoluteAABBs,  // compute absolute aabbs
+               staticDrawableInfo);   // a vector of static drawable info
   if (computeAbsoluteAABBs) {
     // now compute aabbs by constructed staticDrawableInfo
     computeGeneralMeshAbsoluteAABBs(staticDrawableInfo);
@@ -1541,10 +1547,14 @@ void ResourceManager::addObjectToDrawables(
     // ignored for objects since computeAbsoluteAABBs is always set to false
     // after scene is loaded.
     std::vector<StaticDrawableInfo> staticDrawableInfo;
-
-    addComponent(loadedAssetData.meshMetaData, scalingNode, lightSetupKey,
-                 drawables, loadedAssetData.meshMetaData.root, visNodeCache,
-                 false, staticDrawableInfo);
+    addComponent(loadedAssetData.meshMetaData,       // mesh metadata
+                 scalingNode,                        // parent scene node
+                 lightSetupKey,                      // lightSetup key
+                 drawables,                          // drawable group
+                 loadedAssetData.meshMetaData.root,  // mesh transform node
+                 visNodeCache,  // a vector of scene nodes, the visNodeCache
+                 false,         // compute absolute AABBs
+                 staticDrawableInfo);  // a vector of static drawable info
 
     // set the node type for all cached visual nodes
     for (auto node : visNodeCache) {
@@ -1611,8 +1621,14 @@ void ResourceManager::addComponent(
 
   // Recursively add children
   for (auto& child : meshTransformNode.children) {
-    addComponent(metaData, node, lightSetupKey, drawables, child, visNodeCache,
-                 computeAbsoluteAABBs, staticDrawableInfo);
+    addComponent(metaData,       // mesh metadata
+                 node,           // parent scene node
+                 lightSetupKey,  // lightSetup key
+                 drawables,      // drawable group
+                 child,          // mesh transform node
+                 visNodeCache,   // a vector of scene nodes, the visNodeCache
+                 computeAbsoluteAABBs,  // compute absolute aabbs
+                 staticDrawableInfo);   // a vector of static drawable info
   }
 }  // addComponent
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -892,7 +892,7 @@ bool ResourceManager::loadInstanceMeshData(
       }
       if (meshes_[iMesh]->getMeshData()->hasAttribute(
               Mn::Trade::MeshAttribute::Bitangent)) {
-        meshAttributeFlags |= gfx::Drawable::Flag::HasBitangent;
+        meshAttributeFlags |= gfx::Drawable::Flag::HasSeparateBitangent;
       }
 
       createGenericDrawable(
@@ -1603,7 +1603,7 @@ void ResourceManager::addComponent(
     }
     if (meshes_[meshID]->getMeshData()->hasAttribute(
             Mn::Trade::MeshAttribute::Bitangent)) {
-      meshAttributeFlags |= gfx::Drawable::Flag::HasBitangent;
+      meshAttributeFlags |= gfx::Drawable::Flag::HasSeparateBitangent;
     }
     createGenericDrawable(mesh,                // render mesh
                           meshAttributeFlags,  // mesh attribute flags

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -29,6 +29,7 @@
 #include "GenericMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
+#include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
 #include "esp/gfx/MaterialData.h"
 #include "esp/gfx/ShaderManager.h"
@@ -324,7 +325,7 @@ class ResourceManager {
    * child.
    * @param drawables The @ref DrawableGroup with which the object @ref
    * gfx::Drawable will be rendered.
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the added component.
    * @param[out] visNodeCache Cache for pointers to all nodes created as the
    * result of this process.
@@ -333,14 +334,14 @@ class ResourceManager {
                             scene::SceneNode* parent,
                             DrawableGroup* drawables,
                             std::vector<scene::SceneNode*>& visNodeCache,
-                            const Mn::ResourceKey& lightSetup = Mn::ResourceKey{
-                                DEFAULT_LIGHTING_KEY}) {
+                            const Mn::ResourceKey& lightSetupKey =
+                                Mn::ResourceKey{DEFAULT_LIGHTING_KEY}) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           objectAttributesManager_->getObjectHandleByID(objTemplateLibID);
 
       addObjectToDrawables(objTemplateHandleName, parent, drawables,
-                           visNodeCache, lightSetup);
+                           visNodeCache, lightSetupKey);
     }  // else objTemplateID does not exist - shouldn't happen
   }    // addObjectToDrawables
 
@@ -360,7 +361,7 @@ class ResourceManager {
    * child.
    * @param drawables The @ref DrawableGroup with which the object @ref
    * gfx::Drawable will be rendered.
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the added component.
    * @param[out] visNodeCache Cache for pointers to all nodes created as the
    * result of this process.
@@ -369,8 +370,8 @@ class ResourceManager {
                             scene::SceneNode* parent,
                             DrawableGroup* drawables,
                             std::vector<scene::SceneNode*>& visNodeCache,
-                            const Mn::ResourceKey& lightSetup = Mn::ResourceKey{
-                                DEFAULT_LIGHTING_KEY});
+                            const Mn::ResourceKey& lightSetupKey =
+                                Mn::ResourceKey{DEFAULT_LIGHTING_KEY});
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref
@@ -496,7 +497,7 @@ class ResourceManager {
    * the meshes, textures, materials, and component heirarchy of the asset.
    * @param parent The @ref scene::SceneNode of which the component will be a
    * child.
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the added component.
    * @param drawables The @ref DrawableGroup with which the component will be
    * rendered.
@@ -509,7 +510,7 @@ class ResourceManager {
    */
   void addComponent(const MeshMetaData& metaData,
                     scene::SceneNode& parent,
-                    const Mn::ResourceKey& lightSetup,
+                    const Mn::ResourceKey& lightSetupKey,
                     DrawableGroup* drawables,
                     const MeshTransformNode& meshTransformNode,
                     std::vector<scene::SceneNode*>& visNodeCache,
@@ -619,7 +620,7 @@ class ResourceManager {
    * computed
    * @param splitSemanticMesh Split the semantic mesh by objectID, used for A/B
    * testing
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the loaded asset.
    */
   bool loadStageInternal(const AssetInfo& info,
@@ -627,7 +628,7 @@ class ResourceManager {
                          DrawableGroup* drawables = nullptr,
                          bool computeAbsoluteAABBs = false,
                          bool splitSemanticMesh = true,
-                         const Mn::ResourceKey& lightSetup = Mn::ResourceKey{
+                         const Mn::ResourceKey& lightSetupKey = Mn::ResourceKey{
                              NO_LIGHT_KEY});
 
   /**
@@ -704,15 +705,15 @@ class ResourceManager {
    * rendered.
    * @param computeAbsoluteAABBs Whether absolute bounding boxes should be
    * computed
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the loaded asset.
    */
-  bool loadGeneralMeshData(const AssetInfo& info,
-                           scene::SceneNode* parent = nullptr,
-                           DrawableGroup* drawables = nullptr,
-                           bool computeAbsoluteAABBs = false,
-                           const Mn::ResourceKey& lightSetup = Mn::ResourceKey{
-                               NO_LIGHT_KEY});
+  bool loadGeneralMeshData(
+      const AssetInfo& info,
+      scene::SceneNode* parent = nullptr,
+      DrawableGroup* drawables = nullptr,
+      bool computeAbsoluteAABBs = false,
+      const Mn::ResourceKey& lightSetupKey = Mn::ResourceKey{NO_LIGHT_KEY});
 
   /**
    * @brief Load a SUNCG mesh into assets from a file. !Deprecated! TODO:
@@ -742,7 +743,7 @@ class ResourceManager {
    * @brief Checks if light setup is compatible with loaded asset
    */
   bool isLightSetupCompatible(const LoadedAssetData& loadedAssetData,
-                              const Mn::ResourceKey& lightSetup) const;
+                              const Mn::ResourceKey& lightSetupKey) const;
 
   // ======== Geometry helper functions, data structures ========
 
@@ -806,9 +807,10 @@ class ResourceManager {
    * the
    * @ref gfx::Drawable.
    * @param mesh The render mesh.
+   * @param meshAttributeFlags flags for the attributes of the render mesh
    * @param node The @ref scene::SceneNode to which the drawable will be
    * attached.
-   * @param lightSetup The @ref LightSetup key that will be used
+   * @param lightSetupKey The @ref LightSetup key that will be used
    * for the drawable.
    * @param material The @ref MaterialData key that will be used
    * for the drawable.
@@ -821,8 +823,9 @@ class ResourceManager {
    * white.
    */
   void createGenericDrawable(Mn::GL::Mesh& mesh,
+                             gfx::Drawable::Flags& meshAttributeFlags,
                              scene::SceneNode& node,
-                             const Mn::ResourceKey& lightSetup,
+                             const Mn::ResourceKey& lightSetupKey,
                              const Mn::ResourceKey& material,
                              DrawableGroup* group = nullptr);
 

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -39,7 +39,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
     /**
      * indicates the mesh data has separate bi-tangent attribute
      */
-    HasBitangent = 1 << 1
+    HasSeparateBitangent = 1 << 1
   };
   /** @brief Flags */
   typedef Corrade::Containers::EnumSet<Flag> Flags;

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -106,6 +106,8 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
   Magnum::GL::Mesh& mesh_;
 };
 
+CORRADE_ENUMSET_OPERATORS(Drawable::Flags)
+
 }  // namespace gfx
 }  // namespace esp
 

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -5,6 +5,8 @@
 #ifndef ESP_GFX_DRAWABLE_H_
 #define ESP_GFX_DRAWABLE_H_
 
+#include <Corrade/Containers/EnumSet.h>
+
 #include "esp/core/esp.h"
 #include "magnum.h"
 
@@ -24,6 +26,24 @@ class DrawableGroup;
  */
 class Drawable : public Magnum::SceneGraph::Drawable3D {
  public:
+  /** @brief Flag
+   * It will not be used directly in the base class "Drawable" but
+   * it will be used in a couple of sub-classes
+   */
+  enum class Flag {
+    /**
+     * indicates the mesh data has tangent attribute
+     */
+    HasTangent = 1 << 0,
+
+    /**
+     * indicates the mesh data has separate bi-tangent attribute
+     */
+    HasBitangent = 1 << 1
+  };
+  /** @brief Flags */
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+
   /**
    * @brief Constructor
    *

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -44,7 +44,7 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
   if (materialData_->normalTexture) {
     if (meshAttributeFlags & Drawable::Flag::HasTangent) {
       flags_ |= Mn::Shaders::Phong::Flag::NormalTexture;
-      if (meshAttributeFlags & Drawable::Flag::HasBitangent) {
+      if (meshAttributeFlags & Drawable::Flag::HasSeparateBitangent) {
         flags_ |= Mn::Shaders::Phong::Flag::Bitangent;
       }
     } else {

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -20,14 +20,14 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
                                  Mn::GL::Mesh& mesh,
                                  Drawable::Flags& meshAttributeFlags,
                                  ShaderManager& shaderManager,
-                                 const Mn::ResourceKey& lightSetup,
-                                 const Mn::ResourceKey& materialData,
+                                 const Mn::ResourceKey& lightSetupKey,
+                                 const Mn::ResourceKey& materialDataKey,
                                  DrawableGroup* group /* = nullptr */)
     : Drawable{node, mesh, group},
       shaderManager_{shaderManager},
-      lightSetup_{shaderManager.get<LightSetup>(lightSetup)},
+      lightSetup_{shaderManager.get<LightSetup>(lightSetupKey)},
       materialData_{
-          shaderManager.get<MaterialData, PhongMaterialData>(materialData)} {
+          shaderManager.get<MaterialData, PhongMaterialData>(materialDataKey)} {
   flags_ = Mn::Shaders::Phong::Flag::ObjectId;
   if (materialData_->textureMatrix != Mn::Matrix3{}) {
     flags_ |= Mn::Shaders::Phong::Flag::TextureTransformation;

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -48,8 +48,8 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
         flags_ |= Mn::Shaders::Phong::Flag::Bitangent;
       }
     } else {
-      LOG(ERROR) << "Mesh does not have tangents and Magnum cannot generate "
-                    "them yet, ignoring a normal map";
+      LOG(WARNING) << "Mesh does not have tangents and Magnum cannot generate "
+                      "them yet, ignoring a normal map";
     }
   }
   if (materialData_->perVertexObjectId) {

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -22,11 +22,11 @@ class GenericDrawable : public Drawable {
                            Magnum::GL::Mesh& mesh,
                            Drawable::Flags& meshAttributeFlags,
                            ShaderManager& shaderManager,
-                           const Magnum::ResourceKey& lightSetup,
-                           const Magnum::ResourceKey& materialData,
+                           const Magnum::ResourceKey& lightSetupKey,
+                           const Magnum::ResourceKey& materialDataKey,
                            DrawableGroup* group = nullptr);
 
-  void setLightSetup(const Magnum::ResourceKey& lightSetup) override;
+  void setLightSetup(const Magnum::ResourceKey& lightSetupKey) override;
   static constexpr const char* SHADER_KEY_TEMPLATE = "Phong-lights={}-flags={}";
 
  protected:

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -20,6 +20,7 @@ class GenericDrawable : public Drawable {
   //! color for textured buffer and color shader output respectively
   explicit GenericDrawable(scene::SceneNode& node,
                            Magnum::GL::Mesh& mesh,
+                           Drawable::Flags& meshAttributeFlags,
                            ShaderManager& shaderManager,
                            const Magnum::ResourceKey& lightSetup,
                            const Magnum::ResourceKey& materialData,
@@ -49,6 +50,8 @@ class GenericDrawable : public Drawable {
       shader_;
   Magnum::Resource<MaterialData, PhongMaterialData> materialData_;
   Magnum::Resource<LightSetup> lightSetup_;
+
+  Magnum::Shaders::Phong::Flags flags_;
 };
 
 }  // namespace gfx

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -80,9 +80,11 @@ void DrawableTest::addRemoveDrawables() {
 
   esp::scene::SceneNode& node = sceneRootNode.createChild();
 
+  esp::gfx::Drawable::Flags meshAttributeFlags{};
+
   // add a toy box here!
   node.addFeature<esp::gfx::GenericDrawable>(
-      box, resourceManager_->getShaderManager(),
+      box, meshAttributeFlags, resourceManager_->getShaderManager(),
       esp::assets::ResourceManager::NO_LIGHT_KEY,
       esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       drawableGroup_);
@@ -94,6 +96,7 @@ void DrawableTest::addRemoveDrawables() {
   esp::gfx::GenericDrawable* dr = new esp::gfx::GenericDrawable{
       node,
       box,
+      meshAttributeFlags,
       resourceManager_->getShaderManager(),
       esp::assets::ResourceManager::NO_LIGHT_KEY,
       esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
@@ -109,6 +112,7 @@ void DrawableTest::addRemoveDrawables() {
   dr = new esp::gfx::GenericDrawable{
       node,
       box,
+      meshAttributeFlags,
       resourceManager_->getShaderManager(),
       esp::assets::ResourceManager::NO_LIGHT_KEY,
       esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
@@ -135,6 +139,7 @@ void DrawableTest::addRemoveDrawables() {
   dr = new esp::gfx::GenericDrawable{
       node,
       box,
+      meshAttributeFlags,
       resourceManager_->getShaderManager(),
       esp::assets::ResourceManager::NO_LIGHT_KEY,
       esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,


### PR DESCRIPTION
## Motivation and Context

First, this diff fixes a bug. Now it will ignore the normal maps with a warning for meshes without tangents. This is quite similar to:
https://github.com/mosra/magnum-extras/commit/ad06e1ab741cb62eff43bf1b3de3be679d4a1610

Second, it improves the code readability  by changing 
```
lightSetup --> lightSetupKey
material --> materialKey
```
in a number of places.

Third, this is the 1st diff to implement the PBR. (I am going to split the giant PR #812 into many small PRs to make the reviewers' life a bit easier.)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
