### PR TITLE
Add gfx::replay::Recorder

### DIFF
--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_ASSETS_RENDERASSETINSTANCECREATIONINFO_H_
+#define ESP_ASSETS_RENDERASSETINSTANCECREATIONINFO_H_
 
 #include "Asset.h"
 
@@ -43,3 +44,5 @@ struct RenderAssetInstanceCreationInfo {
 
 }  // namespace assets
 }  // namespace esp
+
+#endif

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -20,6 +20,9 @@ set(
   RenderCamera.h
   Renderer.cpp
   Renderer.h
+  replay/Keyframe.h
+  replay/Recorder.cpp
+  replay/Recorder.h
   WindowlessContext.cpp
   WindowlessContext.h
   RenderTarget.cpp

--- a/src/esp/gfx/replay/Keyframe.h
+++ b/src/esp/gfx/replay/Keyframe.h
@@ -15,7 +15,7 @@ class SceneNode;
 namespace gfx {
 namespace replay {
 
-using RenderAssetInstanceKey = uint32_t;
+using RenderAssetInstanceKey = int32_t;
 
 /**
  * @brief serialization/replay-friendly Transform class
@@ -35,7 +35,7 @@ struct Transform {
 struct RenderAssetInstanceState {
   Transform absTransform;  // localToWorld
   // note we currently only support semanticId per instance, not per drawable
-  int semanticId = -1;
+  int semanticId = ID_UNDEFINED;
   // note we don't currently support runtime changes to lightSetupKey
   bool operator==(const RenderAssetInstanceState& rhs) const {
     return absTransform == rhs.absTransform && semanticId == rhs.semanticId;

--- a/src/esp/gfx/replay/Keyframe.h
+++ b/src/esp/gfx/replay/Keyframe.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_REPLAY_KEYFRAME_H_
+#define ESP_GFX_REPLAY_KEYFRAME_H_
 
 #include "esp/assets/Asset.h"
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
@@ -59,3 +60,5 @@ struct Keyframe {
 }  // namespace replay
 }  // namespace gfx
 }  // namespace esp
+
+#endif

--- a/src/esp/gfx/replay/Keyframe.h
+++ b/src/esp/gfx/replay/Keyframe.h
@@ -1,0 +1,61 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "esp/assets/Asset.h"
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+
+namespace esp {
+namespace scene {
+class SceneNode;
+}
+namespace gfx {
+namespace replay {
+
+using RenderAssetInstanceKey = uint32_t;
+
+/**
+ * @brief serialization/replay-friendly Transform class
+ */
+struct Transform {
+  Magnum::Vector3 translation;
+  Magnum::Quaternion rotation;
+  bool operator==(const Transform& rhs) const {
+    return translation == rhs.translation && rotation == rhs.rotation;
+  }
+};
+
+/**
+ * @brief The dynamic state of a render instance that is tracked by the replay
+ * system every frame.
+ */
+struct RenderAssetInstanceState {
+  Transform absTransform;  // localToWorld
+  // note we currently only support semanticId per instance, not per drawable
+  int semanticId = -1;
+  // note we don't currently support runtime changes to lightSetupKey
+  bool operator==(const RenderAssetInstanceState& rhs) const {
+    return absTransform == rhs.absTransform && semanticId == rhs.semanticId;
+  }
+};
+
+/**
+ * @brief A serialization/replay-friendly render keyframe class. See @ref
+ * Recorder.
+ */
+struct Keyframe {
+  std::vector<esp::assets::AssetInfo> loads;
+  std::vector<std::pair<RenderAssetInstanceKey,
+                        esp::assets::RenderAssetInstanceCreationInfo>>
+      creations;
+  std::vector<RenderAssetInstanceKey> deletions;
+  std::vector<std::pair<RenderAssetInstanceKey, RenderAssetInstanceState>>
+      stateUpdates;
+  std::unordered_map<std::string, Transform> userTransforms;
+};
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "Recorder.h"
+
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+#include "esp/io/json.h"
+#include "esp/scene/SceneNode.h"
+
+using namespace rapidjson;
+
+namespace esp {
+namespace gfx {
+namespace replay {
+
+/**
+ * @brief Helper class to get notified when a SceneNode is about to be
+ * destroyed.
+ */
+class NodeDeletionHelper : public Magnum::SceneGraph::AbstractFeature3D {
+ public:
+  NodeDeletionHelper(scene::SceneNode& node_, Recorder* writer)
+      : Magnum::SceneGraph::AbstractFeature3D(node_),
+        node(&node_),
+        recorder_(writer) {}
+
+  virtual ~NodeDeletionHelper() {
+    recorder_->onDeleteRenderAssetInstance(node);
+  }
+
+ private:
+  Recorder* recorder_ = nullptr;
+  const scene::SceneNode* node = nullptr;
+};
+
+Recorder::~Recorder() {
+  // Delete NodeDeletionHelpers. This is important because they hold raw
+  // pointers to this Recorder and these pointers would become dangling
+  // (invalid) after this Recorder is destroyed.
+  for (auto& instanceRecord : instanceRecords_) {
+    delete instanceRecord.deletionHelper;
+  }
+}
+
+void Recorder::onLoadRenderAsset(const esp::assets::AssetInfo& assetInfo) {
+  getKeyframe().loads.push_back(assetInfo);
+}
+
+void Recorder::onCreateRenderAssetInstance(
+    scene::SceneNode* node,
+    const esp::assets::RenderAssetInstanceCreationInfo& creation) {
+  ASSERT(node);
+  ASSERT(findInstance(node) == -1);
+
+  RenderAssetInstanceKey instanceKey = getNewInstanceKey();
+
+  getKeyframe().creations.emplace_back(std::make_pair(instanceKey, creation));
+
+  // Constructing NodeDeletionHelper here is equivalent to calling
+  // node->addFeature. We keep a pointer to deletionHelper so we can delete it
+  // manually later if necessary.
+  NodeDeletionHelper* deletionHelper = new NodeDeletionHelper{*node, this};
+
+  instanceRecords_.emplace_back(InstanceRecord{
+      node, instanceKey, Corrade::Containers::NullOpt, deletionHelper});
+}
+
+void Recorder::saveKeyframe() {
+  updateInstanceStates();
+  advanceKeyframe();
+}
+
+void Recorder::addUserTransformToKeyframe(const std::string& name,
+                                          const Magnum::Vector3& translation,
+                                          const Magnum::Quaternion& rotation) {
+  getKeyframe().userTransforms[name] = Transform{translation, rotation};
+}
+
+void Recorder::addLoadsCreationsDeletions(KeyframeIterator begin,
+                                          KeyframeIterator end,
+                                          Keyframe* dest) {
+  ASSERT(dest);
+  for (KeyframeIterator curr = begin; curr != end; curr++) {
+    const auto& keyframe = *curr;
+    dest->loads.insert(dest->loads.end(), keyframe.loads.begin(),
+                       keyframe.loads.end());
+    dest->creations.insert(dest->creations.end(), keyframe.creations.begin(),
+                           keyframe.creations.end());
+    for (const auto& deletionInstanceKey : keyframe.deletions) {
+      checkAndAddDeletion(dest, deletionInstanceKey);
+    }
+  }
+}
+
+void Recorder::checkAndAddDeletion(Keyframe* keyframe,
+                                   RenderAssetInstanceKey instanceKey) {
+  auto it =
+      std::find_if(keyframe->creations.begin(), keyframe->creations.end(),
+                   [&](const auto& pair) { return pair.first == instanceKey; });
+  if (it != keyframe->creations.end()) {
+    // this deletion just cancels out with an earlier creation
+    keyframe->creations.erase(it);
+  } else {
+    // This deletion has no matching creation so it can't be canceled out.
+    // Include it in the keyframe.
+    keyframe->deletions.push_back(instanceKey);
+  }
+}
+
+void Recorder::onDeleteRenderAssetInstance(const scene::SceneNode* node) {
+  int index = findInstance(node);
+  ASSERT(index != -1);
+
+  auto instanceKey = instanceRecords_[index].instanceKey;
+
+  checkAndAddDeletion(&getKeyframe(), instanceKey);
+
+  instanceRecords_.erase(instanceRecords_.begin() + index);
+}
+
+Keyframe& Recorder::getKeyframe() {
+  return currKeyframe_;
+}
+
+RenderAssetInstanceKey Recorder::getNewInstanceKey() {
+  return nextInstanceKey_++;
+}
+
+int Recorder::findInstance(const scene::SceneNode* queryNode) {
+  auto it = std::find_if(instanceRecords_.begin(), instanceRecords_.end(),
+                         [&queryNode](const InstanceRecord& record) {
+                           return record.node == queryNode;
+                         });
+
+  return it == instanceRecords_.end() ? -1 : int(it - instanceRecords_.begin());
+}
+
+RenderAssetInstanceState Recorder::getInstanceState(
+    const scene::SceneNode* node) {
+  const auto absTransformMat = node->absoluteTransformation();
+  Transform absTransform{
+      absTransformMat.translation(),
+      Magnum::Quaternion::fromMatrix(absTransformMat.rotationShear())};
+
+  return RenderAssetInstanceState{absTransform, node->getSemanticId()};
+}
+
+void Recorder::updateInstanceStates() {
+  for (auto& instanceRecord : instanceRecords_) {
+    auto state = getInstanceState(instanceRecord.node);
+    if (!instanceRecord.recentState || state != instanceRecord.recentState) {
+      getKeyframe().stateUpdates.push_back(
+          std::make_pair(instanceRecord.instanceKey, state));
+      instanceRecord.recentState = state;
+    }
+  }
+}
+
+void Recorder::advanceKeyframe() {
+  savedKeyframes_.emplace_back(std::move(currKeyframe_));
+  currKeyframe_ = Keyframe{};
+}
+
+void Recorder::writeSavedKeyframesToFile(const std::string& filepath) {
+  auto document = writeKeyframesToJsonDocument();
+  esp::io::writeJsonToFile(document, filepath);
+
+  // consolidate saved keyframes into current keyframe
+  addLoadsCreationsDeletions(savedKeyframes_.begin(), savedKeyframes_.end(),
+                             &getKeyframe());
+  savedKeyframes_.clear();
+}
+
+rapidjson::Document Recorder::writeKeyframesToJsonDocument() {
+  LOG(WARNING) << "Recorder::writeKeyframesToJsonDocument: not implemented";
+  return rapidjson::Document();
+#if 0  // coming soon
+  if (savedKeyframes_.empty()) {
+    LOG(WARNING) << "Recorder::writeKeyframesToJsonDocument: no saved "
+                    "keyframes to write";
+    return rapidjson::Document();
+  }
+
+  Document d(kObjectType);
+  Document::AllocatorType& allocator = d.GetAllocator();
+  esp::io::AddMember(d, "keyframes", savedKeyframes_, allocator);
+  return d;
+#endif
+}
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -49,7 +49,7 @@ void Recorder::onCreateRenderAssetInstance(
     scene::SceneNode* node,
     const esp::assets::RenderAssetInstanceCreationInfo& creation) {
   ASSERT(node);
-  ASSERT(findInstance(node) == -1);
+  ASSERT(findInstance(node) == ID_UNDEFINED);
 
   RenderAssetInstanceKey instanceKey = getNewInstanceKey();
 
@@ -108,7 +108,7 @@ void Recorder::checkAndAddDeletion(Keyframe* keyframe,
 
 void Recorder::onDeleteRenderAssetInstance(const scene::SceneNode* node) {
   int index = findInstance(node);
-  ASSERT(index != -1);
+  ASSERT(index != ID_UNDEFINED);
 
   auto instanceKey = instanceRecords_[index].instanceKey;
 
@@ -131,7 +131,8 @@ int Recorder::findInstance(const scene::SceneNode* queryNode) {
                            return record.node == queryNode;
                          });
 
-  return it == instanceRecords_.end() ? -1 : int(it - instanceRecords_.begin());
+  return it == instanceRecords_.end() ? ID_UNDEFINED
+                                      : int(it - instanceRecords_.begin());
 }
 
 RenderAssetInstanceState Recorder::getInstanceState(

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -8,8 +8,6 @@
 #include "esp/io/json.h"
 #include "esp/scene/SceneNode.h"
 
-using namespace rapidjson;
-
 namespace esp {
 namespace gfx {
 namespace replay {
@@ -25,7 +23,7 @@ class NodeDeletionHelper : public Magnum::SceneGraph::AbstractFeature3D {
         node(&node_),
         recorder_(writer) {}
 
-  virtual ~NodeDeletionHelper() {
+  ~NodeDeletionHelper() override {
     recorder_->onDeleteRenderAssetInstance(node);
   }
 

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -1,0 +1,140 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "Keyframe.h"
+
+#include <rapidjson/document.h>
+
+#include <string>
+
+namespace esp {
+namespace assets {
+struct AssetInfo;
+struct RenderAssetInstanceCreationInfo;
+}  // namespace assets
+namespace scene {
+class SceneNode;
+}
+namespace gfx {
+namespace replay {
+
+class NodeDeletionHelper;
+
+/**
+ * @brief Recording for "render replay".
+ *
+ * This class is work in progress (writeSavedKeyframesToFile isn't implemented
+ * yet).
+ *
+ * This class saves and serializes render keyframes. A render keyframe is a
+ * visual snapshot of a scene. It includes the visual parts of a scene, such
+ * that observations can be reproduced (from the same camera perspective or a
+ * different one). The render keyframe includes support for named "user
+ * transforms" which can be used to store cameras, agents, or other
+ * application-specific objects. See also @ref Player (coming soon). See
+ * examples/replay_tutorial.py for usage of this class through bindings (coming
+ * soon).
+ */
+class Recorder {
+ public:
+  ~Recorder();
+
+  /**
+   * @brief User code should call this upon creating a render asset instance so
+   * that Recorder can track the instance.
+   * @param node The root node of the instance
+   * @param creation How the instance was created. Recorder will save this so
+   * that the instance can be re-created later.
+   */
+  void onCreateRenderAssetInstance(
+      scene::SceneNode* node,
+      const esp::assets::RenderAssetInstanceCreationInfo& creation);
+
+  /**
+   * @brief User code should call this upon loading a render asset to inform
+   * Recorder about the asset.
+   * @param assetInfo The asset that was loaded.
+   */
+  void onLoadRenderAsset(const esp::assets::AssetInfo& assetInfo);
+
+  /**
+   * @brief Save/capture a render keyframe (a visual snapshot of the scene).
+   *
+   * User code can call this any time, but the intended usage is to save a
+   * keyframe after stepping the environment and/or when drawing observations.
+   * See also writeSavedKeyframesToFile.
+   */
+  void saveKeyframe();
+
+  /**
+   * @brief Add a named "user transform" which can be used to store cameras,
+   * agents, or other application-specific objects
+   *
+   * The user transforms can be retrieved by name during replay playback. See
+   * @ref Player (coming soon).
+   *
+   * The user transform gets added to the "current" keyframe and will get saved
+   * on the next call to saveKeyframe (but not later keyframes). For
+   * "persistent" user objects, the expected usage is to call this every frame.
+   *
+   * @param name A name, to be used to retrieve the transform later.
+   * @param translation
+   * @param rotation
+   */
+  void addUserTransformToKeyframe(const std::string& name,
+                                  const Magnum::Vector3& translation,
+                                  const Magnum::Quaternion& rotation);
+
+  /**
+   * @brief write saved keyframes to file. Not implemented yet.
+   * @param filepath
+   */
+  void writeSavedKeyframesToFile(const std::string& filepath);
+
+  /**
+   * @brief Reserved for unit-testing.
+   */
+  const std::vector<Keyframe>& debugGetSavedKeyframes() const {
+    return savedKeyframes_;
+  }
+
+ private:
+  // NodeDeletionHelper calls onDeleteRenderAssetInstance
+  friend class NodeDeletionHelper;
+
+  // Helper for tracking render asset instances
+  struct InstanceRecord {
+    scene::SceneNode* node = nullptr;
+    RenderAssetInstanceKey instanceKey = -1;
+    Corrade::Containers::Optional<RenderAssetInstanceState> recentState;
+    NodeDeletionHelper* deletionHelper = nullptr;
+  };
+
+  using KeyframeIterator = std::vector<Keyframe>::const_iterator;
+
+  rapidjson::Document writeKeyframesToJsonDocument();
+  void onDeleteRenderAssetInstance(const scene::SceneNode* node);
+  Keyframe& getKeyframe();
+  void advanceKeyframe();
+  RenderAssetInstanceKey getNewInstanceKey();
+  int findInstance(const scene::SceneNode* queryNode);
+  RenderAssetInstanceState getInstanceState(const scene::SceneNode* node);
+  void updateInstanceStates();
+  void checkAndAddDeletion(Keyframe* keyframe,
+                           RenderAssetInstanceKey instanceKey);
+  void addLoadsCreationsDeletions(KeyframeIterator begin,
+                                  KeyframeIterator end,
+                                  Keyframe* dest);
+
+  std::vector<InstanceRecord> instanceRecords_;
+  Keyframe currKeyframe_;
+  std::vector<Keyframe> savedKeyframes_;
+  RenderAssetInstanceKey nextInstanceKey_ = 0;
+};
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_REPLAY_RECORDER_H_
+#define ESP_GFX_REPLAY_RECORDER_H_
 
 #include "Keyframe.h"
 
@@ -138,3 +139,5 @@ class Recorder {
 }  // namespace replay
 }  // namespace gfx
 }  // namespace esp
+
+#endif

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -109,7 +109,7 @@ class Recorder {
   // Helper for tracking render asset instances
   struct InstanceRecord {
     scene::SceneNode* node = nullptr;
-    RenderAssetInstanceKey instanceKey = -1;
+    RenderAssetInstanceKey instanceKey = ID_UNDEFINED;
     Corrade::Containers::Optional<RenderAssetInstanceState> recentState;
     NodeDeletionHelper* deletionHelper = nullptr;
   };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -51,6 +51,9 @@ target_include_directories(DrawableTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 test(PhysicsTest physics)
 target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+test(GfxReplayTest assets gfx)
+target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 test(ResourceManagerTest assets)
 target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <Corrade/Containers/Optional.h>
+#include <Corrade/Utility/Directory.h>
+#include <Magnum/EigenIntegration/Integration.h>
+#include <Magnum/Math/Range.h>
+#include <gtest/gtest.h>
+#include <string>
+
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+#include "esp/assets/ResourceManager.h"
+#include "esp/gfx/Renderer.h"
+#include "esp/gfx/WindowlessContext.h"
+#include "esp/gfx/replay/Player.h"
+#include "esp/gfx/replay/Recorder.h"
+#include "esp/scene/SceneManager.h"
+
+#include "configure.h"
+
+namespace Cr = Corrade;
+namespace Mn = Magnum;
+
+using esp::assets::ResourceManager;
+using esp::metadata::MetadataMediator;
+using esp::scene::SceneManager;
+
+// Manipulate the scene and save some keyframes using replay::Recorder
+TEST(GfxReplayTest, recorder) {
+  esp::gfx::WindowlessContext::uptr context_ =
+      esp::gfx::WindowlessContext::create_unique(0);
+
+  std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
+
+  // must declare these in this order due to avoid deallocation errors
+  auto MM = MetadataMediator::create();
+  ResourceManager resourceManager(MM);
+  SceneManager sceneManager_;
+  std::string boxFile =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+
+  int sceneID = sceneManager_.initSceneGraph();
+  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+  const esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
+
+  const std::string lightSetupKey = "";
+  esp::assets::RenderAssetInstanceCreationInfo::Flags flags;
+  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
+  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
+  esp::assets::RenderAssetInstanceCreationInfo creation(
+      boxFile, Corrade::Containers::NullOpt, flags, lightSetupKey);
+
+  std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
+  auto* node = resourceManager.loadAndCreateRenderAssetInstance(
+      info, creation, &sceneManager_, tempIDs);
+  ASSERT(node);
+  esp::gfx::replay::Recorder recorder;
+  recorder.onLoadRenderAsset(info);
+  recorder.onCreateRenderAssetInstance(node, creation);
+  recorder.saveKeyframe();
+  node->setTranslation(Mn::Vector3(1.f, 2.f, 3.f));
+  node->setSemanticId(7);
+  recorder.saveKeyframe();
+  delete node;
+  recorder.addUserTransformToKeyframe("my_user_transform",
+                                      Mn::Vector3(4.f, 5.f, 6.f),
+                                      Mn::Quaternion(Mn::Math::ZeroInit));
+  recorder.saveKeyframe();
+
+  // verify 3 saved keyframes
+  const auto& keyframes = recorder.debugGetSavedKeyframes();
+  ASSERT(keyframes.size() == 3);
+
+  // verify frame #0 loads a render asset, creates an instance, and stores a
+  // state update for the instance
+  ASSERT(keyframes[0].loads.size() == 1);
+  ASSERT(keyframes[0].loads[0] == info);
+  ASSERT(keyframes[0].creations.size() == 1);
+  ASSERT(keyframes[0].creations[0].second.filepath.find(
+             "objects/transform_box.glb") != std::string::npos);
+  ASSERT(keyframes[0].stateUpdates.size() == 1);
+  esp::gfx::replay::RenderAssetInstanceKey instanceKey =
+      keyframes[0].creations[0].first;
+  ASSERT(keyframes[0].stateUpdates[0].first == instanceKey);
+
+  // verify frame #1 has our translation and semantic Id
+  ASSERT(keyframes[1].stateUpdates.size() == 1);
+  ASSERT(keyframes[1].stateUpdates[0].second.absTransform.translation ==
+         Mn::Vector3(1.f, 2.f, 3.f));
+  ASSERT(keyframes[1].stateUpdates[0].second.semanticId == 7);
+
+  // verify frame #2 has our deletion and our user transform
+  ASSERT(keyframes[2].deletions.size() == 1);
+  ASSERT(keyframes[2].deletions[0] == instanceKey);
+  ASSERT(keyframes[2].userTransforms.size() == 1);
+  ASSERT(keyframes[2].userTransforms.count("my_user_transform"));
+  ASSERT(keyframes[2].userTransforms.at("my_user_transform").translation ==
+         Mn::Vector3(4.f, 5.f, 6.f));
+}

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -13,7 +13,6 @@
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/gfx/WindowlessContext.h"
-#include "esp/gfx/replay/Player.h"
 #include "esp/gfx/replay/Recorder.h"
 #include "esp/scene/SceneManager.h"
 


### PR DESCRIPTION
## Motivation and Context

Part of the upcoming render-replay feature.

The Recorder class saves and serializes render keyframes. A render keyframe is a visual snapshot of a scene. It includes the visual parts of a scene, such that observations can be reproduced (from the same camera perspective or a different one). The render keyframe includes support for named "user transforms" which can be used to store cameras, agents, or other application-specific objects.

This is only part of the upcoming render-replay feature. Other PRs coming soon:
- gfx::replay::Player
- integration PR, which includes integration with Simulator and ResourceManager, sim bindings, and a python replay tutorial.

Serialization/saving is disabled, waiting on this PR: https://github.com/facebookresearch/habitat-sim/pull/959 .

## How Has This Been Tested

See GfxReplayTest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
