### PR TITLE
[docs] Add Collab links for rigid object tutorial

### DIFF
--- a/docs/pages/index.rst
+++ b/docs/pages/index.rst
@@ -35,7 +35,7 @@ Working with light setups                           :ref:`Page <std:doc:lighting
 
 Extracting Images                                   :ref:`Page <std:doc:image-extractor>`
 
-Interactive Rigid Objects                           :ref:`Page <std:doc:rigid-object-tutorial>`
+Interactive Rigid Objects                           :ref:`Page <std:doc:rigid-object-tutorial>`                                                                         `Interactive Colab <https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/master/examples/tutorials/colabs/rigid_object_tutorial.ipynb>`__
 =================================================== ======================================================================================== ======================
 
 Python Classes

--- a/docs/pages/rigid-object-tutorial.rst
+++ b/docs/pages/rigid-object-tutorial.rst
@@ -13,15 +13,17 @@ Interactive Rigid Objects
 .. contents::
     :class: m-block m-default
 
-First, download the `example objects`_ and extract them into path/to/habitat-sim/data/objects/.
+The example code below is available on `Collab`_, or runnable via:
 
-.. _example objects: http://dl.fbaipublicfiles.com/habitat/objects_v0.2.zip
-
-The example code below is runnable via:
+.. _Collab: <https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/master/examples/tutorials/colabs/rigid_object_tutorial.ipynb>
 
 .. code:: shell-session
 
-    $ python path/to/habitat-sim/examples/tutorials/rigid_object_tutorial.py
+    $ python path/to/habitat-sim/examples/tutorials/nb_python/rigid_object_tutorial.py
+
+First, download the `example objects`_ and extract them into path/to/habitat-sim/data/objects/.
+
+.. _example objects: http://dl.fbaipublicfiles.com/habitat/objects_v0.2.zip
 
 Import necessary modules, define some convenience functions, and initialize the :ref:`Simulator` and :ref:`Agent`.
 


### PR DESCRIPTION
## Motivation and Context

Minor change to add links to the Collab for the rigid object tutorial and correct the python run path.

## How Has This Been Tested

local build

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
