### PR TITLE
add a condition in the Pbr Shader to avoid an error when precomputed tangents are not presented.

### DIFF
--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -85,7 +85,7 @@ uniform mediump float NormalTextureScale
 #endif
 
 // -------------- shader ------------------
-#if defined(NORMAL_TEXTURE)
+#if defined(NORMAL_TEXTURE) && defined(PRECOMPUTED_TANGENT)
 vec3 getNormalFromNormalMap() {
   vec3 tangentNormal =
 #if defined(NORMAL_TEXTURE_SCALE)


### PR DESCRIPTION
## Motivation and Context
As titled.
This is just a temporary fix as in the future we would like to seek the normal mapping without the precomputed tangents.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
