### PR TITLE
[Bug fix] Use flags, not materialData in order to set the uniforms, textures properly in the GenericDrawable. 

### DIFF
--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -130,17 +130,23 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       .setProjectionMatrix(camera.projectionMatrix())
       .setNormalMatrix(transformationMatrix.normalMatrix());
 
-  if (materialData_->textureMatrix != Mn::Matrix3{})
+  if ((flags_ & Mn::Shaders::Phong::Flag::TextureTransformation) &&
+      materialData_->textureMatrix != Mn::Matrix3{}) {
     shader_->setTextureMatrix(materialData_->textureMatrix);
+  }
 
-  if (materialData_->ambientTexture)
+  if (flags_ & Mn::Shaders::Phong::Flag::AmbientTexture) {
     shader_->bindAmbientTexture(*(materialData_->ambientTexture));
-  if (materialData_->diffuseTexture)
+  }
+  if (flags_ & Mn::Shaders::Phong::Flag::DiffuseTexture) {
     shader_->bindDiffuseTexture(*(materialData_->diffuseTexture));
-  if (materialData_->specularTexture)
+  }
+  if (flags_ & Mn::Shaders::Phong::Flag::SpecularTexture) {
     shader_->bindSpecularTexture(*(materialData_->specularTexture));
-  if (materialData_->normalTexture)
+  }
+  if (flags_ & Mn::Shaders::Phong::Flag::NormalTexture) {
     shader_->bindNormalTexture(*(materialData_->normalTexture));
+  }
 
   shader_->draw(mesh_);
 }


### PR DESCRIPTION
## Motivation and Context
This is to address a bug mentioned by @eundersander . Here I quote:
"the warning about lacking tangents is essentially setting up the user to inevitably fail this later assert.
https://github.com/facebookresearch/habitat-sim/commit/77d201a15442e8bb6e68baca5d8552e81c763803#diff-e849e837346024527e3aadac345a485c682ccfe8ba595cc2662a3e328ee707bfR44
Because, on the one hand, the model has a normal texture but not tangents, so the shader is not created with the normalmap flag. But then later in the same file, you have:
```
if (materialData_->normalTexture)
    shader_->bindNormalTexture(*(materialData_->normalTexture)); 
```

The correct way is to use `flags_` not the `materialData_` in the if clause.
This PR is to fix it.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
