### PR TITLE
add BulletDebugManager

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -302,8 +302,20 @@ void initSimBindings(py::module& m) {
       .def("get_existing_joint_motors", &Simulator::getExistingJointMotors,
            "object_id"_a)
       .def("create_motors_for_all_dofs", &Simulator::createMotorsForAllDofs,
-           "object_id"_a, "settings"_a = esp::physics::JointMotorSettings());
-  ;
+           "object_id"_a, "settings"_a = esp::physics::JointMotorSettings())
+
+      .def(
+          "get_physics_num_active_contact_points",
+          &Simulator::getPhysicsNumActiveContactPoints,
+          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
+      .def(
+          "get_physics_num_active_overlapping_pairs",
+          &Simulator::getPhysicsNumActiveOverlappingPairs,
+          R"(The number of active overlapping pairs during the last step. When object bounding boxes overlap and either object is active, additional "narrowphase" collision-detection must be run. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
+      .def(
+          "get_physics_step_collision_summary",
+          &Simulator::getPhysicsStepCollisionSummary,
+          R"(Get a summary of collision-processing from the last physics step.)");
 }
 
 }  // namespace sim

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1120,6 +1120,10 @@ class PhysicsManager {
     return existingArticulatedObjects_.at(objectId)->getMotionType();
   };
 
+  virtual int getNumActiveContactPoints() { return -1; }
+  virtual int getNumActiveOverlappingPairs() { return -1; }
+  virtual std::string getStepCollisionSummary() { return "not implemented"; }
+
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an
    * existing object). Terminate the program and report an error if not. This

--- a/src/esp/physics/bullet/BulletDebugManager.cpp
+++ b/src/esp/physics/bullet/BulletDebugManager.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.h"
+
+#include "BulletDebugManager.h"
+
+#include <sstream>
+
+namespace esp {
+namespace physics {
+
+void BulletDebugManager::mapCollisionObjectTo(const btCollisionObject* colObj,
+                                              const std::string& debugName) {
+  collisionObjectToDebugName_[colObj] = debugName;
+
+  // reference code for debugging
+  // std::cout << debugName << ": " << ((void*)(colObj)) << std::endl;
+}
+
+int BulletDebugManager::getNumActiveContactPoints(
+    btMultiBodyDynamicsWorld* bWorld) {
+  int count = 0;
+  auto func = [&](const btCollisionObject*, const btCollisionObject*,
+                  const btPersistentManifold* manifold) {
+    count += manifold->getNumContacts();
+  };
+
+  processActiveManifolds(bWorld, func);
+
+  return count;
+}
+
+int BulletDebugManager::getNumActiveOverlappingPairs(
+    btMultiBodyDynamicsWorld* bWorld) {
+  int count = 0;
+  auto func = [&](const btCollisionObject*, const btCollisionObject*,
+                  const btPersistentManifold*) { count++; };
+
+  processActiveManifolds(bWorld, func);
+
+  return count;
+}
+
+template <typename Func>
+void BulletDebugManager::processActiveManifolds(
+    btMultiBodyDynamicsWorld* bWorld,
+    Func func) {
+  auto* dispatcher = bWorld->getDispatcher();
+  for (int i = 0; i < dispatcher->getNumManifolds(); i++) {
+    auto* manifold = dispatcher->getManifoldByIndexInternal(i);
+    const btCollisionObject* colObj0 =
+        static_cast<const btCollisionObject*>(manifold->getBody0());
+    const btCollisionObject* colObj1 =
+        static_cast<const btCollisionObject*>(manifold->getBody1());
+
+    // logic copied from btSimulationIslandManager::buildIslands. We want to
+    // count manifolds only if related to non-sleeping bodies.
+    if (((colObj0) && colObj0->getActivationState() != ISLAND_SLEEPING) ||
+        ((colObj1) && colObj1->getActivationState() != ISLAND_SLEEPING)) {
+      func(colObj0, colObj1, manifold);
+    }
+  }
+}
+
+std::string BulletDebugManager::getDebugStringForCollisionObject(
+    const btCollisionObject* colObj) {
+  std::string name = (collisionObjectToDebugName_.count(colObj))
+                         ? collisionObjectToDebugName_[colObj]
+                         : "unknown";
+
+  // reference code to shorten names
+  // const int maxLen = 60;
+  // if (name.size() > maxLen) {
+  //  name = name.substr(name.size() - maxLen, maxLen);
+  //}
+
+  std::string result =
+      name + ", act state " + std::to_string(colObj->getActivationState());
+
+  const auto* broadphaseHandle = colObj->getBroadphaseHandle();
+  if (broadphaseHandle) {
+    result +=
+        ", group " + std::to_string(broadphaseHandle->m_collisionFilterGroup) +
+        ", mask " + std::to_string(broadphaseHandle->m_collisionFilterMask);
+  } else {
+    // this probably means the object hasn't been added to the bullet world
+    result += ", no broadphase handle";
+  }
+  return result;
+}
+
+std::string BulletDebugManager::getStepCollisionSummary(
+    btMultiBodyDynamicsWorld* bWorld) {
+  std::stringstream s;
+  auto func = [&](const btCollisionObject* colObj0,
+                  const btCollisionObject* colObj1,
+                  const btPersistentManifold* manifold) {
+    if (manifold->getNumContacts() > 0) {
+      s << "[" << getDebugStringForCollisionObject(colObj0) << "] vs ["
+        << getDebugStringForCollisionObject(colObj1) << "], "
+        << manifold->getNumContacts() << " points" << std::endl;
+    }
+  };
+
+  processActiveManifolds(bWorld, func);
+
+  const bool isEmpty = s.rdbuf()->in_avail() == 0;
+  if (isEmpty) {
+    s << "(no active collision manifolds)" << std::endl;
+  }
+
+  return s.str();
+}
+
+}  // namespace physics
+}  // namespace esp

--- a/src/esp/physics/bullet/BulletDebugManager.h
+++ b/src/esp/physics/bullet/BulletDebugManager.h
@@ -1,0 +1,69 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+class btCollisionObject;
+class btMultiBodyDynamicsWorld;
+
+namespace esp {
+namespace physics {
+
+class BulletRigidObject;
+
+class BulletDebugManager {
+ public:
+  static BulletDebugManager& get() {
+    static BulletDebugManager mgr;
+    return mgr;
+  }
+
+  /**
+   * @brief Associate a human-readable debug name with the collision object. See
+   * also getStepCollisionSummary.
+   */
+  void mapCollisionObjectTo(const btCollisionObject* colObj,
+                            const std::string& debugName);
+
+  /**
+   * @brief The number of contact points that were active during the last step.
+   * An object resting on another object will involve several active contact
+   * points. Once both objects are asleep, the contact points are inactive. This
+   * count is a proxy for complexity/cost of collision-handling in the current
+   * scene. See also getNumActiveOverlappingPairs.
+   */
+  int getNumActiveContactPoints(btMultiBodyDynamicsWorld* bWorld);
+
+  /**
+   * @brief The number of active overlapping pairs during the last step. When
+   * object bounding boxes overlap and either object is active, additional
+   * "narrowphase" collision-detection must be run. This count is a proxy for
+   * complexity/cost of collision-handling in the current scene. See also
+   * getNumActiveContactPoints.
+   */
+  int getNumActiveOverlappingPairs(btMultiBodyDynamicsWorld* bWorld);
+
+  /**
+   * @brief Get a summary of collision-processing from the last physics step.
+   */
+  std::string getStepCollisionSummary(btMultiBodyDynamicsWorld* bWorld);
+
+  /**
+   * @brief Get the object's debug name plus some useful Bullet collision state.
+   */
+  std::string getDebugStringForCollisionObject(const btCollisionObject* colObj);
+
+ private:
+  template <typename Func>
+  void processActiveManifolds(btMultiBodyDynamicsWorld* bWorld, Func func);
+
+  std::unordered_map<const btCollisionObject*, std::string>
+      collisionObjectToDebugName_;
+};
+
+}  // end namespace physics
+}  // end namespace esp

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -95,8 +95,8 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(std::string filepath,
     return ID_UNDEFINED;
   }
 
-  Cr::Utility::Debug() << "Articulated Link Indices: "
-                       << articulatedObject->getLinkIds();
+  // Cr::Utility::Debug() << "Articulated Link Indices: "
+  //                     << articulatedObject->getLinkIds();
 
   int articulatedObjectID_ = allocateObjectID();
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -21,6 +21,7 @@
 
 #include "BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.h"
 
+#include "BulletDebugManager.h"
 #include "BulletRigidObject.h"
 #include "BulletRigidStage.h"
 #include "esp/physics/PhysicsManager.h"
@@ -226,6 +227,17 @@ class BulletPhysicsManager : public PhysicsManager {
   int nextP2PId_ = 0;
   std::map<int, btMultiBodyPoint2Point*> articulatedP2ps;
   std::map<int, btPoint2PointConstraint*> rigidP2ps;
+
+  int getNumActiveContactPoints() {
+    return BulletDebugManager::get().getNumActiveContactPoints(bWorld_.get());
+  }
+  int getNumActiveOverlappingPairs() {
+    return BulletDebugManager::get().getNumActiveOverlappingPairs(
+        bWorld_.get());
+  }
+  std::string getStepCollisionSummary() {
+    return BulletDebugManager::get().getStepCollisionSummary(bWorld_.get());
+  }
 
  protected:
   //============ Initialization =============

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -150,7 +150,7 @@ bool BulletRigidObject::initialization_LibSpecific(
                         btBroadphaseProxy::AllFilter);
   collisionObjToObjIds_->emplace(bObjectRigidBody_.get(), objectId_);
   BulletDebugManager::get().mapCollisionObjectTo(bObjectRigidBody_.get(),
-                                                 getBulletDebugName());
+                                                 getCollisionDebugName());
 
   //! Sync render pose with physics
   syncPose();
@@ -303,7 +303,7 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
                           btBroadphaseProxy::DefaultFilter);
     collisionObjToObjIds_->emplace(staticCollisionObject.get(), objectId_);
     BulletDebugManager::get().mapCollisionObjectTo(staticCollisionObject.get(),
-                                                   getBulletDebugName());
+                                                   getCollisionDebugName());
     bStaticCollisionObjects_.emplace_back(std::move(staticCollisionObject));
     return true;
   } else if (mt == MotionType::DYNAMIC) {
@@ -350,7 +350,7 @@ void BulletRigidObject::syncPose() {
       btTransform(node().transformationMatrix()));
 }  // syncPose
 
-std::string BulletRigidObject::getBulletDebugName() {
+std::string BulletRigidObject::getCollisionDebugName() {
   return "RigidObject, " + initializationAttributes_->getHandle() + ", id " +
          std::to_string(objectId_);
 }

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -11,6 +11,7 @@
 #include "BulletCollision/CollisionShapes/btConvexTriangleMeshShape.h"
 #include "BulletCollision/Gimpact/btGImpactShape.h"
 #include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
+#include "BulletDebugManager.h"
 #include "BulletRigidObject.h"
 
 //!  A Few considerations in construction
@@ -148,6 +149,9 @@ bool BulletRigidObject::initialization_LibSpecific(
                         btBroadphaseProxy::DefaultFilter,
                         btBroadphaseProxy::AllFilter);
   collisionObjToObjIds_->emplace(bObjectRigidBody_.get(), objectId_);
+  BulletDebugManager::get().mapCollisionObjectTo(bObjectRigidBody_.get(),
+                                                 getBulletDebugName());
+
   //! Sync render pose with physics
   syncPose();
   return true;
@@ -298,6 +302,8 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
                           btBroadphaseProxy::StaticFilter,
                           btBroadphaseProxy::DefaultFilter);
     collisionObjToObjIds_->emplace(staticCollisionObject.get(), objectId_);
+    BulletDebugManager::get().mapCollisionObjectTo(staticCollisionObject.get(),
+                                                   getBulletDebugName());
     bStaticCollisionObjects_.emplace_back(std::move(staticCollisionObject));
     return true;
   } else if (mt == MotionType::DYNAMIC) {
@@ -343,6 +349,11 @@ void BulletRigidObject::syncPose() {
   bObjectRigidBody_->setWorldTransform(
       btTransform(node().transformationMatrix()));
 }  // syncPose
+
+std::string BulletRigidObject::getBulletDebugName() {
+  return "RigidObject, " + initializationAttributes_->getHandle() + ", id " +
+         std::to_string(objectId_);
+}
 
 void BulletRigidObject::setCOM(const Magnum::Vector3&) {
   // Current not supported

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -431,6 +431,8 @@ class BulletRigidObject : public BulletBase,
    * updates. See @ref btRigidBody::setWorldTransform. */
   void syncPose() override;
 
+  std::string getBulletDebugName();
+
  private:
   // === Physical object ===
   //! If true, the object's bounding box will be used for collision once

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -431,7 +431,7 @@ class BulletRigidObject : public BulletBase,
    * updates. See @ref btRigidBody::setWorldTransform. */
   void syncPose() override;
 
-  std::string getBulletDebugName();
+  std::string getCollisionDebugName();
 
  private:
   // === Physical object ===

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -10,6 +10,7 @@
 #include "BulletCollision/CollisionShapes/btConvexTriangleMeshShape.h"
 #include "BulletCollision/Gimpact/btGImpactShape.h"
 #include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
+#include "BulletDebugManager.h"
 #include "BulletRigidStage.h"
 
 namespace esp {
@@ -109,6 +110,9 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
     std::unique_ptr<btRigidBody> sceneCollisionObject =
         std::make_unique<btRigidBody>(cInfo);
     ASSERT(sceneCollisionObject->isStaticObject());
+    BulletDebugManager::get().mapCollisionObjectTo(
+        sceneCollisionObject.get(),
+        getBulletDebugName(bStaticCollisionObjects_.size()));
     bStageArrays_.emplace_back(std::move(indexedVertexArray));
     bStageShapes_.emplace_back(std::move(meshShape));
     bStaticCollisionObjects_.emplace_back(std::move(sceneCollisionObject));
@@ -170,6 +174,11 @@ const Magnum::Range3D BulletRigidStage::getCollisionShapeAabb() const {
   }
   return combinedAABB;
 }  // getCollisionShapeAabb
+
+std::string BulletRigidStage::getBulletDebugName(int subpartId) {
+  return "Stage, " + initializationAttributes_->getHandle() + ", subpart " +
+         std::to_string(subpartId);
+}
 
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -112,7 +112,7 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
     ASSERT(sceneCollisionObject->isStaticObject());
     BulletDebugManager::get().mapCollisionObjectTo(
         sceneCollisionObject.get(),
-        getBulletDebugName(bStaticCollisionObjects_.size()));
+        getCollisionDebugName(bStaticCollisionObjects_.size()));
     bStageArrays_.emplace_back(std::move(indexedVertexArray));
     bStageShapes_.emplace_back(std::move(meshShape));
     bStaticCollisionObjects_.emplace_back(std::move(sceneCollisionObject));
@@ -175,7 +175,7 @@ const Magnum::Range3D BulletRigidStage::getCollisionShapeAabb() const {
   return combinedAABB;
 }  // getCollisionShapeAabb
 
-std::string BulletRigidStage::getBulletDebugName(int subpartId) {
+std::string BulletRigidStage::getCollisionDebugName(int subpartId) {
   return "Stage, " + initializationAttributes_->getHandle() + ", subpart " +
          std::to_string(subpartId);
 }

--- a/src/esp/physics/bullet/BulletRigidStage.h
+++ b/src/esp/physics/bullet/BulletRigidStage.h
@@ -56,7 +56,7 @@ class BulletRigidStage : public BulletBase, public RigidStage {
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node);
 
-  std::string getBulletDebugName(int subpartId);
+  std::string getCollisionDebugName(int subpartId);
 
  public:
   /**

--- a/src/esp/physics/bullet/BulletRigidStage.h
+++ b/src/esp/physics/bullet/BulletRigidStage.h
@@ -56,6 +56,8 @@ class BulletRigidStage : public BulletBase, public RigidStage {
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node);
 
+  std::string getBulletDebugName(int subpartId);
+
  public:
   /**
    * @brief Query the Aabb from bullet physics for the root compound shape of

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -9,6 +9,7 @@
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/BulletIntegration/Integration.h>
 #include "BulletCollision/CollisionShapes/btCompoundShape.h"
+#include "BulletDebugManager.h"
 #include "BulletDynamics/Featherstone/btMultiBodyJointLimitConstraint.h"
 #include "BulletDynamics/Featherstone/btMultiBodyLinkCollider.h"
 #include "esp/assets/ResourceManager.h"
@@ -648,6 +649,12 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
                                  collisionFilterMask);
       // world1->addCollisionObject(col, 2, 1+2);
       // TODO: fix this collision issue
+
+      // TODO: include the articulated object id here
+      const auto& debugModel = getModel();
+      std::string linkDebugName = "URDF, " + debugModel.m_name + ", link " +
+                                  debugModel.getLink(urdfLinkIndex)->m_name;
+      BulletDebugManager::get().mapCollisionObjectTo(col, linkDebugName);
     }
   }
 

--- a/src/esp/physics/bullet/CMakeLists.txt
+++ b/src/esp/physics/bullet/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
   BulletArticulatedObject.h
   BulletBase.cpp
   BulletBase.h
+  BulletDebugManager.cpp
+  BulletDebugManager.h
   BulletPhysicsManager.cpp
   BulletPhysicsManager.h
   BulletRigidObject.cpp

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -18,6 +18,7 @@
 #include "esp/io/io.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/physics/PhysicsManager.h"
+#include "esp/physics/bullet/BulletDebugManager.h"
 #include "esp/scene/ObjectControls.h"
 #include "esp/scene/SemanticScene.h"
 #include "esp/sensor/PinholeCamera.h"

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -762,6 +762,16 @@ class Simulator {
    */
   core::Random::ptr random() { return random_; }
 
+  int getPhysicsNumActiveContactPoints() {
+    return physicsManager_->getNumActiveContactPoints();
+  }
+  int getPhysicsNumActiveOverlappingPairs() {
+    return physicsManager_->getNumActiveOverlappingPairs();
+  }
+  std::string getPhysicsStepCollisionSummary() {
+    return physicsManager_->getStepCollisionSummary();
+  }
+
  protected:
   Simulator(){};
 


### PR DESCRIPTION
## Motivation and Context

Debugging tech to help us identify when/why collision-detection is hurting runtime perf.

Sample output from getStepCollisionSummary:
```
[URDF, kitchen_counter, link body, act state 3, group 1, mask -1] vs [RigidObject, ./data/objects/frl_apartment_cup_03.phys_properties.json, id 13, act state 2, group 2, mask -3], 1 points
[URDF, kitchen_counter, link body, act state 3, group 1, mask -1] vs [RigidObject, ./data/objects/frl_apartment_cup_03.phys_properties.json, id 14, act state 2, group 1, mask -1], 4 points
[URDF, fetch, link l_wheel_link, act state 2, group 1, mask -1] vs [Stage, ./orp/start_data/frl_apartment_stage_pvizplan_empty_simplified.stage_config.json, subpart 11, act state 1, group 2, mask -3], 3 points
[URDF, fetch, link r_wheel_link, act state 2, group 1, mask -1] vs [Stage, ./orp/start_data/frl_apartment_stage_pvizplan_empty_simplified.stage_config.json, subpart 11, act state 1, group 2, mask -3], 1 points
[URDF, fetch, link base_link, act state 2, group 1, mask -1] vs [Stage, ./orp/start_data/frl_apartment_stage_pvizplan_empty_simplified.stage_config.json, subpart 11, act state 1, group 2, mask -3], 1 points
```

Primarily, getStepCollisionSummary indicates which objects are colliding on a given step. Act state (activation state), group, and mask are useful extra information if you're diving deep into Bullet collision-detection but can otherwise be ignored.

## How Has This Been Tested

Ad hoc testing of the simulator.

Note that a slightly different version of getPhysicsNumActiveContactPoints has already merged to master https://github.com/facebookresearch/habitat-sim/pull/814 . That version includes a unit test for getPhysicsNumActiveContactPoints. When this change eventually merges to master, the implementation of getPhysicsNumActiveContactPoints here should replace the old one, and the old unit test should be kept unchanged.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
