### PR TITLE
[Refactor/BUGFIX] Scene Import 1/Prep : Refactor SimulatorConfiguration

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -243,10 +243,6 @@ void initAttributesBindings(py::module& m) {
           R"(Handle for file containing semantic type maps and hierarchy for
           constructions built from this template.)")
       .def_property(
-          "light_setup", &StageAttributes::getLightSetup,
-          &StageAttributes::setLightSetup,
-          R"(Habitat lighting setup to use for constructions built by this template.)")
-      .def_property(
           "frustum_culling", &StageAttributes::getFrustumCulling,
           &StageAttributes::setFrustumCulling,
           R"(Whether frustum culling should be enabled for constructions built by this template.)");

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -29,7 +29,7 @@ void initSimBindings(py::module& m) {
   py::class_<SimulatorConfiguration, SimulatorConfiguration::ptr>(
       m, "SimulatorConfiguration")
       .def(py::init(&SimulatorConfiguration::create<>))
-      .def_readwrite("scene_id", &SimulatorConfiguration::activeSceneID)
+      .def_readwrite("scene_id", &SimulatorConfiguration::activeSceneName)
       .def_readwrite("random_seed", &SimulatorConfiguration::randomSeed)
       .def_readwrite("default_agent_id",
                      &SimulatorConfiguration::defaultAgentId)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -29,7 +29,15 @@ void initSimBindings(py::module& m) {
   py::class_<SimulatorConfiguration, SimulatorConfiguration::ptr>(
       m, "SimulatorConfiguration")
       .def(py::init(&SimulatorConfiguration::create<>))
-      .def_readwrite("scene_id", &SimulatorConfiguration::activeSceneName)
+      .def_readwrite(
+          "scene_dataset_config_file",
+          &SimulatorConfiguration::sceneDatasetConfigFile,
+          R"(The location of the scene dataset configuration file that describes the
+          dataset to be used.)")
+      .def_readwrite(
+          "scene_id", &SimulatorConfiguration::activeSceneName,
+          R"(Either the name of a stage asset or configuration file, or else the name of a scene
+          instance configuration, used to initialize the simulator world.)")
       .def_readwrite("random_seed", &SimulatorConfiguration::randomSeed)
       .def_readwrite("default_agent_id",
                      &SimulatorConfiguration::defaultAgentId)
@@ -53,7 +61,8 @@ void initSimBindings(py::module& m) {
       .def_readwrite(
           "force_separate_semantic_scene_graph",
           &SimulatorConfiguration::forceSeparateSemanticSceneGraph,
-          R"(Required to support playback of any gfx replay that includes a stage with a semantic mesh. Set to false otherwise.)")
+          R"(Required to support playback of any gfx replay that includes a
+          stage with a semantic mesh. Set to false otherwise.)")
       .def_readwrite("requires_textures",
                      &SimulatorConfiguration::requiresTextures)
       .def(py::self == py::self)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -54,6 +54,10 @@ void initSimBindings(py::module& m) {
           R"(Enable replay recording. See sim.gfx_replay.save_keyframe.)")
       .def_readwrite("physics_config_file",
                      &SimulatorConfiguration::physicsConfigFile)
+      .def_readwrite(
+          "override_scene_ligh_defaults",
+          &SimulatorConfiguration::overrideSceneLightDefaults,
+          R"(Override scene lighting setup to use with value specified below.)")
       .def_readwrite("scene_light_setup",
                      &SimulatorConfiguration::sceneLightSetup)
       .def_readwrite("load_semantic_mesh",

--- a/src/esp/bindings_js/bindings_js.cpp
+++ b/src/esp/bindings_js/bindings_js.cpp
@@ -194,7 +194,7 @@ EMSCRIPTEN_BINDINGS(habitat_sim_bindings_js) {
   em::class_<SimulatorConfiguration>("SimulatorConfiguration")
       .smart_ptr_constructor("SimulatorConfiguration",
                              &SimulatorConfiguration::create<>)
-      .property("scene_id", &SimulatorConfiguration::activeSceneID)
+      .property("scene_id", &SimulatorConfiguration::activeSceneName)
       .property("defaultAgentId", &SimulatorConfiguration::defaultAgentId)
       .property("defaultCameraUuid", &SimulatorConfiguration::defaultCameraUuid)
       .property("gpuDeviceId", &SimulatorConfiguration::gpuDeviceId)

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -345,12 +345,6 @@ void StageAttributesManager::setValsFromJSONDoc(
     stageAttributes->setHouseFilename(houseFName);
   }
 
-  if (io::readMember<std::string>(jsonConfig, "lighting_setup", lightSetup)) {
-    // if lighting is specified in stage json to non-empty value, set value
-    // (override default).
-    stageAttributes->setLightSetup(lightSetup);
-  }
-
   // load the rigid object library metadata (no physics init yet...)
   if (jsonConfig.HasMember("rigid object paths") &&
       jsonConfig["rigid object paths"].IsArray()) {

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -38,9 +38,10 @@ class StageAttributesManager
   void setCurrPhysicsManagerAttributesHandle(const std::string& handle) {
     physicsManagerAttributesHandle_ = handle;
   }
+
   /**
-   * @brief copy current @ref esp::sim::SimulatorConfiguration driven values,
-   * such as file paths, to make them available for stage attributes defaults.
+   * @brief copy current @ref esp::sim::SimulatorConfiguration driven values as
+   * defaults, to make them available for stage attributes initialization.
    *
    * @param lightSetup the config-specified light setup
    * @param frustumCulling whether or not (semantic) stage should be
@@ -51,6 +52,7 @@ class StageAttributesManager
     cfgLightSetup_ = lightSetup;
     // set frustum culling default from configuration
     cfgFrustumCulling_ = frustumCulling;
+
   }  // StageAttributesManager::setCurrCfgVals
 
   /**

--- a/src/esp/scene/test/GibsonSceneTest.cpp
+++ b/src/esp/scene/test/GibsonSceneTest.cpp
@@ -47,7 +47,8 @@ TEST(GibsonSemanticSimTest, Basic) {
     GTEST_SKIP_(skip_message.c_str());
   }
   SimulatorConfiguration cfg;
-  cfg.activeSceneID = esp::io::changeExtension(gibsonSemanticFilename, ".glb");
+  cfg.activeSceneName =
+      esp::io::changeExtension(gibsonSemanticFilename, ".glb");
   Simulator simulator(cfg);
   const auto& semanticScene = simulator.getSemanticScene();
   ASSERT_EQ(semanticScene->objects().size(), 34);

--- a/src/esp/scene/test/ReplicaSceneTest.cpp
+++ b/src/esp/scene/test/ReplicaSceneTest.cpp
@@ -99,7 +99,7 @@ void ReplicaSceneTest::testSemanticSceneLoading() {
   }
 
   esp::sim::SimulatorConfiguration cfg;
-  cfg.activeSceneID =
+  cfg.activeSceneName =
       Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply");
 
   esp::sim::Simulator sim{cfg};

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -139,7 +139,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
                                      config_.frustumCulling);
 
   // Build scene file name based on config specification
-  std::string stageFilename = config_.activeSceneID;
+  std::string stageFilename = config_.activeSceneName;
 
   // Create scene attributes with values based on sceneFilename
   auto stageAttributes = stageAttributesMgr->createObject(stageFilename, true);

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -8,7 +8,7 @@ namespace esp {
 namespace sim {
 bool operator==(const SimulatorConfiguration& a,
                 const SimulatorConfiguration& b) {
-  return a.activeSceneID.compare(b.activeSceneID) == 0 &&
+  return a.activeSceneName.compare(b.activeSceneName) == 0 &&
          a.defaultAgentId == b.defaultAgentId &&
          a.gpuDeviceId == b.gpuDeviceId && a.randomSeed == b.randomSeed &&
          a.defaultCameraUuid.compare(b.defaultCameraUuid) == 0 &&

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -19,6 +19,7 @@ bool operator==(const SimulatorConfiguration& a,
          a.enablePhysics == b.enablePhysics &&
          a.loadSemanticMesh == b.loadSemanticMesh &&
          a.requiresTextures == b.requiresTextures &&
+         a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
          a.physicsConfigFile.compare(b.physicsConfigFile) == 0 &&
          a.sceneDatasetConfigFile.compare(b.sceneDatasetConfigFile) == 0 &&
          a.sceneLightSetup.compare(b.sceneLightSetup) == 0;

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -17,11 +17,14 @@ bool operator==(const SimulatorConfiguration& a,
          a.allowSliding == b.allowSliding &&
          a.frustumCulling == b.frustumCulling &&
          a.enablePhysics == b.enablePhysics &&
+         a.enableGfxReplaySave == b.enableGfxReplaySave &&
          a.loadSemanticMesh == b.loadSemanticMesh &&
+         a.forceSeparateSemanticSceneGraph ==
+             b.forceSeparateSemanticSceneGraph &&
          a.requiresTextures == b.requiresTextures &&
-         a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
-         a.physicsConfigFile.compare(b.physicsConfigFile) == 0 &&
          a.sceneDatasetConfigFile.compare(b.sceneDatasetConfigFile) == 0 &&
+         a.physicsConfigFile.compare(b.physicsConfigFile) == 0 &&
+         a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
          a.sceneLightSetup.compare(b.sceneLightSetup) == 0;
 }
 

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -59,6 +59,13 @@ struct SimulatorConfiguration {
    * @brief File location for initial scene dataset to use.
    */
   std::string sceneDatasetConfigFile = "default";
+
+  /**
+   * @brief allows for overriding any scene lighting setup specified in a scene
+   * instance file with the value specified below.
+   */
+  bool overrideSceneLightDefaults = false;
+
   /** @brief Light setup key for scene */
   std::string sceneLightSetup = esp::NO_LIGHT_KEY;
 

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -17,7 +17,7 @@ struct SimulatorConfiguration {
   /**
    * @brief Name of scene or stage config or asset to load
    */
-  std::string activeSceneID;
+  std::string activeSceneName;
   int defaultAgentId = 0;
   int gpuDeviceId = 0;
   unsigned int randomSeed = 0;

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -65,7 +65,7 @@ struct SimTest : Cr::TestSuite::Tester {
       const std::string& scene,
       const std::string& sceneLightingKey = esp::NO_LIGHT_KEY) {
     SimulatorConfiguration simConfig{};
-    simConfig.activeSceneID = scene;
+    simConfig.activeSceneName = scene;
     simConfig.enablePhysics = true;
     simConfig.physicsConfigFile = physicsConfigFile;
     simConfig.sceneLightSetup = sceneLightingKey;
@@ -129,7 +129,7 @@ SimTest::SimTest() {
 
 void SimTest::basic() {
   SimulatorConfiguration cfg;
-  cfg.activeSceneID = vangogh;
+  cfg.activeSceneName = vangogh;
   Simulator simulator(cfg);
   PathFinder::ptr pathfinder = simulator.getPathFinder();
   CORRADE_VERIFY(pathfinder);
@@ -137,20 +137,20 @@ void SimTest::basic() {
 
 void SimTest::reconfigure() {
   SimulatorConfiguration cfg;
-  cfg.activeSceneID = vangogh;
+  cfg.activeSceneName = vangogh;
   Simulator simulator(cfg);
   PathFinder::ptr pathfinder = simulator.getPathFinder();
   simulator.reconfigure(cfg);
   CORRADE_VERIFY(pathfinder == simulator.getPathFinder());
   SimulatorConfiguration cfg2;
-  cfg2.activeSceneID = skokloster;
+  cfg2.activeSceneName = skokloster;
   simulator.reconfigure(cfg2);
   CORRADE_VERIFY(pathfinder != simulator.getPathFinder());
 }
 
 void SimTest::reset() {
   SimulatorConfiguration cfg;
-  cfg.activeSceneID = vangogh;
+  cfg.activeSceneName = vangogh;
   Simulator simulator(cfg);
   PathFinder::ptr pathfinder = simulator.getPathFinder();
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -68,6 +68,7 @@ struct SimTest : Cr::TestSuite::Tester {
     simConfig.activeSceneName = scene;
     simConfig.enablePhysics = true;
     simConfig.physicsConfigFile = physicsConfigFile;
+    simConfig.overrideSceneLightDefaults = true;
     simConfig.sceneLightSetup = sceneLightingKey;
 
     auto sim = Simulator::create_unique(simConfig);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -353,6 +353,8 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("scene", "scene/stage file to load")
       .addSkippedPrefix("magnum", "engine-specific options")
       .setGlobalHelp("Displays a 3D scene file provided on command line")
+      .addOption("dataset", "default")
+      .setHelp("dataset", "dataset configuration file to use")
       .addBooleanOption("enable-physics")
       .addBooleanOption("stage-requires-lighting")
       .setHelp("stage-requires-lighting",
@@ -407,6 +409,8 @@ Viewer::Viewer(const Arguments& arguments)
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
   simConfig.activeSceneName = sceneFileName;
+  simConfig.sceneDatasetConfigFile = args.value("dataset");
+  LOG(INFO) << "Dataset : " << simConfig.sceneDatasetConfigFile;
   simConfig.enablePhysics = useBullet;
   simConfig.frustumCulling = true;
   simConfig.requiresTextures = true;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -406,7 +406,7 @@ Viewer::Viewer(const Arguments& arguments)
 
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
-  simConfig.activeSceneID = sceneFileName;
+  simConfig.activeSceneName = sceneFileName;
   simConfig.enablePhysics = useBullet;
   simConfig.frustumCulling = true;
   simConfig.requiresTextures = true;


### PR DESCRIPTION
## Motivation and Context
This PR is laying pertinent groundwork for the [SceneInstance Import functionality PR found here](https://github.com/facebookresearch/habitat-sim/pull/954). Primarily this PR renames the SimulatorConfiguration field activeSceneID to be activeSceneName - in our system, "ID"s are nearly always integers; "name" or "handle" is used to denote a descriptive string, which is what this field represents.  NOTE : scene_id is still used in the python to reference this field.  

Also, this PR also introduces a bit more support for Scene Dataset name, particularly in viewer (which will be one of the mechanisms used to demonstrate SceneInstance importing once that functionality goes live)

Lastly, this PR repairs omissions in the SimulatorConfiguration equality operator override relating to render replay.

This PR is the first of multiple PRs that will be presented in the next day or two to implement Scene Instance Importing.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing C++ and Python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
