### PR TITLE
--pass object creation attributes to addObjectToDrawables

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -316,7 +316,6 @@ bool ResourceManager::loadStage(
 
   return true;
 }  // ResourceManager::loadScene
-
 bool ResourceManager::buildMeshGroups(
     const AssetInfo& info,
     std::vector<CollisionMeshData>& meshGroup) {
@@ -1865,17 +1864,13 @@ bool ResourceManager::instantiateAssetsOnDemand(
 }  // ResourceManager::instantiateAssetsOnDemand
 
 void ResourceManager::addObjectToDrawables(
-    const std::string& objTemplateHandle,
+    const ObjectAttributes::ptr& ObjectAttributes,
     scene::SceneNode* parent,
     DrawableGroup* drawables,
     std::vector<scene::SceneNode*>& visNodeCache,
     const std::string& lightSetupKey) {
   if (parent != nullptr and drawables != nullptr) {
     //! Add mesh to rendering stack
-
-    // Meta data
-    ObjectAttributes::ptr ObjectAttributes =
-        getObjectAttributesManager()->getObjectByHandle(objTemplateHandle);
 
     const std::string& renderObjectName =
         ObjectAttributes->getRenderAssetHandle();

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -325,50 +325,12 @@ class ResourceManager {
    * specified @ref DrawableGroup as a child of the specified @ref
    * scene::SceneNode if provided.
    *
-   * If the attributes specified by objTemplateID exists in @ref
-   * esp::metadata::managers::ObjectAttributesManager::objectLibrary_, and both
-   * parent and drawables are specified, than an object referenced by that key
-   * is added to the scene.
-   * @param objTemplateLibID The ID of the object attributes in the @ref
-   * esp::metadata::managers::ObjectAttributesManager::objectLibrary_.  This is
-   * expected to exist
-   * @param parent The @ref scene::SceneNode of which the object will be a
-   * child.
-   * @param drawables The @ref DrawableGroup with which the object @ref
-   * gfx::Drawable will be rendered.
-   * @param lightSetupKey The @ref LightSetup key that will be used
-   * for the added component.
-   * @param[out] visNodeCache Cache for pointers to all nodes created as the
-   * result of this process.
-   */
-  void addObjectToDrawables(
-      int objTemplateLibID,
-      scene::SceneNode* parent,
-      DrawableGroup* drawables,
-      std::vector<scene::SceneNode*>& visNodeCache,
-      const std::string& lightSetupKey = DEFAULT_LIGHTING_KEY) {
-    if (objTemplateLibID != ID_UNDEFINED) {
-      const std::string& objTemplateHandleName =
-          metadataMediator_->getObjectAttributesManager()->getObjectHandleByID(
-              objTemplateLibID);
-
-      addObjectToDrawables(objTemplateHandleName, parent, drawables,
-                           visNodeCache, lightSetupKey);
-    }  // else objTemplateID does not exist - shouldn't happen
-  }    // addObjectToDrawables
-
-  /**
-   * @brief Add an object from a specified object template handle to the
-   * specified @ref DrawableGroup as a child of the specified @ref
-   * scene::SceneNode if provided.
-   *
    * If the attributes specified by objTemplateHandle exists in @ref
    * esp::metadata::managers::ObjectAttributesManager::objectLibrary_, and both
    * parent and drawables are specified, than an object referenced by that key
    * is added to the scene.
-   * @param objTemplateHandle The key of the attributes in the @ref  to parse
-   * and load.  The attributes are expected to exist but will be created (in the
-   * case of synthesized objects) if it does not.
+   * @param ObjectAttributes The attributes used to create the object being
+   * added.
    * @param parent The @ref scene::SceneNode of which the object will be a
    * child.
    * @param drawables The @ref DrawableGroup with which the object @ref
@@ -379,7 +341,7 @@ class ResourceManager {
    * result of this process.
    */
   void addObjectToDrawables(
-      const std::string& objTemplateHandle,
+      const metadata::attributes::ObjectAttributes::ptr& ObjectAttributes,
       scene::SceneNode* parent,
       DrawableGroup* drawables,
       std::vector<scene::SceneNode*>& visNodeCache,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -109,9 +109,9 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
           ->getInitializationAttributes()
           ->getIsVisible()) {
     resourceManager_.addObjectToDrawables(
-        configFileHandle, existingObjects_.at(nextObjectID_)->visualNode_,
-        drawables, existingObjects_.at(nextObjectID_)->visualNodes_,
-        lightSetup);
+        existingObjects_.at(nextObjectID_)->getInitializationAttributes(),
+        existingObjects_.at(nextObjectID_)->visualNode_, drawables,
+        existingObjects_.at(nextObjectID_)->visualNodes_, lightSetup);
   }
 
   // finalize rigid object creation

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -99,23 +99,23 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     return ID_UNDEFINED;
   }
 
-  existingObjects_.at(nextObjectID_)
-      ->visualNodes_.push_back(existingObjects_.at(nextObjectID_)->visualNode_);
+  // temp non-owning pointer to object
+  esp::physics::RigidObject* const obj =
+      (existingObjects_.at(nextObjectID_).get());
+
+  obj->visualNodes_.push_back(obj->visualNode_);
 
   //! Draw object via resource manager
   //! Render node as child of physics node
   //! Verify we should make the object drawable
-  if (existingObjects_.at(nextObjectID_)
-          ->getInitializationAttributes()
-          ->getIsVisible()) {
-    resourceManager_.addObjectToDrawables(
-        existingObjects_.at(nextObjectID_)->getInitializationAttributes(),
-        existingObjects_.at(nextObjectID_)->visualNode_, drawables,
-        existingObjects_.at(nextObjectID_)->visualNodes_, lightSetup);
+  if (obj->getInitializationAttributes()->getIsVisible()) {
+    resourceManager_.addObjectToDrawables(obj->getInitializationAttributes(),
+                                          obj->visualNode_, drawables,
+                                          obj->visualNodes_, lightSetup);
   }
 
   // finalize rigid object creation
-  objectSuccess = existingObjects_.at(nextObjectID_)->finalizeObject();
+  objectSuccess = obj->finalizeObject();
   if (!objectSuccess) {
     removeObject(nextObjectID_, true, true);
     LOG(ERROR) << "PhysicsManager::addObject : PhysicsManager::finalizeObject "


### PR DESCRIPTION
## Motivation and Context
This PR is a small change where the attributes specifically used to create an object are passed to RM directly when the object is added to drawables.  It also removes an unused (and unlikely to ever be used) AddToDrawables function overload.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
