### PR TITLE
[sensor] Lift displayObservation from CameraSensor to VisualSensor

### DIFF
--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -168,17 +168,6 @@ void CameraSensor::readObservation(Observation& obs) {
   }
 }
 
-bool CameraSensor::displayObservation(sim::Simulator& sim) {
-  if (!hasRenderTarget()) {
-    return false;
-  }
-
-  drawObservation(sim);
-  renderTarget().blitRgbaToDefault();
-
-  return true;
-}
-
 Corrade::Containers::Optional<Magnum::Vector2> CameraSensor::depthUnprojection()
     const {
   // projectionMatrix_ is managed by implementation class and is set whenever

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -55,14 +55,6 @@ class CameraSensor : public VisualSensor {
   virtual bool getObservationSpace(ObservationSpace& space) override;
 
   /**
-   * @brief Display next observation from Simulator on default frame buffer
-   * @param[in] sim Instance of Simulator class for which the observation needs
-   *                to be displayed
-   * @return Whether the display process was successful or not
-   */
-  virtual bool displayObservation(sim::Simulator& sim) override;
-
-  /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
    * perspective projection model.
    * See @ref gfx::calculateDepthUnprojection

--- a/src/esp/sensor/SensorFactory.cpp
+++ b/src/esp/sensor/SensorFactory.cpp
@@ -2,7 +2,6 @@
 
 #include "esp/scene/SceneNode.h"
 #include "esp/sensor/CameraSensor.h"
-#include "esp/sensor/Sensor.h"
 
 namespace esp {
 namespace sensor {

--- a/src/esp/sensor/SensorFactory.h
+++ b/src/esp/sensor/SensorFactory.h
@@ -1,5 +1,4 @@
 #include "esp/scene/SceneNode.h"
-#include "esp/sensor/CameraSensor.h"
 #include "esp/sensor/Sensor.h"
 
 namespace esp {

--- a/src/esp/sensor/VisualSensor.cpp
+++ b/src/esp/sensor/VisualSensor.cpp
@@ -22,5 +22,16 @@ void VisualSensor::bindRenderTarget(gfx::RenderTarget::uptr&& tgt) {
   tgt_ = std::move(tgt);
 }
 
+bool VisualSensor::displayObservation(sim::Simulator& sim) {
+  if (!hasRenderTarget()) {
+    return false;
+  }
+
+  drawObservation(sim);
+  renderTarget().blitRgbaToDefault();
+
+  return true;
+}
+
 }  // namespace sensor
 }  // namespace esp

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -82,6 +82,14 @@ class VisualSensor : public Sensor {
   }
 
   /**
+   * @brief Display next observation from Simulator on default frame buffer
+   * @param[in] sim Instance of Simulator class for which the observation needs
+   *                to be displayed
+   * @return Whether the display process was successful or not
+   */
+  virtual bool displayObservation(sim::Simulator& sim) override;
+
+  /**
    * @brief Returns RenderCamera
    */
   virtual gfx::RenderCamera* getRenderCamera() = 0;


### PR DESCRIPTION
## Motivation and Context
Quick PR from discussion with @bigbike. displayObservation will be called by all VisualSensors, so this PR lifts it from derived class CameraSensor to VisualSensor. 

This PR also removes unused import statements in SensorFactory as noted here: https://github.com/facebookresearch/habitat-sim/pull/1064/files

## How Has This Been Tested
Build and run tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
