### PR TITLE
--MetadataMediator - Scene Instance Configurations

### DIFF
--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -27,6 +27,8 @@ set(
   managers/ObjectAttributesManager.cpp
   managers/PhysicsAttributesManager.h
   managers/PhysicsAttributesManager.cpp
+  managers/SceneAttributesManager.h
+  managers/SceneAttributesManager.cpp
   managers/SceneDatasetAttributesManager.h
   managers/SceneDatasetAttributesManager.cpp
   managers/StageAttributesManager.h

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -105,6 +105,17 @@ class MetadataMediator {
   }
 
   /**
+   * @brief Return manager for construction and access to scene instance
+   * attributes for current dataset.
+   */
+  const managers::SceneAttributesManager::ptr getSceneAttributesManager()
+      const {
+    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
+    return (nullptr == datasetAttr) ? nullptr
+                                    : datasetAttr->getSceneAttributesManager();
+  }  // MetadataMediator::getStageAttributesManager
+
+  /**
    * @brief Return manager for construction and access to stage attributes for
    * current dataset.
    * @return The current dataset's @ref managers::StageAttributesManager::ptr,

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -107,6 +107,8 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to scene instance
    * attributes for current dataset.
+   * @return The current dataset's @ref managers::SceneAttributesManager::ptr,
+   * or nullptr if no current dataset.
    */
   const managers::SceneAttributesManager::ptr getSceneAttributesManager()
       const {

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -3,9 +3,26 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "SceneAttributes.h"
-
+#include "esp/physics/RigidBase.h"
 namespace esp {
 namespace metadata {
-namespace attributes {}  // namespace attributes
+namespace attributes {
+// All keys must be lowercase
+const std::map<std::string, esp::physics::MotionType>
+    SceneObjectInstanceAttributes::MotionTypeNamesMap = {
+        {"static", esp::physics::MotionType::STATIC},
+        {"kinematic", esp::physics::MotionType::KINEMATIC},
+        {"dynamic", esp::physics::MotionType::DYNAMIC},
+};
+
+SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
+    const std::string& handle)
+    : AbstractAttributes("SceneObjectInstanceAttributes", handle) {
+  setMotionType(-1);  // defaults to unknown
+}
+SceneAttributes::SceneAttributes(const std::string& handle)
+    : AbstractAttributes("SceneAttributes", handle) {}
+
+}  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -8,8 +8,149 @@
 #include "AttributesBase.h"
 
 namespace esp {
+namespace physics {
+enum class MotionType;
+}
 namespace metadata {
-namespace attributes {}  // namespace attributes
+namespace attributes {
+
+/**
+ * @brief This class describes an instance of a stage or object in a scene -
+ * it's template name, translation from the origin, rotation, and (if
+ * appropriate) motiontype
+ */
+class SceneObjectInstanceAttributes : public AbstractAttributes {
+ public:
+  /**
+   * @brief Constant static map to provide mappings from string tags to @ref
+   * esp::assets::AssetType values.  This will be used to map values set in json
+   * for mesh type to @ref esp::assets::AssetType.  Keys must be lowercase.
+   */
+  static const std::map<std::string, esp::physics::MotionType>
+      MotionTypeNamesMap;
+  SceneObjectInstanceAttributes(const std::string& handle);
+
+  /**
+   * @brief Set the translation from the origin of the described
+   * stage/object instance.
+   */
+  void setTranslation(const Magnum::Vector3& translation) {
+    setVec3("translation", translation);
+  }
+  /**
+   * @brief Get the translation from the origin of the described
+   * stage/object instance.
+   */
+  Magnum::Vector3 getTranslation() const { return getVec3("translation"); }
+
+  /**
+   * @brief Set the rotation of the object
+   */
+  void setRotation(const Magnum::Quaternion& rotation) {
+    setQuat("rotation", rotation);
+  }
+  /**
+   * @brief Get the rotation of the object
+   */
+  Magnum::Quaternion getRotation() const { return getQuat("rotation"); }
+
+  /**
+   * @brief Set the motion type for the object.  Ignored for stage instances.
+   */
+  void setMotionType(int motionType) { setInt("motion_type", motionType); }
+
+  /**
+   * @brief Get the motion type for the object.  Ignored for stage instances.
+   */
+  int getMotionType() const { return getInt("motion_type"); }
+
+ public:
+  ESP_SMART_POINTERS(SceneObjectInstanceAttributes)
+};  // class SceneObjectInstanceAttributes
+
+class SceneAttributes : public AbstractAttributes {
+ public:
+  SceneAttributes(const std::string& handle);
+
+  /**
+   * @brief Set the name of the template that describes the scene's stage
+   */
+  void setLightingHandle(const std::string& lightingHandle) {
+    setString("default_lighting", lightingHandle);
+  }
+  /**
+   * @brief Get the name of the template that describes the scene's stage
+   */
+  std::string getLightingHandle() const {
+    return getString("default_lighting");
+  }
+
+  /**
+   * @brief Set the name of the navmesh for the scene
+   */
+  void setNavmeshHandle(const std::string& navmeshHandle) {
+    setString("navmesh_instance", navmeshHandle);
+  }
+  /**
+   * @brief Get the name of the navmesh for the scene
+   */
+  std::string getNavmeshHandle() const { return getString("navmesh_instance"); }
+
+  /**
+   * @brief Set the name of the semantic scene descriptor
+   */
+  void setSemanticSceneHandle(const std::string& semanticSceneDesc) {
+    setString("semantic_scene_instance", semanticSceneDesc);
+  }
+  /**
+   * @brief Get the name of the semantic scene descriptor
+   */
+  std::string getSemanticSceneHandle() const {
+    return getString("semantic_scene_instance");
+  }
+
+  /**
+   * @brief Set the description of the stage placement for this scene instance.
+   */
+  void setStageInstance(SceneObjectInstanceAttributes::ptr _stageInstance) {
+    stageInstance_ = _stageInstance;
+  }
+  /**
+   * @brief Get the description of the stage placement for this scene instance.
+   */
+  const SceneObjectInstanceAttributes::ptr getStageInstance() const {
+    return stageInstance_;
+  }
+
+  /**
+   * @brief Add a description of an object instance to this scene instance
+   */
+  void addObjectInstance(SceneObjectInstanceAttributes::ptr _objInstance) {
+    objectInstances_.push_back(_objInstance);
+  }
+  /**
+   * @brief Get the object instance descriptions for this scene
+   */
+  const std::vector<SceneObjectInstanceAttributes::ptr> getObjectInstances()
+      const {
+    return objectInstances_;
+  }
+
+ protected:
+  /**
+   * @brief The stage instance used by the scene
+   */
+  SceneObjectInstanceAttributes::ptr stageInstance_ = nullptr;
+
+  /**
+   * @brief All the object instance descriptors used by the scene
+   */
+  std::vector<SceneObjectInstanceAttributes::ptr> objectInstances_;
+
+ public:
+  ESP_SMART_POINTERS(SceneAttributes)
+};  // class SceneAttributes
+}  // namespace attributes
 }  // namespace metadata
 }  // namespace esp
 

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -17,6 +17,7 @@ SceneDatasetAttributes::SceneDatasetAttributes(
       managers::LightLayoutAttributesManager::create();
   objectAttributesManager_ = managers::ObjectAttributesManager::create();
   objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
+  sceneAttributesManager_ = managers::SceneAttributesManager::create();
   stageAttributesManager_ = managers::StageAttributesManager::create(
       objectAttributesManager_, physAttrMgr);
 }  // ctor

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -15,6 +15,7 @@
 #include "esp/metadata/managers/AssetAttributesManager.h"
 #include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
+#include "esp/metadata/managers/SceneAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"
 
 namespace esp {
@@ -51,6 +52,14 @@ class SceneDatasetAttributes : public AbstractAttributes {
 
   /**
    * @brief Return manager for construction and access to scene attributes.
+   */
+  const managers::SceneAttributesManager::ptr getSceneAttributesManager()
+      const {
+    return sceneAttributesManager_;
+  }
+
+  /**
+   * @brief Return manager for construction and access to stage attributes.
    */
   const managers::StageAttributesManager::ptr getStageAttributesManager()
       const {
@@ -135,6 +144,12 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * dataset.
    */
   managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+
+  /**
+   * @brief Manages all construction and access to scene instance attributes
+   * from this dataset.
+   */
+  managers::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
 
   /**
    * @brief Manages all construction and access to stage attributes from this

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -135,9 +135,10 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
   if (io::jsonIntoVal<std::string>(jCell, "motion_type", tmpVal)) {
     // motion type tag was found, perform check - first convert to lowercase
     std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
-    if (SceneObjectInstanceAttributes::MotionTypeNamesMap.count(strToLookFor)) {
-      motionTypeVal = static_cast<int>(
-          SceneObjectInstanceAttributes::MotionTypeNamesMap.at(strToLookFor));
+    auto found =
+        SceneObjectInstanceAttributes::MotionTypeNamesMap.find(strToLookFor);
+    if (found != SceneObjectInstanceAttributes::MotionTypeNamesMap.end()) {
+      motionTypeVal = static_cast<int>(found->second);
     } else {
       LOG(WARNING)
           << "SceneAttributesManager::createInstanceAttributesFromJSON : "

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "SceneAttributesManager.h"
+#include "esp/physics/RigidBase.h"
+
+#include "esp/io/io.h"
+#include "esp/io/json.h"
+
+using std::placeholders::_1;
+
+namespace esp {
+namespace metadata {
+
+using attributes::SceneAttributes;
+using attributes::SceneObjectInstanceAttributes;
+
+namespace managers {
+
+SceneAttributes::ptr SceneAttributesManager::createObject(
+    const std::string& sceneInstanceHandle,
+    bool registerTemplate) {
+  std::string msg;
+  SceneAttributes::ptr attrs = this->createFromJsonOrDefaultInternal(
+      sceneInstanceHandle, msg, registerTemplate);
+
+  if (nullptr != attrs) {
+    LOG(INFO) << msg << " scene instance attributes created"
+              << (registerTemplate ? " and registered." : ".");
+  }
+  return attrs;
+}  // SceneAttributesManager::createObject
+
+SceneAttributes::ptr SceneAttributesManager::initNewObjectInternal(
+    const std::string& sceneInstanceHandle,
+    bool builtFromConfig) {
+  SceneAttributes::ptr newAttributes =
+      this->constructFromDefault(sceneInstanceHandle);
+  if (nullptr == newAttributes) {
+    newAttributes = SceneAttributes::create(sceneInstanceHandle);
+  }
+  // attempt to set source directory if exists
+  this->setFileDirectoryFromHandle(newAttributes);
+
+  // any internal default configuration here
+  return newAttributes;
+}  // SceneAttributesManager::initNewObjectInternal
+
+void SceneAttributesManager::setValsFromJSONDoc(
+    SceneAttributes::ptr attribs,
+    const io::JsonGenericValue& jsonConfig) {
+  const std::string attribsName = attribs->getHandle();
+  // Check for stage instance existance
+  if ((jsonConfig.HasMember("stage_instance")) &&
+      (jsonConfig["stage_instance"].IsObject())) {
+    attribs->setStageInstance(
+        createInstanceAttributesFromJSON(jsonConfig["stage_instance"]));
+  } else {
+    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Stage "
+                    "specified for scene "
+                 << attribsName << ", or specification error.";
+  }
+  // Check for object instances existance
+  if ((jsonConfig.HasMember("object_instances")) &&
+      (jsonConfig["object_instances"].IsArray())) {
+    const auto& objectArray = jsonConfig["object_instances"];
+    for (rapidjson::SizeType i = 0; i < objectArray.Size(); i++) {
+      const auto& objCell = objectArray[i];
+      if (objCell.IsObject()) {
+        attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
+      } else {
+        LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : Object "
+                        "specification error in scene "
+                     << attribsName << " at idx : " << i << ".";
+      }
+    }
+  } else {
+    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Objects "
+                    "specified for scene "
+                 << attribsName << ", or specification error.";
+  }
+  std::string dfltLighting = "";
+  if (io::jsonIntoVal<std::string>(jsonConfig, "default_lighting",
+                                   dfltLighting)) {
+    // if "default lighting" is specified in scene json set value.
+    attribs->setLightingHandle(dfltLighting);
+  } else {
+    LOG(WARNING)
+        << "SceneAttributesManager::setValsFromJSONDoc : No default_lighting "
+           "specified for scene "
+        << attribsName << ".";
+  }
+
+  std::string navmeshName = "";
+  if (io::jsonIntoVal<std::string>(jsonConfig, "navmesh_instance",
+                                   navmeshName)) {
+    // if "navmesh_instance" is specified in scene json set value.
+    attribs->setNavmeshHandle(navmeshName);
+  } else {
+    LOG(WARNING)
+        << "SceneAttributesManager::setValsFromJSONDoc : No navmesh_instance "
+           "specified for scene "
+        << attribsName << ".";
+  }
+
+  std::string semanticDesc = "";
+  if (io::jsonIntoVal<std::string>(jsonConfig, "semantic_scene_instance",
+                                   semanticDesc)) {
+    // if "semantic scene instance" is specified in scene json set value.
+    attribs->setSemanticSceneHandle(semanticDesc);
+  } else {
+    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No "
+                    "semantic_scene_instance specified for scene "
+                 << attribsName << ".";
+  }
+}  // SceneAttributesManager::setValsFromJSONDoc
+
+SceneObjectInstanceAttributes::ptr
+SceneAttributesManager::createInstanceAttributesFromJSON(
+    const io::JsonGenericValue& jCell) {
+  SceneObjectInstanceAttributes::ptr instanceAttrs =
+      SceneObjectInstanceAttributes::create("");
+  // template handle describing stage/object instance
+  io::jsonIntoConstSetter<std::string>(
+      jCell, "template_name",
+      std::bind(&SceneObjectInstanceAttributes::setHandle, instanceAttrs, _1));
+
+  // motion type of object.  Ignored for stage.  TODO : veify is valid motion
+  // type using standard mechanism of static map comparison.
+
+  int motionTypeVal = motionTypeVal =
+      static_cast<int>(physics::MotionType::UNDEFINED);
+  std::string tmpVal = "";
+  if (io::jsonIntoVal<std::string>(jCell, "motion_type", tmpVal)) {
+    // motion type tag was found, perform check - first convert to lowercase
+    std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
+    if (SceneObjectInstanceAttributes::MotionTypeNamesMap.count(strToLookFor)) {
+      motionTypeVal = static_cast<int>(
+          SceneObjectInstanceAttributes::MotionTypeNamesMap.at(strToLookFor));
+    } else {
+      LOG(WARNING)
+          << "SceneAttributesManager::createInstanceAttributesFromJSON : "
+             "motion_type value in json  : `"
+          << tmpVal << "|" << strToLookFor
+          << "` does not map to a valid physics::MotionType value, so "
+             "defaulting motion type to MotionType::UNDEFINED.";
+    }
+  }
+  instanceAttrs->setMotionType(motionTypeVal);
+
+  // translation from origin
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jCell, "translation",
+      std::bind(&SceneObjectInstanceAttributes::setTranslation, instanceAttrs,
+                _1));
+
+  // orientation TODO : support euler angles too?
+  io::jsonIntoConstSetter<Magnum::Quaternion>(
+      jCell, "rotation",
+      std::bind(&SceneObjectInstanceAttributes::setRotation, instanceAttrs,
+                _1));
+
+  return instanceAttrs;
+
+}  // SceneAttributesManager::createInstanceAttributesFromJSON
+
+int SceneAttributesManager::registerObjectFinalize(
+    SceneAttributes::ptr sceneAttributes,
+    const std::string& sceneAttributesHandle) {
+  // adds template to library, and returns either the ID of the existing
+  // template referenced by sceneAttributesHandle, or the next available ID
+  // if not found.
+  int datasetTemplateID =
+      this->addObjectToLibrary(sceneAttributes, sceneAttributesHandle);
+  return datasetTemplateID;
+}  // SceneAttributesManager::registerObjectFinalize
+
+}  // namespace managers
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -1,0 +1,145 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+#define ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+
+#include "AttributesManagerBase.h"
+#include "esp/metadata/attributes/SceneAttributes.h"
+
+namespace esp {
+namespace metadata {
+
+namespace managers {
+class SceneAttributesManager
+    : public AttributesManager<attributes::SceneAttributes> {
+ public:
+  SceneAttributesManager()
+      : AttributesManager<attributes::SceneAttributes>::AttributesManager(
+            "Scene Instance",
+            "scene_instance.json") {
+    buildCtorFuncPtrMaps();
+  }
+
+  /**
+   * @brief Creates the descriptive attributes template for a scene instance
+   * described by passed string.
+   *
+   * If a template exists with this handle, this existing template will be
+   * overwritten with the newly created one if registerTemplate is true.
+   *
+   * @param sceneInstanceHandle the origin of the desired dataset template
+   * to be created.
+   * @param registerTemplate whether to add this template to the library.
+   * If the user is going to edit this template, this should be false - any
+   * subsequent editing will require re-registration. Defaults to true. If
+   * specified as true, then this function returns a copy of the registered
+   * template.
+   * @return a reference to the newly-created template.
+   */
+  attributes::SceneAttributes::ptr createObject(
+      const std::string& sceneInstanceHandle,
+      bool registerTemplate = true) override;
+
+  /**
+   * @brief Method to take an existing attributes and set its values from passed
+   * json config file.
+   * @param attribs (out) an existing attributes to be modified.
+   * @param jsonConfig json document to parse
+   */
+  void setValsFromJSONDoc(attributes::SceneAttributes::ptr attribs,
+                          const io::JsonGenericValue& jsonConfig) override;
+
+ protected:
+  /**
+   * @brief Used Internally.  Create a @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes object from the
+   * passed JSON doc.
+   * @param jCell JSON object containing the description of the stage or object
+   * instance.
+   * @return the constructed @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes object
+   */
+  attributes::SceneObjectInstanceAttributes::ptr
+  createInstanceAttributesFromJSON(const io::JsonGenericValue& jCell);
+
+  /**
+   * @brief Used Internally.  Create and configure newly-created scene instance
+   * attributes with any default values, before any specific values are set.
+   *
+   * @param sceneInstanceHandle handle name to be assigned to scene instance
+   * attributes
+   * @param builtFromConfig Whether this scene is being constructed from a
+   * config file or from some other source.
+   * @return Newly created but unregistered SceneAttributes pointer, with only
+   * default values set.
+   */
+  attributes::SceneAttributes::ptr initNewObjectInternal(
+      const std::string& sceneInstanceHandle,
+      bool builtFromConfig) override;
+
+  /**
+   * @brief This method will perform any necessary updating that is
+   * attributesManager-specific upon template removal, such as removing a
+   * specific template handle from the list of file-based template handles in
+   * ObjectAttributesManager.  This should only be called internally.
+   *
+   * @param templateID the ID of the template to remove
+   * @param templateHandle the string key of the attributes desired.
+   */
+
+  void updateObjectHandleLists(
+      CORRADE_UNUSED int templateID,
+      CORRADE_UNUSED const std::string& templateHandle) override {}
+
+  /**
+   * @brief Any scene-instance-attributes-specific resetting that needs to
+   * happen on reset.
+   */
+  void resetFinalize() override {}
+
+  /**
+   * @brief Add a @ref std::shared_ptr<attributesType> object to the
+   * @ref objectLibrary_.  Verify that render and collision handles have been
+   * set properly.  We are doing this since these values can be modified by the
+   * user.
+   *
+   * @param sceneAttributes The attributes template.
+   * @param sceneAttributesHandle The key for referencing the template in the
+   * @ref objectLibrary_.
+   * @return The index in the @ref objectLibrary_ of the registered template.
+   */
+  int registerObjectFinalize(attributes::SceneAttributes::ptr sceneAttributes,
+                             const std::string& sceneAttributesHandle) override;
+
+  /**
+   * @brief This function will assign the appropriately configured function
+   * pointer for the copy constructor as required by
+   * AttributesManager<PhysicsSceneAttributes::ptr>
+   */
+  void buildCtorFuncPtrMaps() override {
+    this->copyConstructorMap_["SceneAttributes"] =
+        &SceneAttributesManager::createObjectCopy<attributes::SceneAttributes>;
+  }  // SceneAttributesManager::buildCtorFuncPtrMaps
+
+  /**
+   * @brief This function is meaningless for this manager's ManagedObjects.
+   * @param handle Ignored.
+   * @return false
+   */
+  virtual bool isValidPrimitiveAttributes(
+      CORRADE_UNUSED const std::string& handle) override {
+    return false;
+  }
+
+ public:
+  ESP_SMART_POINTERS(SceneAttributesManager)
+
+};  // class SceneAttributesManager
+
+}  // namespace managers
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -64,8 +64,8 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                       dsAttribs->getLightLayoutAttributesManager());
 
   // process scene instances - implement handling scene instances TODO
-  // readDatasetJSONCell(dsDir,"scene instances", jsonConfig,
-  //                     dsAttribs->getSceneInstanceManager());
+  readDatasetJSONCell(dsDir, "scene_instances", jsonConfig,
+                      dsAttribs->getSceneAttributesManager());
 
   // process navmesh instances
   io::jsonIntoVal<std::map<std::string, std::string>>(


### PR DESCRIPTION
## Motivation and Context
This PR add support for parsing "scene_instance.json" into SceneAttributes configuration files, which are then consumed to instantiate a scene.  

A "scene_instance.json" file, whose format can be found [here](https://drive.google.com/file/d/1_1fw5y93mAE1FuwQZWqgbQKtVQGOx-CA/view?usp=sharing), describes the layout of a scene, potentially specifying a stage and/or 0 or more objects, a lighting configuration, navmesh and semantic scene descriptor.  This configuration file is parsed by SceneAttributesManager into a SceneAttributes configuration object, which manages references to the various scene assets, including individual instances of SceneInstanceAttributes objects which describe which object and stage templates to use, if any, and where to put the instantiated construct within the scene.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests have passed.  Tests were added to verify that the configuration parsing is proceeding as expected.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
