### PR TITLE
[viewer.cpp] Saving/loading camera position/orientation (support for more general scene nodes)

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -405,7 +405,8 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("recompute-navmesh",
                "Programmatically re-generate the scene navmesh.")
       .addOption("camera-transform-filepath")
-      .setHelp("camera", "Specify path to load camera transform from.")
+      .setHelp("camera-transform-filepath",
+               "Specify path to load camera transform from.")
       .parse(arguments.argc, arguments.argv);
 
   const auto viewportSize = Mn::GL::defaultFramebuffer.viewport().size();
@@ -583,9 +584,9 @@ void Viewer::switchCameraType() {
 }
 
 void Viewer::saveCameraTransformToFile() {
-  const char* saved_transformations_directory_ = "saved_transformations/";
-  if (!Cr::Utility::Directory::exists(saved_transformations_directory_)) {
-    Cr::Utility::Directory::mkpath(saved_transformations_directory_);
+  const char* saved_transformations_directory = "saved_transformations/";
+  if (!Cr::Utility::Directory::exists(saved_transformations_directory)) {
+    Cr::Utility::Directory::mkpath(saved_transformations_directory);
   }
 
   // update temporary save
@@ -595,7 +596,7 @@ void Viewer::saveCameraTransformToFile() {
   saveNodeTransformToFile(
       renderCamera_->node(),
       Cr::Utility::formatString("{}camera.{}.txt",
-                                saved_transformations_directory_,
+                                saved_transformations_directory,
                                 getCurrentTimeString()));
 }
 
@@ -605,12 +606,12 @@ void Viewer::loadCameraTransformFromFile() {
     loadNodeTransformFromFile(renderCamera_->node(), cameraLoadPath_);
   } else {
     // attempting to load from last temporary save
-    LOG(INFO)
-        << "Note: Camera transform file not specified, attempting to load from "
+    LOG(WARNING)
+        << "Camera transform file not specified, attempting to load from "
            "current instance. Use --camera-transform-filepath to specify file "
            "to load from.";
     if (!lastCameraSave_) {
-      LOG(WARNING) << "No transformation saved in current instance.";
+      LOG(ERROR) << "No transformation saved in current instance.";
       return;
     }
 
@@ -620,7 +621,7 @@ void Viewer::loadCameraTransformFromFile() {
   }
 
   if (!flyingCameraMode_) {
-    LOG(INFO) << "Note: the flying camera mode is currently OFF. You may not "
+    LOG(INFO) << "Note: The flying camera mode is currently OFF. You may not "
                  "see any view change.";
   }
 }
@@ -629,7 +630,7 @@ void Viewer::saveNodeTransformToFile(esp::scene::SceneNode& node,
                                      const std::string& filename) {
   std::ofstream file(filename);
   if (!file.good()) {
-    LOG(WARNING) << "Cannot open " << filename << " to output data.";
+    LOG(ERROR) << "Cannot open " << filename << " to output data.";
     return;
   }
 
@@ -649,7 +650,7 @@ void Viewer::loadNodeTransformFromFile(esp::scene::SceneNode& node,
                                        const std::string& filename) {
   std::ifstream file(filename);
   if (!file.good()) {
-    LOG(WARNING) << "Cannot open " << filename << " to load data.";
+    LOG(ERROR) << "Cannot open " << filename << " to load data.";
     return;
   }
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -205,7 +205,7 @@ Key Commands:
   'c' show/hide FPS overlay.
   'n' show/hide NavMesh wireframe.
   'i' Save a screenshot to "./screenshots/year_month_day_hour-minute-second/#.png"
-  'r' Write a replay of the recent simulated frames to a file specified by --gfx-replay-record-filepath.  
+  'r' Write a replay of the recent simulated frames to a file specified by --gfx-replay-record-filepath.
   '[' save camera position/orientation to "./saved_transformations/camera.year_month_day_hour-minute-second.txt"
   ']' load camera position/orientation from file system (useful when flying camera mode is enabled), or else from last save in current instance
 
@@ -434,7 +434,7 @@ Viewer::Viewer(const Arguments& arguments)
     debugBullet_ = true;
   }
 
-  cameraLoadTimeString_ = args.value("camera");
+  cameraLoadPath_ = args.value("camera-transform-filepath");
   gfxReplayRecordFilepath_ = args.value("gfx-replay-record-filepath");
 
   // configure and intialize Simulator
@@ -911,7 +911,6 @@ void Viewer::drawEvent() {
     Mn::GL::defaultFramebuffer.bind();
   }
 
-  sensorRenderTarget->blitRgbaToDefault();
   profiler_.endFrame();
   // Immediately bind the main buffer back so that the "imgui" below can work
   // properly

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -404,7 +404,7 @@ Viewer::Viewer(const Arguments& arguments)
       .addBooleanOption("recompute-navmesh")
       .setHelp("recompute-navmesh",
                "Programmatically re-generate the scene navmesh.")
-      .addOption("camera")
+      .addOption("camera-transform-filepath")
       .setHelp("camera", "Specify path to load camera transform from.")
       .parse(arguments.argc, arguments.argv);
 
@@ -607,9 +607,10 @@ void Viewer::loadCameraTransformFromFile() {
     // attempting to load from last temporary save
     LOG(INFO)
         << "Note: Camera transform file not specified, attempting to load from "
-           "current instance. Use --camera to specify file to load from.";
+           "current instance. Use --camera-transform-filepath to specify file "
+           "to load from.";
     if (!lastCameraSave_) {
-      LOG(INFO) << "No transformation saved in current instance.";
+      LOG(WARNING) << "No transformation saved in current instance.";
       return;
     }
 
@@ -628,7 +629,7 @@ void Viewer::saveNodeTransformToFile(esp::scene::SceneNode& node,
                                      const std::string& filename) {
   std::ofstream file(filename);
   if (!file.good()) {
-    LOG(INFO) << "Cannot open " << filename << " to output data.";
+    LOG(WARNING) << "Cannot open " << filename << " to output data.";
     return;
   }
 
@@ -648,7 +649,7 @@ void Viewer::loadNodeTransformFromFile(esp::scene::SceneNode& node,
                                        const std::string& filename) {
   std::ifstream file(filename);
   if (!file.good()) {
-    LOG(INFO) << "Cannot open " << filename << " to load data.";
+    LOG(WARNING) << "Cannot open " << filename << " to load data.";
     return;
   }
 
@@ -664,8 +665,8 @@ void Viewer::loadNodeTransformFromFile(esp::scene::SceneNode& node,
 
   // checking for corruption
   if (!transform.isRigidTransformation()) {
-    LOG(INFO) << "Warning: Data loaded from " << filename
-              << " is not a valid transformation.";
+    LOG(WARNING) << "Data loaded from " << filename
+                 << " is not a valid transformation.";
     return;
   }
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This feature has been requested by Yili, and he wrote the original code in the branch demo-pbr-before-after.

This adds functionality to save and load the positions of scene nodes, particularly the camera. Currently, the camera position/orientation can be saved to the filesystem by its timestamp for future use. Saved camera position/orientation can be loaded from the filesystem with a timestamp specified in the command line (or else if the timestamp is not specified, from the last save in the current instance of viewer).

In practicality, the camera is usually locked on the agent. So in order for loading camera position/orientation to take effect, a feature called flying camera mode is introduced, in which the camera is unlocked from the agent.

## How Has This Been Tested

Handling and logging for the following errors:
1. Filesystem is not configured properly (directory to store saves doesn't exist)
2. Saved data file was corrupted and no longer represents a valid transformation matrix
3. Other file system errors (lack of permission, etc)
4. User does not provide filename to load data from, or attempts to load a file before having saved one

Ad-hoc testing for loading camera transformations (e.g. robust against pauses in simulation, etc).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
