### PR TITLE
Refactor Multi-Agent Sensors API and allow dynamic adding of Sensors

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -142,9 +142,17 @@ class Agent(object):
         if reconfigure_sensors:
             self._sensors.clear()
             for spec in self.agent_config.sensor_specifications:
-                self.add_sensor(spec)
+                self.add_sensor(spec, modify_agent_config=False)
 
-    def add_sensor(self, spec: hsim.SensorSpec) -> None:
+    def add_sensor(
+        self, spec: hsim.SensorSpec, modify_agent_config: bool = True
+    ) -> None:
+        assert (
+            spec.uuid not in self._sensors
+        ), f"Error, {spec.uuid} already exists in the sensor suite"
+        if modify_agent_config:
+            assert spec not in self.agent_config.sensor_specifications
+            self.agent_config.sensor_specifications.append(spec)
         self._sensors.add(hsim.CameraSensor(self.scene_node.create_child(), spec))
 
     def act(self, action_id: Any) -> bool:

--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -142,9 +142,10 @@ class Agent(object):
         if reconfigure_sensors:
             self._sensors.clear()
             for spec in self.agent_config.sensor_specifications:
-                self._sensors.add(
-                    hsim.CameraSensor(self.scene_node.create_child(), spec)
-                )
+                self.add_sensor(spec)
+
+    def add_sensor(self, spec: hsim.SensorSpec) -> None:
+        self._sensors.add(hsim.CameraSensor(self.scene_node.create_child(), spec))
 
     def act(self, action_id: Any) -> bool:
         r"""Take the action specified by action_id

--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -142,9 +142,9 @@ class Agent(object):
         if reconfigure_sensors:
             self._sensors.clear()
             for spec in self.agent_config.sensor_specifications:
-                self.add_sensor(spec, modify_agent_config=False)
+                self._add_sensor(spec, modify_agent_config=False)
 
-    def add_sensor(
+    def _add_sensor(
         self, spec: hsim.SensorSpec, modify_agent_config: bool = True
     ) -> None:
         assert (

--- a/habitat_sim/sensors/sensor_suite.py
+++ b/habitat_sim/sensors/sensor_suite.py
@@ -1,7 +1,9 @@
+from typing import Dict
+
 from habitat_sim import bindings as hsim
 
 
-class SensorSuite(dict):
+class SensorSuite(Dict[str, hsim.Sensor]):
     r"""Holds all the agents sensors. Simply a dictionary with an extra method
     to lookup the name of a sensor as the key
     """

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -6,7 +6,7 @@
 
 import time
 from os import path as osp
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast, overload
 
 import attr
 import magnum as mn
@@ -29,12 +29,6 @@ from habitat_sim.sensor import SensorSpec, SensorType
 from habitat_sim.sensors.noise_models import make_sensor_noise_model
 from habitat_sim.sim import SimulatorBackend, SimulatorConfiguration
 from habitat_sim.utils.common import quat_from_angle_axis
-
-
-def _overwrite_sensor_spec_uuid(spec: SensorSpec, agent_id: int = 0) -> SensorSpec:
-    if agent_id > 0:
-        spec.uuid = f"agent_{agent_id}/{spec.uuid}"
-    return spec
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -66,8 +60,8 @@ class Simulator(SimulatorBackend):
     config: Configuration
     agents: List[Agent] = attr.ib(factory=list, init=False)
     _num_total_frames: int = attr.ib(default=0, init=False)
-    _default_agent: Agent = attr.ib(init=False, default=None)
-    _sensors: Dict = attr.ib(factory=dict, init=False)
+    _default_agent_id: Optional[int] = attr.ib(init=False, default=None)
+    _sensors: List[Dict[str, Any]] = attr.ib(factory=List[Dict[str, Any]], init=False)
     _initialized: bool = attr.ib(default=False, init=False)
     _previous_step_time: float = attr.ib(
         default=0.0, init=False
@@ -106,22 +100,18 @@ class Simulator(SimulatorBackend):
                 config.agents,
             )
         )
-        for i in range(len(config.agents)):
-            config.agents[i].sensor_specifications = [
-                _overwrite_sensor_spec_uuid(spec, agent_id=i)
-                for spec in config.agents[i].sensor_specifications
-            ]
 
     def __attrs_post_init__(self) -> None:
         self._sanitize_config(self.config)
         self.__set_from_config(self.config)
 
     def close(self) -> None:
-        for sensor in self._sensors.values():
-            sensor.close()
-            del sensor
+        for agent_sensorsuite in self._sensors:
+            for sensor in agent_sensorsuite.values():
+                sensor.close()
+                del sensor
 
-        self._sensors = {}
+        self._sensors = []
 
         for agent in self.agents:
             agent.close()
@@ -129,8 +119,7 @@ class Simulator(SimulatorBackend):
 
         self.agents = []
 
-        del self._default_agent
-        self._default_agent = None
+        self._default_agent_id = None
 
         self.config = None
 
@@ -228,26 +217,21 @@ class Simulator(SimulatorBackend):
         for i in range(len(self.agents)):
             self.agents[i].controls.move_filter_fn = self.step_filter
 
-        self._default_agent = self.get_agent(config.sim_cfg.default_agent_id)
+        self._default_agent_id = config.sim_cfg.default_agent_id
 
-        self._sensors = {}
-        for i in range(len(self.agents)):
-
-            agent_cfg = config.agents[i]
+        self._sensors = [Dict[str, Sensor]() for i in range(len(config.agents))]
+        for agent_id, agent_cfg in enumerate(config.agents):
             for spec in agent_cfg.sensor_specifications:
-                self._update_simulator_sensors(spec.uuid, agent_id=i)
-
-        for i in range(len(self.agents)):
-            self.initialize_agent(i)
+                self._update_simulator_sensors(spec.uuid, agent_id=agent_id)
+            self.initialize_agent(agent_id)
 
     def _update_simulator_sensors(self, uuid: str, agent_id: int = 0) -> None:
-        self._sensors[uuid] = Sensor(
+        self._sensors[agent_id][uuid] = Sensor(
             sim=self, agent=self.get_agent(agent_id), sensor_id=uuid
         )
 
     def add_sensor(self, sensor_spec: SensorSpec, agent_id: int = 0) -> None:
         agent = self.get_agent(agent_id=agent_id)
-        sensor_spec = _overwrite_sensor_spec_uuid(sensor_spec, agent_id=agent_id)
         agent._add_sensor(sensor_spec)
         self._update_simulator_sensors(sensor_spec.uuid, agent_id=agent_id)
 
@@ -270,34 +254,80 @@ class Simulator(SimulatorBackend):
         self._last_state = agent.state
         return agent
 
-    def get_sensor_observations(self) -> Dict[str, Union[ndarray, "Tensor"]]:
-        for _, sensor in self._sensors.items():
-            sensor.draw_observation()
+    @overload
+    def get_sensor_observations(
+        self, agent_ids: int = 0
+    ) -> Dict[str, Union[ndarray, "Tensor"]]:
+        ...
 
-        observations = {}
-        for sensor_uuid, sensor in self._sensors.items():
-            observations[sensor_uuid] = sensor.get_observation()
+    @overload
+    def get_sensor_observations(
+        self, agent_ids: List[int] = ...
+    ) -> List[Dict[str, Union[ndarray, "Tensor"]]]:
+        ...
 
+    def get_sensor_observations(self, agent_ids: Union[int, List[int]] = 0):
+        if isinstance(agent_ids, int):
+            return_single = True
+            agent_ids = [agent_ids]
+
+        for agent_id, agent_sensorsuite in enumerate(self._sensors):
+            if agent_id in agent_ids:
+                for _sensor_uuid, sensor in agent_sensorsuite.items():
+                    sensor.draw_observation()
+
+        observations: List[Dict[str, Union[ndarray, "Tensor"]]] = []
+        for agent_id in agent_ids:
+            agent_observations: Dict[str, Union[ndarray, "Tensor"]] = {}
+            for sensor_uuid, sensor in self._sensors[agent_id].items():
+                agent_observations[sensor_uuid] = sensor.get_observation()
+            observations.append(agent_observations)
+        if return_single:
+            return observations[0]
         return observations
+
+    @property
+    def _default_agent(self) -> Agent:
+        return self.get_agent(self._default_agent_id)
 
     def last_state(self) -> AgentState:
         return self._last_state
 
     def step(
-        self, action: str, dt: float = 1.0 / 60.0
-    ) -> Dict[str, Union[bool, ndarray, "Tensor"]]:
+        self,
+        action: Any,
+        dt: float = 1.0 / 60.0,
+        multi_agent: bool = False,
+    ):
         self._num_total_frames += 1
-        collided = self._default_agent.act(action)
-        self._last_state = self._default_agent.get_state()
+        if not multi_agent:
+            agent_ids: Union[List[int], int] = self._default_agent_id
+            collided = self.default_agent.act(action)
+            self._last_state = self._default_agent.get_state()
+        else:
+            assert isinstance(action, dict)
+            agent_ids = list(action.keys())
+            collided_dict: Dict[int, bool] = {}
+            for agent_id, agent_act in action.items():
+                collided_dict[agent_id] = self._get_agent(agent_id).act(agent_act)
+            # TODO: Maybe should allow MultiAgent state return too...
+            self._last_state = self._get_agents(agent_ids[-1]).get_state()
 
         # step physics by dt
         step_start_Time = time.time()
         super().step_world(dt)
         self._previous_step_time = time.time() - step_start_Time
 
-        observations = self.get_sensor_observations()
+        observations = self.get_sensor_observations(agent_ids=agent_ids)
         # Whether or not the action taken resulted in a collision
-        observations["collided"] = collided
+        if not multi_agent:
+            observations = cast(Dict[str, Union[ndarray, "Tensor"]], observations)
+            observations["collided"] = collided
+        else:
+            for agent_id in action.keys():
+                observations[agent_id]["collided"] = collided_dict[agent_id]
+            # CLUDGE
+            observations = cast(Dict[str, Union[ndarray, "Tensor"]], observations)
 
         return observations
 

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -61,7 +61,7 @@ class Simulator(SimulatorBackend):
     agents: List[Agent] = attr.ib(factory=list, init=False)
     _num_total_frames: int = attr.ib(default=0, init=False)
     _default_agent_id: Optional[int] = attr.ib(init=False, default=None)
-    _sensors: List[Dict[str, Any]] = attr.ib(factory=List[Dict[str, Any]], init=False)
+    _sensors: List[Dict[str, Any]] = attr.ib(init=False)
     _initialized: bool = attr.ib(default=False, init=False)
     _previous_step_time: float = attr.ib(
         default=0.0, init=False
@@ -219,7 +219,9 @@ class Simulator(SimulatorBackend):
 
         self._default_agent_id = config.sim_cfg.default_agent_id
 
-        self._sensors = [Dict[str, Sensor]() for i in range(len(config.agents))]
+        self._sensors: List[Dict[str, Sensor]] = [
+            dict for i in range(len(config.agents))
+        ]
         for agent_id, agent_cfg in enumerate(config.agents):
             for spec in agent_cfg.sensor_specifications:
                 self._update_simulator_sensors(spec.uuid, agent_id=agent_id)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -304,7 +304,6 @@ class Simulator(SimulatorBackend):
     @property
     def _default_agent(self) -> Agent:
         # TODO Deprecate and remove
-        assert self._default_agent_id
         return self.get_agent(self._default_agent_id)
 
     @property

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -290,7 +290,7 @@ class Simulator(SimulatorBackend):
             )
         if agent_id is None:
             agent_id = self._default_agent_id
-        agent = self._get_agent(agent_id=agent_id)
+        agent = self.get_agent(agent_id=agent_id)
         agent._add_sensor(sensor_spec)
         self._update_simulator_sensors(sensor_spec.uuid, agent_id=agent_id)
 

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -13,7 +13,6 @@ import magnum as mn
 import numpy as np
 from magnum import Vector3
 from numpy import ndarray
-from typing_extensions import Literal
 
 try:
     import torch
@@ -296,35 +295,29 @@ class Simulator(SimulatorBackend):
 
     @overload
     def step(
-        self,
-        action: Union[str, int],
-        dt: float = 1.0 / 60.0,
-        multi_agent: Literal[False] = False,
+        self, action: Union[str, int], dt: float = 1.0 / 60.0
     ) -> Dict[str, Union[bool, ndarray, "Tensor"]]:
         ...
 
     @overload
     def step(
-        self, action: dict, dt: float = 1.0 / 60.0, multi_agent: Literal[True] = True
+        self, action: dict, dt: float = 1.0 / 60.0
     ) -> List[Dict[str, Union[bool, ndarray, "Tensor"]]]:
         ...
 
     def step(
-        self,
-        action: Any,
-        dt: float = 1.0 / 60.0,
-        multi_agent: bool = False,
+        self, action: Any, dt: float = 1.0 / 60.0
     ) -> Union[
         List[Dict[str, Union[bool, ndarray, "Tensor"]]],
         Dict[str, Union[bool, ndarray, "Tensor"]],
     ]:
+        multi_agent = isinstance(action, dict)
         self._num_total_frames += 1
         if not multi_agent:
             agent_ids: Union[List[int], int] = self._default_agent_id
             collided = self.default_agent.act(action)
             self._last_state = self._default_agent.get_state()
         else:
-            assert isinstance(action, dict)
             agent_ids = list(action.keys())
             collided_dict: Dict[int, bool] = {}
             for agent_id, agent_act in action.items():

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -319,7 +319,7 @@ class Simulator(SimulatorBackend):
         if not isinstance(action, dict):
             action = {self._default_agent_id: action}
             return_single = True
-        agent_ids = list(action.keys())
+        agent_ids = sorted(action.keys())
         collided_dict: Dict[int, bool] = {}
         for agent_id, agent_act in action.items():
             collided_dict[agent_id] = self.get_agent(agent_id).act(agent_act)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -269,16 +269,15 @@ class Simulator(SimulatorBackend):
         ...
 
     def get_sensor_observations(self, agent_ids: Union[int, List[int]] = 0):
+        return_single = False
         if isinstance(agent_ids, int):
-            return_single = True
             agent_ids = [agent_ids]
-        else:
-            return_single = False
+            return_single = True
 
-        for agent_id, agent_sensorsuite in enumerate(self._sensors):
-            if agent_id in agent_ids:
-                for _sensor_uuid, sensor in agent_sensorsuite.items():
-                    sensor.draw_observation()
+        for agent_id in agent_ids:
+            agent_sensorsuite = self._sensors[agent_id]
+            for _sensor_uuid, sensor in agent_sensorsuite.items():
+                sensor.draw_observation()
 
         observations: List[Dict[str, Union[ndarray, "Tensor"]]] = []
         for agent_id in agent_ids:
@@ -310,17 +309,16 @@ class Simulator(SimulatorBackend):
         ...
 
     def step(
-        self, action: Any, dt: float = 1.0 / 60.0
+        self, action: Union[str, int, dict], dt: float = 1.0 / 60.0
     ) -> Union[
         List[Dict[str, Union[bool, ndarray, "Tensor"]]],
         Dict[str, Union[bool, ndarray, "Tensor"]],
     ]:
         self._num_total_frames += 1
+        return_single = False
         if not isinstance(action, dict):
             action = {self._default_agent_id: action}
             return_single = True
-        else:
-            return_single = False
         agent_ids = list(action.keys())
         collided_dict: Dict[int, bool] = {}
         for agent_id, agent_act in action.items():

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -216,8 +216,7 @@ class Simulator(SimulatorBackend):
             self.__set_from_config(config)
             self.config = config
 
-    def __set_from_config(self, config: Configuration):
-
+    def __set_from_config(self, config: Configuration) -> None:
         self._config_backend(config)
         self._config_agents(config)
         self._config_pathfinder(config)
@@ -278,7 +277,12 @@ class Simulator(SimulatorBackend):
     ) -> Dict[int, Dict[str, Union[ndarray, "Tensor"]]]:
         ...
 
-    def get_sensor_observations(self, agent_ids: Union[int, List[int]] = 0):
+    def get_sensor_observations(
+        self, agent_ids: Union[int, List[int]] = 0
+    ) -> Union[
+        Dict[str, Union[ndarray, "Tensor"]],
+        Dict[int, Dict[str, Union[ndarray, "Tensor"]]],
+    ]:
         if isinstance(agent_ids, int):
             agent_ids = [agent_ids]
             return_single = True
@@ -319,7 +323,7 @@ class Simulator(SimulatorBackend):
         # TODO Deprecate and remove
         return self.__sensors[self._default_agent_id]
 
-    def last_state(self, agent_id: int = 0) -> Optional[AgentState]:
+    def last_state(self, agent_id: int = 0) -> AgentState:
         return self.__last_state[agent_id]
 
     @overload

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -304,12 +304,14 @@ class Simulator(SimulatorBackend):
 
     @overload
     def step(
-        self, action: dict, dt: float = 1.0 / 60.0
+        self, action: Dict[int, Union[str, int]], dt: float = 1.0 / 60.0
     ) -> List[Dict[str, Union[bool, ndarray, "Tensor"]]]:
         ...
 
     def step(
-        self, action: Union[str, int, dict], dt: float = 1.0 / 60.0
+        self,
+        action: Union[str, int, Dict[int, Union[str, int]]],
+        dt: float = 1.0 / 60.0,
     ) -> Union[
         List[Dict[str, Union[bool, ndarray, "Tensor"]]],
         Dict[str, Union[bool, ndarray, "Tensor"]],
@@ -332,8 +334,9 @@ class Simulator(SimulatorBackend):
         self._previous_step_time = time.time() - step_start_Time
 
         multi_observations = self.get_sensor_observations(agent_ids=agent_ids)
-        for agent_id in action.keys():
-            multi_observations[agent_id]["collided"] = collided_dict[agent_id]
+        for obs_id, agent_observation in enumerate(multi_observations):
+            agent_id_obs = agent_ids[obs_id]
+            agent_observation["collided"] = collided_dict[agent_id_obs]
         if return_single:
             return multi_observations[self._default_agent_id]
         return multi_observations

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -248,7 +248,7 @@ class Simulator(SimulatorBackend):
     def add_sensor(self, sensor_spec: SensorSpec, agent_id: int = 0) -> None:
         agent = self.get_agent(agent_id=agent_id)
         sensor_spec = _overwrite_sensor_spec_uuid(sensor_spec, agent_id=agent_id)
-        agent.add_sensor(sensor_spec)
+        agent._add_sensor(sensor_spec)
         self._update_simulator_sensors(sensor_spec.uuid, agent_id=agent_id)
 
     def get_agent(self, agent_id: int) -> Agent:

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -66,7 +66,7 @@ class Simulator(SimulatorBackend):
     config: Configuration
     agents: List[Agent] = attr.ib(factory=list, init=False)
     _num_total_frames: int = attr.ib(default=0, init=False)
-    _default_agent_id: Optional[int] = attr.ib(init=False, default=None)
+    _default_agent_id: Optional[int] = attr.ib(default=0)
     __sensors: List[Dict[str, "Sensor"]] = attr.ib(factory=list, init=False)
     _initialized: bool = attr.ib(default=False, init=False)
     _previous_step_time: float = attr.ib(

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -272,6 +272,8 @@ class Simulator(SimulatorBackend):
         if isinstance(agent_ids, int):
             return_single = True
             agent_ids = [agent_ids]
+        else:
+            return_single = False
 
         for agent_id, agent_sensorsuite in enumerate(self._sensors):
             if agent_id in agent_ids:
@@ -322,9 +324,9 @@ class Simulator(SimulatorBackend):
         agent_ids = list(action.keys())
         collided_dict: Dict[int, bool] = {}
         for agent_id, agent_act in action.items():
-            collided_dict[agent_id] = self._get_agent(agent_id).act(agent_act)
+            collided_dict[agent_id] = self.get_agent(agent_id).act(agent_act)
         # TODO: Maybe should allow MultiAgent state return too...
-        self._last_state = self._get_agents(agent_ids[-1]).get_state()
+        self._last_state = self.get_agent(agent_ids[-1]).get_state()
 
         # step physics by dt
         step_start_Time = time.time()

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -242,6 +242,18 @@ class Simulator(SimulatorBackend):
         )
 
     def add_sensor(self, sensor_spec: SensorSpec, agent_id: int = 0) -> None:
+        if sensor_spec.sensor_type == SensorType.SEMANTIC:
+            raise NotImplementedError(
+                "Adding a semantic sensor currently requires restarting the simulator"
+            )
+        elif (
+            not self.config.sim_cfg.requires_texture
+            and sensor_spec.sensor_type == SensorType.COLOR
+        ):
+            raise ValueError(
+                """Error: Textures not loaded.
+                Cannot dynamically add COLOR sensors unless one already exists."""
+            )
         agent = self.get_agent(agent_id=agent_id)
         agent._add_sensor(sensor_spec)
         self._update_simulator_sensors(sensor_spec.uuid, agent_id=agent_id)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -32,7 +32,8 @@ from habitat_sim.utils.common import quat_from_angle_axis
 
 
 def _overwrite_sensor_spec_uuid(spec: SensorSpec, agent_id: int = 0) -> SensorSpec:
-    spec.uuid = f"agent_{agent_id}/{spec.uuid}" if agent_id > 0 else spec.uuid
+    if agent_id > 0:
+        spec.uuid = f"agent_{agent_id}/{spec.uuid}"
     return spec
 
 

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -37,7 +37,7 @@ def test_unproject():
         sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
 
         # setup camera
-        visual_sensor = sim._sensors[sim._default_agent_id]["color_sensor"]
+        visual_sensor = sim._sensors["color_sensor"]
         scene_graph = sim.get_active_scene_graph()
         scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
         render_camera = scene_graph.get_default_render_camera()

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -37,7 +37,7 @@ def test_unproject():
         sim.agents[0].scene_node.translation = mn.Vector3(0.5, 0, 0)
 
         # setup camera
-        visual_sensor = sim._sensors["color_sensor"]
+        visual_sensor = sim._sensors[sim._default_agent_id]["color_sensor"]
         scene_graph = sim.get_active_scene_graph()
         scene_graph.set_default_render_camera_parameters(visual_sensor._sensor_object)
         render_camera = scene_graph.get_default_render_camera()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -136,7 +136,7 @@ def test_sensors(
 
     with habitat_sim.Simulator(cfg) as sim:
         if add_sensor_lazy:
-            obs = sim.reset()
+            obs: np.ndarray = sim.reset()
             assert len(obs) == 1, "Other sensors were not removed"
             for sensor_spec in additional_sensors:
                 sim.add_sensor(sensor_spec)

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -96,11 +96,13 @@ all_sensor_types = ["color_sensor", "depth_sensor", "semantic_sensor"]
 # NB: This should go last, we have to force a close on the simulator when
 # this value changes, thus we should change it as little as possible
 @pytest.mark.parametrize("frustum_culling", [True, False])
+@pytest.mark.parametrize("add_sensor_lazy", [True, False])
 def test_sensors(
     scene,
     sensor_type,
     gpu2gpu,
     frustum_culling,
+    add_sensor_lazy,
     make_cfg_settings,
 ):
     if not osp.exists(scene):
@@ -109,18 +111,35 @@ def test_sensors(
     if not habitat_sim.cuda_enabled and gpu2gpu:
         pytest.skip("Skipping GPU->GPU test")
 
+    # We only support adding more RGB Sensors if one is already in a scene
+    # We can add depth sensors whenever
+    add_sensor_lazy = add_sensor_lazy and all_sensor_types[1] == sensor_type
+
     for sens in all_sensor_types:
-        make_cfg_settings[sens] = False
+        if add_sensor_lazy:
+            make_cfg_settings[sens] = (
+                sens in all_sensor_types[:2] and sens != sensor_type
+            )
+        else:
+            make_cfg_settings[sens] = False
 
     make_cfg_settings[sensor_type] = True
     make_cfg_settings["scene"] = scene
     make_cfg_settings["frustum_culling"] = frustum_culling
 
     cfg = make_cfg(make_cfg_settings)
+    if add_sensor_lazy:
+        additional_sensors = cfg.agents[0].sensor_specifications[1:]
+        cfg.agents[0].sensor_specifications = cfg.agents[0].sensor_specifications[:1]
     for sensor_spec in cfg.agents[0].sensor_specifications:
         sensor_spec.gpu2gpu_transfer = gpu2gpu
 
     with habitat_sim.Simulator(cfg) as sim:
+        if add_sensor_lazy:
+            obs = sim.reset()
+            assert len(obs) == 1, "Other sensors were not removed"
+            for sensor_spec in additional_sensors:
+                sim.add_sensor(sensor_spec)
         obs, gt = _render_and_load_gt(sim, scene, sensor_type, gpu2gpu)
 
         # Different GPUs and different driver version will produce slightly

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -74,8 +74,11 @@ def test_sim_reset(make_cfg_settings):
 
 def test_sim_multiagent_move_and_reset(make_cfg_settings, num_agents=10):
     sim_cfg = examples.settings.make_cfg(make_cfg_settings)
-    for _ in range(num_agents):
-        sim_cfg.agents.append(copy(sim_cfg.agents[0]))
+    for agent_id in range(1, num_agents):
+        new_agent = copy(sim_cfg.agents[0])
+        for sensor_spec in new_agent.sensor_specifications:
+            sensor_spec = f"{agent_id}_/{sensor_spec.uuid}"
+        sim_cfg.agents.append(new_agent)
     with habitat_sim.Simulator(sim_cfg) as sim:
         agent_initial_states = []
         for i in range(num_agents):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -89,8 +89,8 @@ def test_sim_multiagent_move_and_reset(make_cfg_settings, num_agents=10):
             agent_actions[i] = action
         observations = sim.step(agent_actions)
         # Check all agents either moved or ran into something.
-        for agent_id, (initial_state, agent_obs) in enumerate(
-            zip(agent_initial_states, observations)
+        for initial_state, (agent_id, agent_obs) in zip(
+            agent_initial_states, observations.items()
         ):
             assert (
                 not is_same_state(initial_state, sim.get_agent(agent_id).state)
@@ -106,8 +106,8 @@ def test_sim_multiagent_move_and_reset(make_cfg_settings, num_agents=10):
         assert is_same_state(
             agent_initial_states[2], sim.get_agent(2).state
         ), "Agent 2 did not move"
-        for agent_id, (initial_state, agent_obs) in enumerate(
-            zip(agent_initial_states, observations)
+        for initial_state, (agent_id, agent_obs) in zip(
+            agent_initial_states, observations.items()
         ):
             assert 2 not in observations
             assert agent_id == 2 or (


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
Closes #856 

This also allows other static sensors to be added to the scene (like security cameras / static ortho cameras / bird eye views etc...)
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally. Will add a test case shortly, just want to finalize the API. 

Also expanded the _sensor_dict to be multi-agent compatible, let me know if I should be doing it in a different way, like by making _sensors a ```dict[int, dict]``` instead. 
With this, the only thing unblocking multi-agent support on the habitat-sim part would be testing and the step function.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
