### PR TITLE
--Change name of unknown motion type to "UNDEFINED" and assign value of -1

### DIFF
--- a/src/esp/bindings/PhysicsBindings.cpp
+++ b/src/esp/bindings/PhysicsBindings.cpp
@@ -17,7 +17,7 @@ void initPhysicsBindings(py::module& m) {
 
   // ==== enum object MotionType ====
   py::enum_<MotionType>(m, "MotionType")
-      .value("ERROR_MOTIONTYPE", MotionType::ERROR_MOTIONTYPE)
+      .value("UNDEFINED", MotionType::UNDEFINED)
       .value("STATIC", MotionType::STATIC)
       .value("KINEMATIC", MotionType::KINEMATIC)
       .value("DYNAMIC", MotionType::DYNAMIC);

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -40,9 +40,10 @@ it.
 */
 enum class MotionType {
   /**
-   * Refers to an error (such as a query to non-existing object).
+   * Refers to an error (such as a query to non-existing object) or an
+   * unknown/unspecified value.
    */
-  ERROR_MOTIONTYPE,
+  UNDEFINED = -1,
 
   /**
    * The object is not expected to move and should not allow kinematic updates.

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -281,7 +281,7 @@ void BulletRigidObject::setCollisionFromBB() {
 }  // setCollisionFromBB
 
 bool BulletRigidObject::setMotionType(MotionType mt) {
-  if (mt == MotionType::ERROR_MOTIONTYPE) {
+  if (mt == MotionType::UNDEFINED) {
     return false;
   }
   if (mt == objectMotionType_) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -373,7 +373,7 @@ esp::physics::MotionType Simulator::getObjectMotionType(const int objectID,
   if (sceneHasPhysics(sceneID)) {
     return physicsManager_->getObjectMotionType(objectID);
   }
-  return esp::physics::MotionType::ERROR_MOTIONTYPE;
+  return esp::physics::MotionType::UNDEFINED;
 }
 
 bool Simulator::setObjectMotionType(const esp::physics::MotionType& motionType,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -226,7 +226,7 @@ class Simulator {
    * @param sceneID !! Not used currently !! Specifies which physical scene to
    * query.
    * @return The @ref esp::physics::MotionType of the object or @ref
-   * esp::physics::MotionType::ERROR_MOTIONTYPE if query failed.
+   * esp::physics::MotionType::UNDEFINED if query failed.
    */
   esp::physics::MotionType getObjectMotionType(int objectID, int sceneID = 0);
 


### PR DESCRIPTION
## Motivation and Context
Renaming motion type default value to be "UNDEFINED" and assigning it a value of -1 in the enum class wherein it resides.  This has been done to more accurately reflect what it represents, and to facilitate object motion-type setting via scene instance descriptors in the upcoming MetadataMediator/Dataset/Scene instance import functionality.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
all existing c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
