### PR TITLE
Added buggy skeleton python viewer

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -1,0 +1,39 @@
+from magnum import gl
+from magnum.platform.glfw import Application
+from settings import default_sim_settings, make_cfg
+
+import habitat_sim
+
+# Setting filepath to load
+sim_settings = default_sim_settings
+sim_settings[
+    "scene"
+] = "data/scene_datasets/habitat-test-scenes/frl_apartment_stage.stage_config.json"
+
+
+class SkeletonPythonViewer(Application):
+    def __init__(self):
+        configuration = self.Configuration()
+        configuration.title = "Skeleton Viewer Application"
+        Application.__init__(self, configuration)
+
+        self.viewport_size = gl.default_framebuffer.viewport.size()
+
+        self.cfg = make_cfg(sim_settings)
+        self.sim = habitat_sim.Simulator(self.cfg)
+        self.agent_id = sim_settings["default_agent"]
+        self.step = -1
+
+    def draw_event(self):
+        gl.default_framebuffer.clear(
+            gl.FramebufferClear.COLOR | gl.FramebufferClear.DEPTH
+        )
+        self.swap_buffers()
+
+
+try:
+    exit(SkeletonPythonViewer().exec())
+except Exception:
+    import traceback
+
+    print(str(traceback.format_exc()))


### PR DESCRIPTION
## Motivation and Context

The goal is to create an interactive python app similar to the current C++ viewer app. A similar python app exists in [this PR](https://github.com/facebookresearch/habitat-sim/pull/727) (last active in October), but seems to break in the current master branch. 

As a hopeful step toward debugging, I made a MWE which runs in [Harsh's branch](https://github.com/dexter1691/habitat-sim/tree/python_viewer), but not the current master branch. This skeleton python app is not nearly as fleshed out as Harsh's viewer, but I'm hoping it might be a first step toward incorporating such a viewer.

The objective is to initialize habitat-sim, load a stage, and render it to the application window. Currently, a segfault occurs when habitat-sim is initialized--the working theory is that the issue is related to multiple OpenGL::Context being created (both for the application window and the simulator). (This would suggest that changes to Simulator.cpp might be necessary (note that they were in Harsh's branch).)

Thanks to Alexander Clegg, note that the skeleton app here is very similar to [this tutorial collab](https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/master/examples/tutorials/colabs/ECCV_2020_Navigation.ipynb), so it appears that the segfault occurs only when the tutorial code is executed inside the Application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
