### PR TITLE
fix for PBR fragment shader for WebGL

### DIFF
--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -5,6 +5,8 @@
 // This is an implementation of
 // Karis, Brian. “Real Shading in Unreal Engine 4 by.” (2013).
 
+precision highp float;
+
 // -------------- input ---------------------
 // position, normal, tangent in camera space
 in highp vec3 position;


### PR DESCRIPTION
## Motivation and Context

The shader doesn't compile on Fedora/Ubuntu Chrome WebGL and is currently causing Habitat JS apps to crash.

More context:
https://github.com/facebookresearch/habitat-sim/pull/1002
https://cvmlp.slack.com/archives/CFN5TAUSD/p1606160816031500?thread_ts=1606149864.021100&cid=CFN5TAUSD

## How Has This Been Tested

I tested the fix on a JS app on Ubuntu Chrome. I tested on Mac Chrome, which seems to work fine with or without the fix.

I tested on Mac Safari but hit a possibly-unrelated error with or without the fix: "Platform::WindowlessEglApplication::tryCreateContext(): cannot create EGL context: EGL_BAD_MATCH
WindowlessContext: Unable to create windowless context".

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
