### PR TITLE
--Add managed container template argument to govern object access.

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -47,10 +47,10 @@ namespace managers {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <class T>
+template <class T, bool AccessViaCopies>
 void declareBaseAttributesManager(py::module& m,
                                   const std::string& classStrPrefix) {
-  using MgrClass = AttributesManager<T>;
+  using MgrClass = AttributesManager<T, AccessViaCopies>;
   using AttribsPtr = std::shared_ptr<T>;
   // Most, but not all, of these methods are from ManagedContainer class
   // template.  However, we use AttributesManager as the base class because we
@@ -191,9 +191,10 @@ void initAttributesManagersBindings(py::module& m) {
       .value("END_PRIM_OBJ_TYPE", metadata::PrimObjTypes::END_PRIM_OBJ_TYPES);
 
   // ==== Primitive Asset Attributes Template manager ====
-  declareBaseAttributesManager<AbstractPrimitiveAttributes>(m, "BaseAsset");
+  declareBaseAttributesManager<AbstractPrimitiveAttributes, true>(m,
+                                                                  "BaseAsset");
   py::class_<AssetAttributesManager,
-             AttributesManager<AbstractPrimitiveAttributes>,
+             AttributesManager<AbstractPrimitiveAttributes, true>,
              AssetAttributesManager::ptr>(m, "AssetAttributesManager")
       // AssetAttributesMangaer-specific bindings
       // return appropriately cast capsule templates
@@ -273,16 +274,17 @@ void initAttributesManagersBindings(py::module& m) {
            "handle"_a);
 
   // ==== Light Layout Attributes Template manager ====
-  declareBaseAttributesManager<LightLayoutAttributes>(m, "BaseLightLayout");
+  declareBaseAttributesManager<LightLayoutAttributes, true>(m,
+                                                            "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<LightLayoutAttributesManager,
-             AttributesManager<LightLayoutAttributes>,
+             AttributesManager<LightLayoutAttributes, true>,
              LightLayoutAttributesManager::ptr>(m,
                                                 "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
-  declareBaseAttributesManager<ObjectAttributes>(m, "BaseObject");
+  declareBaseAttributesManager<ObjectAttributes, true>(m, "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes>,
+  py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes, true>,
              ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
@@ -334,17 +336,18 @@ void initAttributesManagersBindings(py::module& m) {
           template chosen from the existing templates being managed.)");
 
   // ==== Stage Attributes Template manager ====
-  declareBaseAttributesManager<StageAttributes>(m, "BaseStage");
+  declareBaseAttributesManager<StageAttributes, true>(m, "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<StageAttributesManager, AttributesManager<StageAttributes>,
+  py::class_<StageAttributesManager, AttributesManager<StageAttributes, true>,
              StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
-  declareBaseAttributesManager<PhysicsManagerAttributes>(m, "BasePhysics");
+  declareBaseAttributesManager<PhysicsManagerAttributes, true>(m,
+                                                               "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<PhysicsAttributesManager,
-             AttributesManager<PhysicsManagerAttributes>,
+             AttributesManager<PhysicsManagerAttributes, true>,
              PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
 
 }  // initAttributesManagersBindings

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -47,10 +47,10 @@ namespace managers {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <class T, bool AccessViaCopies>
+template <class T, core::ManagedContainerAccess Access>
 void declareBaseAttributesManager(py::module& m,
                                   const std::string& classStrPrefix) {
-  using MgrClass = AttributesManager<T, AccessViaCopies>;
+  using MgrClass = AttributesManager<T, Access>;
   using AttribsPtr = std::shared_ptr<T>;
   // Most, but not all, of these methods are from ManagedContainer class
   // template.  However, we use AttributesManager as the base class because we
@@ -191,10 +191,12 @@ void initAttributesManagersBindings(py::module& m) {
       .value("END_PRIM_OBJ_TYPE", metadata::PrimObjTypes::END_PRIM_OBJ_TYPES);
 
   // ==== Primitive Asset Attributes Template manager ====
-  declareBaseAttributesManager<AbstractPrimitiveAttributes, true>(m,
-                                                                  "BaseAsset");
+  declareBaseAttributesManager<AbstractPrimitiveAttributes,
+                               core::ManagedContainerAccess::Copy>(m,
+                                                                   "BaseAsset");
   py::class_<AssetAttributesManager,
-             AttributesManager<AbstractPrimitiveAttributes, true>,
+             AttributesManager<AbstractPrimitiveAttributes,
+                               core::ManagedContainerAccess::Copy>,
              AssetAttributesManager::ptr>(m, "AssetAttributesManager")
       // AssetAttributesMangaer-specific bindings
       // return appropriately cast capsule templates
@@ -274,18 +276,24 @@ void initAttributesManagersBindings(py::module& m) {
            "handle"_a);
 
   // ==== Light Layout Attributes Template manager ====
-  declareBaseAttributesManager<LightLayoutAttributes, true>(m,
-                                                            "BaseLightLayout");
+  declareBaseAttributesManager<LightLayoutAttributes,
+                               core::ManagedContainerAccess::Copy>(
+      m, "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<LightLayoutAttributesManager,
-             AttributesManager<LightLayoutAttributes, true>,
+             AttributesManager<LightLayoutAttributes,
+                               core::ManagedContainerAccess::Copy>,
              LightLayoutAttributesManager::ptr>(m,
                                                 "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
-  declareBaseAttributesManager<ObjectAttributes, true>(m, "BaseObject");
+  declareBaseAttributesManager<ObjectAttributes,
+                               core::ManagedContainerAccess::Copy>(
+      m, "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<ObjectAttributesManager, AttributesManager<ObjectAttributes, true>,
-             ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
+  py::class_<
+      ObjectAttributesManager,
+      AttributesManager<ObjectAttributes, core::ManagedContainerAccess::Copy>,
+      ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
       .def("load_object_configs",
@@ -336,18 +344,24 @@ void initAttributesManagersBindings(py::module& m) {
           template chosen from the existing templates being managed.)");
 
   // ==== Stage Attributes Template manager ====
-  declareBaseAttributesManager<StageAttributes, true>(m, "BaseStage");
+  declareBaseAttributesManager<StageAttributes,
+                               core::ManagedContainerAccess::Copy>(m,
+                                                                   "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<StageAttributesManager, AttributesManager<StageAttributes, true>,
-             StageAttributesManager::ptr>(m, "StageAttributesManager");
+  py::class_<
+      StageAttributesManager,
+      AttributesManager<StageAttributes, core::ManagedContainerAccess::Copy>,
+      StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
-  declareBaseAttributesManager<PhysicsManagerAttributes, true>(m,
-                                                               "BasePhysics");
+  declareBaseAttributesManager<PhysicsManagerAttributes,
+                               core::ManagedContainerAccess::Copy>(
+      m, "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<PhysicsAttributesManager,
-             AttributesManager<PhysicsManagerAttributes, true>,
+             AttributesManager<PhysicsManagerAttributes,
+                               core::ManagedContainerAccess::Copy>,
              PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
 
 }  // initAttributesManagersBindings

--- a/src/esp/core/ManagedContainer.h
+++ b/src/esp/core/ManagedContainer.h
@@ -16,18 +16,18 @@ namespace esp {
 namespace core {
 
 /**
- * @brief This enum describes how objects held in the ManagedConatainers are
+ * @brief This enum describes how objects held in the @ref ManagedConatainer are
  * accessed.
  */
 enum class ManagedContainerAccess {
   /**
-   * @brief When an object is requested to be retrieved, a copy is made and
+   * When an object is requested to be retrieved, a copy is made and
    * returned.  Modifications to this object will only take place if the object
    * is registered.
    */
   Copy,
   /**
-   * @brief When an object is requested to be retrieved, a reference to the
+   * When an object is requested to be retrieved, a reference to the
    * object itself is returned, and all changes will be tracked without
    * registration.
    */

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -475,8 +475,7 @@ class MetadataMediator {
    * internal use.
    */
   attributes::SceneDatasetAttributes::ptr getActiveDSAttribs() const {
-    // do not get copy of dataset attributes until SceneDatasetAttributes deep
-    // copy ctor implemented
+    // do not get copy of dataset attributes
     auto datasetAttr =
         sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
     if (datasetAttr == nullptr) {

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -27,8 +27,9 @@ namespace managers {
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractObjectAttributes.
  */
-template <class T>
-class AbstractObjectAttributesManager : public AttributesManager<T> {
+template <class T, bool AccessViaCopies>
+class AbstractObjectAttributesManager
+    : public AttributesManager<T, AccessViaCopies> {
  public:
   static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
                 "AbstractObjectAttributesManager :: Managed object type must "
@@ -38,7 +39,8 @@ class AbstractObjectAttributesManager : public AttributesManager<T> {
 
   AbstractObjectAttributesManager(const std::string& attrType,
                                   const std::string& JSONTypeExt)
-      : AttributesManager<T>::AttributesManager(attrType, JSONTypeExt) {}
+      : AttributesManager<T, AccessViaCopies>::AttributesManager(attrType,
+                                                                 JSONTypeExt) {}
   virtual ~AbstractObjectAttributesManager() = default;
 
   /**
@@ -152,15 +154,15 @@ class AbstractObjectAttributesManager : public AttributesManager<T> {
   // ======== Typedefs and Instance Variables ========
 
  public:
-  ESP_SMART_POINTERS(AbstractObjectAttributesManager<AbsObjAttrPtr>)
+  ESP_SMART_POINTERS(AbstractObjectAttributesManager<T, AccessViaCopies>);
 
 };  // class AbstractObjectAttributesManager<T>
 
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class T>
-auto AbstractObjectAttributesManager<T>::createObject(
+template <class T, bool AccessViaCopies>
+auto AbstractObjectAttributesManager<T, AccessViaCopies>::createObject(
     const std::string& attributesTemplateHandle,
     bool registerTemplate) -> AbsObjAttrPtr {
   AbsObjAttrPtr attrs;
@@ -192,10 +194,11 @@ auto AbstractObjectAttributesManager<T>::createObject(
 
 }  // AbstractObjectAttributesManager<T>::createObject
 
-template <class T>
-auto AbstractObjectAttributesManager<T>::loadAbstractObjectAttributesFromJson(
-    AbsObjAttrPtr attributes,
-    const io::JsonGenericValue& jsonDoc) -> AbsObjAttrPtr {
+template <class T, bool AccessViaCopies>
+auto AbstractObjectAttributesManager<T, AccessViaCopies>::
+    loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
+                                         const io::JsonGenericValue& jsonDoc)
+        -> AbsObjAttrPtr {
   using std::placeholders::_1;
 
   // scale
@@ -276,8 +279,9 @@ auto AbstractObjectAttributesManager<T>::loadAbstractObjectAttributesFromJson(
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 
-template <class T>
-std::string AbstractObjectAttributesManager<T>::setJSONAssetHandleAndType(
+template <class T, bool AccessViaCopies>
+std::string
+AbstractObjectAttributesManager<T, AccessViaCopies>::setJSONAssetHandleAndType(
     AbsObjAttrPtr attributes,
     const io::JsonGenericValue& jsonDoc,
     const char* jsonMeshTypeTag,

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -27,9 +27,8 @@ namespace managers {
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractObjectAttributes.
  */
-template <class T, bool AccessViaCopies>
-class AbstractObjectAttributesManager
-    : public AttributesManager<T, AccessViaCopies> {
+template <class T, core::ManagedContainerAccess Access>
+class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
                 "AbstractObjectAttributesManager :: Managed object type must "
@@ -39,8 +38,8 @@ class AbstractObjectAttributesManager
 
   AbstractObjectAttributesManager(const std::string& attrType,
                                   const std::string& JSONTypeExt)
-      : AttributesManager<T, AccessViaCopies>::AttributesManager(attrType,
-                                                                 JSONTypeExt) {}
+      : AttributesManager<T, Access>::AttributesManager(attrType, JSONTypeExt) {
+  }
   virtual ~AbstractObjectAttributesManager() = default;
 
   /**
@@ -154,15 +153,15 @@ class AbstractObjectAttributesManager
   // ======== Typedefs and Instance Variables ========
 
  public:
-  ESP_SMART_POINTERS(AbstractObjectAttributesManager<T, AccessViaCopies>);
+  ESP_SMART_POINTERS(AbstractObjectAttributesManager<T, Access>);
 
 };  // class AbstractObjectAttributesManager<T>
 
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class T, bool AccessViaCopies>
-auto AbstractObjectAttributesManager<T, AccessViaCopies>::createObject(
+template <class T, core::ManagedContainerAccess Access>
+auto AbstractObjectAttributesManager<T, Access>::createObject(
     const std::string& attributesTemplateHandle,
     bool registerTemplate) -> AbsObjAttrPtr {
   AbsObjAttrPtr attrs;
@@ -194,8 +193,8 @@ auto AbstractObjectAttributesManager<T, AccessViaCopies>::createObject(
 
 }  // AbstractObjectAttributesManager<T>::createObject
 
-template <class T, bool AccessViaCopies>
-auto AbstractObjectAttributesManager<T, AccessViaCopies>::
+template <class T, core::ManagedContainerAccess Access>
+auto AbstractObjectAttributesManager<T, Access>::
     loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
                                          const io::JsonGenericValue& jsonDoc)
         -> AbsObjAttrPtr {
@@ -279,9 +278,9 @@ auto AbstractObjectAttributesManager<T, AccessViaCopies>::
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 
-template <class T, bool AccessViaCopies>
+template <class T, core::ManagedContainerAccess Access>
 std::string
-AbstractObjectAttributesManager<T, AccessViaCopies>::setJSONAssetHandleAndType(
+AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     AbsObjAttrPtr attributes,
     const io::JsonGenericValue& jsonDoc,
     const char* jsonMeshTypeTag,

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -76,7 +76,8 @@ enum class PrimObjTypes : uint32_t {
 };
 namespace managers {
 class AssetAttributesManager
-    : public AttributesManager<attributes::AbstractPrimitiveAttributes, true> {
+    : public AttributesManager<attributes::AbstractPrimitiveAttributes,
+                               core::ManagedContainerAccess::Copy> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -87,8 +88,8 @@ class AssetAttributesManager
 
   AssetAttributesManager()
       : AttributesManager<attributes::AbstractPrimitiveAttributes,
-                          true>::AttributesManager("Primitive Asset",
-                                                   "prim_config.json") {
+                          core::ManagedContainerAccess::Copy>::
+            AttributesManager("Primitive Asset", "prim_config.json") {
     buildCtorFuncPtrMaps();
   }  // AssetAttributesManager::ctor
 

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -76,7 +76,7 @@ enum class PrimObjTypes : uint32_t {
 };
 namespace managers {
 class AssetAttributesManager
-    : public AttributesManager<attributes::AbstractPrimitiveAttributes> {
+    : public AttributesManager<attributes::AbstractPrimitiveAttributes, true> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -86,8 +86,9 @@ class AssetAttributesManager
   static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
 
   AssetAttributesManager()
-      : AttributesManager<attributes::AbstractPrimitiveAttributes>::
-            AttributesManager("Primitive Asset", "prim_config.json") {
+      : AttributesManager<attributes::AbstractPrimitiveAttributes,
+                          true>::AttributesManager("Primitive Asset",
+                                                   "prim_config.json") {
     buildCtorFuncPtrMaps();
   }  // AssetAttributesManager::ctor
 

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -30,8 +30,9 @@ namespace managers {
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractAttributes.
  */
-template <class T>
-class AttributesManager : public esp::core::ManagedContainer<T> {
+template <class T, bool AccessViaCopies>
+class AttributesManager
+    : public esp::core::ManagedContainer<T, AccessViaCopies> {
  public:
   static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
                 "AttributesManager :: Managed object type must be derived from "
@@ -40,7 +41,8 @@ class AttributesManager : public esp::core::ManagedContainer<T> {
   typedef std::shared_ptr<T> AttribsPtr;
 
   AttributesManager(const std::string& attrType, const std::string& JSONTypeExt)
-      : esp::core::ManagedContainer<T>::ManagedContainer(attrType),
+      : esp::core::ManagedContainer<T, AccessViaCopies>::ManagedContainer(
+            attrType),
         JSONTypeExt_(JSONTypeExt) {}
   virtual ~AttributesManager() = default;
 
@@ -163,14 +165,15 @@ class AttributesManager : public esp::core::ManagedContainer<T> {
   const std::string JSONTypeExt_;
 
  public:
-  ESP_SMART_POINTERS(AttributesManager<AttribsPtr>)
+  ESP_SMART_POINTERS(AttributesManager<T, AccessViaCopies>);
 
 };  // class AttributesManager
 
 /////////////////////////////
 // Class Template Method Definitions
-template <class T>
-std::vector<int> AttributesManager<T>::loadAllFileBasedTemplates(
+template <class T, bool AccessViaCopies>
+std::vector<int>
+AttributesManager<T, AccessViaCopies>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
@@ -200,8 +203,8 @@ std::vector<int> AttributesManager<T>::loadAllFileBasedTemplates(
   return templateIndices;
 }  // AttributesManager<T>::loadAllObjectTemplates
 
-template <class T>
-std::vector<int> AttributesManager<T>::loadAllConfigsFromPath(
+template <class T, bool AccessViaCopies>
+std::vector<int> AttributesManager<T, AccessViaCopies>::loadAllConfigsFromPath(
     const std::string& path,
     bool saveAsDefaults) {
   std::vector<std::string> paths;
@@ -242,8 +245,8 @@ std::vector<int> AttributesManager<T>::loadAllConfigsFromPath(
   return templateIndices;
 }  // AttributesManager<T>::loadAllConfigsFromPath
 
-template <class T>
-void AttributesManager<T>::buildCfgPathsFromJSONAndLoad(
+template <class T, bool AccessViaCopies>
+void AttributesManager<T, AccessViaCopies>::buildCfgPathsFromJSONAndLoad(
     const std::string& configDir,
     const io::JsonGenericValue& jsonPaths) {
   for (rapidjson::SizeType i = 0; i < jsonPaths.Size(); ++i) {
@@ -265,8 +268,8 @@ void AttributesManager<T>::buildCfgPathsFromJSONAndLoad(
             << " templates.";
 }  // AttributesManager<T>::buildCfgPathsFromJSONAndLoad
 
-template <class T>
-auto AttributesManager<T>::createFromJsonOrDefaultInternal(
+template <class T, bool AccessViaCopies>
+auto AttributesManager<T, AccessViaCopies>::createFromJsonOrDefaultInternal(
     const std::string& filename,
     std::string& msg,
     bool registerObj) -> AttribsPtr {

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -18,8 +18,9 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace core {
+enum class ManagedContainerAccess;
 class ManagedContainerBase;
-}
+}  // namespace core
 namespace metadata {
 namespace managers {
 
@@ -29,10 +30,12 @@ namespace managers {
  * @tparam T the type of managed attributes a particular specialization
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractAttributes.
+ * @tparam Access Whether the default access (getters) for this
+ * container provides copies of the objects held, or the actual objects
+ * themselves.
  */
-template <class T, bool AccessViaCopies>
-class AttributesManager
-    : public esp::core::ManagedContainer<T, AccessViaCopies> {
+template <class T, core::ManagedContainerAccess Access>
+class AttributesManager : public esp::core::ManagedContainer<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
                 "AttributesManager :: Managed object type must be derived from "
@@ -41,8 +44,7 @@ class AttributesManager
   typedef std::shared_ptr<T> AttribsPtr;
 
   AttributesManager(const std::string& attrType, const std::string& JSONTypeExt)
-      : esp::core::ManagedContainer<T, AccessViaCopies>::ManagedContainer(
-            attrType),
+      : esp::core::ManagedContainer<T, Access>::ManagedContainer(attrType),
         JSONTypeExt_(JSONTypeExt) {}
   virtual ~AttributesManager() = default;
 
@@ -165,15 +167,14 @@ class AttributesManager
   const std::string JSONTypeExt_;
 
  public:
-  ESP_SMART_POINTERS(AttributesManager<T, AccessViaCopies>);
+  ESP_SMART_POINTERS(AttributesManager<T, Access>);
 
 };  // class AttributesManager
 
 /////////////////////////////
 // Class Template Method Definitions
-template <class T, bool AccessViaCopies>
-std::vector<int>
-AttributesManager<T, AccessViaCopies>::loadAllFileBasedTemplates(
+template <class T, core::ManagedContainerAccess Access>
+std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
@@ -203,8 +204,8 @@ AttributesManager<T, AccessViaCopies>::loadAllFileBasedTemplates(
   return templateIndices;
 }  // AttributesManager<T>::loadAllObjectTemplates
 
-template <class T, bool AccessViaCopies>
-std::vector<int> AttributesManager<T, AccessViaCopies>::loadAllConfigsFromPath(
+template <class T, core::ManagedContainerAccess Access>
+std::vector<int> AttributesManager<T, Access>::loadAllConfigsFromPath(
     const std::string& path,
     bool saveAsDefaults) {
   std::vector<std::string> paths;
@@ -245,8 +246,8 @@ std::vector<int> AttributesManager<T, AccessViaCopies>::loadAllConfigsFromPath(
   return templateIndices;
 }  // AttributesManager<T>::loadAllConfigsFromPath
 
-template <class T, bool AccessViaCopies>
-void AttributesManager<T, AccessViaCopies>::buildCfgPathsFromJSONAndLoad(
+template <class T, core::ManagedContainerAccess Access>
+void AttributesManager<T, Access>::buildCfgPathsFromJSONAndLoad(
     const std::string& configDir,
     const io::JsonGenericValue& jsonPaths) {
   for (rapidjson::SizeType i = 0; i < jsonPaths.Size(); ++i) {
@@ -268,8 +269,8 @@ void AttributesManager<T, AccessViaCopies>::buildCfgPathsFromJSONAndLoad(
             << " templates.";
 }  // AttributesManager<T>::buildCfgPathsFromJSONAndLoad
 
-template <class T, bool AccessViaCopies>
-auto AttributesManager<T, AccessViaCopies>::createFromJsonOrDefaultInternal(
+template <class T, core::ManagedContainerAccess Access>
+auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     const std::string& filename,
     std::string& msg,
     bool registerObj) -> AttribsPtr {

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -16,12 +16,13 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class LightLayoutAttributesManager
-    : public AttributesManager<attributes::LightLayoutAttributes, true> {
+    : public AttributesManager<attributes::LightLayoutAttributes,
+                               core::ManagedContainerAccess::Copy> {
  public:
   LightLayoutAttributesManager()
       : AttributesManager<attributes::LightLayoutAttributes,
-                          true>::AttributesManager("Lighting Layout",
-                                                   "lighting_config.json") {
+                          core::ManagedContainerAccess::Copy>::
+            AttributesManager("Lighting Layout", "lighting_config.json") {
     buildCtorFuncPtrMaps();
   }
 

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -16,12 +16,12 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class LightLayoutAttributesManager
-    : public AttributesManager<attributes::LightLayoutAttributes> {
+    : public AttributesManager<attributes::LightLayoutAttributes, true> {
  public:
   LightLayoutAttributesManager()
-      : AttributesManager<attributes::LightLayoutAttributes>::AttributesManager(
-            "Lighting Layout",
-            "lighting_config.json") {
+      : AttributesManager<attributes::LightLayoutAttributes,
+                          true>::AttributesManager("Lighting Layout",
+                                                   "lighting_config.json") {
     buildCtorFuncPtrMaps();
   }
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -16,12 +16,13 @@ namespace managers {
 /**
  * @brief single instance class managing templates describing physical objects
  */
-class ObjectAttributesManager
-    : public AbstractObjectAttributesManager<attributes::ObjectAttributes,
-                                             true> {
+class ObjectAttributesManager : public AbstractObjectAttributesManager<
+                                    attributes::ObjectAttributes,
+                                    core::ManagedContainerAccess::Copy> {
  public:
   ObjectAttributesManager()
-      : AbstractObjectAttributesManager<attributes::ObjectAttributes, true>::
+      : AbstractObjectAttributesManager<attributes::ObjectAttributes,
+                                        core::ManagedContainerAccess::Copy>::
             AbstractObjectAttributesManager(
                 "Object",
                 "object_config.json") {  // was phys_properties.json

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -17,10 +17,11 @@ namespace managers {
  * @brief single instance class managing templates describing physical objects
  */
 class ObjectAttributesManager
-    : public AbstractObjectAttributesManager<attributes::ObjectAttributes> {
+    : public AbstractObjectAttributesManager<attributes::ObjectAttributes,
+                                             true> {
  public:
   ObjectAttributesManager()
-      : AbstractObjectAttributesManager<attributes::ObjectAttributes>::
+      : AbstractObjectAttributesManager<attributes::ObjectAttributes, true>::
             AbstractObjectAttributesManager(
                 "Object",
                 "object_config.json") {  // was phys_properties.json

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -18,11 +18,12 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class PhysicsAttributesManager
-    : public AttributesManager<attributes::PhysicsManagerAttributes> {
+    : public AttributesManager<attributes::PhysicsManagerAttributes, true> {
  public:
   PhysicsAttributesManager()
-      : AttributesManager<attributes::PhysicsManagerAttributes>::
-            AttributesManager("Physics Manager", "physics_config.json") {
+      : AttributesManager<attributes::PhysicsManagerAttributes,
+                          true>::AttributesManager("Physics Manager",
+                                                   "physics_config.json") {
     buildCtorFuncPtrMaps();
   }
 

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -18,12 +18,13 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class PhysicsAttributesManager
-    : public AttributesManager<attributes::PhysicsManagerAttributes, true> {
+    : public AttributesManager<attributes::PhysicsManagerAttributes,
+                               core::ManagedContainerAccess::Copy> {
  public:
   PhysicsAttributesManager()
       : AttributesManager<attributes::PhysicsManagerAttributes,
-                          true>::AttributesManager("Physics Manager",
-                                                   "physics_config.json") {
+                          core::ManagedContainerAccess::Copy>::
+            AttributesManager("Physics Manager", "physics_config.json") {
     buildCtorFuncPtrMaps();
   }
 

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -43,10 +43,10 @@ enum class SceneInstanceTranslationOrigin {
 };
 
 class SceneAttributesManager
-    : public AttributesManager<attributes::SceneAttributes> {
+    : public AttributesManager<attributes::SceneAttributes, true> {
  public:
   SceneAttributesManager()
-      : AttributesManager<attributes::SceneAttributes>::AttributesManager(
+      : AttributesManager<attributes::SceneAttributes, true>::AttributesManager(
             "Scene Instance",
             "scene_instance.json") {
     buildCtorFuncPtrMaps();

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -43,12 +43,13 @@ enum class SceneInstanceTranslationOrigin {
 };
 
 class SceneAttributesManager
-    : public AttributesManager<attributes::SceneAttributes, true> {
+    : public AttributesManager<attributes::SceneAttributes,
+                               core::ManagedContainerAccess::Copy> {
  public:
   SceneAttributesManager()
-      : AttributesManager<attributes::SceneAttributes, true>::AttributesManager(
-            "Scene Instance",
-            "scene_instance.json") {
+      : AttributesManager<attributes::SceneAttributes,
+                          core::ManagedContainerAccess::Copy>::
+            AttributesManager("Scene Instance", "scene_instance.json") {
     buildCtorFuncPtrMaps();
   }
 

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -14,11 +14,11 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class SceneDatasetAttributesManager
-    : public AttributesManager<attributes::SceneDatasetAttributes> {
+    : public AttributesManager<attributes::SceneDatasetAttributes, false> {
  public:
   SceneDatasetAttributesManager(
       PhysicsAttributesManager::ptr physicsAttributesMgr)
-      : AttributesManager<attributes::SceneDatasetAttributes>::
+      : AttributesManager<attributes::SceneDatasetAttributes, false>::
             AttributesManager("Dataset", "scene_dataset_config.json"),
         physicsAttributesManager_(physicsAttributesMgr) {
     buildCtorFuncPtrMaps();

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -14,11 +14,13 @@ namespace esp {
 namespace metadata {
 namespace managers {
 class SceneDatasetAttributesManager
-    : public AttributesManager<attributes::SceneDatasetAttributes, false> {
+    : public AttributesManager<attributes::SceneDatasetAttributes,
+                               core::ManagedContainerAccess::Share> {
  public:
   SceneDatasetAttributesManager(
       PhysicsAttributesManager::ptr physicsAttributesMgr)
-      : AttributesManager<attributes::SceneDatasetAttributes, false>::
+      : AttributesManager<attributes::SceneDatasetAttributes,
+                          core::ManagedContainerAccess::Share>::
             AttributesManager("Dataset", "scene_dataset_config.json"),
         physicsAttributesManager_(physicsAttributesMgr) {
     buildCtorFuncPtrMaps();

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -26,7 +26,8 @@ namespace managers {
 StageAttributesManager::StageAttributesManager(
     ObjectAttributesManager::ptr objectAttributesMgr,
     PhysicsAttributesManager::ptr physicsAttributesManager)
-    : AbstractObjectAttributesManager<StageAttributes, true>::
+    : AbstractObjectAttributesManager<StageAttributes,
+                                      core::ManagedContainerAccess::Copy>::
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -26,7 +26,7 @@ namespace managers {
 StageAttributesManager::StageAttributesManager(
     ObjectAttributesManager::ptr objectAttributesMgr,
     PhysicsAttributesManager::ptr physicsAttributesManager)
-    : AbstractObjectAttributesManager<StageAttributes>::
+    : AbstractObjectAttributesManager<StageAttributes, true>::
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -11,14 +11,17 @@
 #include "PhysicsAttributesManager.h"
 
 namespace esp {
+namespace core {
+enum class ManagedContainerAccess;
+}
 namespace assets {
 enum class AssetType;
 }  // namespace assets
 namespace metadata {
 namespace managers {
-class StageAttributesManager
-    : public AbstractObjectAttributesManager<attributes::StageAttributes,
-                                             true> {
+class StageAttributesManager : public AbstractObjectAttributesManager<
+                                   attributes::StageAttributes,
+                                   core::ManagedContainerAccess::Copy> {
  public:
   StageAttributesManager(
       ObjectAttributesManager::ptr objectAttributesMgr,

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -17,7 +17,8 @@ enum class AssetType;
 namespace metadata {
 namespace managers {
 class StageAttributesManager
-    : public AbstractObjectAttributesManager<attributes::StageAttributes> {
+    : public AbstractObjectAttributesManager<attributes::StageAttributes,
+                                             true> {
  public:
   StageAttributesManager(
       ObjectAttributesManager::ptr objectAttributesMgr,


### PR DESCRIPTION
## Motivation and Context
This slight refactor adds a nontype template parameter to govern whether the ManagedContainers will provide copies of managed objects upon get, or the object itself.  Certain potential managed objects do not lend themselves to the current process where a copy is provided, and this change enables the actual object that is tracked to be provided to the user.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
