### PR TITLE
refactor ResourceManager render assets

### DIFF
--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -37,6 +37,7 @@ struct AssetInfo {
   geo::CoordinateFrame frame;
   float virtualUnitToMeters = 1.0f;
   bool requiresLighting = false;
+  bool splitInstanceMesh = true;  // only applies to AssetType::INSTANCE_MESH
 
   //! Populates a preset AssetInfo by matching against known filepaths
   static AssetInfo fromPath(const std::string& filepath);

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
   MeshMetaData.h
   Mp3dInstanceMeshData.cpp
   Mp3dInstanceMeshData.h
+  RenderAssetInstanceCreation.h
   ResourceManager.cpp
   ResourceManager.h
 )

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -13,7 +13,7 @@ set(
   MeshMetaData.h
   Mp3dInstanceMeshData.cpp
   Mp3dInstanceMeshData.h
-  RenderAssetInstanceCreation.h
+  RenderAssetInstanceCreationInfo.h
   ResourceManager.cpp
   ResourceManager.h
 )

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
   MeshMetaData.h
   Mp3dInstanceMeshData.cpp
   Mp3dInstanceMeshData.h
+  RenderAssetInstanceCreationInfo.cpp
   RenderAssetInstanceCreationInfo.h
   ResourceManager.cpp
   ResourceManager.h

--- a/src/esp/assets/RenderAssetInstanceCreation.h
+++ b/src/esp/assets/RenderAssetInstanceCreation.h
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "Asset.h"
+
+#include "esp/scene/SceneNode.h"
+
+#include "Magnum/Resource.h"
+
+#include <Corrade/Containers/Optional.h>
+
+namespace esp {
+namespace assets {
+
+// parameters to control how a render asset instance is created
+struct RenderAssetInstanceCreation {
+  std::string filepath;  // see also AssetInfo::filepath
+  Corrade::Containers::Optional<Magnum::Vector3> scale;
+  bool isStatic =
+      false;            // inform the renderer that this instance won't be moved
+  bool isRGBD = false;  // use in RGB and depth observations
+  bool isSemantic = false;  // use in semantic observations
+  std::string lightSetupKey;
+};
+
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.cpp
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.cpp
@@ -10,15 +10,12 @@ namespace assets {
 RenderAssetInstanceCreationInfo::RenderAssetInstanceCreationInfo(
     const std::string& _filepath,
     const Corrade::Containers::Optional<Magnum::Vector3>& _scale,
-    bool isStatic,
-    bool isRGBD,
-    bool isSemantic,
+    const Flags& _flags,
     const std::string& _lightSetupKey)
-    : filepath(_filepath), scale(_scale), lightSetupKey(_lightSetupKey) {
-  flags |= isStatic ? Flag::IsStatic : Flags();
-  flags |= isRGBD ? Flag::IsRGBD : Flags();
-  flags |= isSemantic ? Flag::IsSemantic : Flags();
-}
+    : filepath(_filepath),
+      scale(_scale),
+      flags(_flags),
+      lightSetupKey(_lightSetupKey) {}
 
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.cpp
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "RenderAssetInstanceCreationInfo.h"
+
+namespace esp {
+namespace assets {
+
+RenderAssetInstanceCreationInfo::RenderAssetInstanceCreationInfo(
+    const std::string& _filepath,
+    const Corrade::Containers::Optional<Magnum::Vector3>& _scale,
+    bool isStatic,
+    bool isRGBD,
+    bool isSemantic,
+    const std::string& _lightSetupKey)
+    : filepath(_filepath), scale(_scale), lightSetupKey(_lightSetupKey) {
+  flags |= isStatic ? Flag::IsStatic : Flags();
+  flags |= isRGBD ? Flag::IsRGBD : Flags();
+  flags |= isSemantic ? Flag::IsSemantic : Flags();
+}
+
+}  // namespace assets
+}  // namespace esp

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -28,9 +28,7 @@ struct RenderAssetInstanceCreationInfo {
   RenderAssetInstanceCreationInfo(
       const std::string& _filepath,
       const Corrade::Containers::Optional<Magnum::Vector3>& _scale,
-      bool isStatic,
-      bool isRGBD,
-      bool isSemantic,
+      const Flags& _flags,
       const std::string& _lightSetupKey);
 
   bool isStatic() const { return bool(flags & Flag::IsStatic); }

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -10,6 +10,7 @@
 
 #include "Magnum/Resource.h"
 
+#include <Corrade/Containers/EnumSet.h>
 #include <Corrade/Containers/Optional.h>
 
 namespace esp {
@@ -17,12 +18,28 @@ namespace assets {
 
 // parameters to control how a render asset instance is created
 struct RenderAssetInstanceCreationInfo {
+  enum class Flag : unsigned int {
+    IsStatic = 1 << 0,  // inform the renderer that this instance won't be moved
+    IsRGBD = 1 << 1,    // use in RGB and depth observations
+    IsSemantic = 1 << 2  // use in semantic observations
+  };
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+
+  RenderAssetInstanceCreationInfo(
+      const std::string& _filepath,
+      const Corrade::Containers::Optional<Magnum::Vector3>& _scale,
+      bool isStatic,
+      bool isRGBD,
+      bool isSemantic,
+      const std::string& _lightSetupKey);
+
+  bool isStatic() const { return bool(flags & Flag::IsStatic); }
+  bool isRGBD() const { return bool(flags & Flag::IsRGBD); }
+  bool isSemantic() const { return bool(flags & Flag::IsSemantic); }
+
   std::string filepath;  // see also AssetInfo::filepath
   Corrade::Containers::Optional<Magnum::Vector3> scale;
-  bool isStatic =
-      false;            // inform the renderer that this instance won't be moved
-  bool isRGBD = false;  // use in RGB and depth observations
-  bool isSemantic = false;  // use in semantic observations
+  Flags flags;
   std::string lightSetupKey;
 };
 

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -16,7 +16,7 @@ namespace esp {
 namespace assets {
 
 // parameters to control how a render asset instance is created
-struct RenderAssetInstanceCreation {
+struct RenderAssetInstanceCreationInfo {
   std::string filepath;  // see also AssetInfo::filepath
   Corrade::Containers::Optional<Magnum::Vector3> scale;
   bool isStatic =

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -877,6 +877,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
     const RenderAssetInstanceCreation& creation,
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
+#ifdef ESP_BUILD_PTEX_SUPPORT
   ASSERT(!creation.scale);  // PTex doesn't support scale
   ASSERT(creation.lightSetupKey ==
          NO_LIGHT_KEY);  // PTex doesn't support lighting
@@ -915,6 +916,11 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
     computePTexMeshAbsoluteAABBs(*meshes_.at(metaData.meshIndex.first),
                                  staticDrawableInfo);
   return instanceRoot;
+#else
+  LOG(ERROR) << "PTex support not enabled. Enable the BUILD_PTEX_SUPPORT CMake "
+                "option when building.";
+  return nullptr;
+#endif
 }
 
 bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -437,8 +437,8 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
   } else if (isRenderAssetGeneral(info.type)) {
     meshSuccess = loadRenderAssetGeneral(info);
   } else {
-    ASSERT(
-        false);  // loadRenderAsset doesn't yet support the requested asset type
+    // loadRenderAsset doesn't yet support the requested asset type
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE();
   }
 #if 0  // coming soon
   if (renderKeyframeWriter_) {
@@ -453,8 +453,8 @@ scene::SceneNode* ResourceManager::createRenderAssetInstance(
     scene::SceneNode* parent,
     DrawableGroup* drawables,
     std::vector<scene::SceneNode*>* visNodeCache) {
-  // assert that asset is already loaded
-  CHECK(resourceDict_.count(creation.filepath));
+  CORRADE_ASSERT(resourceDict_.count(creation.filepath), "asset is not loaded",
+                 nullptr);
 
   const LoadedAssetData& loadedAssetData = resourceDict_.at(creation.filepath);
   if (!isLightSetupCompatible(loadedAssetData, creation.lightSetupKey)) {
@@ -468,21 +468,22 @@ scene::SceneNode* ResourceManager::createRenderAssetInstance(
   const auto& info = loadedAssetData.assetInfo;
   scene::SceneNode* newNode = nullptr;
   if (info.type == AssetType::FRL_PTEX_MESH) {
-    ASSERT(
-        !visNodeCache);  // createRenderAssetInstancePTex doesn't support this
+    CORRADE_ASSERT(!visNodeCache,
+                   "createRenderAssetInstancePTex doesn't support this",
+                   nullptr);
     newNode = createRenderAssetInstancePTex(creation, parent, drawables);
   } else if (info.type == AssetType::INSTANCE_MESH) {
-    ASSERT(
-        !visNodeCache);  // createRenderAssetInstanceIMesh doesn't support this
+    CORRADE_ASSERT(!visNodeCache,
+                   "createRenderAssetInstanceIMesh doesn't support this",
+                   nullptr);
     newNode = createRenderAssetInstanceIMesh(creation, parent, drawables);
   } else if (isRenderAssetGeneral(info.type) ||
              info.type == AssetType::PRIMITIVE) {
     newNode = createRenderAssetInstanceGeneralPrimitive(
         creation, parent, drawables, visNodeCache);
   } else {
-    ASSERT(false);  // createRenderAssetInstance doesn't yet support the
-                    // requested asset type
-    newNode = nullptr;
+    // createRenderAssetInstance doesn't yet support the requested asset type
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE();
   }
 
 #if 0  // coming soon
@@ -529,7 +530,7 @@ bool ResourceManager::loadStageInternal(
         }
         // create render asset instance if requested
         if (parent) {
-          ASSERT(creation);
+          CORRADE_INTERNAL_ASSERT(creation);
           createRenderAssetInstance(*creation, parent, drawables);
         }
         return true;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1878,6 +1878,9 @@ bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,
                                          scene::SceneNode* parent,
                                          DrawableGroup* drawables) {
   ASSERT(parent != nullptr);
+
+  LOG(WARNING) << "SUNCG support is deprecated. This codepath is untested.";
+
   std::string houseFile = Cr::Utility::Directory::join(
       Cr::Utility::Directory::current(), houseInfo.filepath);
   const auto& json = io::parseJsonFile(houseFile);

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -30,6 +30,7 @@
 #include "GenericMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
+#include "RenderAssetInstanceCreation.h"
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
 #include "esp/gfx/MaterialData.h"
@@ -363,12 +364,12 @@ class ResourceManager {
    * @param[out] visNodeCache Cache for pointers to all nodes created as the
    * result of this process.
    */
-  void addObjectToDrawables(int objTemplateLibID,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            std::vector<scene::SceneNode*>& visNodeCache,
-                            const Mn::ResourceKey& lightSetupKey =
-                                Mn::ResourceKey{DEFAULT_LIGHTING_KEY}) {
+  void addObjectToDrawables(
+      int objTemplateLibID,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      std::vector<scene::SceneNode*>& visNodeCache,
+      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           metadataMediator_->getObjectAttributesManager()->getObjectHandleByID(
@@ -400,12 +401,12 @@ class ResourceManager {
    * @param[out] visNodeCache Cache for pointers to all nodes created as the
    * result of this process.
    */
-  void addObjectToDrawables(const std::string& objTemplateHandle,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            std::vector<scene::SceneNode*>& visNodeCache,
-                            const Mn::ResourceKey& lightSetupKey =
-                                Mn::ResourceKey{DEFAULT_LIGHTING_KEY});
+  void addObjectToDrawables(
+      const std::string& objTemplateHandle,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      std::vector<scene::SceneNode*>& visNodeCache,
+      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref
@@ -658,24 +659,21 @@ class ResourceManager {
    * If both parent and drawables are provided, add the mesh to the
    * scene graph for rendering.
    * @param info The @ref AssetInfo for the mesh, already parsed from a file.
+   * @param creation How to instance the render asset, or nullptr if not
+   * instancing.
    * @param parent The @ref scene::SceneNode to which the mesh will be added
-   * as a child.
+   * as a child. See also creation->isRGBD and creation->isSemantic. nullptr if
+   * not instancing.
    * @param drawables The @ref DrawableGroup with which the mesh will be
-   * rendered.
-   * @param computeAbsoluteAABBs Whether absolute bounding boxes should be
-   * computed
+   * rendered. See also creation->isRGBD and creation->isSemantic. nullptr if
+   * not instancing.
    * @param splitSemanticMesh Split the semantic mesh by objectID, used for A/B
    * testing
-   * @param lightSetupKey The @ref LightSetup key that will be used
-   * for the loaded asset.
    */
   bool loadStageInternal(const AssetInfo& info,
-                         scene::SceneNode* parent = nullptr,
-                         DrawableGroup* drawables = nullptr,
-                         bool computeAbsoluteAABBs = false,
-                         bool splitSemanticMesh = true,
-                         const Mn::ResourceKey& lightSetupKey = Mn::ResourceKey{
-                             NO_LIGHT_KEY});
+                         const RenderAssetInstanceCreation* creation,
+                         scene::SceneNode* parent,
+                         DrawableGroup* drawables);
 
   /**
    * @brief Builds the appropriate collision mesh groups for the passed
@@ -705,61 +703,68 @@ class ResourceManager {
       bool createSemanticInfo);
 
   /**
-   * @brief Load a PTex mesh into assets from a file and add it to the scene
-   * graph for rendering.
-   * @return true if the mesh is loaded, otherwise false
-   *
-   * @param info The @ref AssetInfo for the mesh, already parsed from a
-   * file.
-   * @param parent The @ref scene::SceneNode to which the mesh will be added
-   * as a child.
-   * @param drawables The @ref DrawableGroup with which the mesh will be
-   * rendered.
+   * @brief Load a render asset so it can be instanced. See also
+   * createRenderAssetInstance.
    */
-  bool loadPTexMeshData(const AssetInfo& info,
-                        scene::SceneNode* parent,
-                        DrawableGroup* drawables);
+  bool loadRenderAsset(const AssetInfo& info);
 
   /**
-   * @brief Load an instance mesh (e.g. Matterport reconstruction) into assets
-   * from a file and add it to the scene graph for rendering.
-   *
-   * @param info The @ref AssetInfo for the mesh, already parsed from a file.
-   * @param parent The @ref scene::SceneNode to which the mesh will be added
-   * as a child.
-   * @param drawables The @ref DrawableGroup with which the mesh will be
-   * rendered.
-   * @param computeAbsoluteAABBs Whether absolute bounding boxes should be
-   * computed
-   * @param splitSemanticMesh Split the semantic mesh by objectID
+   * @brief PTex Mesh backend for loadRenderAsset
    */
-  bool loadInstanceMeshData(const AssetInfo& info,
-                            scene::SceneNode* parent,
-                            DrawableGroup* drawables,
-                            bool computeAbsoluteAABBs,
-                            bool splitSemanticMesh);  // was default true
+  bool loadRenderAssetPTex(const AssetInfo& info);
 
   /**
-   * @brief Load a mesh (e.g. gltf) into assets from a file.
-   *
-   * If both parent and drawables are provided, add the mesh to the
-   * scene graph for rendering.
-   * @param info The @ref AssetInfo for the mesh, already parsed from a file.
-   * @param parent The @ref scene::SceneNode to which the mesh will be added
-   * as a child.
-   * @param drawables The @ref DrawableGroup with which the mesh will be
-   * rendered.
-   * @param computeAbsoluteAABBs Whether absolute bounding boxes should be
-   * computed
-   * @param lightSetupKey The @ref LightSetup key that will be used
-   * for the loaded asset.
+   * @brief Instance Mesh backend for loadRenderAsset
    */
-  bool loadGeneralMeshData(
-      const AssetInfo& info,
-      scene::SceneNode* parent = nullptr,
-      DrawableGroup* drawables = nullptr,
-      bool computeAbsoluteAABBs = false,
-      const Mn::ResourceKey& lightSetupKey = Mn::ResourceKey{NO_LIGHT_KEY});
+  bool loadRenderAssetIMesh(const AssetInfo& info);
+
+  /**
+   * @brief General Mesh backend for loadRenderAsset
+   */
+  bool loadRenderAssetGeneral(const AssetInfo& info);
+
+  /**
+   * @brief Create a render asset instance.
+   *
+   * @param creation Controls how the instance is created.
+   * @param parent The @ref scene::SceneNode to which the instance will be added
+   * as a child. See also creation.isRGBD and isSemantic.
+   * @param drawables The @ref DrawableGroup with which the instance will be
+   * rendered. See also creation.isRGBD and isSemantic.
+   * @param[out] visNodeCache Optional; cache for pointers to all nodes created
+   * as the result of this process.
+   */
+  scene::SceneNode* createRenderAssetInstance(
+      const RenderAssetInstanceCreation& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      std::vector<scene::SceneNode*>* visNodeCache = nullptr);
+
+  /**
+   * @brief PTex Mesh backend for createRenderAssetInstance
+   */
+  scene::SceneNode* createRenderAssetInstancePTex(
+      const RenderAssetInstanceCreation& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables);
+
+  /**
+   * @brief Instance Mesh backend for createRenderAssetInstance
+   */
+  scene::SceneNode* createRenderAssetInstanceIMesh(
+      const RenderAssetInstanceCreation& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables);
+
+  /**
+   * @brief backend for both General Mesh and Primitive Mesh, for
+   * createRenderAssetInstance
+   */
+  scene::SceneNode* createRenderAssetInstanceGeneralPrimitive(
+      const RenderAssetInstanceCreation& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables,
+      std::vector<scene::SceneNode*>* userVisNodeCache);
 
   /**
    * @brief Load a SUNCG mesh into assets from a file. !Deprecated! TODO:

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -30,7 +30,7 @@
 #include "GenericMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
-#include "RenderAssetInstanceCreation.h"
+#include "RenderAssetInstanceCreationInfo.h"
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
 #include "esp/gfx/MaterialData.h"
@@ -671,7 +671,7 @@ class ResourceManager {
    * testing
    */
   bool loadStageInternal(const AssetInfo& info,
-                         const RenderAssetInstanceCreation* creation,
+                         const RenderAssetInstanceCreationInfo* creation,
                          scene::SceneNode* parent,
                          DrawableGroup* drawables);
 
@@ -735,7 +735,7 @@ class ResourceManager {
    * as the result of this process.
    */
   scene::SceneNode* createRenderAssetInstance(
-      const RenderAssetInstanceCreation& creation,
+      const RenderAssetInstanceCreationInfo& creation,
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>* visNodeCache = nullptr);
@@ -744,7 +744,7 @@ class ResourceManager {
    * @brief PTex Mesh backend for createRenderAssetInstance
    */
   scene::SceneNode* createRenderAssetInstancePTex(
-      const RenderAssetInstanceCreation& creation,
+      const RenderAssetInstanceCreationInfo& creation,
       scene::SceneNode* parent,
       DrawableGroup* drawables);
 
@@ -752,7 +752,7 @@ class ResourceManager {
    * @brief Instance Mesh backend for createRenderAssetInstance
    */
   scene::SceneNode* createRenderAssetInstanceIMesh(
-      const RenderAssetInstanceCreation& creation,
+      const RenderAssetInstanceCreationInfo& creation,
       scene::SceneNode* parent,
       DrawableGroup* drawables);
 
@@ -761,7 +761,7 @@ class ResourceManager {
    * createRenderAssetInstance
    */
   scene::SceneNode* createRenderAssetInstanceGeneralPrimitive(
-      const RenderAssetInstanceCreation& creation,
+      const RenderAssetInstanceCreationInfo& creation,
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>* userVisNodeCache);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -57,7 +57,7 @@ bool PhysicsManager::addStageFinalize(const std::string& handle) {
 int PhysicsManager::addObject(const int objectLibId,
                               DrawableGroup* drawables,
                               scene::SceneNode* attachmentNode,
-                              const Magnum::ResourceKey& lightSetup) {
+                              const std::string& lightSetup) {
   const std::string& configHandle =
       resourceManager_.getObjectAttributesManager()->getObjectHandleByID(
           objectLibId);
@@ -68,7 +68,7 @@ int PhysicsManager::addObject(const int objectLibId,
 int PhysicsManager::addObject(const std::string& configFileHandle,
                               DrawableGroup* drawables,
                               scene::SceneNode* attachmentNode,
-                              const Magnum::ResourceKey& lightSetup) {
+                              const std::string& lightSetup) {
   //! Make rigid object and add it to existingObjects
   int nextObjectID_ = allocateObjectID();
   scene::SceneNode* objectNode = attachmentNode;

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -181,8 +181,8 @@ class PhysicsManager {
   int addObject(const std::string& configFile,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-                    assets::ResourceManager::DEFAULT_LIGHTING_KEY});
+                const std::string& lightSetup =
+                    assets::ResourceManager::DEFAULT_LIGHTING_KEY);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
@@ -199,8 +199,8 @@ class PhysicsManager {
   int addObject(const int objectLibId,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const Magnum::ResourceKey& lightSetup = Magnum::ResourceKey{
-                    assets::ResourceManager::DEFAULT_LIGHTING_KEY});
+                const std::string& lightSetup =
+                    assets::ResourceManager::DEFAULT_LIGHTING_KEY);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref


### PR DESCRIPTION
## Motivation and Context

This PR is (mostly) a no-op refactor of ResourceManager (no behavior change). The motivation is to unblock the upcoming render replay feature.

I introduce the terms "render asset" and "render asset instance". A render asset is basically a mesh. A render asset can be of type InstanceMesh ("IMesh"), PTex, Primitive, or General (see `isRenderAssetGeneral`).

A somewhat unrelated change is mixed in here: I'm converting some usage of ResourceKey (a hash) to std::string so that I can better serialize the key.

This is (mostly) a no-op refactor that conceptually replaces `loadPTexMeshData / loadInstanceMeshData / loadGeneralMeshData` with `loadRenderAssetPTex,createRenderAssetInstancePTex / loadRenderAssetIMesh,createRenderAssetInstanceIMesh / loadRenderAssetGeneral,createRenderAssetInstanceGeneralPrimitive`.

Some things you can do with render assets and instances:
- Load a render asset (without adding anything to the scene graph; see `loadRenderAsset`).
- Create instances of a render asset (add instances to the scene graph so they show up in observations; see `createRenderAssetInstance`).
- Move a render asset instance in the scene (and coming soon, you can hide or unhide it).
- Delete a render asset instance (remove the instance from the scene graph).
- Unload a render asset (only after all its instances have been deleted; at present, I think the only way to unload is to reconfigure/reset the simulator).

More details about render assets:
- Currently, a render asset instance isn't a formal class/object in our code. It's a subtree of scene nodes and drawables. It *is* a formal object in the serialization code I'm writing for render replay.
- A PhysicsObject's attributes include its render asset. A PhysicsObject has an associated render asset instance at runtime.
- A stage has an associated RGBD/"render" render asset instance and optional "semantic" render asset instance.
- An articulated object will have an associated render asset instance per link at runtime (articulated objects aren't merged to master yet).

Some goals/benefits of this refactor:
- Cleaner separation between render and simulation code: a replay renderer will be able to load and display stage visuals without calling loadStage, processing stageAttributes, or loading stage collision geometry.
- unified loading of render assets: loadRenderAsset
- unified creation of instances: createRenderAssetInstance
- Users of render assets are (mostly) agnostic to the underlying type: stage, objects, and articulated object links have associated render assets, but they (mostly) don't care what type.
- Any render asset type can be used for RGBD, Semantic, or both.
- Where render asset types differ, we're explicit. E.g. explicit asserts that convey that PTex doesn't support scale or lighting.

Some possible future use cases this unlocks (these are side benefits; the main motivation for this PR is unblocking render replay):
- preload render assets (load prior to use)
- unload and reload render assets on demand
- add separate semantic render assets to objects or links
- use PTex or InstanceMesh render assets with objects and links

## How Has This Been Tested

Loading stages with render assets of type PTex, InstanceMesh, and General (GLB), in the viewer
Adding physics objects in the viewer
Testing semantic rendering using a modified semantic_id_tutorial.py
I ran SimTest, which tests adding a primitive

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
