### PR TITLE
[BUGFIX] : Handle class template with multiple params in Smart Ptr Macro

### DIFF
--- a/src/esp/core/esp.h
+++ b/src/esp/core/esp.h
@@ -107,19 +107,19 @@ inline std::ostream& operator<<(std::ostream& os, const box3f& bbox) {
 }
 
 // smart pointers macro
-#define ESP_SMART_POINTERS(T)                                 \
- public:                                                      \
-  typedef std::shared_ptr<T> ptr;                             \
-  typedef std::unique_ptr<T> uptr;                            \
-  typedef std::shared_ptr<const T> cptr;                      \
-  typedef std::unique_ptr<const T> ucptr;                     \
-  template <typename... Targs>                                \
-  static inline ptr create(Targs&&... args) {                 \
-    return std::make_shared<T>(std::forward<Targs>(args)...); \
-  }                                                           \
-  template <typename... Targs>                                \
-  static inline uptr create_unique(Targs&&... args) {         \
-    return std::make_unique<T>(std::forward<Targs>(args)...); \
+#define ESP_SMART_POINTERS(...)                                         \
+ public:                                                                \
+  typedef std::shared_ptr<__VA_ARGS__> ptr;                             \
+  typedef std::unique_ptr<__VA_ARGS__> uptr;                            \
+  typedef std::shared_ptr<const __VA_ARGS__> cptr;                      \
+  typedef std::unique_ptr<const __VA_ARGS__> ucptr;                     \
+  template <typename... Targs>                                          \
+  static inline ptr create(Targs&&... args) {                           \
+    return std::make_shared<__VA_ARGS__>(std::forward<Targs>(args)...); \
+  }                                                                     \
+  template <typename... Targs>                                          \
+  static inline uptr create_unique(Targs&&... args) {                   \
+    return std::make_unique<__VA_ARGS__>(std::forward<Targs>(args)...); \
   }
 
 // pimpl macro backed by unique_ptr pointer


### PR DESCRIPTION
## Motivation and Context
Our current smart pointer macro breaks if a class template with more than one type parameter is passed to it.  This is because the C Preprocessor sees the type definition, including the list of params, and breaks it into multiple types.

(so `MyType<T,U>` is seen as `MyType<T` and `U>`)

The changes introduced in this small PR fix this issue.  Thanks @mosra!

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
