### PR TITLE
[WIP] manual MotionState sync for dynamic objects

### DIFF
--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -622,12 +622,16 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   //! SceneGraph
   std::vector<esp::scene::SceneNode*> visualNodes_;
 
- protected:
-  /** @brief Used to synchronize other simulator's notion of the object state
-   * after it was changed kinematically. Called automatically on kinematic
-   * updates.*/
-  virtual void syncPose() { return; }
+  /** @brief Used to synchronize object states between Habitat and
+   * external physics simulation libraries. Called automatically on kinematic
+   * updates.
+   *
+   * @param from Specifies the directionality of the state sync. If true, set
+   * the Habitat state from the physics simulation state.
+   */
+  virtual void syncPose(bool from = false) { return; }
 
+ protected:
   /** @brief The @ref MotionType of the object. Determines what operations can
    * be performed on this object. */
   MotionType objectMotionType_;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -161,6 +161,14 @@ void BulletPhysicsManager::stepPhysics(double dt) {
   int numSubStepsTaken =
       bWorld_->stepSimulation(dt, /*maxSubSteps*/ 10000, fixedTimeStep_);
   worldTime_ += numSubStepsTaken * fixedTimeStep_;
+
+  // Manually sync the motionstates for all DYNAMIC objects. KINEMATIC and
+  // STATIC sync should always be one-way.
+  for (auto& objectItr : existingObjects_) {
+    if (objectItr.second->getMotionType() == MotionType::DYNAMIC) {
+      objectItr.second->syncPose(true);
+    }
+  }
 }
 
 void BulletPhysicsManager::setMargin(const int physObjectID,

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -312,10 +312,17 @@ void BulletRigidObject::shiftOrigin(const Magnum::Vector3& shift) {
 
 //! Synchronize Physics transformations
 //! Needed after changing the pose from Magnum side
-void BulletRigidObject::syncPose() {
+void BulletRigidObject::syncPose(bool from) {
   //! For syncing objects
-  bObjectRigidBody_->setWorldTransform(
-      btTransform(node().transformationMatrix()));
+  if (!from) {
+    // render to simulation
+    bObjectRigidBody_->setWorldTransform(
+        btTransform(node().transformationMatrix()));
+  } else {
+    // render from simulation
+    bObjectRigidBody_->getMotionState()->setWorldTransform(
+        bObjectRigidBody_->getWorldTransform());
+  }
 }  // syncPose
 
 void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -432,13 +432,16 @@ class BulletRigidObject : public BulletBase,
   bool initialization_LibSpecific(
       const assets::ResourceManager& resMgr) override;
 
- protected:
-  /**
-   * @brief Used to synchronize Bullet's notion of the object state
-   * after it was changed kinematically. Called automatically on kinematic
-   * updates. See @ref btRigidBody::setWorldTransform. */
-  void syncPose() override;
+  /** @brief Used to synchronize object states between Habitat and
+   * Bullet. Called automatically on kinematic
+   * updates. Called to set state from Bullet after @ref stepPhysics.
+   *
+   * @param from Specifies the directionality of the state sync. If true, set
+   * the Habitat state from the Bullet state.
+   */
+  void syncPose(bool from = false) override;
 
+ protected:
   /**
    * @brief construct a @ref btRigidBody for this object configured by
    * MotionType and add it to the world.


### PR DESCRIPTION
## Motivation and Context

Habitat uses btMotionState to synchronize object states with Bullet simulation. Internally, Bullet sets btMotionState for dynamic objects to interpolate motion between actualized discrete steps and requested time deltas. This results in the state de-sync shown in the image:
![image](https://user-images.githubusercontent.com/1445143/96803068-1b717100-13c0-11eb-97ed-7ae1634fc4f3.png)

This PR provides one possible solution to this issue: manually synchronize the motion state transforms for dynamic objects after stepping Bullet.

## How Has This Been Tested

Locally with viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
