### PR TITLE
Futureproof PIL/CFFI versions for colab install.

### DIFF
--- a/examples/colab_utils/colab_install.sh
+++ b/examples/colab_utils/colab_install.sh
@@ -24,13 +24,13 @@ wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh &&
 ln -s /usr/local/lib/python3.6/dist-packages /usr/local/lib/python3.6/site-packages
 
 ##Install Habitat-Sim and Magnum binaries
-conda config --set pip_interop_enabled True 
+conda config --set pip_interop_enabled True
 NIGHTLY="${NIGHTLY:-false}" #setting the ENV $NIGHTLY to true will install the nightly version from conda
 CHANNEL="${CHANNEL:-aihabitat}"
 if ${NIGHTLY}; then
   CHANNEL="${CHANNEL}-nightly"
 fi
-conda install -S -y --prefix /usr/local -c "${CHANNEL}" -c conda-forge habitat-sim headless withbullet python=3.6 "pillow==${PIL_VERSION}" "cffi==${CFFI_VERSION}" 
+conda install -S -y --prefix /usr/local -c "${CHANNEL}" -c conda-forge habitat-sim headless withbullet python=3.6 "pillow==${PIL_VERSION}" "cffi==${CFFI_VERSION}"
 
 #Shallow GIT clone for speed
 git clone https://github.com/facebookresearch/habitat-lab --depth 1

--- a/examples/colab_utils/colab_install.sh
+++ b/examples/colab_utils/colab_install.sh
@@ -13,6 +13,9 @@ catch() {
     echo "An error occured during the installation of Habitat-sim or Habitat-Lab." >&2
   fi
 }
+#Don't change the colab versions for these libraries
+PIL_VERSION="$(python -c 'import PIL; print(PIL.__version__)')"
+CFFI_VERSION="$(python -c 'import cffi; print(cffi.__version__)')"
 #Install Miniconda
 cd /content/
 wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -bfp /usr/local
@@ -21,13 +24,13 @@ wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh &&
 ln -s /usr/local/lib/python3.6/dist-packages /usr/local/lib/python3.6/site-packages
 
 ##Install Habitat-Sim and Magnum binaries
-conda config --set default_threads 4 #Enables multithread conda installation
+conda config --set pip_interop_enabled True 
 NIGHTLY="${NIGHTLY:-false}" #setting the ENV $NIGHTLY to true will install the nightly version from conda
 CHANNEL="${CHANNEL:-aihabitat}"
 if ${NIGHTLY}; then
   CHANNEL="${CHANNEL}-nightly"
 fi
-conda install -y --prefix /usr/local -c "${CHANNEL}" -c conda-forge habitat-sim headless withbullet python=3.6
+conda install -S -y --prefix /usr/local -c "${CHANNEL}" -c conda-forge habitat-sim headless withbullet python=3.6 "pillow==${PIL_VERSION}" "cffi==${CFFI_VERSION}" 
 
 #Shallow GIT clone for speed
 git clone https://github.com/facebookresearch/habitat-lab --depth 1
@@ -42,7 +45,6 @@ pip install "${reqs[@]/#/-r}"
 set -e
 python setup.py develop --all
 pip install . #Reinstall to trigger sys.path update
-pip install -U --force-reinstall cffi pyopenssl pillow #Fix conflicts with Colab installs
 cd /content/habitat-sim/
 rm -rf habitat_sim/ # Deletes the habitat_sim folder so it doesn't interfere with import path
 


### PR DESCRIPTION
This will make it so we don't have to worry about the Colab versions for these two libraries by keeping conda from clobbering those two libraries which are imported early.

This should remove the need to do an explicit importlib reload on future Colabs.
## Motivation and Context
Easier Colab install
<!--- Why is this change required? What problem does it solve? -->
Because it can overwrite cffi and PIL on colab so that which causes issues since each library is only partially loaded. This means the user won't have to let habitat-lab crash the first time.

## How Has This Been Tested
On Colab
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
