### PR TITLE
[WebGL] Viewer improve CMake  and folder path handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,8 +468,6 @@ jobs:
               nvm use v11.9.0
               . ~/emsdk/emsdk_env.sh
               ./build_js.sh
-              # TODO: Later fix this in the cmake build step
-              cp -v build_js/Release/bin/hsim_bindings.* build_js/esp/bindings_js/
       - run:
           name: Run sim benchmark
           command: |

--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -12,7 +12,15 @@ target_link_libraries(
          sim
 )
 
-set_target_properties(hsim_bindings PROPERTIES LINK_FLAGS "--bind")
+set_target_properties(
+  hsim_bindings
+  PROPERTIES
+    LINK_FLAGS "--bind"
+    # Override the Magnum-set default which is in $<CONFIG>/bin or $<CONFIG>/lib
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 # copy JS/HTML/CSS resources for WebGL build
 set(

--- a/src/esp/bindings_js/index.js
+++ b/src/esp/bindings_js/index.js
@@ -17,13 +17,20 @@ import {
 } from "./modules/utils";
 
 function preload(url) {
-  let file = url;
-  if (url.indexOf("http") === 0) {
-    const splits = url.split("/");
-    file = splits[splits.length - 1];
+  let file_parents_str = "/";
+  const splits = url.split("/");
+  let file = splits[splits.length - 1];
+  if (url.indexOf("http") === -1) {
+    let file_parents = splits.slice(0, splits.length - 1);
+    for (let i = 0; i < splits.length - 1; i += 1) {
+      file_parents_str += file_parents[i] + "/";
+      if (!FS.analyzePath(file_parents_str).exists) {
+        FS.mkdir(file_parents_str, 777);
+      }
+    }
   }
-  FS.createPreloadedFile("/", file, url, true, false);
-  return file;
+  FS.createPreloadedFile(file_parents_str, file, url, true, false);
+  return file_parents_str + file;
 }
 
 Module.preRun.push(() => {


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This solves two issues. One it removes the need for a cp after building the viewer and also allows the viewer to take in arbitrary relative urls (including those in folders or absolute file locations).

Now we can have folders of scenes, configs, and other params on the webserver and they will load properly.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.

Closes #527 