### PR TITLE
[WIP] Prototype Simulator API for creating/assigning simple Phong materials

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -331,6 +331,33 @@ class ResourceManager {
   }
 
   /**
+   * @brief Create and register a new Phong color material (no textures).
+   *
+   * Prototype feature, API likely to change.
+   *
+   * @return The unique id of the material for instance assignment.
+   */
+  int createPhongColorMaterial(const Mn::Color4& diffuse,
+                               const Mn::Color4& specular,
+                               const Mn::Color4& ambient = Mn::Color3(0),
+                               float shininess = 80) {
+    auto finalMaterial = gfx::PhongMaterialData::create_unique();
+
+    finalMaterial->shininess = shininess;
+
+    finalMaterial->ambientColor = ambient;
+    finalMaterial->diffuseColor = diffuse;
+    finalMaterial->specularColor = specular;
+
+    shaderManager_.set<gfx::MaterialData>(std::to_string(nextMaterialID_),
+                                          finalMaterial.release());
+
+    return nextMaterialID_++;
+  }
+
+  gfx::ShaderManager& getShaderManager() { return shaderManager_; }
+
+  /**
    * @brief Construct a unified @ref MeshData from a loaded asset's collision
    * meshes.
    *

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -273,6 +273,14 @@ void initSimBindings(py::module& m) {
           "set_object_light_setup", &Simulator::setObjectLightSetup,
           "object_id"_a, "light_setup_key"_a, "scene_id"_a = 0,
           R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)")
+      .def(
+          "create_phong_color_material", &Simulator::createPhongColorMaterial,
+          "diffuse"_a, "specular"_a, "ambient"_a, "shininess"_a = 0,
+          R"(Prototype API, unstable. Create a new Phong color material and return the material key for assignment with Simulator.set_object_material(object_id, material_key).)")
+      .def(
+          "set_object_material", &Simulator::setObjectMaterial, "object_id"_a,
+          "material_key"_a,
+          R"(Prototype API, unstable. Assign a material to all of an object's Drawables.)")
 
       .def(
           "get_num_active_contact_points",

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -27,40 +27,9 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetupKey)},
       materialData_{
-          shaderManager.get<MaterialData, PhongMaterialData>(materialDataKey)} {
-  flags_ = Mn::Shaders::Phong::Flag::ObjectId;
-  if (materialData_->textureMatrix != Mn::Matrix3{}) {
-    flags_ |= Mn::Shaders::Phong::Flag::TextureTransformation;
-  }
-  if (materialData_->ambientTexture) {
-    flags_ |= Mn::Shaders::Phong::Flag::AmbientTexture;
-  }
-  if (materialData_->diffuseTexture) {
-    flags_ |= Mn::Shaders::Phong::Flag::DiffuseTexture;
-  }
-  if (materialData_->specularTexture) {
-    flags_ |= Mn::Shaders::Phong::Flag::SpecularTexture;
-  }
-  if (materialData_->normalTexture) {
-    if (meshAttributeFlags & Drawable::Flag::HasTangent) {
-      flags_ |= Mn::Shaders::Phong::Flag::NormalTexture;
-      if (meshAttributeFlags & Drawable::Flag::HasSeparateBitangent) {
-        flags_ |= Mn::Shaders::Phong::Flag::Bitangent;
-      }
-    } else {
-      LOG(WARNING) << "Mesh does not have tangents and Magnum cannot generate "
-                      "them yet, ignoring a normal map";
-    }
-  }
-  if (materialData_->perVertexObjectId) {
-    flags_ |= Mn::Shaders::Phong::Flag::InstancedObjectId;
-  }
-  if (materialData_->vertexColored) {
-    flags_ |= Mn::Shaders::Phong::Flag::VertexColor;
-  }
-
-  // update the shader early here to to avoid doing it during the render loop
-  updateShader();
+          shaderManager.get<MaterialData, PhongMaterialData>(materialDataKey)},
+      meshAttributeFlags_{meshAttributeFlags} {
+  setMaterial(shaderManager_, materialDataKey);
 }
 
 void GenericDrawable::setLightSetup(const Mn::ResourceKey& resourceKey) {
@@ -179,6 +148,45 @@ Mn::ResourceKey GenericDrawable::getShaderKey(
   return Corrade::Utility::formatString(
       SHADER_KEY_TEMPLATE, lightCount,
       static_cast<Mn::Shaders::Phong::Flags::UnderlyingType>(flags));
+}
+
+void GenericDrawable::setMaterial(ShaderManager& shaderManager,
+                                  const Mn::ResourceKey& materialDataKey) {
+  materialData_ =
+      shaderManager.get<MaterialData, PhongMaterialData>(materialDataKey);
+
+  flags_ = Mn::Shaders::Phong::Flag::ObjectId;
+  if (materialData_->textureMatrix != Mn::Matrix3{}) {
+    flags_ |= Mn::Shaders::Phong::Flag::TextureTransformation;
+  }
+  if (materialData_->ambientTexture) {
+    flags_ |= Mn::Shaders::Phong::Flag::AmbientTexture;
+  }
+  if (materialData_->diffuseTexture) {
+    flags_ |= Mn::Shaders::Phong::Flag::DiffuseTexture;
+  }
+  if (materialData_->specularTexture) {
+    flags_ |= Mn::Shaders::Phong::Flag::SpecularTexture;
+  }
+  if (materialData_->normalTexture) {
+    if (meshAttributeFlags_ & Drawable::Flag::HasTangent) {
+      flags_ |= Mn::Shaders::Phong::Flag::NormalTexture;
+      if (meshAttributeFlags_ & Drawable::Flag::HasSeparateBitangent) {
+        flags_ |= Mn::Shaders::Phong::Flag::Bitangent;
+      }
+    } else {
+      LOG(WARNING) << "Mesh does not have tangents and Magnum cannot generate "
+                      "them yet, ignoring a normal map";
+    }
+  }
+  if (materialData_->perVertexObjectId) {
+    flags_ |= Mn::Shaders::Phong::Flag::InstancedObjectId;
+  }
+  if (materialData_->vertexColored) {
+    flags_ |= Mn::Shaders::Phong::Flag::VertexColor;
+  }
+
+  updateShader();
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -27,6 +27,15 @@ class GenericDrawable : public Drawable {
                            DrawableGroup* group = nullptr);
 
   void setLightSetup(const Magnum::ResourceKey& lightSetupKey) override;
+
+  /**
+   * @brief Set the materialKey for this Drawable and update the shader
+   *
+   * Prototype feature, API likely to change.
+   */
+  void setMaterial(ShaderManager& shaderManager,
+                   const Mn::ResourceKey& materialDataKey);
+
   static constexpr const char* SHADER_KEY_TEMPLATE = "Phong-lights={}-flags={}";
 
  protected:
@@ -49,6 +58,8 @@ class GenericDrawable : public Drawable {
   Magnum::Resource<LightSetup> lightSetup_;
 
   Magnum::Shaders::Phong::Flags flags_;
+
+  Drawable::Flags& meshAttributeFlags_;
 };
 
 }  // namespace gfx

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -841,7 +841,18 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       break;
     case KeyEvent::Key::T:
       // Test key. Put what you want here...
-      torqueLastObject();
+      // torqueLastObject();
+      {
+        if (!simulator_->getExistingObjectIDs().empty()) {
+          Mn::Color4 randColor((rand() % 100) * 0.01, (rand() % 100) * 0.01,
+                               (rand() % 100) * 0.01, 1);
+          Mn::Debug{} << "Trying to set material: " << randColor;
+          int matId = simulator_->createPhongColorMaterial(randColor, randColor,
+                                                           randColor);
+          simulator_->setObjectMaterial(
+              simulator_->getExistingObjectIDs().back(), matId);
+        }
+      }
       break;
     case KeyEvent::Key::N:
       // toggle navmesh visualization


### PR DESCRIPTION
## Motivation and Context

Quick prototype implementation of color material creation/assignment designed to enable primitive visualization shapes to be generated with custom user color materials.

Note: this is not intended to be the final API, will not be merged. Merge this with your branch to utilize.

## How Has This Been Tested

Locally in viewer with `RIGHT-CLICK` to place objects and `'t'` to swap colors (gif color optimization is poor 😉 ):

![material-swaping](https://user-images.githubusercontent.com/1445143/99110954-10b19280-25a0-11eb-94c6-cc94c7b8228f.gif)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
