### PR TITLE
[BUG FIX] Attributes manager bindings load objects missing comma

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -75,12 +75,15 @@ void declareBaseAttributesManager(py::module& m,
           R"(Returns a list of template handles that either contain or explicitly do not
             contain the passed search_str, based on the value of boolean contains.)",
           "search_str"_a = "", "contains"_a = true)
-      .def("load_configs", &MgrClass::loadAllConfigsFromPath,
-           R"(Build templates for all JSON files with appropriate extension
+      .def(
+          "load_configs",
+          static_cast<std::vector<int> (MgrClass::*)(const std::string&, bool)>(
+              &MgrClass::loadAllConfigsFromPath),
+          R"(Build templates for all JSON files with appropriate extension
             that exist in the provided file or directory path. If save_as_defaults
             is true, then these templates will be unable to be deleted)"
-           "path"_a,
-           "save_as_defaults"_a = false)
+          "path"_a,
+          "save_as_defaults"_a = false)
       .def("create_template",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&, bool)>(
                &MgrClass::createObject),

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -81,9 +81,8 @@ void declareBaseAttributesManager(py::module& m,
               &MgrClass::loadAllConfigsFromPath),
           R"(Build templates for all JSON files with appropriate extension
             that exist in the provided file or directory path. If save_as_defaults
-            is true, then these templates will be unable to be deleted)"
-          "path"_a,
-          "save_as_defaults"_a = false)
+            is true, then these templates will be unable to be deleted)",
+          "path"_a, "save_as_defaults"_a = false)
       .def("create_template",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&, bool)>(
                &MgrClass::createObject),
@@ -289,9 +288,8 @@ void initAttributesManagersBindings(py::module& m) {
            R"(DEPRECATED : use "load_configs" instead.
             Build templates for all files with ".object_config.json" extension
             that exist in the provided file or directory path. If save_as_defaults
-            is true, then these templates will be unable to be deleted)"
-           "path"_a,
-           "save_as_defaults"_a = false)
+            is true, then these templates will be unable to be deleted)",
+           "path"_a, "save_as_defaults"_a = false)
 
       // manage file-based templates access
       .def(


### PR DESCRIPTION
## Motivation and Context
The attributes manager bindings were missing a comma after the context help. This PR addresses this.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests passed.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
