### PR TITLE
Add import linter contract pre-commit hook and fix SensorSubtype Python bindings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,11 @@ repos:
     -   id: mypy
         pass_filenames: false
 
+-   repo: https://github.com/seddonym/import-linter
+    rev: v1.2
+    hooks:
+    -   id: import-linter
+
 -   repo: https://github.com/kynan/nbstripout
     rev: 0.3.9
     hooks:

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -16,7 +16,7 @@ from settings import default_sim_settings, make_cfg
 
 import habitat_sim
 import habitat_sim.agent
-from habitat_sim import bindings as hsim
+from habitat_sim.nav import ShortestPath
 from habitat_sim.physics import MotionType
 from habitat_sim.utils.common import (
     d3_40_colors_rgb,
@@ -410,7 +410,7 @@ class DemoRunner:
 
         # initialize and compute shortest path to goal
         if self._sim_settings["compute_shortest_path"]:
-            self._shortest_path = hsim.ShortestPath()
+            self._shortest_path = ShortestPath()
             self.compute_shortest_path(
                 start_state.position, self._sim_settings["goal_position"]
             )

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -4,7 +4,6 @@
 
 import habitat_sim
 import habitat_sim.agent
-from habitat_sim import bindings as hsim
 
 default_sim_settings = {
     # settings shared by example.py and benchmark.py
@@ -37,7 +36,7 @@ default_sim_settings = {
 
 # build SimulatorConfiguration
 def make_cfg(settings):
-    sim_cfg = hsim.SimulatorConfiguration()
+    sim_cfg = habitat_sim.SimulatorConfiguration()
     if "frustum_culling" in settings:
         sim_cfg.frustum_culling = settings["frustum_culling"]
     else:
@@ -60,28 +59,28 @@ def make_cfg(settings):
     # define default sensor parameters (see src/esp/Sensor/Sensor.h)
     sensors = {
         "color_sensor": {  # active if sim_settings["color_sensor"]
-            "sensor_type": hsim.SensorType.COLOR,
+            "sensor_type": habitat_sim.SensorType.COLOR,
             "resolution": [settings["height"], settings["width"]],
             "position": [0.0, settings["sensor_height"], 0.0],
-            "sensor_subtype": hsim.SensorSubType.PINHOLE,
+            "sensor_subtype": habitat_sim.SensorSubType.PINHOLE,
         },
         "depth_sensor": {  # active if sim_settings["depth_sensor"]
-            "sensor_type": hsim.SensorType.DEPTH,
+            "sensor_type": habitat_sim.SensorType.DEPTH,
             "resolution": [settings["height"], settings["width"]],
             "position": [0.0, settings["sensor_height"], 0.0],
-            "sensor_subtype": hsim.SensorSubType.PINHOLE,
+            "sensor_subtype": habitat_sim.SensorSubType.PINHOLE,
         },
         "semantic_sensor": {  # active if sim_settings["semantic_sensor"]
-            "sensor_type": hsim.SensorType.SEMANTIC,
+            "sensor_type": habitat_sim.SensorType.SEMANTIC,
             "resolution": [settings["height"], settings["width"]],
             "position": [0.0, settings["sensor_height"], 0.0],
-            "sensor_subtype": hsim.SensorSubType.PINHOLE,
+            "sensor_subtype": habitat_sim.SensorSubType.PINHOLE,
         },
         "ortho_sensor": {  # active if sim_settings["ortho_sensor"]
-            "sensor_type": hsim.SensorType.COLOR,
+            "sensor_type": habitat_sim.SensorType.COLOR,
             "resolution": [settings["height"], settings["width"]],
             "position": [0.0, settings["sensor_height"], 0.0],
-            "sensor_subtype": hsim.SensorSubType.ORTHOGRAPHIC,
+            "sensor_subtype": habitat_sim.SensorSubType.ORTHOGRAPHIC,
         },
     }
 
@@ -89,7 +88,7 @@ def make_cfg(settings):
     sensor_specs = []
     for sensor_uuid, sensor_params in sensors.items():
         if settings[sensor_uuid]:
-            sensor_spec = hsim.SensorSpec()
+            sensor_spec = habitat_sim.SensorSpec()
             sensor_spec.uuid = sensor_uuid
             sensor_spec.sensor_type = sensor_params["sensor_type"]
             sensor_spec.sensor_subtype = sensor_params["sensor_subtype"]

--- a/habitat_sim/__init__.py
+++ b/habitat_sim/__init__.py
@@ -51,6 +51,7 @@ if not getattr(builtins, "__HSIM_SETUP__", False):
         SceneNodeType,
         Sensor,
         SensorSpec,
+        SensorSubType,
         SensorType,
         SimulatorConfiguration,
         cuda_enabled,

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,24 @@ per-file-ignores =
 	examples/tutorials/nb_python/*.py:B008,F841
 	tools/run-clang-tidy.py:B001
 
+[importlinter]
+root_packages=
+	examples
+	habitat_sim
+	tests
+contract_types =
+	forbidden_import: tools.custom_il_contracts.ForbiddenContractDirect
+
+[importlinter:contract:1]
+name = examples and tests do not import habitat_sim.bindings directly
+type = forbidden_import
+source_modules=
+	examples
+	tests
+forbidden_modules=
+	habitat_sim.bindings
+allow_indirect_imports=True
+
 [tool:pytest]
 addopts = --verbose -rsxX -q
 testpaths = tests

--- a/tests/test_pyrobot_noisy_controls.py
+++ b/tests/test_pyrobot_noisy_controls.py
@@ -13,8 +13,8 @@ import quaternion  # noqa: F401
 import habitat_sim
 import habitat_sim.errors
 import habitat_sim.utils.common
-from habitat_sim import bindings as hsim
 from habitat_sim.agent.controls.pyrobot_noisy_controls import pyrobot_noise_models
+from habitat_sim.scene import SceneGraph
 
 
 def _delta_translation(a, b):
@@ -38,7 +38,7 @@ def _delta_rotation(a, b):
 )
 def test_pyrobot_noisy_actions(noise_multiplier, robot, controller):
     np.random.seed(0)
-    scene_graph = hsim.SceneGraph()
+    scene_graph = SceneGraph()
     agent_config = habitat_sim.AgentConfiguration()
     agent_config.action_space = dict(
         noisy_move_backward=habitat_sim.ActionSpec(

--- a/tools/custom_il_contracts.py
+++ b/tools/custom_il_contracts.py
@@ -1,0 +1,144 @@
+from importlinter.application import output
+from importlinter.domain import fields, helpers
+from importlinter.domain.contract import Contract, ContractCheck
+from importlinter.domain.ports.graph import ImportGraph
+
+
+class ForbiddenContractDirect(Contract):
+    """
+    Forbidden contracts check that one set of modules are not imported by another set of modules.
+    Indirect imports will also be checked.
+    Configuration options:
+        - source_modules:    A list of Modules that should not import the forbidden modules.
+        - forbidden_modules: A list of Modules that should not be imported by the source modules.
+        - ignore_imports:    A set of DirectImports. These imports will be ignored: if the import
+                             would cause a contract to be broken, adding it to the set will cause
+                             the contract be kept instead. (Optional.)
+    """
+
+    type_name = "forbidden_direct"
+
+    source_modules = fields.ListField(subfield=fields.ModuleField())
+    forbidden_modules = fields.ListField(subfield=fields.ModuleField())
+    ignore_imports = fields.SetField(
+        subfield=fields.DirectImportField(), required=False
+    )
+    allow_indirect_imports = fields.StringField(required=False)
+
+    def check(self, graph: ImportGraph) -> ContractCheck:
+        is_kept = True
+        invalid_chains = []
+
+        helpers.pop_imports(
+            graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
+        )
+
+        self._check_all_modules_exist_in_graph(graph)
+        self._check_external_forbidden_modules(graph)
+
+        # We only need to check for illegal imports for forbidden modules that are in the graph.
+        forbidden_modules_in_graph = [
+            m for m in self.forbidden_modules if m.name in graph.modules  # type: ignore
+        ]
+
+        for source_module in self.source_modules:  # type: ignore
+            for forbidden_module in forbidden_modules_in_graph:
+                subpackage_chain_data = {
+                    "upstream_module": forbidden_module.name,
+                    "downstream_module": source_module.name,
+                    "chains": [],
+                }
+
+                chains = graph.find_shortest_chains(
+                    importer=source_module.name, imported=forbidden_module.name
+                )
+                if chains:
+                    if self._allow_indirect_imports():
+                        chains = [chain for chain in chains if len(chain) <= 2]
+                        if len(chains) == 0:
+                            continue
+                    is_kept = False
+                    for chain in chains:
+                        chain_data = []
+                        for importer, imported in [
+                            (chain[i], chain[i + 1]) for i in range(len(chain) - 1)
+                        ]:
+                            import_details = graph.get_import_details(
+                                importer=importer, imported=imported
+                            )
+                            line_numbers = tuple(
+                                j["line_number"] for j in import_details
+                            )
+                            chain_data.append(
+                                {
+                                    "importer": importer,
+                                    "imported": imported,
+                                    "line_numbers": line_numbers,
+                                }
+                            )
+                        subpackage_chain_data["chains"].append(chain_data)
+                if subpackage_chain_data["chains"]:
+                    invalid_chains.append(subpackage_chain_data)
+
+        return ContractCheck(kept=is_kept, metadata={"invalid_chains": invalid_chains})
+
+    def render_broken_contract(self, check: "ContractCheck") -> None:
+        count = 0
+        for chains_data in check.metadata["invalid_chains"]:
+            downstream, upstream = (
+                chains_data["downstream_module"],
+                chains_data["upstream_module"],
+            )
+            output.print_error(f"{downstream} is not allowed to import {upstream}:")
+            output.new_line()
+            count += len(chains_data["chains"])
+            for chain in chains_data["chains"]:
+                first_line = True
+                for direct_import in chain:
+                    importer, imported = (
+                        direct_import["importer"],
+                        direct_import["imported"],
+                    )
+                    line_numbers = ", ".join(
+                        f"l.{n}" for n in direct_import["line_numbers"]
+                    )
+                    import_string = f"{importer} -> {imported} ({line_numbers})"
+                    if first_line:
+                        output.print_error(f"-   {import_string}", bold=False)
+                        first_line = False
+                    else:
+                        output.indent_cursor()
+                        output.print_error(import_string, bold=False)
+                output.new_line()
+
+            output.new_line()
+
+    def _check_all_modules_exist_in_graph(self, graph: ImportGraph) -> None:
+        for module in self.source_modules:  # type: ignore
+            if module.name not in graph.modules:
+                raise ValueError(f"Module '{module.name}' does not exist.")
+
+    def _check_external_forbidden_modules(self, graph: ImportGraph) -> None:
+        if (
+            self._contains_external_forbidden_modules(graph)
+            and not self._graph_was_built_with_externals()
+        ):
+            raise ValueError(
+                "The top level configuration must have include_external_packages=True "
+                "when there are external forbidden modules."
+            )
+
+    def _contains_external_forbidden_modules(self, graph: ImportGraph) -> bool:
+        root_packages = self.session_options["root_packages"]
+        return not all(
+            m.root_package_name in root_packages for m in self.forbidden_modules  # type: ignore
+        )
+
+    def _allow_indirect_imports(self) -> bool:
+        return self.allow_indirect_imports and self.allow_indirect_imports in (
+            "True",
+            "true",
+        )
+
+    def _graph_was_built_with_externals(self) -> bool:
+        return self.session_options.get("include_external_packages") in ("True", "true")


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Adds a pre-commit hook that enforces a custom import contract that forbids examples and test modules from directly using habitat_sim.bindings. This way, it reminds users to create an alternative location for the Python binding which we missed for the SensorSubtype.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
CircleCI and locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
