### PR TITLE
Add json validator pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     -   id: check-docstring-first
     -   id: check-executables-have-shebangs
     -   id: check-json
+        # The JSONS below support comments (against spec)
         exclude: ^(.eslintrc.json|tsconfig.json)
     -   id: check-merge-conflict
     -   id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: 'build|data/datasets|data/scene_datasets|src/deps|src/obsolete'
+exclude: 'build|data/datasets|data/scene_datasets|node_modules/|src/deps|src/obsolete'
 
 default_language_version:
     python: python3
@@ -15,10 +15,11 @@ repos:
     -   id: check-docstring-first
     -   id: check-executables-have-shebangs
     -   id: check-json
-        # The JSONS below support comments (against spec)
+        # The JSONs below support comments (against spec)
         exclude: ^(.eslintrc.json|tsconfig.json)
     -   id: check-merge-conflict
     -   id: check-toml
+    -   id: check-yaml
     -   id: debug-statements
     -   id: mixed-line-ending
         args: ['--fix=lf']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
     -   id: check-case-conflict
     -   id: check-docstring-first
     -   id: check-executables-have-shebangs
+    -   id: check-json
+        exclude: ^(.eslintrc.json|tsconfig.json)
     -   id: check-merge-conflict
     -   id: check-toml
     -   id: debug-statements


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ensures that only properly formatted JSONs can be committed (unless added to the pre-commit exclude)
<!--- Please link to an existing issue here if one exists. -->
Partially addresses this comment: https://github.com/facebookresearch/habitat-sim/pull/852#discussion_r503550351
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Ran the pre-commit hook locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] dev tools
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
