### PR TITLE
Adds an upgrade_warning for SimulatorConfig

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -50,8 +50,10 @@ def make_cfg(settings):
     if "scene_light_setup" in settings:
         sim_cfg.scene_light_setup = settings["scene_light_setup"]
     sim_cfg.gpu_device_id = 0
-    if not hasattr(sim_cfg, 'scene_id'):
-        raise RuntimeException("Error: Please upgrade habitat-sim.")
+    if not hasattr(sim_cfg, "scene_id"):
+        raise RuntimeError(
+            "Error: Please upgrade habitat-sim. SimulatorConfig API version mismatch"
+        )
     sim_cfg.scene_id = settings["scene"]
 
     # define default sensor parameters (see src/esp/Sensor/Sensor.h)

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -50,6 +50,8 @@ def make_cfg(settings):
     if "scene_light_setup" in settings:
         sim_cfg.scene_light_setup = settings["scene_light_setup"]
     sim_cfg.gpu_device_id = 0
+    if not hasattr(sim_cfg, 'scene_id'):
+        raise RuntimeException("Error: Please upgrade habitat-sim.")
     sim_cfg.scene_id = settings["scene"]
 
     # define default sensor parameters (see src/esp/Sensor/Sensor.h)


### PR DESCRIPTION
Warn users that they need to upgrade habitat_sim

## Motivation and Context
Adds an exception asking people to upgrade habitat_sim if their SimConfiguration object is outdated.

Closes #938 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
