### PR TITLE
viewer: avoid std::exit(), it's not doing nice things to the codebase

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -903,7 +903,12 @@ void Viewer::keyPressEvent(KeyEvent& event) {
   const auto key = event.key();
   switch (key) {
     case KeyEvent::Key::Esc:
-      std::exit(0);
+      /* Using Application::exit(), which exits at the next iteration of the
+         event loop (same as the window close button would do). Using
+         std::exit() would exit immediately, but without calling any scoped
+         destructors, which could hide potential destruction order issues or
+         crashes at exit. We don't want that. */
+      exit(0);
       break;
     case KeyEvent::Key::Space:
       simulating_ = !simulating_;


### PR DESCRIPTION
## Motivation and Context

Uncovered while @bigbike was debugging a crash on exit, which happened only when closing the window via the close button and not via pressing <kbd>Esc</kbd>. This is why.

I switched to [Application::exit()](https://doc.magnum.graphics/magnum/classMagnum_1_1Platform_1_1GlfwApplication.html#a7de5fd1778375d52c93d8ee50495684c), which exits at the next iteration of the event loop (same as the window close button would do). Using `std::exit()` would exit immediately, but without calling any scoped destructors, which could hide potential destruction order issues or crashes at exit. We don't want that.

## How Has This Been Tested

I had more than enough pain with CIs this week, so I hope this won't add more to the pile. :fire: 
