### PR TITLE
[Refactor/BUGFIX] Scene Import 2/Prep : ResourceManager and loop fixes

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -277,19 +277,21 @@ bool ResourceManager::loadStage(
   AssetInfo& infoToUse = renderInfo;
   if (assetInfoMap.count("collision")) {
     AssetInfo colInfo = assetInfoMap.at("collision");
-    LOG(INFO) << "ResourceManager::loadStage : start load collision asset "
-              << colInfo.filepath << ".";
+    if (resourceDict_.count(colInfo.filepath) == 0) {
+      LOG(INFO) << "ResourceManager::loadStage : start load collision asset "
+                << colInfo.filepath << ".";
+      // will not reload if already present
+      bool collisionMeshSuccess =
+          loadStageInternal(colInfo,   // AssetInfo
+                            nullptr,   // creation
+                            nullptr,   // parent scene node
+                            nullptr);  // drawable group
 
-    // should this be checked to make sure we do not reload?
-    bool collisionMeshSuccess = loadStageInternal(colInfo,  // AssetInfo
-                                                  nullptr,  // creation
-                                                  nullptr,  // parent scene node
-                                                  nullptr);  // drawable group
-
-    if (!collisionMeshSuccess) {
-      LOG(ERROR) << " ResourceManager::loadStage : Stage collision mesh "
-                    "load failed.  Aborting scene initialization.";
-      return false;
+      if (!collisionMeshSuccess) {
+        LOG(ERROR) << " ResourceManager::loadStage : Stage collision mesh "
+                      "load failed.  Aborting scene initialization.";
+        return false;
+      }
     }
     // if we have a collision mesh, and it does not exist already as a
     // collision object, add it

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -259,6 +259,8 @@ bool ResourceManager::loadStage(
   }
   RenderAssetInstanceCreationInfo renderCreation(
       renderInfo.filepath, Cr::Containers::NullOpt, flags, renderLightSetupKey);
+  LOG(INFO) << "ResourceManager::loadStage : start load render asset "
+            << renderInfo.filepath << ".";
 
   bool renderMeshSuccess = loadStageInternal(renderInfo,  // AssetInfo
                                              &renderCreation,
@@ -275,6 +277,9 @@ bool ResourceManager::loadStage(
   AssetInfo& infoToUse = renderInfo;
   if (assetInfoMap.count("collision")) {
     AssetInfo colInfo = assetInfoMap.at("collision");
+    LOG(INFO) << "ResourceManager::loadStage : start load collision asset "
+              << colInfo.filepath << ".";
+
     // should this be checked to make sure we do not reload?
     bool collisionMeshSuccess = loadStageInternal(colInfo,  // AssetInfo
                                                   nullptr,  // creation
@@ -559,6 +564,8 @@ bool ResourceManager::loadStageInternal(
     DrawableGroup* drawables) {
   // scene mesh loading
   const std::string& filename = info.filepath;
+  LOG(INFO) << "ResourceManager::loadStageInternal : Attempting to load stage "
+            << filename << " ";
   bool meshSuccess = true;
   if (info.filepath.compare(EMPTY_SCENE) != 0) {
     if (!Cr::Utility::Directory::exists(filename)) {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1083,6 +1083,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   ASSERT(isRenderAssetGeneral(info.type));
 
   const std::string& filename = info.filepath;
+  const std::string dispFileName = Cr::Utility::Directory::filename(filename);
   CHECK(resourceDict_.count(filename) == 0);
 
   // Preferred plugins, Basis target GPU format
@@ -1102,7 +1103,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
             Mn::GL::Extensions::KHR::texture_compression_astc_ldr>())
 #endif
     {
-      LOG(INFO) << "Importing Basis files as ASTC 4x4";
+      LOG(INFO) << "Importing Basis files as ASTC 4x4 for " << dispFileName;
       metadata->configuration().setValue("format", "Astc4x4RGBA");
     }
 #ifdef MAGNUM_TARGET_GLES
@@ -1113,7 +1114,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
                  Mn::GL::Extensions::ARB::texture_compression_bptc>())
 #endif
     {
-      LOG(INFO) << "Importing Basis files as BC7";
+      LOG(INFO) << "Importing Basis files as BC7 for " << dispFileName;
       metadata->configuration().setValue("format", "Bc7RGBA");
     }
 #ifdef MAGNUM_TARGET_WEBGL
@@ -1129,7 +1130,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
                  Mn::GL::Extensions::EXT::texture_compression_s3tc>())
 #endif
     {
-      LOG(INFO) << "Importing Basis files as BC3";
+      LOG(INFO) << "Importing Basis files as BC3 for " << dispFileName;
       metadata->configuration().setValue("format", "Bc3RGBA");
     }
 #ifndef MAGNUM_TARGET_GLES2
@@ -1139,7 +1140,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
                 Mn::GL::Extensions::ARB::ES3_compatibility>())
 #endif
     {
-      LOG(INFO) << "Importing Basis files as ETC2";
+      LOG(INFO) << "Importing Basis files as ETC2 for " << dispFileName;
       metadata->configuration().setValue("format", "Etc2RGBA");
     }
 #else /* For ES2, fall back to PVRTC as ETC2 is not available */
@@ -1150,7 +1151,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
         if (context.isExtensionSupported<Mn::IMG::texture_compression_pvrtc>())
 #endif
     {
-      LOG(INFO) << "Importing Basis files as PVRTC 4bpp";
+      LOG(INFO) << "Importing Basis files as PVRTC 4bpp for " << dispFileName;
       metadata->configuration().setValue("format", "PvrtcRGBA4bpp");
     }
 #endif
@@ -1158,7 +1159,8 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
     else /* ES3 has ETC2 always */
     {
       LOG(WARNING) << "No supported GPU compressed texture format detected, "
-                      "Basis images will get imported as RGBA8";
+                      "Basis images will get imported as RGBA8 for "
+                   << dispFileName;
       metadata->configuration().setValue("format", "RGBA8");
     }
 #endif

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -509,7 +509,7 @@ class AssetAttributesManager
   void resetFinalize() override {
     // build default attributes::AbstractPrimitiveAttributes objects - reset
     // does not remove constructor mappings;
-    for (const std::pair<PrimObjTypes, const char*>& elem :
+    for (const std::pair<const PrimObjTypes, const char*>& elem :
          PrimitiveNames3DMap) {
       if (elem.first == PrimObjTypes::END_PRIM_OBJ_TYPES) {
         continue;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -932,7 +932,7 @@ int Simulator::getAgentObservations(
   if (ag != nullptr) {
     const std::map<std::string, sensor::Sensor::ptr>& sensors =
         ag->getSensorSuite().getSensors();
-    for (std::pair<std::string, sensor::Sensor::ptr> s : sensors) {
+    for (const std::pair<const std::string, sensor::Sensor::ptr>& s : sensors) {
       sensor::Observation obs;
       if (s.second->getObservation(*this, obs)) {
         observations[s.first] = obs;
@@ -963,7 +963,7 @@ int Simulator::getAgentObservationSpaces(
   if (ag != nullptr) {
     const std::map<std::string, sensor::Sensor::ptr>& sensors =
         ag->getSensorSuite().getSensors();
-    for (std::pair<std::string, sensor::Sensor::ptr> s : sensors) {
+    for (const std::pair<const std::string, sensor::Sensor::ptr>& s : sensors) {
       sensor::ObservationSpace space;
       if (s.second->getObservationSpace(space)) {
         spaces[s.first] = space;


### PR DESCRIPTION
## Motivation and Context
This small PR fixes loop vars not having const specified, and adds file name to info message for basis loading.  It also checks whether a render asset has been loaded with the same name as a specified collision asset during loadStage before allowing loadStageInternal to be called, which was throwing an unnecessary error message before.  This PR also serves to remove some secondary functionality from [the already very large Scene Import 1.0 PR that can be found here](https://github.com/facebookresearch/habitat-sim/pull/954)

This is the 2nd of multiple SceneImport PRs that will be presented over the next day or two.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
