### PR TITLE
[CIRCLECI] Improve PYTEST output Habitat-Sim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,10 +121,11 @@ commands:
                 ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh
                 export PATH=$HOME/miniconda/bin:$PATH
+                conda config --set pip_interop_enabled True
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-parallel typeguard
+                pip install pytest-sugar pytest-xdist typeguard
               fi
       - run:
           name: Install emscripten
@@ -506,12 +507,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest --workers 4 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
+              pytest -n 4 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest --workers 4 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
+              pytest -n 4 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               . ~/emsdk/emsdk_env.sh


### PR DESCRIPTION
This allows us to have a much cleaner pytest output when running tests in parallel and lets us know instantly which test is failing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Currently, it's impossible to tell even in which file pytest is failing. I can even enable -vv here which will tell us what individual call is failing in habitat-sim. Furthermore, this gives us a progress bar, more frequent updates, and an overall cleaner output. It also can tell us what tests fail as soon as they fail. This all while allowing us to maintain our parallel pytests for habitat-sim. It will also make the output a little nice for habitat-lab tests. 

I switched to pytest-xdist since it has better support with other plugins. We can switch back to pytest-parallel output if preferred, but we aren't using any of the advanced features to test concurency/threading at the moment. pytest-sugar works with pytest-parallel, just the progress-monitor doesn't work.

Output Before:
<img width="1328" alt="Screen Shot 2020-11-05 at 10 13 06 AM" src="https://user-images.githubusercontent.com/2053727/98280069-abcabc80-1f4f-11eb-9ebd-55607c5cd177.png">

Output After:
<img width="1328" alt="Screen Shot 2020-11-05 at 10 14 01 AM" src="https://user-images.githubusercontent.com/2053727/98280116-bedd8c80-1f4f-11eb-8231-8c7af4673f4c.png">

As a bonus, errors will show up instantly instead of waiting for all tests to finish before the stack trace is shown.

This is an entirely optional plugin so it doesn't affect any local testing, it just gives cleaner output.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
On CIRCLECI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
