### PR TITLE
Jupytext requires nbformat <= 5.0.8 at the moment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,7 @@ repos:
         pass_filenames: true
         additional_dependencies:
             - 'jupytext==1.6.0'
+            - 'nbformat<=5.0.8'
             - black
             - isort
         always_run: false


### PR DESCRIPTION
With the introduction of the nbformat version 4.5 (and cell ids) in `nbformat>=5.1.0`, the pre-commit test in Circle CI started to fail, cf. https://github.com/mwouts/jupytext/issues/715

With this commit we add the requirement `nbformat <=5.0.8`, i.e. the last version of nbformat expected to work with Jupytext at the moment.
