### PR TITLE
--[Refactor/BugFix] Move global default const string resource keys to esp.h

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -205,8 +205,7 @@ bool ResourceManager::loadStage(
         flags |= RenderAssetInstanceCreationInfo::Flag::IsStatic;
       }
       RenderAssetInstanceCreationInfo creation(
-          semanticStageFilename, Cr::Containers::NullOpt, flags,
-          metadata::MetadataMediator::NO_LIGHT_KEY);
+          semanticStageFilename, Cr::Containers::NullOpt, flags, NO_LIGHT_KEY);
 
       bool semanticStageSuccess =
           loadStageInternal(semanticInfo,  // AssetInfo
@@ -936,10 +935,9 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
 #ifdef ESP_BUILD_PTEX_SUPPORT
-  ASSERT(!creation.scale);  // PTex doesn't support scale
-  ASSERT(creation.lightSetupKey ==
-         metadata::MetadataMediator::NO_LIGHT_KEY);  // PTex doesn't support
-                                                     // lighting
+  ASSERT(!creation.scale);                         // PTex doesn't support scale
+  ASSERT(creation.lightSetupKey == NO_LIGHT_KEY);  // PTex doesn't support
+                                                   // lighting
 
   const std::string& filename = creation.filepath;
   const LoadedAssetData& loadedAssetData = resourceDict_.at(creation.filepath);
@@ -1034,9 +1032,8 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceIMesh(
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
   ASSERT(!creation.scale);  // IMesh doesn't support scale
-  ASSERT(creation.lightSetupKey ==
-         metadata::MetadataMediator::NO_LIGHT_KEY);  // IMesh doesn't support
-                                                     // lighting
+  ASSERT(creation.lightSetupKey == NO_LIGHT_KEY);  // IMesh doesn't support
+                                                   // lighting
 
   const bool computeAbsoluteAABBs = creation.isStatic();
 
@@ -1060,13 +1057,11 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceIMesh(
     // meshes_.at(iMesh)->getMeshData()->hasAttribute(Mn::Trade::MeshAttribute::Tangent)
     // It will SEGFAULT!
     createDrawable(*(meshes_.at(iMesh)->getMagnumGLMesh()),  // render mesh
-                   meshAttributeFlags,      // mesh attribute flags
-                   node,                    // scene node
-                   creation.lightSetupKey,  // lightSetup key
-                   metadata::MetadataMediator::
-                       PER_VERTEX_OBJECT_ID_MATERIAL_KEY,  // material
-                                                           // key
-                   drawables);                             // drawable group
+                   meshAttributeFlags,                 // mesh attribute flags
+                   node,                               // scene node
+                   creation.lightSetupKey,             // lightSetup key
+                   PER_VERTEX_OBJECT_ID_MATERIAL_KEY,  // material key
+                   drawables);                         // drawable group
 
     if (computeAbsoluteAABBs) {
       staticDrawableInfo.emplace_back(StaticDrawableInfo{node, iMesh});
@@ -1922,7 +1917,7 @@ void ResourceManager::addComponent(
     Mn::ResourceKey materialKey;
     if (materialIDLocal == ID_UNDEFINED ||
         metaData.materialIndex.second == ID_UNDEFINED) {
-      materialKey = metadata::MetadataMediator::DEFAULT_MATERIAL_KEY;
+      materialKey = DEFAULT_MATERIAL_KEY;
     } else {
       materialKey =
           std::to_string(metaData.materialIndex.first + materialIDLocal);
@@ -1977,13 +1972,12 @@ void ResourceManager::addPrimitiveToDrawables(int primitiveID,
   // so do not need to worry about the tangent or bitangent.
   // it might be changed in the future.
   gfx::Drawable::Flags meshAttributeFlags{};
-  createDrawable(
-      *primitive_meshes_.at(primitiveID),              // render mesh
-      meshAttributeFlags,                              // meshAttributeFlags
-      node,                                            // scene node
-      metadata::MetadataMediator::NO_LIGHT_KEY,        // lightSetup key
-      metadata::MetadataMediator::WHITE_MATERIAL_KEY,  // material key
-      drawables);                                      // drawable group
+  createDrawable(*primitive_meshes_.at(primitiveID),  // render mesh
+                 meshAttributeFlags,                  // meshAttributeFlags
+                 node,                                // scene node
+                 NO_LIGHT_KEY,                        // lightSetup key
+                 WHITE_MATERIAL_KEY,                  // material key
+                 drawables);                          // drawable group
 }
 
 void ResourceManager::removePrimitiveMesh(int primitiveID) {
@@ -2069,8 +2063,7 @@ bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,
           flags |= RenderAssetInstanceCreationInfo::Flag::IsRGBD;
           flags |= RenderAssetInstanceCreationInfo::Flag::IsSemantic;
           RenderAssetInstanceCreationInfo objectCreation(
-              info.filepath, Cr::Containers::NullOpt, flags,
-              metadata::MetadataMediator::NO_LIGHT_KEY);
+              info.filepath, Cr::Containers::NullOpt, flags, NO_LIGHT_KEY);
           createRenderAssetInstance(objectCreation, &objectNode, drawables);
         }
         return objectNode;
@@ -2126,26 +2119,22 @@ bool ResourceManager::loadSUNCGHouseFile(const AssetInfo& houseInfo,
   return true;
 }
 void ResourceManager::initDefaultLightSetups() {
-  shaderManager_.set(metadata::MetadataMediator::NO_LIGHT_KEY,
-                     gfx::LightSetup{});
+  shaderManager_.set(NO_LIGHT_KEY, gfx::LightSetup{});
   shaderManager_.setFallback(gfx::LightSetup{});
 }
 
 void ResourceManager::initDefaultMaterials() {
-  shaderManager_.set<gfx::MaterialData>(
-      metadata::MetadataMediator::DEFAULT_MATERIAL_KEY,
-      new gfx::PhongMaterialData{});
+  shaderManager_.set<gfx::MaterialData>(DEFAULT_MATERIAL_KEY,
+                                        new gfx::PhongMaterialData{});
   auto whiteMaterialData = new gfx::PhongMaterialData;
   whiteMaterialData->ambientColor = Magnum::Color4{1.0};
-  shaderManager_.set<gfx::MaterialData>(
-      metadata::MetadataMediator::WHITE_MATERIAL_KEY, whiteMaterialData);
+  shaderManager_.set<gfx::MaterialData>(WHITE_MATERIAL_KEY, whiteMaterialData);
   auto perVertexObjectId = new gfx::PhongMaterialData{};
   perVertexObjectId->perVertexObjectId = true;
   perVertexObjectId->vertexColored = true;
   perVertexObjectId->ambientColor = Mn::Color4{1.0};
-  shaderManager_.set<gfx::MaterialData>(
-      metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
-      perVertexObjectId);
+  shaderManager_.set<gfx::MaterialData>(PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+                                        perVertexObjectId);
   shaderManager_.setFallback<gfx::MaterialData>(new gfx::PhongMaterialData{});
 }
 
@@ -2154,8 +2143,7 @@ bool ResourceManager::isLightSetupCompatible(
     const Magnum::ResourceKey& lightSetupKey) const {
   // if light setup has lights in it, but asset was loaded in as flat shaded,
   // there may be an error when rendering.
-  return lightSetupKey ==
-             Mn::ResourceKey{metadata::MetadataMediator::NO_LIGHT_KEY} ||
+  return lightSetupKey == Mn::ResourceKey{NO_LIGHT_KEY} ||
          loadedAssetData.assetInfo.requiresLighting;
 }
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -288,8 +288,7 @@ class ResourceManager {
    * @brief Get a named @ref LightSetup
    */
   Mn::Resource<gfx::LightSetup> getLightSetup(
-      const Mn::ResourceKey& key = Mn::ResourceKey{
-          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY}) {
+      const Mn::ResourceKey& key = Mn::ResourceKey{DEFAULT_LIGHTING_KEY}) {
     return shaderManager_.get<gfx::LightSetup>(key);
   }
 
@@ -304,7 +303,7 @@ class ResourceManager {
    */
   void setLightSetup(gfx::LightSetup setup,
                      const Mn::ResourceKey& key = Mn::ResourceKey{
-                         metadata::MetadataMediator::DEFAULT_LIGHTING_KEY}) {
+                         DEFAULT_LIGHTING_KEY}) {
     shaderManager_.set(key, std::move(setup), Mn::ResourceDataState::Mutable,
                        Mn::ResourcePolicy::Manual);
   }
@@ -347,8 +346,7 @@ class ResourceManager {
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>& visNodeCache,
-      const std::string& lightSetupKey =
-          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY) {
+      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY) {
     if (objTemplateLibID != ID_UNDEFINED) {
       const std::string& objTemplateHandleName =
           metadataMediator_->getObjectAttributesManager()->getObjectHandleByID(
@@ -385,8 +383,7 @@ class ResourceManager {
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>& visNodeCache,
-      const std::string& lightSetupKey =
-          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
+      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Create a new drawable primitive attached to the desired @ref

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -166,9 +166,8 @@ void initGfxBindings(py::module& m) {
       .def(py::self == py::self)
       .def(py::self != py::self);
 
-  m.attr("DEFAULT_LIGHTING_KEY") =
-      metadata::MetadataMediator::DEFAULT_LIGHTING_KEY;
-  m.attr("NO_LIGHT_KEY") = metadata::MetadataMediator::NO_LIGHT_KEY;
+  m.attr("DEFAULT_LIGHTING_KEY") = DEFAULT_LIGHTING_KEY;
+  m.attr("NO_LIGHT_KEY") = NO_LIGHT_KEY;
 }
 
 }  // namespace gfx

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -125,16 +125,12 @@ void initSimBindings(py::module& m) {
       .def(
           "add_object", &Simulator::addObject, "object_lib_id"_a,
           "attachment_node"_a = nullptr,
-          "light_setup_key"_a =
-              metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
-          "scene_id"_a = 0,
+          "light_setup_key"_a = DEFAULT_LIGHTING_KEY, "scene_id"_a = 0,
           R"(Instance an object into the scene via a template referenced by library id. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
       .def(
           "add_object_by_handle", &Simulator::addObjectByHandle,
           "object_lib_handle"_a, "attachment_node"_a = nullptr,
-          "light_setup_key"_a =
-              metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
-          "scene_id"_a = 0,
+          "light_setup_key"_a = DEFAULT_LIGHTING_KEY, "scene_id"_a = 0,
           R"(Instance an object into the scene via a template referenced by its handle. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
       .def("remove_object", &Simulator::removeObject, "object_id"_a,
            "delete_object_node"_a = true, "delete_visual_node"_a = true,
@@ -280,11 +276,11 @@ void initSimBindings(py::module& m) {
               smooth : (Bool) whether or not to smooth trajectory using a Catmull-Rom spline interpolating spline.
               num_interpolations : (Integer) the number of interpolation points to find between successive key points.)")
       .def("get_light_setup", &Simulator::getLightSetup,
-           "key"_a = metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
+           "key"_a = DEFAULT_LIGHTING_KEY,
            R"(Get a copy of the LightSetup registered with a specific key.)")
       .def(
           "set_light_setup", &Simulator::setLightSetup, "light_setup"_a,
-          "key"_a = metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
+          "key"_a = DEFAULT_LIGHTING_KEY,
           R"(Register a LightSetup with a specific key. If a LightSetup is already registered with this key, it will be overriden. All Drawables referencing the key will use the newly registered LightSetup.)")
       .def(
           "set_object_light_setup", &Simulator::setObjectLightSetup,

--- a/src/esp/core/esp.h
+++ b/src/esp/core/esp.h
@@ -150,6 +150,33 @@ constexpr double PHYSICS_ATTR_UNDEFINED = -1.0;
 
 static const double NO_TIME = 0.0;
 
+/**
+ * @brief The @ref ShaderManager key for @ref LightInfo which has no lights
+ */
+constexpr char NO_LIGHT_KEY[] = "no_lights";
+
+/**
+ *@brief The @ref ShaderManager key for the default @ref LightInfo
+ */
+constexpr char DEFAULT_LIGHTING_KEY[] = "";
+
+/**
+ *@brief The @ref ShaderManager key for the default @ref MaterialInfo
+ */
+constexpr char DEFAULT_MATERIAL_KEY[] = "";
+
+/**
+ *@brief The @ref ShaderManager key for full ambient white @ref MaterialInfo
+ *used for primitive wire-meshes
+ */
+constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
+
+/**
+ *@brief The @ref ShaderManager key for @ref MaterialInfo with per-vertex
+ * object ID
+ */
+constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] = "per_vertex_object_id";
+
 template <typename T>
 inline bool equal(const std::vector<std::shared_ptr<T>>& a,
                   const std::vector<std::shared_ptr<T>>& b) {

--- a/src/esp/core/esp.h
+++ b/src/esp/core/esp.h
@@ -151,23 +151,26 @@ constexpr double PHYSICS_ATTR_UNDEFINED = -1.0;
 static const double NO_TIME = 0.0;
 
 /**
- * @brief The @ref ShaderManager key for @ref LightInfo which has no lights
+ * @brief The @ref esp::gfx::ShaderManager key for @ref esp::gfx::LightInfo
+ * which has no lights
  */
 constexpr char NO_LIGHT_KEY[] = "no_lights";
 
 /**
- *@brief The @ref ShaderManager key for the default @ref LightInfo
+ *@brief The @ref esp::gfx::ShaderManager key for the default @ref
+ *esp::gfx::LightInfo
  */
 constexpr char DEFAULT_LIGHTING_KEY[] = "";
 
 /**
- *@brief The @ref ShaderManager key for the default @ref MaterialInfo
+ *@brief The @ref esp::gfx::ShaderManager key for the default @ref
+ *esp::gfx::MaterialInfo
  */
 constexpr char DEFAULT_MATERIAL_KEY[] = "";
 
 /**
- *@brief The @ref ShaderManager key for full ambient white @ref MaterialInfo
- *used for primitive wire-meshes
+ *@brief The @ref esp::gfx::ShaderManager key for full ambient white @ref
+ *esp::gfx::MaterialInfo used for primitive wire-meshes
  */
 constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
 

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -7,13 +7,6 @@
 namespace esp {
 namespace metadata {
 
-// static constexpr arrays require redundant definitions until C++17
-constexpr char MetadataMediator::NO_LIGHT_KEY[];
-constexpr char MetadataMediator::DEFAULT_LIGHTING_KEY[];
-constexpr char MetadataMediator::DEFAULT_MATERIAL_KEY[];
-constexpr char MetadataMediator::WHITE_MATERIAL_KEY[];
-constexpr char MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY[];
-
 void MetadataMediator::buildAttributesManagers() {
   physicsAttributesManager_ = managers::PhysicsAttributesManager::create();
   sceneDatasetAttributesManager_ =

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -22,34 +22,6 @@ namespace esp {
 namespace metadata {
 class MetadataMediator {
  public:
-  /**
-   * @brief The @ref ShaderManager key for @ref LightInfo which has no lights
-   */
-  static constexpr char NO_LIGHT_KEY[] = "no_lights";
-
-  /**
-   *@brief The @ref ShaderManager key for the default @ref LightInfo
-   */
-  static constexpr char DEFAULT_LIGHTING_KEY[] = "";
-
-  /**
-   *@brief The @ref ShaderManager key for the default @ref MaterialInfo
-   */
-  static constexpr char DEFAULT_MATERIAL_KEY[] = "";
-
-  /**
-   *@brief The @ref ShaderManager key for full ambient white @ref MaterialInfo
-   *used for primitive wire-meshes
-   */
-  static constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
-
-  /**
-   *@brief The @ref ShaderManager key for @ref MaterialInfo with per-vertex
-   * object ID
-   */
-  static constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] =
-      "per_vertex_object_id";
-
   MetadataMediator(const std::string& _defaultSceneDataset = "default")
       : activeSceneDataset_(_defaultSceneDataset) {
     buildAttributesManagers();

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -30,7 +30,7 @@ StageAttributesManager::StageAttributesManager(
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),
-      cfgLightSetup_(metadata::MetadataMediator::NO_LIGHT_KEY) {
+      cfgLightSetup_(NO_LIGHT_KEY) {
   buildCtorFuncPtrMaps();
 }  // StageAttributesManager ctor
 
@@ -188,8 +188,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
   // set defaults from SimulatorConfig values; these can also be overridden by
   // json, for example.
   newAttributes->setLightSetup(cfgLightSetup_);
-  newAttributes->setRequiresLighting(cfgLightSetup_ !=
-                                     metadata::MetadataMediator::NO_LIGHT_KEY);
+  newAttributes->setRequiresLighting(cfgLightSetup_ != NO_LIGHT_KEY);
   // set value from config so not necessary to be passed as argument
   newAttributes->setFrustumCulling(cfgFrustumCulling_);
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -181,8 +181,7 @@ class PhysicsManager {
   int addObject(const std::string& configFile,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup =
-                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
@@ -199,8 +198,7 @@ class PhysicsManager {
   int addObject(const int objectLibId,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup =
-                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -179,8 +179,7 @@ class Simulator {
    */
   int addObject(int objectLibId,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetupKey =
-                    metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
+                const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY,
                 int sceneID = 0);
 
   /**
@@ -201,8 +200,7 @@ class Simulator {
    */
   int addObjectByHandle(const std::string& objectLibHandle,
                         scene::SceneNode* attachmentNode = nullptr,
-                        const std::string& lightSetupKey =
-                            metadata::MetadataMediator::DEFAULT_LIGHTING_KEY,
+                        const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY,
                         int sceneID = 0);
 
   /**
@@ -778,9 +776,7 @@ class Simulator {
    *
    * @param key The string key of the @ref gfx::LightSetup.
    */
-  gfx::LightSetup getLightSetup(
-      const std::string& key =
-          metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
+  gfx::LightSetup getLightSetup(const std::string& key = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Register a @ref gfx::LightSetup with a key name.
@@ -792,8 +788,7 @@ class Simulator {
    * @param key Key to identify this @ref gfx::LightSetup.
    */
   void setLightSetup(gfx::LightSetup lightSetup,
-                     const std::string& key =
-                         metadata::MetadataMediator::DEFAULT_LIGHTING_KEY);
+                     const std::string& key = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Set the light setup of an object

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -5,11 +5,14 @@
 #ifndef ESP_SIM_SIMULATORCONFIGURATION_H_
 #define ESP_SIM_SIMULATORCONFIGURATION_H_
 
-#include "esp/metadata/MetadataMediator.h"
+#include <string>
+
+#include "esp/core/esp.h"
+#include "esp/physics/configure.h"
 
 namespace esp {
-namespace sim {
 
+namespace sim {
 struct SimulatorConfiguration {
   /**
    * @brief Name of scene or stage config or asset to load
@@ -53,7 +56,7 @@ struct SimulatorConfiguration {
    */
   std::string sceneDatasetConfigFile = "default";
   /** @brief Light setup key for scene */
-  std::string sceneLightSetup = metadata::MetadataMediator::NO_LIGHT_KEY;
+  std::string sceneLightSetup = esp::NO_LIGHT_KEY;
 
   ESP_SMART_POINTERS(SimulatorConfiguration)
 };

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -89,22 +89,21 @@ void DrawableTest::addRemoveDrawables() {
   // add a toy box here!
   node.addFeature<esp::gfx::GenericDrawable>(
       box, meshAttributeFlags, resourceManager_->getShaderManager(),
-      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
-      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+      esp::NO_LIGHT_KEY, esp::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       drawableGroup_);
   // we already had 5 boxes in the scene, so the id for the above toy box must
   // be 5
   int toyBoxId = 5;
 
   // step 1: basic tests
-  esp::gfx::GenericDrawable* dr = new esp::gfx::GenericDrawable{
-      node,
-      box,
-      meshAttributeFlags,
-      resourceManager_->getShaderManager(),
-      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
-      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
-      drawableGroup_};
+  esp::gfx::GenericDrawable* dr =
+      new esp::gfx::GenericDrawable{node,
+                                    box,
+                                    meshAttributeFlags,
+                                    resourceManager_->getShaderManager(),
+                                    esp::NO_LIGHT_KEY,
+                                    esp::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+                                    drawableGroup_};
 
   // we already had 5 boxes in the scene, 1 toy box added before the current
   // one, so the id should be 6
@@ -113,14 +112,13 @@ void DrawableTest::addRemoveDrawables() {
   CORRADE_VERIFY(dr->drawables() == drawableGroup_);
 
   // step 2: add a single drawable to a group
-  dr = new esp::gfx::GenericDrawable{
-      node,
-      box,
-      meshAttributeFlags,
-      resourceManager_->getShaderManager(),
-      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
-      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
-      nullptr};
+  dr = new esp::gfx::GenericDrawable{node,
+                                     box,
+                                     meshAttributeFlags,
+                                     resourceManager_->getShaderManager(),
+                                     esp::NO_LIGHT_KEY,
+                                     esp::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+                                     nullptr};
   // it has NOT been added to this group, so it should not find it!
   CORRADE_VERIFY(!drawableGroup_->hasDrawable(dr->getDrawableId()));
   drawableGroup_->add(*dr);
@@ -140,14 +138,13 @@ void DrawableTest::addRemoveDrawables() {
   CORRADE_VERIFY(!drawableGroup_->hasDrawable(toyBoxId));
 
   // step 5: remove a drawable, that is NOT in the group! should be fine!!
-  dr = new esp::gfx::GenericDrawable{
-      node,
-      box,
-      meshAttributeFlags,
-      resourceManager_->getShaderManager(),
-      esp::metadata::MetadataMediator::NO_LIGHT_KEY,
-      esp::metadata::MetadataMediator::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
-      nullptr};
+  dr = new esp::gfx::GenericDrawable{node,
+                                     box,
+                                     meshAttributeFlags,
+                                     resourceManager_->getShaderManager(),
+                                     esp::NO_LIGHT_KEY,
+                                     esp::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
+                                     nullptr};
   drawableGroup_->remove(*dr);
   CORRADE_VERIFY(!drawableGroup_->hasDrawable(dr->getDrawableId()));
 }

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -63,7 +63,7 @@ struct SimTest : Cr::TestSuite::Tester {
 
   Simulator::uptr getSimulator(
       const std::string& scene,
-      const std::string& sceneLightingKey = MetadataMediator::NO_LIGHT_KEY) {
+      const std::string& sceneLightingKey = esp::NO_LIGHT_KEY) {
     SimulatorConfiguration simConfig{};
     simConfig.activeSceneID = scene;
     simConfig.enablePhysics = true;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -396,8 +396,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig.requiresTextures = true;
   if (args.isSet("stage-requires-lighting")) {
     Mn::Debug{} << "Stage using DEFAULT_LIGHTING_KEY";
-    simConfig.sceneLightSetup =
-        esp::metadata::MetadataMediator::DEFAULT_LIGHTING_KEY;
+    simConfig.sceneLightSetup = esp::DEFAULT_LIGHTING_KEY;
   }
 
   // setup the PhysicsManager config file


### PR DESCRIPTION
## Motivation and Context
[Please see this previous PR](https://github.com/facebookresearch/habitat-sim/pull/966).  Moving the default string constants created a difficulty with the implementation of the scene import functionality where SceneConfiguration could not be easily referenced within MetadataMediator; Furthermore, precedent has been set to have constants in esp.h (with esp::ID_UNDEFINED).  This PR moves these keys to their hopefully final home, in esp.h.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing cpp and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
