### PR TITLE
forceSeparateSemanticSceneGraph and loadAndCreateRenderAssetInstance

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -182,7 +182,8 @@ bool ResourceManager::loadStage(
     const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
     esp::scene::SceneManager* sceneManagerPtr,
     std::vector<int>& activeSceneIDs,
-    bool loadSemanticMesh) {
+    bool createSemanticMesh,
+    bool forceSeparateSemanticSceneGraph) {
   // create AssetInfos here for each potential mesh file for the scene, if they
   // are unique.
   bool buildCollisionMesh =
@@ -192,7 +193,7 @@ bool ResourceManager::loadStage(
   const std::string renderLightSetupKey(stageAttributes->getLightSetup());
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, buildCollisionMesh,
-                                          loadSemanticMesh);
+                                          createSemanticMesh);
 
   // set equal to current Simulator::activeSemanticSceneID_ value
   int activeSemanticSceneID = activeSceneIDs[0];
@@ -245,6 +246,14 @@ bool ResourceManager::loadStage(
   } else {  // not wanting to create semantic mesh
     LOG(INFO) << "ResourceManager::loadStage : Not loading semantic mesh";
   }
+
+  if (forceSeparateSemanticSceneGraph &&
+      activeSemanticSceneID == activeSceneIDs[0]) {
+    // Create a separate semantic scene graph if it wasn't already created
+    // above.
+    activeSemanticSceneID = sceneManagerPtr->initSceneGraph();
+  }
+
   // save active semantic scene ID so that simulator can consume
   activeSceneIDs[1] = activeSemanticSceneID;
   const bool isSeparateSemanticScene = activeSceneIDs[1] != activeSceneIDs[0];

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -181,6 +181,10 @@ class ResourceManager {
    * made, its activeID should be pushed onto vector
    * @param createSemanticMesh If the semantic mesh should be created, based on
    * @ref SimulatorConfiguration
+   * @param forceSeparateSemanticSceneGraph Force creation of a separate
+   * semantic scene graph, even when no semantic mesh is loaded for the stage.
+   * This is required to support playback of any replay that includes a
+   * semantic-only render asset instance.
    * @return Whether or not the scene load succeeded.
    */
   bool loadStage(
@@ -188,7 +192,8 @@ class ResourceManager {
       const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
       esp::scene::SceneManager* sceneManagerPtr,
       std::vector<int>& activeSceneIDs,
-      bool createSemanticMesh);
+      bool createSemanticMesh,
+      bool forceSeparateSemanticSceneGraph = false);
 
   /**
    * @brief Construct scene collision mesh group based on name and type of

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -492,6 +492,22 @@ class ResourceManager {
    */
   inline void setRequiresTextures(bool newVal) { requiresTextures_ = newVal; }
 
+  /**
+   * @brief Load a render asset (if not already loaded) and create a render
+   * asset instance.
+   *
+   * @param assetInfo the render asset to load
+   * @param creation How to create the instance
+   * @param sceneManagerPtr Info about the scene graph(s). See loadStage.
+   * @param activeSceneIDs Info about the scene graph(s). See loadStage.
+   * @return the root node of the instance, or nullptr (if the load failed)
+   */
+  scene::SceneNode* loadAndCreateRenderAssetInstance(
+      const AssetInfo& assetInfo,
+      const RenderAssetInstanceCreationInfo& creation,
+      esp::scene::SceneManager* sceneManagerPtr,
+      const std::vector<int>& activeSceneIDs);
+
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -45,6 +45,8 @@ void initSimBindings(py::module& m) {
                      &SimulatorConfiguration::sceneLightSetup)
       .def_readwrite("load_semantic_mesh",
                      &SimulatorConfiguration::loadSemanticMesh)
+      .def_readwrite("force_separate_semantic_scene_graph",
+                     &SimulatorConfiguration::forceSeparateSemanticSceneGraph)
       .def_readwrite("requires_textures",
                      &SimulatorConfiguration::requiresTextures)
       .def(py::self == py::self)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -45,8 +45,10 @@ void initSimBindings(py::module& m) {
                      &SimulatorConfiguration::sceneLightSetup)
       .def_readwrite("load_semantic_mesh",
                      &SimulatorConfiguration::loadSemanticMesh)
-      .def_readwrite("force_separate_semantic_scene_graph",
-                     &SimulatorConfiguration::forceSeparateSemanticSceneGraph)
+      .def_readwrite(
+          "force_separate_semantic_scene_graph",
+          &SimulatorConfiguration::forceSeparateSemanticSceneGraph,
+          R"(Required to support playback of any gfx replay that includes a stage with a semantic mesh. Set to false otherwise.)")
       .def_readwrite("requires_textures",
                      &SimulatorConfiguration::requiresTextures)
       .def(py::self == py::self)

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -199,9 +199,9 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
     std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};
     // Load scene
-    loadSuccess = resourceManager_->loadStage(stageAttributes, physicsManager_,
-                                              sceneManager_.get(), tempIDs,
-                                              config_.loadSemanticMesh);
+    loadSuccess = resourceManager_->loadStage(
+        stageAttributes, physicsManager_, sceneManager_.get(), tempIDs,
+        config_.loadSemanticMesh, config_.forceSeparateSemanticSceneGraph);
 
     if (!loadSuccess) {
       LOG(ERROR) << "Cannot load " << stageFilename;

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -36,6 +36,12 @@ struct SimulatorConfiguration {
    */
   bool loadSemanticMesh = true;
   /**
+   * Force creation of a separate semantic scene graph, even when no semantic
+   * mesh is loaded for the stage. This is required to support playback of any
+   * replay that includes a semantic-only render asset instance.
+   */
+  bool forceSeparateSemanticSceneGraph = false;
+  /**
    * @brief Whether or not to load textures for the meshes. This MUST be true
    * for RGB rendering
    */

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -37,8 +37,9 @@ struct SimulatorConfiguration {
   bool loadSemanticMesh = true;
   /**
    * Force creation of a separate semantic scene graph, even when no semantic
-   * mesh is loaded for the stage. This is required to support playback of any
-   * replay that includes a semantic-only render asset instance.
+   * mesh is loaded for the stage. Required to support playback of any replay
+   * that includes a semantic-only render asset instance. Set to false
+   * otherwise.
    */
   bool forceSeparateSemanticSceneGraph = false;
   /**


### PR DESCRIPTION
## Motivation and Context

This PR supports the upcoming render-replay feature.

### forceSeparateSemanticSceneGraph
A review of two "modes" for our renderer: depending on the stage, we either create a single scene graph (for RGB, depth, and semantic observations), or we create two scene graphs (loosely speaking, one is for RGB+depth and one is for semantic).

Previously, the "mode" decision was coupled to what stage you're loading (some stages have separate RGBD and Semantic models, others don't). For playback of a render replay, we won't load a stage at all (we'll use EMPTY_STAGE). However, I still need a way to select the mode (before loading any models). So, I've added SimulatorConfiguration.forceSeparateSemanticSceneGraph. 

### loadAndCreateRenderAssetInstance
This is pretty straightforward usage of our existing loadRenderAsset and createRenderAssetInstance. The only complication here is the selection of scene graph based on the creation flags. RenderAssetInstanceCreationInfo has isStatic, isRGBD, and isSemantic flags. Currently, we only support a few combinations of these flags:
- Non-static instances must have both isRGBD and isSemantic.
- For a static instance, it depends on the renderer mode (see above). In practice, this means a user has to be careful to use forceSeparateSemanticSceneGraph correctly before playing back a render replay. Here's an example: [replay_tutorial.py](https://github.com/eundersander/habitat-sim/blob/eundersander/serialize_for_render4/examples/tutorials/nb_python/replay_tutorial.py)
## How Has This Been Tested

I've added a unit test. I've also used this a lot in my in-progress render-replay branch, e.g. [replay_tutorial.py](https://github.com/eundersander/habitat-sim/blob/eundersander/serialize_for_render4/examples/tutorials/nb_python/replay_tutorial.py)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
