### PR TITLE
[sensor] A camera to render the scene into the cubemap

### DIFF
--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -18,6 +18,8 @@ set(
   magnum.h
   RenderCamera.cpp
   RenderCamera.h
+  CubeMapCamera.cpp
+  CubeMapCamera.h
   Renderer.cpp
   Renderer.h
   replay/Keyframe.h

--- a/src/esp/gfx/CubeMapCamera.cpp
+++ b/src/esp/gfx/CubeMapCamera.cpp
@@ -40,32 +40,12 @@ CubeMapCamera& CubeMapCamera::restoreTransformation() {
 }
 
 CubeMapCamera& CubeMapCamera::switchToFace(unsigned int cubeSideIndex) {
-  switch (cubeSideIndex) {
-    case 0:
-      switchToFace(Mn::GL::CubeMapCoordinate::PositiveX);
-      break;
-    case 1:
-      switchToFace(Mn::GL::CubeMapCoordinate::NegativeX);
-      break;
-    case 2:
-      switchToFace(Mn::GL::CubeMapCoordinate::PositiveY);
-      break;
-    case 3:
-      switchToFace(Mn::GL::CubeMapCoordinate::NegativeY);
-      break;
-    case 4:
-      switchToFace(Mn::GL::CubeMapCoordinate::PositiveZ);
-      break;
-    case 5:
-      switchToFace(Mn::GL::CubeMapCoordinate::NegativeZ);
-      break;
-    default:
-      LOG(ERROR)
-          << "Warning: CubeMapCamera::switchToFace(): the index of cube side "
-          << cubeSideIndex
-          << " is illegal. Camera orientation stays unchanged.";
-      break;
-  }
+  CORRADE_ASSERT(cubeSideIndex < 6,
+                 "CubeMapCamera::switchToFace(): the index of the cube side,"
+                     << cubeSideIndex << "is illegal.",
+                 *this);
+  switchToFace(Mn::GL::CubeMapCoordinate(
+      int(Mn::GL::CubeMapCoordinate::PositiveX) + cubeSideIndex));
   return *this;
 }
 
@@ -95,7 +75,7 @@ CubeMapCamera& CubeMapCamera::switchToFace(Mn::GL::CubeMapCoordinate cubeSide) {
         return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, 1.0}, -yUp);
         break;
       default:
-        return Mn::Matrix4{Magnum::Math::IdentityInit};
+        CORRADE_INTERNAL_ASSERT_UNREACHABLE();
         break;
     }
   };
@@ -107,13 +87,15 @@ CubeMapCamera& CubeMapCamera::switchToFace(Mn::GL::CubeMapCoordinate cubeSide) {
 CubeMapCamera& CubeMapCamera::setProjectionMatrix(int width,
                                                   float znear,
                                                   float zfar) {
+  // NOLINTNEXTLINE(google-build-using-namespace)
+  using namespace Mn::Math::Literals;
   MagnumCamera::setProjectionMatrix(
       Mn::Matrix4::perspectiveProjection(
-          Mn::Deg{90.0},  // horizontal field of view angle
-          1.0,            // aspect ratio (width/height)
-          znear,          // z-near plane
-          zfar))          // z-far plane
-      .setViewport(Magnum::Vector2i(width, width));
+          Mn::Deg{90.0_degf},  // horizontal field of view angle
+          1.0,                 // aspect ratio (width/height)
+          znear,               // z-near plane
+          zfar))               // z-far plane
+      .setViewport({width, width});
   return *this;
 }
 

--- a/src/esp/gfx/CubeMapCamera.cpp
+++ b/src/esp/gfx/CubeMapCamera.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+#include "CubeMapCamera.h"
+#include <Magnum/EigenIntegration/Integration.h>
+
+namespace Mn = Magnum;
+namespace Cr = Corrade;
+
+namespace esp {
+namespace gfx {
+
+CubeMapCamera::CubeMapCamera(scene::SceneNode& node) : RenderCamera(node) {
+  updateOriginalViewingMatrix();
+}
+CubeMapCamera::CubeMapCamera(scene::SceneNode& node,
+                             const vec3f& eye,
+                             const vec3f& target,
+                             const vec3f& up)
+    : CubeMapCamera(node,
+                    Mn::Vector3{eye},
+                    Mn::Vector3{target},
+                    Mn::Vector3{up}) {}
+CubeMapCamera::CubeMapCamera(scene::SceneNode& node,
+                             const Mn::Vector3& eye,
+                             const Mn::Vector3& target,
+                             const Mn::Vector3& up)
+    : RenderCamera(node, eye, target, up) {
+  updateOriginalViewingMatrix();
+}
+CubeMapCamera& CubeMapCamera::updateOriginalViewingMatrix() {
+  originalViewingMatrix_ = this->node().transformation();
+  return *this;
+}
+
+CubeMapCamera& CubeMapCamera::restoreTransformation() {
+  this->node().setTransformation(originalViewingMatrix_);
+  return *this;
+}
+
+CubeMapCamera& CubeMapCamera::switchToFace(unsigned int cubeSideIndex) {
+  switch (cubeSideIndex) {
+    case 0:
+      switchToFace(Mn::GL::CubeMapCoordinate::PositiveX);
+      break;
+    case 1:
+      switchToFace(Mn::GL::CubeMapCoordinate::NegativeX);
+      break;
+    case 2:
+      switchToFace(Mn::GL::CubeMapCoordinate::PositiveY);
+      break;
+    case 3:
+      switchToFace(Mn::GL::CubeMapCoordinate::NegativeY);
+      break;
+    case 4:
+      switchToFace(Mn::GL::CubeMapCoordinate::PositiveZ);
+      break;
+    case 5:
+      switchToFace(Mn::GL::CubeMapCoordinate::NegativeZ);
+      break;
+    default:
+      LOG(ERROR)
+          << "Warning: CubeMapCamera::switchToFace(): the index of cube side "
+          << cubeSideIndex
+          << " is illegal. Camera orientation stays unchanged.";
+      break;
+  }
+  return *this;
+}
+
+CubeMapCamera& CubeMapCamera::switchToFace(Mn::GL::CubeMapCoordinate cubeSide) {
+  Mn::Vector3 eye{0.0, 0.0, 0.0};
+  Mn::Vector3 yUp{0.0, 1.0, 0.0};
+  Mn::Vector3 zUp{0.0, 0.0, 1.0};
+
+  auto cameraLocalTransform = [&]() {
+    switch (cubeSide) {
+      case Mn::GL::CubeMapCoordinate::PositiveX:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{-1.0, 0.0, 0.0}, -yUp);
+        break;
+      case Mn::GL::CubeMapCoordinate::NegativeX:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{1.0, 0.0, 0.0}, -yUp);
+        break;
+      case Mn::GL::CubeMapCoordinate::PositiveY:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 1.0, 0.0}, -zUp);
+        break;
+      case Mn::GL::CubeMapCoordinate::NegativeY:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, -1.0, 0.0}, zUp);
+        break;
+      case Mn::GL::CubeMapCoordinate::PositiveZ:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, -1.0}, -yUp);
+        break;
+      case Mn::GL::CubeMapCoordinate::NegativeZ:
+        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, 1.0}, -yUp);
+        break;
+      default:
+        return Mn::Matrix4{Magnum::Math::IdentityInit};
+        break;
+    }
+  };
+  this->node().setTransformation(originalViewingMatrix_ *
+                                 cameraLocalTransform());
+  return *this;
+}
+
+CubeMapCamera& CubeMapCamera::setProjectionMatrix(int width,
+                                                  float znear,
+                                                  float zfar) {
+  MagnumCamera::setProjectionMatrix(
+      Mn::Matrix4::perspectiveProjection(
+          Mn::Deg{90.0},  // horizontal field of view angle
+          1.0,            // aspect ratio (width/height)
+          znear,          // z-near plane
+          zfar))          // z-far plane
+      .setViewport(Magnum::Vector2i(width, width));
+  return *this;
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/CubeMapCamera.cpp
+++ b/src/esp/gfx/CubeMapCamera.cpp
@@ -91,10 +91,10 @@ CubeMapCamera& CubeMapCamera::setProjectionMatrix(int width,
   using namespace Mn::Math::Literals;
   MagnumCamera::setProjectionMatrix(
       Mn::Matrix4::perspectiveProjection(
-          Mn::Deg{90.0_degf},  // horizontal field of view angle
-          1.0,                 // aspect ratio (width/height)
-          znear,               // z-near plane
-          zfar))               // z-far plane
+          90.0_degf,  // horizontal field of view angle
+          1.0,        // aspect ratio (width/height)
+          znear,      // z-near plane
+          zfar))      // z-far plane
       .setViewport({width, width});
   return *this;
 }

--- a/src/esp/gfx/CubeMapCamera.h
+++ b/src/esp/gfx/CubeMapCamera.h
@@ -45,8 +45,7 @@ class CubeMapCamera : public RenderCamera {
   virtual ~CubeMapCamera(){};
   /**
    * @brief Move the camera towards a specified cube face
-   * @param cubeSide, the cube map coordinate, see the following pictures
-   * NOTE: +Y is top
+   * ```
    *           +----+
    *           | -Y |
    * +----+----+----+----+
@@ -54,6 +53,9 @@ class CubeMapCamera : public RenderCamera {
    * +----+----+----+----+
    *           | +Y |
    *           +----+
+   * ```
+   * @param cubeSide, the cube map coordinate, see the following pictures
+   * NOTE: +Y is top
    * CAREFUL! the local transformation of the camera node will be set after
    * calling this function.
    * @return Reference to self (for method chaining)
@@ -61,13 +63,7 @@ class CubeMapCamera : public RenderCamera {
   CubeMapCamera& switchToFace(Magnum::GL::CubeMapCoordinate cubeSide);
   /**
    * @brief Overload, move the camera towards a specified cube face
-   * @param cubSideIndex, the index of the cube map coordinate.
-   * 0: +X
-   * 1: -X
-   * 2: +Y
-   * 3: -Y
-   * 4: +Z
-   * 5: -Z
+   * ```
    *           +----+
    *           | -Y |
    * +----+----+----+----+
@@ -75,12 +71,21 @@ class CubeMapCamera : public RenderCamera {
    * +----+----+----+----+
    *           | +Y |
    *           +----+
+   * ```
+   * @param cubSideIndex, the index of the cube map coordinate.
+   * 0: +X
+   * 1: -X
+   * 2: +Y
+   * 3: -Y
+   * 4: +Z
+   * 5: -Z
    * @return Reference to self (for method chaining)
    */
   CubeMapCamera& switchToFace(unsigned int cubeSideIndex);
 
   /**
-   * Calling the the setProjectionMatrix from base class is not allowed
+   * Calling the the setProjectionMatrix from the base class is not allowed.
+   * Use the new one instead.
    */
   RenderCamera& setProjectionMatrix(int width,
                                     int height,

--- a/src/esp/gfx/CubeMapCamera.h
+++ b/src/esp/gfx/CubeMapCamera.h
@@ -1,0 +1,125 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_GFX_CUBEMAPCAMERA_H_
+#define ESP_GFX_CUBEMAPCAMERA_H_
+
+#include <Magnum/GL/CubeMapTexture.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/Math/Tags.h>
+#include "esp/core/esp.h"
+#include "esp/gfx/RenderCamera.h"
+
+namespace esp {
+namespace gfx {
+class CubeMapCamera : public RenderCamera {
+ public:
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   */
+  explicit CubeMapCamera(scene::SceneNode& node);
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   * @param eye, the eye position (parent node space)
+   * @param target, the target position (parent node space)
+   * @param up, the up direction (parent node space)
+   */
+  explicit CubeMapCamera(scene::SceneNode& node,
+                         const vec3f& eye,
+                         const vec3f& target,
+                         const vec3f& up);
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   * @param eye, the eye position (parent node space)
+   * @param target, the target position (parent node space)
+   * @param up, the up direction (parent node space)
+   */
+  explicit CubeMapCamera(scene::SceneNode& node,
+                         const Magnum::Vector3& eye,
+                         const Magnum::Vector3& target,
+                         const Magnum::Vector3& up);
+  virtual ~CubeMapCamera(){};
+  /**
+   * @brief Move the camera towards a specified cube face
+   * @param cubeSide, the cube map coordinate, see the following pictures
+   * NOTE: +Y is top
+   *           +----+
+   *           | -Y |
+   * +----+----+----+----+
+   * | -Z | -X | +Z | +X |
+   * +----+----+----+----+
+   *           | +Y |
+   *           +----+
+   * CAREFUL! the local transformation of the camera node will be set after
+   * calling this function.
+   * @return Reference to self (for method chaining)
+   */
+  CubeMapCamera& switchToFace(Magnum::GL::CubeMapCoordinate cubeSide);
+  /**
+   * @brief Overload, move the camera towards a specified cube face
+   * @param cubSideIndex, the index of the cube map coordinate.
+   * 0: +X
+   * 1: -X
+   * 2: +Y
+   * 3: -Y
+   * 4: +Z
+   * 5: -Z
+   *           +----+
+   *           | -Y |
+   * +----+----+----+----+
+   * | -Z | -X | +Z | +X |
+   * +----+----+----+----+
+   *           | +Y |
+   *           +----+
+   * @return Reference to self (for method chaining)
+   */
+  CubeMapCamera& switchToFace(unsigned int cubeSideIndex);
+
+  /**
+   * Calling the the setProjectionMatrix from base class is not allowed
+   */
+  RenderCamera& setProjectionMatrix(int width,
+                                    int height,
+                                    float znear,
+                                    float zfar,
+                                    float hfov) = delete;
+  /**
+   * @brief Set the projection matrix
+   * @param width, the width of the square image plane
+   * @param znear the near clipping plane
+   * @param znear the far clipping plane
+   */
+  CubeMapCamera& setProjectionMatrix(int width, float znear, float zfar);
+
+  /**
+   * @brief Update the original viewing matrix. It MUST be called after each
+   * time the local transformation of camera node has been set.
+   * @return Reference to self (for method chaining)
+   */
+  CubeMapCamera& updateOriginalViewingMatrix();
+
+  /**
+   * @brief restore the local transformation of the camera node using the stored
+   * original viewing matrix.
+   * It is useful, since @ref switchToFace() will change the local
+   * transformations and user want to revert such changes.
+   * @return Reference to self (for method chaining)
+   */
+  CubeMapCamera& restoreTransformation();
+
+ protected:
+  // viewing matrix (in parent node space) computed by Mn::Matrix4::lookAt(eye,
+  // target, up)
+  // this is exactly the matrix set to the node in the constructor
+  // default value: identity matrix
+  Magnum::Matrix4 originalViewingMatrix_ =
+      Magnum::Matrix4{Magnum::Math::IdentityInit};
+  ESP_SMART_POINTERS(CubeMapCamera)
+};
+}  // namespace gfx
+}  // namespace esp
+#endif

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -11,6 +11,7 @@
 #include <Magnum/SceneGraph/Drawable.h>
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
+#include "esp/scene/SceneGraph.h"
 
 namespace Mn = Magnum;
 namespace Cr = Corrade;
@@ -54,13 +55,33 @@ RenderCamera::RenderCamera(scene::SceneNode& node) : MagnumCamera{node} {
 }
 
 RenderCamera::RenderCamera(scene::SceneNode& node,
+                           const Mn::Vector3& eye,
+                           const Mn::Vector3& target,
+                           const Mn::Vector3& up)
+
+    : RenderCamera(node) {
+  // once it is attached, set the transformation
+  resetViewingParameters(eye, target, up);
+}
+
+RenderCamera::RenderCamera(scene::SceneNode& node,
                            const vec3f& eye,
                            const vec3f& target,
                            const vec3f& up)
-    : RenderCamera(node) {
-  // once it is attached, set the transformation
-  node.setTransformation(Mn::Matrix4::lookAt(
-      Mn::Vector3{eye}, Mn::Vector3{target}, Mn::Vector3{up}));
+    : RenderCamera(node,
+                   Mn::Vector3{eye},
+                   Mn::Vector3{target},
+                   Mn::Vector3{up}) {}
+
+RenderCamera& RenderCamera::resetViewingParameters(const Mn::Vector3& eye,
+                                                   const Mn::Vector3& target,
+                                                   const Mn::Vector3& up) {
+  this->node().setTransformation(Mn::Matrix4::lookAt(eye, target, up));
+  return *this;
+}
+
+bool RenderCamera::isInSceneGraph(const scene::SceneGraph& sceneGraph) {
+  return (this->node().scene() == sceneGraph.getRootNode().parent());
 }
 
 RenderCamera& RenderCamera::setProjectionMatrix(int width,

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -43,11 +43,55 @@ class RenderCamera : public MagnumCamera {
   typedef Corrade::Containers::EnumSet<Flag> Flags;
   CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
 
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   */
   RenderCamera(scene::SceneNode& node);
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   * @param eye, the eye position (in PARENT node space)
+   * @param target, the target position (in PARENT node space)
+   * @param up, the up direction (in PARENT node space)
+   * NOTE: it will override any relative transformation w.r.t its parent node
+   */
   RenderCamera(scene::SceneNode& node,
                const vec3f& eye,
                const vec3f& target,
                const vec3f& up);
+  /**
+   * @brief Constructor
+   * @param node, the scene node to which the camera is attached
+   * @param eye, the eye position (in PARENT node space)
+   * @param target, the target position (in PARENT node space)
+   * @param up, the up direction (in PARENT node space)
+   * NOTE: it will override any relative transformation w.r.t its parent node
+   */
+  RenderCamera(scene::SceneNode& node,
+               const Magnum::Vector3& eye,
+               const Magnum::Vector3& target,
+               const Magnum::Vector3& up);
+  /**
+   * @brief Reset the initial viewing parameters of the camera
+   * @param eye, the eye position (in PARENT node space)
+   * @param target, the target position (in PARENT node space)
+   * @param up, the up direction (in PARENT node space)
+   * @return Reference to self (for method chaining)
+   * NOTE: it will override any relative transformation w.r.t its parent node
+   */
+  virtual RenderCamera& resetViewingParameters(const Magnum::Vector3& eye,
+                                               const Magnum::Vector3& target,
+                                               const Magnum::Vector3& up);
+  /**
+   * @brief Tell if the camera is attached to the scene graph
+   * @return true if it is attached to this scene graph, otherwise false
+   */
+  bool isInSceneGraph(const scene::SceneGraph& sceneGraph);
+
+  /**
+   * @brief destructor
+   */
   virtual ~RenderCamera() {
     // do nothing, let magnum handle the camera
   }


### PR DESCRIPTION
## Motivation and Context
This is a camera that can be put into the scene (attaching to a node in the scene graph), and render the surroundings into the cubemap.
We need the cubemap for:
- Fisheye sensor;
- Pbr Image based rendering;

More about this camera:
- It is a render camera that can render the scene. So it is inherited from the RenderCamera;
- The FOV is fixed to 90 degrees;
- The rendering plane is a square (width must be the same as height.);
- It has a convenient function called SwitchToFace() to control which cubemap's face it is rendering to;

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
