### PR TITLE
--Support stand alone Metadata Mediator, and building Simulator from MM

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -188,10 +188,7 @@ class Simulator(SimulatorBackend):
 
     def _config_backend(self, config: Configuration) -> None:
         if not self._initialized:
-            if config.metadata_mediator is not None:
-                super().__init__(config.metadata_mediator)
-            else:
-                super().__init__(config.sim_cfg)
+            super().__init__(config.sim_cfg, config.metadata_mediator)
             self._initialized = True
         else:
             super().reconfigure(config.sim_cfg)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -30,6 +30,7 @@ import habitat_sim.errors
 from habitat_sim.agent.agent import Agent, AgentConfiguration, AgentState
 from habitat_sim.bindings import cuda_enabled
 from habitat_sim.logging import logger
+from habitat_sim.metadata import MetadataMediator
 from habitat_sim.nav import GreedyGeodesicFollower, NavMeshSettings, PathFinder
 from habitat_sim.sensor import SensorSpec, SensorType
 from habitat_sim.sensors.noise_models import make_sensor_noise_model
@@ -45,13 +46,15 @@ class Configuration(object):
 
     :property sim_cfg: The configuration of the backend of the simulator
     :property agents: A list of agent configurations
-
+    :property metadata_mediator: (optional) The metadata mediator to build the simulator from
     Ties together a backend config, `sim_cfg` and a list of agent
     configurations `agents`.
     """
 
     sim_cfg: SimulatorConfiguration
     agents: List[AgentConfiguration]
+    # An existing Metadata Mediator can also be used to construct a SimulatorBackend
+    metadata_mediator: MetadataMediator = attr.ib(default=None)
 
 
 @attr.s(auto_attribs=True)
@@ -185,7 +188,10 @@ class Simulator(SimulatorBackend):
 
     def _config_backend(self, config: Configuration) -> None:
         if not self._initialized:
-            super().__init__(config.sim_cfg)
+            if config.metadata_mediator is not None:
+                super().__init__(config.metadata_mediator)
+            else:
+                super().__init__(config.sim_cfg)
             self._initialized = True
         else:
             super().reconfigure(config.sim_cfg)

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -54,7 +54,7 @@ class Configuration(object):
     sim_cfg: SimulatorConfiguration
     agents: List[AgentConfiguration]
     # An existing Metadata Mediator can also be used to construct a SimulatorBackend
-    metadata_mediator: MetadataMediator = attr.ib(default=None)
+    metadata_mediator: Optional[MetadataMediator] = None
 
 
 @attr.s(auto_attribs=True)

--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -17,6 +17,8 @@ namespace metadata {
 
 void initMetadataMediatorBindings(py::module& m) {
   py::class_<MetadataMediator, MetadataMediator::ptr>(m, "MetadataMediator")
+      .def(py::init(&MetadataMediator::create<>))
+      .def(py::init<const sim::SimulatorConfiguration&>())
       .def_property(
           "active_dataset", &MetadataMediator::getActiveSceneDatasetName,
           &MetadataMediator::setActiveSceneDatasetName,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -116,7 +116,7 @@ void initSimBindings(py::module& m) {
           R"(The currently active dataset being used.  Will attempt to load
             configuration files specified if does not already exist.)")
       /* --- Template Manager accessors --- */
-      // We wish a copy of the metadata mediator smart poitner so that we
+      // We wish a copy of the metadata mediator smart pointer so that we
       // increment its ref counter
       .def_property(
           "metadata_mediator", &Simulator::getMetadataMediator,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -116,6 +116,8 @@ void initSimBindings(py::module& m) {
           R"(The currently active dataset being used.  Will attempt to load
             configuration files specified if does not already exist.)")
       /* --- Template Manager accessors --- */
+      // We wish a copy of the metadata mediator smart poitner so that we
+      // increment its ref counter
       .def_property(
           "metadata_mediator", &Simulator::getMetadataMediator,
           &Simulator::setMetadataMediator, py::return_value_policy::copy,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -74,6 +74,8 @@ void initSimBindings(py::module& m) {
 
   // ==== Simulator ====
   py::class_<Simulator, Simulator::ptr>(m, "Simulator")
+      // add constructor to build Simulator from existing MetadataMediator
+      .def(py::init<esp::metadata::MetadataMediator::ptr>())
       .def(py::init<const SimulatorConfiguration&>())
       .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
            R"(PYTHON DOES NOT GET OWNERSHIP)",
@@ -113,8 +115,12 @@ void initSimBindings(py::module& m) {
           &Simulator::setActiveSceneDatasetName,
           R"(The currently active dataset being used.  Will attempt to load
             configuration files specified if does not already exist.)")
-      /* --- Physics functions --- */
       /* --- Template Manager accessors --- */
+      .def_property(
+          "metadata_mediator", &Simulator::getMetadataMediator,
+          &Simulator::setMetadataMediator, py::return_value_policy::copy,
+          R"(This construct manages all configuration template managers
+          and the Scene Dataset Configurations)")
       .def("get_asset_template_manager", &Simulator::getAssetAttributesManager,
            pybind11::return_value_policy::reference,
            R"(Get the current dataset's AssetAttributesManager instance

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -74,9 +74,9 @@ void initSimBindings(py::module& m) {
 
   // ==== Simulator ====
   py::class_<Simulator, Simulator::ptr>(m, "Simulator")
-      // add constructor to build Simulator from existing MetadataMediator
-      .def(py::init<esp::metadata::MetadataMediator::ptr>())
-      .def(py::init<const SimulatorConfiguration&>())
+      // modify constructor to pass MetadataMediator
+      .def(py::init<const SimulatorConfiguration&,
+                    esp::metadata::MetadataMediator::ptr>())
       .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
            R"(PYTHON DOES NOT GET OWNERSHIP)",
            py::return_value_policy::reference)

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -42,6 +42,14 @@ class MetadataMediator {
   bool setSimulatorConfiguration(const sim::SimulatorConfiguration& cfg);
 
   /**
+   * @brief Return the current @ref esp::sim::SimulatorConfiguration this
+   * MetadataMediator is using.  Used to build Simulator from existing MM.
+   */
+  const sim::SimulatorConfiguration& getSimulatorConfiguration() const {
+    return this->simConfig_;
+  }
+
+  /**
    * @brief Creates a dataset attributes using @p sceneDatasetName, and
    * registers it. NOTE If an existing dataset attributes exists with this
    * handle, then this will exit with a message unless @p overwrite is true.

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -37,6 +37,15 @@ using metadata::attributes::PhysicsManagerAttributes;
 using metadata::attributes::SceneObjectInstanceAttributes;
 using metadata::attributes::StageAttributes;
 
+Simulator::Simulator(metadata::MetadataMediator::ptr _metadataMediator)
+    : metadataMediator_{_metadataMediator},
+      random_{core::Random::create(
+          metadataMediator_->getSimulatorConfiguration().randomSeed)},
+      requiresTextures_{Cr::Containers::NullOpt} {
+  // initalize members according to MM's configuration
+  reconfigure(metadataMediator_->getSimulatorConfiguration());
+}
+
 Simulator::Simulator(const SimulatorConfiguration& cfg)
     : random_{core::Random::create(cfg.randomSeed)},
       requiresTextures_{Cr::Containers::NullOpt} {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -37,17 +37,10 @@ using metadata::attributes::PhysicsManagerAttributes;
 using metadata::attributes::SceneObjectInstanceAttributes;
 using metadata::attributes::StageAttributes;
 
-Simulator::Simulator(metadata::MetadataMediator::ptr _metadataMediator)
+Simulator::Simulator(const SimulatorConfiguration& cfg,
+                     metadata::MetadataMediator::ptr _metadataMediator)
     : metadataMediator_{_metadataMediator},
-      random_{core::Random::create(
-          metadataMediator_->getSimulatorConfiguration().randomSeed)},
-      requiresTextures_{Cr::Containers::NullOpt} {
-  // initalize members according to MM's configuration
-  reconfigure(metadataMediator_->getSimulatorConfiguration());
-}
-
-Simulator::Simulator(const SimulatorConfiguration& cfg)
-    : random_{core::Random::create(cfg.randomSeed)},
+      random_{core::Random::create(cfg.randomSeed)},
       requiresTextures_{Cr::Containers::NullOpt} {
   // initalize members according to cfg
   // NOTE: NOT SO GREAT NOW THAT WE HAVE virtual functions

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -43,6 +43,12 @@ namespace esp {
 namespace sim {
 class Simulator {
  public:
+  /**
+   * @brief This constructor will build a Simulator using the config that is
+   * held in the passed MetadataMediator
+   */
+  explicit Simulator(metadata::MetadataMediator::ptr _metadataMediator);
+
   explicit Simulator(const SimulatorConfiguration& cfg);
   virtual ~Simulator();
 
@@ -847,6 +853,8 @@ class Simulator {
    */
   void setMetadataMediator(metadata::MetadataMediator::ptr _metadataMediator) {
     metadataMediator_ = _metadataMediator;
+    // set newly added MM to have current Simulator Config
+    metadataMediator_->setSimulatorConfiguration(this->config_);
   }
 
   /**

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -43,13 +43,9 @@ namespace esp {
 namespace sim {
 class Simulator {
  public:
-  /**
-   * @brief This constructor will build a Simulator using the config that is
-   * held in the passed MetadataMediator
-   */
-  explicit Simulator(metadata::MetadataMediator::ptr _metadataMediator);
-
-  explicit Simulator(const SimulatorConfiguration& cfg);
+  explicit Simulator(
+      const SimulatorConfiguration& cfg,
+      metadata::MetadataMediator::ptr _metadataMediator = nullptr);
   virtual ~Simulator();
 
   /**

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -137,8 +137,6 @@ struct SimTest : Cr::TestSuite::Tester {
                           {0.0, 5.0, 5.0},
                           LightPositionModel::CAMERA}};
 };
-
-enum : std::size_t { NumSims = 2 };
 struct {
   // display name for sim being tested
   const char* name;
@@ -147,9 +145,8 @@ struct {
                              const std::string& scene,
                              const std::string& sceneLightingKey);
 
-} SimulatorBuilder[NumSims]{
-    {"built with SimConfig", &SimTest::getSimulator},
-    {"built with MetadataMediator", &SimTest::getSimulatorMM}};
+} SimulatorBuilder[]{{"built with SimConfig", &SimTest::getSimulator},
+                     {"built with MetadataMediator", &SimTest::getSimulatorMM}};
 SimTest::SimTest() {
   // clang-format off
   addTests({&SimTest::basic,
@@ -167,7 +164,7 @@ SimTest::SimTest() {
             &SimTest::recomputeNavmeshWithStaticObjects,
             &SimTest::loadingObjectTemplates,
             &SimTest::buildingPrimAssetObjectTemplates,
-            &SimTest::addSensorToObject}, NumSims );
+            &SimTest::addSensorToObject}, Cr::Containers::arraySize(SimulatorBuilder) );
   // clang-format on
 }
 
@@ -214,6 +211,7 @@ void SimTest::reconfigure() {
 }
 
 void SimTest::reset() {
+  CORRADE_VERIFY(true);
   auto testReset = [&](Simulator& simulator) {
     PathFinder::ptr pathfinder = simulator.getPathFinder();
     auto pinholeCameraSpec = SensorSpec::create();

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -97,7 +97,7 @@ struct SimTest : Cr::TestSuite::Tester {
     simConfig.sceneLightSetup = sceneLightingKey;
 
     MetadataMediator::ptr MM = MetadataMediator::create(simConfig);
-    auto sim = Simulator::create_unique(MM);
+    auto sim = Simulator::create_unique(simConfig, MM);
     auto objAttrMgr = sim->getObjectAttributesManager();
     objAttrMgr->loadAllConfigsFromPath(
         Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
@@ -179,7 +179,7 @@ void SimTest::basic() {
   SimulatorConfiguration cfg_mm;
   cfg_mm.activeSceneName = vangogh;
   MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
-  Simulator simulator_mm(MM);
+  Simulator simulator_mm(cfg_mm, MM);
   PathFinder::ptr pathfinder_mm = simulator_mm.getPathFinder();
   CORRADE_VERIFY(pathfinder_mm);
 }
@@ -200,7 +200,7 @@ void SimTest::reconfigure() {
   SimulatorConfiguration cfg_mm;
   cfg_mm.activeSceneName = vangogh;
   MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
-  Simulator simulator_mm(MM);
+  Simulator simulator_mm(cfg_mm, MM);
   PathFinder::ptr pathfinder_mm = simulator_mm.getPathFinder();
   simulator_mm.reconfigure(cfg_mm);
   CORRADE_VERIFY(pathfinder_mm == simulator_mm.getPathFinder());
@@ -244,7 +244,7 @@ void SimTest::reset() {
   SimulatorConfiguration cfg_mm;
   cfg_mm.activeSceneName = vangogh;
   MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
-  Simulator simulator_mm(MM);
+  Simulator simulator_mm(cfg_mm, MM);
   testReset(simulator_mm);
 }
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -29,6 +29,7 @@ using esp::assets::ResourceManager;
 using esp::gfx::LightInfo;
 using esp::gfx::LightPositionModel;
 using esp::gfx::LightSetup;
+using esp::metadata::MetadataMediator;
 using esp::metadata::attributes::AbstractPrimitiveAttributes;
 using esp::metadata::attributes::ObjectAttributes;
 using esp::nav::PathFinder;
@@ -62,7 +63,8 @@ const std::string screenshotDir =
 struct SimTest : Cr::TestSuite::Tester {
   explicit SimTest();
 
-  Simulator::uptr getSimulator(
+  static Simulator::uptr getSimulator(
+      SimTest& self,
       const std::string& scene,
       const std::string& sceneLightingKey = esp::NO_LIGHT_KEY) {
     SimulatorConfiguration simConfig{};
@@ -77,11 +79,33 @@ struct SimTest : Cr::TestSuite::Tester {
     objAttrMgr->loadAllConfigsFromPath(
         Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
 
-    sim->setLightSetup(lightSetup1, "custom_lighting_1");
-    sim->setLightSetup(lightSetup2, "custom_lighting_2");
+    sim->setLightSetup(self.lightSetup1, "custom_lighting_1");
+    sim->setLightSetup(self.lightSetup2, "custom_lighting_2");
     return sim;
   }
 
+  //! build a simulator via an instanced Metadata Mediator
+  static Simulator::uptr getSimulatorMM(
+      SimTest& self,
+      const std::string& scene,
+      const std::string& sceneLightingKey = esp::NO_LIGHT_KEY) {
+    SimulatorConfiguration simConfig{};
+    simConfig.activeSceneName = scene;
+    simConfig.enablePhysics = true;
+    simConfig.physicsConfigFile = physicsConfigFile;
+    simConfig.overrideSceneLightDefaults = true;
+    simConfig.sceneLightSetup = sceneLightingKey;
+
+    MetadataMediator::ptr MM = MetadataMediator::create(simConfig);
+    auto sim = Simulator::create_unique(MM);
+    auto objAttrMgr = sim->getObjectAttributesManager();
+    objAttrMgr->loadAllConfigsFromPath(
+        Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+
+    sim->setLightSetup(self.lightSetup1, "custom_lighting_1");
+    sim->setLightSetup(self.lightSetup2, "custom_lighting_2");
+    return sim;
+  }
   void checkPinholeCameraRGBAObservation(
       Simulator& sim,
       const std::string& groundTruthImageFile,
@@ -114,11 +138,25 @@ struct SimTest : Cr::TestSuite::Tester {
                           LightPositionModel::CAMERA}};
 };
 
+enum : std::size_t { NumSims = 2 };
+struct {
+  // display name for sim being tested
+  const char* name;
+  // function pointer to constructor to simulator
+  Simulator::uptr (*creator)(SimTest& self,
+                             const std::string& scene,
+                             const std::string& sceneLightingKey);
+
+} SimulatorBuilder[NumSims]{
+    {"built with SimConfig", &SimTest::getSimulator},
+    {"built with MetadataMediator", &SimTest::getSimulatorMM}};
 SimTest::SimTest() {
   // clang-format off
   addTests({&SimTest::basic,
             &SimTest::reconfigure,
-            &SimTest::reset,
+            &SimTest::reset});
+            //test instances test both mechanisms for constructing simulator
+  addInstancedTests({
             &SimTest::getSceneRGBAObservation,
             &SimTest::getSceneWithLightingRGBAObservation,
             &SimTest::getDefaultLightingRGBAObservation,
@@ -129,7 +167,7 @@ SimTest::SimTest() {
             &SimTest::recomputeNavmeshWithStaticObjects,
             &SimTest::loadingObjectTemplates,
             &SimTest::buildingPrimAssetObjectTemplates,
-            &SimTest::addSensorToObject});
+            &SimTest::addSensorToObject}, NumSims );
   // clang-format on
 }
 
@@ -139,6 +177,14 @@ void SimTest::basic() {
   Simulator simulator(cfg);
   PathFinder::ptr pathfinder = simulator.getPathFinder();
   CORRADE_VERIFY(pathfinder);
+
+  // test for MM ctor
+  SimulatorConfiguration cfg_mm;
+  cfg_mm.activeSceneName = vangogh;
+  MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
+  Simulator simulator_mm(MM);
+  PathFinder::ptr pathfinder_mm = simulator_mm.getPathFinder();
+  CORRADE_VERIFY(pathfinder_mm);
 }
 
 void SimTest::reconfigure() {
@@ -152,33 +198,56 @@ void SimTest::reconfigure() {
   cfg2.activeSceneName = skokloster;
   simulator.reconfigure(cfg2);
   CORRADE_VERIFY(pathfinder != simulator.getPathFinder());
+
+  // test using MM ctor
+  SimulatorConfiguration cfg_mm;
+  cfg_mm.activeSceneName = vangogh;
+  MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
+  Simulator simulator_mm(MM);
+  PathFinder::ptr pathfinder_mm = simulator_mm.getPathFinder();
+  simulator_mm.reconfigure(cfg_mm);
+  CORRADE_VERIFY(pathfinder_mm == simulator_mm.getPathFinder());
+  SimulatorConfiguration cfg2_mm;
+  cfg2_mm.activeSceneName = skokloster;
+  simulator_mm.reconfigure(cfg2_mm);
+  CORRADE_VERIFY(pathfinder_mm != simulator_mm.getPathFinder());
 }
 
 void SimTest::reset() {
+  auto testReset = [&](Simulator& simulator) {
+    PathFinder::ptr pathfinder = simulator.getPathFinder();
+    auto pinholeCameraSpec = SensorSpec::create();
+    pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
+    pinholeCameraSpec->sensorType = SensorType::Color;
+    pinholeCameraSpec->position = {0.0f, 1.5f, 5.0f};
+    pinholeCameraSpec->resolution = {100, 100};
+    AgentConfiguration agentConfig{};
+    agentConfig.sensorSpecifications = {pinholeCameraSpec};
+    auto agent = simulator.addAgent(agentConfig);
+
+    auto stateOrig = AgentState::create();
+    agent->getState(stateOrig);
+
+    simulator.reset();
+
+    auto stateFinal = AgentState::create();
+    agent->getState(stateFinal);
+    CORRADE_VERIFY(stateOrig->position == stateFinal->position);
+    CORRADE_VERIFY(stateOrig->rotation == stateFinal->rotation);
+    CORRADE_VERIFY(pathfinder == simulator.getPathFinder());
+  };
+
   SimulatorConfiguration cfg;
   cfg.activeSceneName = vangogh;
   Simulator simulator(cfg);
-  PathFinder::ptr pathfinder = simulator.getPathFinder();
+  testReset(simulator);
+  // build simulator with MM
 
-  auto pinholeCameraSpec = SensorSpec::create();
-  pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
-  pinholeCameraSpec->sensorType = SensorType::Color;
-  pinholeCameraSpec->position = {0.0f, 1.5f, 5.0f};
-  pinholeCameraSpec->resolution = {100, 100};
-  AgentConfiguration agentConfig{};
-  agentConfig.sensorSpecifications = {pinholeCameraSpec};
-  auto agent = simulator.addAgent(agentConfig);
-
-  auto stateOrig = AgentState::create();
-  agent->getState(stateOrig);
-
-  simulator.reset();
-
-  auto stateFinal = AgentState::create();
-  agent->getState(stateFinal);
-  CORRADE_VERIFY(stateOrig->position == stateFinal->position);
-  CORRADE_VERIFY(stateOrig->rotation == stateFinal->rotation);
-  CORRADE_VERIFY(pathfinder == simulator.getPathFinder());
+  SimulatorConfiguration cfg_mm;
+  cfg_mm.activeSceneName = vangogh;
+  MetadataMediator::ptr MM = MetadataMediator::create(cfg_mm);
+  Simulator simulator_mm(MM);
+  testReset(simulator_mm);
 }
 
 void SimTest::checkPinholeCameraRGBAObservation(
@@ -228,7 +297,9 @@ void SimTest::getSceneRGBAObservation() {
   Corrade::Utility::Debug() << "Starting Test : getSceneRGBAObservation ";
   setTestCaseName(CORRADE_FUNCTION);
   Corrade::Utility::Debug() << "About to build simulator";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   Corrade::Utility::Debug() << "Built simulator";
   checkPinholeCameraRGBAObservation(*simulator, "SimTestExpectedScene.png",
                                     maxThreshold, 0.75f);
@@ -238,7 +309,9 @@ void SimTest::getSceneWithLightingRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : getSceneWithLightingRGBAObservation ";
   setTestCaseName(CORRADE_FUNCTION);
-  auto simulator = getSimulator(vangogh, "custom_lighting_1");
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, "custom_lighting_1");
   checkPinholeCameraRGBAObservation(
       *simulator, "SimTestExpectedSceneWithLighting.png", maxThreshold, 0.75f);
 }
@@ -246,7 +319,9 @@ void SimTest::getSceneWithLightingRGBAObservation() {
 void SimTest::getDefaultLightingRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : getDefaultLightingRGBAObservation ";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
@@ -261,7 +336,9 @@ void SimTest::getDefaultLightingRGBAObservation() {
 void SimTest::getCustomLightingRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : getCustomLightingRGBAObservation ";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
@@ -277,7 +354,9 @@ void SimTest::getCustomLightingRGBAObservation() {
 void SimTest::updateLightSetupRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : updateLightSetupRGBAObservation ";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   // update default lighting
@@ -311,7 +390,9 @@ void SimTest::updateLightSetupRGBAObservation() {
 void SimTest::updateObjectLightSetupRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : updateObjectLightSetupRGBAObservation ";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
@@ -335,7 +416,9 @@ void SimTest::updateObjectLightSetupRGBAObservation() {
 void SimTest::multipleLightingSetupsRGBAObservation() {
   Corrade::Utility::Debug()
       << "Starting Test : multipleLightingSetupsRGBAObservation ";
-  auto simulator = getSimulator(planeStage);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   // make sure updates apply to all objects using the light setup
@@ -367,7 +450,9 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
 void SimTest::recomputeNavmeshWithStaticObjects() {
   Corrade::Utility::Debug()
       << "Starting Test : recomputeNavmeshWithStaticObjects ";
-  auto simulator = getSimulator(skokloster);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, skokloster, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
 
@@ -430,7 +515,9 @@ void SimTest::recomputeNavmeshWithStaticObjects() {
 
 void SimTest::loadingObjectTemplates() {
   Corrade::Utility::Debug() << "Starting Test : loadingObjectTemplates ";
-  auto simulator = getSimulator(planeStage);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
 
@@ -492,7 +579,9 @@ void SimTest::loadingObjectTemplates() {
 void SimTest::buildingPrimAssetObjectTemplates() {
   Corrade::Utility::Debug()
       << "Starting Test : buildingPrimAssetObjectTemplates ";
-  auto simulator = getSimulator(planeStage);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
 
   // test that the correct number of default primitive assets are available as
   // render/collision targets
@@ -633,7 +722,9 @@ void SimTest::buildingPrimAssetObjectTemplates() {
 
 void SimTest::addSensorToObject() {
   Corrade::Utility::Debug() << "Starting Test : addSensorToObject ";
-  auto simulator = getSimulator(vangogh);
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("sphere");

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -23,17 +23,21 @@ def test_no_navmesh_smoke():
     agent_config.sensor_specifications = []
 
     sim_cfg.scene_id = "data/test_assets/scenes/stage_floor1.glb"
+    hab_cfg = habitat_sim.Configuration(sim_cfg, [agent_config])
 
-    with habitat_sim.Simulator(
-        habitat_sim.Configuration(sim_cfg, [agent_config])
-    ) as sim:
-        sim.initialize_agent(0)
+    mm = habitat_sim.metadata.MetadataMediator(sim_cfg)
+    hab_cfg_mm = habitat_sim.Configuration(sim_cfg, [agent_config], mm)
 
-        random.seed(0)
-        for _ in range(50):
-            obs = sim.step(random.choice(list(agent_config.action_space.keys())))
-            # Can't collide with no navmesh
-            assert not obs["collided"]
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        with habitat_sim.Simulator(ctor_arg) as sim:
+            sim.initialize_agent(0)
+
+            random.seed(0)
+            for _ in range(50):
+                obs = sim.step(random.choice(list(agent_config.action_space.keys())))
+                # Can't collide with no navmesh
+                assert not obs["collided"]
 
 
 def test_empty_scene():
@@ -45,41 +49,55 @@ def test_empty_scene():
     cfg_settings["depth_sensor"] = True
 
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    with habitat_sim.Simulator(hab_cfg) as sim:
-        assert sim.get_stage_initialization_template() == None
+    hab_cfg_mm = examples.settings.make_cfg(cfg_settings)
+    mm = habitat_sim.metadata.MetadataMediator(hab_cfg.sim_cfg)
+    hab_cfg_mm.metadata_mediator = mm
 
-        # test that empty frames can be rendered without a scene mesh
-        for _ in range(2):
-            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        with habitat_sim.Simulator(ctor_arg) as sim:
+            assert sim.get_stage_initialization_template() == None
+
+            # test that empty frames can be rendered without a scene mesh
+            for _ in range(2):
+                sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
 
 
 def test_sim_reset(make_cfg_settings):
-    with habitat_sim.Simulator(examples.settings.make_cfg(make_cfg_settings)) as sim:
-        agent_config = sim.config.agents[0]
-        sim.initialize_agent(0)
-        initial_state = sim.agents[0].initial_state
-        # Take random steps in the environment
-        for _ in range(10):
-            action = random.choice(list(agent_config.action_space.keys()))
-            sim.step(action)
+    hab_cfg = examples.settings.make_cfg(make_cfg_settings)
+    hab_cfg_mm = examples.settings.make_cfg(make_cfg_settings)
+    mm = habitat_sim.metadata.MetadataMediator(hab_cfg.sim_cfg)
+    hab_cfg_mm.metadata_mediator = mm
 
-        sim.reset()
-        new_state = sim.agents[0].get_state()
-        same_position = all(initial_state.position == new_state.position)
-        same_rotation = np.isclose(
-            initial_state.rotation, new_state.rotation, rtol=1e-4
-        )  # Numerical error can cause slight deviations
-        assert same_position and same_rotation
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        with habitat_sim.Simulator(ctor_arg) as sim:
+            agent_config = sim.config.agents[0]
+            sim.initialize_agent(0)
+            initial_state = sim.agents[0].initial_state
+            # Take random steps in the environment
+            for _ in range(10):
+                action = random.choice(list(agent_config.action_space.keys()))
+                sim.step(action)
+
+            sim.reset()
+            new_state = sim.agents[0].get_state()
+            same_position = all(initial_state.position == new_state.position)
+            same_rotation = np.isclose(
+                initial_state.rotation, new_state.rotation, rtol=1e-4
+            )  # Numerical error can cause slight deviations
+            assert same_position and same_rotation
 
 
 def test_sim_multiagent_move_and_reset(make_cfg_settings, num_agents=10):
-    sim_cfg = examples.settings.make_cfg(make_cfg_settings)
+    hab_cfg = examples.settings.make_cfg(make_cfg_settings)
     for agent_id in range(1, num_agents):
-        new_agent = copy(sim_cfg.agents[0])
+        new_agent = copy(hab_cfg.agents[0])
         for sensor_spec in new_agent.sensor_specifications:
             sensor_spec = f"{agent_id}_/{sensor_spec.uuid}"
-        sim_cfg.agents.append(new_agent)
-    with habitat_sim.Simulator(sim_cfg) as sim:
+        hab_cfg.agents.append(new_agent)
+
+    with habitat_sim.Simulator(hab_cfg) as sim:
         agent_initial_states = []
         for i in range(num_agents):
             sim.initialize_agent(i)
@@ -126,12 +144,15 @@ def test_keep_agent():
 
     sim_cfg.scene_id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     agents = []
+    hab_cfg = habitat_sim.Configuration(sim_cfg, [agent_config])
+    mm = habitat_sim.metadata.MetadataMediator(sim_cfg)
+    hab_cfg_mm = habitat_sim.Configuration(sim_cfg, [agent_config], mm)
 
-    for _ in range(3):
-        with habitat_sim.Simulator(
-            habitat_sim.Configuration(sim_cfg, [agent_config])
-        ) as sim:
-            agents.append(sim.get_agent(0))
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        for _ in range(3):
+            with habitat_sim.Simulator(ctor_arg) as sim:
+                agents.append(sim.get_agent(0))
 
 
 # Make sure you can construct and destruct the simulator multiple times
@@ -140,26 +161,37 @@ def test_multiple_construct_destroy():
     agent_config = habitat_sim.AgentConfiguration()
 
     sim_cfg.scene_id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
+    hab_cfg = habitat_sim.Configuration(sim_cfg, [agent_config])
+    mm = habitat_sim.metadata.MetadataMediator(sim_cfg)
+    hab_cfg_mm = habitat_sim.Configuration(sim_cfg, [agent_config], mm)
 
-    for _ in range(3):
-        with habitat_sim.Simulator(habitat_sim.Configuration(sim_cfg, [agent_config])):
-            pass
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        for _ in range(3):
+            with habitat_sim.Simulator(ctor_arg):
+                pass
 
 
 def test_scene_bounding_boxes():
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    with habitat_sim.Simulator(hab_cfg) as sim:
-        scene_graph = sim.get_active_scene_graph()
-        root_node = scene_graph.get_root_node()
-        root_node.compute_cumulative_bb()
-        scene_bb = root_node.cumulative_bb
-        ground_truth = mn.Range3D.from_size(
-            mn.Vector3(-0.775869, -0.0233012, -1.6706),
-            mn.Vector3(6.76937, 3.86304, 3.5359),
-        )
-        assert ground_truth == scene_bb
+    hab_cfg_mm = examples.settings.make_cfg(cfg_settings)
+    mm = habitat_sim.metadata.MetadataMediator(hab_cfg.sim_cfg)
+    hab_cfg_mm.metadata_mediator = mm
+
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        with habitat_sim.Simulator(ctor_arg) as sim:
+            scene_graph = sim.get_active_scene_graph()
+            root_node = scene_graph.get_root_node()
+            root_node.compute_cumulative_bb()
+            scene_bb = root_node.cumulative_bb
+            ground_truth = mn.Range3D.from_size(
+                mn.Vector3(-0.775869, -0.0233012, -1.6706),
+                mn.Vector3(6.76937, 3.86304, 3.5359),
+            )
+            assert ground_truth == scene_bb
 
 
 def test_object_template_editing():
@@ -167,42 +199,50 @@ def test_object_template_editing():
     cfg_settings["scene"] = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"
     cfg_settings["enable_physics"] = True
     hab_cfg = examples.settings.make_cfg(cfg_settings)
-    with habitat_sim.Simulator(hab_cfg) as sim:
-        # test creating a new template with a test asset
-        transform_box_path = osp.abspath("data/test_assets/objects/transform_box.glb")
-        transform_box_template = habitat_sim.attributes.ObjectAttributes()
-        transform_box_template.render_asset_handle = transform_box_path
-        obj_mgr = sim.get_object_template_manager()
-        old_library_size = obj_mgr.get_num_templates()
-        transform_box_template_id = obj_mgr.register_template(
-            transform_box_template, "transform_box_template"
-        )
-        assert obj_mgr.get_num_templates() > old_library_size
-        assert transform_box_template_id != -1
+    hab_cfg_mm = examples.settings.make_cfg(cfg_settings)
+    mm = habitat_sim.metadata.MetadataMediator(hab_cfg.sim_cfg)
+    hab_cfg_mm.metadata_mediator = mm
 
-        # test loading a test asset template from file
-        sphere_path = osp.abspath("data/test_assets/objects/sphere")
-        old_library_size = obj_mgr.get_num_templates()
-        template_ids = obj_mgr.load_configs(sphere_path)
-        assert len(template_ids) > 0
-        assert obj_mgr.get_num_templates() > old_library_size
+    test_list = [hab_cfg, hab_cfg_mm]
+    for ctor_arg in test_list:
+        with habitat_sim.Simulator(ctor_arg) as sim:
+            # test creating a new template with a test asset
+            transform_box_path = osp.abspath(
+                "data/test_assets/objects/transform_box.glb"
+            )
+            transform_box_template = habitat_sim.attributes.ObjectAttributes()
+            transform_box_template.render_asset_handle = transform_box_path
+            obj_mgr = sim.get_object_template_manager()
+            old_library_size = obj_mgr.get_num_templates()
+            transform_box_template_id = obj_mgr.register_template(
+                transform_box_template, "transform_box_template"
+            )
+            assert obj_mgr.get_num_templates() > old_library_size
+            assert transform_box_template_id != -1
 
-        # test getting and editing template reference - changes underlying template
-        sphere_template = obj_mgr.get_template_by_ID(template_ids[0])
-        assert sphere_template.render_asset_handle.endswith("sphere.glb")
-        sphere_scale = np.array([2.0, 2.0, 2.0])
-        sphere_template.scale = sphere_scale
-        obj_mgr.register_template(sphere_template, sphere_template.handle)
-        sphere_template2 = obj_mgr.get_template_by_ID(template_ids[0])
-        assert sphere_template2.scale == sphere_scale
+            # test loading a test asset template from file
+            sphere_path = osp.abspath("data/test_assets/objects/sphere")
+            old_library_size = obj_mgr.get_num_templates()
+            template_ids = obj_mgr.load_configs(sphere_path)
+            assert len(template_ids) > 0
+            assert obj_mgr.get_num_templates() > old_library_size
 
-        # test adding a new object
-        object_id = sim.add_object(template_ids[0])
-        assert object_id != -1
+            # test getting and editing template reference - changes underlying template
+            sphere_template = obj_mgr.get_template_by_ID(template_ids[0])
+            assert sphere_template.render_asset_handle.endswith("sphere.glb")
+            sphere_scale = np.array([2.0, 2.0, 2.0])
+            sphere_template.scale = sphere_scale
+            obj_mgr.register_template(sphere_template, sphere_template.handle)
+            sphere_template2 = obj_mgr.get_template_by_ID(template_ids[0])
+            assert sphere_template2.scale == sphere_scale
 
-        # test getting initialization templates
-        stage_init_template = sim.get_stage_initialization_template()
-        assert stage_init_template.render_asset_handle == cfg_settings["scene"]
+            # test adding a new object
+            object_id = sim.add_object(template_ids[0])
+            assert object_id != -1
 
-        obj_init_template = sim.get_object_initialization_template(object_id)
-        assert obj_init_template.render_asset_handle.endswith("sphere.glb")
+            # test getting initialization templates
+            stage_init_template = sim.get_stage_initialization_template()
+            assert stage_init_template.render_asset_handle == cfg_settings["scene"]
+
+            obj_init_template = sim.get_object_initialization_template(object_id)
+            assert obj_init_template.render_asset_handle.endswith("sphere.glb")


### PR DESCRIPTION
## Motivation and Context
This PR adds the ability to construct a Metadata Mediator in python, either from an existing Simulator Configuration or using a default, without requiring a Simulator to exist.  It also adds the ability to pass an existing Metadata Mediator into Simulator as a constructor default, as well as to retrieve a reference to the Metadata Mediator currently in use from Simulator.

The purpose of this is that Metadata Mediator maintains all the configuration files that have been loaded into the system, which can be expensive for large datasets.  By enabling the MM to be created and accessed independent of a Simulator instance, this loading process can be performed once, and then maintained through multiple simulator lifetimes.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing C++ and python tests.  Simtest.cpp has been modified to test Simulators constructed using MM as well as those constructed from SimulatorConfiguration.  TODO : python test is pending.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ x I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
