### PR TITLE
render replay integration and python bindings

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -28,6 +28,7 @@ default_sim_settings = {
     "test_scene_data_url": "http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip",
     "goal_position": [5.047, 0.199, 11.145],
     "enable_physics": False,
+    "enable_gfx_replay_save": False,
     "physics_config_file": "./data/default.physics_config.json",
     "num_objects": 10,
     "test_object_index": 0,

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -39,6 +39,7 @@
 #include "esp/gfx/GenericDrawable.h"
 #include "esp/gfx/MaterialUtil.h"
 #include "esp/gfx/PbrDrawable.h"
+#include "esp/gfx/replay/Recorder.h"
 #include "esp/io/io.h"
 #include "esp/io/json.h"
 #include "esp/physics/PhysicsManager.h"
@@ -500,11 +501,9 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
     // loadRenderAsset doesn't yet support the requested asset type
     CORRADE_INTERNAL_ASSERT_UNREACHABLE();
   }
-#if 0  // coming soon
-  if (renderKeyframeWriter_) {
-    renderKeyframeWriter_->onLoadRenderAsset(info);
+  if (gfxReplayRecorder_) {
+    gfxReplayRecorder_->onLoadRenderAsset(info);
   }
-#endif
   return meshSuccess;
 }
 
@@ -546,11 +545,10 @@ scene::SceneNode* ResourceManager::createRenderAssetInstance(
     CORRADE_INTERNAL_ASSERT_UNREACHABLE();
   }
 
-#if 0  // coming soon
-  if (renderKeyframeWriter_ && newNode) {
-    renderKeyframeWriter_->onCreateRenderAssetInstance(&newNode, creation);
+  if (gfxReplayRecorder_ && newNode) {
+    gfxReplayRecorder_->onCreateRenderAssetInstance(newNode, creation);
   }
-#endif
+
   return newNode;
 }
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -56,7 +56,10 @@ namespace Mn = Magnum;
 namespace esp {
 namespace gfx {
 class Drawable;
+namespace replay {
+class Recorder;
 }
+}  // namespace gfx
 namespace scene {
 struct SceneConfiguration;
 }
@@ -425,6 +428,15 @@ class ResourceManager {
    * for rendering. Textures will not be loaded if this is false.
    */
   inline void setRequiresTextures(bool newVal) { requiresTextures_ = newVal; }
+
+  /**
+   * @brief Set a replay recorder so that ResourceManager can notify it about
+   * render assets.
+   */
+  void setRecorder(
+      const std::shared_ptr<gfx::replay::Recorder>& gfxReplayRecorder) {
+    gfxReplayRecorder_ = gfxReplayRecorder;
+  }
 
   /**
    * @brief Load a render asset (if not already loaded) and create a render
@@ -956,6 +968,11 @@ class ResourceManager {
    * @brief Flag to load textures of meshes
    */
   bool requiresTextures_ = true;
+
+  /**
+   * @brief See @ref setRecorder.
+   */
+  std::shared_ptr<esp::gfx::replay::Recorder> gfxReplayRecorder_;
 };  // class ResourceManager
 
 CORRADE_ENUMSET_OPERATORS(ResourceManager::Flags)

--- a/src/esp/bindings/CMakeLists.txt
+++ b/src/esp/bindings/CMakeLists.txt
@@ -8,6 +8,7 @@ pybind11_add_module(
   GeoBindings.cpp
   GfxBindings.cpp
   MetadataMediatorBindings.cpp
+  GfxReplayBindings.cpp
   OpaqueTypes.h
   PhysicsBindings.cpp
   SceneBindings.cpp

--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "esp/bindings/bindings.h"
+
+#include <Magnum/PythonBindings.h>
+#include <Magnum/SceneGraph/PythonBindings.h>
+
+#include "esp/gfx/replay/Player.h"
+#include "esp/gfx/replay/ReplayManager.h"
+
+namespace py = pybind11;
+using py::literals::operator""_a;
+
+namespace esp {
+namespace gfx {
+namespace replay {
+
+void initGfxReplayBindings(py::module& m) {
+  py::class_<Player, Player::ptr>(m, "Player")
+      .def("get_num_keyframes", &Player::getNumKeyframes,
+           R"(Get the currently-set keyframe, or -1 if no keyframe is set.)")
+
+      .def(
+          "set_keyframe_index", &Player::setKeyframeIndex,
+          R"(Set a keyframe by index, or pass -1 to clear the currently-set keyframe.)")
+
+      .def("get_keyframe_index", &Player::getKeyframeIndex,
+           R"(Get the number of keyframes read from file.)")
+
+      .def(
+          "get_user_transform",
+          [](Player& self, const std::string& name) {
+            Magnum::Vector3 translation;
+            Magnum::Quaternion rotation;
+            bool found = self.getUserTransform(name, &translation, &rotation);
+            return found ? py::make_tuple(translation, rotation)
+                         : py::make_tuple(nullptr, nullptr);
+          },
+          R"(todo)");
+
+  py::class_<ReplayManager, ReplayManager::ptr>(m, "ReplayManager")
+      .def(
+          "save_keyframe",
+          [](ReplayManager& self) {
+            if (!self.getRecorder()) {
+              LOG(ERROR) << "save_keyframe: not enabled. See "
+                            "SimulatorConfiguration::enableGfxReplaySave.";
+              return;
+            }
+            self.getRecorder()->saveKeyframe();
+          },
+          R"(Save a render keyframe; a render keyframe can be loaded later and used to draw observations.)")
+
+      .def(
+          "add_user_transform_to_keyframe",
+          [](ReplayManager& self, const std::string& name,
+             const Magnum::Vector3& translation,
+             const Magnum::Quaternion& rotation) {
+            if (!self.getRecorder()) {
+              LOG(ERROR) << "add_user_transform_to_keyframe: not enabled. See "
+                            "SimulatorConfiguration::enableGfxReplaySave.";
+              return;
+            }
+            self.getRecorder()->addUserTransformToKeyframe(name, translation,
+                                                           rotation);
+          },
+          R"(Add a user transform to the current render keyframe; it will get stored with the keyframe and will be available later upon loading the keyframe)")
+
+      .def(
+          "write_saved_keyframes_to_file",
+          [](ReplayManager& self, const std::string& filepath) {
+            if (!self.getRecorder()) {
+              LOG(ERROR) << "write_saved_keyframes_to_file: not enabled. See "
+                            "SimulatorConfiguration::enableGfxReplaySave.";
+              return;
+            }
+            self.getRecorder()->writeSavedKeyframesToFile(filepath);
+          },
+          R"(Write all saved keyframes to a file, then discard the keyframes.)")
+
+      .def("read_keyframes_from_file", &ReplayManager::readKeyframesFromFile,
+           R"(Create a Player object from a replay file.)");
+}
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -35,19 +35,20 @@ void initGfxReplayBindings(py::module& m) {
             Magnum::Vector3 translation;
             Magnum::Quaternion rotation;
             bool found = self.getUserTransform(name, &translation, &rotation);
-            return found ? py::make_tuple(translation, rotation)
-                         : py::make_tuple(nullptr, nullptr);
+            return found ? py::cast<py::object>(
+                               py::make_tuple(translation, rotation))
+                         : py::cast<py::object>(Py_None);
           },
-          R"(todo)");
+          R"(Get a previously-added user transform. See also ReplayManager.add_user_transform_to_keyframe.)");
 
   py::class_<ReplayManager, ReplayManager::ptr>(m, "ReplayManager")
       .def(
           "save_keyframe",
           [](ReplayManager& self) {
             if (!self.getRecorder()) {
-              LOG(ERROR) << "save_keyframe: not enabled. See "
-                            "SimulatorConfiguration::enableGfxReplaySave.";
-              return;
+              throw std::runtime_error(
+                  "replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
             }
             self.getRecorder()->saveKeyframe();
           },
@@ -59,9 +60,9 @@ void initGfxReplayBindings(py::module& m) {
              const Magnum::Vector3& translation,
              const Magnum::Quaternion& rotation) {
             if (!self.getRecorder()) {
-              LOG(ERROR) << "add_user_transform_to_keyframe: not enabled. See "
-                            "SimulatorConfiguration::enableGfxReplaySave.";
-              return;
+              throw std::runtime_error(
+                  "replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
             }
             self.getRecorder()->addUserTransformToKeyframe(name, translation,
                                                            rotation);
@@ -72,9 +73,9 @@ void initGfxReplayBindings(py::module& m) {
           "write_saved_keyframes_to_file",
           [](ReplayManager& self, const std::string& filepath) {
             if (!self.getRecorder()) {
-              LOG(ERROR) << "write_saved_keyframes_to_file: not enabled. See "
-                            "SimulatorConfiguration::enableGfxReplaySave.";
-              return;
+              throw std::runtime_error(
+                  "replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
             }
             self.getRecorder()->writeSavedKeyframesToFile(filepath);
           },

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -13,6 +13,7 @@
 
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
+#include "esp/gfx/replay/ReplayManager.h"
 #include "esp/scene/SemanticScene.h"
 #include "esp/sim/Simulator.h"
 #include "esp/sim/SimulatorConfiguration.h"
@@ -39,6 +40,10 @@ void initSimBindings(py::module& m) {
       .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
       .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling)
       .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
+      .def_readwrite(
+          "enable_gfx_replay_save",
+          &SimulatorConfiguration::enableGfxReplaySave,
+          R"(Enable replay recording. See sim.gfx_replay.save_keyframe.)")
       .def_readwrite("physics_config_file",
                      &SimulatorConfiguration::physicsConfigFile)
       .def_readwrite("scene_light_setup",
@@ -72,6 +77,9 @@ void initSimBindings(py::module& m) {
             Not available for all datasets
             )")
       .def_property_readonly("renderer", &Simulator::getRenderer)
+      .def_property_readonly(
+          "gfx_replay", &Simulator::getGfxReplayManager,
+          R"(Use the gfx_replay object for replay recording and playback.)")
       .def("seed", &Simulator::seed, "new_seed"_a)
       .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
       .def("reset", &Simulator::reset)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -78,8 +78,8 @@ void initSimBindings(py::module& m) {
             )")
       .def_property_readonly("renderer", &Simulator::getRenderer)
       .def_property_readonly(
-          "gfx_replay", &Simulator::getGfxReplayManager,
-          R"(Use the gfx_replay object for replay recording and playback.)")
+          "gfx_replay_manager", &Simulator::getGfxReplayManager,
+          R"(Use gfx_replay_manager for replay recording and playback.)")
       .def("seed", &Simulator::seed, "new_seed"_a)
       .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
       .def("reset", &Simulator::reset)

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -87,6 +87,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   esp::physics::initPhysicsBindings(m);
   esp::scene::initSceneBindings(m);
   esp::gfx::initGfxBindings(m);
+  esp::gfx::replay::initGfxReplayBindings(m);
   esp::sensor::initSensorBindings(m);
   esp::nav::initShortestPathBindings(m);
   esp::sim::initSimBindings(m);

--- a/src/esp/bindings/bindings.h
+++ b/src/esp/bindings/bindings.h
@@ -24,7 +24,10 @@ void initGeoBindings(pybind11::module& m);
 
 namespace gfx {
 void initGfxBindings(pybind11::module& m);
+namespace replay {
+void initGfxReplayBindings(pybind11::module& m);
 }
+}  // namespace gfx
 
 namespace nav {
 void initShortestPathBindings(pybind11::module& m);

--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -25,6 +25,8 @@ set(
   replay/Player.h
   replay/Recorder.cpp
   replay/Recorder.h
+  replay/ReplayManager.h
+  replay/ReplayManager.cpp
   WindowlessContext.cpp
   WindowlessContext.h
   RenderTarget.cpp

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -26,8 +26,19 @@ void Player::readKeyframesFromFile(const std::string& filepath) {
   clearFrame();
   keyframes_.clear();
 
-  auto newDoc = esp::io::parseJsonFile(filepath);
-  readKeyframesFromJsonDocument(newDoc);
+  if (!Corrade::Utility::Directory::exists(filepath)) {
+    LOG(ERROR) << "Player::readKeyframesFromFile: file " << filepath
+               << " not found.";
+    return;
+  }
+  try {
+    auto newDoc = esp::io::parseJsonFile(filepath);
+    readKeyframesFromJsonDocument(newDoc);
+  } catch (...) {
+    LOG(ERROR)
+        << "Player::readKeyframesFromFile: failed to parse keyframes from "
+        << filepath << ".";
+  }
 }
 
 int Player::getKeyframeIndex() const {

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -166,9 +166,26 @@ void Recorder::writeSavedKeyframesToFile(const std::string& filepath) {
   auto document = writeKeyframesToJsonDocument();
   esp::io::writeJsonToFile(document, filepath);
 
+  consolidateSavedKeyframes();
+}
+
+std::string Recorder::writeSavedKeyframesToString() {
+  auto document = writeKeyframesToJsonDocument();
+
+  consolidateSavedKeyframes();
+
+  return esp::io::jsonToString(document);
+}
+
+void Recorder::consolidateSavedKeyframes() {
   // consolidate saved keyframes into current keyframe
   addLoadsCreationsDeletions(savedKeyframes_.begin(), savedKeyframes_.end(),
                              &getKeyframe());
+  // clear instanceRecord.recentState to ensure updates get included in the next
+  // saved keyframe.
+  for (auto& instanceRecord : instanceRecords_) {
+    instanceRecord.recentState = Corrade::Containers::NullOpt;
+  }
   savedKeyframes_.clear();
 }
 

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -96,6 +96,11 @@ class Recorder {
   void writeSavedKeyframesToFile(const std::string& filepath);
 
   /**
+   * @brief write saved keyframes to string. Not implemented yet.
+   */
+  std::string writeSavedKeyframesToString();
+
+  /**
    * @brief Reserved for unit-testing.
    */
   const std::vector<Keyframe>& debugGetSavedKeyframes() const {
@@ -129,6 +134,7 @@ class Recorder {
   void addLoadsCreationsDeletions(KeyframeIterator begin,
                                   KeyframeIterator end,
                                   Keyframe* dest);
+  void consolidateSavedKeyframes();
 
   std::vector<InstanceRecord> instanceRecords_;
   Keyframe currKeyframe_;

--- a/src/esp/gfx/replay/ReplayManager.cpp
+++ b/src/esp/gfx/replay/ReplayManager.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "ReplayManager.h"
+
+namespace esp {
+namespace gfx {
+namespace replay {
+
+std::shared_ptr<Player> ReplayManager::readKeyframesFromFile(
+    const std::string& filepath) {
+  auto player = std::make_shared<Player>(playerCallback_);
+  player->readKeyframesFromFile(filepath);
+  if (!player->getNumKeyframes()) {
+    LOG(ERROR) << "ReplayManager::readKeyframesFromFile: failed to load any "
+                  "keyframes from ["
+               << filepath << "]";
+    return nullptr;
+  }
+  return player;
+}
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/replay/ReplayManager.h
+++ b/src/esp/gfx/replay/ReplayManager.h
@@ -1,0 +1,61 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_GFX_REPLAY_REPLAYMANAGER_H_
+#define ESP_GFX_REPLAY_REPLAYMANAGER_H_
+
+#include "Player.h"
+#include "Recorder.h"
+
+namespace esp {
+namespace gfx {
+namespace replay {
+
+/**
+ * @brief Helper class for the replay python bindings (GfxReplayBindings.cpp)
+ *
+ * This class is intended to be used as a singleton. It optionally keeps a
+ * pointer to a Recorder instance, and it helps construct Player instances.
+ */
+class ReplayManager {
+ public:
+  /**
+   * @brief Optionally make a Recorder instance available to python, or pass
+   * nullptr.
+   */
+  void setRecorder(const std::shared_ptr<Recorder>& writer) {
+    recorder_ = writer;
+  }
+
+  /**
+   * @brief Get a Recorder instance, or nullptr if it isn't enabled.
+   */
+  std::shared_ptr<Recorder> getRecorder() const { return recorder_; }
+
+  /**
+   * @brief Set a Player callback; this is needed to construct Player instances.
+   */
+  void setPlayerCallback(
+      const Player::LoadAndCreateRenderAssetInstanceCallback& callback) {
+    playerCallback_ = callback;
+  }
+
+  /**
+   * @brief Read keyframes from a file and construct a Player. Returns nullptr
+   * if no keyframes could be read.
+   */
+  std::shared_ptr<Player> readKeyframesFromFile(const std::string& filepath);
+
+ private:
+  std::shared_ptr<Recorder> recorder_;
+  Player::LoadAndCreateRenderAssetInstanceCallback playerCallback_;
+
+  ESP_SMART_POINTERS(ReplayManager)
+};
+
+}  // namespace replay
+}  // namespace gfx
+}  // namespace esp
+
+#endif

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -32,6 +32,9 @@ class SemanticScene;
 }  // namespace scene
 namespace gfx {
 class Renderer;
+namespace replay {
+class ReplayManager;
+}  // namespace replay
 }  // namespace gfx
 }  // namespace esp
 
@@ -67,6 +70,10 @@ class Simulator {
 
   scene::SceneGraph& getActiveSceneGraph();
   scene::SceneGraph& getActiveSemanticSceneGraph();
+
+  std::shared_ptr<gfx::replay::ReplayManager> getGfxReplayManager() {
+    return gfxReplayMgr_;
+  }
 
   void saveFrame(const std::string& filename);
 
@@ -829,6 +836,15 @@ class Simulator {
     metadataMediator_ = _metadataMediator;
   }
 
+  /**
+   * @brief Load and add a render asset instance to the current scene graph(s).
+   * @param assetInfo the asset to load
+   * @param creation how to create the instance
+   */
+  scene::SceneNode* loadAndCreateRenderAssetInstance(
+      const assets::AssetInfo& assetInfo,
+      const assets::RenderAssetInstanceCreationInfo& creation);
+
  protected:
   Simulator(){};
 
@@ -842,6 +858,8 @@ class Simulator {
   bool sceneHasPhysics(int sceneID) const {
     return isValidScene(sceneID) && physicsManager_ != nullptr;
   }
+
+  void reconfigureReplayManager();
 
   gfx::WindowlessContext::uptr context_ = nullptr;
   std::shared_ptr<gfx::Renderer> renderer_ = nullptr;
@@ -863,6 +881,8 @@ class Simulator {
   std::shared_ptr<scene::SemanticScene> semanticScene_ = nullptr;
 
   std::shared_ptr<physics::PhysicsManager> physicsManager_ = nullptr;
+
+  std::shared_ptr<esp::gfx::replay::ReplayManager> gfxReplayMgr_;
 
   core::Random::ptr random_;
   SimulatorConfiguration config_;

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -34,6 +34,10 @@ struct SimulatorConfiguration {
    */
   bool enablePhysics = false;
   /**
+   * @brief todo
+   */
+  bool enableGfxReplaySave = false;
+  /**
    * @brief Whether or not to load the semantic mesh
    */
   bool loadSemanticMesh = true;

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -2,12 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <Corrade/Containers/Optional.h>
-#include <Corrade/Utility/Directory.h>
-#include <Magnum/EigenIntegration/Integration.h>
-#include <Magnum/Math/Range.h>
-#include <gtest/gtest.h>
-#include <string>
+#include "configure.h"
 
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/assets/ResourceManager.h"
@@ -17,7 +12,14 @@
 #include "esp/gfx/replay/Recorder.h"
 #include "esp/scene/SceneManager.h"
 
-#include "configure.h"
+#include <Corrade/Containers/Optional.h>
+#include <Corrade/Utility/Directory.h>
+#include <Magnum/EigenIntegration/Integration.h>
+#include <Magnum/Math/Range.h>
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
 
 namespace Cr = Corrade;
 namespace Mn = Magnum;
@@ -233,4 +235,35 @@ TEST(GfxReplayTest, player) {
       ASSERT(userTranslation == Mn::Vector3(4.f, 5.f, 6.f));
     }
   }
+}
+
+TEST(GfxReplayTest, playerReadMissingFile) {
+  auto dummyCallback =
+      [&](const esp::assets::AssetInfo& assetInfo,
+          const esp::assets::RenderAssetInstanceCreationInfo& creation) {
+        return nullptr;
+      };
+  esp::gfx::replay::Player player(dummyCallback);
+
+  player.readKeyframesFromFile("file_that_does_not_exist.json");
+  EXPECT_EQ(player.getNumKeyframes(), 0);
+}
+
+TEST(GfxReplayTest, playerReadInvalidFile) {
+  auto testFilepath =
+      Corrade::Utility::Directory::join(DATA_DIR, "./gfx_replay_test.json");
+
+  std::ofstream out(testFilepath);
+  out << "{invalid json";
+  out.close();
+
+  auto dummyCallback =
+      [&](const esp::assets::AssetInfo& assetInfo,
+          const esp::assets::RenderAssetInstanceCreationInfo& creation) {
+        return nullptr;
+      };
+  esp::gfx::replay::Player player(dummyCallback);
+
+  player.readKeyframesFromFile(testFilepath);
+  EXPECT_EQ(player.getNumKeyframes(), 0);
 }


### PR DESCRIPTION
## Motivation and Context

This PR integrates the render-replay Recorder and Player into Simulator and ResourceManager and sets up python bindings to use them. Recorder and Player are already merged and unit-tested so this PR is fairly small and just does the hookup/integration.

~Note file reading/writing is still disabled (waiting on https://github.com/facebookresearch/habitat-sim/pull/980 ) so this is more like a stub implementation. I may wait for https://github.com/facebookresearch/habitat-sim/pull/980 to merge before merging this, but I'd like to get this under review now.~ Update: https://github.com/facebookresearch/habitat-sim/pull/980 has merged.

I have a working replay tutorial which I was planning to merge as a separate PR (or I can add it here if requested). Anyway it's [here](https://github.com/eundersander/habitat-sim/blob/eundersander/replay_tutorial/examples/tutorials/nb_python/replay_tutorial.py) if you want to check out usage of the python bindings.

## How Has This Been Tested

This integration was tested in upcoming [replay tutorial](https://github.com/eundersander/habitat-sim/blob/eundersander/replay_tutorial/examples/tutorials/nb_python/replay_tutorial.py), including testing the exception-throwing in the bindings.

Note that Player and Recorder are already individually unit-tested in GfxReplayTest.cpp (already in master). The error-handling changes to Player here include new unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
