### PR TITLE
Unify RigidObject construction pipeline and MotionType treatment.

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -46,16 +46,9 @@ BulletRigidObject::~BulletRigidObject() {
     activateCollisionIsland();
   }
 
-  if (objectMotionType_ != MotionType::STATIC) {
-    // remove rigid body from the world
-    bWorld_->removeRigidBody(bObjectRigidBody_.get());
-  } else if (objectMotionType_ == MotionType::STATIC) {
-    // remove collision objects from the world
-    for (auto& co : bStaticCollisionObjects_) {
-      bWorld_->removeRigidBody(co.get());
-      collisionObjToObjIds_->erase(co.get());
-    }
-  }
+  // remove rigid body from the world
+  bWorld_->removeRigidBody(bObjectRigidBody_.get());
+
   collisionObjToObjIds_->erase(bObjectRigidBody_.get());
 
 }  //~BulletRigidObject
@@ -127,12 +120,10 @@ bool BulletRigidObject::initialization_LibSpecific(
   bObjectShape_->setMargin(margin);
 
   bObjectShape_->setLocalScaling(btVector3{tmpAttr->getScale()});
-
+  bObjectShape_->recalculateLocalAabb();
   // create the bObjectRigidBody_
-  constructRigidBody(false);
+  constructAndAddRigidBody(objectMotionType_);
 
-  //! Add to world
-  bWorld_->addRigidBody(bObjectRigidBody_.get());
   return true;
 }  // initialization_LibSpecific
 
@@ -246,6 +237,10 @@ void BulletRigidObject::constructBulletCompoundFromMeshes(
         bObjectConvexShapes_.back()->addPoint(
             btVector3(transformFromLocalToWorld.transformPoint(v)), false);
       }
+      bObjectConvexShapes_.back()->optimizeConvexHull();
+      bObjectConvexShapes_.back()->initializePolyhedralFeatures();
+      // Remove local convex margin in favor of margin on the containing
+      // compound
       bObjectConvexShapes_.back()->setMargin(0.0);
       bObjectConvexShapes_.back()->recalcLocalAabb();
       //! Add to compound shape stucture
@@ -285,61 +280,18 @@ void BulletRigidObject::setCollisionFromBB() {
 }  // setCollisionFromBB
 
 bool BulletRigidObject::setMotionType(MotionType mt) {
+  if (mt == MotionType::ERROR_MOTIONTYPE) {
+    return false;
+  }
   if (mt == objectMotionType_) {
     return true;  // no work
   }
 
   // remove the existing object from the world to change its type
-  if (objectMotionType_ == MotionType::STATIC) {
-    bWorld_->removeRigidBody(bStaticCollisionObjects_.back().get());
-    collisionObjToObjIds_->erase(bStaticCollisionObjects_.back().get());
-    bStaticCollisionObjects_.clear();
-  } else {
-    bWorld_->removeRigidBody(bObjectRigidBody_.get());
-  }
-
-  if (mt == MotionType::KINEMATIC) {
-    if (!(bObjectRigidBody_->getCollisionFlags() &
-          btCollisionObject::CF_KINEMATIC_OBJECT)) {
-      // we need to construct a new rigidBody configured for kinematics
-      constructRigidBody(true);
-    }
-    objectMotionType_ = MotionType::KINEMATIC;
-    bWorld_->addRigidBody(bObjectRigidBody_.get());
-    setActive();
-    return true;
-  } else if (mt == MotionType::STATIC) {
-    objectMotionType_ = MotionType::STATIC;
-
-    // mass == 0 to indicate static. See isStaticObject assert below. See also
-    // examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
-    btVector3 localInertia(0, 0, 0);
-    btRigidBody::btRigidBodyConstructionInfo cInfo(
-        /*mass*/ 0.0, nullptr, bObjectShape_.get(), localInertia);
-    cInfo.m_startWorldTransform = bObjectRigidBody_->getWorldTransform();
-    std::unique_ptr<btRigidBody> staticCollisionObject =
-        std::make_unique<btRigidBody>(cInfo);
-    ASSERT(staticCollisionObject->isStaticObject());
-    bWorld_->addRigidBody(
-        staticCollisionObject.get(),
-        2,       // collisionFilterGroup (2 == StaticFilter)
-        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
-    collisionObjToObjIds_->emplace(staticCollisionObject.get(), objectId_);
-    bStaticCollisionObjects_.emplace_back(std::move(staticCollisionObject));
-    return true;
-  } else if (mt == MotionType::DYNAMIC) {
-    if (bObjectRigidBody_->getCollisionFlags() &
-        btCollisionObject::CF_KINEMATIC_OBJECT) {
-      // we need to construct a new rigidBody configured for dynamics
-      constructRigidBody(false);
-    }
-    objectMotionType_ = MotionType::DYNAMIC;
-    bWorld_->addRigidBody(bObjectRigidBody_.get());
-    setActive();
-    return true;
-  }
-
-  return false;
+  bWorld_->removeRigidBody(bObjectRigidBody_.get());
+  constructAndAddRigidBody(mt);
+  objectMotionType_ = mt;
+  return true;
 }  // setMotionType
 
 void BulletRigidObject::shiftOrigin(const Magnum::Vector3& shift) {
@@ -365,13 +317,13 @@ void BulletRigidObject::syncPose() {
       btTransform(node().transformationMatrix()));
 }  // syncPose
 
-void BulletRigidObject::constructRigidBody(bool kinematic) {
+void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   // get this object's creation template, appropriately cast
   auto tmpAttr = getInitializationAttributes();
 
   double mass = 0;
   btVector3 bInertia = {0, 0, 0};
-  if (!kinematic) {
+  if (mt == MotionType::DYNAMIC) {
     mass = tmpAttr->getMass();
     bInertia = btVector3(tmpAttr->getInertia());
     if (bInertia == btVector3{0, 0, 0}) {
@@ -382,14 +334,19 @@ void BulletRigidObject::constructRigidBody(bool kinematic) {
   }
 
   //! Bullet rigid body setup
+  auto motionState = (mt == MotionType::STATIC) ? nullptr : &(btMotionState());
+
   btRigidBody::btRigidBodyConstructionInfo info =
-      btRigidBody::btRigidBodyConstructionInfo(mass, &(btMotionState()),
+      btRigidBody::btRigidBodyConstructionInfo(mass, motionState,
                                                bObjectShape_.get(), bInertia);
 
   info.m_friction = tmpAttr->getFrictionCoefficient();
   info.m_restitution = tmpAttr->getRestitutionCoefficient();
   info.m_linearDamping = tmpAttr->getLinearDamping();
   info.m_angularDamping = tmpAttr->getAngularDamping();
+  if (bObjectRigidBody_ != nullptr) {
+    info.m_startWorldTransform = bObjectRigidBody_->getWorldTransform();
+  }
 
   //! Create rigid body
   if (collisionObjToObjIds_->count(bObjectRigidBody_.get())) {
@@ -398,22 +355,30 @@ void BulletRigidObject::constructRigidBody(bool kinematic) {
   bObjectRigidBody_ = std::make_unique<btRigidBody>(info);
   collisionObjToObjIds_->emplace(bObjectRigidBody_.get(), objectId_);
 
-  // set the
-  if (kinematic) {
+  if (mt == MotionType::KINEMATIC) {
     bObjectRigidBody_->setCollisionFlags(
         bObjectRigidBody_->getCollisionFlags() |
         btCollisionObject::CF_KINEMATIC_OBJECT);
+    ASSERT(bObjectRigidBody_->isKinematicObject());
   }
-  syncPose();
+
+  // add the object to the world
+  if (mt == MotionType::STATIC) {
+    ASSERT(bObjectRigidBody_->isStaticObject());
+    bWorld_->addRigidBody(
+        bObjectRigidBody_.get(),
+        2,       // collisionFilterGroup (2 == StaticFilter)
+        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
+  } else {
+    bWorld_->addRigidBody(bObjectRigidBody_.get());
+    setActive();
+  }
 }
 
 void BulletRigidObject::activateCollisionIsland() {
   // activate nearby objects in the simulation island as computed on the
   // previous collision detection pass
   btCollisionObject* thisColObj = bObjectRigidBody_.get();
-  if (getMotionType() == MotionType::STATIC) {
-    thisColObj = bStaticCollisionObjects_.back().get();
-  }
   auto& colObjs = bWorld_->getCollisionWorld()->getCollisionObjectArray();
   for (auto objIx = 0; objIx < colObjs.size(); ++objIx) {
     if (colObjs[objIx]->getIslandTag() == thisColObj->getIslandTag()) {

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -334,7 +334,7 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   }
 
   //! Bullet rigid body setup
-  auto motionState = (mt == MotionType::STATIC) ? nullptr : &(btMotionState());
+  auto motionState = (mt == MotionType::STATIC) ? nullptr : &(this->btMotionState());
 
   btRigidBody::btRigidBodyConstructionInfo info =
       btRigidBody::btRigidBodyConstructionInfo(mass, motionState,

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -237,8 +237,8 @@ void BulletRigidObject::constructBulletCompoundFromMeshes(
         bObjectConvexShapes_.back()->addPoint(
             btVector3(transformFromLocalToWorld.transformPoint(v)), false);
       }
-      bObjectConvexShapes_.back()->optimizeConvexHull();
-      bObjectConvexShapes_.back()->initializePolyhedralFeatures();
+      // bObjectConvexShapes_.back()->optimizeConvexHull();
+      // bObjectConvexShapes_.back()->initializePolyhedralFeatures();
       // Remove local convex margin in favor of margin on the containing
       // compound
       bObjectConvexShapes_.back()->setMargin(0.0);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -229,6 +229,7 @@ void BulletRigidObject::constructBulletCompoundFromMeshes(
         bObjectConvexShapes_.back()->addPoint(
             btVector3(transformFromLocalToWorld.transformPoint(v)), false);
       }
+
     } else {
       bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>());
       // transform points into world space, including any scale/shear in
@@ -334,7 +335,8 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   }
 
   //! Bullet rigid body setup
-  auto motionState = (mt == MotionType::STATIC) ? nullptr : &(this->btMotionState());
+  auto motionState =
+      (mt == MotionType::STATIC) ? nullptr : &(this->btMotionState());
 
   btRigidBody::btRigidBodyConstructionInfo info =
       btRigidBody::btRigidBodyConstructionInfo(mass, motionState,

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -294,7 +294,7 @@ class BulletRigidObject : public BulletBase,
    * @param linVel Linear velocity to set.
    */
   void setLinearVelocity(const Magnum::Vector3& linVel) override {
-    if (objectMotionType_ == MotionType::DYNAMIC) {
+    if (objectMotionType_ != MotionType::STATIC) {
       setActive();
       bObjectRigidBody_->setLinearVelocity(btVector3(linVel));
     }
@@ -310,7 +310,7 @@ class BulletRigidObject : public BulletBase,
    * angles.
    */
   void setAngularVelocity(const Magnum::Vector3& angVel) override {
-    if (objectMotionType_ == MotionType::DYNAMIC) {
+    if (objectMotionType_ != MotionType::STATIC) {
       setActive();
       bObjectRigidBody_->setAngularVelocity(btVector3(angVel));
     }
@@ -440,10 +440,10 @@ class BulletRigidObject : public BulletBase,
   void syncPose() override;
 
   /**
-   * @brief construct a @ref btRigidBody for this object configured for either
-   * kinematics or dynamics.
+   * @brief construct a @ref btRigidBody for this object configured by
+   * MotionType and add it to the world.
    */
-  void constructRigidBody(bool kinematic = false);
+  void constructAndAddRigidBody(MotionType mt);
 
   /**
    * @brief Iterate through all collision objects and active all objects sharing

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -246,9 +246,9 @@ def test_dynamics():
             test_lin_vel = np.array([1.0, 0.0, 0.0])
             test_ang_vel = np.array([0.0, 1.0, 0.0])
 
-            # no velocity setting for KINEMATIC objects
+            # velocity setting for KINEMATIC objects won't be simulated, but will be recorded for bullet internal usage.
             sim.set_linear_velocity(test_lin_vel, object2_id)
-            assert sim.get_linear_velocity(object2_id) == np.array([0.0, 0.0, 0.0])
+            assert sim.get_linear_velocity(object2_id) == test_lin_vel
 
             sim.set_object_motion_type(
                 habitat_sim.physics.MotionType.DYNAMIC, object2_id


### PR DESCRIPTION
## Motivation and Context

Recent changes brought all MotionTypes into the `btRigidBody` API. This PR cleans up unnecessary separate treatment and unifies the construction pipeline.


Note: some changes to existing physical simulation results are expected as `STATIC` objects will now have the properly configured friction, restitution, and damping.

Velocity setting for KINEMATIC objects is allowed. These will not be integrated, but may improve Bullet internal contact response with DYNAMIC objects.

## How Has This Been Tested

All tests should still pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
