### PR TITLE
[PYTHON_BINDINGS] Expose navmesh triangles to Python

### DIFF
--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -100,8 +100,8 @@ void initShortestPathBindings(py::module& m) {
           "navmesh_vertices",
           [](PathFinder& self) { return self.getNavMeshData()->vbo; })
       .def_property_readonly(
-          "navmesh_normals",
-          [](PathFinder& self) { return self.getNavMeshData()->nbo; })
+          "navmesh_vertex_indices",
+          [](PathFinder& self) { return self.getNavMeshData()->ibo; })
       .def("load_nav_mesh", &PathFinder::loadNavMesh)
       .def("save_nav_mesh", &PathFinder::saveNavMesh, "path"_a)
       .def("distance_to_closest_obstacle",

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -96,12 +96,10 @@ void initShortestPathBindings(py::module& m) {
       .def("island_radius", &PathFinder::islandRadius, "pt"_a)
       .def_property_readonly("is_loaded", &PathFinder::isLoaded)
       .def_property_readonly("navigable_area", &PathFinder::getNavigableArea)
-      .def_property_readonly(
-          "navmesh_vertices",
-          [](PathFinder& self) { return self.getNavMeshData()->vbo; })
-      .def_property_readonly(
-          "navmesh_vertex_indices",
-          [](PathFinder& self) { return self.getNavMeshData()->ibo; })
+      .def("build_navmesh_vertices",
+           [](PathFinder& self) { return self.getNavMeshData()->vbo; })
+      .def("build_navmesh_vertex_indices",
+           [](PathFinder& self) { return self.getNavMeshData()->ibo; })
       .def("load_nav_mesh", &PathFinder::loadNavMesh)
       .def("save_nav_mesh", &PathFinder::saveNavMesh, "path"_a)
       .def("distance_to_closest_obstacle",

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -10,6 +10,7 @@
 
 #include <Magnum/Math/Vector3.h>
 
+#include "esp/assets/MeshData.h"
 #include "esp/core/esp.h"
 #include "esp/nav/GreedyFollower.h"
 #include "esp/nav/PathFinder.h"
@@ -95,6 +96,12 @@ void initShortestPathBindings(py::module& m) {
       .def("island_radius", &PathFinder::islandRadius, "pt"_a)
       .def_property_readonly("is_loaded", &PathFinder::isLoaded)
       .def_property_readonly("navigable_area", &PathFinder::getNavigableArea)
+      .def_property_readonly(
+          "navmesh_vertices",
+          [](PathFinder& self) { return self.getNavMeshData()->vbo; })
+      .def_property_readonly(
+          "navmesh_normals",
+          [](PathFinder& self) { return self.getNavMeshData()->nbo; })
       .def("load_nav_mesh", &PathFinder::loadNavMesh)
       .def("save_nav_mesh", &PathFinder::saveNavMesh, "path"_a)
       .def("distance_to_closest_obstacle",

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -58,7 +58,8 @@ def test_recompute_navmesh(test_scene):
 
         # compute shortest paths between these points on the loaded navmesh
         loaded_navmesh_path_results = get_shortest_path(sim, samples)
-
+        assert len(sim.pathfinder.build_navmesh_vertices()) > 0
+        assert len(sim.pathfinder.build_navmesh_vertex_indices()) > 0
         hab_cfg = examples.settings.make_cfg(cfg_settings)
         agent_config = hab_cfg.agents[hab_cfg.sim_cfg.default_agent_id]
         agent_config.radius *= 2.0
@@ -70,6 +71,8 @@ def test_recompute_navmesh(test_scene):
         navmesh_settings.set_defaults()
         assert sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         assert sim.pathfinder.is_loaded
+        assert len(sim.pathfinder.build_navmesh_vertices()) > 0
+        assert len(sim.pathfinder.build_navmesh_vertex_indices()) > 0
 
         recomputed_navmesh_results = get_shortest_path(sim, samples)
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It allows Python code to directly get the triangles from the NavMesh, before it was impossible to get NavMesh data into Python directly. This will add a property to pathfinders that is an array of 3D arrays indicating the triangles.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally, it builds properly 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
