### PR TITLE
[Refactor] Scene Import 3/prep : Simple Attributes Display name & attributes load efficiency

### DIFF
--- a/src/esp/core/ManagedContainer.h
+++ b/src/esp/core/ManagedContainer.h
@@ -17,7 +17,7 @@ namespace core {
 /**
  * @brief Class template defining responsibilities and functionality for
  * managing @ref esp::core::AbstractManagedObject constructs.
- * @tparam ManagedPtr the type of managed object a particular specialization of
+ * @tparam T the type of managed object a particular specialization of
  * this class works with.  Must inherit from @ref
  * esp::core::AbstractManagedObject.
  */
@@ -231,11 +231,11 @@ class ManagedContainer : public ManagedContainerBase {
   }  // ManagedContainer::getObjectByID
 
   /**
-   * @brief Get a reference to the managed object for the asset
-   * identified by the passed objectHandle.  Should only be used
-   * internally. Users should only ever access copies of managed objects.
+   * @brief Get a reference to the managed object identified by the passed
+   * objectHandle.  Should only be used internally. Users should only ever
+   * access copies of managed objects.
    *
-   * @param objectHandle The key referencing the asset in @ref
+   * @param objectHandle The key referencing the managed object in @ref
    * objectLibrary_.
    * @return A reference to the managed object, or nullptr if does not
    * exist

--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -197,10 +197,10 @@ class ManagedContainerBase {
   const std::string& getObjectType() const { return objectType_; }
 
  protected:
-  //======== Internally accessed getter ================
+  //======== Internally accessed getter/setter ================
 
   /**
-   * @brief Retrieve shared pointer to object held in library
+   * @brief Retrieve shared pointer to object held in library, NOT a copy.
    * @param handle the name of the object held in the smart pointer
    */
   template <class U>

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -5,6 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
 #define ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
 
+#include <Corrade/Utility/Directory.h>
 #include "esp/core/AbstractManagedObject.h"
 #include "esp/core/Configuration.h"
 
@@ -46,6 +47,21 @@ class AbstractAttributes : public esp::core::AbstractManagedObject,
     setString("handle", handle);
   }
   std::string getHandle() const override { return getString("handle"); }
+
+  /**
+   * @brief This will return a simplified version of the attributes handle. Note
+   * : there's no guarantee this handle will be sufficiently unique to identify
+   * this attributes, so this should only be used for logging, and not for
+   * attempts to search for attributes.
+   */
+  std::string getSimplifiedHandle() {
+    // first parse for file name, and then get rid of extension(s).
+    return Corrade::Utility::Directory::splitExtension(
+               Corrade::Utility::Directory::splitExtension(
+                   Corrade::Utility::Directory::filename(getHandle()))
+                   .first)
+        .first;
+  }
 
   /**
    * @brief directory where files used to construct attributes can be found.

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -172,8 +172,16 @@ auto AbstractObjectAttributesManager<T>::createObject(
                                                     registerTemplate);
     msg = "Primitive Asset (" + attributesTemplateHandle + ") Based";
   } else {
+    LOG(INFO) << "AbstractObjectAttributesManager<T>::createObject  ("
+              << this->objectType_ << ") : Making attributes with handle : "
+              << attributesTemplateHandle;
     attrs = this->createFromJsonOrDefaultInternal(attributesTemplateHandle, msg,
                                                   registerTemplate);
+
+    LOG(INFO) << "AbstractObjectAttributesManager<T>::createObject  ("
+              << this->objectType_
+              << ") : Done making attributes with handle : "
+              << attributesTemplateHandle;
 
   }  // if this is prim else
   if (nullptr != attrs) {

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -127,12 +127,23 @@ class AttributesManager : public esp::core::ManagedContainer<T> {
    */
   virtual void setValsFromJSONDoc(AttribsPtr attribs,
                                   const io::JsonGenericValue& jsonConfig) = 0;
+  /**
+   * @brief Return a properly formated JSON file name for the attributes managed
+   * by this manager.  This will change the extension to the appropriate json
+   * extension.
+   * @param filename The original filename
+   * @return a candidate JSON file name for the attributes managed by this
+   * manager.
+   */
+  std::string getFormattedJSONFileName(const std::string& filename) {
+    return this->convertFilenameToJSON(filename, this->JSONTypeExt_);
+  }
 
  protected:
   /**
-   * @brief Called intenrally from createObject.  This will create either a file
-   * based AbstractAttributes or a default one based on whether the passed file
-   * name exists and has appropriate string tag/extension for @ref
+   * @brief Called intenrally from createObject.  This will create either a
+   * file based AbstractAttributes or a default one based on whether the
+   * passed file name exists and has appropriate string tag/extension for @ref
    * esp::metadata::attributes::AbstractAttributes.
    *
    * @param filename the file holding the configuration of the object
@@ -163,18 +174,25 @@ std::vector<int> AttributesManager<T>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
-  for (int i = 0; i < paths.size(); ++i) {
-    auto attributesFilename = paths[i];
-    LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Load "
-              << this->objectType_ << " template: " << attributesFilename;
-    auto tmplt = this->createObjectFromJSONFile(attributesFilename, true);
+  if (paths.size() > 0) {
+    std::string dir = Cr::Utility::Directory::path(paths[0]);
+    LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Loading "
+              << paths.size() << " " << this->objectType_
+              << " templates found in " << dir;
+    for (int i = 0; i < paths.size(); ++i) {
+      auto attributesFilename = paths[i];
+      LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Load "
+                << this->objectType_ << " template: "
+                << Cr::Utility::Directory::filename(attributesFilename);
+      auto tmplt = this->createObjectFromJSONFile(attributesFilename, true);
 
-    // save handles in list of defaults, so they are not removed, if desired.
-    if (saveAsDefaults) {
-      std::string tmpltHandle = tmplt->getHandle();
-      this->undeletableObjectNames_.insert(tmpltHandle);
+      // save handles in list of defaults, so they are not removed, if desired.
+      if (saveAsDefaults) {
+        std::string tmpltHandle = tmplt->getHandle();
+        this->undeletableObjectNames_.insert(tmpltHandle);
+      }
+      templateIndices[i] = tmplt->getID();
     }
-    templateIndices[i] = tmplt->getID();
   }
   LOG(INFO)
       << "AttributesManager::loadAllFileBasedTemplates : Loaded file-based "
@@ -188,34 +206,36 @@ std::vector<int> AttributesManager<T>::loadAllConfigsFromPath(
     bool saveAsDefaults) {
   std::vector<std::string> paths;
   std::vector<int> templateIndices;
-  namespace Directory = Cr::Utility::Directory;
-  std::string attributesFilepath =
-      this->convertFilenameToJSON(path, this->JSONTypeExt_);
-  const bool dirExists = Directory::isDirectory(path);
-  const bool fileExists = Directory::exists(attributesFilepath);
+  namespace Dir = Cr::Utility::Directory;
 
-  if (!dirExists && !fileExists) {
-    LOG(WARNING) << "AttributesManager::loadAllConfigsFromPath : Parsing "
-                 << this->objectType_ << " : Cannot find " << path << " or "
-                 << attributesFilepath << ". Aborting parse.";
-    return templateIndices;
-  }
-
-  if (fileExists) {
-    paths.push_back(attributesFilepath);
-  }
-
+  // Check if directory
+  const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
     LOG(INFO) << "AttributesManager::loadAllConfigsFromPath : Parsing "
               << this->objectType_ << " library directory: " + path;
-    for (auto& file : Directory::list(path, Directory::Flag::SortAscending)) {
-      std::string absoluteSubfilePath = Directory::join(path, file);
+    for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
+      std::string absoluteSubfilePath = Dir::join(path, file);
       if (Cr::Utility::String::endsWith(absoluteSubfilePath,
                                         this->JSONTypeExt_)) {
         paths.push_back(absoluteSubfilePath);
       }
     }
-  }
+  } else {
+    // not a directory, perhaps a file
+    std::string attributesFilepath = getFormattedJSONFileName(path);
+    const bool fileExists = Dir::exists(attributesFilepath);
+
+    if (fileExists) {
+      paths.push_back(attributesFilepath);
+    } else {  // neither a directory or a file
+      LOG(WARNING) << "AttributesManager::loadAllConfigsFromPath : Parsing "
+                   << this->objectType_ << " : Cannot find " << path
+                   << " as directory or " << attributesFilepath
+                   << " as config file. Aborting parse.";
+      return templateIndices;
+    }  // if fileExists else
+  }    // if dirExists else
+
   // build templates from aggregated paths
   templateIndices = this->loadAllFileBasedTemplates(paths, saveAsDefaults);
 
@@ -256,10 +276,15 @@ auto AttributesManager<T>::createFromJsonOrDefaultInternal(
   std::string jsonAttrFileName =
       (Cr::Utility::String::endsWith(filename, this->JSONTypeExt_)
            ? filename
-           : this->convertFilenameToJSON(filename, this->JSONTypeExt_));
+           : getFormattedJSONFileName(filename));
   // Check if this configuration file exists and if so use it to build
   // attributes
   bool jsonFileExists = (this->isValidFileName(jsonAttrFileName));
+  LOG(INFO) << "AttributesManager<T>::createFromJsonOrDefaultInternal  ("
+            << this->objectType_
+            << ") : Proposing JSON name : " << jsonAttrFileName
+            << " from original name : " << filename << " | This file "
+            << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
     attrs = this->createObjectFromJSONFile(jsonAttrFileName, registerObj);


### PR DESCRIPTION
## Motivation and Context
This small PR provides a few functions that are used by Scene Import, and is intended to simplify [the existing very large Scene Import 1.0 PR that can be found here](https://github.com/facebookresearch/habitat-sim/pull/954) by separating some of the file changes from it that are not related to the primary functionality. 

A mechanism is provided by which attributes can provide a simplified name, useful for display purposes (only).  Often an attributes template's handle is composed of its filename with complete file path (in order to guarantee uniqueness), which can be unwieldy for display purposes.  This simplified name is only the file name of the attributes, without any extensions. This name will hold no guarantees of uniqueness, however; the standard getHandle() query should be used for such purposes.

This also refactors the attributes path loading process to query directories first, then file names (instead of the other way around which was the former behavior).  This will speed up large scene dataset attributes loading since usually this function (loadAllConfigsFromPath) is called with one or multiple directory names.  More info feedback is also being provided regarding the creation and loading of attributes.  Lastly, it also clarifies some comments in the Managed Containers to be more descriptive. 

This is the 3rd of multiple Scene Import PRs that will be presented over the next day or two.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
