### PR TITLE
disable PBR shader for js build

### DIFF
--- a/src/esp/core/CMakeLists.txt
+++ b/src/esp/core/CMakeLists.txt
@@ -22,6 +22,10 @@ if(BUILD_WITH_BULLET)
   set(ESP_BUILD_WITH_BULLET ON)
 endif()
 
+if(IS_JS_BUILD)
+  set(ESP_IS_JS_BUILD ON)
+endif()
+
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/configure.h
 )

--- a/src/esp/core/configure.h.cmake
+++ b/src/esp/core/configure.h.cmake
@@ -15,3 +15,5 @@
 #cmakedefine ESP_BUILD_WITH_CUDA
 
 #cmakedefine ESP_BUILD_WITH_BULLET
+
+#cmakedefine ESP_IS_JS_BUILD

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -86,8 +86,12 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   }
   // assign MM to RM on create or reconfigure
   if (!resourceManager_) {
+    assets::ResourceManager::Flags flags;
+#ifdef ESP_IS_JS_BUILD
+    flags |= assets::ResourceManager::Flag::BuildPhongFromPbr;
+#endif
     resourceManager_ =
-        std::make_unique<assets::ResourceManager>(metadataMediator_);
+        std::make_unique<assets::ResourceManager>(metadataMediator_, flags);
   } else {
     resourceManager_->setMetadataMediator(metadataMediator_);
   }


### PR DESCRIPTION
## Motivation and Context

The PBR shader isn't working with Fedora WebGL. This is a temporary workaround. I fall back to the Phong shader for the JS build. I will test on Mac shortly and update my description here.

This PR also sets up the IS_JS_BUILD build option to support this kind of tweak going forward.

## How Has This Been Tested

Running my WIP JS app locally on Fedora.

I will test on Mac shortly and update my description here.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
