### PR TITLE
--Replace auto-gen lambda args with accurate arguments

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,5 +48,4 @@ WarningsAsErrors:
 -bugprone-unused-raii,
 -clang-diagnostic-deprecated-declarations,
 -clang-analyzer-cplusplus.PlacementNew,
-' # TODO fix std::binds later
 # TODO Figure out if PlacementNew is a false positive

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,6 +48,5 @@ WarningsAsErrors:
 -bugprone-unused-raii,
 -clang-diagnostic-deprecated-declarations,
 -clang-analyzer-cplusplus.PlacementNew,
--modernize-avoid-bind,
 ' # TODO fix std::binds later
 # TODO Figure out if PlacementNew is a false positive

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -44,8 +44,7 @@ esp::vec3f jsonToVec3f(const JsonGenericValue& jsonArray);
  * @brief Check passed json doc for existence of passed jsonTag as value of
  * type T. If present, populate passed setter with value. Returns
  * whether tag is found and successfully populated, or not. Logs an error if
- * @p tag is found but is inappropriate type.  Should use explicit type cast
- * on function call if setter is specified using std::bind()
+ * @p tag is found but is inappropriate type.
  *
  * @tparam T type of destination variable - must be supported type.
  * @param d json document to parse
@@ -71,8 +70,7 @@ bool jsonIntoSetter(const JsonGenericValue& d,
  * type T, where the consuming setter will treat the value as const. If
  * present, populate passed setter with value. Returns whether @p tag is found
  * and successfully populated, or not. Logs an error if tag is found but is
- * inappropriate type.  Should use explicit type cast on function call if
- * setter is specified using std::bind()
+ * inappropriate type.
  *
  * @tparam T type of destination variable - must be supported type.
  * @param d json document to parse

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -198,48 +198,64 @@ auto AbstractObjectAttributesManager<T, Access>::
     loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
                                          const io::JsonGenericValue& jsonDoc)
         -> AbsObjAttrPtr {
-  using std::placeholders::_1;
-
   // scale
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonDoc, "scale", std::bind(&T::setScale, attributes, _1));
+      jsonDoc, "scale", [attributes](const Magnum::Vector3& scale) {
+        attributes->setScale(scale);
+      });
 
   // collision asset size
   io::jsonIntoConstSetter<Magnum::Vector3>(
       jsonDoc, "collision_asset_size",
-      std::bind(&T::setCollisionAssetSize, attributes, _1));
+      [attributes](const Magnum::Vector3& collision_asset_size) {
+        attributes->setCollisionAssetSize(collision_asset_size);
+      });
   // margin
-  io::jsonIntoSetter<double>(jsonDoc, "margin",
-                             std::bind(&T::setMargin, attributes, _1));
+  io::jsonIntoSetter<double>(jsonDoc, "margin", [attributes](double margin) {
+    attributes->setMargin(margin);
+  });
   // initialize with collisions on/off
   io::jsonIntoSetter<bool>(jsonDoc, "is_collidable",
-                           std::bind(&T::setIsCollidable, attributes, _1));
+                           [attributes](bool is_collidable) {
+                             attributes->setIsCollidable(is_collidable);
+                           });
 
   // load the friction coefficient
   io::jsonIntoSetter<double>(
       jsonDoc, "friction_coefficient",
-      std::bind(&T::setFrictionCoefficient, attributes, _1));
+      [attributes](double friction_coefficient) {
+        attributes->setFrictionCoefficient(friction_coefficient);
+      });
 
   // load the restitution coefficient
   io::jsonIntoSetter<double>(
       jsonDoc, "restitution_coefficient",
-      std::bind(&T::setRestitutionCoefficient, attributes, _1));
+      [attributes](double restitution_coefficient) {
+        attributes->setRestitutionCoefficient(restitution_coefficient);
+      });
 
   // if object will be flat or phong shaded
   io::jsonIntoSetter<bool>(jsonDoc, "requires_lighting",
-                           std::bind(&T::setRequiresLighting, attributes, _1));
+                           [attributes](bool requires_lighting) {
+                             attributes->setRequiresLighting(requires_lighting);
+                           });
 
   // units to meters
   io::jsonIntoSetter<double>(jsonDoc, "units_to_meters",
-                             std::bind(&T::setUnitsToMeters, attributes, _1));
+                             [attributes](double units_to_meters) {
+                               attributes->setUnitsToMeters(units_to_meters);
+                             });
 
   // load object/scene specific up orientation
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonDoc, "up", std::bind(&T::setOrientUp, attributes, _1));
+      jsonDoc, "up",
+      [attributes](const Magnum::Vector3& up) { attributes->setOrientUp(up); });
 
   // load object/scene specific front orientation
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonDoc, "front", std::bind(&T::setOrientFront, attributes, _1));
+      jsonDoc, "front", [attributes](const Magnum::Vector3& front) {
+        attributes->setOrientFront(front);
+      });
 
   // 4. parse render and collision mesh filepaths
   // current value - also place holder for json read result
@@ -247,14 +263,18 @@ auto AbstractObjectAttributesManager<T, Access>::
   // is true if mesh name is found in JSON and different than current value
   std::string rndrFName = setJSONAssetHandleAndType(
       attributes, jsonDoc, "render_asset_type", "render_asset", rTmpFName,
-      std::bind(&T::setRenderAssetType, attributes, _1));
+      [attributes](int render_asset_type) {
+        attributes->setRenderAssetType(render_asset_type);
+      });
 
   // current value - also place holder for json read result
   std::string cTmpFName = attributes->getCollisionAssetHandle();
   // is true if mesh name is found in JSON and different than current value
   std::string colFName = setJSONAssetHandleAndType(
       attributes, jsonDoc, "collision_asset_type", "collision_asset", cTmpFName,
-      std::bind(&T::setCollisionAssetType, attributes, _1));
+      [attributes](int collision_asset_type) {
+        attributes->setCollisionAssetType(collision_asset_type);
+      });
   // use non-empty result if either result is empty
   attributes->setRenderAssetHandle(rndrFName.compare("") == 0 ? colFName
                                                               : rndrFName);

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -98,27 +98,28 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
   // jsonConfig here holds the JSON description for a single light attributes.
   // set position
   bool posIsSet = io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "position", [lightAttribs](auto&& PH1) {
-        lightAttribs->setPosition(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "position", [lightAttribs](const Magnum::Vector3& position) {
+        lightAttribs->setPosition(position);
       });
 
   // set direction
   bool dirIsSet = io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "direction", [lightAttribs](auto&& PH1) {
-        lightAttribs->setDirection(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "direction",
+      [lightAttribs](const Magnum::Vector3& direction) {
+        lightAttribs->setDirection(direction);
       });
 
   // set color
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "color", [lightAttribs](auto&& PH1) {
-        lightAttribs->setColor(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "color", [lightAttribs](const Magnum::Vector3& color) {
+        lightAttribs->setColor(color);
       });
 
   // set intensity
-  io::jsonIntoSetter<double>(
-      jsonConfig, "intensity", [lightAttribs](auto&& PH1) {
-        lightAttribs->setIntensity(std::forward<decltype(PH1)>(PH1));
-      });
+  io::jsonIntoSetter<double>(jsonConfig, "intensity",
+                             [lightAttribs](double intensity) {
+                               lightAttribs->setIntensity(intensity);
+                             });
 
   // type of light - should map to enum values in esp::gfx::LightType
   int typeVal = -1;
@@ -158,14 +159,16 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
       const auto& spotArea = jsonConfig["spot"];
       // set inner cone angle
       io::jsonIntoSetter<Magnum::Rad>(
-          spotArea, "innerConeAngle", [lightAttribs](auto&& PH1) {
-            lightAttribs->setInnerConeAngle(std::forward<decltype(PH1)>(PH1));
+          spotArea, "innerConeAngle",
+          [lightAttribs](Magnum::Rad innerConeAngle) {
+            lightAttribs->setInnerConeAngle(innerConeAngle);
           });
 
       // set outer cone angle
       io::jsonIntoSetter<Magnum::Rad>(
-          spotArea, "outerConeAngle", [lightAttribs](auto&& PH1) {
-            lightAttribs->setOuterConeAngle(std::forward<decltype(PH1)>(PH1));
+          spotArea, "outerConeAngle",
+          [lightAttribs](Magnum::Rad outerConeAngle) {
+            lightAttribs->setOuterConeAngle(outerConeAngle);
           });
     }
   }  // if member spot present

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -80,48 +80,49 @@ void ObjectAttributesManager::setValsFromJSONDoc(
 
   // Populate with object-specific fields found in json, if any are there.
   // object mass
-  io::jsonIntoSetter<double>(jsonConfig, "mass", [objAttributes](auto&& PH1) {
-    objAttributes->setMass(std::forward<decltype(PH1)>(PH1));
+  io::jsonIntoSetter<double>(jsonConfig, "mass", [objAttributes](double mass) {
+    objAttributes->setMass(mass);
   });
   // linear damping
-  io::jsonIntoSetter<double>(
-      jsonConfig, "linear_damping", [objAttributes](auto&& PH1) {
-        objAttributes->setLinearDamping(std::forward<decltype(PH1)>(PH1));
-      });
+  io::jsonIntoSetter<double>(jsonConfig, "linear_damping",
+                             [objAttributes](double linear_damping) {
+                               objAttributes->setLinearDamping(linear_damping);
+                             });
   // angular damping
   io::jsonIntoSetter<double>(
-      jsonConfig, "angular_damping", [objAttributes](auto&& PH1) {
-        objAttributes->setAngularDamping(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "angular_damping", [objAttributes](double angular_damping) {
+        objAttributes->setAngularDamping(angular_damping);
       });
   // Use bounding box as collision object
-  io::jsonIntoSetter<bool>(jsonConfig, "use_bounding_box_for_collision",
-                           [objAttributes](auto&& PH1) {
-                             objAttributes->setBoundingBoxCollisions(
-                                 std::forward<decltype(PH1)>(PH1));
-                           });
+  io::jsonIntoSetter<bool>(
+      jsonConfig, "use_bounding_box_for_collision",
+      [objAttributes](bool use_bounding_box_for_collision) {
+        objAttributes->setBoundingBoxCollisions(use_bounding_box_for_collision);
+      });
   // Join collision meshes if specified
   io::jsonIntoSetter<bool>(
-      jsonConfig, "join_collision_meshes", [objAttributes](auto&& PH1) {
-        objAttributes->setJoinCollisionMeshes(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "join_collision_meshes",
+      [objAttributes](bool join_collision_meshes) {
+        objAttributes->setJoinCollisionMeshes(join_collision_meshes);
       });
 
   // The object's interia matrix diagonal
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "inertia", [objAttributes](auto&& PH1) {
-        objAttributes->setInertia(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "inertia", [objAttributes](const Magnum::Vector3& inertia) {
+        objAttributes->setInertia(inertia);
       });
 
   // The object's semantic ID
-  io::jsonIntoSetter<int>(
-      jsonConfig, "semantic_id", [objAttributes](auto&& PH1) {
-        objAttributes->setSemanticId(std::forward<decltype(PH1)>(PH1));
-      });
+  io::jsonIntoSetter<int>(jsonConfig, "semantic_id",
+                          [objAttributes](int semantic_id) {
+                            objAttributes->setSemanticId(semantic_id);
+                          });
 
   // The center of mass (in the local frame of the object)
   // if COM is provided, use it for mesh shift
   bool comIsSet = io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "COM", [objAttributes](auto&& PH1) {
-        objAttributes->setCOM(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "COM", [objAttributes](const Magnum::Vector3& COM) {
+        objAttributes->setCOM(COM);
       });
   // if com is set from json, don't compute from shape, and vice versa
   objAttributes->setComputeCOMFromShape(!comIsSet);
@@ -148,15 +149,14 @@ ObjectAttributes::ptr ObjectAttributesManager::initNewObjectInternal(
     // set defaults for passed render asset handles
     this->setDefaultAssetNameBasedAttributes(
         newAttributes, true, newAttributes->getRenderAssetHandle(),
-        [newAttributes](auto&& PH1) {
-          newAttributes->setRenderAssetType(std::forward<decltype(PH1)>(PH1));
+        [newAttributes](int render_asset_type) {
+          newAttributes->setRenderAssetType(render_asset_type);
         });
     // set defaults for passed collision asset handles
     this->setDefaultAssetNameBasedAttributes(
         newAttributes, false, newAttributes->getCollisionAssetHandle(),
-        [newAttributes](auto&& PH1) {
-          newAttributes->setCollisionAssetType(
-              std::forward<decltype(PH1)>(PH1));
+        [newAttributes](int collision_asset_type) {
+          newAttributes->setCollisionAssetType(collision_asset_type);
         });
   }
   return newAttributes;

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -36,43 +36,43 @@ void PhysicsAttributesManager::setValsFromJSONDoc(
         jsonConfig) {  // load the simulator preference - default is "none"
                        // simulator, set in
   // attributes ctor.
-  io::jsonIntoConstSetter<std::string>(jsonConfig, "physics_simulator",
-                                       [physicsManagerAttributes](auto&& PH1) {
-                                         physicsManagerAttributes->setSimulator(
-                                             std::forward<decltype(PH1)>(PH1));
-                                       });
-
-  // load the physics timestep
-  io::jsonIntoSetter<double>(
-      jsonConfig, "timestep", [physicsManagerAttributes](auto&& PH1) {
-        physicsManagerAttributes->setTimestep(std::forward<decltype(PH1)>(PH1));
+  io::jsonIntoConstSetter<std::string>(
+      jsonConfig, "physics_simulator",
+      [physicsManagerAttributes](const std::string& simulator) {
+        physicsManagerAttributes->setSimulator(simulator);
       });
 
-  // load the max substeps between time step
-  io::jsonIntoSetter<int>(jsonConfig, "max_substeps",
-                          [physicsManagerAttributes](auto&& PH1) {
-                            physicsManagerAttributes->setMaxSubsteps(
-                                std::forward<decltype(PH1)>(PH1));
-                          });
-  // load the friction coefficient
-  io::jsonIntoSetter<double>(jsonConfig, "friction_coefficient",
-                             [physicsManagerAttributes](auto&& PH1) {
-                               physicsManagerAttributes->setFrictionCoefficient(
-                                   std::forward<decltype(PH1)>(PH1));
+  // load the physics timestep
+  io::jsonIntoSetter<double>(jsonConfig, "timestep",
+                             [physicsManagerAttributes](double timestep) {
+                               physicsManagerAttributes->setTimestep(timestep);
                              });
+
+  // load the max substeps between time step
+  io::jsonIntoSetter<int>(
+      jsonConfig, "max_substeps", [physicsManagerAttributes](int max_substeps) {
+        physicsManagerAttributes->setMaxSubsteps(max_substeps);
+      });
+  // load the friction coefficient
+  io::jsonIntoSetter<double>(
+      jsonConfig, "friction_coefficient",
+      [physicsManagerAttributes](double friction_coefficient) {
+        physicsManagerAttributes->setFrictionCoefficient(friction_coefficient);
+      });
 
   // load the restitution coefficient
   io::jsonIntoSetter<double>(
       jsonConfig, "restitution_coefficient",
-      [physicsManagerAttributes](auto&& PH1) {
+      [physicsManagerAttributes](double restitution_coefficient) {
         physicsManagerAttributes->setRestitutionCoefficient(
-            std::forward<decltype(PH1)>(PH1));
+            restitution_coefficient);
       });
 
   // load world gravity
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonConfig, "gravity", [physicsManagerAttributes](auto&& PH1) {
-        physicsManagerAttributes->setGravity(std::forward<decltype(PH1)>(PH1));
+      jsonConfig, "gravity",
+      [physicsManagerAttributes](const Magnum::Vector3 gravity) {
+        physicsManagerAttributes->setGravity(gravity);
       });
 
 }  // PhysicsAttributesManager::createFileBasedAttributesTemplate

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -71,7 +71,7 @@ void PhysicsAttributesManager::setValsFromJSONDoc(
   // load world gravity
   io::jsonIntoConstSetter<Magnum::Vector3>(
       jsonConfig, "gravity",
-      [physicsManagerAttributes](const Magnum::Vector3 gravity) {
+      [physicsManagerAttributes](const Magnum::Vector3& gravity) {
         physicsManagerAttributes->setGravity(gravity);
       });
 

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -126,8 +126,9 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
       createEmptyInstanceAttributes("");
   // template handle describing stage/object instance
   io::jsonIntoConstSetter<std::string>(
-      jCell, "template_name", [instanceAttrs](auto&& PH1) {
-        instanceAttrs->setHandle(std::forward<decltype(PH1)>(PH1));
+      jCell, "template_name",
+      [instanceAttrs](const std::string& template_name) {
+        instanceAttrs->setHandle(template_name);
       });
 
   // Check for translation origin override for a particular instance.  Default
@@ -159,14 +160,15 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
 
   // translation from origin
   io::jsonIntoConstSetter<Magnum::Vector3>(
-      jCell, "translation", [instanceAttrs](auto&& PH1) {
-        instanceAttrs->setTranslation(std::forward<decltype(PH1)>(PH1));
+      jCell, "translation",
+      [instanceAttrs](const Magnum::Vector3& translation) {
+        instanceAttrs->setTranslation(translation);
       });
 
   // orientation TODO : support euler angles too?
   io::jsonIntoConstSetter<Magnum::Quaternion>(
-      jCell, "rotation", [instanceAttrs](auto&& PH1) {
-        instanceAttrs->setRotation(std::forward<decltype(PH1)>(PH1));
+      jCell, "rotation", [instanceAttrs](const Magnum::Quaternion& rotation) {
+        instanceAttrs->setRotation(rotation);
       });
 
   return instanceAttrs;

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -130,7 +130,7 @@ TEST(IOTest, JsonTest) {
   // test basic attributes populating
 
   std::string attr_str =
-      "{\"render mesh\": \"banana.glb\",\"join collision "
+      "{\"render asset\": \"banana.glb\",\"join collision "
       "meshes\":false,\"mass\": 0.066,\"scale\": [2.0,2.0,2]}";
 
   // io::JsonGenericValue :
@@ -138,34 +138,38 @@ TEST(IOTest, JsonTest) {
   // io::JsonGenericValue :
   const esp::io::JsonGenericValue jsonDoc = tmpJSON.GetObject();
 
-  // for function ptr placeholder
-  using std::placeholders::_1;
   ObjectAttributes::ptr attributes = ObjectAttributes::create("temp");
 
   bool success = false;
   // test vector
   success = esp::io::jsonIntoConstSetter<Magnum::Vector3>(
-      jsonDoc, "scale", std::bind(&ObjectAttributes::setScale, attributes, _1));
+      jsonDoc, "scale", [attributes](const Magnum::Vector3& scale) {
+        attributes->setScale(scale);
+      });
   EXPECT_EQ(success, true);
   EXPECT_EQ(attributes->getScale()[1], 2);
 
   // test double
   success = esp::io::jsonIntoSetter<double>(
-      jsonDoc, "mass", std::bind(&ObjectAttributes::setMass, attributes, _1));
+      jsonDoc, "mass",
+      [attributes](double mass) { attributes->setMass(mass); });
   EXPECT_EQ(success, true);
   EXPECT_EQ(attributes->getMass(), 0.066);
 
   // test bool
   success = esp::io::jsonIntoSetter<bool>(
       jsonDoc, "join collision meshes",
-      std::bind(&ObjectAttributes::setJoinCollisionMeshes, attributes, _1));
+      [attributes](bool join_collision_meshes) {
+        attributes->setJoinCollisionMeshes(join_collision_meshes);
+      });
   EXPECT_EQ(success, true);
   EXPECT_EQ(attributes->getJoinCollisionMeshes(), false);
 
   // test string
-  success = esp::io::jsonIntoSetter<std::string>(
-      jsonDoc, "render mesh",
-      std::bind(&ObjectAttributes::setRenderAssetHandle, attributes, _1));
+  success = esp::io::jsonIntoConstSetter<std::string>(
+      jsonDoc, "render asset", [attributes](const std::string& render_asset) {
+        attributes->setRenderAssetHandle(render_asset);
+      });
   EXPECT_EQ(success, true);
   EXPECT_EQ(attributes->getRenderAssetHandle(), "banana.glb");
 }


### PR DESCRIPTION
## Motivation and Context
[A recent PR](https://github.com/facebookresearch/habitat-sim/pull/1094) updated clang-tidy to flag std::bind when used to pass a function as an argument and replace it with a more efficient lambda, but, being autogenerated, the synthesized lambdas tend to be contextually arcane.

This PR refactors these lambdas to be more readable.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
C++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
