### PR TITLE
Integrate per-frame profiler into viewer.cpp

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -780,11 +780,11 @@ void Viewer::drawEvent() {
 
 
   _profiler.endFrame();
-  _profiler.printStatistics(10);
   swapBuffers();
   timeline_.nextFrame();
   /* Schedule a redraw only if profiling is enabled to avoid hogging the CPU */
   if(_profiler.isEnabled()) {
+      _profiler.printStatistics(10);
       redraw();
   }
 }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -12,6 +12,8 @@
 #else
 #include <Magnum/Platform/GlfwApplication.h>
 #endif
+#include <Magnum/GL/Context.h>
+#include <Magnum/GL/Extensions.h>
 #include <Magnum/GL/Framebuffer.h>
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/GL/RenderbufferFormat.h>
@@ -21,7 +23,6 @@
 #include <Magnum/Shaders/Generic.h>
 #include <Magnum/Shaders/Shaders.h>
 #include <Magnum/Timeline.h>
-
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/nav/PathFinder.h"
@@ -325,15 +326,6 @@ Key Commands:
       Mn::DebugTools::GLFrameProfiler::Value::CpuDuration |
       Mn::DebugTools::GLFrameProfiler::Value::GpuDuration;
 
-#ifdef MAGNUM_TARGET_GLES
-  if (Mn::GL::Context::current()
-          .isExtensionSupported<
-              Mn::GL::Extensions::ARB::pipeline_statistics_query>()) {
-    values |= Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio |
-              Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio;
-  }
-#endif
-
   Mn::DebugTools::GLFrameProfiler profiler_{profilerValues, 50};
 };
 
@@ -509,6 +501,17 @@ Viewer::Viewer(const Arguments& arguments)
 
   objectPickingHelper_ = std::make_unique<ObjectPickingHelper>(viewportSize);
   timeline_.start();
+
+#ifndef MAGNUM_TARGET_GLES
+  if (Mn::GL::Context::current()
+          .isExtensionSupported<
+              Mn::GL::Extensions::ARB::pipeline_statistics_query>()) {
+    profilerValues |=
+        Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio |
+        Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio;
+    profiler_.setup(profilerValues, 50);
+  }
+#endif
 
   printHelpText();
 }  // end Viewer::Viewer

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -503,6 +503,9 @@ Viewer::Viewer(const Arguments& arguments)
   objectPickingHelper_ = std::make_unique<ObjectPickingHelper>(viewportSize);
   timeline_.start();
 
+  //Set up profiler to default disabled
+  profiler_.disable();
+
   printHelpText();
 }  // end Viewer::Viewer
 
@@ -729,8 +732,6 @@ void Viewer::drawEvent() {
     renderCamera_->draw(objectPickingHelper_->getDrawables(), flags);
 
     Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::Blending);
-
-    profiler_.disable();
   }
 
   sensorRenderTarget->blitRgbaToDefault();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -321,7 +321,7 @@ Key Commands:
   // included)
 
   // Profiling
-  Mn::DebugTools::GLFrameProfiler _profiler{
+  Mn::DebugTools::GLFrameProfiler profiler_{
       Mn::DebugTools::GLFrameProfiler::Value::FrameTime |
           Mn::DebugTools::GLFrameProfiler::Value::CpuDuration |
           Mn::DebugTools::GLFrameProfiler::Value::GpuDuration |
@@ -730,7 +730,7 @@ void Viewer::drawEvent() {
 
     Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::Blending);
 
-    _profiler.disable();
+    profiler_.disable();
   }
 
   sensorRenderTarget->blitRgbaToDefault();
@@ -739,7 +739,7 @@ void Viewer::drawEvent() {
   Mn::GL::defaultFramebuffer.bind();
 
   imgui_.newFrame();
-  _profiler.beginFrame();
+  profiler_.beginFrame();
   if (showFPS_) {
     ImGui::SetNextWindowPos(ImVec2(10, 10));
     ImGui::Begin("main", NULL,
@@ -775,12 +775,12 @@ void Viewer::drawEvent() {
   Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::ScissorTest);
   Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::Blending);
 
-  _profiler.endFrame();
+  profiler_.endFrame();
   swapBuffers();
   timeline_.nextFrame();
   /* Schedule a redraw only if profiling is enabled to avoid hogging the CPU */
-  if (_profiler.isEnabled()) {
-    _profiler.printStatistics(10);
+  if (profiler_.isEnabled()) {
+    profiler_.printStatistics(10);
     redraw();
   }
 }
@@ -1062,7 +1062,7 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       invertGravity();
       break;
     case KeyEvent::Key::Comma:
-      _profiler.isEnabled() ? _profiler.disable() : _profiler.enable();
+      profiler_.isEnabled() ? profiler_.disable() : profiler_.enable();
       break;
     default:
       break;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -51,8 +51,6 @@
 #include "ObjectPickingHelper.h"
 #include "esp/physics/configure.h"
 
-using std::chrono::high_resolution_clock;
-
 constexpr float moveSensitivity = 0.1f;
 constexpr float lookSensitivity = 11.25f;
 constexpr float rgbSensorHeight = 1.5f;
@@ -323,7 +321,6 @@ Key Commands:
   // included)
 
   //Profiling
-  //high_resolution_clock::time_point frameBeginTime;
    Mn::DebugTools::GLFrameProfiler _profiler{
         Mn::DebugTools::GLFrameProfiler::Value::FrameTime|
         Mn::DebugTools::GLFrameProfiler::Value::CpuDuration|

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -503,7 +503,7 @@ Viewer::Viewer(const Arguments& arguments)
   objectPickingHelper_ = std::make_unique<ObjectPickingHelper>(viewportSize);
   timeline_.start();
 
-  //Set up profiler to default disabled
+  // Set up profiler to default disabled
   profiler_.disable();
 
   printHelpText();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -12,15 +12,15 @@
 #else
 #include <Magnum/Platform/GlfwApplication.h>
 #endif
-#include <Magnum/PixelFormat.h>
-#include <Magnum/SceneGraph/Camera.h>
-#include <Magnum/Timeline.h>
 #include <Magnum/GL/Framebuffer.h>
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/GL/RenderbufferFormat.h>
 #include <Magnum/Image.h>
+#include <Magnum/PixelFormat.h>
+#include <Magnum/SceneGraph/Camera.h>
 #include <Magnum/Shaders/Generic.h>
 #include <Magnum/Shaders/Shaders.h>
+#include <Magnum/Timeline.h>
 
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
@@ -34,8 +34,8 @@
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/String.h>
-#include <Magnum/DebugTools/Screenshot.h>
 #include <Magnum/DebugTools/FrameProfiler.h>
+#include <Magnum/DebugTools/Screenshot.h>
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Renderer.h>
@@ -320,14 +320,14 @@ Key Commands:
   // returns the number of visible drawables (meshVisualizer drawables are not
   // included)
 
-  //Profiling
-   Mn::DebugTools::GLFrameProfiler _profiler{
-        Mn::DebugTools::GLFrameProfiler::Value::FrameTime|
-        Mn::DebugTools::GLFrameProfiler::Value::CpuDuration|
-        Mn::DebugTools::GLFrameProfiler::Value::GpuDuration|
-        Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio|
-        Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio
-    , 50};
+  // Profiling
+  Mn::DebugTools::GLFrameProfiler _profiler{
+      Mn::DebugTools::GLFrameProfiler::Value::FrameTime |
+          Mn::DebugTools::GLFrameProfiler::Value::CpuDuration |
+          Mn::DebugTools::GLFrameProfiler::Value::GpuDuration |
+          Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio |
+          Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio,
+      50};
 };
 
 Viewer::Viewer(const Arguments& arguments)
@@ -775,14 +775,13 @@ void Viewer::drawEvent() {
   Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::ScissorTest);
   Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::Blending);
 
-
   _profiler.endFrame();
   swapBuffers();
   timeline_.nextFrame();
   /* Schedule a redraw only if profiling is enabled to avoid hogging the CPU */
-  if(_profiler.isEnabled()) {
-      _profiler.printStatistics(10);
-      redraw();
+  if (_profiler.isEnabled()) {
+    _profiler.printStatistics(10);
+    redraw();
   }
 }
 
@@ -1063,8 +1062,8 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       invertGravity();
       break;
     case KeyEvent::Key::Comma:
-       _profiler.isEnabled() ? _profiler.disable() : _profiler.enable();
-       break;
+      _profiler.isEnabled() ? _profiler.disable() : _profiler.enable();
+      break;
     default:
       break;
   }


### PR DESCRIPTION
## Motivation and Context

We wish to integrate the FrameProfiler functionality which is present in magnum-player into the habitat simulator viewer.
## How Has This Been Tested

Build and run, compare functionality to magnum-player profiling tool
![1](https://user-images.githubusercontent.com/15386768/104255029-c03ea000-543d-11eb-9405-0f2855da999a.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
