### PR TITLE
[Clang-Tidy] Tighten clang-tidy warnings into errors for bugprone.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,5 +43,4 @@ WarningsAsErrors:
 '*,
 -bugprone-branch-clone,
 -bugprone-narrowing-conversions,
--bugprone-unused-raii,
 -clang-diagnostic-deprecated-declarations'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,4 +42,5 @@ performance-*,
 WarningsAsErrors:
 '*,
 -bugprone-narrowing-conversions,
+-bugprone-unused-raii,
 -clang-diagnostic-deprecated-declarations'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,5 @@ performance-*,
 # then start updating the code.
 WarningsAsErrors:
 '*,
--bugprone-branch-clone,
 -bugprone-narrowing-conversions,
 -clang-diagnostic-deprecated-declarations'

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -40,6 +40,7 @@ namespace metadata {
 
 void initAttributesBindings(py::module& m) {
   // ==== AbstractManagedObject ====
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<AbstractManagedObject, AbstractManagedObject::ptr>(
       m, "AbstractManagedObject");
 

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -274,12 +274,14 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Light Layout Attributes Template manager ====
   declareBaseAttributesManager<LightLayoutAttributes>(m, "BaseLightLayout");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<LightLayoutAttributesManager,
              AttributesManager<LightLayoutAttributes>,
              LightLayoutAttributesManager::ptr>(m,
                                                 "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
   declareBaseAttributesManager<ObjectAttributes>(m, "BaseObject");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes>,
              ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
@@ -333,12 +335,14 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Stage Attributes Template manager ====
   declareBaseAttributesManager<StageAttributes>(m, "BaseStage");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<StageAttributesManager, AttributesManager<StageAttributes>,
              StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
   declareBaseAttributesManager<PhysicsManagerAttributes>(m, "BasePhysics");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<PhysicsAttributesManager,
              AttributesManager<PhysicsManagerAttributes>,
              PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -38,6 +38,7 @@ namespace sensor {
 
 void initSensorBindings(py::module& m) {
   // ==== Observation ====
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<Observation, Observation::ptr>(m, "Observation");
 
   // TODO fill out other SensorTypes

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -204,22 +204,26 @@ bool SemanticScene::loadMp3dHouse(
         }
         break;
       }
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       case 'P': {  // portal or panorama
         // P portal_index region0_index region1_index label  xlo ylo zlo xhi
         //   yhi zhi  0 0 0 0
         // P name  panorama_index region_index 0  px py pz  0 0 0 0 0
         break;
       }
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       case 'S': {  // surface
         // S surface_index region_index 0 label px py pz  nx ny nz  xlo ylo
         // zlo
         //   xhi yhi zhi  0 0 0 0 0
         break;
       }
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       case 'V': {  // vertex
         // V vertex_index surface_index label  px py pz  nx ny nz  0 0 0
         break;
       }
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       case 'I': {  // image
         // I image_index panorama_index  name camera_index yaw_index e00 e01
         //   e02 e03 e10 e11 e12 e13 e20 e21 e22 e23 e30 e31 e32 e33  i00 i01


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* There were a few annoying RAII warnings and bugprone-branch clones that were being emitted as warnings instead of errors. It seems like the RAII warnings are false positives though since Caffe2 has similar nolints. False positive occurs when a module is constructed with nodefs, which usually is an error, but in these few cases is not. When it is not an error, nolint comments should be explicit.
* Now the main warning left in the code base is implicit narrowing conversions.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and on CircleCI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
-
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
