### PR TITLE
[bugfix] Replica Ptex without physics

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -244,7 +244,7 @@ bool ResourceManager::loadStage(
   // the collision mesh is empty scene
 
   if ((_physicsManager != nullptr) &&
-      (infoToUse.filepath.compare(EMPTY_SCENE) != 0)) {
+      (infoToUse.filepath.compare(EMPTY_SCENE) != 0) && buildCollisionMesh) {
     bool success = buildMeshGroups(infoToUse, meshGroup);
     if (!success) {
       return false;


### PR DESCRIPTION
## Motivation and Context

Addresses issue #865. PTex collision mesh group creation is not supported, but was being called even when physics was not enabled. This is temporary patch to skip creation of the RigidStage when a stage is loaded and physics is not enabled. 

A better fix would be to support collisionMeshGroups for PTex assets. 

## How Has This Been Tested

Locally with viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
