### PR TITLE
Add gfx::replay::Player

### DIFF
--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -21,6 +21,8 @@ set(
   Renderer.cpp
   Renderer.h
   replay/Keyframe.h
+  replay/Player.cpp
+  replay/Player.h
   replay/Recorder.cpp
   replay/Recorder.h
   WindowlessContext.cpp

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "Player.h"
+
+#include "esp/assets/ResourceManager.h"
+#include "esp/core/esp.h"
+
+#include <rapidjson/document.h>
+
+namespace esp {
+namespace gfx {
+namespace replay {
+
+void Player::readKeyframesFromJsonDocument(const rapidjson::Document&) {
+  LOG(WARNING) << "Player::readKeyframesFromJsonDocument: not implemented";
+#if 0  // coming soon
+  ASSERT(keyframes_.empty());
+  esp::io::ReadMember(d, "keyframes", keyframes_);
+#endif
+}
+
+Player::Player(const LoadAndCreateRenderAssetInstanceCallback& callback)
+    : loadAndCreateRenderAssetInstanceCallback(callback) {}
+
+void Player::readKeyframesFromFile(const std::string& filepath) {
+  clearFrame();
+  keyframes_.clear();
+
+  auto newDoc = esp::io::parseJsonFile(filepath);
+  readKeyframesFromJsonDocument(newDoc);
+}
+
+int Player::getKeyframeIndex() const {
+  return frameIndex_;
+}
+
+int Player::getNumKeyframes() const {
+  return keyframes_.size();
+}
+
+void Player::setKeyframeIndex(int frameIndex) {
+  ASSERT(frameIndex == -1 ||
+         (frameIndex >= 0 && frameIndex < getNumKeyframes()));
+
+  if (frameIndex < frameIndex_) {
+    clearFrame();
+  }
+
+  while (frameIndex_ < frameIndex) {
+    applyKeyframe(keyframes_[++frameIndex_]);
+  }
+}
+
+bool Player::getUserTransform(const std::string& name,
+                              Magnum::Vector3* translation,
+                              Magnum::Quaternion* rotation) const {
+  ASSERT(frameIndex_ >= 0 && frameIndex_ < getNumKeyframes());
+  ASSERT(translation);
+  ASSERT(rotation);
+  const auto& keyframe = keyframes_[frameIndex_];
+  const auto& it = keyframe.userTransforms.find(name);
+  if (it != keyframe.userTransforms.end()) {
+    *translation = it->second.translation;
+    *rotation = it->second.rotation;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void Player::clearFrame() {
+  for (const auto& pair : createdInstances_) {
+    delete pair.second;
+  }
+  createdInstances_.clear();
+  assetInfos_.clear();
+  frameIndex_ = -1;
+}
+
+void Player::applyKeyframe(const Keyframe& keyframe) {
+  for (const auto& assetInfo : keyframe.loads) {
+    ASSERT(assetInfos_.count(assetInfo.filepath) == 0);
+    if (failedFilepaths_.count(assetInfo.filepath)) {
+      continue;
+    }
+    assetInfos_[assetInfo.filepath] = assetInfo;
+  }
+
+  for (const auto& pair : keyframe.creations) {
+    const auto& creation = pair.second;
+    if (!assetInfos_.count(creation.filepath)) {
+      if (!failedFilepaths_.count(creation.filepath)) {
+        LOG(WARNING) << "Player: missing asset info for [" << creation.filepath
+                     << "]";
+        failedFilepaths_.insert(creation.filepath);
+      }
+      continue;
+    }
+    ASSERT(assetInfos_.count(creation.filepath));
+    auto node = loadAndCreateRenderAssetInstanceCallback(
+        assetInfos_[creation.filepath], creation);
+    if (!node) {
+      if (!failedFilepaths_.count(creation.filepath)) {
+        LOG(WARNING) << "Player: load failed for asset [" << creation.filepath
+                     << "]";
+        failedFilepaths_.insert(creation.filepath);
+      }
+      continue;
+    }
+
+    const auto& instanceKey = pair.first;
+    ASSERT(createdInstances_.count(instanceKey) == 0);
+    createdInstances_[instanceKey] = node;
+  }
+
+  for (const auto& deletionInstanceKey : keyframe.deletions) {
+    const auto& it = createdInstances_.find(deletionInstanceKey);
+    if (it == createdInstances_.end()) {
+      // missing instance for this key, probably due to a failed instance
+      // creation
+      continue;
+    }
+
+    auto node = it->second;
+    delete node;
+    createdInstances_.erase(deletionInstanceKey);
+  }
+
+  for (const auto& pair : keyframe.stateUpdates) {
+    const auto& it = createdInstances_.find(pair.first);
+    if (it == createdInstances_.end()) {
+      // missing instance for this key, probably due to a failed instance
+      // creation
+      continue;
+    }
+    auto node = it->second;
+    const auto& state = pair.second;
+    node->setTranslation(state.absTransform.translation);
+    node->setRotation(state.absTransform.rotation);
+    setSemanticIdForSubtree(node, state.semanticId);
+  }
+}
+
+void Player::setSemanticIdForSubtree(esp::scene::SceneNode* rootNode,
+                                     int semanticId) {
+  if (rootNode->getSemanticId() == semanticId) {
+    // We assume the entire subtree's semanticId matches the root's, so we can
+    // early out here.
+    return;
+  }
+
+  // See also RigidBase setSemanticId. That function uses a prepared container
+  // of visual nodes, whereas this function traverses the subtree to touch all
+  // nodes (including visual nodes). The results should be the same.
+  auto cb = [&](esp::scene::SceneNode& node) {
+    node.setSemanticId(semanticId);
+  };
+  esp::scene::preOrderTraversalWithCallback(*rootNode, cb);
+}
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -1,0 +1,114 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_GFX_REPLAY_PLAYER_H_
+#define ESP_GFX_REPLAY_PLAYER_H_
+
+#include "Keyframe.h"
+
+#include "esp/assets/Asset.h"
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+
+#include <rapidjson/document.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace esp {
+namespace scene {
+class SceneNode;
+}
+namespace gfx {
+namespace replay {
+
+/**
+ * @brief Playback for "render replay".
+ *
+ * This class is work in progress (readKeyframesFromFile isn't implemented
+ * yet).
+ *
+ * This class reads render keyframes from a file so that observations can be
+ * reproduced (from the same camera perspective or a different one). A loaded
+ * keyframe can be set (applied to the scene) with setKeyframeIndex; render
+ * asset instances are added to the scene as needed and new observations can be
+ * rendered. Render assets are loaded as needed. See also @ref Recorder. See
+ * examples/replay_tutorial.py for usage of this class through bindings (coming
+ * soon).
+ */
+class Player {
+ public:
+  using LoadAndCreateRenderAssetInstanceCallback =
+      std::function<esp::scene::SceneNode*(
+          const esp::assets::AssetInfo&,
+          const esp::assets::RenderAssetInstanceCreationInfo&)>;
+
+  /**
+   * @brief Construct a Player.
+   * @param callback A function to load and create a render asset instance.
+   */
+  Player(const LoadAndCreateRenderAssetInstanceCallback& callback);
+
+  /**
+   * @brief Read keyframes. See also @ref Recorder::writeSavedKeyframesToFile.
+   * After calling this, use @ref setKeyframeIndex to set a keyframe.
+   * @param filepath
+   */
+  void readKeyframesFromFile(const std::string& filepath);
+
+  /**
+   * @brief Get the currently-set keyframe, or -1 if no keyframe is set.
+   */
+  int getKeyframeIndex() const;
+
+  /**
+   * @brief Get the number of keyframes read from file.
+   */
+  int getNumKeyframes() const;
+
+  /**
+   * @brief Set a keyframe by index, or pass -1 to clear the currently-set
+   * keyframe.
+   */
+  void setKeyframeIndex(int frameIndex);
+
+  /**
+   * @brief Get a user transform. See @ref Recorder::addUserTransformToKeyframe
+   * for usage tips.
+   */
+  bool getUserTransform(const std::string& name,
+                        Magnum::Vector3* translation,
+                        Magnum::Quaternion* rotation) const;
+
+  /**
+   * @brief Reserved for unit-testing.
+   */
+  void debugSetKeyframes(std::vector<Keyframe>&& keyframes) {
+    keyframes_ = std::move(keyframes);
+  }
+
+ private:
+  void readKeyframesFromJsonDocument(const rapidjson::Document& d);
+  void clearFrame();
+  void applyKeyframe(const Keyframe& keyframe);
+  static void setSemanticIdForSubtree(esp::scene::SceneNode* rootNode,
+                                      int semanticId);
+
+  LoadAndCreateRenderAssetInstanceCallback
+      loadAndCreateRenderAssetInstanceCallback;
+  int frameIndex_ = -1;
+  std::vector<Keyframe> keyframes_;
+  std::map<std::string, esp::assets::AssetInfo> assetInfos_;
+  std::map<RenderAssetInstanceKey, scene::SceneNode*> createdInstances_;
+  std::set<std::string> failedFilepaths_;
+
+  ESP_SMART_POINTERS(Player)
+};
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp
+
+#endif

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -13,6 +13,7 @@
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/gfx/WindowlessContext.h"
+#include "esp/gfx/replay/Player.h"
 #include "esp/gfx/replay/Recorder.h"
 #include "esp/scene/SceneManager.h"
 
@@ -64,7 +65,7 @@ TEST(GfxReplayTest, recorder) {
   delete node;
   recorder.addUserTransformToKeyframe("my_user_transform",
                                       Mn::Vector3(4.f, 5.f, 6.f),
-                                      Mn::Quaternion(Mn::Math::ZeroInit));
+                                      Mn::Quaternion(Mn::Math::IdentityInit));
   recorder.saveKeyframe();
 
   // verify 3 saved keyframes
@@ -96,4 +97,140 @@ TEST(GfxReplayTest, recorder) {
   ASSERT(keyframes[2].userTransforms.count("my_user_transform"));
   ASSERT(keyframes[2].userTransforms.at("my_user_transform").translation ==
          Mn::Vector3(4.f, 5.f, 6.f));
+}
+
+// construct some render keyframes and play them using replay::Player
+TEST(GfxReplayTest, player) {
+  esp::gfx::WindowlessContext::uptr context_ =
+      esp::gfx::WindowlessContext::create_unique(0);
+
+  std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
+
+  // must declare these in this order due to avoid deallocation errors
+  auto MM = MetadataMediator::create();
+  ResourceManager resourceManager(MM);
+  SceneManager sceneManager_;
+  std::string boxFile =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+
+  int sceneID = sceneManager_.initSceneGraph();
+  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+
+  // retrieve last child of scene root node
+  auto& rootNode = sceneGraph.getRootNode();
+  const auto* lastRootChild = rootNode.children().first();
+  ASSERT(lastRootChild);
+  while (lastRootChild->nextSibling()) {
+    lastRootChild = lastRootChild->nextSibling();
+  }
+
+  // Construct Player. Hook up ResourceManager::loadAndCreateRenderAssetInstance
+  // to Player via callback.
+  auto callback =
+      [&](const esp::assets::AssetInfo& assetInfo,
+          const esp::assets::RenderAssetInstanceCreationInfo& creation) {
+        std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
+        return resourceManager.loadAndCreateRenderAssetInstance(
+            assetInfo, creation, &sceneManager_, tempIDs);
+      };
+  esp::gfx::replay::Player player(callback);
+
+  std::vector<esp::gfx::replay::Keyframe> keyframes;
+
+  esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
+  esp::gfx::replay::RenderAssetInstanceKey instanceKey = 7;
+
+  const std::string lightSetupKey = "";
+  esp::assets::RenderAssetInstanceCreationInfo::Flags flags;
+  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
+  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
+  esp::assets::RenderAssetInstanceCreationInfo creation(
+      boxFile, Corrade::Containers::NullOpt, flags, lightSetupKey);
+
+  /*
+  // Keyframe struct shown here for reference
+  struct Keyframe {
+    std::vector<esp::assets::AssetInfo> loads;
+    std::vector<std::pair<RenderAssetInstanceKey,
+                          esp::assets::RenderAssetInstanceCreationInfo>>
+        creations;
+    std::vector<RenderAssetInstanceKey> deletions;
+    std::vector<std::pair<RenderAssetInstanceKey, RenderAssetInstanceState>>
+        stateUpdates;
+    std::unordered_map<std::string, Transform> userTransforms;
+  };
+  */
+
+  // keyframe #0: load a render asset and create a render asset instance
+  keyframes.emplace_back(esp::gfx::replay::Keyframe{
+      {info}, {{instanceKey, creation}}, {}, {}, {}});
+
+  constexpr int semanticId = 4;
+  esp::gfx::replay::RenderAssetInstanceState stateUpdate{
+      {Mn::Vector3(1.f, 2.f, 3.f), Mn::Quaternion(Mn::Math::IdentityInit)},
+      semanticId};
+
+  // keyframe #1: a state update
+  keyframes.emplace_back(
+      esp::gfx::replay::Keyframe{{}, {}, {}, {{instanceKey, stateUpdate}}, {}});
+
+  // keyframe #2: delete instance
+  keyframes.emplace_back(
+      esp::gfx::replay::Keyframe{{}, {}, {instanceKey}, {}, {}});
+
+  // keyframe #3: include a user transform
+  keyframes.emplace_back(
+      esp::gfx::replay::Keyframe{{},
+                                 {},
+                                 {},
+                                 {},
+                                 {{"my_user_transform",
+                                   {Mn::Vector3(4.f, 5.f, 6.f),
+                                    Mn::Quaternion(Mn::Math::IdentityInit)}}}});
+
+  player.debugSetKeyframes(std::move(keyframes));
+
+  ASSERT(player.getNumKeyframes() == 4);
+  ASSERT(player.getKeyframeIndex() == -1);
+
+  // test setting keyframes in various order
+  const auto keyframeIndicesToTest = {-1, 0, 1,  2, 3,  -1, 3, 2,
+                                      1,  0, -1, 1, -1, 2,  0};
+
+  for (const auto keyframeIndex : keyframeIndicesToTest) {
+    player.setKeyframeIndex(keyframeIndex);
+
+    if (keyframeIndex == -1) {
+      // assert that lastRootChild doesn't have a sibling
+      ASSERT(!lastRootChild->nextSibling());
+    } else if (keyframeIndex == 0) {
+      // assert that a new node was created under root
+      ASSERT(lastRootChild->nextSibling());
+    } else if (keyframeIndex == 1) {
+      // assert that our stateUpdate was applied
+      ASSERT(lastRootChild->nextSibling());
+      const esp::scene::SceneNode* instanceNode =
+          static_cast<const esp::scene::SceneNode*>(
+              lastRootChild->nextSibling());
+      ASSERT(instanceNode->translation() == Mn::Vector3(1.f, 2.f, 3.f));
+      ASSERT(instanceNode->getSemanticId() == semanticId);
+    } else if (keyframeIndex == 2) {
+      // assert that lastRootChild doesn't have a sibling
+      ASSERT(!lastRootChild->nextSibling());
+      // assert that there's no user transform
+      Mn::Vector3 userTranslation;
+      Mn::Quaternion userRotation;
+      ASSERT(!player.getUserTransform("my_user_transform", &userTranslation,
+                                      &userRotation));
+    } else if (keyframeIndex == 3) {
+      // assert that lastRootChild doesn't have a sibling
+      ASSERT(!lastRootChild->nextSibling());
+      // assert on expected user transform
+      Mn::Vector3 userTranslation;
+      Mn::Quaternion userRotation;
+      ASSERT(player.getUserTransform("my_user_transform", &userTranslation,
+                                     &userRotation));
+      ASSERT(userTranslation == Mn::Vector3(4.f, 5.f, 6.f));
+    }
+  }
 }


### PR DESCRIPTION
## Motivation and Context

Part of the upcoming render-replay feature.

The Player class reads render keyframes from a file so that observations can be reproduced (from the same camera perspective or a different one). A loaded keyframe can be set (applied to the scene) with setKeyframeIndex; render asset instances are added to the scene as needed and new observations can be rendered. Render assets are loaded as needed.

This is only part of the upcoming render-replay feature. Coming soon:
- an integration PR, which includes integration with Simulator and ResourceManager, sim bindings, and a python replay tutorial
- Serialization/saving (currently disabled) #959

## How Has This Been Tested

player test added to GfxReplayTest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
