### PR TITLE
Make nav point sampling more robust

### DIFF
--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -76,6 +76,14 @@
     :param end: The desired end location
     :return: The actual ending location, if such a location exists, or ``{NAN, NAN, NAN}``
 
+.. py:function:: habitat_sim.nav.PathFinder.get_random_navigable_point
+    :summary: Samples a navigable point uniformly at random from the navmesh
+
+    :param max_tries: The maximum number of times to retry sampling if it fails and the navmesh
+    seems fine.  Setting this higher can sometimes be warranted, but needing to typically
+    indicates an error with the navmesh.
+    :return: A navigable point or ``{NAN, NAN, NAN}`` if this fails
+
 .. py:function:: habitat_sim.nav.PathFinder.snap_point
     :summary: Snaps a point to the closet navigable location
 

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -78,7 +78,8 @@ void initShortestPathBindings(py::module& m) {
       .def("get_topdown_view", &PathFinder::getTopDownView,
            R"(Returns the topdown view of the PathFinder's navmesh.)",
            "meters_per_pixel"_a, "height"_a)
-      .def("get_random_navigable_point", &PathFinder::getRandomNavigablePoint)
+      .def("get_random_navigable_point", &PathFinder::getRandomNavigablePoint,
+           "max_tries"_a = 10)
       .def("find_path", py::overload_cast<ShortestPath&>(&PathFinder::findPath),
            "path"_a)
       .def("find_path",

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1344,7 +1344,7 @@ bool PathFinder::build(const NavMeshSettings& bs,
 }
 
 vec3f PathFinder::getRandomNavigablePoint(const int maxTries /*= 10*/) {
-  return pimpl_->getRandomNavigablePoint();
+  return pimpl_->getRandomNavigablePoint(maxTries);
 }
 
 bool PathFinder::findPath(ShortestPath& path) {

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -931,9 +931,10 @@ vec3f PathFinder::Impl::getRandomNavigablePoint() {
         "NavMesh has no navigable area, this indicates an issue with the "
         "NavMesh");
 
-  int i = 0;
   vec3f pt;
-  for (int i = 0; i < MAX_TRIES; ++i) {
+
+  int i;
+  for (i = 0; i < MAX_TRIES; ++i) {
     dtPolyRef ref;
     dtStatus status =
         navQuery_->findRandomPoint(filter_.get(), frand, &ref, pt.data());

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -74,7 +74,7 @@ std::tuple<dtStatus, dtPolyRef, vec3f> projectToPoly(
   dtPolyRef polyRef;
   // Initialize with all NANs at dtStatusSucceed(status) == true does NOT mean
   // that it found a point to project to..........
-  vec3f polyXYZ{NAN, NAN, NAN};
+  vec3f polyXYZ = vec3f::Constant(Mn::Constants::nan());
   dtStatus status = navQuery->findNearestPoly(pt.data(), polyPickExt, filter,
                                               &polyRef, polyXYZ.data());
 
@@ -225,7 +225,7 @@ struct PathFinder::Impl {
              const float* bmax);
   bool build(const NavMeshSettings& bs, const esp::assets::MeshData& mesh);
 
-  vec3f getRandomNavigablePoint(const int maxTries);
+  vec3f getRandomNavigablePoint(int maxTries);
 
   bool findPath(ShortestPath& path);
   bool findPath(MultiGoalShortestPath& path);
@@ -943,7 +943,7 @@ vec3f PathFinder::Impl::getRandomNavigablePoint(const int maxTries /*= 10*/) {
   if (i == maxTries) {
     LOG(ERROR) << "Failed to getRandomNavigablePoint.  Try increasing max "
                   "tries if the navmesh is fine but just hard to sample from";
-    return {NAN, NAN, NAN};
+    return vec3f::Constant(Mn::Constants::nan());
   } else {
     return pt;
   }
@@ -1195,7 +1195,7 @@ T PathFinder::Impl::snapPoint(const T& pt) {
   if (dtStatusSucceed(status)) {
     return T{projectedPt};
   } else {
-    return {NAN, NAN, NAN};
+    return {Mn::Constants::nan(), Mn::Constants::nan(), Mn::Constants::nan()};
   }
 }
 

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -191,7 +191,7 @@ class PathFinder {
    * the returned point will be `{NAN, NAN, NAN}`. Use @ref
    * isNavigable to check if the point is navigable.
    */
-  vec3f getRandomNavigablePoint(const int maxTries = 10);
+  vec3f getRandomNavigablePoint(int maxTries = 10);
 
   /**
    * @brief Finds the shortest path between two points on the navigation mesh

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -182,13 +182,16 @@ class PathFinder {
   /**
    * @brief Returns a random navigable point
    *
+   * @param maxTries[in] The maximum number of tries sampling will be retried if
+   * it fails.
+   *
    * @return A random navigable point.
    *
    * @note This method can fail.  If it does,
-   * the returned point will be arbitrary and may not be navigable. Use @ref
+   * the returned point will be {NAN, NAN, NAN}. Use @ref
    * isNavigable to check if the point is navigable.
    */
-  vec3f getRandomNavigablePoint();
+  vec3f getRandomNavigablePoint(const int maxTries = 10);
 
   /**
    * @brief Finds the shortest path between two points on the navigation mesh
@@ -241,7 +244,7 @@ class PathFinder {
    *
    * @param[in] pt The point to snap to the navigation mesh
    *
-   * @return The closest navigation point to @ref pt.  Will be {inf, inf, inf}
+   * @return The closest navigation point to @ref pt.  Will be {NAN, NAN, NAN}
    * if no navigable point was within a reasonable distance
    */
   template <typename T>

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -188,7 +188,7 @@ class PathFinder {
    * @return A random navigable point.
    *
    * @note This method can fail.  If it does,
-   * the returned point will be {NAN, NAN, NAN}. Use @ref
+   * the returned point will be `{NAN, NAN, NAN}`. Use @ref
    * isNavigable to check if the point is navigable.
    */
   vec3f getRandomNavigablePoint(const int maxTries = 10);
@@ -244,7 +244,7 @@ class PathFinder {
    *
    * @param[in] pt The point to snap to the navigation mesh
    *
-   * @return The closest navigation point to @ref pt.  Will be {NAN, NAN, NAN}
+   * @return The closest navigation point to @ref pt.  Will be `{NAN, NAN, NAN}`
    * if no navigable point was within a reasonable distance
    */
   template <typename T>


### PR DESCRIPTION
## Motivation and Context

Looking at the recast code, there are two reasons why `navQuery_->findRandomPoint` would fail on a well formed navmesh. 

1. It fails to sample a polygon.  This can happen because the tile is sampled without checking to see if it has any polygons to select
2. There is a machine precision error that causes the sampled point to fail a point-in-poly test.

In both cases, trying again makes sense.  I added a runtime error to throw when the navmesh is definitely bad, no navigable area.

## How Has This Been Tested

Made a little script that samples a couple hundred million points.  That use to error once or twice even tho the navmesh is fine.  It no longer errors.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
