### PR TITLE
Add comments to clarify per-frame profiler

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -551,45 +551,35 @@ Viewer::Viewer(const Arguments& arguments)
    * idling, and CpuDuration and GpuDuration should be roughly equal for faster
    * rendering times
    *
-   * FrameTime: (Units::Nanoseconds) Time to render per frame, 1/FPS, 2 frame
-   * delay
+   * FrameTime: (Units::Nanoseconds) Time to render per frame, 1/FPS
    *
    * CpuDuration: (Units::Nanoseconds) CPU time spent processing events,
    * physics, traversing SceneGraph, and submitting data to GPU/drivers per
    * frame
-   * Measured using std::chrono::high_resolution_clock, 1 frame delay
    *
-   * GpuDuration: (Units::Nanoseconds) GPU time spent rendering data submitted
-   * by CPU per frame
-   * Uses asynchronous querying to measure the amount of time
-   * to fully complete a set of GL commands without stalling rendering, 3 frame
-   * delay
-   * Asynchronous querying extensions: ARB_timer_query (OpenGL 3.3),
-   * EXT_disjoint_timer_query (OpenGL ES, WebGL), EXT_disjoint_timer_query
-   * (WebGL2)
-   * Requires an active OpenGL context
+   * GpuDuration: (Units::Nanoseconds) Measures how much time it takes for the
+   * GPU to process all work submitted by CPU Uses asynchronous querying to
+   * measure the amount of time to fully complete a set of GL commands without
+   * stalling rendering
    */
   Mn::DebugTools::GLFrameProfiler::Values profilerValues =
       Mn::DebugTools::GLFrameProfiler::Value::FrameTime |
       Mn::DebugTools::GLFrameProfiler::Value::CpuDuration |
       Mn::DebugTools::GLFrameProfiler::Value::GpuDuration;
 
-/**
- * VertexFetchRatio and PrimitiveClipRatio only supported for GL 4.6
- *
- * VertexFetchRatio: (Units::RatioThousandths) Ratio of vertex shader
- * invocations to count of vertices submitted
- *
- * PrimitiveClipRatio:  (Units::PercentageThousandths) Ratio of primitives
- * discarded by the clipping stage to count of primitives submitted
- */
+// VertexFetchRatio and PrimitiveClipRatio only supported for GL 4.6
 #ifndef MAGNUM_TARGET_GLES
   if (Mn::GL::Context::current()
           .isExtensionSupported<
               Mn::GL::Extensions::ARB::pipeline_statistics_query>()) {
     profilerValues |=
-        Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio |
-        Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio;
+        Mn::DebugTools::GLFrameProfiler::Value::
+            VertexFetchRatio |  // Ratio of vertex shader invocations to count
+                                // of vertices submitted
+        Mn::DebugTools::GLFrameProfiler::Value::
+            PrimitiveClipRatio;  // Ratio of primitives discarded by the
+                                 // clipping stage to count of primitives
+                                 // submitted
   }
 #endif
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -525,18 +525,26 @@ Viewer::Viewer(const Arguments& arguments)
 
   // Set up per frame profiler to be aware of bottlenecking in processing data
   Mn::DebugTools::GLFrameProfiler::Values profilerValues =
-      Mn::DebugTools::GLFrameProfiler::Value::FrameTime | // Time to render per frame frame
-      Mn::DebugTools::GLFrameProfiler::Value::CpuDuration | // Time to process action (eg. physics, key presses) data per frame
-      Mn::DebugTools::GLFrameProfiler::Value::GpuDuration; // Time to process graphics data per frame
+      Mn::DebugTools::GLFrameProfiler::Value::FrameTime |  // Time to render per
+                                                           // frame frame
+      Mn::DebugTools::GLFrameProfiler::Value::
+          CpuDuration |  // Time to process action (eg. physics, key presses)
+                         // data per frame
+      Mn::DebugTools::GLFrameProfiler::Value::
+          GpuDuration;  // Time to process graphics data per frame
 
 // VertexFetchRatio and PrimitiveClipRatio only supported for GL 4.6
 #ifndef MAGNUM_TARGET_GLES
   if (Mn::GL::Context::current()
           .isExtensionSupported<
               Mn::GL::Extensions::ARB::pipeline_statistics_query>()) {
-    profilerValues |=
-        Mn::DebugTools::GLFrameProfiler::Value::VertexFetchRatio | // How many times the ver­tex shad­er executes per ver­tex
-        Mn::DebugTools::GLFrameProfiler::Value::PrimitiveClipRatio; // Ratio of primitives discarded by the clipping stage to count of primitives submitted
+    profilerValues |= Mn::DebugTools::GLFrameProfiler::Value::
+                          VertexFetchRatio |  // How many times the ver­tex
+                                              // shad­er executes per ver­tex
+                      Mn::DebugTools::GLFrameProfiler::Value::
+                          PrimitiveClipRatio;  // Ratio of primitives discarded
+                                               // by the clipping stage to count
+                                               // of primitives submitted
   }
 #endif
 
@@ -711,7 +719,8 @@ void Viewer::wiggleLastObject() {
 
 float timeSinceLastSimulation = 0.0;
 void Viewer::drawEvent() {
-  //Wrap profiler measurements around all methods to render images from RenderCamera
+  // Wrap profiler measurements around all methods to render images from
+  // RenderCamera
   profiler_.beginFrame();
 
   Mn::GL::defaultFramebuffer.clear(Mn::GL::FramebufferClear::Color |
@@ -789,7 +798,7 @@ void Viewer::drawEvent() {
 
   sensorRenderTarget->blitRgbaToDefault();
 
-  //Do not include ImGui content drawing in per frame profiler measurements
+  // Do not include ImGui content drawing in per frame profiler measurements
   profiler_.endFrame();
 
   // Immediately bind the main buffer back so that the "imgui" below can work


### PR DESCRIPTION
## Motivation and Context

We added a per-frame profiler in #1015 to display frame duration, cpu duration, and gpu duration at runtime to be aware of bottlenecks in data processing when running our viewer. This PR adds comments to clarify how to interpret values.

## How Has This Been Tested
Build and run

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
