### PR TITLE
--[BUGFIX] Incorrect requiresTextures state is used.

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -182,7 +182,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     // reinitalize members
     if (!renderer_) {
       gfx::Renderer::Flags flags;
-      if (!config_.requiresTextures)
+      if (!(*requiresTextures_))
         flags |= gfx::Renderer::Flag::NoTextures;
       renderer_ = gfx::Renderer::create(flags);
     }


### PR DESCRIPTION
## Motivation and Context
The modified code addresses a bug in rare instances, where Simulator::requiresLighting_ is true, config_.requiresLighting is false, and the renderer_ did not exist but is now needing to be created.  The existing code was using the incorrect value for requiresLighting (see line 112 in Simulator) - config_.requiresLighting's value is ignored by Simulator if Simulator::requiresLighting_ is true.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
