### PR TITLE
--[Refactor/Bugfix] Move static const ShaderManager default light and material keys to MM

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -82,34 +82,6 @@ class ResourceManager {
   using Importer = Mn::Trade::AbstractImporter;
 
   /**
-   * @brief The @ref ShaderManager key for @ref LightInfo which has no lights
-   */
-  static constexpr char NO_LIGHT_KEY[] = "no_lights";
-
-  /**
-   *@brief The @ref ShaderManager key for the default @ref LightInfo
-   */
-  static constexpr char DEFAULT_LIGHTING_KEY[] = "";
-
-  /**
-   *@brief The @ref ShaderManager key for the default @ref MaterialInfo
-   */
-  static constexpr char DEFAULT_MATERIAL_KEY[] = "";
-
-  /**
-   *@brief The @ref ShaderManager key for full ambient white @ref MaterialInfo
-   *used for primitive wire-meshes
-   */
-  static constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
-
-  /**
-   *@brief The @ref ShaderManager key for @ref MaterialInfo with per-vertex
-   * object ID
-   */
-  static constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] =
-      "per_vertex_object_id";
-
-  /**
    * @brief Flag
    *
    * @see @ref Flags, @ref flags()
@@ -316,7 +288,8 @@ class ResourceManager {
    * @brief Get a named @ref LightSetup
    */
   Mn::Resource<gfx::LightSetup> getLightSetup(
-      const Mn::ResourceKey& key = Mn::ResourceKey{DEFAULT_LIGHTING_KEY}) {
+      const Mn::ResourceKey& key = Mn::ResourceKey{
+          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY}) {
     return shaderManager_.get<gfx::LightSetup>(key);
   }
 
@@ -331,7 +304,7 @@ class ResourceManager {
    */
   void setLightSetup(gfx::LightSetup setup,
                      const Mn::ResourceKey& key = Mn::ResourceKey{
-                         DEFAULT_LIGHTING_KEY}) {
+                         metadata::MetadataMediator::DEFAULT_LIGHTING_KEY}) {
     shaderManager_.set(key, std::move(setup), Mn::ResourceDataState::Mutable,
                        Mn::ResourcePolicy::Manual);
   }
@@ -374,7 +347,8 @@ class ResourceManager {
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>& visNodeCache,
-      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY) {
+      const std::string& lightSetupKey =
+          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           metadataMediator_->getObjectAttributesManager()->getObjectHandleByID(
@@ -411,7 +385,8 @@ class ResourceManager {
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>& visNodeCache,
-      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY);
+      const std::string& lightSetupKey =
+          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref
@@ -565,6 +540,15 @@ class ResourceManager {
 
   //======== Scene Functions ========
 
+  /**
+   * @brief Determines if passed type is a general mesh data.
+   * @param type The type to verify.
+   * @return Whether it is a General
+   */
+  inline bool isRenderAssetGeneral(AssetType type) {
+    return type == AssetType::MP3D_MESH || type == AssetType::UNKNOWN ||
+           type == AssetType::SUNCG_OBJECT;
+  }
   /**
    * @brief Recursive contruction of scene nodes for an asset.
    *

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -167,8 +167,8 @@ void initGfxBindings(py::module& m) {
       .def(py::self != py::self);
 
   m.attr("DEFAULT_LIGHTING_KEY") =
-      assets::ResourceManager::DEFAULT_LIGHTING_KEY;
-  m.attr("NO_LIGHT_KEY") = assets::ResourceManager::NO_LIGHT_KEY;
+      metadata::MetadataMediator::DEFAULT_LIGHTING_KEY;
+  m.attr("NO_LIGHT_KEY") = metadata::MetadataMediator::NO_LIGHT_KEY;
 }
 
 }  // namespace gfx

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -125,13 +125,15 @@ void initSimBindings(py::module& m) {
       .def(
           "add_object", &Simulator::addObject, "object_lib_id"_a,
           "attachment_node"_a = nullptr,
-          "light_setup_key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+          "light_setup_key"_a =
+              metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
           "scene_id"_a = 0,
           R"(Instance an object into the scene via a template referenced by library id. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
       .def(
           "add_object_by_handle", &Simulator::addObjectByHandle,
           "object_lib_handle"_a, "attachment_node"_a = nullptr,
-          "light_setup_key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+          "light_setup_key"_a =
+              metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
           "scene_id"_a = 0,
           R"(Instance an object into the scene via a template referenced by its handle. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
       .def("remove_object", &Simulator::removeObject, "object_id"_a,
@@ -278,11 +280,11 @@ void initSimBindings(py::module& m) {
               smooth : (Bool) whether or not to smooth trajectory using a Catmull-Rom spline interpolating spline.
               num_interpolations : (Integer) the number of interpolation points to find between successive key points.)")
       .def("get_light_setup", &Simulator::getLightSetup,
-           "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+           "key"_a = metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
            R"(Get a copy of the LightSetup registered with a specific key.)")
       .def(
           "set_light_setup", &Simulator::setLightSetup, "light_setup"_a,
-          "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+          "key"_a = metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
           R"(Register a LightSetup with a specific key. If a LightSetup is already registered with this key, it will be overriden. All Drawables referencing the key will use the newly registered LightSetup.)")
       .def(
           "set_object_light_setup", &Simulator::setObjectLightSetup,

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -71,7 +71,8 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    */
   uint64_t getDrawableId() { return drawableId_; }
 
-  virtual void setLightSetup(const Magnum::ResourceKey& lightSetup){};
+  virtual void setLightSetup(
+      CORRADE_UNUSED const Magnum::ResourceKey& lightSetup){};
 
   Magnum::GL::Mesh& getMesh() { return mesh_; }
 

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -6,6 +6,14 @@
 
 namespace esp {
 namespace metadata {
+
+// static constexpr arrays require redundant definitions until C++17
+constexpr char MetadataMediator::NO_LIGHT_KEY[];
+constexpr char MetadataMediator::DEFAULT_LIGHTING_KEY[];
+constexpr char MetadataMediator::DEFAULT_MATERIAL_KEY[];
+constexpr char MetadataMediator::WHITE_MATERIAL_KEY[];
+constexpr char MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY[];
+
 void MetadataMediator::buildAttributesManagers() {
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create();
   sceneDatasetAttributesManager_ =

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -22,6 +22,34 @@ namespace esp {
 namespace metadata {
 class MetadataMediator {
  public:
+  /**
+   * @brief The @ref ShaderManager key for @ref LightInfo which has no lights
+   */
+  static constexpr char NO_LIGHT_KEY[] = "no_lights";
+
+  /**
+   *@brief The @ref ShaderManager key for the default @ref LightInfo
+   */
+  static constexpr char DEFAULT_LIGHTING_KEY[] = "";
+
+  /**
+   *@brief The @ref ShaderManager key for the default @ref MaterialInfo
+   */
+  static constexpr char DEFAULT_MATERIAL_KEY[] = "";
+
+  /**
+   *@brief The @ref ShaderManager key for full ambient white @ref MaterialInfo
+   *used for primitive wire-meshes
+   */
+  static constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
+
+  /**
+   *@brief The @ref ShaderManager key for @ref MaterialInfo with per-vertex
+   * object ID
+   */
+  static constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] =
+      "per_vertex_object_id";
+
   MetadataMediator(const std::string& _defaultSceneDataset = "default")
       : activeSceneDataset_(_defaultSceneDataset) {
     buildAttributesManagers();

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -30,7 +30,7 @@ StageAttributesManager::StageAttributesManager(
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),
-      cfgLightSetup_(assets::ResourceManager::NO_LIGHT_KEY) {
+      cfgLightSetup_(metadata::MetadataMediator::NO_LIGHT_KEY) {
   buildCtorFuncPtrMaps();
 }  // StageAttributesManager ctor
 
@@ -189,7 +189,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
   // json, for example.
   newAttributes->setLightSetup(cfgLightSetup_);
   newAttributes->setRequiresLighting(cfgLightSetup_ !=
-                                     assets::ResourceManager::NO_LIGHT_KEY);
+                                     metadata::MetadataMediator::NO_LIGHT_KEY);
   // set value from config so not necessary to be passed as argument
   newAttributes->setFrustumCulling(cfgFrustumCulling_);
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -182,7 +182,7 @@ class PhysicsManager {
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup =
-                    assets::ResourceManager::DEFAULT_LIGHTING_KEY);
+                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
@@ -200,7 +200,7 @@ class PhysicsManager {
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup =
-                    assets::ResourceManager::DEFAULT_LIGHTING_KEY);
+                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -180,7 +180,7 @@ class Simulator {
   int addObject(int objectLibId,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetupKey =
-                    assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
                 int sceneID = 0);
 
   /**
@@ -202,7 +202,7 @@ class Simulator {
   int addObjectByHandle(const std::string& objectLibHandle,
                         scene::SceneNode* attachmentNode = nullptr,
                         const std::string& lightSetupKey =
-                            assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+                            metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
                         int sceneID = 0);
 
   /**
@@ -779,7 +779,8 @@ class Simulator {
    * @param key The string key of the @ref gfx::LightSetup.
    */
   gfx::LightSetup getLightSetup(
-      const std::string& key = assets::ResourceManager::DEFAULT_LIGHTING_KEY);
+      const std::string& key =
+          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Register a @ref gfx::LightSetup with a key name.
@@ -790,9 +791,9 @@ class Simulator {
    * @param lightSetup The @ref gfx::LightSetup this key will now reference.
    * @param key Key to identify this @ref gfx::LightSetup.
    */
-  void setLightSetup(
-      gfx::LightSetup lightSetup,
-      const std::string& key = assets::ResourceManager::DEFAULT_LIGHTING_KEY);
+  void setLightSetup(gfx::LightSetup lightSetup,
+                     const std::string& key =
+                         metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Set the light setup of an object

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -5,8 +5,7 @@
 #ifndef ESP_SIM_SIMULATORCONFIGURATION_H_
 #define ESP_SIM_SIMULATORCONFIGURATION_H_
 
-#include "esp/assets/ResourceManager.h"
-#include "esp/physics/configure.h"
+#include "esp/metadata/MetadataMediator.h"
 
 namespace esp {
 namespace sim {
@@ -54,7 +53,7 @@ struct SimulatorConfiguration {
    */
   std::string sceneDatasetConfigFile = "default";
   /** @brief Light setup key for scene */
-  std::string sceneLightSetup = assets::ResourceManager::NO_LIGHT_KEY;
+  std::string sceneLightSetup = metadata::MetadataMediator::NO_LIGHT_KEY;
 
   ESP_SMART_POINTERS(SimulatorConfiguration)
 };

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -89,8 +89,8 @@ void DrawableTest::addRemoveDrawables() {
   // add a toy box here!
   node.addFeature<esp::gfx::GenericDrawable>(
       box, meshAttributeFlags, resourceManager_->getShaderManager(),
-      esp::assets::ResourceManager::NO_LIGHT_KEY,
-      esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
+      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       drawableGroup_);
   // we already had 5 boxes in the scene, so the id for the above toy box must
   // be 5
@@ -102,8 +102,8 @@ void DrawableTest::addRemoveDrawables() {
       box,
       meshAttributeFlags,
       resourceManager_->getShaderManager(),
-      esp::assets::ResourceManager::NO_LIGHT_KEY,
-      esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
+      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       drawableGroup_};
 
   // we already had 5 boxes in the scene, 1 toy box added before the current
@@ -118,8 +118,8 @@ void DrawableTest::addRemoveDrawables() {
       box,
       meshAttributeFlags,
       resourceManager_->getShaderManager(),
-      esp::assets::ResourceManager::NO_LIGHT_KEY,
-      esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
+      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       nullptr};
   // it has NOT been added to this group, so it should not find it!
   CORRADE_VERIFY(!drawableGroup_->hasDrawable(dr->getDrawableId()));
@@ -145,8 +145,8 @@ void DrawableTest::addRemoveDrawables() {
       box,
       meshAttributeFlags,
       resourceManager_->getShaderManager(),
-      esp::assets::ResourceManager::NO_LIGHT_KEY,
-      esp::assets::ResourceManager::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
+      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       nullptr};
   drawableGroup_->remove(*dr);
   CORRADE_VERIFY(!drawableGroup_->hasDrawable(dr->getDrawableId()));

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -28,6 +28,7 @@ using esp::assets::ResourceManager;
 using esp::gfx::LightInfo;
 using esp::gfx::LightPositionModel;
 using esp::gfx::LightSetup;
+using esp::metadata::MetadataMediator;
 using esp::metadata::attributes::AbstractPrimitiveAttributes;
 using esp::metadata::attributes::ObjectAttributes;
 using esp::nav::PathFinder;
@@ -62,7 +63,7 @@ struct SimTest : Cr::TestSuite::Tester {
 
   Simulator::uptr getSimulator(
       const std::string& scene,
-      const std::string& sceneLightingKey = ResourceManager::NO_LIGHT_KEY) {
+      const std::string& sceneLightingKey = MetadataMediator::NO_LIGHT_KEY) {
     SimulatorConfiguration simConfig{};
     simConfig.activeSceneID = scene;
     simConfig.enablePhysics = true;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -397,7 +397,7 @@ Viewer::Viewer(const Arguments& arguments)
   if (args.isSet("stage-requires-lighting")) {
     Mn::Debug{} << "Stage using DEFAULT_LIGHTING_KEY";
     simConfig.sceneLightSetup =
-        esp::assets::ResourceManager::DEFAULT_LIGHTING_KEY;
+        esp::metadata::MetadataMediator::DEFAULT_LIGHTING_KEY;
   }
 
   // setup the PhysicsManager config file


### PR DESCRIPTION
## Motivation and Context
ResourceManager defined static const string keys to be used for default lighting and material entries in ShaderManager.  With the advent of MetadataMediator, which was designed specifically to be able to exist independent of a Simulator instance, these keys may be required by attributes templates when ResourceManager does not exist.  This PR moves these keys from ResourceManager to MetadataMediator.  There should be no impact on any python code since these values are accessed via python bindings, which have not changed.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Existing c++ and python tests passed.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
