### PR TITLE
Add Stage/Object Collidable setting

### DIFF
--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -105,6 +105,9 @@ Below are stage-specific physical and object-related quantities.  These values w
 "gravity"
 	- 3-vector
 	- Gravity to use for physical modeling.
+"is_collidable"
+	- boolean
+	- Whether the stage should be added to the collision and physics simulation world upon instancing.
 "margin"
 	- double
 	- Distance margin for collision calculations.
@@ -162,6 +165,9 @@ Below are object-specific physical quantities.  These values will override simil
 "scale"
 	- 3-vector
 	- The default scale to be used for the object.
+"is_collidable"
+	- boolean
+	- Whether the object should be added to the simulation world with a collision shape upon instancing.
 "margin"
 	- double
 	- Distance margin for collision calculations.

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -149,6 +149,10 @@ void initAttributesBindings(py::module& m) {
           R"(Whether collisions involving constructions built from
            this template should be solved using the collision mesh
            or a primitive.)")
+      .def_property(
+          "is_collidable", &ObjectAttributes::getIsCollidable,
+          &ObjectAttributes::setIsCollidable,
+          R"(Whether constructions built from this template are collidable upon initialization.)")
       .def_property_readonly(
           "is_dirty", &AbstractObjectAttributes::getIsDirty,
           R"(Whether values in this attributes have been changed requiring
@@ -199,10 +203,6 @@ void initAttributesBindings(py::module& m) {
           "is_visibile", &ObjectAttributes::getIsVisible,
           &ObjectAttributes::setIsVisible,
           R"(Whether objects constructed from this template are visible.)")
-      .def_property(
-          "is_collidable", &ObjectAttributes::getIsCollidable,
-          &ObjectAttributes::setIsCollidable,
-          R"(Whether objects constructed from this template are collidable.)")
       .def_property(
           "semantic_id", &ObjectAttributes::getSemanticId,
           &ObjectAttributes::setSemanticId,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -233,6 +233,16 @@ void initSimBindings(py::module& m) {
           "apply_torque", &Simulator::applyTorque, "torque"_a, "object_id"_a,
           "scene_id"_a = 0,
           R"(Apply torque to an object. Only applies to MotionType::DYNAMIC objects.)")
+      .def("get_object_is_collidable", &Simulator::getObjectIsCollidable,
+           "object_id"_a, R"(Get whether or not an object is collidable.)")
+      .def("set_object_is_collidable", &Simulator::setObjectIsCollidable,
+           "collidable"_a, "object_id"_a,
+           R"(Set whether or not an object is collidable.)")
+      .def("get_stage_is_collidable", &Simulator::getStageIsCollidable,
+           R"(Get whether or not the static stage is collidable.)")
+      .def("set_stage_is_collidable", &Simulator::setStageIsCollidable,
+           "collidable"_a,
+           R"(Set whether or not the static stage is collidable.)")
       .def(
           "contact_test", &Simulator::contactTest, "object_id"_a,
           "scene_id"_a = 0,

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -34,6 +34,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setRenderAssetIsPrimitive(false);
   setCollisionAssetIsPrimitive(false);
   setUseMeshCollision(true);
+  setIsCollidable(true);
   setUnitsToMeters(1.0);
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
@@ -55,7 +56,6 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
   setRequiresLighting(true);
   setIsVisible(true);
   setSemanticId(0);
-  setIsCollidable(true);
 }  // ObjectAttributes ctor
 
 StageAttributes::StageAttributes(const std::string& handle)

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -44,6 +44,13 @@ class AbstractObjectAttributes : public AbstractAttributes {
   void setMargin(double margin) { setDouble("margin", margin); }
   double getMargin() const { return getDouble("margin"); }
 
+  // if object should be checked for collisions - if other objects can collide
+  // with this object
+  void setIsCollidable(bool isCollidable) {
+    setBool("is_collidable", isCollidable);
+  }
+  bool getIsCollidable() const { return getBool("is_collidable"); }
+
   /**
    * @brief set default up orientation for object/stage mesh
    */
@@ -234,13 +241,6 @@ class ObjectAttributes : public AbstractObjectAttributes {
   void setSemanticId(uint32_t semanticId) { setInt("semanticId", semanticId); }
 
   uint32_t getSemanticId() const { return getInt("semanticId"); }
-
-  // if object should be checked for collisions - if other objects can collide
-  // with this object
-  void setIsCollidable(bool isCollidable) {
-    setBool("is_collidable", isCollidable);
-  }
-  bool getIsCollidable() const { return getBool("is_collidable"); }
 
  public:
   ESP_SMART_POINTERS(ObjectAttributes)

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -238,9 +238,9 @@ class ObjectAttributes : public AbstractObjectAttributes {
   // if object should be checked for collisions - if other objects can collide
   // with this object
   void setIsCollidable(bool isCollidable) {
-    setBool("isCollidable", isCollidable);
+    setBool("is_collidable", isCollidable);
   }
-  bool getIsCollidable() { return getBool("isCollidable"); }
+  bool getIsCollidable() const { return getBool("is_collidable"); }
 
  public:
   ESP_SMART_POINTERS(ObjectAttributes)

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -201,6 +201,9 @@ auto AbstractObjectAttributesManager<T>::loadAbstractObjectAttributesFromJson(
   // margin
   io::jsonIntoSetter<double>(jsonDoc, "margin",
                              std::bind(&T::setMargin, attributes, _1));
+  // initialize with collisions on/off
+  io::jsonIntoSetter<bool>(jsonDoc, "is_collidable",
+                           std::bind(&T::setIsCollidable, attributes, _1));
 
   // load the friction coefficient
   io::jsonIntoSetter<double>(

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -24,8 +24,8 @@ bool PhysicsManager::initPhysics(scene::SceneNode* node) {
 
 bool PhysicsManager::initPhysicsFinalize() {
   //! Create new scene node
-  staticStageObject_ =
-      physics::RigidStage::create_unique(&physicsNode_->createChild());
+  staticStageObject_ = physics::RigidStage::create_unique(
+      &physicsNode_->createChild(), resourceManager_);
   return true;
 }
 
@@ -50,7 +50,7 @@ bool PhysicsManager::addStage(
 
 bool PhysicsManager::addStageFinalize(const std::string& handle) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(resourceManager_, handle);
+  bool sceneSuccess = staticStageObject_->initialize(handle);
   return sceneSuccess;
 }
 
@@ -170,8 +170,9 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
 bool PhysicsManager::makeAndAddRigidObject(int newObjectID,
                                            const std::string& handle,
                                            scene::SceneNode* objectNode) {
-  auto ptr = physics::RigidObject::create_unique(objectNode, newObjectID);
-  bool objSuccess = ptr->initialize(resourceManager_, handle);
+  auto ptr = physics::RigidObject::create_unique(objectNode, newObjectID,
+                                                 resourceManager_);
+  bool objSuccess = ptr->initialize(handle);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -843,6 +843,22 @@ class PhysicsManager {
     return false;
   };
 
+  /**
+   * @brief Set and object to collidable or not.
+   */
+  bool setCollidable(const int physObjectID, bool collidable) {
+    assertIDValidity(physObjectID);
+    return existingObjects_.at(physObjectID)->setCollidable(collidable);
+  };
+
+  /**
+   * @brief Get whether or not an object is collision active.
+   */
+  bool getCollidable(const int physObjectID) {
+    assertIDValidity(physObjectID);
+    return existingObjects_.at(physObjectID)->getCollidable();
+  };
+
   /** @brief Return the library implementation type for the simulator currently
    * in use. Use to check for a particular implementation.
    * @return The implementation type of this simulator.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -844,9 +844,9 @@ class PhysicsManager {
   };
 
   /**
-   * @brief Set and object to collidable or not.
+   * @brief Set an object to collidable or not.
    */
-  bool setCollidable(const int physObjectID, bool collidable) {
+  bool setObjectIsCollidable(const int physObjectID, bool collidable) {
     assertIDValidity(physObjectID);
     return existingObjects_.at(physObjectID)->setCollidable(collidable);
   };
@@ -854,10 +854,22 @@ class PhysicsManager {
   /**
    * @brief Get whether or not an object is collision active.
    */
-  bool getCollidable(const int physObjectID) {
+  bool getObjectIsCollidable(const int physObjectID) {
     assertIDValidity(physObjectID);
     return existingObjects_.at(physObjectID)->getCollidable();
   };
+
+  /**
+   * @brief Set the stage to collidable or not.
+   */
+  bool setStageIsCollidable(bool collidable) {
+    return staticStageObject_->setCollidable(collidable);
+  };
+
+  /**
+   * @brief Get whether or not the stage is collision active.
+   */
+  bool getStageIsCollidable() { return staticStageObject_->getCollidable(); };
 
   /** @brief Return the library implementation type for the simulator currently
    * in use. Use to check for a particular implementation.

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -69,9 +69,11 @@ enum class MotionType {
 
 class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
  public:
-  RigidBase(scene::SceneNode* rigidBodyNode)
+  RigidBase(scene::SceneNode* rigidBodyNode,
+            const assets::ResourceManager& resMgr)
       : Magnum::SceneGraph::AbstractFeature3D(*rigidBodyNode),
-        visualNode_(&rigidBodyNode->createChild()) {}
+        visualNode_(&rigidBodyNode->createChild()),
+        resMgr_(resMgr) {}
 
   /**
    * @brief Virtual destructor for a @ref RigidBase.
@@ -101,8 +103,7 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialize(const assets::ResourceManager& resMgr,
-                          const std::string& handle) = 0;
+  virtual bool initialize(const std::string& handle) = 0;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidStage that
@@ -119,8 +120,7 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * pertaining to the object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialization_LibSpecific(
-      const assets::ResourceManager& resMgr) = 0;
+  virtual bool initialization_LibSpecific() = 0;
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
    * after @ref RigidObject or @ref RigidStage is created.
@@ -139,6 +139,15 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * @return true if successfully set, false otherwise.
    */
   virtual bool setMotionType(MotionType mt) = 0;
+
+  /**
+   * @brief Set a rigid as collidable or not. Derived implementations handle the
+   * specifics of modifying the collision properties.
+   */
+  virtual bool setCollidable(CORRADE_UNUSED bool collidable) { return false; };
+
+  bool getCollidable() { return isCollidable_; }
+
   /**
    * @brief Check whether object is being actively simulated, or sleeping.
    * Kinematic objects are always active, but derived dynamics implementations
@@ -632,6 +641,11 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
    * be performed on this object. */
   MotionType objectMotionType_;
 
+  /** @brief Flag sepcifying whether or not the object has an active collision
+   * shape.
+   */
+  bool isCollidable_ = false;
+
   /**
    * @brief Saved attributes when the object was initialized.
    */
@@ -640,6 +654,10 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   //! Access for the object to its own PhysicsManager id. Scene will keep -1.
   int objectId_ = -1;
+
+  //! Reference to the ResourceManager for internal access to the object's asset
+  //! data.
+  const assets::ResourceManager& resMgr_;
 
  public:
   ESP_SMART_POINTERS(RigidBase)

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -7,13 +7,14 @@
 namespace esp {
 namespace physics {
 
-RigidObject::RigidObject(scene::SceneNode* rigidBodyNode, int objectId)
-    : RigidBase(rigidBodyNode), velControl_(VelocityControl::create()) {
+RigidObject::RigidObject(scene::SceneNode* rigidBodyNode,
+                         int objectId,
+                         const assets::ResourceManager& resMgr)
+    : RigidBase(rigidBodyNode, resMgr), velControl_(VelocityControl::create()) {
   objectId_ = objectId;
 }
 
-bool RigidObject::initialize(const assets::ResourceManager& resMgr,
-                             const std::string& handle) {
+bool RigidObject::initialize(const std::string& handle) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidObject more than once";
     return false;
@@ -21,9 +22,9 @@ bool RigidObject::initialize(const assets::ResourceManager& resMgr,
 
   // save a copy of the template at initialization time
   initializationAttributes_ =
-      resMgr.getObjectAttributesManager()->getObjectCopyByHandle(handle);
+      resMgr_.getObjectAttributesManager()->getObjectCopyByHandle(handle);
 
-  return initialization_LibSpecific(resMgr);
+  return initialization_LibSpecific();
 }  // RigidObject::initialize
 
 bool RigidObject::finalizeObject() {
@@ -52,7 +53,7 @@ bool RigidObject::finalizeObject() {
   return finalizeObject_LibSpecific();
 }  // RigidObject::finalizeObject
 
-bool RigidObject::initialization_LibSpecific(const assets::ResourceManager&) {
+bool RigidObject::initialization_LibSpecific() {
   // default kineamtic unless a simulator is initialized...
   objectMotionType_ = MotionType::KINEMATIC;
   return true;

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -95,7 +95,9 @@ class RigidObject : public RigidBase {
    * @param rigidBodyNode The @ref scene::SceneNode this feature will be
    * attached to.
    */
-  RigidObject(scene::SceneNode* rigidBodyNode, int objectId);
+  RigidObject(scene::SceneNode* rigidBodyNode,
+              int objectId,
+              const assets::ResourceManager& resMgr);
 
   /**
    * @brief Virtual destructor for a @ref RigidObject.
@@ -109,8 +111,7 @@ class RigidObject : public RigidBase {
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const assets::ResourceManager& resMgr,
-                  const std::string& handle) override;
+  bool initialize(const std::string& handle) override;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that
@@ -141,8 +142,7 @@ class RigidObject : public RigidBase {
    * components pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialization_LibSpecific(
-      const assets::ResourceManager& resMgr) override;
+  bool initialization_LibSpecific() override;
 
   /**
    * @brief any physics-lib-specific finalization code that needs to be run

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -7,20 +7,20 @@
 namespace esp {
 namespace physics {
 
-RigidStage::RigidStage(scene::SceneNode* rigidBodyNode)
-    : RigidBase(rigidBodyNode) {}
+RigidStage::RigidStage(scene::SceneNode* rigidBodyNode,
+                       const assets::ResourceManager& resMgr)
+    : RigidBase(rigidBodyNode, resMgr) {}
 
-bool RigidStage::initialize(const assets::ResourceManager& resMgr,
-                            const std::string& handle) {
+bool RigidStage::initialize(const std::string& handle) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidStage more than once";
     return false;
   }
   objectMotionType_ = MotionType::STATIC;
   initializationAttributes_ =
-      resMgr.getStageAttributesManager()->getObjectCopyByHandle(handle);
+      resMgr_.getStageAttributesManager()->getObjectCopyByHandle(handle);
 
-  return initialization_LibSpecific(resMgr);
+  return initialization_LibSpecific();
 }
 
 }  // namespace physics

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -14,7 +14,8 @@ namespace esp {
 namespace physics {
 class RigidStage : public RigidBase {
  public:
-  RigidStage(scene::SceneNode* rigidBodyNode);
+  RigidStage(scene::SceneNode* rigidBodyNode,
+             const assets::ResourceManager& resMgr);
 
   /**
    * @brief Virtual destructor for a @ref RigidStage.
@@ -29,8 +30,7 @@ class RigidStage : public RigidBase {
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const assets::ResourceManager& resMgr,
-                  const std::string& handle) override;
+  bool initialize(const std::string& handle) override;
 
   /**
    * @brief Get a copy of the template used to initialize this stage object.
@@ -59,10 +59,7 @@ class RigidStage : public RigidBase {
    * pertaining to the stage object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialization_LibSpecific(
-      CORRADE_UNUSED const assets::ResourceManager& resMgr) override {
-    return true;
-  }
+  bool initialization_LibSpecific() override { return true; }
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
    * after@ref RigidStage is created.  Called from finalizeObject.  Overridden

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -39,7 +39,8 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
   Corrade::Utility::Debug() << "creating staticStageObject_";
   //! Create new scene node
   staticStageObject_ = physics::BulletRigidStage::create_unique(
-      &physicsNode_->createChild(), bWorld_, collisionObjToObjIds_);
+      &physicsNode_->createChild(), resourceManager_, bWorld_,
+      collisionObjToObjIds_);
   Corrade::Utility::Debug() << "creating staticStageObject_ .. done";
 
   return true;
@@ -49,7 +50,7 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
 // https://github.com/mosra/magnum-integration/issues/20
 bool BulletPhysicsManager::addStageFinalize(const std::string& handle) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(resourceManager_, handle);
+  bool sceneSuccess = staticStageObject_->initialize(handle);
 
   return sceneSuccess;
 }
@@ -58,8 +59,9 @@ bool BulletPhysicsManager::makeAndAddRigidObject(int newObjectID,
                                                  const std::string& handle,
                                                  scene::SceneNode* objectNode) {
   auto ptr = physics::BulletRigidObject::create_unique(
-      objectNode, newObjectID, bWorld_, collisionObjToObjIds_);
-  bool objSuccess = ptr->initialize(resourceManager_, handle);
+      objectNode, newObjectID, resourceManager_, bWorld_,
+      collisionObjToObjIds_);
+  bool objSuccess = ptr->initialize(handle);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -35,11 +35,12 @@ namespace physics {
 BulletRigidObject::BulletRigidObject(
     scene::SceneNode* rigidBodyNode,
     int objectId,
+    const assets::ResourceManager& resMgr,
     std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
     std::shared_ptr<std::map<const btCollisionObject*, int> >
         collisionObjToObjIds)
     : BulletBase(std::move(bWorld), std::move(collisionObjToObjIds)),
-      RigidObject(rigidBodyNode, objectId),
+      RigidObject(rigidBodyNode, objectId, resMgr),
       MotionState(*rigidBodyNode) {}
 
 BulletRigidObject::~BulletRigidObject() {
@@ -56,9 +57,26 @@ BulletRigidObject::~BulletRigidObject() {
 
 }  //~BulletRigidObject
 
-bool BulletRigidObject::initialization_LibSpecific(
-    const assets::ResourceManager& resMgr) {
+bool BulletRigidObject::initialization_LibSpecific() {
+  // TODO: add is_dynamic flag
   objectMotionType_ = MotionType::DYNAMIC;
+
+  isCollidable_ = getInitializationAttributes()->getIsCollidable();
+
+  // create the bObjectRigidBody_
+  constructAndAddRigidBody(objectMotionType_);
+
+  return true;
+}  // initialization_LibSpecific
+
+bool BulletRigidObject::finalizeObject_LibSpecific() {
+  if (usingBBCollisionShape_) {
+    setCollisionFromBB();
+  }
+  return true;
+}  // finalizeObject_LibSpecifc
+
+bool BulletRigidObject::constructCollisionShape() {
   // get this object's creation template, appropriately cast
   auto tmpAttr = getInitializationAttributes();
 
@@ -82,12 +100,13 @@ bool BulletRigidObject::initialization_LibSpecific(
     // if using prim collider get appropriate bullet collision primitive
     // attributes and build bullet collision shape
     auto primAttributes =
-        resMgr.getAssetAttributesManager()->getObjectCopyByHandle(
+        resMgr_.getAssetAttributesManager()->getObjectCopyByHandle(
             collisionAssetHandle);
     // primitive object pointer construction
     auto primObjPtr = buildPrimitiveCollisionObject(
         primAttributes->getPrimObjType(), primAttributes->getHalfLength());
     if (nullptr == primObjPtr) {
+      bObjectShape_.reset();
       return false;
     }
     primObjPtr->setLocalScaling(btVector3(tmpAttr->getCollisionAssetSize()));
@@ -99,9 +118,9 @@ bool BulletRigidObject::initialization_LibSpecific(
   } else {
     // mesh collider
     const std::vector<assets::CollisionMeshData>& meshGroup =
-        resMgr.getCollisionMesh(collisionAssetHandle);
+        resMgr_.getCollisionMesh(collisionAssetHandle);
     const assets::MeshMetaData& metaData =
-        resMgr.getMeshMetaData(collisionAssetHandle);
+        resMgr_.getMeshMetaData(collisionAssetHandle);
 
     if (!usingBBCollisionShape_) {
       constructBulletCompoundFromMeshes(Magnum::Matrix4{}, meshGroup,
@@ -124,18 +143,14 @@ bool BulletRigidObject::initialization_LibSpecific(
 
   bObjectShape_->setLocalScaling(btVector3{tmpAttr->getScale()});
   bObjectShape_->recalculateLocalAabb();
-  // create the bObjectRigidBody_
-  constructAndAddRigidBody(objectMotionType_);
 
-  return true;
-}  // initialization_LibSpecific
-
-bool BulletRigidObject::finalizeObject_LibSpecific() {
-  if (usingBBCollisionShape_) {
-    setCollisionFromBB();
+  if (!originShift_.isZero()) {
+    // for deferred creation of the shape
+    shiftObjectCollisionShape(originShift_);
   }
+
   return true;
-}  // finalizeObject_LibSpecifc
+}
 
 std::unique_ptr<btCollisionShape>
 BulletRigidObject::buildPrimitiveCollisionObject(int primTypeVal,
@@ -262,6 +277,10 @@ void BulletRigidObject::constructBulletCompoundFromMeshes(
 void BulletRigidObject::setCollisionFromBB() {
   btVector3 dim(node().getCumulativeBB().size() / 2.0);
 
+  if (!bObjectShape_) {
+    bObjectShape_ = std::make_unique<btCompoundShape>();
+  }
+
   for (auto& shape : bGenericShapes_) {
     bObjectShape_->removeChildShape(shape.get());
   }
@@ -270,16 +289,20 @@ void BulletRigidObject::setCollisionFromBB() {
   bObjectShape_->addChildShape(btTransform::getIdentity(),
                                bGenericShapes_.back().get());
   bObjectShape_->recalculateLocalAabb();
-  bObjectRigidBody_->setCollisionShape(bObjectShape_.get());
 
-  auto tmpAttr = getInitializationAttributes();
-  btVector3 bInertia(tmpAttr->getInertia());
-  if (bInertia == btVector3{0, 0, 0}) {
-    // allow bullet to compute the inertia tensor if we don't have one
-    bObjectShape_->calculateLocalInertia(getMass(),
-                                         bInertia);  // overrides bInertia
+  if (isCollidable_) {
+    // otherwise this setup is deferred
+    bObjectRigidBody_->setCollisionShape(bObjectShape_.get());
 
-    setInertiaVector(Magnum::Vector3(bInertia));
+    auto tmpAttr = getInitializationAttributes();
+    btVector3 bInertia(tmpAttr->getInertia());
+    if (bInertia == btVector3{0, 0, 0}) {
+      // allow bullet to compute the inertia tensor if we don't have one
+      bObjectShape_->calculateLocalInertia(getMass(),
+                                           bInertia);  // overrides bInertia
+
+      setInertiaVector(Magnum::Vector3(bInertia));
+    }
   }
 }  // setCollisionFromBB
 
@@ -298,10 +321,37 @@ bool BulletRigidObject::setMotionType(MotionType mt) {
   return true;
 }  // setMotionType
 
+bool BulletRigidObject::setCollidable(bool collidable) {
+  if (collidable == isCollidable_) {
+    // no work
+    return true;
+  }
+
+  isCollidable_ = collidable;
+  if (!isCollidable_ && !isActive()) {
+    activateCollisionIsland();
+  }
+  bWorld_->removeRigidBody(bObjectRigidBody_.get());
+  constructAndAddRigidBody(objectMotionType_);
+
+  return true;
+}
+
 void BulletRigidObject::shiftOrigin(const Magnum::Vector3& shift) {
   if (visualNode_)
     visualNode_->translate(shift);
+  node().computeCumulativeBB();
 
+  originShift_ = shift;
+
+  if (bObjectShape_) {
+    // otherwise deferred to construction
+    shiftObjectCollisionShape(originShift_);
+  }
+}  // shiftOrigin
+
+void BulletRigidObject::shiftObjectCollisionShape(
+    const Magnum::Vector3& shift) {
   // shift all children of the parent collision shape
   for (int i = 0; i < bObjectShape_->getNumChildShapes(); i++) {
     btTransform cT = bObjectShape_->getChildTransform(i);
@@ -310,8 +360,7 @@ void BulletRigidObject::shiftOrigin(const Magnum::Vector3& shift) {
   }
   // recompute the Aabb once when done
   bObjectShape_->recalculateLocalAabb();
-  node().computeCumulativeBB();
-}  // shiftOrigin
+}
 
 //! Synchronize Physics transformations
 //! Needed after changing the pose from Magnum side
@@ -325,15 +374,24 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   // get this object's creation template, appropriately cast
   auto tmpAttr = getInitializationAttributes();
 
+  if (bObjectShape_ == nullptr && isCollidable_) {
+    constructCollisionShape();
+  }
+
   double mass = 0;
   btVector3 bInertia = {0, 0, 0};
   if (mt == MotionType::DYNAMIC) {
     mass = tmpAttr->getMass();
     bInertia = btVector3(tmpAttr->getInertia());
     if (bInertia == btVector3{0, 0, 0}) {
-      // allow bullet to compute the inertia tensor if we don't have one
-      bObjectShape_->calculateLocalInertia(mass,
-                                           bInertia);  // overrides bInertia
+      if (bObjectShape_ != nullptr) {
+        // allow bullet to compute the inertia tensor if we don't have one
+        bObjectShape_->calculateLocalInertia(mass,
+                                             bInertia);  // overrides bInertia
+      } else {
+        // TODO: better default given object information?
+        bInertia = btVector3(1.0, 1.0, 1.0);
+      }
     }
   }
 
@@ -344,6 +402,12 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   btRigidBody::btRigidBodyConstructionInfo info =
       btRigidBody::btRigidBodyConstructionInfo(mass, motionState,
                                                bObjectShape_.get(), bInertia);
+
+  if (!isCollidable_) {
+    // set an empty collision shape to disable collisions
+    bEmptyShape_ = std::make_unique<btCompoundShape>();
+    info.m_collisionShape = bEmptyShape_.get();
+  }
 
   info.m_friction = tmpAttr->getFrictionCoefficient();
   info.m_restitution = tmpAttr->getRestitutionCoefficient();

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -409,12 +409,19 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
     info.m_collisionShape = bEmptyShape_.get();
   }
 
-  info.m_friction = tmpAttr->getFrictionCoefficient();
-  info.m_restitution = tmpAttr->getRestitutionCoefficient();
-  info.m_linearDamping = tmpAttr->getLinearDamping();
-  info.m_angularDamping = tmpAttr->getAngularDamping();
   if (bObjectRigidBody_ != nullptr) {
+    // set physical properties from possibly modified current rigidBody
     info.m_startWorldTransform = bObjectRigidBody_->getWorldTransform();
+    info.m_friction = bObjectRigidBody_->getFriction();
+    info.m_restitution = bObjectRigidBody_->getRestitution();
+    info.m_linearDamping = bObjectRigidBody_->getLinearDamping();
+    info.m_angularDamping = bObjectRigidBody_->getAngularDamping();
+  } else {
+    // set properties from initialization template
+    info.m_friction = tmpAttr->getFrictionCoefficient();
+    info.m_restitution = tmpAttr->getRestitutionCoefficient();
+    info.m_linearDamping = tmpAttr->getLinearDamping();
+    info.m_angularDamping = tmpAttr->getAngularDamping();
   }
 
   //! Create rigid body

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -34,6 +34,8 @@ BulletRigidStage::~BulletRigidStage() {
   }
 }
 bool BulletRigidStage::initialization_LibSpecific() {
+  isCollidable_ = getInitializationAttributes()->getIsCollidable();
+
   if (isCollidable_) {
     // defer construction until necessary
     constructAndAddCollisionObjects();

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -19,11 +19,12 @@ namespace physics {
 
 BulletRigidStage::BulletRigidStage(
     scene::SceneNode* rigidBodyNode,
+    const assets::ResourceManager& resMgr,
     std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
     std::shared_ptr<std::map<const btCollisionObject*, int> >
         collisionObjToObjIds)
     : BulletBase(std::move(bWorld), std::move(collisionObjToObjIds)),
-      RigidStage{rigidBodyNode} {}
+      RigidStage{rigidBodyNode, resMgr} {}
 
 BulletRigidStage::~BulletRigidStage() {
   // remove collision objects from the world
@@ -32,16 +33,15 @@ BulletRigidStage::~BulletRigidStage() {
     collisionObjToObjIds_->erase(co.get());
   }
 }
-bool BulletRigidStage::initialization_LibSpecific(
-    const assets::ResourceManager& resMgr) {
+bool BulletRigidStage::initialization_LibSpecific() {
   const auto collisionAssetHandle =
       initializationAttributes_->getCollisionAssetHandle();
 
   const std::vector<assets::CollisionMeshData>& meshGroup =
-      resMgr.getCollisionMesh(collisionAssetHandle);
+      resMgr_.getCollisionMesh(collisionAssetHandle);
 
   const assets::MeshMetaData& metaData =
-      resMgr.getMeshMetaData(collisionAssetHandle);
+      resMgr_.getMeshMetaData(collisionAssetHandle);
 
   constructBulletSceneFromMeshes(Magnum::Matrix4{}, meshGroup, metaData.root);
   for (auto& object : bStaticCollisionObjects_) {

--- a/src/esp/physics/bullet/BulletRigidStage.h
+++ b/src/esp/physics/bullet/BulletRigidStage.h
@@ -56,6 +56,18 @@ class BulletRigidStage : public BulletBase, public RigidStage {
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node);
 
+  /**
+   * @brief Adds static stage collision objects to the simulation world after
+   * contructing them if necessary.
+   */
+  void constructAndAddCollisionObjects();
+
+  /**
+   * @brief Set the stage to collidable or not by adding/removing the static
+   * collision shapes from the simulation world.
+   */
+  bool setCollidable(bool collidable) override;
+
  public:
   /**
    * @brief Query the Aabb from bullet physics for the root compound shape of

--- a/src/esp/physics/bullet/BulletRigidStage.h
+++ b/src/esp/physics/bullet/BulletRigidStage.h
@@ -22,6 +22,7 @@ namespace physics {
 class BulletRigidStage : public BulletBase, public RigidStage {
  public:
   BulletRigidStage(scene::SceneNode* rigidBodyNode,
+                   const assets::ResourceManager& resMgr,
                    std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
                    std::shared_ptr<std::map<const btCollisionObject*, int>>
                        collisionObjToObjIds);
@@ -39,8 +40,7 @@ class BulletRigidStage : public BulletBase, public RigidStage {
    * pertaining to the stage object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialization_LibSpecific(
-      const assets::ResourceManager& resMgr) override;
+  bool initialization_LibSpecific() override;
 
   /**
    * @brief Recursively construct the static collision mesh objects from

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -515,6 +515,20 @@ class Simulator {
    */
   bool contactTest(int objectID, int sceneID = 0);
 
+  bool setCollidable(const int objectID, bool collidable) {
+    if (sceneHasPhysics(0)) {
+      return physicsManager_->setCollidable(objectID, collidable);
+    }
+    return false;
+  };
+
+  bool getCollidable(const int objectID) {
+    if (sceneHasPhysics(0)) {
+      return physicsManager_->getCollidable(objectID);
+    }
+    return false;
+  };
+
   /**
    * @brief Raycast into the collision world of a scene.
    *

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -515,6 +515,9 @@ class Simulator {
    */
   bool contactTest(int objectID, int sceneID = 0);
 
+  /**
+   * @brief Set an object to collidable or not.
+   */
   bool setObjectIsCollidable(bool collidable, const int objectID) {
     if (sceneHasPhysics(0)) {
       return physicsManager_->setObjectIsCollidable(objectID, collidable);
@@ -522,6 +525,9 @@ class Simulator {
     return false;
   };
 
+  /**
+   * @brief Get whether or not an object is collision active.
+   */
   bool getObjectIsCollidable(const int objectID) {
     if (sceneHasPhysics(0)) {
       return physicsManager_->getObjectIsCollidable(objectID);
@@ -529,6 +535,9 @@ class Simulator {
     return false;
   };
 
+  /**
+   * @brief Set the stage to collidable or not.
+   */
   bool setStageIsCollidable(bool collidable) {
     if (sceneHasPhysics(0)) {
       return physicsManager_->setStageIsCollidable(collidable);
@@ -536,6 +545,9 @@ class Simulator {
     return false;
   };
 
+  /**
+   * @brief Get whether or not the stage is collision active.
+   */
   bool getStageIsCollidable() {
     if (sceneHasPhysics(0)) {
       return physicsManager_->getStageIsCollidable();

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -515,16 +515,30 @@ class Simulator {
    */
   bool contactTest(int objectID, int sceneID = 0);
 
-  bool setCollidable(const int objectID, bool collidable) {
+  bool setObjectIsCollidable(bool collidable, const int objectID) {
     if (sceneHasPhysics(0)) {
-      return physicsManager_->setCollidable(objectID, collidable);
+      return physicsManager_->setObjectIsCollidable(objectID, collidable);
     }
     return false;
   };
 
-  bool getCollidable(const int objectID) {
+  bool getObjectIsCollidable(const int objectID) {
     if (sceneHasPhysics(0)) {
-      return physicsManager_->getCollidable(objectID);
+      return physicsManager_->getObjectIsCollidable(objectID);
+    }
+    return false;
+  };
+
+  bool setStageIsCollidable(bool collidable) {
+    if (sceneHasPhysics(0)) {
+      return physicsManager_->setStageIsCollidable(collidable);
+    }
+    return false;
+  };
+
+  bool getStageIsCollidable() {
+    if (sceneHasPhysics(0)) {
+      return physicsManager_->getStageIsCollidable();
     }
     return false;
   };

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -519,7 +519,7 @@ class Simulator {
    * @brief Set an object to collidable or not.
    */
   bool setObjectIsCollidable(bool collidable, const int objectID) {
-    if (sceneHasPhysics(0)) {
+    if (sceneHasPhysics(activeSceneID_)) {
       return physicsManager_->setObjectIsCollidable(objectID, collidable);
     }
     return false;
@@ -529,7 +529,7 @@ class Simulator {
    * @brief Get whether or not an object is collision active.
    */
   bool getObjectIsCollidable(const int objectID) {
-    if (sceneHasPhysics(0)) {
+    if (sceneHasPhysics(activeSceneID_)) {
       return physicsManager_->getObjectIsCollidable(objectID);
     }
     return false;
@@ -539,7 +539,7 @@ class Simulator {
    * @brief Set the stage to collidable or not.
    */
   bool setStageIsCollidable(bool collidable) {
-    if (sceneHasPhysics(0)) {
+    if (sceneHasPhysics(activeSceneID_)) {
       return physicsManager_->setStageIsCollidable(collidable);
     }
     return false;
@@ -549,7 +549,7 @@ class Simulator {
    * @brief Get whether or not the stage is collision active.
    */
   bool getStageIsCollidable() {
-    if (sceneHasPhysics(0)) {
+    if (sceneHasPhysics(activeSceneID_)) {
       return physicsManager_->getStageIsCollidable();
     }
     return false;

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -576,6 +576,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
         "front":[0,2.1,0],
         "render_asset": "testJSONRenderAsset.glb",
         "collision_asset": "testJSONCollisionAsset.glb",
+        "is_collidable": false,
         "gravity": [9,8,7],
         "origin":[1,2,3],
         "semantic_asset":"testJSONSemanticAsset.glb",
@@ -601,6 +602,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
   ASSERT_EQ(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
   ASSERT_EQ(stageAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
   ASSERT_EQ(stageAttr->getCollisionAssetHandle(), "testJSONCollisionAsset.glb");
+  ASSERT_EQ(stageAttr->getIsCollidable(), false);
   // stage-specific attributes
   ASSERT_EQ(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
   ASSERT_EQ(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
@@ -629,6 +631,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
         "front":[0,2.1,0],
         "render_asset": "testJSONRenderAsset.glb",
         "collision_asset": "testJSONCollisionAsset.glb",
+        "is_collidable": false,
         "mass": 9,
         "use_bounding_box_for_collision": true,
         "join_collision_meshes":true,
@@ -653,6 +656,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
   ASSERT_EQ(objAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
   ASSERT_EQ(objAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
   ASSERT_EQ(objAttr->getCollisionAssetHandle(), "testJSONCollisionAsset.glb");
+  ASSERT_EQ(objAttr->getIsCollidable(), false);
   // object-specific attributes
   ASSERT_EQ(objAttr->getMass(), 9);
   ASSERT_EQ(objAttr->getBoundingBoxCollisions(), true);

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -274,10 +274,23 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
     ASSERT_TRUE(physicsManager_->contactTest(objectId0));
     ASSERT_FALSE(physicsManager_->contactTest(objectId1));
 
+    // set stage to non-collidable
+    ASSERT_TRUE(physicsManager_->getStageIsCollidable());
+    physicsManager_->setStageIsCollidable(false);
+    ASSERT_FALSE(physicsManager_->getStageIsCollidable());
+    ASSERT_FALSE(physicsManager_->contactTest(objectId0));
+
     // move box 0 into box 1
     physicsManager_->setTranslation(objectId0, Magnum::Vector3{1.1, 1.1, 0});
     ASSERT_TRUE(physicsManager_->contactTest(objectId0));
     ASSERT_TRUE(physicsManager_->contactTest(objectId1));
+
+    // set box 0 to non-collidable
+    ASSERT_TRUE(physicsManager_->getObjectIsCollidable(objectId0));
+    physicsManager_->setObjectIsCollidable(objectId0, false);
+    ASSERT_FALSE(physicsManager_->getObjectIsCollidable(objectId0));
+    ASSERT_FALSE(physicsManager_->contactTest(objectId0));
+    ASSERT_FALSE(physicsManager_->contactTest(objectId1));
   }
 }
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -412,3 +412,16 @@ def test_raycast():
             )
             assert abs(raycast_results.hits[0].ray_distance - 2.8935) < 0.001
             assert raycast_results.hits[0].object_id == 0
+
+            # test raycast against a non-collidable object.
+            # should not register a hit with the object.
+            sim.set_object_is_collidable(False, cube_obj_id)
+            raycast_results = sim.cast_ray(test_ray_1)
+            assert raycast_results.has_hits()
+            assert len(raycast_results.hits) == 1
+
+            # test raycast against a non-collidable stage.
+            # should not register any hits.
+            sim.set_stage_is_collidable(False)
+            raycast_results = sim.cast_ray(test_ray_1)
+            assert not raycast_results.has_hits()


### PR DESCRIPTION
## Motivation and Context

To support 3D visualization use cases in Habitat, this PR adds a flag and getter/setters to enable/disable collisions for objects and stages. This is done by manipulating the collision shape allowing all MotionType properties regardless of collidable setting. Flag exposed to Simulator API in C++ and Python as well as Object and Stage Attributes and config files.

Includes minor bugfix:
 - Friction/restitution/damping set on objects after construction were getting overwritten by initialization attributes when changing object MotionType.

## How Has This Been Tested

Unit tests added for config value parsing, contact and raycast tests w/ non-collidable objects and stage.

Local testing results in viewer:
- 3 stacks of objects with bottom object of different MotionType: dynamic(left), kinematic(middle), static(right).
- Procedure:
  - objects are simulated until sleeping
  - bottom of each stack is set to non-collidable (notice Bullet debug disappears and other objects fall through)
  - all objects are set to DYNAMIC (notice non-collidable objects fall through the ground)
  - gravity is inverted and non-collidable objects "fall" upward through the ground
  - gravity is returned to normal and all objects are set to collidable, falling into neat stacks.

![collidable-test](https://user-images.githubusercontent.com/1445143/98874543-4e42de00-242f-11eb-9d57-ace5d2786ef4.gif)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
