### PR TITLE
--MetadataMediator : Tests and bindings.

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -271,6 +271,15 @@ class ResourceManager {
   }
 
   /**
+   * @brief Set a reference to the current @ref metadataMediator_.  Perform any
+   * initialization that may be required when @ref metadataMediator_ is changed.
+   * @param _MM a reference to the new @ref metadataMediator_.
+   */
+  void setMetadataMediator(metadata::MetadataMediator::ptr _MM) {
+    metadataMediator_ = _MM;
+  }
+
+  /**
    * @brief Retrieve the composition of all transforms applied to a mesh
    * since it was loaded.
    *

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -83,9 +83,11 @@ void initSimBindings(py::module& m) {
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")
-      .def_property("active_dataset", &Simulator::getActiveDatasetName,
-                    &Simulator::setActiveDatasetName,
-                    R"(The currently active dataset being used.)")
+      .def_property(
+          "active_dataset", &Simulator::getActiveSceneDatasetName,
+          &Simulator::setActiveSceneDatasetName,
+          R"(The currently active dataset being used.  Will attempt to load
+            configuration files specified if does not already exist.)")
       /* --- Physics functions --- */
       /* --- Template Manager accessors --- */
       .def("get_asset_template_manager", &Simulator::getAssetAttributesManager,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -83,6 +83,9 @@ void initSimBindings(py::module& m) {
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")
+      .def_property("active_dataset", &Simulator::getActiveDatasetName,
+                    &Simulator::setActiveDatasetName,
+                    R"(The currently active dataset being used.)")
       /* --- Physics functions --- */
       /* --- Template Manager accessors --- */
       .def("get_asset_template_manager", &Simulator::getAssetAttributesManager,

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -12,57 +12,59 @@ void MetadataMediator::buildAttributesManagers() {
       managers::SceneDatasetAttributesManager::create(
           physicsAttributesManager_);
   // create blank default attributes manager
-  createDataset(activeDataset_);
+  createDataset(activeSceneDataset_);
 }  // MetadataMediator::buildAttributesManagers
 
-bool MetadataMediator::createDataset(const std::string& datasetName,
+bool MetadataMediator::createDataset(const std::string& sceneDatasetName,
                                      bool overwrite) {
   // see if exists
   bool exists =
-      sceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName);
+      sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName);
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
-      LOG(WARNING) << "MetadataMediator::setActiveDataset : Dataset "
-                   << datasetName
+      LOG(WARNING) << "MetadataMediator::createDataset : Dataset "
+                   << sceneDatasetName
                    << " already exists.  To reload and overwrite existing "
                       "data, set overwrite to true. Aborting.";
       return false;
     }
     // overwrite specified, make sure not locked
-    sceneDatasetAttributesManager_->setLock(datasetName, false);
+    sceneDatasetAttributesManager_->setLock(sceneDatasetName, false);
   }
   // by here dataset either does not exist or exists but is unlocked.
   auto datasetAttribs =
-      sceneDatasetAttributesManager_->createObject(datasetName, true);
+      sceneDatasetAttributesManager_->createObject(sceneDatasetName, true);
   if (nullptr == datasetAttribs) {
     // not created, do not set name
     LOG(WARNING) << "MetadataMediator::createDataset : Unknown dataset "
-                 << datasetName
+                 << sceneDatasetName
                  << " does not exist and is not able to be created.  Aborting.";
     return false;
   }
   // if not null then successfully created
-  LOG(INFO) << "MetadataMediator::createDataset : Dataset " << datasetName
+  LOG(INFO) << "MetadataMediator::createDataset : Dataset " << sceneDatasetName
             << " successfully created.";
   return true;
 }  // MetadataMediator::createDataset
 
-bool MetadataMediator::setActiveDatasetName(const std::string& datasetName) {
+bool MetadataMediator::setActiveSceneDatasetName(
+    const std::string& sceneDatasetName) {
   // first check if dataset exists, if so then set default
-  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(datasetName)) {
-    LOG(INFO) << "MetadataMediator::setActiveDatasetName : Old active dataset "
-              << activeDataset_ << " changed to " << datasetName
-              << " successfully.";
-    activeDataset_ = datasetName;
+  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName)) {
+    LOG(INFO)
+        << "MetadataMediator::setActiveSceneDatasetName : Old active dataset "
+        << activeSceneDataset_ << " changed to " << sceneDatasetName
+        << " successfully.";
+    activeSceneDataset_ = sceneDatasetName;
     return true;
   }
   // if does not exist, attempt to create it
-  bool success = createDataset(datasetName);
+  bool success = createDataset(sceneDatasetName);
   // if successfully created, set default name to access dataset attributes in
   // SceneDatasetAttributesManager
   if (success) {
-    activeDataset_ = datasetName;
+    activeSceneDataset_ = sceneDatasetName;
   }
   return success;
 }  // namespace metadata

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -22,8 +22,8 @@ namespace esp {
 namespace metadata {
 class MetadataMediator {
  public:
-  MetadataMediator(const std::string& _defaultDataset = "default")
-      : activeDataset_(_defaultDataset) {
+  MetadataMediator(const std::string& _defaultSceneDataset = "default")
+      : activeSceneDataset_(_defaultSceneDataset) {
     buildAttributesManagers();
   }  // namespace metadata
   ~MetadataMediator() {}
@@ -38,30 +38,31 @@ class MetadataMediator {
   void buildAttributesManagers();
 
   /**
-   * @brief Creates a dataset attributes using @p datasetName, and registers it.
-   * NOTE If an existing dataset attributes exists with this handle, then this
-   * will exit with a message unless @p overwrite is true.
-   * @param datasetName The name of the dataset to load or create.
+   * @brief Creates a dataset attributes using @p sceneDatasetName, and
+   * registers it. NOTE If an existing dataset attributes exists with this
+   * handle, then this will exit with a message unless @p overwrite is true.
+   * @param sceneDatasetName The name of the dataset to load or create.
    * @param overwrite Whether to overwrite an existing dataset or not
    * @return Whether successfully created a new dataset or not.
    */
-  bool createDataset(const std::string& datasetName, bool overwrite = true);
+  bool createDataset(const std::string& sceneDatasetName,
+                     bool overwrite = true);
 
   /**
    * @brief Sets default dataset attributes, if it exists already.  If it does
    * not exist, it will attempt to load a dataset_config.json with the given
    * name.  If none exists it will create an "empty" dataset attributes and give
    * it the passed name.
-   * @param datasetName the name of the existing dataset to use as default, or a
-   * json file describing the desired dataset attributes, or some handle to use
-   * for an empty dataset.
+   * @param sceneDatasetName the name of the existing dataset to use as default,
+   * or a json file describing the desired dataset attributes, or some handle to
+   * use for an empty dataset.
    * @return whether successful or not
    */
-  bool setActiveDatasetName(const std::string& datasetName);
+  bool setActiveSceneDatasetName(const std::string& sceneDatasetName);
   /**
    * @brief Returns the name of the current default dataset
    */
-  std::string getActiveDatasetName() const { return activeDataset_; }
+  std::string getActiveSceneDatasetName() const { return activeSceneDataset_; }
 
   /**
    * @brief Return manager for construction and access to asset attributes for
@@ -177,11 +178,11 @@ class MetadataMediator {
     // do not get copy of dataset attributes until SceneDatasetAttributes deep
     // copy ctor implemented
     auto datasetAttr =
-        sceneDatasetAttributesManager_->getObjectByHandle(activeDataset_);
+        sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
     if (nullptr == datasetAttr) {
       LOG(ERROR)
           << "MetadataMediator::getActiveDSAttribs : Unknown dataset named "
-          << activeDataset_ << ". Aborting";
+          << activeSceneDataset_ << ". Aborting";
       return nullptr;
     }
     return datasetAttr;
@@ -190,7 +191,7 @@ class MetadataMediator {
   /**
    * @brief String name of current, default dataset.
    */
-  std::string activeDataset_;
+  std::string activeSceneDataset_;
   /**
    * @brief Manages all construction and access to asset attributes.
    */

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -32,6 +32,16 @@ StageAttributesManager::StageAttributesManager(
   buildCtorFuncPtrMaps();
 }  // StageAttributesManager ctor
 
+void StageAttributesManager::buildCtorFuncPtrMaps() {
+  this->copyConstructorMap_["StageAttributes"] =
+      &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
+  // create none-type stage attributes and set as undeletable
+  // based on default
+  auto tmplt = this->createDefaultObject("NONE", true);
+  std::string tmpltHandle = tmplt->getHandle();
+  this->undeletableObjectNames_.insert(tmpltHandle);
+}  // StageAttributesManager::buildCtorFuncPtrMaps
+
 int StageAttributesManager::registerObjectFinalize(
     StageAttributes::ptr stageAttributes,
     const std::string& stageAttributesHandle) {
@@ -85,12 +95,11 @@ int StageAttributesManager::registerObjectFinalize(
     // system - if so then setCollisionAssetIsPrimitive to false
     stageAttributes->setCollisionAssetIsPrimitive(false);
   } else if (std::string::npos != stageAttributesHandle.find("NONE")) {
-    // Render asset handle will be NONE as well - force type to be unknown
+    // Collision asset handle will be NONE as well - force type to be unknown
     stageAttributes->setCollisionAssetType(
         static_cast<int>(AssetType::UNKNOWN));
     stageAttributes->setCollisionAssetIsPrimitive(false);
   } else {
-    // Else, means no collision data specified, use specified render data
     // Else, means no collision data specified, use specified render data
     LOG(INFO)
         << "StageAttributesManager::registerObjectFinalize "
@@ -356,7 +365,7 @@ void StageAttributesManager::setValsFromJSONDoc(
       objectAttributesMgr_->loadAllConfigsFromPath(absolutePath, true);
     }
   }  // if load rigid object library metadata
-}  // namespace managers
+}  // StageAttributesManager::setValsFromJSONDoc
 
 }  // namespace managers
 }  // namespace metadata

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -168,10 +168,7 @@ class StageAttributesManager
    * pointer for the copy constructor as required by
    * AttributesManager<StageAttributes::ptr>
    */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["StageAttributes"] =
-        &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
-  }  // StageAttributesManager::buildCtorFuncPtrMaps
+  void buildCtorFuncPtrMaps() override;
 
   // instance vars
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -76,9 +76,9 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   // set dataset upon creation or reconfigure
   if (!metadataMediator_) {
     metadataMediator_ =
-        metadata::MetadataMediator::create(cfg.datasetConfigFile);
+        metadata::MetadataMediator::create(cfg.sceneDatasetConfigFile);
   } else {
-    metadataMediator_->setActiveDatasetName(cfg.datasetConfigFile);
+    metadataMediator_->setActiveSceneDatasetName(cfg.sceneDatasetConfigFile);
   }
   // assign MM to RM on create or reconfigure
   if (!resourceManager_) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -73,12 +73,19 @@ void Simulator::close() {
 }
 
 void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
+  // set dataset upon creation or reconfigure
   if (!metadataMediator_) {
-    metadataMediator_ = metadata::MetadataMediator::create();
+    metadataMediator_ =
+        metadata::MetadataMediator::create(cfg.datasetConfigFile);
+  } else {
+    metadataMediator_->setActiveDatasetName(cfg.datasetConfigFile);
   }
+  // assign MM to RM on create or reconfigure
   if (!resourceManager_) {
     resourceManager_ =
         std::make_unique<assets::ResourceManager>(metadataMediator_);
+  } else {
+    resourceManager_->setMetadataMediator(metadataMediator_);
   }
 
   if (!sceneManager_) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -130,8 +130,8 @@ class Simulator {
   /**
    * @brief Get current active dataset name from @ref metadataMediator_.
    */
-  std::string getActiveDatasetName() {
-    return metadataMediator_->getActiveDatasetName();
+  std::string getActiveSceneDatasetName() {
+    return metadataMediator_->getActiveSceneDatasetName();
   }
 
   /**
@@ -139,8 +139,8 @@ class Simulator {
    * @param _dsHandle The desired dataset to switch to. If has not been loaded,
    * an attempt will be made to load it.
    */
-  void setActiveDatasetName(const std::string& _dsHandle) {
-    metadataMediator_->setActiveDatasetName(_dsHandle);
+  void setActiveSceneDatasetName(const std::string& _dsHandle) {
+    metadataMediator_->setActiveSceneDatasetName(_dsHandle);
   }
 
   /** @brief Return the library implementation type for the simulator currently

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -127,6 +127,22 @@ class Simulator {
     return metadataMediator_->getStageAttributesManager();
   }
 
+  /**
+   * @brief Get current active dataset name from @ref metadataMediator_.
+   */
+  std::string getActiveDatasetName() {
+    return metadataMediator_->getActiveDatasetName();
+  }
+
+  /**
+   * @brief Set current active dataset name from @ref metadataMediator_.
+   * @param _dsHandle The desired dataset to switch to. If has not been loaded,
+   * an attempt will be made to load it.
+   */
+  void setActiveDatasetName(const std::string& _dsHandle) {
+    metadataMediator_->setActiveDatasetName(_dsHandle);
+  }
+
   /** @brief Return the library implementation type for the simulator currently
    * in use. Use to check for a particular implementation.
    * @return The implementation type of this simulator.

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -41,9 +41,9 @@ struct SimulatorConfiguration {
   std::string physicsConfigFile = ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH;
 
   /**
-   * @brief File location for initial dataset to use.
+   * @brief File location for initial scene dataset to use.
    */
-  std::string datasetConfigFile = "default";
+  std::string sceneDatasetConfigFile = "default";
   /** @brief Light setup key for scene */
   std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,6 +20,9 @@ target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY
 
 test(CoreTest io)
 
+test(MetadataMediatorTest assets metadata)
+target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 test(NavTest nav assets)
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -1,0 +1,314 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include "esp/metadata/MetadataMediator.h"
+#include "esp/metadata/managers/AssetAttributesManager.h"
+#include "esp/metadata/managers/AttributesManagerBase.h"
+#include "esp/metadata/managers/ObjectAttributesManager.h"
+#include "esp/metadata/managers/PhysicsAttributesManager.h"
+#include "esp/metadata/managers/StageAttributesManager.h"
+
+#include "configure.h"
+
+using esp::metadata::MetadataMediator;
+
+namespace AttrMgrs = esp::metadata::managers;
+namespace Attrs = esp::metadata::attributes;
+
+using esp::metadata::MetadataMediator;
+
+using AttrMgrs::AttributesManager;
+using Attrs::AbstractPrimitiveAttributes;
+using Attrs::CapsulePrimitiveAttributes;
+using Attrs::ConePrimitiveAttributes;
+using Attrs::CubePrimitiveAttributes;
+using Attrs::CylinderPrimitiveAttributes;
+using Attrs::IcospherePrimitiveAttributes;
+using Attrs::ObjectAttributes;
+using Attrs::PhysicsManagerAttributes;
+using Attrs::SceneAttributes;
+using Attrs::StageAttributes;
+using Attrs::UVSpherePrimitiveAttributes;
+const std::string physicsConfigFile =
+    Cr::Utility::Directory::join(DATA_DIR,
+                                 "test_assets/testing.physics_config.json");
+const std::string datasetConfigFile = Cr::Utility::Directory::join(
+    DATA_DIR,
+    "test_assets/dataset_tests/test_dataset.scene_dataset_config.json");
+
+class MetadataMediatorTest : public testing::Test {
+ protected:
+  void SetUp() override { MM = MetadataMediator::create(datasetConfigFile); };
+  void testLoadStages() {
+    const auto stageAttributesMgr = MM->getStageAttributesManager();
+    int numHandles = stageAttributesMgr->getNumObjects();
+    // should be 3 - one original, one based on original but changed, and one
+    // new
+    ASSERT_EQ(numHandles, 3);
+
+    // get list of matching handles for base - should always only be 1
+    auto attrHandles = stageAttributesMgr->getObjectHandlesBySubstring(
+        "dataset_test_stage.stage_config.json", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    auto attr = stageAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // get render asset handle for later comparison
+    auto renderAssetHandle = attr->getRenderAssetHandle();
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify set to values in file
+    ASSERT_EQ(attr->getScale(), Magnum::Vector3(2, 2, 2));
+    ASSERT_EQ(attr->getRequiresLighting(), true);
+    ASSERT_EQ(attr->getMargin(), 0.03);
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.3);
+    ASSERT_EQ(attr->getRestitutionCoefficient(), 0.3);
+    ASSERT_EQ(attr->getOrigin(), Magnum::Vector3(0, 0, 0));
+    ASSERT_EQ(attr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+    ASSERT_EQ(attr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+
+    // get list of matching handles for modified base - should always only be 1
+    attrHandles = stageAttributesMgr->getObjectHandlesBySubstring(
+        "modified_test_stage", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = stageAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify set to override values in dataset_config file
+    ASSERT_EQ(attr->getScale(), Magnum::Vector3(1, 1, 1));
+    ASSERT_EQ(attr->getMargin(), 0.041);
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.4);
+    ASSERT_EQ(attr->getRestitutionCoefficient(), 0.5);
+    ASSERT_EQ(attr->getUnitsToMeters(), 1.0);
+
+    // get list of matching handles for new - should always only be 1
+    attrHandles =
+        stageAttributesMgr->getObjectHandlesBySubstring("new_test_stage", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = stageAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify set to values in dataset_config file
+    auto newRenderAssetHandle = attr->getRenderAssetHandle();
+    // verify same renderasset handle to loaded stage attributes
+    ASSERT_EQ(renderAssetHandle, newRenderAssetHandle);
+    // verify values set correctly
+    ASSERT_EQ(attr->getOrientUp(), Magnum::Vector3(0, -1, 0));
+    ASSERT_EQ(attr->getScale(), Magnum::Vector3(2, 2, 2));
+    ASSERT_EQ(attr->getGravity(), Magnum::Vector3(0, 9.8, 0));
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.35);
+    ASSERT_EQ(attr->getRestitutionCoefficient(), 0.25);
+    ASSERT_EQ(attr->getUnitsToMeters(), 2.0);
+    ASSERT_EQ(attr->getRequiresLighting(), false);
+
+    // get new attributes but don't register
+    attr = stageAttributesMgr->createObject("new_default_attributes", false);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify contains default attributes value
+    ASSERT_EQ(attr->getOrigin(), Magnum::Vector3(1.0, 2.0, 3.0));
+
+  }  // testLoadStages
+
+  void testLoadObjects() {
+    const auto objectAttributesMgr = MM->getObjectAttributesManager();
+    int numHandles = objectAttributesMgr->getNumFileTemplateObjects();
+    // should be 6 file-based templates - 4 original, one based on an original
+    // but changed, and one new
+    ASSERT_EQ(numHandles, 6);
+
+    // get list of matching handles for base object - should always only be 1
+    auto attrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
+        "dataset_test_object1.object_config.json", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    auto attr = objectAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify set to values in file
+    ASSERT_EQ(attr->getScale(), Magnum::Vector3(1, 1, 1));
+    ASSERT_EQ(attr->getRequiresLighting(), true);
+    ASSERT_EQ(attr->getMargin(), 0.03);
+    ASSERT_EQ(attr->getMass(), 0.038);
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.5);
+    ASSERT_EQ(attr->getRestitutionCoefficient(), 0.2);
+    ASSERT_EQ(attr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+    ASSERT_EQ(attr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+    ASSERT_EQ(attr->getUnitsToMeters(), 1.0);
+    ASSERT_EQ(attr->getBoundingBoxCollisions(), false);
+    ASSERT_EQ(attr->getJoinCollisionMeshes(), true);
+
+    // get list of matching handles for modified base - should always only be 1
+    attrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
+        "modified_test_object1_1_slick_heavy", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = objectAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify identical to copied object except for override values in
+    // dataset_config file
+    ASSERT_EQ(attr->getScale(), Magnum::Vector3(1, 1, 1));
+    ASSERT_EQ(attr->getRequiresLighting(), true);
+    ASSERT_EQ(attr->getMargin(), 0.03);
+    ASSERT_EQ(attr->getMass(), 3.5);
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.2);
+    ASSERT_EQ(attr->getRestitutionCoefficient(), 0.2);
+    ASSERT_EQ(attr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+    ASSERT_EQ(attr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+    ASSERT_EQ(attr->getUnitsToMeters(), 1.0);
+    ASSERT_EQ(attr->getBoundingBoxCollisions(), false);
+    ASSERT_EQ(attr->getJoinCollisionMeshes(), true);
+
+    // get list of matching handles for new - should always only be 1
+    attrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
+        "new_test_object3", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = objectAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify set to values in dataset_config file
+    auto newRenderAssetHandle = attr->getRenderAssetHandle();
+    // verify same renderasset handle to loaded stage attributes
+    ASSERT_NE(std::string::npos,
+              newRenderAssetHandle.find("dataset_test_object3.glb"));
+    // verify values set correctly
+
+    ASSERT_EQ(attr->getMass(), 1.1);
+    ASSERT_EQ(attr->getFrictionCoefficient(), 0.1);
+    ASSERT_EQ(attr->getInertia(), Magnum::Vector3(3, 2, 1));
+
+    // get new attributes but don't register
+    attr = objectAttributesMgr->createObject("new_default_attributes", false);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify contains default attributes value
+    ASSERT_EQ(attr->getMass(), 10.0);
+    ASSERT_EQ(attr->getInertia(), Magnum::Vector3(3, 2, 1));
+  }  // testLoadObjects
+
+  void testLoadLights() {
+    const auto lightsLayoutAttributesMgr =
+        MM->getLightLayoutAttributesManager();
+    // get # of loaded light layout attributes.
+    int numHandles = lightsLayoutAttributesMgr->getNumObjects();
+    // Should be 3 : file based, copy and new
+    ASSERT_EQ(numHandles, 3);
+    // get list of matching handles for base light config - should always only
+    // be 1
+    auto attrHandles = lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
+        "dataset_test_lights.lighting_config.json", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    auto attr =
+        lightsLayoutAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify the number of lights within the lighting layout
+    ASSERT_EQ(12, attr->getNumLightInstances());
+
+    // get list of matching handles for modified light config - should always
+    // only be 1
+    attrHandles = lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
+        "modified_test_lights", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = lightsLayoutAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify the number of lights within the lighting layout
+    ASSERT_EQ(12, attr->getNumLightInstances());
+
+    // get list of matching handles for new light config - should always only be
+    // 1
+    attrHandles = lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
+        "new_test_lights_0", true);
+    ASSERT_EQ(attrHandles.size(), 1);
+    // get copy of attributes
+    attr = lightsLayoutAttributesMgr->getObjectCopyByHandle(attrHandles[0]);
+    // verify existence
+    ASSERT_NE(nullptr, attr);
+    // verify the number of lights within the lighting layout
+    ASSERT_EQ(3, attr->getNumLightInstances());
+
+  }  // testLoadLights
+
+  void testLoadSceneInstances() {
+    const auto sceneAttributesMgr = MM->getSceneAttributesManager();
+
+  }  // testLoadSceneInstances
+
+  void testLoadNavmesh() {
+    // get map of navmeshes
+    const auto navmeshMap = MM->getActiveNavmeshMap();
+    // should have 2
+    ASSERT_EQ(navmeshMap.size(), 2);
+
+    // should hold 2 keys
+    ASSERT_NE(navmeshMap.count("navmesh_path1"), 0);
+    ASSERT_NE(navmeshMap.count("navmesh_path2"), 0);
+    // each key should hold specific value
+    ASSERT_EQ(navmeshMap.at("navmesh_path1"), "test_navmesh_path1");
+    ASSERT_EQ(navmeshMap.at("navmesh_path2"), "test_navmesh_path2");
+  }  // testLoadNavmesh
+
+  void testLoadSemanticScene() {
+    // get map of semantic scene instances
+    const auto semanticMap = MM->getActiveSemanticSceneDescriptorMap();
+    // should have 2
+    ASSERT_EQ(semanticMap.size(), 2);
+    // should hold 2 keys
+    ASSERT_NE(semanticMap.count("semantic_descriptor_path1"), 0);
+    ASSERT_NE(semanticMap.count("semantic_descriptor_path2"), 0);
+    // each key should hold specific value
+    ASSERT_EQ(semanticMap.at("semantic_descriptor_path1"),
+              "test_semantic_descriptor_path1");
+    ASSERT_EQ(semanticMap.at("semantic_descriptor_path2"),
+              "test_semantic_descriptor_path2");
+  }  // testLoadSemanticScene
+
+  MetadataMediator::ptr MM = nullptr;
+
+};  // class MetadataMediatorTest
+
+/**
+ * @brief This test will verify that the physics attributes' managers' JSON
+ * loading process is working as expected.
+ */
+TEST_F(MetadataMediatorTest, MetadataMediatorTest_CreateTestDataset) {
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::MetadataMediatorTest_CreateTestDataset : "
+               "Dataset name : "
+            << datasetConfigFile;
+  // verify dataset name
+  ASSERT_EQ(MM->getActiveDatasetName(), datasetConfigFile);
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadStages";
+  testLoadStages();
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadObjects";
+  testLoadObjects();
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadLights";
+  testLoadLights();
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadSceneInstances";
+  testLoadSceneInstances();
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadNavmesh";
+  testLoadNavmesh();
+
+  LOG(INFO) << "Starting "
+               "MetadataMediatorTest::testLoadSemanticScene";
+  testLoadSemanticScene();
+
+}  // MetadataMediatorTest, MetadataMediatorTest_CreateTestDataset

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -34,13 +34,15 @@ using Attrs::UVSpherePrimitiveAttributes;
 const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
                                  "test_assets/testing.physics_config.json");
-const std::string datasetConfigFile = Cr::Utility::Directory::join(
+const std::string sceneDatasetConfigFile = Cr::Utility::Directory::join(
     DATA_DIR,
     "test_assets/dataset_tests/test_dataset.scene_dataset_config.json");
 
 class MetadataMediatorTest : public testing::Test {
  protected:
-  void SetUp() override { MM = MetadataMediator::create(datasetConfigFile); };
+  void SetUp() override {
+    MM = MetadataMediator::create(sceneDatasetConfigFile);
+  };
   void testLoadStages() {
     const auto stageAttributesMgr = MM->getStageAttributesManager();
     int numHandles = stageAttributesMgr->getNumObjects();
@@ -283,9 +285,9 @@ TEST_F(MetadataMediatorTest, MetadataMediatorTest_CreateTestDataset) {
   LOG(INFO) << "Starting "
                "MetadataMediatorTest::MetadataMediatorTest_CreateTestDataset : "
                "Dataset name : "
-            << datasetConfigFile;
+            << sceneDatasetConfigFile;
   // verify dataset name
-  ASSERT_EQ(MM->getActiveDatasetName(), datasetConfigFile);
+  ASSERT_EQ(MM->getActiveSceneDatasetName(), sceneDatasetConfigFile);
 
   LOG(INFO) << "Starting "
                "MetadataMediatorTest::testLoadStages";

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -44,9 +44,9 @@ class MetadataMediatorTest : public testing::Test {
   void testLoadStages() {
     const auto stageAttributesMgr = MM->getStageAttributesManager();
     int numHandles = stageAttributesMgr->getNumObjects();
-    // should be 3 - one original, one based on original but changed, and one
-    // new
-    ASSERT_EQ(numHandles, 3);
+    // should be 4 - one for default NONE stage, one original, one based on
+    // original but changed, and one new
+    ASSERT_EQ(numHandles, 4);
 
     // get list of matching handles for base - should always only be 1
     auto attrHandles = stageAttributesMgr->getObjectHandlesBySubstring(


### PR DESCRIPTION
## Motivation and Context
This PR adds a c++ test to verify MetadataMediator functionality.  It also makes Sim.reconfigure maintain an appropriate current ref to the current MetadataMediator in ResourceManager, and provides some accessors.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Passes all existing c++ and python tests; Adds tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
