### PR TITLE
Dynamic culling

### DIFF
--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -67,8 +67,12 @@ void initSceneBindings(py::module& m) {
       .def_property_readonly(
           "mesh_bb", &SceneNode::getMeshBB,
           R"(The axis aligned bounding box of the mesh drawables attached to this node.)")
-      .def_property_readonly("absolute_translation",
-                             &SceneNode::absoluteTranslation);
+      .def_property_readonly(
+          "absolute_translation",
+          py::overload_cast<>(&SceneNode::absoluteTranslation))
+      .def_property_readonly(
+          "absolute_translation",
+          py::overload_cast<>(&SceneNode::absoluteTranslation, py::const_));
 
   py::class_<SceneGraph>(m, "SceneGraph")
       .def(py::init())

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -120,21 +120,17 @@ size_t RenderCamera::cull(
                           Mn::Matrix4>& a) {
         // obtain the absolute aabb
         auto& node = static_cast<scene::SceneNode&>(a.first.get().object());
-        Corrade::Containers::Optional<Mn::Range3D> aabb =
-            node.getAbsoluteAABB();
-        if (aabb) {
-          // if it has an absolute aabb, it is a static mesh
-          Cr::Containers::Optional<int> culledPlane =
-              rangeFrustum(*aabb, frustum, node.getFrustumPlaneIndex());
-          if (culledPlane) {
-            node.setFrustumPlaneIndex(*culledPlane);
-          }
-          // if it has value, it means the aabb is culled
-          return (culledPlane != Cr::Containers::NullOpt);
-        } else {
-          // keep the drawable if its node does not have an absolute AABB
-          return false;
+        // This updates the AABB for dynamic objects if needed
+        node.setClean();
+        const Mn::Range3D& aabb = node.getAbsoluteAABB();
+
+        Cr::Containers::Optional<int> culledPlane =
+            rangeFrustum(aabb, frustum, node.getFrustumPlaneIndex());
+        if (culledPlane) {
+          node.setFrustumPlaneIndex(*culledPlane);
         }
+        // if it has value, it means the aabb is culled
+        return (culledPlane != Cr::Containers::NullOpt);
       });
 
   return (newEndIter - drawableTransforms.begin());

--- a/src/esp/scene/SceneNode.cpp
+++ b/src/esp/scene/SceneNode.cpp
@@ -66,6 +66,11 @@ Mn::Vector3 SceneNode::absoluteTranslation() const {
     return absoluteTransformation_.translation();
 }
 
+Mn::Vector3 SceneNode::absoluteTranslation() {
+  setClean();
+  return absoluteTransformation_.translation();
+}
+
 const Mn::Range3D& SceneNode::getAbsoluteAABB() const {
   if (aabb_)
     return *aabb_;

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -72,6 +72,8 @@ class SceneNode : public MagnumObject,
 
   Magnum::Vector3 absoluteTranslation() const;
 
+  Magnum::Vector3 absoluteTranslation();
+
   //! recursively compute the cumulative bounding box of the full scene graph
   //! tree for which this node is the root
   const Magnum::Range3D& computeCumulativeBB();

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -32,7 +32,8 @@ enum class SceneNodeType {
   OBJECT = 4,  // objects added via physics api
 };
 
-class SceneNode : public MagnumObject {
+class SceneNode : public MagnumObject,
+                  public Magnum::SceneGraph::AbstractFeature3D {
  public:
   // creating a scene node "in the air" is not allowed.
   // it must set an existing node as its parent node.
@@ -69,9 +70,7 @@ class SceneNode : public MagnumObject {
   //! Sets node semanticId
   virtual void setSemanticId(int semanticId) { semanticId_ = semanticId; }
 
-  Magnum::Vector3 absoluteTranslation() const {
-    return this->absoluteTransformation().translation();
-  }
+  Magnum::Vector3 absoluteTranslation() const;
 
   //! recursively compute the cumulative bounding box of the full scene graph
   //! tree for which this node is the root
@@ -81,9 +80,7 @@ class SceneNode : public MagnumObject {
   const Magnum::Range3D& getMeshBB() const { return meshBB_; };
 
   //! return the global bounding box for the mesh stored at this node
-  Corrade::Containers::Optional<Magnum::Range3D> getAbsoluteAABB() const {
-    return aabb_;
-  };
+  const Magnum::Range3D& getAbsoluteAABB() const;
 
   //! return the cumulative bounding box of the full scene graph tree for which
   //! this node is the root
@@ -107,6 +104,8 @@ class SceneNode : public MagnumObject {
   friend class SceneGraph;
   SceneNode(MagnumScene& parentNode);
 
+  void clean(const Magnum::Matrix4& absoluteTransformation) override;
+
   // the type of the attached object (e.g., sensor, agent etc.)
   SceneNodeType type_ = SceneNodeType::EMPTY;
   int id_ = ID_UNDEFINED;
@@ -120,7 +119,15 @@ class SceneNode : public MagnumObject {
 
   //! the cumulative bounding box of the full scene graph tree for which this
   //! node is the root
-  Magnum::Range3D cumulativeBB_;
+  Magnum::Range3D cumulativeBB_ = {{0.0, 0.0, 0.0}, {1e5, 1e5, 1e5}};
+
+  //! The cumulativeBB in world coordinates
+  //! This is returned instead of aabb_ if that doesn't exist
+  //! due to this being a node that is part of a dynamic object
+  Magnum::Range3D worldCumulativeBB_;
+
+  //! The absolute translation of this node, updated in clea
+  Magnum::Vector3 absoluteTranslation_;
 
   //! the global bounding box for *static* meshes stored at this node
   //  NOTE: this is different from the local bounding box meshBB_ defined above:

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -124,10 +124,11 @@ class SceneNode : public MagnumObject,
   //! The cumulativeBB in world coordinates
   //! This is returned instead of aabb_ if that doesn't exist
   //! due to this being a node that is part of a dynamic object
-  Magnum::Range3D worldCumulativeBB_;
+  mutable Corrade::Containers::Optional<Magnum::Range3D> worldCumulativeBB_ =
+      Corrade::Containers::NullOpt;
 
-  //! The absolute translation of this node, updated in clea
-  Magnum::Vector3 absoluteTranslation_;
+  //! The absolute translation of this node, updated in clean
+  Magnum::Matrix4 absoluteTransformation_;
 
   //! the global bounding box for *static* meshes stored at this node
   //  NOTE: this is different from the local bounding box meshBB_ defined above:


### PR DESCRIPTION
## Motivation and Context

Culling for dynamic objects.  This updates the local AABB to be in world coordinates if a scene node doesn't have a precomputed AABB.  Uses caching and lazy computation to be efficient (@mosra I think I have done this correctly, but I would appreciate a double check).

## How Has This Been Tested

Tests pass, in the viewer now you can see the number of culled objects increase as you add objects.

## Types of changes

New feature (non-breaking change which adds functionality)
