### PR TITLE
pbr.frag fix for point lights attenuation

### DIFF
--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -270,7 +270,7 @@ void main() {
     // that to make the distance zero -- which will then ensure the
     // attenuation is always 1.0
     highp float dist =
-        length(LightDirections[iLight].xyz) * LightDirections[iLight].w;
+        length(LightDirections[iLight].xyz - position) * LightDirections[iLight].w;
     // If range is 0 for whatever reason, clamp it to a small value to
     // avoid a NaN when dist is 0 as well (which is the case for
     // directional lights).


### PR DESCRIPTION
## Motivation and Context

Bugfix for point lights attenuation calculation.



My test case here is a GLOBAL red point light and a GLOBAL green point light placed arbitrarily in the ReplicaCAD scene. In the before video, notice how the  attentuation changes dramatically as the camera moves. For GLOBAL lights, this shouldn't happen.

Before:
![point_lights_before](https://user-images.githubusercontent.com/6557808/101415571-0b90ec00-389d-11eb-9232-84f79640fb70.gif)




After:
![point_lights_after](https://user-images.githubusercontent.com/6557808/101415912-91149c00-389d-11eb-8ef5-218d0baa2bba.gif)



Here's a different test, a single CAMERA red point light placed in front of the camera, slightly offset to the right. As desired, it moves with the camera. (I don't have a "before" video for this case but I did want to test it with this fix).
![camera_point_light_test](https://user-images.githubusercontent.com/6557808/101416399-a63dfa80-389e-11eb-9ebc-82bcf5ed3d22.gif)



## How Has This Been Tested

See gifs above. For the first two gifs, I tested in the viewer by hard-coding these point lights:
```
    esp::gfx::LightInfo info1{.vector{0.0, 0.0, 0.0, 1.0},
                            .color{3.0, 0.0, 0.0},
                            .model{esp::gfx::LightPositionModel::GLOBAL}};
    esp::gfx::LightInfo info0{.vector{1.8, 1.0, 4.3, 1.0},
                            .color{0.0, 3.0, 0.0},
                            .model{esp::gfx::LightPositionModel::GLOBAL}};
    std::vector<esp::gfx::LightInfo> lightSetup{info0, info1};
    simulator_->setLightSetup(lightSetup);    
```

I also tested a CAMERA light:
```
    esp::gfx::LightInfo info1{.vector{0.5, 0.0, -2.0, 1.0},
                            .color{3.0, 0.0, 0.0},
                            .model{esp::gfx::LightPositionModel::CAMERA}};
    std::vector<esp::gfx::LightInfo> lightSetup{info1};
    simulator_->setLightSetup(lightSetup);    
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
