### PR TITLE
Bullet collision tuning

### DIFF
--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -135,10 +135,9 @@ class BulletBase {
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
   /** @brief Static data: All components of a @ref RigidObjectType::SCENE are
-   * stored here. See @ref btCollisionObject.  Also, all objects set to STATIC
-   * are stored here.
+   * stored here. Also, all objects set to STATIC are stored here.
    */
-  std::vector<std::unique_ptr<btCollisionObject>> bStaticCollisionObjects_;
+  std::vector<std::unique_ptr<btRigidBody>> bStaticCollisionObjects_;
 
   //! Object data: Composite convex collision shape
   std::vector<std::unique_ptr<btConvexHullShape>> bObjectConvexShapes_;

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -144,7 +144,9 @@ bool BulletRigidObject::initialization_LibSpecific(
   bObjectRigidBody_ = std::make_unique<btRigidBody>(info);
 
   //! Add to world
-  bWorld_->addRigidBody(bObjectRigidBody_.get());
+  bWorld_->addRigidBody(bObjectRigidBody_.get(),
+                        btBroadphaseProxy::DefaultFilter,
+                        btBroadphaseProxy::AllFilter);
   collisionObjToObjIds_->emplace(bObjectRigidBody_.get(), objectId_);
   //! Sync render pose with physics
   syncPose();
@@ -270,7 +272,9 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
         bObjectRigidBody_->getCollisionFlags() &
         ~btCollisionObject::CF_STATIC_OBJECT);
     objectMotionType_ = MotionType::KINEMATIC;
-    bWorld_->addRigidBody(bObjectRigidBody_.get());
+    bWorld_->addRigidBody(bObjectRigidBody_.get(),
+                          btBroadphaseProxy::KinematicFilter,
+                          btBroadphaseProxy::DefaultFilter);
     return true;
   } else if (mt == MotionType::STATIC) {
     bObjectRigidBody_->setCollisionFlags(
@@ -290,10 +294,9 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
     std::unique_ptr<btRigidBody> staticCollisionObject =
         std::make_unique<btRigidBody>(cInfo);
     ASSERT(staticCollisionObject->isStaticObject());
-    bWorld_->addRigidBody(
-        staticCollisionObject.get(),
-        2,       // collisionFilterGroup (2 == StaticFilter)
-        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
+    bWorld_->addRigidBody(staticCollisionObject.get(),
+                          btBroadphaseProxy::StaticFilter,
+                          btBroadphaseProxy::DefaultFilter);
     collisionObjToObjIds_->emplace(staticCollisionObject.get(), objectId_);
     bStaticCollisionObjects_.emplace_back(std::move(staticCollisionObject));
     return true;
@@ -305,7 +308,9 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
         bObjectRigidBody_->getCollisionFlags() &
         ~btCollisionObject::CF_KINEMATIC_OBJECT);
     objectMotionType_ = MotionType::DYNAMIC;
-    bWorld_->addRigidBody(bObjectRigidBody_.get());
+    bWorld_->addRigidBody(bObjectRigidBody_.get(),
+                          btBroadphaseProxy::DefaultFilter,
+                          btBroadphaseProxy::AllFilter);
     setActive();
     return true;
   } else if (mt == MotionType::RENDER_ONLY) {

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -25,7 +25,7 @@ BulletRigidStage::BulletRigidStage(
 BulletRigidStage::~BulletRigidStage() {
   // remove collision objects from the world
   for (auto& co : bStaticCollisionObjects_) {
-    bWorld_->removeCollisionObject(co.get());
+    bWorld_->removeRigidBody(co.get());
     collisionObjToObjIds_->erase(co.get());
   }
 }
@@ -45,7 +45,7 @@ bool BulletRigidStage::initialization_LibSpecific(
     object->setFriction(initializationAttributes_->getFrictionCoefficient());
     object->setRestitution(
         initializationAttributes_->getRestitutionCoefficient());
-    bWorld_->addCollisionObject(object.get());
+    bWorld_->addRigidBody(object.get());
     collisionObjToObjIds_->emplace(object.get(), objectId_);
   }
 
@@ -97,14 +97,17 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
 
     // re-build the bvh after setting margin
     meshShape->buildOptimizedBvh();
-    std::unique_ptr<btCollisionObject> sceneCollisionObject =
-        std::make_unique<btCollisionObject>();
-    sceneCollisionObject->setCollisionShape(meshShape.get());
-    // rotation|translation are properties of the object
-    sceneCollisionObject->setWorldTransform(
+    // mass == 0 to indicate static. See isStaticObject assert below. See also
+    // examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
+    btVector3 localInertia(0, 0, 0);
+    btRigidBody::btRigidBodyConstructionInfo cInfo(
+        /*mass*/ 0.0, nullptr, meshShape.get(), localInertia);
+    cInfo.m_startWorldTransform =
         btTransform{btMatrix3x3{transformFromLocalToWorld.rotation()},
-                    btVector3{transformFromLocalToWorld.translation()}});
-
+                    btVector3{transformFromLocalToWorld.translation()}};
+    std::unique_ptr<btRigidBody> sceneCollisionObject =
+        std::make_unique<btRigidBody>(cInfo);
+    ASSERT(sceneCollisionObject->isStaticObject());
     bStageArrays_.emplace_back(std::move(indexedVertexArray));
     bStageShapes_.emplace_back(std::move(meshShape));
     bStaticCollisionObjects_.emplace_back(std::move(sceneCollisionObject));

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -45,7 +45,8 @@ bool BulletRigidStage::initialization_LibSpecific(
     object->setFriction(initializationAttributes_->getFrictionCoefficient());
     object->setRestitution(
         initializationAttributes_->getRestitutionCoefficient());
-    bWorld_->addRigidBody(object.get());
+    bWorld_->addRigidBody(object.get(), btBroadphaseProxy::StaticFilter,
+                          btBroadphaseProxy::DefaultFilter);
     collisionObjToObjIds_->emplace(object.get(), objectId_);
   }
 


### PR DESCRIPTION
## Motivation and Context

Various small fixes to improve runtime perf related to Bullet collision-detection. For details, see inline comments.

One change here is an overhaul of collision filtering. This is the choice of "group" and "mask" for collision objects added to the Bullet world. My new proposed scheme is:

- Static objects use group btBroadphaseProxy::StaticFilter and are set to collide with dynamic objects.
- Dynamic objects use group btBroadphaseProxy::DefaultFilter and are set to collide with static objects, kinematic objects, and other dynamic objects.
- Kinematic objects use group btBroadphaseProxy::KinematicFilter and are set to collide with dynamic objects.
- castRay uses group btBroadphaseProxy::DefaultFilter and is set to collide with everything (btBroadphaseProxy::AllFilter). This is the default Bullet behavior set in src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp RayResultCallback .
- contactTest behaves like castRay. It uses group btBroadphaseProxy::DefaultFilter and is set to collide with everything (btBroadphaseProxy::AllFilter). Default Bullet behavior. See /usr/include/bullet/BulletCollision/CollisionDispatch/btCollisionWorld.h ContactResultCallback.

## How Has This Been Tested

Ad hoc testing with Andrew Z's pvizplan object-rearrangement project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
