### PR TITLE
rapidjson serialization and refactor

### DIFF
--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -26,6 +26,8 @@ struct RenderAssetInstanceCreationInfo {
   };
   typedef Corrade::Containers::EnumSet<Flag> Flags;
 
+  RenderAssetInstanceCreationInfo() = default;
+
   RenderAssetInstanceCreationInfo(
       const std::string& _filepath,
       const Corrade::Containers::Optional<Magnum::Vector3>& _scale,

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -6,6 +6,7 @@
 
 #include "esp/assets/ResourceManager.h"
 #include "esp/core/esp.h"
+#include "esp/io/JsonAllTypes.h"
 
 #include <rapidjson/document.h>
 
@@ -13,12 +14,9 @@ namespace esp {
 namespace gfx {
 namespace replay {
 
-void Player::readKeyframesFromJsonDocument(const rapidjson::Document&) {
-  LOG(WARNING) << "Player::readKeyframesFromJsonDocument: not implemented";
-#if 0  // coming soon
+void Player::readKeyframesFromJsonDocument(const rapidjson::Document& d) {
   ASSERT(keyframes_.empty());
-  esp::io::ReadMember(d, "keyframes", keyframes_);
-#endif
+  esp::io::readMember(d, "keyframes", keyframes_);
 }
 
 Player::Player(const LoadAndCreateRenderAssetInstanceCallback& callback)

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -5,6 +5,7 @@
 #include "Recorder.h"
 
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
+#include "esp/io/JsonAllTypes.h"
 #include "esp/io/json.h"
 #include "esp/scene/SceneNode.h"
 
@@ -172,20 +173,16 @@ void Recorder::writeSavedKeyframesToFile(const std::string& filepath) {
 }
 
 rapidjson::Document Recorder::writeKeyframesToJsonDocument() {
-  LOG(WARNING) << "Recorder::writeKeyframesToJsonDocument: not implemented";
-  return rapidjson::Document();
-#if 0  // coming soon
   if (savedKeyframes_.empty()) {
     LOG(WARNING) << "Recorder::writeKeyframesToJsonDocument: no saved "
                     "keyframes to write";
     return rapidjson::Document();
   }
 
-  Document d(kObjectType);
-  Document::AllocatorType& allocator = d.GetAllocator();
-  esp::io::AddMember(d, "keyframes", savedKeyframes_, allocator);
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  esp::io::addMember(d, "keyframes", savedKeyframes_, allocator);
   return d;
-#endif
 }
 
 }  // namespace replay

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -1,6 +1,15 @@
 add_library(
   io STATIC
-  io.cpp io.h json.cpp json.h
+  io.cpp
+  io.h
+  json.cpp
+  json.h
+  JsonAllTypes.h
+  JsonBuiltinTypes.h
+  JsonEspTypes.cpp
+  JsonEspTypes.h
+  JsonMagnumTypes.h
+  JsonStlTypes.h
 )
 
 target_link_libraries(

--- a/src/esp/io/JsonAllTypes.h
+++ b/src/esp/io/JsonAllTypes.h
@@ -1,0 +1,74 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONALLTYPES_H_
+#define ESP_IO_JSONALLTYPES_H_
+
+/** @file
+ * @brief Include file for all helper functions for serializing types to
+ * rapidjson.
+ *
+ * These helpers are designed so that every builtin type and user type can be
+ * serialized/deserialized with esp::io::addMember/readMember. The leads to
+ * uniform and readable serialization code. To achieve this, every user type
+ * defines toJsonValue/fromJsonValue, and then template versions of
+ * addMember/readMember will automatically use these.
+ *
+ * toJsonValue/fromJsonValue for all types should go in the headers below. If
+ * the implementation is short, prefer an inline definition (for brevity). If
+ * the implementation is long, prefer a separate definition in the corresponding
+ * cpp.
+ *
+ * See IOTest.cpp for example usage.
+ */
+
+#include "JsonBuiltinTypes.h"
+#include "JsonEspTypes.h"
+#include "JsonMagnumTypes.h"
+#include "JsonStlTypes.h"
+
+namespace esp {
+namespace io {
+
+// These were declared in JsonBuiltinTypes.h. The definitions are placed here,
+// after all type-specific toJsonValue/fromJsonValue definitions. The quirky
+// ordering is to ensure these definitions see the correct versions of
+// toJsonValue/fromJsonValue for the template type objects.
+
+template <typename T>
+inline JsonGenericValue toJsonArrayHelper(const T* objects,
+                                          int count,
+                                          JsonAllocator& allocator) {
+  JsonGenericValue arr(rapidjson::kArrayType);
+  for (int i = 0; i < count; i++) {
+    arr.PushBack(toJsonValue(objects[i], allocator), allocator);
+  }
+  return arr;
+}
+
+template <typename T>
+void addMember(rapidjson::Value& value,
+               rapidjson::GenericStringRef<char> name,
+               const T& obj,
+               JsonAllocator& allocator) {
+  addMember(value, name, toJsonValue(obj, allocator), allocator);
+}
+
+template <typename T>
+bool readMember(const rapidjson::Value& value, const char* tag, T& x) {
+  if (!value.HasMember(tag)) {
+    // return false but don't log an error
+    return false;
+  }
+  if (!fromJsonValue(value[tag], x)) {
+    LOG(ERROR) << "Failed to parse JSON tag \"" << tag << "\"";
+    return false;
+  }
+  return true;
+}
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/JsonBuiltinTypes.h
+++ b/src/esp/io/JsonBuiltinTypes.h
@@ -16,6 +16,7 @@
 #include <rapidjson/document.h>
 
 #include <string>
+#include <typeinfo>
 
 namespace esp {
 namespace io {

--- a/src/esp/io/JsonBuiltinTypes.h
+++ b/src/esp/io/JsonBuiltinTypes.h
@@ -1,0 +1,285 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONBUILTINTYPES_H_
+#define ESP_IO_JSONBUILTINTYPES_H_
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "esp/core/logging.h"
+
+#include <Corrade/Utility/Macros.h>
+
+#include <rapidjson/document.h>
+
+#include <string>
+
+namespace esp {
+namespace io {
+
+// Make these types easier to read/type. We'll use them everywhere.
+typedef rapidjson::GenericValue<rapidjson::UTF8<> > JsonGenericValue;
+typedef rapidjson::MemoryPoolAllocator<> JsonAllocator;
+
+// template addMember/readMember to match any type. These are declared here,
+// before all toJsonValue/fromJsonValue definitions, and they are defined
+// later in JsonBuiltinTypes.hpp. The quirky ordering is to avoid some compile
+// errors.
+
+template <typename T>
+void addMember(JsonGenericValue& value,
+               rapidjson::GenericStringRef<char> name,
+               const T& obj,
+               JsonAllocator& allocator);
+
+template <typename T>
+bool readMember(const JsonGenericValue& value, const char* name, T& x);
+
+/**
+ * @brief Fallback implementation for fromJsonValue to produce a runtime error
+ * for types that haven't implemented fromJsonValue.
+ */
+template <typename T>
+bool fromJsonValue(CORRADE_UNUSED const JsonGenericValue& obj,
+                   CORRADE_UNUSED T& val) {
+  // If you've already implemented fromJsonValue for your type and you're still
+  // hitting this, the underlying issue might be the ordering among json helper
+  // definitions.
+  LOG(ERROR) << "Unsupported type. Aborting. You need to implement "
+                "fromJsonValue for typeid(T).name() = "
+             << typeid(T).name() << ".";
+  return false;
+}
+
+/**
+ * @brief Fallback implementation for toJsonValue to produce a runtime error for
+ * types that haven't implemented toJsonValue.
+ */
+template <typename T>
+JsonGenericValue toJsonValue(const T&, JsonAllocator&) {
+  // If you've already implemented toJsonValue for your type and you're still
+  // hitting this, the underlying issue might be the ordering among json helper
+  // definitions.
+  LOG(ERROR) << "Unsupported type. Aborting. You need to implement toJsonValue "
+                "for typeid(T).name() = "
+             << typeid(T).name() << ".";
+  return JsonGenericValue(rapidjson::kObjectType);
+}
+
+// toJsonValue wrappers for the 7 rapidjson builtin types. A JsonGenericValue
+// can be directly constructed from the builtin types.
+
+inline JsonGenericValue toJsonValue(bool x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(int x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(unsigned x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(int64_t x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(uint64_t x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(double x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+inline JsonGenericValue toJsonValue(float x, JsonAllocator&) {
+  return JsonGenericValue(x);
+}
+
+// fromJsonValue wrappers for the 7 rapidjson builtin types
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, bool& val) {
+  if (obj.IsBool()) {
+    val = obj.Get<bool>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid boolean value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, int& val) {
+  if (obj.IsNumber()) {
+    val = obj.Get<int>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid int value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, unsigned& val) {
+  if (obj.IsNumber()) {
+    val = obj.Get<unsigned>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid unsigned int value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, int64_t& val) {
+  if (obj.IsNumber()) {
+    val = obj.Get<int64_t>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid int64_t value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, uint64_t& val) {
+  if (obj.IsNumber()) {
+    val = obj.Get<uint64_t>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid uint64_t value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, double& val) {
+  if (obj.IsNumber()) {
+    val = obj.GetDouble();
+    return true;
+  }
+  LOG(ERROR) << "Invalid double value";
+  return false;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj string tag to look for in json doc
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, float& val) {
+  if (obj.IsNumber()) {
+    val = obj.Get<float>();
+    return true;
+  }
+  LOG(ERROR) << "Invalid float value";
+  return false;
+}
+
+// wrappers intended for enums
+
+template <typename T>
+void addMemberAsUint32(JsonGenericValue& value,
+                       rapidjson::GenericStringRef<char> name,
+                       const T& x,
+                       JsonAllocator& allocator) {
+  static_assert(sizeof(T) == sizeof(uint32_t), "size match");
+  uint32_t xAsUint32 = static_cast<uint32_t>(x);
+  addMember(value, name, xAsUint32, allocator);
+}
+
+template <typename T>
+bool readMemberAsUint32(const JsonGenericValue& value, const char* name, T& x) {
+  static_assert(sizeof(T) == sizeof(uint32_t), "size match");
+  uint32_t xAsUint32;
+  if (readMember(value, name, xAsUint32)) {
+    x = static_cast<T>(xAsUint32);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Helper to convert an array of objects to a json array object.
+ *
+ * Don't use this directly to serialize stl vectors; use addMember(d, "myvec",
+ * myvec, allocator) instead.
+ *
+ * Note there is no corresponding "from" helper because that operation requires
+ * more error-handling and must be done case-by-case.
+ *
+ * @param objects pointer to objects
+ * @param count
+ * @param allocator
+ * @return serialized json value
+ */
+template <typename T>
+inline JsonGenericValue toJsonArrayHelper(const T* objects,
+                                          int count,
+                                          JsonAllocator& allocator);
+
+// wrappers for rapidjson's standard Value type
+
+inline void addMember(JsonGenericValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      JsonGenericValue& child,
+                      JsonAllocator& allocator) {
+  value.AddMember(name, child, allocator);
+}
+
+inline void addMember(JsonGenericValue& value,
+                      rapidjson::GenericStringRef<char> name,
+                      JsonGenericValue&& child,
+                      JsonAllocator& allocator) {
+  value.AddMember(name, child, allocator);
+}
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/JsonEspTypes.cpp
+++ b/src/esp/io/JsonEspTypes.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "JsonAllTypes.h"
+
+namespace esp {
+namespace io {
+
+JsonGenericValue toJsonValue(const esp::gfx::replay::Keyframe& keyframe,
+                             JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+
+  esp::io::addMember(obj, "loads", keyframe.loads, allocator);
+
+  if (!keyframe.creations.empty()) {
+    JsonGenericValue creationsArray(rapidjson::kArrayType);
+    for (const auto& pair : keyframe.creations) {
+      JsonGenericValue creationPairObj(rapidjson::kObjectType);
+      esp::io::addMember(creationPairObj, "instanceKey", pair.first, allocator);
+      esp::io::addMember(creationPairObj, "creation", pair.second, allocator);
+
+      creationsArray.PushBack(creationPairObj, allocator);
+    }
+    esp::io::addMember(obj, "creations", creationsArray, allocator);
+  }
+
+  esp::io::addMember(obj, "deletions", keyframe.deletions, allocator);
+
+  if (!keyframe.stateUpdates.empty()) {
+    JsonGenericValue stateUpdatesArray(rapidjson::kArrayType);
+    for (const auto& pair : keyframe.stateUpdates) {
+      JsonGenericValue stateObj(rapidjson::kObjectType);
+      esp::io::addMember(stateObj, "instanceKey", pair.first, allocator);
+      esp::io::addMember(stateObj, "state", pair.second, allocator);
+      stateUpdatesArray.PushBack(stateObj, allocator);
+    }
+    esp::io::addMember(obj, "stateUpdates", stateUpdatesArray, allocator);
+  }
+
+  if (!keyframe.userTransforms.empty()) {
+    JsonGenericValue userTransformsArray(rapidjson::kArrayType);
+    for (const auto& pair : keyframe.userTransforms) {
+      JsonGenericValue wrapperObj(rapidjson::kObjectType);
+      esp::io::addMember(wrapperObj, "name", pair.first, allocator);
+      esp::io::addMember(wrapperObj, "transform", pair.second, allocator);
+      userTransformsArray.PushBack(wrapperObj, allocator);
+    }
+    esp::io::addMember(obj, "userTransforms", userTransformsArray, allocator);
+  }
+
+  return obj;
+}
+
+bool fromJsonValue(const JsonGenericValue& obj,
+                   esp::gfx::replay::Keyframe& keyframe) {
+  esp::io::readMember(obj, "loads", keyframe.loads);
+
+  auto itr = obj.FindMember("creations");
+  if (itr != obj.MemberEnd()) {
+    const JsonGenericValue& creationsArray = itr->value;
+    keyframe.creations.reserve(creationsArray.Size());
+    for (const auto& creationPairObj : creationsArray.GetArray()) {
+      std::pair<esp::gfx::replay::RenderAssetInstanceKey,
+                esp::assets::RenderAssetInstanceCreationInfo>
+          pair;
+      esp::io::readMember(creationPairObj, "instanceKey", pair.first);
+      esp::io::readMember(creationPairObj, "creation", pair.second);
+      keyframe.creations.emplace_back(std::move(pair));
+    }
+  }
+
+  esp::io::readMember(obj, "deletions", keyframe.deletions);
+
+  itr = obj.FindMember("stateUpdates");
+  if (itr != obj.MemberEnd()) {
+    const JsonGenericValue& stateUpdatesArray = itr->value;
+    keyframe.stateUpdates.reserve(stateUpdatesArray.Size());
+    for (const auto& stateObj : stateUpdatesArray.GetArray()) {
+      std::pair<esp::gfx::replay::RenderAssetInstanceKey,
+                esp::gfx::replay::RenderAssetInstanceState>
+          pair;
+      esp::io::readMember(stateObj, "instanceKey", pair.first);
+      esp::io::readMember(stateObj, "state", pair.second);
+      keyframe.stateUpdates.emplace_back(std::move(pair));
+    }
+  }
+
+  itr = obj.FindMember("userTransforms");
+  if (itr != obj.MemberEnd()) {
+    const JsonGenericValue& userTransformsArray = itr->value;
+    for (const auto& userTransformObj : userTransformsArray.GetArray()) {
+      std::string name;
+      esp::gfx::replay::Transform transform;
+      esp::io::readMember(userTransformObj, "name", name);
+      esp::io::readMember(userTransformObj, "transform", transform);
+      keyframe.userTransforms[name] = transform;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -1,0 +1,161 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONESPTYPES_H_
+#define ESP_IO_JSONESPTYPES_H_
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+#include "JsonMagnumTypes.h"
+
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
+#include "esp/core/esp.h"
+#include "esp/gfx/replay/Keyframe.h"
+
+namespace esp {
+namespace io {
+
+inline JsonGenericValue toJsonValue(const esp::vec3f& vec,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue floatsArray(rapidjson::kArrayType);
+  for (int i = 0; i < vec.size(); i++) {
+    floatsArray.PushBack(vec.data()[i], allocator);
+  }
+  return floatsArray;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& floatsArray,
+                          esp::vec3f& vec) {
+  // TODO: helper for objects that are simply arrays, with error-handling
+  ASSERT(floatsArray.Size() == vec.size());
+  for (int i = 0; i < vec.size(); i++) {
+    vec.data()[i] = floatsArray[i].GetFloat();
+  }
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(const esp::geo::CoordinateFrame& frame,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "up", frame.up(), allocator);
+  addMember(obj, "front", frame.front(), allocator);
+  addMember(obj, "origin", frame.origin(), allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::geo::CoordinateFrame& frame) {
+  esp::vec3f up;
+  esp::vec3f front;
+  esp::vec3f origin;
+  readMember(obj, "up", up);
+  readMember(obj, "front", front);
+  readMember(obj, "origin", origin);
+  frame = esp::geo::CoordinateFrame(up, front, origin);
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(const esp::assets::AssetInfo& x,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMemberAsUint32(obj, "type", x.type, allocator);
+  addMember(obj, "filepath", x.filepath, allocator);
+  addMember(obj, "frame", x.frame, allocator);
+  addMember(obj, "virtualUnitToMeters", x.virtualUnitToMeters, allocator);
+  addMember(obj, "requiresLighting", x.requiresLighting, allocator);
+  addMember(obj, "splitInstanceMesh", x.splitInstanceMesh, allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::assets::AssetInfo& x) {
+  readMemberAsUint32(obj, "type", x.type);
+  readMember(obj, "filepath", x.filepath);
+  readMember(obj, "frame", x.frame);
+  readMember(obj, "virtualUnitToMeters", x.virtualUnitToMeters);
+  readMember(obj, "requiresLighting", x.requiresLighting);
+  readMember(obj, "splitInstanceMesh", x.splitInstanceMesh);
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(
+    const esp::assets::RenderAssetInstanceCreationInfo& x,
+    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "filepath", x.filepath, allocator);
+  addMember(obj, "scale", x.scale, allocator);
+  addMember(obj, "isStatic", x.isStatic(), allocator);
+  addMember(obj, "isRGBD", x.isRGBD(), allocator);
+  addMember(obj, "isSemantic", x.isSemantic(), allocator);
+  addMember(obj, "lightSetupKey", x.lightSetupKey, allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::assets::RenderAssetInstanceCreationInfo& x) {
+  readMember(obj, "filepath", x.filepath);
+  readMember(obj, "scale", x.scale);
+  bool isStatic;
+  readMember(obj, "isStatic", isStatic);
+  bool isRGBD;
+  readMember(obj, "isRGBD", isRGBD);
+  bool isSemantic;
+  readMember(obj, "isSemantic", isSemantic);
+  if (isStatic) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsStatic;
+  }
+  if (isRGBD) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
+  }
+  if (isSemantic) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
+  }
+  readMember(obj, "lightSetupKey", x.lightSetupKey);
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(const esp::gfx::replay::Transform& x,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "translation", x.translation, allocator);
+  addMember(obj, "rotation", x.rotation, allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::gfx::replay::Transform& x) {
+  readMember(obj, "translation", x.translation);
+  readMember(obj, "rotation", x.rotation);
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(
+    const esp::gfx::replay::RenderAssetInstanceState& x,
+    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "absTransform", x.absTransform, allocator);
+  addMember(obj, "semanticId", x.semanticId, allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::gfx::replay::RenderAssetInstanceState& x) {
+  readMember(obj, "absTransform", x.absTransform);
+  readMember(obj, "semanticId", x.semanticId);
+  return true;
+}
+
+JsonGenericValue toJsonValue(const esp::gfx::replay::Keyframe& x,
+                             JsonAllocator& allocator);
+
+bool fromJsonValue(const JsonGenericValue& keyframeObj,
+                   esp::gfx::replay::Keyframe& keyframe);
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -99,11 +99,11 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
                           esp::assets::RenderAssetInstanceCreationInfo& x) {
   readMember(obj, "filepath", x.filepath);
   readMember(obj, "scale", x.scale);
-  bool isStatic;
+  bool isStatic = false;
   readMember(obj, "isStatic", isStatic);
-  bool isRGBD;
+  bool isRGBD = false;
   readMember(obj, "isRGBD", isRGBD);
-  bool isSemantic;
+  bool isSemantic = false;
   readMember(obj, "isSemantic", isSemantic);
   if (isStatic) {
     x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsStatic;

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -1,0 +1,142 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONMAGNUMTYPES_H_
+#define ESP_IO_JSONMAGNUMTYPES_H_
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+#include "esp/core/logging.h"
+
+#include <Corrade/Containers/Optional.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Math/Quaternion.h>
+
+namespace esp {
+namespace io {
+
+inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
+                                    JsonAllocator& allocator) {
+  return toJsonArrayHelper(vec.data(), 3, allocator);
+}
+
+/**
+ * @brief Specialization to handle Magnum::Vector3 values. Populate passed @p
+ * val with value. Returns whether successfully populated, or not. Logs an error
+ * if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
+  if (obj.IsArray() && obj.Size() == 3) {
+    for (rapidjson::SizeType i = 0; i < 3; ++i) {
+      if (obj[i].IsNumber()) {
+        val[i] = obj[i].GetDouble();
+      } else {
+        LOG(ERROR) << " Invalid numeric value specified in JSON Vec3, index :"
+                   << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+inline JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue arr(rapidjson::kArrayType);
+  arr.PushBack(quat.scalar(), allocator);
+  for (int i = 0; i < 3; i++) {
+    arr.PushBack(quat.vector()[i], allocator);
+  }
+  return arr;
+}
+
+/**
+ * @brief Specialization to handle Magnum::Quaternion values. Populate passed @p
+ * val with value. Returns whether successfully populated, or not. Logs an error
+ * if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          Magnum::Quaternion& val) {
+  if (obj.IsArray() && obj.Size() == 4) {
+    for (rapidjson::SizeType i = 0; i < 4; ++i) {
+      if (obj[i].IsNumber()) {
+        if (i == 0) {
+          val.scalar() = obj[0].GetFloat();
+        } else {
+          val.vector()[i - 1] = obj[i].GetFloat();
+        }
+      } else {
+        LOG(ERROR)
+            << " Invalid numeric value specified in JSON Quaternion, index :"
+            << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+// Containers::Optional is handled differently than ordinary structs. Instead of
+// offering toJsonValue/fromJsonValue, we offer addMember/readMember, which
+// simply omits adding/reading a value for the case of NullOpt.
+template <typename T>
+void addMember(rapidjson::Value& value,
+               rapidjson::GenericStringRef<char> name,
+               const Corrade::Containers::Optional<T>& x,
+               JsonAllocator& allocator) {
+  if (x) {
+    const T& item = *x;
+    addMember(value, name, item, allocator);
+  }
+}
+
+template <typename T>
+bool readMember(const rapidjson::Value& value,
+                const char* name,
+                Corrade::Containers::Optional<T>& x) {
+  if (value.HasMember(name)) {
+    x = T();
+    return readMember(value, name, *x);
+  } else {
+    x = Corrade::Containers::NullOpt;
+    return true;
+  }
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Rad& val) {
+  if (obj.IsNumber()) {
+    val = Magnum::Rad{obj.GetFloat()};
+    return true;
+  }
+  LOG(ERROR) << "Invalid double value";
+  return true;
+}
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/JsonStlTypes.h
+++ b/src/esp/io/JsonStlTypes.h
@@ -1,0 +1,127 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONSTLTYPES_H_
+#define ESP_IO_JSONSTLTYPES_H_
+
+/** @file
+ * @brief See JsonAllTypes.h. Don't include this header directly in user code.
+ */
+
+#include "JsonBuiltinTypes.h"
+
+namespace esp {
+namespace io {
+
+inline JsonGenericValue toJsonValue(const std::string& str,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue strObj;
+  strObj.SetString(str.c_str(), allocator);
+  return strObj;
+}
+
+/**
+ * @brief Populate passed @p val with value. Returns whether successfully
+ * populated, or not. Logs an error if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+inline bool fromJsonValue(const JsonGenericValue& obj, std::string& val) {
+  if (obj.IsString()) {
+    val = obj.GetString();
+    return true;
+  }
+  LOG(ERROR) << "Invalid string value";
+  return false;
+}
+
+// For std::vector, we use rapidjson::kArrayType. For an empty vector, we
+// omit the member altogether rather than add an empty array.
+
+template <typename T>
+void addMember(JsonGenericValue& value,
+               rapidjson::GenericStringRef<char> name,
+               const std::vector<T>& vec,
+               JsonAllocator& allocator) {
+  if (!vec.empty()) {
+    addMember(value, name, toJsonArrayHelper(vec.data(), vec.size(), allocator),
+              allocator);
+  }
+}
+
+template <typename T>
+bool readMember(const JsonGenericValue& value,
+                const char* tag,
+                std::vector<T>& vec) {
+  ASSERT(vec.empty());
+  JsonGenericValue::ConstMemberIterator itr = value.FindMember(tag);
+  if (itr != value.MemberEnd()) {
+    const JsonGenericValue& arr = itr->value;
+    if (!arr.IsArray()) {
+      LOG(ERROR) << "JSON tag " << tag << " is not an array";
+      return false;
+    }
+    vec.reserve(arr.Size());
+    for (int i = 0; i < arr.Size(); i++) {
+      const auto& itemObj = arr[i];
+      T item;
+      if (!fromJsonValue(itemObj, item)) {
+        vec.clear();  // return an empty container on failure
+        LOG(ERROR) << "Failed to parse array element " << i << " in JSON tag "
+                   << tag;
+        return false;
+      }
+      vec.emplace_back(std::move(item));
+    }
+  }
+  // if the tag isn't found, the container is left empty and we return success
+  return true;
+}
+
+/**
+ * @brief Specialization to handle reading a JSON object into an
+ * std::map<std::string, std::string>.  Check passed json doc for existence of
+ * passed @p tag and verify it is an object. If present, populate passed @p val
+ * with key-value pairs in cell. Returns whether tag is found and successfully
+ * populated, or not. Logs an error if tag is found but is inappropriately
+ * configured
+ *
+ * @param d json document to parse
+ * @param tag string tag to look for in json doc
+ * @param val destination std::map to be populated
+ * @return whether successful or not
+ */
+
+template <>
+inline bool readMember(const JsonGenericValue& d,
+                       const char* tag,
+                       std::map<std::string, std::string>& val) {
+  if (d.HasMember(tag)) {
+    if (d[tag].IsObject()) {
+      const auto& jCell = d[tag];
+      for (rapidjson::Value::ConstMemberIterator it = jCell.MemberBegin();
+           it != jCell.MemberEnd(); ++it) {
+        const std::string key = it->name.GetString();
+        if (it->value.IsString()) {
+          val.emplace(key, it->value.GetString());
+        } else {
+          LOG(ERROR) << "Invalid string value specified in JSON config " << tag
+                     << " at " << key << ". Skipping.";
+        }
+      }  // for each value
+      return true;
+    } else {  // if member is object
+      LOG(ERROR) << "Invalid JSON Object value specified in JSON config at "
+                 << tag << "; Unable to populate std::map.";
+    }
+  }  // if has tag
+  return false;
+}  // readMember<Magnum::Vector3>
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -5,6 +5,8 @@
 #ifndef ESP_IO_JSON_H_
 #define ESP_IO_JSON_H_
 
+#include "JsonAllTypes.h"
+
 #include <cstdint>
 #define RAPIDJSON_NO_INT64DEFINE
 #include <rapidjson/document.h>
@@ -22,7 +24,6 @@ namespace esp {
 namespace io {
 
 typedef rapidjson::Document JsonDocument;
-typedef rapidjson::GenericValue<rapidjson::UTF8<> > JsonGenericValue;
 
 //! Write a JsonDocument to file
 bool writeJsonToFile(const JsonDocument& document, const std::string& file);
@@ -38,285 +39,6 @@ std::string jsonToString(const JsonDocument& d);
 
 //! Return Vec3f coordinates representation of given JsonObject of array type
 esp::vec3f jsonToVec3f(const JsonGenericValue& jsonArray);
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as @tparam T.
- * MUST BE SPECIALIZED due to json tag queries relying on named, type-specific
- * getters.
- *
- * @tparam T type of value to be populated.
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-template <typename T>
-bool jsonIntoVal(CORRADE_UNUSED const JsonGenericValue& d,
-                 const char* tag,
-                 CORRADE_UNUSED T& val) {
-  LOG(ERROR) << "Unsupported typename specified for JSON tag " << tag
-             << ". Aborting.";
-  return false;
-}  // jsonIntoVal template definition
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * float. If present, populate passed @p val with value. Returns whether tag
- * is found and successfully populated, or not. Logs an error if tag is found
- * but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        float& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsNumber()) {
-      val = d[tag].GetFloat();
-      return true;
-    }
-    LOG(ERROR) << "Invalid float value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<float>
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * double. If present, populate passed @p val with value. Returns whether tag
- * is found and successfully populated, or not. Logs an error if tag is found
- * but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        double& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsNumber()) {
-      val = d[tag].GetDouble();
-      return true;
-    }
-    LOG(ERROR) << "Invalid double value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<double>
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * int. If present, populate passed @p val with value. Returns whether tag
- * is found and successfully populated, or not. Logs an error if tag is found
- * but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d, const char* tag, int& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsNumber()) {
-      val = d[tag].GetInt();
-      return true;
-    }
-    LOG(ERROR) << "Invalid int value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<int>
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * boolean. If present, populate passed @p val with value. Returns whether tag
- * is found and successfully populated, or not. Logs an error if tag is found
- * but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d, const char* tag, bool& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsBool()) {
-      val = d[tag].GetBool();
-      return true;
-    }
-    LOG(ERROR) << "Invalid boolean value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<bool>
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * double. If present, populate passed @p val with
- * value. Returns whether tag is found and successfully populated, or not. Logs
- * an error if tag is found but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        std::string& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsString()) {
-      val = d[tag].GetString();
-      return true;
-    }
-    LOG(ERROR) << "Invalid string value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<std::string>
-
-/**
- * @brief Check passed json doc for existence of passed @p tag as
- * double. If present, populate passed @p val with value. Returns whether tag
- * is found and successfully populated, or not. Logs an error if tag is found
- * but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        Magnum::Rad& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsNumber()) {
-      val = Magnum::Rad{d[tag].GetFloat()};
-      return true;
-    }
-    LOG(ERROR) << "Invalid double value specified in JSON config at " << tag;
-  }
-  return false;
-}  // jsonIntoVal<double>
-
-/**
- * @brief Specialization to handle Magnum::Vector3 values.  Check passed json
- * doc for existence of passed @p tag as Magnum::Vector3. If present, populate
- * passed @p val with value. Returns whether tag is found and successfully
- * populated, or not. Logs an error if tag is found but is inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        Magnum::Vector3& val) {
-  if (d.HasMember(tag) && d[tag].IsArray() && d[tag].Size() == 3) {
-    for (rapidjson::SizeType i = 0; i < 3; ++i) {
-      if (d[tag][i].IsNumber()) {
-        val[i] = d[tag][i].GetDouble();
-      } else {
-        LOG(ERROR) << " Invalid numeric value specified in JSON Vec3 config at "
-                   << tag << " index :" << i;
-        return false;
-      }
-    }  // build array
-    return true;
-  }
-  return false;
-}  // jsonIntoVal<Magnum::Vector3>
-
-/**
- * @brief Specialization to handle Magnum::Quaternion values.  Check passed json
- * doc for existence of passed @p tag as Magnum::Quaternion. If present,
- * populate passed @p val with value. Returns whether tag is found and
- * successfully populated, or not. Logs an error if tag is found but is
- * inappropriate type.
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination value to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        Magnum::Quaternion& val) {
-  if (d.HasMember(tag) && d[tag].IsArray() && d[tag].Size() == 4) {
-    for (rapidjson::SizeType i = 0; i < 4; ++i) {
-      if (d[tag][i].IsNumber()) {
-        if (i == 0) {
-          val.scalar() = d[tag][0].GetFloat();
-        } else {
-          val.vector()[i - 1] = d[tag][i].GetFloat();
-        }
-      } else {
-        LOG(ERROR)
-            << " Invalid numeric value specified in JSON Quaternion config at "
-            << tag << " index :" << i;
-        return false;
-      }
-    }  // build array
-    return true;
-  }
-  return false;
-}  // jsonIntoVal<Magnum::Quaternion>
-
-/**
- * @brief Specialization to handle reading a JSON object into an
- * std::map<std::string, std::string>.  Check passed json doc for existence of
- * passed @p tag and verify it is an object. If present, populate passed @p val
- * with key-value pairs in cell. Returns whether tag is found and successfully
- * populated, or not. Logs an error if tag is found but is inappropriately
- * configured
- *
- * @param d json document to parse
- * @param tag string tag to look for in json doc
- * @param val destination std::map to be populated
- * @return whether successful or not
- */
-
-template <>
-inline bool jsonIntoVal(const JsonGenericValue& d,
-                        const char* tag,
-                        std::map<std::string, std::string>& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsObject()) {
-      const auto& jCell = d[tag];
-      for (rapidjson::Value::ConstMemberIterator it = jCell.MemberBegin();
-           it != jCell.MemberEnd(); ++it) {
-        const std::string key = it->name.GetString();
-        if (it->value.IsString()) {
-          val.emplace(key, it->value.GetString());
-        } else {
-          LOG(ERROR) << "Invalid string value specified in JSON config " << tag
-                     << " at " << key << ". Skipping.";
-        }
-      }  // for each value
-      return true;
-    } else {  // if member is object
-      LOG(ERROR) << "Invalid JSON Object value specified in JSON config at "
-                 << tag << "; Unable to populate std::map.";
-    }
-  }  // if has tag
-  return false;
-}  // jsonIntoVal<Magnum::Vector3>
 
 /**
  * @brief Check passed json doc for existence of passed jsonTag as value of
@@ -337,7 +59,7 @@ bool jsonIntoSetter(const JsonGenericValue& d,
                     const char* tag,
                     std::function<void(T)> setter) {
   T val;
-  if (jsonIntoVal(d, tag, val)) {
+  if (readMember(d, tag, val)) {
     setter(val);
     return true;
   }
@@ -364,7 +86,7 @@ bool jsonIntoConstSetter(const JsonGenericValue& d,
                          const char* tag,
                          std::function<void(const T)> setter) {
   T val;
-  if (jsonIntoVal(d, tag, val)) {
+  if (readMember(d, tag, val)) {
     setter(val);
     return true;
   }

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -288,7 +288,7 @@ std::string AbstractObjectAttributesManager<T>::setJSONAssetHandleAndType(
   //-1 if tag is not found in json.
   int typeVal = -1;
   std::string tmpVal = "";
-  if (io::jsonIntoVal<std::string>(jsonDoc, jsonMeshTypeTag, tmpVal)) {
+  if (io::readMember<std::string>(jsonDoc, jsonMeshTypeTag, tmpVal)) {
     // tag was found, perform check
     std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
     if (T::AssetTypeNamesMap.count(strToLookFor)) {
@@ -308,7 +308,7 @@ std::string AbstractObjectAttributesManager<T>::setJSONAssetHandleAndType(
   }  // if type is found in json.  If not typeVal is -1
 
   // Read json for new mesh handle if present
-  if (io::jsonIntoVal<std::string>(jsonDoc, jsonMeshHandleTag, assetName)) {
+  if (io::readMember<std::string>(jsonDoc, jsonMeshHandleTag, assetName)) {
     // value is specified in json doc
     if ((this->isValidPrimitiveAttributes(assetName)) &&
         (oldFName.compare(assetName) != 0)) {

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -81,8 +81,8 @@ void SceneAttributesManager::setValsFromJSONDoc(
                  << attribsName << ", or specification error.";
   }
   std::string dfltLighting = "";
-  if (io::jsonIntoVal<std::string>(jsonConfig, "default_lighting",
-                                   dfltLighting)) {
+  if (io::readMember<std::string>(jsonConfig, "default_lighting",
+                                  dfltLighting)) {
     // if "default lighting" is specified in scene json set value.
     attribs->setLightingHandle(dfltLighting);
   } else {
@@ -93,8 +93,8 @@ void SceneAttributesManager::setValsFromJSONDoc(
   }
 
   std::string navmeshName = "";
-  if (io::jsonIntoVal<std::string>(jsonConfig, "navmesh_instance",
-                                   navmeshName)) {
+  if (io::readMember<std::string>(jsonConfig, "navmesh_instance",
+                                  navmeshName)) {
     // if "navmesh_instance" is specified in scene json set value.
     attribs->setNavmeshHandle(navmeshName);
   } else {
@@ -105,8 +105,8 @@ void SceneAttributesManager::setValsFromJSONDoc(
   }
 
   std::string semanticDesc = "";
-  if (io::jsonIntoVal<std::string>(jsonConfig, "semantic_scene_instance",
-                                   semanticDesc)) {
+  if (io::readMember<std::string>(jsonConfig, "semantic_scene_instance",
+                                  semanticDesc)) {
     // if "semantic scene instance" is specified in scene json set value.
     attribs->setSemanticSceneHandle(semanticDesc);
   } else {
@@ -131,7 +131,7 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
 
   int motionTypeVal = static_cast<int>(physics::MotionType::UNDEFINED);
   std::string tmpVal = "";
-  if (io::jsonIntoVal<std::string>(jCell, "motion_type", tmpVal)) {
+  if (io::readMember<std::string>(jCell, "motion_type", tmpVal)) {
     // motion type tag was found, perform check - first convert to lowercase
     std::string strToLookFor = Cr::Utility::String::lowercase(tmpVal);
     auto found =

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -68,11 +68,11 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                       dsAttribs->getSceneAttributesManager());
 
   // process navmesh instances
-  io::jsonIntoVal<std::map<std::string, std::string>>(
+  io::readMember<std::map<std::string, std::string>>(
       jsonConfig, "navmesh_instances", dsAttribs->editNavmeshMap());
 
   // process semantic scene descriptor instances
-  io::jsonIntoVal<std::map<std::string, std::string>>(
+  io::readMember<std::map<std::string, std::string>>(
       jsonConfig, "semantic_scene_descriptor_instances",
       dsAttribs->editSemanticSceneDescrMap());
 
@@ -198,7 +198,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   std::string newTemplateHandle = "";
   std::string newTemplateSrcDir = "";
   // try to find original file name for attributes
-  if (io::jsonIntoVal<std::string>(jCell, "original_file", originalFile)) {
+  if (io::readMember<std::string>(jCell, "original_file", originalFile)) {
     // verify that a template with this field as the original file was loaded.
     std::vector<std::string> handles =
         attrMgr->getObjectHandlesBySubstring(originalFile, true);
@@ -216,8 +216,8 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   }
 
   // try to find new template name for attributes
-  if (io::jsonIntoVal<std::string>(jCell, "template_handle",
-                                   newTemplateHandle)) {
+  if (io::readMember<std::string>(jCell, "template_handle",
+                                  newTemplateHandle)) {
     // if a new template handle has been specified, then this is a valid
     // configuration cell only if either an original to copy from or a source
     // directory for this template's new assets is specified.

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -332,20 +332,20 @@ void StageAttributesManager::setValsFromJSONDoc(
   stageAttributes->setSemanticAssetType(
       static_cast<int>(AssetType::INSTANCE_MESH));
 
-  if (io::jsonIntoVal<std::string>(jsonConfig, "nav_asset", navmeshFName)) {
+  if (io::readMember<std::string>(jsonConfig, "nav_asset", navmeshFName)) {
     navmeshFName = Cr::Utility::Directory::join(stageLocFileDir, navmeshFName);
     // if "nav mesh" is specified in stage json set value (override default).
     stageAttributes->setNavmeshAssetHandle(navmeshFName);
   }
 
-  if (io::jsonIntoVal<std::string>(jsonConfig, "house_filename", houseFName)) {
+  if (io::readMember<std::string>(jsonConfig, "house_filename", houseFName)) {
     houseFName = Cr::Utility::Directory::join(stageLocFileDir, houseFName);
     // if "house filename" is specified in stage json, set value (override
     // default).
     stageAttributes->setHouseFilename(houseFName);
   }
 
-  if (io::jsonIntoVal<std::string>(jsonConfig, "lighting_setup", lightSetup)) {
+  if (io::readMember<std::string>(jsonConfig, "lighting_setup", lightSetup)) {
     // if lighting is specified in stage json to non-empty value, set value
     // (override default).
     stageAttributes->setLightSetup(lightSetup);

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -180,7 +180,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     int x{std::numeric_limits<int>::lowest()};
     addMember(d, "myint", x, allocator);
     int x2{0};
-    readMember(d, "myint", x2);
+    EXPECT_TRUE(readMember(d, "myint", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -188,7 +188,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     unsigned x{std::numeric_limits<unsigned>::max()};
     addMember(d, "myunsigned", x, allocator);
     unsigned x2{0};
-    readMember(d, "myunsigned", x2);
+    EXPECT_TRUE(readMember(d, "myunsigned", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -196,7 +196,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     int64_t x{std::numeric_limits<int64_t>::lowest()};
     addMember(d, "myint64_t", x, allocator);
     int64_t x2{0};
-    readMember(d, "myint64_t", x2);
+    EXPECT_TRUE(readMember(d, "myint64_t", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -204,7 +204,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     uint64_t x{std::numeric_limits<uint64_t>::max()};
     addMember(d, "myuint64_t", x, allocator);
     uint64_t x2{0};
-    readMember(d, "myuint64_t", x2);
+    EXPECT_TRUE(readMember(d, "myuint64_t", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -212,7 +212,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     float x{1.0 / 7};
     addMember(d, "myfloat", x, allocator);
     float x2{0};
-    readMember(d, "myfloat", x2);
+    EXPECT_TRUE(readMember(d, "myfloat", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -220,7 +220,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     double x{1.0 / 13};
     addMember(d, "mydouble", x, allocator);
     double x2{0};
-    readMember(d, "mydouble", x2);
+    EXPECT_TRUE(readMember(d, "mydouble", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -228,7 +228,7 @@ TEST(IOTest, JsonBuiltinTypesTest) {
     bool x{true};
     addMember(d, "mybool", x, allocator);
     bool x2{false};
-    readMember(d, "mybool", x2);
+    EXPECT_TRUE(readMember(d, "mybool", x2));
     EXPECT_EQ(x2, x);
   }
 
@@ -254,21 +254,21 @@ TEST(IOTest, JsonStlTypesTest) {
   std::string s{"hello world"};
   addMember(d, "s", s, allocator);
   std::string s2;
-  readMember(d, "s", s2);
+  EXPECT_TRUE(readMember(d, "s", s2));
   EXPECT_EQ(s2, s);
 
   // test a vector of ints
   std::vector<int> vec{3, 4, 5, 6};
   addMember(d, "vec", vec, allocator);
   std::vector<int> vec2;
-  readMember(d, "vec", vec2);
+  EXPECT_TRUE(readMember(d, "vec", vec2));
   EXPECT_EQ(vec2, vec);
 
   // test an empty vector
   std::vector<float> emptyVec{};
   addMember(d, "emptyVec", emptyVec, allocator);
   std::vector<float> emptyVec2;
-  readMember(d, "emptyVec", emptyVec2);
+  EXPECT_TRUE(readMember(d, "emptyVec", emptyVec2));
   EXPECT_EQ(emptyVec2, emptyVec);
 
   // test reading a vector of wrong type
@@ -285,13 +285,13 @@ TEST(IOTest, JsonMagnumTypesTest) {
   Magnum::Vector3 vec{1, 2, 3};
   addMember(d, "myvec", vec, allocator);
   Magnum::Vector3 vec2;
-  readMember(d, "myvec", vec2);
+  EXPECT_TRUE(readMember(d, "myvec", vec2));
   EXPECT_EQ(vec2, vec);
 
   Magnum::Quaternion quat{{1, 2, 3}, 4};
   addMember(d, "myquat", quat, allocator);
   Magnum::Quaternion quat2;
-  readMember(d, "myquat", quat2);
+  EXPECT_TRUE(readMember(d, "myquat", quat2));
   EXPECT_EQ(quat2, quat);
 
   // test reading the wrong type (wrong number of fields)
@@ -314,57 +314,78 @@ TEST(IOTest, JsonEspTypesTest) {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
-  // add RenderAssetInstanceCreationInfo
-  esp::assets::RenderAssetInstanceCreationInfo creationInfo(
-      "test_filepath", Magnum::Vector3(1.f, 2.f, 3.f),
-      esp::assets::RenderAssetInstanceCreationInfo::Flags(),
-      "test_light_setup");
-  addMember(d, "creationInfo", creationInfo, allocator);
+  {
+    // vec3f
+    esp::vec3f vec{1, 2, 3};
+    addMember(d, "myvec3f", vec, allocator);
+    esp::vec3f vec2;
+    EXPECT_TRUE(readMember(d, "myvec3f", vec2));
+    EXPECT_EQ(vec2, vec);
 
-  // AssetInfo
-  esp::assets::AssetInfo assetInfo{
-      esp::assets::AssetType::MP3D_MESH,
-      "test_filepath2",
-      esp::geo::CoordinateFrame(esp::vec3f(1.f, 0.f, 0.f),
-                                esp::vec3f(0.f, 0.f, 1.f),
-                                esp::vec3f(1.f, 2.f, 3.f)),
-      4.f,
-      true,
-      false};
-  addMember(d, "assetInfo", assetInfo, allocator);
+    // test reading the wrong type (wrong number of fields)
+    std::vector<float> wrongNumFieldsVec{1, 3, 4, 4};
+    addMember(d, "mywrongNumFieldsVec", wrongNumFieldsVec, allocator);
+    esp::vec3f vec3;
+    EXPECT_FALSE(readMember(d, "mywrongNumFieldsVec", vec3));
 
-  // add RenderAssetInstanceState
-  esp::gfx::replay::RenderAssetInstanceState state{
-      {Magnum::Vector3(1.f, 2.f, 3.f),
-       Magnum::Quaternion::rotation(Magnum::Rad{1.f},
-                                    Magnum::Vector3(0.f, 1.f, 0.f))},
-      4};
-  addMember(d, "state", state, allocator);
+    // test reading the wrong type (array elements aren't numbers)
+    std::vector<std::string> vecOfStrings{"1", "2", "3"};
+    addMember(d, "myVecOfStrings", vecOfStrings, allocator);
+    EXPECT_FALSE(readMember(d, "myVecOfStrings", vec3));
+  }
 
-  // read and compare RenderAssetInstanceCreationInfo
-  esp::assets::RenderAssetInstanceCreationInfo creationInfo2;
-  readMember(d, "creationInfo", creationInfo2);
-  EXPECT_EQ(creationInfo2.filepath, creationInfo.filepath);
-  EXPECT_EQ(creationInfo2.scale, creationInfo.scale);
-  EXPECT_EQ(creationInfo2.flags, creationInfo.flags);
-  EXPECT_EQ(creationInfo2.lightSetupKey, creationInfo.lightSetupKey);
+  {
+    // RenderAssetInstanceCreationInfo
+    esp::assets::RenderAssetInstanceCreationInfo creationInfo(
+        "test_filepath", Magnum::Vector3(1.f, 2.f, 3.f),
+        esp::assets::RenderAssetInstanceCreationInfo::Flags(),
+        "test_light_setup");
+    addMember(d, "creationInfo", creationInfo, allocator);
+    esp::assets::RenderAssetInstanceCreationInfo creationInfo2;
+    EXPECT_TRUE(readMember(d, "creationInfo", creationInfo2));
+    EXPECT_EQ(creationInfo2.filepath, creationInfo.filepath);
+    EXPECT_EQ(creationInfo2.scale, creationInfo.scale);
+    EXPECT_EQ(creationInfo2.flags, creationInfo.flags);
+    EXPECT_EQ(creationInfo2.lightSetupKey, creationInfo.lightSetupKey);
+  }
 
-  // read and compare AssetInfo
-  esp::assets::AssetInfo assetInfo2;
-  readMember(d, "assetInfo", assetInfo2);
-  EXPECT_EQ(assetInfo2.type, assetInfo.type);
-  EXPECT_EQ(assetInfo2.filepath, assetInfo.filepath);
-  EXPECT_EQ(assetInfo2.frame.up(), assetInfo.frame.up());
-  EXPECT_EQ(assetInfo2.frame.front(), assetInfo.frame.front());
-  EXPECT_EQ(assetInfo2.frame.origin(), assetInfo.frame.origin());
-  EXPECT_EQ(assetInfo2.virtualUnitToMeters, assetInfo.virtualUnitToMeters);
-  EXPECT_EQ(assetInfo2.requiresLighting, assetInfo.requiresLighting);
-  EXPECT_EQ(assetInfo2.splitInstanceMesh, assetInfo.splitInstanceMesh);
+  {
+    // AssetInfo
+    esp::assets::AssetInfo assetInfo{
+        esp::assets::AssetType::MP3D_MESH,
+        "test_filepath2",
+        esp::geo::CoordinateFrame(esp::vec3f(1.f, 0.f, 0.f),
+                                  esp::vec3f(0.f, 0.f, 1.f),
+                                  esp::vec3f(1.f, 2.f, 3.f)),
+        4.f,
+        true,
+        false};
+    addMember(d, "assetInfo", assetInfo, allocator);
+    esp::assets::AssetInfo assetInfo2;
+    EXPECT_TRUE(readMember(d, "assetInfo", assetInfo2));
+    EXPECT_EQ(assetInfo2.type, assetInfo.type);
+    EXPECT_EQ(assetInfo2.filepath, assetInfo.filepath);
+    EXPECT_EQ(assetInfo2.frame.up(), assetInfo.frame.up());
+    EXPECT_EQ(assetInfo2.frame.front(), assetInfo.frame.front());
+    EXPECT_EQ(assetInfo2.frame.origin(), assetInfo.frame.origin());
+    EXPECT_EQ(assetInfo2.virtualUnitToMeters, assetInfo.virtualUnitToMeters);
+    EXPECT_EQ(assetInfo2.requiresLighting, assetInfo.requiresLighting);
+    EXPECT_EQ(assetInfo2.splitInstanceMesh, assetInfo.splitInstanceMesh);
+  }
 
-  // read and compare RenderAssetInstanceState
-  esp::gfx::replay::RenderAssetInstanceState state2;
-  readMember(d, "state", state2);
-  EXPECT_EQ(state2, state);
+  {
+    // RenderAssetInstanceState
+    esp::gfx::replay::RenderAssetInstanceState state{
+        {Magnum::Vector3(1.f, 2.f, 3.f),
+         Magnum::Quaternion::rotation(Magnum::Rad{1.f},
+                                      Magnum::Vector3(0.f, 1.f, 0.f))},
+        4};
+    addMember(d, "state", state, allocator);
+    // read and compare RenderAssetInstanceState
+    esp::gfx::replay::RenderAssetInstanceState state2;
+    EXPECT_TRUE(readMember(d, "state", state2));
+    EXPECT_EQ(state2, state);
+  }
 }
 
 namespace {

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -4,12 +4,16 @@
 
 #include <Corrade/Utility/Directory.h>
 #include <gtest/gtest.h>
+#include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/core/esp.h"
+#include "esp/io/JsonAllTypes.h"
 #include "esp/io/io.h"
 #include "esp/io/json.h"
 #include "esp/metadata/attributes/ObjectAttributes.h"
 
 #include "configure.h"
+
+#include <limits>
 
 using namespace esp::io;
 
@@ -164,4 +168,257 @@ TEST(IOTest, JsonTest) {
       std::bind(&ObjectAttributes::setRenderAssetHandle, attributes, _1));
   EXPECT_EQ(success, true);
   EXPECT_EQ(attributes->getRenderAssetHandle(), "banana.glb");
+}
+
+// Serialize/deserialize the 7 rapidjson builtin types using
+// io::addMember/readMember and assert equality.
+TEST(IOTest, JsonBuiltinTypesTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  {
+    int x{std::numeric_limits<int>::lowest()};
+    addMember(d, "myint", x, allocator);
+    int x2{0};
+    readMember(d, "myint", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    unsigned x{std::numeric_limits<unsigned>::max()};
+    addMember(d, "myunsigned", x, allocator);
+    unsigned x2{0};
+    readMember(d, "myunsigned", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    int64_t x{std::numeric_limits<int64_t>::lowest()};
+    addMember(d, "myint64_t", x, allocator);
+    int64_t x2{0};
+    readMember(d, "myint64_t", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    uint64_t x{std::numeric_limits<uint64_t>::max()};
+    addMember(d, "myuint64_t", x, allocator);
+    uint64_t x2{0};
+    readMember(d, "myuint64_t", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    float x{1.0 / 7};
+    addMember(d, "myfloat", x, allocator);
+    float x2{0};
+    readMember(d, "myfloat", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    double x{1.0 / 13};
+    addMember(d, "mydouble", x, allocator);
+    double x2{0};
+    readMember(d, "mydouble", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  {
+    bool x{true};
+    addMember(d, "mybool", x, allocator);
+    bool x2{false};
+    readMember(d, "mybool", x2);
+    EXPECT_EQ(x2, x);
+  }
+
+  // verify failure to read bool into int
+  {
+    int x2{0};
+    EXPECT_FALSE(readMember(d, "mybool", x2));
+  }
+
+  // verify failure to read missing tag
+  {
+    int x2{0};
+    EXPECT_FALSE(readMember(d, "my_missing_int", x2));
+  }
+}
+
+// Serialize/deserialize a few stl types using io::addMember/readMember and
+// assert equality.
+TEST(IOTest, JsonStlTypesTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  std::string s{"hello world"};
+  addMember(d, "s", s, allocator);
+  std::string s2;
+  readMember(d, "s", s2);
+  EXPECT_EQ(s2, s);
+
+  // test a vector of ints
+  std::vector<int> vec{3, 4, 5, 6};
+  addMember(d, "vec", vec, allocator);
+  std::vector<int> vec2;
+  readMember(d, "vec", vec2);
+  EXPECT_EQ(vec2, vec);
+
+  // test an empty vector
+  std::vector<float> emptyVec{};
+  addMember(d, "emptyVec", emptyVec, allocator);
+  std::vector<float> emptyVec2;
+  readMember(d, "emptyVec", emptyVec2);
+  EXPECT_EQ(emptyVec2, emptyVec);
+
+  // test reading a vector of wrong type
+  std::vector<std::string> vec3;
+  EXPECT_FALSE(readMember(d, "vec", vec3));
+}
+
+// Serialize/deserialize a few Magnum types using io::addMember/readMember and
+// assert equality.
+TEST(IOTest, JsonMagnumTypesTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  Magnum::Vector3 vec{1, 2, 3};
+  addMember(d, "myvec", vec, allocator);
+  Magnum::Vector3 vec2;
+  readMember(d, "myvec", vec2);
+  EXPECT_EQ(vec2, vec);
+
+  Magnum::Quaternion quat{{1, 2, 3}, 4};
+  addMember(d, "myquat", quat, allocator);
+  Magnum::Quaternion quat2;
+  readMember(d, "myquat", quat2);
+  EXPECT_EQ(quat2, quat);
+
+  // test reading the wrong type (wrong number of fields)
+  Magnum::Quaternion quat3;
+  EXPECT_FALSE(readMember(d, "myvec", quat3));
+
+  // test reading the wrong type (wrong number of fields)
+  Magnum::Vector3 vec3;
+  EXPECT_FALSE(readMember(d, "myquat", vec3));
+
+  // test reading the wrong type (array elements aren't numbers)
+  std::vector<std::string> vecOfStrings{"1", "2", "3"};
+  addMember(d, "myVecOfStrings", vecOfStrings, allocator);
+  EXPECT_FALSE(readMember(d, "myVecOfStrings", vec3));
+}
+
+// Serialize/deserialize a few esp types using io::addMember/readMember and
+// assert equality.
+TEST(IOTest, JsonEspTypesTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  // add RenderAssetInstanceCreationInfo
+  esp::assets::RenderAssetInstanceCreationInfo creationInfo(
+      "test_filepath", Magnum::Vector3(1.f, 2.f, 3.f),
+      esp::assets::RenderAssetInstanceCreationInfo::Flags(),
+      "test_light_setup");
+  addMember(d, "creationInfo", creationInfo, allocator);
+
+  // AssetInfo
+  esp::assets::AssetInfo assetInfo{
+      esp::assets::AssetType::MP3D_MESH,
+      "test_filepath2",
+      esp::geo::CoordinateFrame(esp::vec3f(1.f, 0.f, 0.f),
+                                esp::vec3f(0.f, 0.f, 1.f),
+                                esp::vec3f(1.f, 2.f, 3.f)),
+      4.f,
+      true,
+      false};
+  addMember(d, "assetInfo", assetInfo, allocator);
+
+  // add RenderAssetInstanceState
+  esp::gfx::replay::RenderAssetInstanceState state{
+      {Magnum::Vector3(1.f, 2.f, 3.f),
+       Magnum::Quaternion::rotation(Magnum::Rad{1.f},
+                                    Magnum::Vector3(0.f, 1.f, 0.f))},
+      4};
+  addMember(d, "state", state, allocator);
+
+  // read and compare RenderAssetInstanceCreationInfo
+  esp::assets::RenderAssetInstanceCreationInfo creationInfo2;
+  readMember(d, "creationInfo", creationInfo2);
+  EXPECT_EQ(creationInfo2.filepath, creationInfo.filepath);
+  EXPECT_EQ(creationInfo2.scale, creationInfo.scale);
+  EXPECT_EQ(creationInfo2.flags, creationInfo.flags);
+  EXPECT_EQ(creationInfo2.lightSetupKey, creationInfo.lightSetupKey);
+
+  // read and compare AssetInfo
+  esp::assets::AssetInfo assetInfo2;
+  readMember(d, "assetInfo", assetInfo2);
+  EXPECT_EQ(assetInfo2.type, assetInfo.type);
+  EXPECT_EQ(assetInfo2.filepath, assetInfo.filepath);
+  EXPECT_EQ(assetInfo2.frame.up(), assetInfo.frame.up());
+  EXPECT_EQ(assetInfo2.frame.front(), assetInfo.frame.front());
+  EXPECT_EQ(assetInfo2.frame.origin(), assetInfo.frame.origin());
+  EXPECT_EQ(assetInfo2.virtualUnitToMeters, assetInfo.virtualUnitToMeters);
+  EXPECT_EQ(assetInfo2.requiresLighting, assetInfo.requiresLighting);
+  EXPECT_EQ(assetInfo2.splitInstanceMesh, assetInfo.splitInstanceMesh);
+
+  // read and compare RenderAssetInstanceState
+  esp::gfx::replay::RenderAssetInstanceState state2;
+  readMember(d, "state", state2);
+  EXPECT_EQ(state2, state);
+}
+
+namespace {
+// some test structs for JsonUserTypeTest below
+struct MyNestedStruct {
+  std::string a;
+};
+
+struct MyOuterStruct {
+  MyNestedStruct nested;
+  float b;
+};
+
+// Beware, toJsonValue/fromJsonValue should generally go in JsonAllTypes.h,
+// not scattered in user code as done here.
+inline JsonGenericValue toJsonValue(const MyNestedStruct& x,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "a", x.a, allocator);
+  return obj;
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, MyNestedStruct& x) {
+  readMember(obj, "a", x.a);
+  return true;
+}
+
+inline JsonGenericValue toJsonValue(const MyOuterStruct& x,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "nested", x.nested, allocator);
+  addMember(obj, "b", x.b, allocator);
+  return obj;
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, MyOuterStruct& x) {
+  readMember(obj, "nested", x.nested);
+  readMember(obj, "b", x.b);
+  return true;
+}
+}  // namespace
+
+// Serialize/deserialize MyOuterStruct using io::addMember/readMember and assert
+// equality.
+TEST(IOTest, JsonUserTypeTest) {
+  rapidjson::Document d(rapidjson::kObjectType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+
+  MyOuterStruct myStruct{{"hello world"}, 2.f};
+  addMember(d, "myStruct", myStruct, allocator);
+
+  MyOuterStruct myStruct2;
+  readMember(d, "myStruct", myStruct2);
+
+  EXPECT_EQ(myStruct2.nested.a, myStruct.nested.a);
+  EXPECT_EQ(myStruct2.b, myStruct.b);
 }


### PR DESCRIPTION
## Motivation and Context

This is a second stab at json helpers for writing, which has grown into a larger refactor. The earlier work is here: https://github.com/facebookresearch/habitat-sim/pull/959 . Per @jturner65 's [suggestion](https://github.com/facebookresearch/habitat-sim/pull/959#issuecomment-740161636), I've refactored to consolidate my new write helpers with the existing read helpers.

From JsonAllTypes.h:
These helpers are designed so that every builtin type and user type can be serialized/deserialized with esp::io::addMember/readMember. The leads to uniform and readable serialization code. To achieve this, every user type defines toJsonValue/fromJsonValue, and then template versions of addMember/readMember will automatically use these.

## How Has This Been Tested

See IOTest. I've also tested with the upcoming render-replay feature.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
