### PR TITLE
Make noise_models use slot_classes for extra speed.

### DIFF
--- a/habitat_sim/agent/controls/object_controls.py
+++ b/habitat_sim/agent/controls/object_controls.py
@@ -24,7 +24,7 @@ def _noop_filter(start: _3d_point, end: _3d_point) -> _3d_point:
     return end
 
 
-@attr.s
+@attr.s(auto_attribs=True, slots=True)
 class ObjectControls(object):
     r"""Used to implement actions
 

--- a/habitat_sim/agent/controls/object_controls.py
+++ b/habitat_sim/agent/controls/object_controls.py
@@ -24,7 +24,7 @@ def _noop_filter(start: _3d_point, end: _3d_point) -> _3d_point:
     return end
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True)
 class ObjectControls(object):
     r"""Used to implement actions
 

--- a/habitat_sim/agent/controls/pyrobot_noisy_controls.py
+++ b/habitat_sim/agent/controls/pyrobot_noisy_controls.py
@@ -26,7 +26,7 @@ from habitat_sim.agent.controls.controls import ActuationSpec, SceneNodeControl
 from habitat_sim.registry import registry
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class _TruncatedMultivariateGaussian:
     mean: Union[np.ndarray, Sequence[float]]
     cov: Union[np.ndarray, Sequence[float]]
@@ -69,19 +69,19 @@ class _TruncatedMultivariateGaussian:
         return sample
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class MotionNoiseModel:
     linear: _TruncatedMultivariateGaussian
     rotation: _TruncatedMultivariateGaussian
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class ControllerNoiseModel:
     linear_motion: MotionNoiseModel
     rotational_motion: MotionNoiseModel
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class RobotNoiseModel:
     ILQR: ControllerNoiseModel
     Proportional: ControllerNoiseModel

--- a/habitat_sim/sensors/noise_models/gaussian_noise_model.py
+++ b/habitat_sim/sensors/noise_models/gaussian_noise_model.py
@@ -25,7 +25,7 @@ def _simulate(image, intensity_constant, mean, sigma):
     )
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class GaussianNoiseModelCPUImpl:
     intensity_constant: float
     mean: int
@@ -36,7 +36,7 @@ class GaussianNoiseModelCPUImpl:
 
 
 @registry.register_noise_model
-@attr.s(auto_attribs=True, kw_only=True)
+@attr.s(auto_attribs=True, kw_only=True, slots=True)
 class GaussianNoiseModel(SensorNoiseModel):
     intensity_constant: float = 0.2
     mean: int = 0

--- a/habitat_sim/sensors/noise_models/no_noise_model.py
+++ b/habitat_sim/sensors/noise_models/no_noise_model.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 @registry.register_noise_model(name="None")
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class NoSensorNoiseModel(SensorNoiseModel):
     @staticmethod
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:

--- a/habitat_sim/sensors/noise_models/poisson_noise_model.py
+++ b/habitat_sim/sensors/noise_models/poisson_noise_model.py
@@ -27,7 +27,7 @@ def _simulate(image: ndarray) -> ndarray:
     return noisy_rgb
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class PoissonNoiseModelCPUImpl:
     @staticmethod
     def simulate(image: ndarray) -> ndarray:
@@ -35,7 +35,7 @@ class PoissonNoiseModelCPUImpl:
 
 
 @registry.register_noise_model
-@attr.s(auto_attribs=True, kw_only=True)
+@attr.s(auto_attribs=True, kw_only=True, slots=True)
 class PoissonNoiseModel(SensorNoiseModel):
     def __attrs_post_init__(self) -> None:
         self._impl = PoissonNoiseModelCPUImpl()

--- a/habitat_sim/sensors/noise_models/salt_and_pepper_noise_model.py
+++ b/habitat_sim/sensors/noise_models/salt_and_pepper_noise_model.py
@@ -29,7 +29,7 @@ def _simulate(image: ndarray, s_vs_p: float, amount: float) -> ndarray:
     return noisy_rgb
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class SaltAndPepperNoiseModelCPUImpl:
     s_vs_p: float
     amount: float
@@ -39,7 +39,7 @@ class SaltAndPepperNoiseModelCPUImpl:
 
 
 @registry.register_noise_model
-@attr.s(auto_attribs=True, kw_only=True)
+@attr.s(auto_attribs=True, kw_only=True, slots=True)
 class SaltAndPepperNoiseModel(SensorNoiseModel):
     s_vs_p: float = 0.5
     amount: float = 0.05

--- a/habitat_sim/sensors/noise_models/speckle_noise_model.py
+++ b/habitat_sim/sensors/noise_models/speckle_noise_model.py
@@ -26,7 +26,7 @@ def _simulate(
     return noisy_rgb
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class SpeckleNoiseModelCPUImpl:
     intensity_constant: float
     mean: int
@@ -37,7 +37,7 @@ class SpeckleNoiseModelCPUImpl:
 
 
 @registry.register_noise_model
-@attr.s(auto_attribs=True, kw_only=True)
+@attr.s(auto_attribs=True, kw_only=True, slots=True)
 class SpeckleNoiseModel(SensorNoiseModel):
     intensity_constant: float = 0.2
     mean: int = 0


### PR DESCRIPTION
## Motivation and Context
* Noise models are often a bottleneck in Habitat-Sim. I realized since we are using attr.s for all of them, we can make them slot classes to make them just a tiny bit faster.

## How Has This Been Tested
on CircleCI with PyTest
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.

@erikwijmans was looking more closely at the attr.s features and thought we should be using this one more aggressively in noise models. It hasn't broken anything, and it should speed up things if only by a tiny amount.