### PR TITLE
Add ptex collision mesh data

### DIFF
--- a/src/esp/assets/PTexMeshData.h
+++ b/src/esp/assets/PTexMeshData.h
@@ -93,6 +93,13 @@ class PTexMeshData : public BaseMesh {
 
   std::string atlasFolder_;
   std::vector<MeshData> submeshes_;
+  // In the case of splitting the mesh, we need seperate containers
+  // to hold the collsion mesh data as the contiguous meshdata be split up
+  // TODO We should use a decimated mesh for collsions here instead
+  //! @brief Stores the vertices for the collision mesh when the mesh is split
+  Corrade::Containers::Array<Magnum::Vector3> collisionVbo_;
+  //! @brief Stores the indices for the collision mesh when the mesh is split
+  Corrade::Containers::Array<Magnum::UnsignedInt> collisionIbo_;
 
   // ==== rendering ====
   // we will have to use smart pointer here since each item within the structure

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -332,7 +332,12 @@ bool ResourceManager::buildMeshGroups(
       colMeshGroupSuccess = buildStageCollisionMeshGroup<GenericMeshData>(
           info.filepath, meshGroup);
     }
-    // TODO : PTEX collision support
+#ifdef ESP_BUILD_PTEX_SUPPORT
+    else if (info.type == AssetType::FRL_PTEX_MESH) {
+      colMeshGroupSuccess =
+          buildStageCollisionMeshGroup<PTexMeshData>(info.filepath, meshGroup);
+    }
+#endif
 
     // failure during build of collision mesh group
     if (!colMeshGroupSuccess) {


### PR DESCRIPTION
## Motivation and Context

Add collision mesh data to ptex meshes.  Slightly messy as there are some complications of ownership, but, at some point, we will want to use a decimated mesh for collisions so the containers that only are used when the mesh is split will be used all the time.

Closes #866 
Fixes #865 

## How Has This Been Tested

Locally.  Viewer loads the ptex mesh and navmesh recomputation works as expected with it.

## Types of changes


Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

