### PR TITLE
Experimental: disable color textures, lighting toggle, force y-up

### DIFF
--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -33,6 +33,7 @@ class GenericDrawable : public Drawable {
   virtual void draw(const Magnum::Matrix4& transformationMatrix,
                     Magnum::SceneGraph::Camera3D& camera) override;
 
+  void updateFlags();
   void updateShader();
   void updateShaderLightingParameters(
       const Magnum::Matrix4& transformationMatrix,
@@ -49,7 +50,10 @@ class GenericDrawable : public Drawable {
   Magnum::Resource<LightSetup> lightSetup_;
 
   Magnum::Shaders::Phong::Flags flags_;
+  Drawable::Flags meshAttributeFlags_;
 };
+
+extern bool g_disableColorTextures;
 
 }  // namespace gfx
 }  // namespace esp

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -256,8 +256,8 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
     assetTypeSetter(static_cast<int>(AssetType::MP3D_MESH));
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
-    up = up2;
-    fwd = fwd2;
+    // up = up2;
+    // fwd = fwd2;
   } else if (this->isValidPrimitiveAttributes(fileName)) {
     assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
   } else {


### PR DESCRIPTION
## Motivation and Context

Do not merge.

I'm just documenting this experimental `lighting_viewer` branch in case anyone wants to use it. It's useful when running the viewer to evaluate lighting. These changes probably aren't appropriate to merge to master.

It has three features:
- It forces y-up convention for `glb` files because that's commonly what I need (our Viewer app should get a command-line option to choose up convention; that would be a much better solution).
- It adds a lighting toggle, `L` key. It cycles between 5 camera-relative light directions, then back to default lighting. Viewing lighting from camera-left then camera-right is useful for evaluating normal maps.
- It adds a toggle to disable color textures, ';' key. With color textures disabled, most things look white but still lit. It's much easier to evaluate lighting and normal maps with the color textures removed.

![disable_color_textures](https://user-images.githubusercontent.com/6557808/96662669-ae98a100-1303-11eb-95ad-0e699c6a7928.png)

## How Has This Been Tested

Nope

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
