### PR TITLE
[bugfix] Remove STATIC Support

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -381,12 +381,34 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
 }
 
 void BulletRigidObject::activateCollisionIsland() {
+  btCollisionObject* thisColObj = bObjectRigidBody_.get();
+
+  // first query overlapping pairs of the current object from the most recent
+  // broadphase to collect relevant simulation islands.
+  std::set<int> overlappingSimulationIslands = {thisColObj->getIslandTag()};
+  auto& pairCache =
+      bWorld_->getCollisionWorld()->getPairCache()->getOverlappingPairArray();
+
+  for (int i = 0; i < pairCache.size(); ++i) {
+    if (pairCache.at(i).m_pProxy0->m_clientObject == thisColObj) {
+      overlappingSimulationIslands.insert(
+          static_cast<btCollisionObject*>(
+              pairCache.at(i).m_pProxy1->m_clientObject)
+              ->getIslandTag());
+    } else if (pairCache.at(i).m_pProxy1->m_clientObject == thisColObj) {
+      overlappingSimulationIslands.insert(
+          static_cast<btCollisionObject*>(
+              pairCache.at(i).m_pProxy0->m_clientObject)
+              ->getIslandTag());
+    }
+  }
+
   // activate nearby objects in the simulation island as computed on the
   // previous collision detection pass
-  btCollisionObject* thisColObj = bObjectRigidBody_.get();
   auto& colObjs = bWorld_->getCollisionWorld()->getCollisionObjectArray();
   for (auto objIx = 0; objIx < colObjs.size(); ++objIx) {
-    if (colObjs[objIx]->getIslandTag() == thisColObj->getIslandTag()) {
+    if (overlappingSimulationIslands.count(colObjs[objIx]->getIslandTag()) >
+        0) {
       colObjs[objIx]->activate();
     }
   }


### PR DESCRIPTION
## Motivation and Context

Previously PR #801 fixed an issue where removal of sleeping objects did not wake nearby objects causing simulation artifacts. This was done by iteratively waking all objects which were part of the same simulation island as the sleeping object (`activateCollisionIsland`). 

However, `STATIC` btRigidBodies do not share a simulation island tag with non-static objects which they are in contact with, causing this previous fix to miss the case that the supporting object is STATIC, not sleeping.

This PR adds a step to the `activateCollisionIsland` which checks the previously computed overlapping pairs to collect all relevant simulation islands to activate.

## How Has This Been Tested

Adjusted the existing test to catch this case.

Viewer testing: bottom object is STATIC. Green denotes STATIC or sleeping. First remove a sleeping DYNAMIC object, then remove the bottom STATIC support.

**Before:**
![support_bugfix_before](https://user-images.githubusercontent.com/1445143/98053925-9427f280-1dee-11eb-9a5e-84c2db47094e.gif)


**After:**
![support_bugfix_after](https://user-images.githubusercontent.com/1445143/98053935-9722e300-1dee-11eb-99c3-02eeb7d62061.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
