### PR TITLE
add smooth moving/looking in viewer

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -806,28 +806,33 @@ void Viewer::moveAndLook(int repetitions) {
       defaultAgent_->act("lookDown");
     }
 
+    bool moved = false;
     if (keysPressed[KeyEvent::Key::A]) {
       defaultAgent_->act("moveLeft");
-      recAgentLocation();
+      moved = true;
     }
     if (keysPressed[KeyEvent::Key::D]) {
       defaultAgent_->act("moveRight");
-      recAgentLocation();
+      moved = true;
     }
     if (keysPressed[KeyEvent::Key::S]) {
       defaultAgent_->act("moveBackward");
-      recAgentLocation();
+      moved = true;
     }
     if (keysPressed[KeyEvent::Key::W]) {
       defaultAgent_->act("moveForward");
-      recAgentLocation();
+      moved = true;
     }
     if (keysPressed[KeyEvent::Key::X]) {
       defaultAgent_->act("moveDown");
-      recAgentLocation();
+      moved = true;
     }
     if (keysPressed[KeyEvent::Key::Z]) {
       defaultAgent_->act("moveUp");
+      moved = true;
+    }
+
+    if (moved) {
       recAgentLocation();
     }
   }


### PR DESCRIPTION
## Motivation and Context

Previously, the viewer controls to move and look-around moved the agent in discrete steps, and multiple controls could not be used at the same time. To rationalize this, holding "W" in the viewer had the same effect as doing so in a text editor: the agent moves forward once, pauses, and then stutters forward.

To obtain smoother movement and looking-around, this feature does 3 things:
1. Holding movement keys now results in gliding forward smoothly
2. Roughly, the rate of movement is independent of frame rate (i.e. it is nearly constant in the world time)
3. Multiple movement/look-around keys can be handled simultaneously

## How Has This Been Tested

Only ad-hoc testing so far. I am concerned that physics may behave slightly differently around pauses (spacebar) and frame-by-frame stepping (.) now, since a minor change was made here. I believe that this was a slight fix, but I don't fully understand the original code, so I could have misinterpreted the situation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
