### PR TITLE
add BulletPhysicsManager::getContactPoints and python bindings

### DIFF
--- a/src/esp/bindings/PhysicsBindings.cpp
+++ b/src/esp/bindings/PhysicsBindings.cpp
@@ -61,6 +61,28 @@ void initPhysicsBindings(py::module& m) {
       .def_readonly("hits", &RaycastResults::hits)
       .def_readonly("ray", &RaycastResults::ray)
       .def("has_hits", &RaycastResults::hasHits);
+
+  py::class_<ContactPointData, ContactPointData::ptr>(m, "ContactPointData")
+      .def(py::init(&ContactPointData::create<>))
+      .def_readwrite("object_id_a", &ContactPointData::objectIdA)
+      .def_readwrite("object_id_b", &ContactPointData::objectIdB)
+      .def_readwrite("link_id_a", &ContactPointData::linkIndexA)
+      .def_readwrite("link_id_b", &ContactPointData::linkIndexB)
+      .def_readwrite("position_on_a_in_ws", &ContactPointData::positionOnAInWS)
+      .def_readwrite("position_on_b_in_ws", &ContactPointData::positionOnBInWS)
+      .def_readwrite("contact_normal_on_b_in_ws",
+                     &ContactPointData::contactNormalOnBInWS)
+      .def_readwrite("contact_distance", &ContactPointData::contactDistance)
+      .def_readwrite("normal_force", &ContactPointData::normalForce)
+      .def_readwrite("linear_friction_force1",
+                     &ContactPointData::linearFrictionForce1)
+      .def_readwrite("linear_friction_force2",
+                     &ContactPointData::linearFrictionForce2)
+      .def_readwrite("linear_friction_direction1",
+                     &ContactPointData::linearFrictionDirection1)
+      .def_readwrite("linear_friction_direction2",
+                     &ContactPointData::linearFrictionDirection2)
+      .def_readwrite("is_active", &ContactPointData::isActive);
 }
 
 }  // namespace physics

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -238,6 +238,10 @@ void initSimBindings(py::module& m) {
           "scene_id"_a = 0,
           R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
       .def(
+          "get_physics_contact_points", &Simulator::getPhysicsContactPoints,
+          "scene_id"_a = 0,
+          R"(Return a list of ContactPointData objects describing the contacts from the most recent physics substep.)")
+      .def(
           "cast_ray", &Simulator::castRay, "ray"_a, "max_distance"_a = 100.0,
           "scene_id"_a = 0,
           R"(Cast a ray into the collidable scene and return hit results. Physics must be enabled. max_distance in units of ray length.)")

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -66,6 +66,37 @@ struct RaycastResults {
   ESP_SMART_POINTERS(RaycastResults)
 };
 
+// based on Bullet b3ContactPointData
+struct ContactPointData {
+  int objectIdA = -2;  // stage is -1
+  int objectIdB = -2;
+  int linkIndexA = -1;  // -1 if not a multibody
+  int linkIndexB = -1;
+
+  Magnum::Vector3 positionOnAInWS;  // contact point location on object A, in
+                                    // world space coordinates
+  Magnum::Vector3 positionOnBInWS;  // contact point location on object B, in
+                                    // world space coordinates
+  Magnum::Vector3
+      contactNormalOnBInWS;  // the separating contact normal, pointing from
+                             // object B towards object A
+  double contactDistance =
+      0.0;  // negative number is penetration, positive is distance.
+
+  double normalForce = 0.0;
+
+  double linearFrictionForce1 = 0.0;
+  double linearFrictionForce2 = 0.0;
+  Magnum::Vector3 linearFrictionDirection1;
+  Magnum::Vector3 linearFrictionDirection2;
+
+  // the contact is considered active if at least one object is active (not
+  // asleep)
+  bool isActive = false;
+
+  ESP_SMART_POINTERS(ContactPointData)
+};
+
 // TODO: repurpose to manage multiple physical worlds. Currently represents
 // exactly one world.
 
@@ -1049,6 +1080,8 @@ class PhysicsManager {
   virtual bool contactTest(CORRADE_UNUSED const int physObjectID) {
     return false;
   };
+
+  virtual std::vector<ContactPointData> getContactPoints() const { return {}; }
 
   /** @brief Return the library implementation type for the simulator currently
    * in use. Use to check for a particular implementation.

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -188,6 +188,13 @@ class BulletPhysicsManager : public PhysicsManager {
   bool contactTest(const int physObjectID) override;
 
   /**
+   * @brief Return ContactPointData objects describing the contacts from the
+   * most recent physics substep. This implementation is roughly identical to
+   * PyBullet's getContactPoints.
+   */
+  std::vector<ContactPointData> getContactPoints() const override;
+
+  /**
    * @brief Cast a ray into the collision world and return a @ref RaycastResults
    * with hit information.
    *
@@ -322,6 +329,8 @@ class BulletPhysicsManager : public PhysicsManager {
   std::shared_ptr<std::map<const btCollisionObject*, int>>
       collisionObjToObjIds_;
 
+  int m_recentNumSubStepsTaken = -1;  // for recent call to stepPhysics
+
  private:
   /** @brief Check if a particular mesh can be used as a collision mesh for
    * Bullet.
@@ -331,6 +340,10 @@ class BulletPhysicsManager : public PhysicsManager {
    * @return true if valid, false otherwise.
    */
   bool isMeshPrimitiveValid(const assets::CollisionMeshData& meshData) override;
+
+  void lookUpObjectIdAndLinkId(const btCollisionObject* colObj,
+                               int* objectId,
+                               int* linkId) const;
 
   ESP_SMART_POINTERS(BulletPhysicsManager)
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -558,6 +558,14 @@ bool Simulator::contactTest(const int objectID, const int sceneID) {
   return false;
 }
 
+std::vector<esp::physics::ContactPointData> Simulator::getPhysicsContactPoints(
+    const int sceneID) {
+  if (sceneHasPhysics(sceneID)) {
+    return physicsManager_->getContactPoints();
+  }
+  return {};
+}
+
 esp::physics::RaycastResults Simulator::castRay(const esp::geo::Ray& ray,
                                                 float maxDistance,
                                                 const int sceneID) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -715,6 +715,9 @@ class Simulator {
    */
   bool contactTest(int objectID, int sceneID = 0);
 
+  std::vector<esp::physics::ContactPointData> getPhysicsContactPoints(
+      const int sceneID);
+
   /**
    * @brief Raycast into the collision world of a scene.
    *


### PR DESCRIPTION
## Motivation and Context

`BulletPhysicsManager::getContactPoints` returns `ContactPointData` objects describing the contacts from the most recent physics substep. This implementation is roughly identical to PyBullet's `getContactPoints`.

Users should take care to call stepWorld with a dt equal to the Bullet substep dt prior to calling getContactPoints, because getContactPoints only returns data about the most recent substep. There's a warning to encourage correct usage.

The most obvious usage is to get info about the recent substep during physics simulation. However, another planned use case is similar to an async "what if" collision query, as follows:
1. Save the state of the physics world.
2. Move desired query object(s) to a desired query pose.
3. stepWorld(substepDt)
4. getContactPoints()
5. Restore the state of the physics world.

There are more direct, efficient ways to do async queries in C++ Bullet, but the steps above are common in existing PyBullet user code, e.g. https://github.com/caelan/pybullet-planning/blob/8ec64398f41a2151de5ce1ab6213cfb220cde924/examples/test_kuka_pick.py#L22 . So let's offer this function in Habitat Bullet in order to be compatible with PyBullet.

## How Has This Been Tested

Ad hoc testing in viewer and rigid_object_tutorial.py. We'll need to add unit tests before merging this into `master`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
