### PR TITLE
--Enable override of default Attributes Registration checks

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -157,7 +157,8 @@ void declareBaseAttributesManager(py::module& m,
       .def("register_template", &MgrClass::registerObject,
            R"(This registers a copy of the passed template in the library, and
              returns the template's integer ID.)",
-           "template"_a, "specified_handle"_a = "")
+           "template"_a, "specified_handle"_a = "",
+           "force_registration"_a = false)
       .def("get_template_by_ID",
            static_cast<AttribsPtr (MgrClass::*)(int)>(
                &MgrClass::getObjectCopyByID),

--- a/src/esp/core/ManagedContainer.h
+++ b/src/esp/core/ManagedContainer.h
@@ -153,21 +153,25 @@ class ManagedContainer : public ManagedContainerBase {
    *
    * @param managedObject The managed object.
    * @param objectHandle The key for referencing the managed object in
-   * the
-   * @ref objectLibrary_. Will be set as origin handle for managed
+   * the @ref objectLibrary_. Will be set as origin handle for managed
    * object. If empty string, use existing origin handle.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail in registerObjectFinalize.
+   *
    * @return The unique ID of the managed object being registered, or
    * ID_UNDEFINED if failed
    */
   int registerObject(ManagedPtr managedObject,
-                     const std::string& objectHandle = "") {
+                     const std::string& objectHandle = "",
+                     bool forceRegistration = false) {
     if (nullptr == managedObject) {
       LOG(ERROR) << "ManagedContainer::registerObject : Invalid "
                     "(null) managed object passed to registration. Aborting.";
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
-      return registerObjectFinalize(managedObject, objectHandle);
+      return registerObjectFinalize(managedObject, objectHandle,
+                                    forceRegistration);
     }
     std::string handleToSet = managedObject->getHandle();
     if ("" == handleToSet) {
@@ -176,7 +180,8 @@ class ManagedContainer : public ManagedContainerBase {
                  << objectType_ << " managed object to register. Aborting.";
       return ID_UNDEFINED;
     }
-    return registerObjectFinalize(managedObject, handleToSet);
+    return registerObjectFinalize(managedObject, handleToSet,
+                                  forceRegistration);
   }  // ManagedContainer::registerObject
 
   /**
@@ -498,11 +503,14 @@ class ManagedContainer : public ManagedContainerBase {
    * @param object the managed object to be registered
    * @param objectHandle the name to register the managed object with.
    * Expected to be valid.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The unique ID of the managed object being registered, or
    * ID_UNDEFINED if failed
    */
   virtual int registerObjectFinalize(ManagedPtr object,
-                                     const std::string& objectHandle) = 0;
+                                     const std::string& objectHandle,
+                                     bool forceRegistration) = 0;
 
   /**
    * @brief Build a shared pointer to a copy of a the passed managed object,

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -123,7 +123,8 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
 
 int AssetAttributesManager::registerObjectFinalize(
     AbstractPrimitiveAttributes::ptr primAttributesTemplate,
-    const std::string&) {
+    const std::string&,
+    bool) {
   std::string primAttributesHandle = primAttributesTemplate->getHandle();
   // verify that attributes has been edited in a legal manner
   if (!primAttributesTemplate->isValidTemplate()) {

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -449,14 +449,17 @@ class AssetAttributesManager
    * object to the @ref objectLibrary_.
    *
    * @param attributesTemplate The attributes template.
-   * @param ignored Not used for asset attributes templates - handle is derived
-   * by configuration.
+   * @param objectHandle Not used for asset attributes templates - handle is
+   * derived by configuration.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of object
    * template.
    */
   int registerObjectFinalize(
       attributes::AbstractPrimitiveAttributes::ptr attributesTemplate,
-      const std::string& ignored = "") override;
+      CORRADE_UNUSED const std::string& objectHandle,
+      CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -153,7 +153,7 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
 int LightLayoutAttributesManager::registerObjectFinalize(
     LightLayoutAttributes::ptr lightAttribs,
     const std::string& lightAttribsHandle,
-    bool forceRegistration) {
+    bool) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by LightLayoutAttributesHandle, or the next available
   // ID if not found.

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -152,7 +152,8 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
 
 int LightLayoutAttributesManager::registerObjectFinalize(
     LightLayoutAttributes::ptr lightAttribs,
-    const std::string& lightAttribsHandle) {
+    const std::string& lightAttribsHandle,
+    bool forceRegistration) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by LightLayoutAttributesHandle, or the next available
   // ID if not found.

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -105,7 +105,8 @@ class LightLayoutAttributesManager
    */
   int registerObjectFinalize(
       attributes::LightLayoutAttributes::ptr LightLayoutAttributesTemplate,
-      const std::string& LightLayoutAttributesHandle) override;
+      const std::string& LightLayoutAttributesHandle,
+      CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief Any lights-attributes-specific resetting that needs to happen on

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -181,7 +181,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     return ID_UNDEFINED;
   }
 
-  std::map<int, std::string>* mapToUse;
+  std::map<int, std::string>* mapToUse = nullptr;
   // Handles for rendering and collision assets
   std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
   std::string collisionAssetHandle = objectTemplate->getCollisionAssetHandle();
@@ -253,8 +253,10 @@ int ObjectAttributesManager::registerObjectFinalize(
   // Add object template to template library
   int objectTemplateID =
       this->addObjectToLibrary(objectTemplate, objectTemplateHandle);
-
-  mapToUse->emplace(objectTemplateID, objectTemplateHandle);
+      
+  if(mapToUse != nullptr){
+    mapToUse->emplace(objectTemplateID, objectTemplateHandle);
+  }
 
   return objectTemplateID;
 }  // ObjectAttributesManager::registerObjectFinalize

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -170,7 +170,8 @@ void ObjectAttributesManager::setDefaultAssetNameBasedAttributes(
 
 int ObjectAttributesManager::registerObjectFinalize(
     ObjectAttributes::ptr objectTemplate,
-    const std::string& objectTemplateHandle) {
+    const std::string& objectTemplateHandle,
+    bool forceRegistration) {
   if (objectTemplate->getRenderAssetHandle() == "") {
     LOG(ERROR)
         << "ObjectAttributesManager::registerObjectFinalize : "
@@ -197,6 +198,16 @@ int ObjectAttributesManager::registerObjectFinalize(
     // to physicsFileObjTmpltLibByID_ - verify file  exists
     objectTemplate->setRenderAssetIsPrimitive(false);
     mapToUse = &physicsFileObjTmpltLibByID_;
+  } else if (forceRegistration) {
+    // Forcing registration in case of computationaly generated assets
+    LOG(WARNING)
+        << "ObjectAttributesManager::registerObjectFinalize "
+           ": Render asset template handle : "
+        << renderAssetHandle << " specified in object template with handle : "
+        << objectTemplateHandle
+        << " does not correspond to any existing file or primitive render "
+           "asset.  Objects created from this template may fail. ";
+    objectTemplate->setRenderAssetIsPrimitive(false);
   } else {
     // If renderAssetHandle is neither valid file name nor existing primitive
     // attributes template hande, fail

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -253,8 +253,8 @@ int ObjectAttributesManager::registerObjectFinalize(
   // Add object template to template library
   int objectTemplateID =
       this->addObjectToLibrary(objectTemplate, objectTemplateHandle);
-      
-  if(mapToUse != nullptr){
+
+  if (mapToUse != nullptr) {
     mapToUse->emplace(objectTemplateID, objectTemplateHandle);
   }
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -220,12 +220,15 @@ class ObjectAttributesManager
    * @param attributesTemplate The attributes template.
    * @param attributesTemplateHandle The key for referencing the template in the
    * @ref objectLibrary_. Will be set as origin handle for template.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of object
    * template.
    */
   int registerObjectFinalize(
       attributes::ObjectAttributes::ptr attributesTemplate,
-      const std::string& attributesTemplateHandle) override;
+      const std::string& attributesTemplateHandle,
+      bool forceRegistration) override;
 
   /**
    * @brief Any object-attributes-specific resetting that needs to happen on

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -113,12 +113,15 @@ class PhysicsAttributesManager
    * @param physicsAttributesTemplate The attributes template.
    * @param physicsAttributesHandle The key for referencing the template in the
    * @ref objectLibrary_.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of object
    * template.
    */
   int registerObjectFinalize(
       attributes::PhysicsManagerAttributes::ptr physicsAttributesTemplate,
-      const std::string& physicsAttributesHandle) override {
+      const std::string& physicsAttributesHandle,
+      CORRADE_UNUSED bool forceRegistration) override {
     // adds template to library, and returns either the ID of the existing
     // template referenced by physicsAttributesHandle, or the next available ID
     // if not found.

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -167,7 +167,8 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
 
 int SceneAttributesManager::registerObjectFinalize(
     SceneAttributes::ptr sceneAttributes,
-    const std::string& sceneAttributesHandle) {
+    const std::string& sceneAttributesHandle,
+    bool forceRegistration) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by sceneAttributesHandle, or the next available ID
   // if not found.

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -168,7 +168,7 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
 int SceneAttributesManager::registerObjectFinalize(
     SceneAttributes::ptr sceneAttributes,
     const std::string& sceneAttributesHandle,
-    bool forceRegistration) {
+    bool) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by sceneAttributesHandle, or the next available ID
   // if not found.

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -108,10 +108,13 @@ class SceneAttributesManager
    * @param sceneAttributes The attributes template.
    * @param sceneAttributesHandle The key for referencing the template in the
    * @ref objectLibrary_.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of the registered template.
    */
   int registerObjectFinalize(attributes::SceneAttributes::ptr sceneAttributes,
-                             const std::string& sceneAttributesHandle) override;
+                             const std::string& sceneAttributesHandle,
+                             CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief This function will assign the appropriately configured function

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -298,7 +298,8 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
 
 int SceneDatasetAttributesManager::registerObjectFinalize(
     attributes::SceneDatasetAttributes::ptr SceneDatasetAttributes,
-    const std::string& SceneDatasetAttributesHandle) {
+    const std::string& SceneDatasetAttributesHandle,
+    bool forceRegistration) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by SceneDatasetAttributesHandle, or the next available
   // ID if not found.

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -299,7 +299,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
 int SceneDatasetAttributesManager::registerObjectFinalize(
     attributes::SceneDatasetAttributes::ptr SceneDatasetAttributes,
     const std::string& SceneDatasetAttributesHandle,
-    bool forceRegistration) {
+    bool) {
   // adds template to library, and returns either the ID of the existing
   // template referenced by SceneDatasetAttributesHandle, or the next available
   // ID if not found.

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -190,13 +190,15 @@ class SceneDatasetAttributesManager
    *
    * @param SceneDatasetAttributes The attributes template.
    * @param SceneDatasetAttributesHandle The key for referencing the template in
-   * the
-   * @ref objectLibrary_.
+   * the @ref objectLibrary_.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of the registered template.
    */
   int registerObjectFinalize(
       attributes::SceneDatasetAttributes::ptr SceneDatasetAttributes,
-      const std::string& SceneDatasetAttributesHandle) override;
+      const std::string& SceneDatasetAttributesHandle,
+      CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief This function will assign the appropriately configured function

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -46,7 +46,8 @@ void StageAttributesManager::buildCtorFuncPtrMaps() {
 
 int StageAttributesManager::registerObjectFinalize(
     StageAttributes::ptr stageAttributes,
-    const std::string& stageAttributesHandle) {
+    const std::string& stageAttributesHandle,
+    bool forceRegistration) {
   if (stageAttributes->getRenderAssetHandle() == "") {
     LOG(ERROR)
         << "StageAttributesManager::registerObjectFinalize : "
@@ -76,6 +77,14 @@ int StageAttributesManager::registerObjectFinalize(
     // Render asset handle will be NONE as well - force type to be unknown
     stageAttributes->setRenderAssetType(static_cast<int>(AssetType::UNKNOWN));
     stageAttributes->setRenderAssetIsPrimitive(false);
+  } else if (forceRegistration) {
+    LOG(WARNING)
+        << "StageAttributesManager::registerObjectFinalize "
+           ": Render asset template handle : "
+        << renderAssetHandle << " specified in stage template with handle : "
+        << stageAttributesHandle
+        << " does not correspond to any existing file or primitive render "
+           "asset. This attributes is not in a valid state.";
   } else {
     // If renderAssetHandle is not valid file name needs to  fail
     LOG(ERROR)

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -144,13 +144,16 @@ class StageAttributesManager
    * @param StageAttributesTemplate The attributes template.
    * @param StageAttributesHandle The key for referencing the template in the
    * @ref objectLibrary_.
+   * @param forceRegistration Will register object even if conditional
+   * registration checks fail.
    * @return The index in the @ref objectLibrary_ of object
    * template.
    */
 
   int registerObjectFinalize(
       attributes::StageAttributes::ptr StageAttributesTemplate,
-      const std::string& StageAttributesHandle) override;
+      const std::string& StageAttributesHandle,
+      bool forceRegistration) override;
 
   /**
    * @brief Any scene-attributes-specific resetting that needs to happen on


### PR DESCRIPTION
## Motivation and Context
Currently to register an object or stage attributes the specified render asset handle must exist, either as a valid object on disk, a valid existing primitive, or (in the case of a stage) be "none".  If none of these conditions are true, the registration will fail and the attributes will not be added to the attributesManager library.  This is useful in case errors exist in the attributes, so that object creation does not fail due to misnamed target assets.  

The ability to override registration checks for object and stage attributes checks is useful for when render assets are computationally/"hand" crafted meshes.  This PR adds a boolean argument to the registration process that allows for overriding the non-existing asset failure with a warning. 

The default behavior will be to fail if specified render handle does not correspond to a known/knowable asset.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
