### PR TITLE
--[Bugfix] Should be returning a ref, not a copy.

### DIFF
--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -121,7 +121,7 @@ class LightLayoutAttributes : public AbstractAttributes {
   /**
    * @brief Get the lighting instances for this layout
    */
-  const std::map<std::string, LightInstanceAttributes::ptr> getLightInstances()
+  const std::map<std::string, LightInstanceAttributes::ptr>& getLightInstances()
       const {
     return lightInstances_;
   }

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -185,7 +185,7 @@ class SceneAttributes : public AbstractAttributes {
   /**
    * @brief Get the object instance descriptions for this scene
    */
-  const std::vector<SceneObjectInstanceAttributes::ptr> getObjectInstances()
+  const std::vector<SceneObjectInstanceAttributes::ptr>& getObjectInstances()
       const {
     return objectInstances_;
   }


### PR DESCRIPTION
## Motivation and Context
Minor Bugfix - These two methods should be returning const refs to the desired containers, not copies.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes
C++ and python
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
