### PR TITLE
fix for test_configure_and_on_start_step

### DIFF
--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -93,6 +93,9 @@ def test_range_context():
 # Use configure() to capture a desired range of train steps.
 def test_configure_and_on_start_step():
 
+    os.environ[_ENV_VAR_NAME] = "1"
+    importlib.reload(profiling_utils)
+
     # Use mock range_push/range_pop. This test only looks to confirm that these
     # functions get called at the right time.
     def fake_range_push(msg):


### PR DESCRIPTION
## Motivation and Context

This unit test can randomly fail based on the order of other tests running. I'm fixing it.

## How Has This Been Tested

I'm unable to reproduce the failure, so this fix is somewhat speculative. I re-ran the test locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
