### PR TITLE
Use normalMatrix in the GenericDrawable

### DIFF
--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -49,7 +49,8 @@ void GenericDrawable::updateShaderLightingParameters(
   lightColors.reserve(lightSetup_->size());
   std::vector<Mn::Color3> lightSpecularColors;
   lightSpecularColors.reserve(lightSetup_->size());
-  constexpr float dummyRange = 10000;
+  constexpr float dummyRange = Mn::Constants::inf();
+  ;
   std::vector<float> lightRanges(lightSetup_->size(), dummyRange);
   const Mn::Color4 ambientLightColor = getAmbientLightColor(*lightSetup_);
 
@@ -95,7 +96,7 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
               : (materialData_->perVertexObjectId ? 0 : node_.getSemanticId()))
       .setTransformationMatrix(transformationMatrix)
       .setProjectionMatrix(camera.projectionMatrix())
-      .setNormalMatrix(transformationMatrix.rotationScaling());
+      .setNormalMatrix(transformationMatrix.normalMatrix());
 
   if (materialData_->textureMatrix != Mn::Matrix3{})
     shader_->setTextureMatrix(materialData_->textureMatrix);

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -40,9 +40,6 @@ class GenericDrawable : public Drawable {
   Magnum::ResourceKey getShaderKey(Magnum::UnsignedInt lightCount,
                                    Magnum::Shaders::Phong::Flags flags) const;
 
-  Magnum::GL::Texture2D* texture_;
-  Magnum::Color4 color_;
-
   // shader parameters
   ShaderManager& shaderManager_;
   Magnum::Resource<Magnum::GL::AbstractShaderProgram, Magnum::Shaders::Phong>


### PR DESCRIPTION
## Motivation and Context
- Use `normalMatrix()` in the GenericDrawable;
- Light range is set to `Mn::Constants::inf()`;
- Remove not used variables;

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
