### PR TITLE
--[BUGFIX] query both x and y offset in mouseScrollEvent for an active scroll.

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -974,12 +974,15 @@ void Viewer::mouseReleaseEvent(MouseEvent& event) {
 }
 
 void Viewer::mouseScrollEvent(MouseScrollEvent& event) {
-  if (!event.offset().y()) {
+  // shift+scroll is forced into x direction on mac, seemingly at OS level, so
+  // use both x and y offsets.
+  float scrollModVal = event.offset().y() + event.offset().x();
+  if (!(scrollModVal)) {
     return;
   }
   // Use shift for fine-grained zooming
   float modVal = (event.modifiers() & MouseEvent::Modifier::Shift) ? 1.01 : 1.1;
-  float mod = event.offset().y() > 0 ? modVal : 1.0 / modVal;
+  float mod = scrollModVal > 0 ? modVal : 1.0 / modVal;
   auto& cam = getAgentCamera();
   cam.modZoom(mod);
   redraw();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -976,7 +976,9 @@ void Viewer::mouseReleaseEvent(MouseEvent& event) {
 void Viewer::mouseScrollEvent(MouseScrollEvent& event) {
   // shift+scroll is forced into x direction on mac, seemingly at OS level, so
   // use both x and y offsets.
-  float scrollModVal = event.offset().y() + event.offset().x();
+  float scrollModVal = abs(event.offset().y()) > abs(event.offset().x())
+                           ? event.offset().y()
+                           : event.offset().x();
   if (!(scrollModVal)) {
     return;
   }


### PR DESCRIPTION
## Motivation and Context
This PR fixes a bug with how viewer processes mouseScrollEvent offsets on a mac by looking at both x and y offsets if a mouseScrollEvent is processed.  If shift is pressed, the scroll is defaulted to be horizontal on a mac, whereas previously in viewer we only examined the y offset to determine if a valid scroll has occurred, and in what direction.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
C++ and python
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
