### PR TITLE
Added doc build before conda binaries build to fix documentation build for conda binaries build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
                 cd ..
               fi
       - run:
-          name: Build sim documentation
+          name: Build habitat sim and documentation
           no_output_timeout: 20m
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
@@ -360,7 +360,7 @@ jobs:
               git submodule update --init
               ./build-public.sh
       - run:
-          name: Install Habitat Lab
+          name: Install Habitat Sim and Habitat Lab
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
@@ -665,6 +665,12 @@ workflows:
 
   version_conda_release:
     jobs:
+      - build_and_test_habitat_lab_conda:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*.*/ # v0.1.5-rc1
+            branches:
+              ignore: /.*/
       - install_and_test_ubuntu:
           filters:
             tags:
@@ -673,6 +679,7 @@ workflows:
               ignore: /.*/
       - update_docs:
           requires:
+            - build_and_test_habitat_lab_conda
             - install_and_test_ubuntu
           filters:
             tags:
@@ -681,6 +688,7 @@ workflows:
               ignore: /.*/
       - build_conda_binaries:
           requires:
+            - build_and_test_habitat_lab_conda
             - install_and_test_ubuntu
           filters:
             tags:


### PR DESCRIPTION
## Motivation and Context
Added doc build before conda binaries build to fix documentation build for conda binaries build introduced here https://github.com/facebookresearch/habitat-sim/pull/886.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
