### PR TITLE
rapidjson serialization for some Habitat types

### DIFF
--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -25,6 +25,8 @@ struct RenderAssetInstanceCreationInfo {
   };
   typedef Corrade::Containers::EnumSet<Flag> Flags;
 
+  RenderAssetInstanceCreationInfo() = default;
+
   RenderAssetInstanceCreationInfo(
       const std::string& _filepath,
       const Corrade::Containers::Optional<Magnum::Vector3>& _scale,

--- a/src/esp/gfx/replay/Keyframe.h
+++ b/src/esp/gfx/replay/Keyframe.h
@@ -1,0 +1,40 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "esp/assets/Asset.h"
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+
+namespace esp {
+namespace scene {
+class SceneNode;
+}
+namespace gfx {
+namespace replay {
+
+using RenderAssetInstanceKey = uint32_t;
+
+// serialization/replay-friendly Transform class
+struct Transform {
+  Magnum::Vector3 translation;
+  Magnum::Quaternion rotation;
+  bool operator==(const Transform& rhs) const {
+    return translation == rhs.translation && rotation == rhs.rotation;
+  }
+};
+
+struct RenderAssetInstanceState {
+  Transform absTransform;  // localToWorld
+  // note we currently only support semanticId per instance, not per drawable
+  int semanticId = -1;
+  // note we don't currently support runtime changes to lightSetupKey
+  bool operator==(const RenderAssetInstanceState& rhs) const {
+    return absTransform == rhs.absTransform && semanticId == rhs.semanticId;
+  }
+};
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/io/JsonAllTypes.h
+++ b/src/esp/io/JsonAllTypes.h
@@ -23,6 +23,7 @@
 // below.
 #include "JsonEspTypes.h"
 #include "JsonMagnumTypes.h"
+#include "JsonStlTypes.h"
 
 // This must go after all ToRJsonValue/FromRJsonValue. The quirky ordering is to
 // avoid some compile errors.

--- a/src/esp/io/JsonAllTypes.h
+++ b/src/esp/io/JsonAllTypes.h
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief Include file for all helper functions for serializing types to
+ * rapidjson.
+ *
+ * These helpers are designed so that every builtin type and user type can be
+ * serialized/deserialized with esp::io::AddMember/ReadMember. The leads to
+ * uniform and readable serialization code. To achieve this, every complex user
+ * type defines ToRJsonValue/FromRJsonValue, and then template versions of
+ * AddMember/ReadMember will automatically use these.
+ *
+ * See IOTest.cpp for example usage.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+// ToRJsonValue/FromRJsonValue for all user types should go in the headers
+// below.
+#include "JsonEspTypes.h"
+#include "JsonMagnumTypes.h"
+
+// This must go after all ToRJsonValue/FromRJsonValue. The quirky ordering is to
+// avoid some compile errors.
+#include "JsonBuiltinTypes.hpp"

--- a/src/esp/io/JsonBuiltinTypes.h
+++ b/src/esp/io/JsonBuiltinTypes.h
@@ -19,107 +19,76 @@ namespace io {
 using RJsonValue = rapidjson::Value;
 using RJsonAllocator = rapidjson::MemoryPoolAllocator<>;
 
-// AddMember wrappers for the 7 rapidjson builtin types
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      bool obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+// template AddMember/ReadMember to match any type. These are declared here,
+// before all ToRJsonValue/FromRJsonValue definitions, and they are defined
+// later in JsonBuiltinTypes.hpp. The quirky ordering is to avoid some compile
+// errors.
+template <typename T>
+void AddMember(RJsonValue& value,
+               rapidjson::GenericStringRef<char> name,
+               const T& obj,
+               RJsonAllocator& allocator);
+
+template <typename T>
+void ReadMember(const RJsonValue& value, const char* name, T& x);
+
+// ToRJsonValue wrappers for the 7 rapidjson builtin types. A ToRJsonValue can
+// be directly constructed from the builtin types.
+inline RJsonValue ToRJsonValue(bool x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      int obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(int x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      unsigned obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(unsigned x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      int64_t obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(int64_t x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      uint64_t obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(uint64_t x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      double obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(double x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      float obj,
-                      RJsonAllocator& allocator) {
-  value.AddMember(name, obj, allocator);
+inline RJsonValue ToRJsonValue(float x, RJsonAllocator& allocator) {
+  return RJsonValue(x);
 }
 
-// ReadMember wrappers for the 7 rapidjson builtin types
-inline void ReadMember(const RJsonValue& value, const char* name, bool& obj) {
-  obj = value[name].Get<bool>();
+// FromRJsonValue wrappers for the 7 rapidjson builtin types
+inline void FromRJsonValue(const RJsonValue& obj, bool& x) {
+  x = obj.Get<bool>();
 }
 
-inline void ReadMember(const RJsonValue& value, const char* name, int& obj) {
-  obj = value[name].Get<int>();
+inline void FromRJsonValue(const RJsonValue& obj, int& x) {
+  x = obj.Get<int>();
 }
 
-inline void ReadMember(const RJsonValue& value,
-                       const char* name,
-                       unsigned& obj) {
-  obj = value[name].Get<unsigned>();
+inline void FromRJsonValue(const RJsonValue& obj, unsigned& x) {
+  x = obj.Get<unsigned>();
 }
 
-inline void ReadMember(const RJsonValue& value,
-                       const char* name,
-                       int64_t& obj) {
-  obj = value[name].Get<int64_t>();
+inline void FromRJsonValue(const RJsonValue& obj, int64_t& x) {
+  x = obj.Get<int64_t>();
 }
 
-inline void ReadMember(const RJsonValue& value,
-                       const char* name,
-                       uint64_t& obj) {
-  obj = value[name].Get<uint64_t>();
+inline void FromRJsonValue(const RJsonValue& obj, uint64_t& x) {
+  x = obj.Get<uint64_t>();
 }
 
-inline void ReadMember(const RJsonValue& value, const char* name, double& obj) {
-  obj = value[name].Get<double>();
+inline void FromRJsonValue(const RJsonValue& obj, double& x) {
+  x = obj.Get<double>();
 }
 
-inline void ReadMember(const RJsonValue& value, const char* name, float& obj) {
-  obj = value[name].Get<float>();
-}
-
-// TODO: consider RAPIDJSON_HAS_STDSTRING instead of implementing these
-// std::string helpers
-inline void AddMember(RJsonValue& value,
-                      rapidjson::GenericStringRef<char> name,
-                      const std::string& str,
-                      RJsonAllocator& allocator) {
-  RJsonValue strObj;
-  strObj.SetString(str.c_str(), allocator);
-  value.AddMember(name, strObj, allocator);
-}
-
-inline void ReadMember(const RJsonValue& value,
-                       const char* name,
-                       std::string& str) {
-  const RJsonValue& strObj = value[name];
-  str = strObj.GetString();
+inline void FromRJsonValue(const RJsonValue& obj, float& x) {
+  x = obj.Get<float>();
 }
 
 // wrappers intended for enums
@@ -155,20 +124,6 @@ inline void AddMember(RJsonValue& value,
                       RJsonAllocator& allocator) {
   value.AddMember(name, child, allocator);
 }
-
-// These are template versions of AddMember/ReadMember that will match any
-// type T. They expect to find ToJsonValue/FromJsonValue overloads for T.
-// These are declared here, before all ToRJsonValue/FromRJsonValue definitions,
-// and they are defined later in JsonBuiltinTypes.hpp. The quirky ordering is to
-// avoid some compile errors.
-template <typename T>
-void AddMember(RJsonValue& value,
-               rapidjson::GenericStringRef<char> name,
-               const T& obj,
-               RJsonAllocator& allocator);
-
-template <typename T>
-void ReadMember(const RJsonValue& value, const char* name, T& x);
 
 }  // namespace io
 }  // namespace esp

--- a/src/esp/io/JsonBuiltinTypes.h
+++ b/src/esp/io/JsonBuiltinTypes.h
@@ -1,0 +1,174 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include <rapidjson/document.h>
+
+#include <string>
+
+namespace esp {
+namespace io {
+
+// Make these types easier to read/type. We'll use them everywhere.
+using RJsonValue = rapidjson::Value;
+using RJsonAllocator = rapidjson::MemoryPoolAllocator<>;
+
+// AddMember wrappers for the 7 rapidjson builtin types
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      bool obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      int obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      unsigned obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      int64_t obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      uint64_t obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      double obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      float obj,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, obj, allocator);
+}
+
+// ReadMember wrappers for the 7 rapidjson builtin types
+inline void ReadMember(const RJsonValue& value, const char* name, bool& obj) {
+  obj = value[name].Get<bool>();
+}
+
+inline void ReadMember(const RJsonValue& value, const char* name, int& obj) {
+  obj = value[name].Get<int>();
+}
+
+inline void ReadMember(const RJsonValue& value,
+                       const char* name,
+                       unsigned& obj) {
+  obj = value[name].Get<unsigned>();
+}
+
+inline void ReadMember(const RJsonValue& value,
+                       const char* name,
+                       int64_t& obj) {
+  obj = value[name].Get<int64_t>();
+}
+
+inline void ReadMember(const RJsonValue& value,
+                       const char* name,
+                       uint64_t& obj) {
+  obj = value[name].Get<uint64_t>();
+}
+
+inline void ReadMember(const RJsonValue& value, const char* name, double& obj) {
+  obj = value[name].Get<double>();
+}
+
+inline void ReadMember(const RJsonValue& value, const char* name, float& obj) {
+  obj = value[name].Get<float>();
+}
+
+// TODO: consider RAPIDJSON_HAS_STDSTRING instead of implementing these
+// std::string helpers
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      const std::string& str,
+                      RJsonAllocator& allocator) {
+  RJsonValue strObj;
+  strObj.SetString(str.c_str(), allocator);
+  value.AddMember(name, strObj, allocator);
+}
+
+inline void ReadMember(const RJsonValue& value,
+                       const char* name,
+                       std::string& str) {
+  const RJsonValue& strObj = value[name];
+  str = strObj.GetString();
+}
+
+// wrappers intended for enums
+template <typename T>
+void AddMemberAsUint32(RJsonValue& value,
+                       rapidjson::GenericStringRef<char> name,
+                       const T& x,
+                       RJsonAllocator& allocator) {
+  static_assert(sizeof(T) == sizeof(uint32_t), "size match");
+  uint32_t xAsUint32 = (uint32_t)x;
+  AddMember(value, name, xAsUint32, allocator);
+}
+
+template <typename T>
+void ReadMemberAsUint32(const RJsonValue& value, const char* name, T& x) {
+  static_assert(sizeof(T) == sizeof(uint32_t), "size match");
+  uint32_t xAsUint32;
+  ReadMember(value, name, xAsUint32);
+  x = (T)(xAsUint32);
+}
+
+// wrappers for rapidjson's standard Value type
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      RJsonValue& child,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, child, allocator);
+}
+
+inline void AddMember(RJsonValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      RJsonValue&& child,
+                      RJsonAllocator& allocator) {
+  value.AddMember(name, child, allocator);
+}
+
+// These are template versions of AddMember/ReadMember that will match any
+// type T. They expect to find ToJsonValue/FromJsonValue overloads for T.
+// These are declared here, before all ToRJsonValue/FromRJsonValue definitions,
+// and they are defined later in JsonBuiltinTypes.hpp. The quirky ordering is to
+// avoid some compile errors.
+template <typename T>
+void AddMember(RJsonValue& value,
+               rapidjson::GenericStringRef<char> name,
+               const T& obj,
+               RJsonAllocator& allocator);
+
+template <typename T>
+void ReadMember(const RJsonValue& value, const char* name, T& x);
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonBuiltinTypes.hpp
+++ b/src/esp/io/JsonBuiltinTypes.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+namespace esp {
+namespace io {
+
+// These were declared in JsonBuiltinTypes.h. The declarations are placed here,
+// after all type-specific ToRJsonValue/FromRJsonValue definitions. The quirky
+// ordering is to avoid some compile errors.
+template <typename T>
+void AddMember(rapidjson::Value& value,
+               rapidjson::GenericStringRef<char> name,
+               const T& obj,
+               RJsonAllocator& allocator) {
+  // If you get a compile error here, you may need to implement ToRJsonValue
+  // for your type in JsonAllTypes.h. See JasonEspTypes.h for examples. Beware
+  // you can't directly serialize pointer types.
+  AddMember(value, name, ToRJsonValue(obj, allocator), allocator);
+}
+
+template <typename T>
+void ReadMember(const rapidjson::Value& value, const char* name, T& x) {
+  // todo: error-handling on missing name
+  // If you get a compile error here, you may need to implement FromRJsonValue
+  // for your type in JsonAllTypes.h. See JasonEspTypes.h for examples. Beware
+  // you can't directly deserialize pointer types.
+  FromRJsonValue(value[name], x);
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -1,0 +1,144 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+#include "JsonMagnumTypes.h"
+
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+#include "esp/core/esp.h"
+#include "esp/gfx/replay/Keyframe.h"
+
+namespace esp {
+namespace io {
+
+inline RJsonValue ToRJsonValue(const esp::vec3f& vec,
+                               RJsonAllocator& allocator) {
+  RJsonValue floatsArray(rapidjson::kArrayType);
+  for (int i = 0; i < vec.size(); i++) {
+    floatsArray.PushBack(vec.data()[i], allocator);
+  }
+  return floatsArray;
+}
+
+inline void FromRJsonValue(const RJsonValue& floatsArray, esp::vec3f& vec) {
+  // TODO: helper for objects that are simply arrays, with error-handling
+  ASSERT(floatsArray.Size() == vec.size());
+  for (int i = 0; i < vec.size(); i++) {
+    vec.data()[i] = floatsArray[i].GetFloat();
+  }
+}
+
+inline RJsonValue ToRJsonValue(const esp::geo::CoordinateFrame& frame,
+                               RJsonAllocator& allocator) {
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMember(obj, "up", frame.up(), allocator);
+  AddMember(obj, "front", frame.front(), allocator);
+  AddMember(obj, "origin", frame.origin(), allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj,
+                           esp::geo::CoordinateFrame& frame) {
+  esp::vec3f up;
+  esp::vec3f front;
+  esp::vec3f origin;
+  ReadMember(obj, "up", up);
+  ReadMember(obj, "front", front);
+  ReadMember(obj, "origin", origin);
+  frame = esp::geo::CoordinateFrame(up, front, origin);
+}
+
+inline RJsonValue ToRJsonValue(const esp::assets::AssetInfo& x,
+                               RJsonAllocator& allocator) {
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMemberAsUint32(obj, "type", x.type, allocator);
+  AddMember(obj, "filepath", x.filepath, allocator);
+  AddMember(obj, "frame", x.frame, allocator);
+  AddMember(obj, "virtualUnitToMeters", x.virtualUnitToMeters, allocator);
+  AddMember(obj, "requiresLighting", x.requiresLighting, allocator);
+  AddMember(obj, "splitInstanceMesh", x.splitInstanceMesh, allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj, esp::assets::AssetInfo& x) {
+  ReadMemberAsUint32(obj, "type", x.type);
+  ReadMember(obj, "filepath", x.filepath);
+  ReadMember(obj, "frame", x.frame);
+  ReadMember(obj, "virtualUnitToMeters", x.virtualUnitToMeters);
+  ReadMember(obj, "requiresLighting", x.requiresLighting);
+  ReadMember(obj, "splitInstanceMesh", x.splitInstanceMesh);
+}
+
+inline RJsonValue ToRJsonValue(
+    const esp::assets::RenderAssetInstanceCreationInfo& x,
+    RJsonAllocator& allocator) {
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMember(obj, "filepath", x.filepath, allocator);
+  AddMember(obj, "scale", x.scale, allocator);
+  AddMember(obj, "isStatic", x.isStatic(), allocator);
+  AddMember(obj, "isRGBD", x.isRGBD(), allocator);
+  AddMember(obj, "isSemantic", x.isSemantic(), allocator);
+  AddMember(obj, "lightSetupKey", x.lightSetupKey, allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj,
+                           esp::assets::RenderAssetInstanceCreationInfo& x) {
+  ReadMember(obj, "filepath", x.filepath);
+  ReadMember(obj, "scale", x.scale);
+  bool isStatic;
+  ReadMember(obj, "isStatic", isStatic);
+  bool isRGBD;
+  ReadMember(obj, "isRGBD", isRGBD);
+  bool isSemantic;
+  ReadMember(obj, "isSemantic", isSemantic);
+  if (isStatic) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsStatic;
+  }
+  if (isRGBD) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
+  }
+  if (isSemantic) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
+  }
+  ReadMember(obj, "lightSetupKey", x.lightSetupKey);
+}
+
+inline RJsonValue ToRJsonValue(const esp::gfx::replay::Transform& x,
+                               RJsonAllocator& allocator) {
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMember(obj, "translation", x.translation, allocator);
+  AddMember(obj, "rotation", x.rotation, allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj,
+                           esp::gfx::replay::Transform& x) {
+  ReadMember(obj, "translation", x.translation);
+  ReadMember(obj, "rotation", x.rotation);
+}
+
+inline RJsonValue ToRJsonValue(
+    const esp::gfx::replay::RenderAssetInstanceState& x,
+    RJsonAllocator& allocator) {
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMember(obj, "absTransform", x.absTransform, allocator);
+  AddMember(obj, "semanticId", x.semanticId, allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj,
+                           esp::gfx::replay::RenderAssetInstanceState& x) {
+  ReadMember(obj, "absTransform", x.absTransform);
+  ReadMember(obj, "semanticId", x.semanticId);
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -10,8 +10,12 @@
 
 #include "JsonBuiltinTypes.h"
 
+#include "esp/core/logging.h"
+
 #include <Corrade/Containers/Optional.h>
+#include <Magnum/Magnum.h>
 #include <Magnum/Math/Matrix4.h>
+#include <Magnum/Math/Quaternion.h>
 
 namespace esp {
 namespace io {

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -1,0 +1,100 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+#include <Corrade/Containers/Optional.h>
+#include <Magnum/Math/Matrix4.h>
+
+namespace esp {
+namespace io {
+
+inline RJsonValue ToRJsonValue(const Magnum::Matrix4& obj,
+                               RJsonAllocator& allocator) {
+  // perf todo: optimize for common case where last column is (0, 0, 0, 1)
+  // TODO: helper for objects that are simply arrays, with error-handling
+  RJsonValue floatsArray(rapidjson::kArrayType);
+  for (int i = 0; i < obj.Rows * obj.Cols; i++) {
+    floatsArray.PushBack(obj.data()[i], allocator);
+  }
+  return floatsArray;
+}
+
+inline void FromRJsonValue(const RJsonValue& floatsArray,
+                           Magnum::Matrix4& obj) {
+  // TODO: helper for objects that are simply arrays, with error-handling
+  ASSERT(floatsArray.Size() == obj.Rows * obj.Cols);
+  for (int i = 0; i < floatsArray.Size(); i++) {
+    obj.data()[i] = floatsArray[i].GetFloat();
+  }
+}
+
+inline RJsonValue ToRJsonValue(const Magnum::Vector3& vec,
+                               RJsonAllocator& allocator) {
+  RJsonValue floatsArray(rapidjson::kArrayType);
+  for (int i = 0; i < vec.Size; i++) {
+    floatsArray.PushBack(vec.data()[i], allocator);
+  }
+  return floatsArray;
+}
+
+inline void FromRJsonValue(const RJsonValue& floatsArray,
+                           Magnum::Vector3& vec) {
+  // TODO: helper for objects that are simply arrays, with error-handling
+  ASSERT(floatsArray.Size() == vec.Size);
+  for (int i = 0; i < vec.Size; i++) {
+    vec.data()[i] = floatsArray[i].GetFloat();
+  }
+}
+
+inline RJsonValue ToRJsonValue(const Magnum::Quaternion& quat,
+                               RJsonAllocator& allocator) {
+  // [vector object, w] is a verbose way to store a quat. As compared to an
+  // array of 4 floats, it has the advantage of being unambiguous about order.
+  RJsonValue obj(rapidjson::kObjectType);
+  AddMember(obj, "v", quat.vector(), allocator);
+  AddMember(obj, "w", quat.scalar(), allocator);
+  return obj;
+}
+
+inline void FromRJsonValue(const RJsonValue& obj, Magnum::Quaternion& quat) {
+  ReadMember(obj, "v", quat.vector());
+  ReadMember(obj, "w", quat.scalar());
+}
+
+// Containers::Optional is handled differently than ordinary structs. Instead of
+// offering ToRJsonValue/FromRJsonValue, we offer AddMember/ReadMember, which
+// simply omits adding/reading a value for the case of NullOpt.
+template <typename T>
+void AddMember(rapidjson::Value& value,
+               rapidjson::GenericStringRef<char> name,
+               const Corrade::Containers::Optional<T>& x,
+               RJsonAllocator& allocator) {
+  if (x) {
+    const T& item = *x;
+    AddMember(value, name, item, allocator);
+  }
+}
+
+template <typename T>
+void ReadMember(const rapidjson::Value& value,
+                const char* name,
+                Corrade::Containers::Optional<T>& x) {
+  rapidjson::Value::ConstMemberIterator itr = value.FindMember(name);
+  if (value.HasMember(name)) {
+    x = T();
+    ReadMember(value, name, *x);
+  } else {
+    x = Corrade::Containers::NullOpt;
+  }
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonStlTypes.h
+++ b/src/esp/io/JsonStlTypes.h
@@ -1,0 +1,62 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+namespace esp {
+namespace io {
+
+// TODO: consider RAPIDJSON_HAS_STDSTRING instead of implementing these
+// std::string helpers
+inline RJsonValue ToRJsonValue(const std::string& str,
+                               RJsonAllocator& allocator) {
+  RJsonValue strObj;
+  strObj.SetString(str.c_str(), allocator);
+  return strObj;
+}
+
+inline void FromRJsonValue(const RJsonValue& strObj, std::string& str) {
+  str = strObj.GetString();
+}
+
+// For std::vector, we use rapidjson::kArrayType. For an empty vector, we
+// omit the member altogether rather than add an empty array.
+template <typename T>
+void AddMember(RJsonValue& value,
+               rapidjson::GenericStringRef<char> name,
+               const std::vector<T>& vec,
+               RJsonAllocator& allocator) {
+  if (!vec.empty()) {
+    RJsonValue arr(rapidjson::kArrayType);
+    for (const auto& item : vec) {
+      arr.PushBack(esp::io::ToRJsonValue(item, allocator), allocator);
+    }
+    AddMember(value, name, arr, allocator);
+  }
+}
+
+template <typename T>
+void ReadMember(const RJsonValue& value,
+                const char* name,
+                std::vector<T>& vec) {
+  RJsonValue::ConstMemberIterator itr = value.FindMember(name);
+  if (itr != value.MemberEnd()) {
+    const RJsonValue& arr = itr->value;
+    vec.reserve(arr.Size());
+    for (const auto& itemObj : arr.GetArray()) {
+      T item;
+      FromRJsonValue(itemObj, item);
+      vec.emplace_back(std::move(item));
+    }
+  }
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -222,6 +222,33 @@ TEST(IOTest, JsonUserTypeTest) {
   ASSERT(myStruct2.b == myStruct.b);
 }
 
+// Serialize/deserialize a few stl types using io::AddMember/ReadMember and
+// assert equality.
+TEST(IOTest, JsonStlTypesTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  std::string s{"hello world"};
+  AddMember(d, "s", s, allocator);
+  std::string s2;
+  ReadMember(d, "s", s2);
+  ASSERT(s2 == s);
+
+  // test a vector of ints
+  std::vector<int> vec{3, 4, 5, 6};
+  AddMember(d, "vec", vec, allocator);
+  std::vector<int> vec2;
+  ReadMember(d, "vec", vec2);
+  ASSERT(vec2 == vec);
+
+  // test an empty vector
+  std::vector<float> emptyVec{};
+  AddMember(d, "emptyVec", emptyVec, allocator);
+  std::vector<float> emptyVec2;
+  ReadMember(d, "emptyVec", emptyVec2);
+  ASSERT(emptyVec2 == emptyVec);
+}
+
 // Serialize/deserialize a few esp types using io::AddMember/ReadMember and
 // assert equality.
 TEST(IOTest, JsonEspTypesTest) {


### PR DESCRIPTION
## Motivation and Context

I've added rapidjson serialization for some Habitat types. This supports the upcoming render-replay feature. It may also be useful for other serialization needs like Sim Replay.

Render-replay may eventually support other serialization formats, but json is good enough for the MVP. Some benefits of json: 1. human-readable and easy to debug, and 2. I can easily load it into Unity using C#.

Because I have a lot of user types to serialize, I've also added some rapidjson helper functions. See JsonAllTypes.h. These helpers are designed so that every builtin type and user type can be serialized/deserialized with `esp::io::AddMember`/`ReadMember`. This leads to uniform and readable serialization code. To achieve this, every complex user type defines `ToRJsonValue`/`FromRJsonValue`, and then template versions of `AddMember`/`ReadMember` will automatically use these.

There's a bit of duplication with existing serialization helpers in json.h (e.g. Magnum::Vector3). I was unable to use those helpers because they don't quite fit the pattern I'm using involving rapidjson::Values.

## How Has This Been Tested

Unit tests in IOTest. I've also used this a lot in my in-progress render-replay branch, e.g. [Recorder.cpp](https://github.com/eundersander/habitat-sim/blob/eundersander/serialize_for_render4/src/esp/gfx/replay/Recorder.cpp)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
