### PR TITLE
Fix the conda binary build

### DIFF
--- a/conda-build/habitat-sim/meta.yaml
+++ b/conda-build/habitat-sim/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - setuptools
     - attrs>=19.1.0
+    - smmap<4.0,>=3.0.1
     - numba
     - numpy>=1.13
     - gitpython
@@ -43,6 +44,7 @@ requirements:
 
   run:
     - python x.x
+    - smmap<4.0,>=3.0.1
     - gitpython
     - attrs>=19.1.0
     - numba


### PR DESCRIPTION
## Motivation and Context

`gitpython`'s pip package requires `smmap<4.0,>=3.0.1`, however, it's conda package does not list this requirement properly.  That mismatch means conda-build pulls a version of smmap that will later break the build due to dependency checking for gitpython failing.

## How Has This Been Tested

The CI


