### PR TITLE
[Refactor] Managed Container access refactor

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -161,13 +161,13 @@ void declareBaseAttributesManager(py::module& m,
            "force_registration"_a = false)
       .def("get_template_by_ID",
            static_cast<AttribsPtr (MgrClass::*)(int)>(
-               &MgrClass::getObjectCopyByID),
+               &MgrClass::getObjectOrCopyByID),
            R"(This returns a copy of the template specified by the passed
              ID if it exists, and NULL if it does not.)",
            "ID"_a)
       .def("get_template_by_handle",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&)>(
-               &MgrClass::getObjectCopyByHandle),
+               &MgrClass::getObjectOrCopyByHandle),
            R"(This returns a copy of the template specified by the passed
              handle if it exists, and NULL if it does not.)",
            "handle"_a);

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -47,7 +47,7 @@ namespace managers {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 void declareBaseAttributesManager(py::module& m,
                                   const std::string& classStrPrefix) {
   using MgrClass = AttributesManager<T, Access>;
@@ -192,11 +192,10 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Primitive Asset Attributes Template manager ====
   declareBaseAttributesManager<AbstractPrimitiveAttributes,
-                               core::ManagedContainerAccess::Copy>(m,
-                                                                   "BaseAsset");
+                               core::ManagedObjectAccess::Copy>(m, "BaseAsset");
   py::class_<AssetAttributesManager,
              AttributesManager<AbstractPrimitiveAttributes,
-                               core::ManagedContainerAccess::Copy>,
+                               core::ManagedObjectAccess::Copy>,
              AssetAttributesManager::ptr>(m, "AssetAttributesManager")
       // AssetAttributesMangaer-specific bindings
       // return appropriately cast capsule templates
@@ -277,22 +276,21 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Light Layout Attributes Template manager ====
   declareBaseAttributesManager<LightLayoutAttributes,
-                               core::ManagedContainerAccess::Copy>(
+                               core::ManagedObjectAccess::Copy>(
       m, "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<LightLayoutAttributesManager,
-             AttributesManager<LightLayoutAttributes,
-                               core::ManagedContainerAccess::Copy>,
-             LightLayoutAttributesManager::ptr>(m,
-                                                "LightLayoutAttributesManager");
+  py::class_<
+      LightLayoutAttributesManager,
+      AttributesManager<LightLayoutAttributes, core::ManagedObjectAccess::Copy>,
+      LightLayoutAttributesManager::ptr>(m, "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
   declareBaseAttributesManager<ObjectAttributes,
-                               core::ManagedContainerAccess::Copy>(
-      m, "BaseObject");
+                               core::ManagedObjectAccess::Copy>(m,
+                                                                "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       ObjectAttributesManager,
-      AttributesManager<ObjectAttributes, core::ManagedContainerAccess::Copy>,
+      AttributesManager<ObjectAttributes, core::ManagedObjectAccess::Copy>,
       ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
@@ -345,23 +343,22 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Stage Attributes Template manager ====
   declareBaseAttributesManager<StageAttributes,
-                               core::ManagedContainerAccess::Copy>(m,
-                                                                   "BaseStage");
+                               core::ManagedObjectAccess::Copy>(m, "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       StageAttributesManager,
-      AttributesManager<StageAttributes, core::ManagedContainerAccess::Copy>,
+      AttributesManager<StageAttributes, core::ManagedObjectAccess::Copy>,
       StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
   declareBaseAttributesManager<PhysicsManagerAttributes,
-                               core::ManagedContainerAccess::Copy>(
-      m, "BasePhysics");
+                               core::ManagedObjectAccess::Copy>(m,
+                                                                "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<PhysicsAttributesManager,
              AttributesManager<PhysicsManagerAttributes,
-                               core::ManagedContainerAccess::Copy>,
+                               core::ManagedObjectAccess::Copy>,
              PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
 
 }  // initAttributesManagersBindings

--- a/src/esp/core/ManagedContainer.h
+++ b/src/esp/core/ManagedContainer.h
@@ -19,7 +19,7 @@ namespace core {
  * @brief This enum describes how objects held in the @ref ManagedConatainer are
  * accessed.
  */
-enum class ManagedContainerAccess {
+enum class ManagedObjectAccess {
   /**
    * When an object is requested to be retrieved, a copy is made and
    * returned.  Modifications to this object will only take place if the object
@@ -44,7 +44,7 @@ enum class ManagedContainerAccess {
  * container provides copies of the objects held, or the actual objects
  * themselves.
  */
-template <class T, ManagedContainerAccess Access>
+template <class T, ManagedObjectAccess Access>
 class ManagedContainer : public ManagedContainerBase {
  public:
   static_assert(std::is_base_of<AbstractManagedObject, T>::value,
@@ -314,7 +314,7 @@ class ManagedContainer : public ManagedContainerBase {
   }  // removeAllObjects
 
   /**
-   * @brief remove managed objects that contain passed substring and that have
+   * @brief Remove managed objects that contain passed substring and that have
    * not been marked as default/non-removable, and return a vector of the
    * managed objects removed.
    * @param subStr substring to search for within existing primitive object
@@ -359,7 +359,7 @@ class ManagedContainer : public ManagedContainerBase {
       return nullptr;
     }
     auto orig = getObjectInternal<T>(objectHandle);
-    if (Access == ManagedContainerAccess::Copy) {
+    if (Access == ManagedObjectAccess::Copy) {
       return this->copyObject(orig);
     } else {
       return orig;
@@ -380,7 +380,7 @@ class ManagedContainer : public ManagedContainerBase {
       return nullptr;
     }
     auto orig = getObjectInternal<T>(objectHandle);
-    if (Access == ManagedContainerAccess::Copy) {
+    if (Access == ManagedObjectAccess::Copy) {
       return this->copyObject(orig);
     } else {
       return orig;
@@ -650,7 +650,7 @@ class ManagedContainer : public ManagedContainerBase {
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class T, ManagedContainerAccess Access>
+template <class T, ManagedObjectAccess Access>
 auto ManagedContainer<T, Access>::removeObjectsBySubstring(
     const std::string& subStr,
     bool contains) -> std::vector<ManagedPtr> {
@@ -668,7 +668,7 @@ auto ManagedContainer<T, Access>::removeObjectsBySubstring(
   return res;
 }  // ManagedContainer<T, Access>::removeObjectsBySubstring
 
-template <class T, ManagedContainerAccess Access>
+template <class T, ManagedObjectAccess Access>
 auto ManagedContainer<T, Access>::removeObjectInternal(
     const std::string& objectHandle,
     const std::string& sourceStr) -> ManagedPtr {

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -175,7 +175,7 @@ class MetadataMediator {
   }  // MetadataMediator::getStageAttributesManager
 
   /**
-   * @brief Return current physics manager attributes.
+   * @brief Return a copy of the current physics manager attributes.
    */
   attributes::PhysicsManagerAttributes::ptr
   getCurrentPhysicsManagerAttributes() {

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -27,7 +27,7 @@ namespace managers {
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractObjectAttributes.
  */
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
@@ -160,7 +160,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 auto AbstractObjectAttributesManager<T, Access>::createObject(
     const std::string& attributesTemplateHandle,
     bool registerTemplate) -> AbsObjAttrPtr {
@@ -193,7 +193,7 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
 
 }  // AbstractObjectAttributesManager<T>::createObject
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 auto AbstractObjectAttributesManager<T, Access>::
     loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
                                          const io::JsonGenericValue& jsonDoc)
@@ -278,7 +278,7 @@ auto AbstractObjectAttributesManager<T, Access>::
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 std::string
 AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     AbsObjAttrPtr attributes,

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -77,7 +77,7 @@ enum class PrimObjTypes : uint32_t {
 namespace managers {
 class AssetAttributesManager
     : public AttributesManager<attributes::AbstractPrimitiveAttributes,
-                               core::ManagedContainerAccess::Copy> {
+                               core::ManagedObjectAccess::Copy> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -88,7 +88,7 @@ class AssetAttributesManager
 
   AssetAttributesManager()
       : AttributesManager<attributes::AbstractPrimitiveAttributes,
-                          core::ManagedContainerAccess::Copy>::
+                          core::ManagedObjectAccess::Copy>::
             AttributesManager("Primitive Asset", "prim_config.json") {
     buildCtorFuncPtrMaps();
   }  // AssetAttributesManager::ctor
@@ -188,7 +188,8 @@ class AssetAttributesManager
   }  // AssetAttributeManager::getTemplateHandlesByPrimType
 
   /**
-   * @brief Return the default capsule template, either solid or wireframe.
+   * @brief Return a copy of the default capsule template, either solid or
+   * wireframe.
    * @param isWireFrame whether should be wireframe or solid template
    * @return appropriately cast template
    */

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -18,7 +18,7 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace core {
-enum class ManagedContainerAccess;
+enum class ManagedObjectAccess;
 class ManagedContainerBase;
 }  // namespace core
 namespace metadata {
@@ -34,7 +34,7 @@ namespace managers {
  * container provides copies of the objects held, or the actual objects
  * themselves.
  */
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 class AttributesManager : public esp::core::ManagedContainer<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
@@ -173,7 +173,7 @@ class AttributesManager : public esp::core::ManagedContainer<T, Access> {
 
 /////////////////////////////
 // Class Template Method Definitions
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
@@ -204,7 +204,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
   return templateIndices;
 }  // AttributesManager<T>::loadAllObjectTemplates
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 std::vector<int> AttributesManager<T, Access>::loadAllConfigsFromPath(
     const std::string& path,
     bool saveAsDefaults) {
@@ -246,7 +246,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllConfigsFromPath(
   return templateIndices;
 }  // AttributesManager<T>::loadAllConfigsFromPath
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 void AttributesManager<T, Access>::buildCfgPathsFromJSONAndLoad(
     const std::string& configDir,
     const io::JsonGenericValue& jsonPaths) {
@@ -269,7 +269,7 @@ void AttributesManager<T, Access>::buildCfgPathsFromJSONAndLoad(
             << " templates.";
 }  // AttributesManager<T>::buildCfgPathsFromJSONAndLoad
 
-template <class T, core::ManagedContainerAccess Access>
+template <class T, core::ManagedObjectAccess Access>
 auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     const std::string& filename,
     std::string& msg,

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -17,11 +17,11 @@ namespace metadata {
 namespace managers {
 class LightLayoutAttributesManager
     : public AttributesManager<attributes::LightLayoutAttributes,
-                               core::ManagedContainerAccess::Copy> {
+                               core::ManagedObjectAccess::Copy> {
  public:
   LightLayoutAttributesManager()
       : AttributesManager<attributes::LightLayoutAttributes,
-                          core::ManagedContainerAccess::Copy>::
+                          core::ManagedObjectAccess::Copy>::
             AttributesManager("Lighting Layout", "lighting_config.json") {
     buildCtorFuncPtrMaps();
   }

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -16,13 +16,13 @@ namespace managers {
 /**
  * @brief single instance class managing templates describing physical objects
  */
-class ObjectAttributesManager : public AbstractObjectAttributesManager<
-                                    attributes::ObjectAttributes,
-                                    core::ManagedContainerAccess::Copy> {
+class ObjectAttributesManager
+    : public AbstractObjectAttributesManager<attributes::ObjectAttributes,
+                                             core::ManagedObjectAccess::Copy> {
  public:
   ObjectAttributesManager()
       : AbstractObjectAttributesManager<attributes::ObjectAttributes,
-                                        core::ManagedContainerAccess::Copy>::
+                                        core::ManagedObjectAccess::Copy>::
             AbstractObjectAttributesManager(
                 "Object",
                 "object_config.json") {  // was phys_properties.json

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -19,11 +19,11 @@ namespace metadata {
 namespace managers {
 class PhysicsAttributesManager
     : public AttributesManager<attributes::PhysicsManagerAttributes,
-                               core::ManagedContainerAccess::Copy> {
+                               core::ManagedObjectAccess::Copy> {
  public:
   PhysicsAttributesManager()
       : AttributesManager<attributes::PhysicsManagerAttributes,
-                          core::ManagedContainerAccess::Copy>::
+                          core::ManagedObjectAccess::Copy>::
             AttributesManager("Physics Manager", "physics_config.json") {
     buildCtorFuncPtrMaps();
   }

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -44,11 +44,11 @@ enum class SceneInstanceTranslationOrigin {
 
 class SceneAttributesManager
     : public AttributesManager<attributes::SceneAttributes,
-                               core::ManagedContainerAccess::Copy> {
+                               core::ManagedObjectAccess::Copy> {
  public:
   SceneAttributesManager()
       : AttributesManager<attributes::SceneAttributes,
-                          core::ManagedContainerAccess::Copy>::
+                          core::ManagedObjectAccess::Copy>::
             AttributesManager("Scene Instance", "scene_instance.json") {
     buildCtorFuncPtrMaps();
   }

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -15,12 +15,12 @@ namespace metadata {
 namespace managers {
 class SceneDatasetAttributesManager
     : public AttributesManager<attributes::SceneDatasetAttributes,
-                               core::ManagedContainerAccess::Share> {
+                               core::ManagedObjectAccess::Share> {
  public:
   SceneDatasetAttributesManager(
       PhysicsAttributesManager::ptr physicsAttributesMgr)
       : AttributesManager<attributes::SceneDatasetAttributes,
-                          core::ManagedContainerAccess::Share>::
+                          core::ManagedObjectAccess::Share>::
             AttributesManager("Dataset", "scene_dataset_config.json"),
         physicsAttributesManager_(physicsAttributesMgr) {
     buildCtorFuncPtrMaps();

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -27,7 +27,7 @@ StageAttributesManager::StageAttributesManager(
     ObjectAttributesManager::ptr objectAttributesMgr,
     PhysicsAttributesManager::ptr physicsAttributesManager)
     : AbstractObjectAttributesManager<StageAttributes,
-                                      core::ManagedContainerAccess::Copy>::
+                                      core::ManagedObjectAccess::Copy>::
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -11,17 +11,14 @@
 #include "PhysicsAttributesManager.h"
 
 namespace esp {
-namespace core {
-enum class ManagedContainerAccess;
-}
 namespace assets {
 enum class AssetType;
 }  // namespace assets
 namespace metadata {
 namespace managers {
-class StageAttributesManager : public AbstractObjectAttributesManager<
-                                   attributes::StageAttributes,
-                                   core::ManagedContainerAccess::Copy> {
+class StageAttributesManager
+    : public AbstractObjectAttributesManager<attributes::StageAttributes,
+                                             core::ManagedObjectAccess::Copy> {
  public:
   StageAttributesManager(
       ObjectAttributesManager::ptr objectAttributesMgr,

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -113,7 +113,7 @@ class AttributesManagersTest : public testing::Test {
     // verify it exists
     ASSERT_NE(nullptr, attrTemplate1);
     // retrieve a copy of the named attributes template
-    auto attrTemplate2 = mgr->getObjectCopyByHandle(handle);
+    auto attrTemplate2 = mgr->getObjectOrCopyByHandle(handle);
     // verify copy has same quantities and values as original
     ASSERT_EQ(attrTemplate1->getHandle(), attrTemplate2->getHandle());
 
@@ -133,7 +133,7 @@ class AttributesManagersTest : public testing::Test {
     ASSERT_EQ(oldID, newID);
 
     // get another copy
-    auto attrTemplate3 = mgr->getObjectCopyByHandle(handle);
+    auto attrTemplate3 = mgr->getObjectOrCopyByHandle(handle);
     // verify added field is present and the same
     ASSERT_EQ(attrTemplate3->getString(keyStr),
               attrTemplate2->getString(keyStr));
@@ -242,7 +242,7 @@ class AttributesManagersTest : public testing::Test {
       int tmpltID = mgr->registerObject(attrTemplate1, newHandleIter);
       // verify template added
       ASSERT_NE(tmpltID, -1);
-      auto attrTemplate2 = mgr->getObjectCopyByHandle(newHandleIter);
+      auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
       // verify added template  exists
       ASSERT_NE(nullptr, attrTemplate2);
     }
@@ -259,7 +259,7 @@ class AttributesManagersTest : public testing::Test {
       int tmpltID = mgr->registerObject(tmplt);
       // verify template added
       ASSERT_NE(tmpltID, -1);
-      auto attrTemplate2 = mgr->getObjectCopyByHandle(tmplt->getHandle());
+      auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
       // verify added template  exists
       ASSERT_NE(nullptr, attrTemplate2);
     }
@@ -319,7 +319,7 @@ class AttributesManagersTest : public testing::Test {
     int newID = mgr->registerObject(newAttrTemplate0, newHandle);
 
     // get a copy of added template
-    auto attrTemplate3 = mgr->getObjectCopyByHandle(newHandle);
+    auto attrTemplate3 = mgr->getObjectOrCopyByHandle(newHandle);
 
     // remove new template by name
     auto newAttrTemplate1 = mgr->removeObjectByHandle(newHandle);
@@ -389,7 +389,7 @@ class AttributesManagersTest : public testing::Test {
 
     // get new template
     std::shared_ptr<T> newAttribs =
-        assetAttributesManager_->getObjectCopyByHandle<T>(newHandle);
+        assetAttributesManager_->getObjectOrCopyByHandle<T>(newHandle);
     // verify template has modified values
     int newValue = newAttribs->template get<int>(ctorModField);
     ASSERT_EQ(legalVal, newValue);


### PR DESCRIPTION
## Motivation and Context
Minor refactor for Managed Containers of some things that bothered me (all are internal to c++ sim code) : 
1. Change name of Type Param to ManagedObjectAccess, since it governs how the managed objects are accessed, not how the managed container is accessed.

2. Made getObjectOrCopyByXXX methods that are intended to be used by the python bindings and any other access that might be expected to be MC-type-agnostic (such as testing).  This is intended to provide either a ptr to a copy of the managed object or a ptr to the object itself, a decision that is governed by the type of the ManagedContainer (specifically the Type Param ManagedObjectAccess).  Internally/programmatically, access will still be direct, either retrieving a copy or the object itself depending on the requirements of the consumer. 

3.  Fixed a bunch of comments to be more relevant/accurate/descriptive.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and Python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
