### PR TITLE
gfx-replay recording for C++ viewer

### DIFF
--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -90,13 +90,13 @@ class Recorder {
                                   const Magnum::Quaternion& rotation);
 
   /**
-   * @brief write saved keyframes to file. Not implemented yet.
+   * @brief write saved keyframes to file.
    * @param filepath
    */
   void writeSavedKeyframesToFile(const std::string& filepath);
 
   /**
-   * @brief write saved keyframes to string. Not implemented yet.
+   * @brief write saved keyframes to string.
    */
   std::string writeSavedKeyframesToString();
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -26,6 +26,8 @@
 #include <Magnum/Timeline.h>
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
+#include "esp/gfx/replay/Recorder.h"
+#include "esp/gfx/replay/ReplayManager.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/scene/ObjectControls.h"
 #include "esp/scene/SceneNode.h"
@@ -321,6 +323,7 @@ Key Commands:
   esp::gfx::RenderCamera* renderCamera_ = nullptr;
   esp::scene::SceneGraph* activeSceneGraph_ = nullptr;
   bool drawObjectBBs = false;
+  std::string gfxReplayRecordFilepath_;
 
   Mn::Timeline timeline_;
 
@@ -361,6 +364,9 @@ Viewer::Viewer(const Arguments& arguments)
                "Stage asset should be lit with Phong shading.")
       .addBooleanOption("debug-bullet")
       .setHelp("debug-bullet", "Render Bullet physics debug wireframes.")
+      .addOption("gfx-replay-record-filepath")
+      .setHelp("gfx-replay-record-filepath",
+               "Enable replay recording with R key.")
       .addOption("physics-config", ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH)
       .setHelp("physics-config",
                "Provide a non-default PhysicsManager config file.")
@@ -406,6 +412,8 @@ Viewer::Viewer(const Arguments& arguments)
     debugBullet_ = true;
   }
 
+  gfxReplayRecordFilepath_ = args.value("gfx-replay-record-filepath");
+
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
   simConfig.activeSceneName = sceneFileName;
@@ -414,6 +422,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig.enablePhysics = useBullet;
   simConfig.frustumCulling = true;
   simConfig.requiresTextures = true;
+  simConfig.enableGfxReplaySave = !gfxReplayRecordFilepath_.empty();
   if (args.isSet("stage-requires-lighting")) {
     Mn::Debug{} << "Stage using DEFAULT_LIGHTING_KEY";
     simConfig.sceneLightSetup = esp::DEFAULT_LIGHTING_KEY;
@@ -717,6 +726,10 @@ void Viewer::drawEvent() {
       // even if timeSinceLastSimulation is quite large
       simulator_->stepWorld(1.0 / 60.0);
       simulateSingleStep_ = false;
+      const auto recorder = simulator_->getGfxReplayManager()->getRecorder();
+      if (recorder) {
+        recorder->saveKeyframe();
+      }
     }
     // reset timeSinceLastSimulation, accounting for potential overflow
     timeSinceLastSimulation = fmod(timeSinceLastSimulation, 1.0 / 60.0);
@@ -998,6 +1011,12 @@ void Viewer::mouseMoveEvent(MouseMoveEvent& event) {
 void Viewer::keyPressEvent(KeyEvent& event) {
   const auto key = event.key();
   switch (key) {
+    case KeyEvent::Key::R: {
+      const auto recorder = simulator_->getGfxReplayManager()->getRecorder();
+      if (recorder) {
+        recorder->writeSavedKeyframesToFile(gfxReplayRecordFilepath_);
+      }
+    } break;
     case KeyEvent::Key::Esc:
       /* Using Application::exit(), which exits at the next iteration of the
          event loop (same as the window close button would do). Using

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -195,6 +195,7 @@ Key Commands:
   'c' show/hide FPS overlay.
   'n' show/hide NavMesh wireframe.
   'i' Save a screenshot to "./screenshots/year_month_day_hour-minute-second/#.png"
+  'r' Write a replay of the recent simulated frames to a file specified by --gfx-replay-record-filepath.
 
   Object Interactions:
   SPACE: Toggle physics simulation on/off
@@ -208,7 +209,7 @@ Key Commands:
   'f': (physics) Push the most recently added object.
   't': (physics) Torque the most recently added object.
   'v': (physics) Invert gravity.
-==================================================
+  ==================================================
   )";
 
   //! Print viewer help text to terminal output.


### PR DESCRIPTION
## Motivation and Context

This adds gfx-replay recording to the C++ viewer. Specify an output filepath via command line. A keyframe is saved after every physics step. Press R to write all keyframes to the file. Every time you press R, you'll overwrite the old replay file with new keyframes.

## How Has This Been Tested

Ad hoc testing in the viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
