### PR TITLE
Pytest bugfix and PyTorch dependency softening

### DIFF
--- a/habitat_sim/sensors/noise_models/no_noise_model.py
+++ b/habitat_sim/sensors/noise_models/no_noise_model.py
@@ -9,7 +9,6 @@ from typing import Union
 import attr
 import numpy as np
 from numpy import ndarray
-from torch import Tensor
 
 from habitat_sim.registry import registry
 from habitat_sim.sensor import SensorType
@@ -28,7 +27,9 @@ class NoSensorNoiseModel(SensorNoiseModel):
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:
         return True
 
-    def apply(self, x: Union[ndarray, Tensor]) -> Union[ndarray, Tensor]:
+    def apply(
+        self, x: Union[ndarray, "torch.Tensor"]
+    ) -> Union[ndarray, "torch.Tensor"]:
         if isinstance(x, np.ndarray):
             return x.copy()
         elif torch is not None and torch.is_tensor(x):

--- a/habitat_sim/sensors/noise_models/sensor_noise_model.py
+++ b/habitat_sim/sensors/noise_models/sensor_noise_model.py
@@ -9,7 +9,11 @@ from typing import Optional, Union
 
 import attr
 from numpy import ndarray
-from torch import Tensor
+
+try:
+    from torch import Tensor
+except ImportError:
+    pass
 
 from habitat_sim.sensor import SensorType
 
@@ -39,7 +43,7 @@ class SensorNoiseModel(abc.ABC):
         """
 
     def __call__(
-        self, sensor_observation: Union[ndarray, Tensor]
-    ) -> Union[ndarray, Tensor]:
+        self, sensor_observation: Union[ndarray, "Tensor"]
+    ) -> Union[ndarray, "Tensor"]:
         r"""Alias of `apply()`"""
         return self.apply(sensor_observation)

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -1,6 +1,7 @@
 import math
 
 import hypothesis
+import pytest
 from hypothesis import strategies as st
 
 import habitat_sim
@@ -16,12 +17,18 @@ def test_data_func():
     return pf, pf.get_random_navigable_point()
 
 
+@pytest.fixture(scope="function")
+def test_data():
+    return test_data_func()
+
+
 @hypothesis.given(
     nudge=st.tuples(st.floats(-10, 10), st.floats(-2.5, 2.5), st.floats(-10, 10)),
+    test_data=st.just(test_data_func()),
 )
 @hypothesis.settings(max_examples=int(1e3))
-def test_snap_point(nudge):
-    pf, start_pt = test_data_func()
+def test_snap_point(nudge, test_data):
+    pf, start_pt = test_data
 
     pt = start_pt + nudge
 

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -1,14 +1,12 @@
 import math
 
 import hypothesis
-import pytest
 from hypothesis import strategies as st
 
 import habitat_sim
 
 
-@pytest.fixture(scope="function")
-def test_data():
+def test_data_func():
     pf = habitat_sim.PathFinder()
     pf.load_nav_mesh(
         "data/scene_datasets/habitat-test-scenes/skokloster-castle.navmesh"
@@ -19,11 +17,11 @@ def test_data():
 
 
 @hypothesis.given(
-    nudge=st.tuples(st.floats(-10, 10), st.floats(-2.5, 2.5), st.floats(-10, 10))
+    nudge=st.tuples(st.floats(-10, 10), st.floats(-2.5, 2.5), st.floats(-10, 10)),
 )
 @hypothesis.settings(max_examples=int(1e3))
-def test_snap_point(nudge, test_data):
-    pf, start_pt = test_data
+def test_snap_point(nudge):
+    pf, start_pt = test_data_func()
 
     pt = start_pt + nudge
 


### PR DESCRIPTION
## Motivation and Context

Fixes two bugs. One in our hypothesis code that only generated a single navigable point for our hypothesis testing, and softened some hard dependency on PyTorch that were not necessary.

This should resolve the CircleCI issues.
<!--- Why is this change required? What problem does it solve? -->
```
E                               hypothesis.errors.FailedHealthCheck: tests/test_snap_point.py::test_snap_point uses the 'test_data' fixture, which is reset between function calls but not between test cases generated by `@given(...)`.  You can change it to a module- or session-scoped fixture if it is safe to reuse; if not we recommend using a context manager inside your test function.  See https://docs.pytest.org/en/latest/fixture.html#sharing-test-data for details on fixture scope.
E                               See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.function_scoped_fixture to the suppress_health_check settings for this test.
```
Error caused by new version of Hypothesis posted above.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally with PyTest in an environment that doesn't have PyTorch installed
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.

@erikwijmans Not sure if this is actually supposed to be evaluated on the same point or not. I can add a separate hypothesis test that operates on a fixed random point if that is what is desired.
