### PR TITLE
--Verify torch and cuda are installed if required by python tests

### DIFF
--- a/tests/test_data_extraction.py
+++ b/tests/test_data_extraction.py
@@ -2,6 +2,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+import pytest
+
+# skip all tests if torch not installed
+torch = pytest.importorskip("torch")
 from torch import nn as nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, Dataset

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -10,6 +10,9 @@ import os
 from io import StringIO
 from unittest.mock import patch
 
+import pytest
+
+import habitat_sim
 from habitat_sim.utils import profiling_utils
 
 _ENV_VAR_NAME = "HABITAT_PROFILING"
@@ -17,7 +20,8 @@ _ENV_VAR_NAME = "HABITAT_PROFILING"
 # Based on the env var, reloading the profiling_utils module should set
 # profiling_utils._enable_profiling to True or False.
 def test_env_var_enable():
-
+    if not habitat_sim.cuda_enabled:
+        pytest.skip("No CUDA present so skipping test_env_var_enable test")
     # test with env var not set
     os.environ.pop(_ENV_VAR_NAME, None)
     importlib.reload(profiling_utils)
@@ -47,6 +51,8 @@ def test_env_var_enable():
 
 # Create nested ranges and verify the code runs without error.
 def test_nested_range_push_pop():
+    if not habitat_sim.cuda_enabled:
+        pytest.skip("No CUDA present so skipping test_nested_range_push_pop test")
 
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
@@ -64,6 +70,8 @@ def test_nested_range_push_pop():
 
 # Create ranges via RangeContext and verify the code runs without error.
 def test_range_context():
+    if not habitat_sim.cuda_enabled:
+        pytest.skip("No CUDA present so skipping test_range_context test")
 
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
@@ -92,6 +100,8 @@ def test_range_context():
 
 # Use configure() to capture a desired range of train steps.
 def test_configure_and_on_start_step():
+    if not habitat_sim.cuda_enabled:
+        pytest.skip("No CUDA present so skipping test_configure_and_on_start_step test")
 
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -11,17 +11,19 @@ from io import StringIO
 from unittest.mock import patch
 
 import pytest
+from torch import cuda
 
-import habitat_sim
 from habitat_sim.utils import profiling_utils
 
 _ENV_VAR_NAME = "HABITAT_PROFILING"
 
 # Based on the env var, reloading the profiling_utils module should set
 # profiling_utils._enable_profiling to True or False.
+@pytest.mark.skipif(
+    not cuda.is_available(),
+    reason="Torch not installed with CUDA support so skipping test_env_var_enable test",
+)
 def test_env_var_enable():
-    if not habitat_sim.cuda_enabled:
-        pytest.skip("No CUDA present so skipping test_env_var_enable test")
     # test with env var not set
     os.environ.pop(_ENV_VAR_NAME, None)
     importlib.reload(profiling_utils)
@@ -50,10 +52,11 @@ def test_env_var_enable():
 
 
 # Create nested ranges and verify the code runs without error.
+@pytest.mark.skipif(
+    not cuda.is_available(),
+    reason="Torch not installed with CUDA support so skipping test_nested_range_push_pop test",
+)
 def test_nested_range_push_pop():
-    if not habitat_sim.cuda_enabled:
-        pytest.skip("No CUDA present so skipping test_nested_range_push_pop test")
-
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
 
@@ -69,10 +72,11 @@ def test_nested_range_push_pop():
 
 
 # Create ranges via RangeContext and verify the code runs without error.
+@pytest.mark.skipif(
+    not cuda.is_available(),
+    reason="Torch not installed with CUDA support so skipping test_range_context test",
+)
 def test_range_context():
-    if not habitat_sim.cuda_enabled:
-        pytest.skip("No CUDA present so skipping test_range_context test")
-
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
 
@@ -100,9 +104,6 @@ def test_range_context():
 
 # Use configure() to capture a desired range of train steps.
 def test_configure_and_on_start_step():
-    if not habitat_sim.cuda_enabled:
-        pytest.skip("No CUDA present so skipping test_configure_and_on_start_step test")
-
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
 

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -17,12 +17,14 @@ from habitat_sim.utils import profiling_utils
 
 _ENV_VAR_NAME = "HABITAT_PROFILING"
 
+test_requires_torch_cuda = pytest.mark.skipif(
+    not cuda.is_available(),
+    reason="Torch not installed with CUDA support so skipping test",
+)
+
 # Based on the env var, reloading the profiling_utils module should set
 # profiling_utils._enable_profiling to True or False.
-@pytest.mark.skipif(
-    not cuda.is_available(),
-    reason="Torch not installed with CUDA support so skipping test_env_var_enable test",
-)
+@test_requires_torch_cuda
 def test_env_var_enable():
     # test with env var not set
     os.environ.pop(_ENV_VAR_NAME, None)
@@ -52,10 +54,7 @@ def test_env_var_enable():
 
 
 # Create nested ranges and verify the code runs without error.
-@pytest.mark.skipif(
-    not cuda.is_available(),
-    reason="Torch not installed with CUDA support so skipping test_nested_range_push_pop test",
-)
+@test_requires_torch_cuda
 def test_nested_range_push_pop():
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)
@@ -72,10 +71,7 @@ def test_nested_range_push_pop():
 
 
 # Create ranges via RangeContext and verify the code runs without error.
-@pytest.mark.skipif(
-    not cuda.is_available(),
-    reason="Torch not installed with CUDA support so skipping test_range_context test",
-)
+@test_requires_torch_cuda
 def test_range_context():
     os.environ[_ENV_VAR_NAME] = "1"
     importlib.reload(profiling_utils)

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -11,14 +11,17 @@ from io import StringIO
 from unittest.mock import patch
 
 import pytest
-from torch import cuda
 
 from habitat_sim.utils import profiling_utils
 
 _ENV_VAR_NAME = "HABITAT_PROFILING"
 
+# skip all tests if torch not installed
+torch = pytest.importorskip("torch")
+
+# skip specific tests if torch does not have cuda available
 test_requires_torch_cuda = pytest.mark.skipif(
-    not cuda.is_available(),
+    not torch.cuda.is_available(),
     reason="Torch not installed with CUDA support so skipping test",
 )
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -47,7 +47,7 @@ def _render_and_load_gt(sim, scene, sensor_type, gpu2gpu):
     gt = np.load(gt_obs_file)
 
     if gpu2gpu:
-        import torch
+        torch = pytest.importorskip("torch")
 
         for k, v in obs.items():
             if torch.is_tensor(v):


### PR DESCRIPTION
## Motivation and Context
This PR introduces code that will skip pytest tests that require soft dependencies that may not be installed, such as torch or torch with cuda
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes
Python tests pass, appropriately skip non-cuda installs.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
