### PR TITLE
--MetadataMediator - Lighting Layout Configurations

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -239,6 +239,15 @@ class ResourceManager {
     return metadataMediator_->getAssetAttributesManager();
   }
   /**
+   * @brief Return manager for construction and access to light and lighting
+   * layout attributes.
+   */
+  const metadata::managers::LightLayoutAttributesManager::ptr
+  getLightLayoutAttributesManager() const {
+    return metadataMediator_->getLightLayoutAttributesManager();
+  }
+
+  /**
    * @brief Return manager for construction and access to object attributes.
    */
   const metadata::managers::ObjectAttributesManager::ptr

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -9,6 +9,7 @@
 
 #include "esp/core/AbstractManagedObject.h"
 #include "esp/metadata/attributes/AttributesBase.h"
+#include "esp/metadata/attributes/LightLayoutAttributes.h"
 #include "esp/metadata/attributes/ObjectAttributes.h"
 #include "esp/metadata/attributes/PhysicsManagerAttributes.h"
 #include "esp/metadata/attributes/PrimitiveAssetAttributes.h"
@@ -26,6 +27,8 @@ using Attrs::ConePrimitiveAttributes;
 using Attrs::CubePrimitiveAttributes;
 using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
+using Attrs::LightInstanceAttributes;
+using Attrs::LightLayoutAttributes;
 using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
 using Attrs::StageAttributes;
@@ -246,6 +249,42 @@ void initAttributesBindings(py::module& m) {
           "frustrum_culling", &StageAttributes::getFrustrumCulling,
           &StageAttributes::setFrustrumCulling,
           R"(Whether frustrum culling should be enabled for constructions built by this template.)");
+
+  // ==== LightInstanceAttributes ====
+  py::class_<LightInstanceAttributes, AbstractAttributes,
+             LightInstanceAttributes::ptr>(m, "LightInstanceAttributes")
+      .def(py::init(&LightInstanceAttributes::create<>))
+      .def(py::init(&LightInstanceAttributes::create<const std::string&>))
+      .def_property(
+          "position", &LightInstanceAttributes::getPosition,
+          &LightInstanceAttributes::setPosition,
+          R"(The 3-vector representation of the desired position of the light in the scene.)")
+      .def_property(
+          "direction", &LightInstanceAttributes::getDirection,
+          &LightInstanceAttributes::setDirection,
+          R"(The 3-vector representation of the desired direction of the light in the scene.)")
+      .def_property(
+          "color", &LightInstanceAttributes::getColor,
+          &LightInstanceAttributes::setColor,
+          R"(The 3-vector representation of the desired color of the light.)")
+      .def_property("intensity", &LightInstanceAttributes::getIntensity,
+                    &LightInstanceAttributes::setIntensity,
+                    R"(The intensity to use for the light.)")
+      .def_property("type", &LightInstanceAttributes::getType,
+                    &LightInstanceAttributes::setType,
+                    R"(The type of the light.)")
+      .def_property(
+          "spot_inner_cone_angle", &LightInstanceAttributes::getInnerConeAngle,
+          &LightInstanceAttributes::setInnerConeAngle,
+          R"(The inner cone angle to use for the dispersion of spot lights.
+                    Ignored for other types of lights.)")
+      .def_property(
+          "spot_outer_cone_angle", &LightInstanceAttributes::getOuterConeAngle,
+          &LightInstanceAttributes::setOuterConeAngle,
+          R"(The outter cone angle to use for the dispersion of spot lights.
+                    Ignored for other types of lights.)");
+
+  // TODO : LightLayoutAttributes
 
   // ==== PhysicsManagerAttributes ====
   py::class_<PhysicsManagerAttributes, AbstractAttributes,

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -8,10 +8,12 @@
 #include <Magnum/Magnum.h>
 #include <Magnum/PythonBindings.h>
 
+#include "esp/metadata/attributes/LightLayoutAttributes.h"
 #include "esp/metadata/attributes/ObjectAttributes.h"
 
 #include "esp/metadata/managers/AssetAttributesManager.h"
 #include "esp/metadata/managers/AttributesManagerBase.h"
+#include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"
@@ -27,6 +29,7 @@ using Attrs::ConePrimitiveAttributes;
 using Attrs::CubePrimitiveAttributes;
 using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
+using Attrs::LightLayoutAttributes;
 using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
 using Attrs::StageAttributes;
@@ -265,7 +268,13 @@ void initAttributesManagersBindings(py::module& m) {
              NULL if none exists.)",
            "handle"_a);
 
-  // ==== Physical Object Attributes Template manager ====
+  // ==== Light Layout Attributes Template manager ====
+  declareBaseAttributesManager<LightLayoutAttributes>(m, "BaseLightLayout");
+  py::class_<LightLayoutAttributesManager,
+             AttributesManager<LightLayoutAttributes>,
+             LightLayoutAttributesManager::ptr>(m,
+                                                "LightLayoutAttributesManager");
+  // ==== Object Attributes Template manager ====
   declareBaseAttributesManager<ObjectAttributes>(m, "BaseObject");
   py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes>,
              ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -85,23 +85,29 @@ void initSimBindings(py::module& m) {
                     R"(Enable or disable the frustum culling)")
       /* --- Physics functions --- */
       /* --- Template Manager accessors --- */
-      .def(
-          "get_asset_template_manager", &Simulator::getAssetAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's AssetAttributesManager instance for configuring primitive asset templates.)")
-      .def(
-          "get_object_template_manager", &Simulator::getObjectAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's ObjectAttributesManager instance for configuring object templates.)")
-      .def(
-          "get_physics_template_manager",
-          &Simulator::getPhysicsAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's PhysicsAttributesManager instance for configuring PhysicsManager templates.)")
-      .def(
-          "get_stage_template_manager", &Simulator::getStageAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's StageAttributesManager instance for configuring simulation stage templates.)")
+      .def("get_asset_template_manager", &Simulator::getAssetAttributesManager,
+           pybind11::return_value_policy::reference,
+           R"(Get the current dataset's AssetAttributesManager instance
+            for configuring primitive asset templates.)")
+      .def("get_lighting_template_manager",
+           &Simulator::getLightLayoutAttributesManager,
+           pybind11::return_value_policy::reference,
+           R"(Get the current dataset's LightLayoutAttributesManager instance
+            for configuring light templates and layouts.)")
+      .def("get_object_template_manager",
+           &Simulator::getObjectAttributesManager,
+           pybind11::return_value_policy::reference,
+           R"(Get the current dataset's ObjectAttributesManager instance
+            for configuring object templates.)")
+      .def("get_physics_template_manager",
+           &Simulator::getPhysicsAttributesManager,
+           pybind11::return_value_policy::reference,
+           R"(Get the current dataset's PhysicsAttributesManager instance
+            for configuring PhysicsManager templates.)")
+      .def("get_stage_template_manager", &Simulator::getStageAttributesManager,
+           pybind11::return_value_policy::reference,
+           R"(Get the current dataset's StageAttributesManager instance
+            for configuring simulation stage templates.)")
       .def(
           "get_physics_simulation_library",
           &Simulator::getPhysicsSimulationLibrary,

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -37,11 +37,12 @@ class Configuration {
   bool setVec3(const std::string& key, const Magnum::Vector3& value) {
     return set(key, value);
   }
-
   bool setQuat(const std::string& key, const Magnum::Quaternion& value) {
     return set(key, value);
   }
-
+  bool setRad(const std::string& key, const Magnum::Rad& value) {
+    return set(key, value);
+  }
   template <typename T>
   T get(const std::string& key) const {
     return cfg.value<T>(key);
@@ -58,6 +59,9 @@ class Configuration {
   }
   Magnum::Quaternion getQuat(const std::string& key) const {
     return get<Magnum::Quaternion>(key);
+  }
+  Magnum::Rad getRad(const std::string& key) const {
+    return get<Magnum::Rad>(key);
   }
 
   /**@brief Add a string to a group and return the resulting group size. */

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -40,7 +40,7 @@ class Configuration {
   bool setQuat(const std::string& key, const Magnum::Quaternion& value) {
     return set(key, value);
   }
-  bool setRad(const std::string& key, const Magnum::Rad& value) {
+  bool setRad(const std::string& key, Magnum::Rad value) {
     return set(key, value);
   }
   template <typename T>

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -185,6 +185,32 @@ inline bool jsonIntoVal(const JsonGenericValue& d,
 }  // jsonIntoVal<std::string>
 
 /**
+ * @brief Check passed json doc for existence of passed @p tag as
+ * double. If present, populate passed @p val with value. Returns whether tag
+ * is found and successfully populated, or not. Logs an error if tag is found
+ * but is inappropriate type.
+ *
+ * @param d json document to parse
+ * @param tag string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+
+template <>
+inline bool jsonIntoVal(const JsonGenericValue& d,
+                        const char* tag,
+                        Magnum::Rad& val) {
+  if (d.HasMember(tag)) {
+    if (d[tag].IsNumber()) {
+      val = Magnum::Rad{d[tag].GetFloat()};
+      return true;
+    }
+    LOG(ERROR) << "Invalid double value specified in JSON config at " << tag;
+  }
+  return false;
+}  // jsonIntoVal<double>
+
+/**
  * @brief Specialization to handle Magnum::Vector3 values.  Check passed json
  * doc for existence of passed @p tag as Magnum::Vector3. If present, populate
  * passed @p val with value. Returns whether tag is found and successfully

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -5,20 +5,24 @@
 set(
   metadata_SOURCES
   attributes/AttributesBase.h
+  attributes/LightLayoutAttributes.h
+  attributes/LightLayoutAttributes.cpp
   attributes/ObjectAttributes.h
   attributes/ObjectAttributes.cpp
-  attributes/SceneAttributes.h
-  attributes/SceneAttributes.cpp
-  attributes/SceneDatasetAttributes.h
-  attributes/SceneDatasetAttributes.cpp
   attributes/PhysicsManagerAttributes.h
   attributes/PhysicsManagerAttributes.cpp
   attributes/PrimitiveAssetAttributes.h
   attributes/PrimitiveAssetAttributes.cpp
+  attributes/SceneAttributes.h
+  attributes/SceneAttributes.cpp
+  attributes/SceneDatasetAttributes.h
+  attributes/SceneDatasetAttributes.cpp
   managers/AttributesManagerBase.h
   managers/AbstractObjectAttributesManagerBase.h
   managers/AssetAttributesManager.h
   managers/AssetAttributesManager.cpp
+  managers/LightLayoutAttributesManager.h
+  managers/LightLayoutAttributesManager.cpp
   managers/ObjectAttributesManager.h
   managers/ObjectAttributesManager.cpp
   managers/PhysicsAttributesManager.h

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -8,8 +8,9 @@ namespace esp {
 namespace metadata {
 void MetadataMediator::buildAttributesManagers() {
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create();
-  datasetAttributesManager_ = managers::SceneDatasetAttributesManager::create(
-      physicsAttributesManager_);
+  SceneDatasetAttributesManager_ =
+      managers::SceneDatasetAttributesManager::create(
+          physicsAttributesManager_);
   // create blank default attributes manager
   createDataset(activeDataset_);
 }  // MetadataMediator::buildAttributesManagers
@@ -17,7 +18,8 @@ void MetadataMediator::buildAttributesManagers() {
 bool MetadataMediator::createDataset(const std::string& datasetName,
                                      bool overwrite) {
   // see if exists
-  bool exists = datasetAttributesManager_->getObjectLibHasHandle(datasetName);
+  bool exists =
+      SceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName);
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
@@ -28,11 +30,11 @@ bool MetadataMediator::createDataset(const std::string& datasetName,
       return false;
     }
     // overwrite specified, make sure not locked
-    datasetAttributesManager_->setLock(datasetName, false);
+    SceneDatasetAttributesManager_->setLock(datasetName, false);
   }
   // by here dataset either does not exist or exists but is unlocked.
   auto datasetAttribs =
-      datasetAttributesManager_->createObject(datasetName, true);
+      SceneDatasetAttributesManager_->createObject(datasetName, true);
   if (nullptr == datasetAttribs) {
     // not created, do not set name
     LOG(WARNING) << "MetadataMediator::createDataset : Unknown dataset "
@@ -48,11 +50,11 @@ bool MetadataMediator::createDataset(const std::string& datasetName,
 
 bool MetadataMediator::setActiveDatasetName(const std::string& datasetName) {
   // first check if dataset exists, if so then set default
-  if (datasetAttributesManager_->getObjectLibHasHandle(datasetName)) {
+  if (SceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName)) {
+    LOG(INFO) << "MetadataMediator::setActiveDatasetName : Old active dataset "
+              << activeDataset_ << " changed to " << datasetName
+              << " successfully.";
     activeDataset_ = datasetName;
-    LOG(INFO) << "MetadataMediator::setActiveDatasetName : Default dataset "
-                 "changed to "
-              << datasetName << " successfully.";
     return true;
   }
   // if does not exist, attempt to create it

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -8,7 +8,7 @@ namespace esp {
 namespace metadata {
 void MetadataMediator::buildAttributesManagers() {
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create();
-  SceneDatasetAttributesManager_ =
+  sceneDatasetAttributesManager_ =
       managers::SceneDatasetAttributesManager::create(
           physicsAttributesManager_);
   // create blank default attributes manager
@@ -19,7 +19,7 @@ bool MetadataMediator::createDataset(const std::string& datasetName,
                                      bool overwrite) {
   // see if exists
   bool exists =
-      SceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName);
+      sceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName);
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
@@ -30,11 +30,11 @@ bool MetadataMediator::createDataset(const std::string& datasetName,
       return false;
     }
     // overwrite specified, make sure not locked
-    SceneDatasetAttributesManager_->setLock(datasetName, false);
+    sceneDatasetAttributesManager_->setLock(datasetName, false);
   }
   // by here dataset either does not exist or exists but is unlocked.
   auto datasetAttribs =
-      SceneDatasetAttributesManager_->createObject(datasetName, true);
+      sceneDatasetAttributesManager_->createObject(datasetName, true);
   if (nullptr == datasetAttribs) {
     // not created, do not set name
     LOG(WARNING) << "MetadataMediator::createDataset : Unknown dataset "
@@ -50,7 +50,7 @@ bool MetadataMediator::createDataset(const std::string& datasetName,
 
 bool MetadataMediator::setActiveDatasetName(const std::string& datasetName) {
   // first check if dataset exists, if so then set default
-  if (SceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName)) {
+  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName)) {
     LOG(INFO) << "MetadataMediator::setActiveDatasetName : Old active dataset "
               << activeDataset_ << " changed to " << datasetName
               << " successfully.";

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -12,6 +12,7 @@
 #include "esp/core/Configuration.h"
 
 #include "esp/metadata/managers/AssetAttributesManager.h"
+#include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
 #include "esp/metadata/managers/SceneDatasetAttributesManager.h"
@@ -19,7 +20,6 @@
 
 namespace esp {
 namespace metadata {
-namespace Attrs = esp::metadata::attributes;
 class MetadataMediator {
  public:
   MetadataMediator(const std::string& _defaultDataset = "default")
@@ -69,7 +69,7 @@ class MetadataMediator {
    */
   const managers::AssetAttributesManager::ptr getAssetAttributesManager()
       const {
-    Attrs::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
+    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     return (nullptr == datasetAttr) ? nullptr
                                     : datasetAttr->getAssetAttributesManager();
   }
@@ -78,9 +78,21 @@ class MetadataMediator {
    * @brief Return manager for construction and access to object attributes for
    * current dataset.
    */
+  const managers::LightLayoutAttributesManager::ptr
+  getLightLayoutAttributesManager() const {
+    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
+    return (nullptr == datasetAttr)
+               ? nullptr
+               : datasetAttr->getLightLayoutAttributesManager();
+  }
+
+  /**
+   * @brief Return manager for construction and access to object attributes for
+   * current dataset.
+   */
   const managers::ObjectAttributesManager::ptr getObjectAttributesManager()
       const {
-    Attrs::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
+    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     return (nullptr == datasetAttr) ? nullptr
                                     : datasetAttr->getObjectAttributesManager();
   }
@@ -91,7 +103,7 @@ class MetadataMediator {
    */
   const managers::StageAttributesManager::ptr getStageAttributesManager()
       const {
-    Attrs::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
+    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     return (nullptr == datasetAttr) ? nullptr
                                     : datasetAttr->getStageAttributesManager();
   }  // MetadataMediator::getStageAttributesManager
@@ -138,11 +150,11 @@ class MetadataMediator {
    * @brief Retrieve the current default dataset object.  Currently only for
    * internal use.
    */
-  Attrs::SceneDatasetAttributes::ptr getActiveDSAttribs() const {
+  attributes::SceneDatasetAttributes::ptr getActiveDSAttribs() const {
     // do not get copy of dataset attributes until SceneDatasetAttributes deep
     // copy ctor implemented
     auto datasetAttr =
-        datasetAttributesManager_->getObjectByHandle(activeDataset_);
+        SceneDatasetAttributesManager_->getObjectByHandle(activeDataset_);
     if (nullptr == datasetAttr) {
       LOG(ERROR)
           << "MetadataMediator::getActiveDSAttribs : Unknown dataset named "
@@ -159,7 +171,7 @@ class MetadataMediator {
   /**
    * @brief Manages all construction and access to asset attributes.
    */
-  managers::SceneDatasetAttributesManager::ptr datasetAttributesManager_ =
+  managers::SceneDatasetAttributesManager::ptr SceneDatasetAttributesManager_ =
       nullptr;
 
   /**

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -154,7 +154,7 @@ class MetadataMediator {
     // do not get copy of dataset attributes until SceneDatasetAttributes deep
     // copy ctor implemented
     auto datasetAttr =
-        SceneDatasetAttributesManager_->getObjectByHandle(activeDataset_);
+        sceneDatasetAttributesManager_->getObjectByHandle(activeDataset_);
     if (nullptr == datasetAttr) {
       LOG(ERROR)
           << "MetadataMediator::getActiveDSAttribs : Unknown dataset named "
@@ -171,7 +171,7 @@ class MetadataMediator {
   /**
    * @brief Manages all construction and access to asset attributes.
    */
-  managers::SceneDatasetAttributesManager::ptr SceneDatasetAttributesManager_ =
+  managers::SceneDatasetAttributesManager::ptr sceneDatasetAttributesManager_ =
       nullptr;
 
   /**

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -66,6 +66,8 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to asset attributes for
    * current dataset.
+   * @return The current dataset's @ref managers::AssetAttributesManager::ptr,
+   * or nullptr if no current dataset.
    */
   const managers::AssetAttributesManager::ptr getAssetAttributesManager()
       const {
@@ -77,6 +79,9 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to object attributes for
    * current dataset.
+   * @return The current dataset's @ref
+   * managers::LightLayoutAttributesManager::ptr, or nullptr if no current
+   * dataset.
    */
   const managers::LightLayoutAttributesManager::ptr
   getLightLayoutAttributesManager() const {
@@ -89,6 +94,8 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to object attributes for
    * current dataset.
+   * @return The current dataset's @ref managers::ObjectAttributesManager::ptr,
+   * or nullptr if no current dataset.
    */
   const managers::ObjectAttributesManager::ptr getObjectAttributesManager()
       const {
@@ -100,6 +107,8 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to stage attributes for
    * current dataset.
+   * @return The current dataset's @ref managers::StageAttributesManager::ptr,
+   * or nullptr if no current dataset.
    */
   const managers::StageAttributesManager::ptr getStageAttributesManager()
       const {
@@ -118,7 +127,7 @@ class MetadataMediator {
   }
 
   /**
-   * @brief Return copy of map of current active dataset's navmeshes.
+   * @brief Return copy of map of current active dataset's navmesh handles.
    */
   const std::map<std::string, std::string> getActiveNavmeshMap() const {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
@@ -130,7 +139,8 @@ class MetadataMediator {
   }
 
   /**
-   * @brief Return copy of map of current active dataset's navmeshes.
+   * @brief Return copy of map of current active dataset's semantic scene
+   * descriptor handles.
    */
   const std::map<std::string, std::string> getActiveSemanticSceneDescriptorMap()
       const {

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -4,6 +4,7 @@
 
 #include "LightLayoutAttributes.h"
 using Magnum::Math::Literals::operator""_radf;
+using Magnum::Math::Literals::operator""_degf;
 
 namespace esp {
 namespace metadata {
@@ -18,7 +19,7 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
   setType("point");
   // ignored for all but spot lights
   setInnerConeAngle(0.0_radf);
-  setOuterConeAngle(1.57_radf);
+  setOuterConeAngle(90.0_degf);
 }  // ctor
 
 LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "LightLayoutAttributes.h"
+using namespace Magnum::Math::Literals;
+
 namespace esp {
 namespace metadata {
 namespace attributes {
@@ -15,8 +17,8 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
   setIntensity(1.0);
   setType("point");
   // ignored for all but spot lights
-  setInnerConeAngle(0.75);
-  setOuterConeAngle(1.5);
+  setInnerConeAngle(0.75_radf);
+  setOuterConeAngle(1.5_radf);
 }  // ctor
 
 LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "LightLayoutAttributes.h"
+namespace esp {
+namespace metadata {
+namespace attributes {
+
+LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
+    : AbstractAttributes("LightInstanceAttributes", handle) {
+  setPosition({0.0, 0.0, 0.0});
+  setDirection({0.0, -1.0, 0.0});
+  setColor({1.0, 1.0, 1.0});
+  setIntensity(1.0);
+  setType("point");
+  // ignored for all but spot lights
+  setInnerConeAngle(0.75);
+  setOuterConeAngle(1.5);
+}  // ctor
+
+LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)
+    : AbstractAttributes("LightLayoutAttributes", handle) {}
+
+}  // namespace attributes
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -17,8 +17,8 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
   setIntensity(1.0);
   setType("point");
   // ignored for all but spot lights
-  setInnerConeAngle(0.75_radf);
-  setOuterConeAngle(1.5_radf);
+  setInnerConeAngle(0.0_radf);
+  setOuterConeAngle(1.57_radf);
 }  // ctor
 
 LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "LightLayoutAttributes.h"
-using namespace Magnum::Math::Literals;
+using Magnum::Math::Literals::operator""_radf;
 
 namespace esp {
 namespace metadata {

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -1,0 +1,140 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_METADATA_ATTRIBUTES_LIGHTLAYOUTATTRIBUTES_H_
+#define ESP_METADATA_ATTRIBUTES_LIGHTLAYOUTATTRIBUTES_H_
+
+#include "AttributesBase.h"
+
+namespace esp {
+namespace metadata {
+namespace attributes {
+
+/**
+ * @brief This class describes an instance of a light -
+ * it's template name, location/direction, color, intensity, type and other
+ * parameters if appropriate.
+ */
+class LightInstanceAttributes : public AbstractAttributes {
+ public:
+  LightInstanceAttributes(const std::string& handle = "");
+
+  /**
+   * @brief Get/Set the position of the light.
+   */
+  void setPosition(const Magnum::Vector3& position) {
+    setVec3("position", position);
+  }
+  Magnum::Vector3 getPosition() const { return getVec3("position"); }
+
+  /**
+   * @brief Get/Set the direction of the light.
+   */
+  void setDirection(const Magnum::Vector3& direction) {
+    setVec3("direction", direction);
+  }
+  Magnum::Vector3 getDirection() const { return getVec3("direction"); }
+
+  /**
+   * @brief Get/Set the color of the light.
+   */
+  void setColor(const Magnum::Vector3& color) { setVec3("color", color); }
+  Magnum::Vector3 getColor() const { return getVec3("color"); }
+
+  /**
+   * @brief Get/Set the color scale of the light.
+   */
+  void setIntensity(double intensity) { setDouble("intensity", intensity); }
+  double getIntensity() const { return getDouble("intensity"); }
+
+  /**
+   * @brief Get/Set the type of the light
+   */
+  void setType(const std::string& type) { setString("type", type); }
+  std::string getType() const { return getString("type"); }
+
+  /**
+   * @brief Get/Set inner cone angle for spotlights.  Should be ignored for
+   * other lights
+   */
+  void setInnerConeAngle(double innerConeAngle) {
+    setDouble("innerConeAngle", innerConeAngle);
+  }
+  double getInnerConeAngle() const { return getDouble("innerConeAngle"); }
+
+  /**
+   * @brief Get/Set inner cone angle for spotlights. Should be ignored for other
+   * lights
+   */
+  void setOuterConeAngle(double outerConeAngle) {
+    setDouble("outerConeAngle", outerConeAngle);
+  }
+  double getOuterConeAngle() const { return getDouble("outerConeAngle"); }
+
+ public:
+  ESP_SMART_POINTERS(LightInstanceAttributes)
+
+};  // class LightInstanceAttributes
+
+/**
+ * @brief This class describes a lighting layout, consisting of a series of
+ * lights.
+ */
+class LightLayoutAttributes : public AbstractAttributes {
+ public:
+  LightLayoutAttributes(const std::string& handle = "");
+
+  /**
+   * @brief Add a light instance to this lighting layout
+   */
+  void addLightInstance(LightInstanceAttributes::ptr _lightInstance) {
+    lightInstances_.emplace(_lightInstance->getHandle(), _lightInstance);
+  }
+
+  /**
+   * @brief Remove a light from this lighting layout
+   */
+  LightInstanceAttributes::ptr removeLightInstance(const std::string& handle) {
+    auto inst = getLightInstance(handle);
+    if (nullptr != inst) {
+      lightInstances_.erase(handle);
+    }
+    return inst;
+  }
+
+  LightInstanceAttributes::ptr getLightInstance(const std::string& handle) {
+    if (lightInstances_.count(handle) == 0) {
+      return nullptr;
+    }
+    auto inst = lightInstances_.at(handle);
+    return inst;
+  }
+
+  /**
+   * @brief Get the lighting instances for this layout
+   */
+  const std::map<std::string, LightInstanceAttributes::ptr> getLightInstances()
+      const {
+    return lightInstances_;
+  }
+
+  /**
+   * @brief Return how many lights are in this light layout
+   */
+  int getNumLightInstances() { return lightInstances_.size(); }
+
+ protected:
+  /**
+   * @brief The light instances used by this lighting layout
+   */
+  std::map<std::string, LightInstanceAttributes::ptr> lightInstances_;
+
+ public:
+  ESP_SMART_POINTERS(LightLayoutAttributes)
+};  // namespace attributes
+}  // namespace attributes
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_ATTRIBUTES_LIGHTLAYOUTATTRIBUTES_H_

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -58,19 +58,19 @@ class LightInstanceAttributes : public AbstractAttributes {
    * @brief Get/Set inner cone angle for spotlights.  Should be ignored for
    * other lights
    */
-  void setInnerConeAngle(double innerConeAngle) {
-    setDouble("innerConeAngle", innerConeAngle);
+  void setInnerConeAngle(const Magnum::Rad& innerConeAngle) {
+    setRad("innerConeAngle", innerConeAngle);
   }
-  double getInnerConeAngle() const { return getDouble("innerConeAngle"); }
+  Magnum::Rad getInnerConeAngle() const { return getRad("innerConeAngle"); }
 
   /**
    * @brief Get/Set inner cone angle for spotlights. Should be ignored for other
    * lights
    */
-  void setOuterConeAngle(double outerConeAngle) {
-    setDouble("outerConeAngle", outerConeAngle);
+  void setOuterConeAngle(const Magnum::Rad& outerConeAngle) {
+    setRad("outerConeAngle", outerConeAngle);
   }
-  double getOuterConeAngle() const { return getDouble("outerConeAngle"); }
+  Magnum::Rad getOuterConeAngle() const { return getRad("outerConeAngle"); }
 
  public:
   ESP_SMART_POINTERS(LightInstanceAttributes)

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -58,7 +58,7 @@ class LightInstanceAttributes : public AbstractAttributes {
    * @brief Get/Set inner cone angle for spotlights.  Should be ignored for
    * other lights
    */
-  void setInnerConeAngle(const Magnum::Rad& innerConeAngle) {
+  void setInnerConeAngle(Magnum::Rad innerConeAngle) {
     setRad("innerConeAngle", innerConeAngle);
   }
   Magnum::Rad getInnerConeAngle() const { return getRad("innerConeAngle"); }
@@ -67,7 +67,7 @@ class LightInstanceAttributes : public AbstractAttributes {
    * @brief Get/Set inner cone angle for spotlights. Should be ignored for other
    * lights
    */
-  void setOuterConeAngle(const Magnum::Rad& outerConeAngle) {
+  void setOuterConeAngle(Magnum::Rad outerConeAngle) {
     setRad("outerConeAngle", outerConeAngle);
   }
   Magnum::Rad getOuterConeAngle() const { return getRad("outerConeAngle"); }

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -13,6 +13,8 @@ SceneDatasetAttributes::SceneDatasetAttributes(
     const managers::PhysicsAttributesManager::ptr physAttrMgr)
     : AbstractAttributes("SceneDatasetAttributes", datasetName) {
   assetAttributesManager_ = managers::AssetAttributesManager::create();
+  lightLayoutAttributesManager_ =
+      managers::LightLayoutAttributesManager::create();
   objectAttributesManager_ = managers::ObjectAttributesManager::create();
   objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
   stageAttributesManager_ = managers::StageAttributesManager::create(

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -13,6 +13,7 @@
 #include "AttributesBase.h"
 
 #include "esp/metadata/managers/AssetAttributesManager.h"
+#include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"
 
@@ -31,6 +32,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const {
     return assetAttributesManager_;
   }
+
   /**
    * @brief Return manager for construction and access to object attributes.
    */
@@ -38,6 +40,15 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const {
     return objectAttributesManager_;
   }
+
+  /**
+   * @brief Return manager for construction and access to light attributes.
+   */
+  const managers::LightLayoutAttributesManager::ptr
+  getLightLayoutAttributesManager() const {
+    return lightLayoutAttributesManager_;
+  }
+
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
@@ -61,14 +72,14 @@ class SceneDatasetAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Only DatasetAttributesManager should directly edit navemesh and
+   * @brief Only SceneDatasetAttributesManager should directly edit navemesh and
    * semantic scene descriptor maps. Return the map for navmesh file locations
    * for building/modification
    */
   std::map<std::string, std::string>& editNavmeshMap() { return navmeshMap_; }
 
   /**
-   * @brief Only DatasetAttributesManager should directly edit navemesh and
+   * @brief Only SceneDatasetAttributesManager should directly edit navemesh and
    * semantic scene descriptor maps. Return the map for semantic scene
    * descriptor file locations for building/modification
    */
@@ -111,13 +122,23 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * attributes for object construction
    */
   managers::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
+
+  /**
+   * @brief Manages all construction and access to light attributes from this
+   * dataset.
+   */
+  managers::LightLayoutAttributesManager::ptr lightLayoutAttributesManager_ =
+      nullptr;
+
   /**
    * @brief Manages all construction and access to object attributes from this
    * dataset.
    */
   managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+
   /**
    * @brief Manages all construction and access to scene attributes from this
+   * @brief Manages all construction and access to stage attributes from this
    * dataset.
    */
   managers::StageAttributesManager::ptr stageAttributesManager_ = nullptr;

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -137,7 +137,6 @@ class SceneDatasetAttributes : public AbstractAttributes {
   managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
 
   /**
-   * @brief Manages all construction and access to scene attributes from this
    * @brief Manages all construction and access to stage attributes from this
    * dataset.
    */

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "LightLayoutAttributesManager.h"
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+using std::placeholders::_1;
+namespace Cr = Corrade;
+
+namespace esp {
+namespace metadata {
+using attributes::LightInstanceAttributes;
+using attributes::LightLayoutAttributes;
+namespace managers {
+
+LightLayoutAttributes::ptr LightLayoutAttributesManager::createObject(
+    const std::string& lightConfigName,
+    bool registerTemplate) {
+  std::string msg;
+  bool doRegister = registerTemplate;
+  // File based attributes are automatically registered.
+  std::string jsonAttrFileName =
+      this->convertFilenameToJSON(lightConfigName, this->JSONTypeExt_);
+  bool jsonFileExists = (this->isValidFileName(jsonAttrFileName));
+  if (jsonFileExists) {
+    // if exists, force registration to be true.
+    doRegister = true;
+  }
+  // build attributes
+  LightLayoutAttributes::ptr attrs =
+      this->createFromJsonOrDefaultInternal(lightConfigName, msg, doRegister);
+
+  if (nullptr != attrs) {
+    LOG(INFO) << msg << " light layout attributes created"
+              << (doRegister ? " and registered." : ".");
+  }
+  return attrs;
+}  // PhysicsAttributesManager::createObject
+
+void LightLayoutAttributesManager::setValsFromJSONDoc(
+    attributes::LightLayoutAttributes::ptr lightAttribs,
+    const io::JsonGenericValue& jsonConfig) {
+  const std::string layoutNameAndPath = lightAttribs->getHandle();
+  // this will parse jsonConfig for the description of each light, and build an
+  // attributes for each.
+  // set file directory here, based on layout name
+  std::string dirname = Cr::Utility::Directory::path(layoutNameAndPath);
+  std::string filenameExt = Cr::Utility::Directory::filename(layoutNameAndPath);
+  // remove ".lighting_config.json" from name
+  std::string layoutName =
+      Cr::Utility::Directory::splitExtension(
+          Cr::Utility::Directory::splitExtension(filenameExt).first)
+          .first;
+  LightInstanceAttributes::ptr lightInstanceAttribs = nullptr;
+  if (jsonConfig.HasMember("lights") && jsonConfig["lights"].IsObject()) {
+    const auto& lightCell = jsonConfig["lights"];
+    // iterate through objects
+    for (rapidjson::Value::ConstMemberIterator it = lightCell.MemberBegin();
+         it != lightCell.MemberEnd(); ++it) {
+      // create attributes and set its name to be the tag in the JSON for the
+      // individual light
+      const std::string key = it->name.GetString();
+      const auto& obj = it->value;
+      // TODO construct name using file name prepended to key
+      lightInstanceAttribs = LightInstanceAttributes::create(key);
+      // set file directory here, based on layout's directory
+      lightInstanceAttribs->setFileDirectory(lightAttribs->getFileDirectory());
+      // set attributes values from JSON doc
+      this->setLightInstanceValsFromJSONDoc(lightInstanceAttribs, obj);
+
+      // add ref to object in appropriate layout
+      lightAttribs->addLightInstance(lightInstanceAttribs);
+
+      LOG(INFO) << "LightLayoutAttributesManager::setValsFromJSONDoc : "
+                   "LightInstanceAttributes "
+                << lightInstanceAttribs->getHandle()
+                << " created successfully and added to LightLayoutAttributes "
+                << layoutName << ".";
+    }
+    // register
+    this->postCreateRegister(lightAttribs, true);
+
+  } else {
+    LOG(WARNING)
+        << "LightLayoutAttributesManager::setValsFromJSONDoc : " << layoutName
+        << " does not contain a \"lights\" object and so no parsing was "
+           "done.";
+  }
+}  // LightLayoutAttributesManager::setValsFromJSONDoc
+
+void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
+    LightInstanceAttributes::ptr lightAttribs,
+    const io::JsonGenericValue& jsonConfig) {
+  // jsonConfig here holds the JSON description for a single light attributes.
+  // set position
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonConfig, "position",
+      std::bind(&LightInstanceAttributes::setPosition, lightAttribs, _1));
+  // set direction
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonConfig, "direction",
+      std::bind(&LightInstanceAttributes::setDirection, lightAttribs, _1));
+  // set color
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonConfig, "color",
+      std::bind(&LightInstanceAttributes::setColor, lightAttribs, _1));
+  // set intensity
+  io::jsonIntoSetter<double>(
+      jsonConfig, "intensity",
+      std::bind(&LightInstanceAttributes::setIntensity, lightAttribs, _1));
+  // type of light
+  io::jsonIntoSetter<std::string>(
+      jsonConfig, "type",
+      std::bind(&LightInstanceAttributes::setType, lightAttribs, _1));
+  // read spotlight params
+  if (jsonConfig.HasMember("spot")) {
+    if (!jsonConfig["spot"].IsObject()) {
+      LOG(WARNING)
+          << "LightLayoutAttributesManager::setValsFromJSONDoc : \"spot\" "
+             "cell in JSON config unable to be parsed to set "
+             "spotlight parameters so skipping.";
+    } else {
+      const auto& spotArea = jsonConfig["spot"];
+      // set inner cone angle
+      io::jsonIntoSetter<double>(
+          spotArea, "innerConeAngle",
+          std::bind(&LightInstanceAttributes::setInnerConeAngle, lightAttribs,
+                    _1));
+
+      // set outer cone angle
+      io::jsonIntoSetter<double>(
+          spotArea, "outerConeAngle",
+          std::bind(&LightInstanceAttributes::setOuterConeAngle, lightAttribs,
+                    _1));
+    }
+  }  // if member spot present
+}  // LightLayoutAttributesManager::setValsFromJSONDoc
+
+LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
+    const std::string& handleName,
+    bool builtFromConfig) {
+  attributes::LightLayoutAttributes::ptr newAttributes =
+      this->constructFromDefault(handleName);
+  // if no default then create new.
+  if (nullptr == newAttributes) {
+    newAttributes = attributes::LightLayoutAttributes::create(handleName);
+  }
+  return newAttributes;
+}  // LightLayoutAttributesManager::initNewObjectInternal
+
+int LightLayoutAttributesManager::registerObjectFinalize(
+    LightLayoutAttributes::ptr lightAttribs,
+    const std::string& lightAttribsHandle) {
+  // adds template to library, and returns either the ID of the existing
+  // template referenced by LightLayoutAttributesHandle, or the next available
+  // ID if not found.
+  int LightLayoutAttributesID =
+      this->addObjectToLibrary(lightAttribs, lightAttribsHandle);
+
+  return LightLayoutAttributesID;
+}  // LightLayoutAttributesManager::registerObjectFinalize
+
+}  // namespace managers
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -124,13 +124,13 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
     } else {
       const auto& spotArea = jsonConfig["spot"];
       // set inner cone angle
-      io::jsonIntoSetter<double>(
+      io::jsonIntoSetter<Magnum::Rad>(
           spotArea, "innerConeAngle",
           std::bind(&LightInstanceAttributes::setInnerConeAngle, lightAttribs,
                     _1));
 
       // set outer cone angle
-      io::jsonIntoSetter<double>(
+      io::jsonIntoSetter<Magnum::Rad>(
           spotArea, "outerConeAngle",
           std::bind(&LightInstanceAttributes::setOuterConeAngle, lightAttribs,
                     _1));

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -1,0 +1,146 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_METADATA_MANAGERS_LIGHTATTRIBUTEMANAGER_H_
+#define ESP_METADATA_MANAGERS_LIGHTATTRIBUTEMANAGER_H_
+
+#include "AttributesManagerBase.h"
+
+#include "esp/metadata/attributes/LightLayoutAttributes.h"
+
+namespace Cr = Corrade;
+
+namespace esp {
+namespace metadata {
+namespace managers {
+class LightLayoutAttributesManager
+    : public AttributesManager<attributes::LightLayoutAttributes> {
+ public:
+  LightLayoutAttributesManager()
+      : AttributesManager<attributes::LightLayoutAttributes>::AttributesManager(
+            "Lighting Layout",
+            "lighting_config.json") {
+    buildCtorFuncPtrMaps();
+  }
+
+  /**
+   * @brief Creates one or more instances of LightLayoutAttributes based on the
+   * whether @p lightConfigName is a file or a not.  If it is a file it will
+   * consider the contents of that file a layout and will use the file name as
+   * the layout name and load all the attributes described and assign them to
+   * that layout.  File-based loads will automatically register, regardless of
+   * what @p registerTemplate is.
+   *
+   * If a template/layout exists with this handle, this existing template/layout
+   * will be overwritten with the newly created one if registerTemplate is true.
+   *
+   * @param lightConfigName The configuration file to parse, or the name of the
+   * single light's attributs to create.
+   * @param registerTemplate whether to add this template to the library.
+   * Defaults to false - overridden if @p lightConfigName is a JSON file.
+   * @return a reference to the created light attributes.
+   */
+  attributes::LightLayoutAttributes::ptr createObject(
+      const std::string& lightConfigName,
+      bool registerTemplate = false) override;
+
+  /**
+   * @brief Function to take an existing LightLayoutAttributes and set its
+   * values from passed json config file.
+   * @param lightAttribs (out) an existing attributes to be modified.
+   * @param jsonConfig json document to parse
+   */
+  void setValsFromJSONDoc(attributes::LightLayoutAttributes::ptr lightAttribs,
+                          const io::JsonGenericValue& jsonConfig) override;
+
+  /**
+   * @brief Function to take an existing LightInstanceAttributes and set its
+   * values from passed json config file
+   * @param lightInstAttribs (out) an existing attributes to be modified.
+   * @param jsonConfig json document to parse
+   */
+  void setLightInstanceValsFromJSONDoc(
+      attributes::LightInstanceAttributes::ptr lightInstAttribs,
+      const io::JsonGenericValue& jsonConfig);
+
+ protected:
+  /**
+   * @brief Used Internally.  Create and configure newly-created attributes with
+   * any default values, before any specific values are set.
+   *
+   * @param handleName handle name to be assigned to attributes\
+   * @param builtFromConfig whether this LightLayoutAttributes is being built
+   * from a config file, or from some other source (i.e. handleName contains
+   * config file name)
+   * @return Newly created but unregistered LightLayoutAttributes pointer, with
+   * only default values set.
+   */
+  attributes::LightLayoutAttributes::ptr initNewObjectInternal(
+      const std::string& handleName,
+      bool builtFromConfig) override;
+
+  /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+  void updateObjectHandleLists(
+      CORRADE_UNUSED int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {}
+
+  /**
+   * @brief Add a copy of the @ref
+   * esp::metadata::attributes::LightLayoutAttributes shared_ptr object to
+   * the @ref objectLibrary_.
+   *
+   * @param LightLayoutAttributesTemplate The attributes template.
+   * @param LightLayoutAttributesHandle The key for referencing the template in
+   * the
+   * @ref objectLibrary_.
+   * @return The index in the @ref objectLibrary_ of object
+   * template.
+   */
+  int registerObjectFinalize(
+      attributes::LightLayoutAttributes::ptr LightLayoutAttributesTemplate,
+      const std::string& LightLayoutAttributesHandle) override;
+
+  /**
+   * @brief Any lights-attributes-specific resetting that needs to happen on
+   * reset.
+   */
+  void resetFinalize() override {}
+
+  /**
+   * @brief This function will assign the appropriately configured function
+   * pointer for the copy constructor as required by
+   * AttributesManager<LightLayoutAttributes::ptr>
+   */
+  void buildCtorFuncPtrMaps() override {
+    this->copyConstructorMap_["LightLayoutAttributes"] =
+        &LightLayoutAttributesManager::createObjectCopy<
+            attributes::LightLayoutAttributes>;
+  }  // LightLayoutAttributesManager::buildCtorFuncPtrMaps
+
+  /**
+   * @brief Light Attributes has no reason to check this value
+   * @param handle String name of primitive asset attributes desired
+   * @return whether handle exists or not in asset attributes library
+   */
+  bool isValidPrimitiveAttributes(
+      CORRADE_UNUSED const std::string& handle) override {
+    return false;
+  }
+
+ public:
+  ESP_SMART_POINTERS(LightLayoutAttributesManager)
+
+};  // LightLayoutAttributesManager
+
+}  // namespace managers
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_MANAGERS_LIGHTATTRIBUTEMANAGER_H_

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -59,9 +59,9 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
   readDatasetJSONCell(dsDir, "objects", jsonConfig,
                       dsAttribs->getObjectAttributesManager());
 
-  // process light setups - implement handling light setups TODO
-  // readDatasetJSONCell(dsDir,"light setups", jsonConfig,
-  //                     dsAttribs->getLightsAttributesManager());
+  // process light setups - implement handling light setups
+  readDatasetJSONCell(dsDir, "light_setups", jsonConfig,
+                      dsAttribs->getLightLayoutAttributesManager());
 
   // process scene instances - implement handling scene instances TODO
   // readDatasetJSONCell(dsDir,"scene instances", jsonConfig,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -86,18 +86,29 @@ class Simulator {
   // TODO: support multi-scene physics (default sceneID=0 currently).
 
   /**
-   * @brief Return manager for construction and access to asset attributes.
+   * @brief Return manager for construction and access to asset attributes for
+   * the current dataset.
    */
   const metadata::managers::AssetAttributesManager::ptr
   getAssetAttributesManager() const {
-    return resourceManager_->getAssetAttributesManager();
+    return metadataMediator_->getAssetAttributesManager();
   }
   /**
-   * @brief Return manager for construction and access to object attributes.
+   * @brief Return manager for construction and access to light attributes and
+   * layouts for the current dataset.
+   */
+  const metadata::managers::LightLayoutAttributesManager::ptr
+  getLightLayoutAttributesManager() const {
+    return metadataMediator_->getLightLayoutAttributesManager();
+  }
+
+  /**
+   * @brief Return manager for construction and access to object attributes and
+   * layouts for the current dataset.
    */
   const metadata::managers::ObjectAttributesManager::ptr
   getObjectAttributesManager() const {
-    return resourceManager_->getObjectAttributesManager();
+    return metadataMediator_->getObjectAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to physics world
@@ -105,14 +116,15 @@ class Simulator {
    */
   const metadata::managers::PhysicsAttributesManager::ptr
   getPhysicsAttributesManager() const {
-    return resourceManager_->getPhysicsAttributesManager();
+    return metadataMediator_->getPhysicsAttributesManager();
   }
   /**
-   * @brief Return manager for construction and access to scene attributes.
+   * @brief Return manager for construction and access to scene attributes for
+   * the current dataset.
    */
   const metadata::managers::StageAttributesManager::ptr
   getStageAttributesManager() const {
-    return resourceManager_->getStageAttributesManager();
+    return metadataMediator_->getStageAttributesManager();
   }
 
   /** @brief Return the library implementation type for the simulator currently

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -38,10 +38,12 @@ struct SimulatorConfiguration {
    * for RGB rendering
    */
   bool requiresTextures = true;
-  std::string physicsConfigFile =
-      ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH;  // should we instead link a
-                                            // PhysicsManagerConfiguration
-                                            // object here?
+  std::string physicsConfigFile = ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH;
+
+  /**
+   * @brief File location for initial dataset to use.
+   */
+  std::string datasetConfigFile = "default";
   /** @brief Light setup key for scene */
   std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -16,6 +16,7 @@
 
 namespace Cr = Corrade;
 
+using namespace Magnum::Math::Literals;
 namespace AttrMgrs = esp::metadata::managers;
 namespace Attrs = esp::metadata::attributes;
 
@@ -474,8 +475,8 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
   ASSERT_EQ(lightAttr->getColor(), Magnum::Vector3(2, 1, -1));
   ASSERT_EQ(lightAttr->getIntensity(), -0.1);
   ASSERT_EQ(lightAttr->getType(), "spot");
-  ASSERT_EQ(lightAttr->getInnerConeAngle(), -0.75);
-  ASSERT_EQ(lightAttr->getOuterConeAngle(), -1.57);
+  ASSERT_EQ(lightAttr->getInnerConeAngle(), -0.75_radf);
+  ASSERT_EQ(lightAttr->getOuterConeAngle(), -1.57_radf);
 }  // AttributesManagers_LightJSONLoadTest
 /**
  * @brief This test will verify that the Stage attributes' managers' JSON

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -16,7 +16,7 @@
 
 namespace Cr = Corrade;
 
-using namespace Magnum::Math::Literals;
+using Magnum::Math::Literals::operator""_radf;
 namespace AttrMgrs = esp::metadata::managers;
 namespace Attrs = esp::metadata::attributes;
 


### PR DESCRIPTION
## Motivation and Context
This PR adds support for parsing lighting layout files, of the format found [here](https://drive.google.com/file/d/1oPO9m3ws69k8wlipgU0C1XPGoLf8P_v5/view?usp=sharing) into appropriately configured attributes files, which are to then be used to instantiate lights in scenes.

A ".lighting_config.json" configuration file is assumed to describe a single lighting layout, consisting off multiple lights. The file is parsed so that each light entry is parsed into a LightInstanceAttributes object, which is aggregated into a single LightLayoutAttributes object.  This in turn is used to instance a lighting layout upon scene creation.
   
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All existing c++ and python tests passed.  Tests were added to verify proper parsing of JSON.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
