### PR TITLE
[Potential Speedup] Set render buffer properly based on sensor type

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -63,43 +63,35 @@ struct RenderTarget::Impl {
 
     if (!(flags_ & Flag::NoRgbaBuffer)) {
       colorBuffer_.setStorage(Mn::GL::RenderbufferFormat::SRGB8Alpha8, size);
-      LOG(INFO) << "Has rgba buffer";
     }
     if (!(flags_ & Flag::NoObjectIdBuffer)) {
       objectIdBuffer_.setStorage(Mn::GL::RenderbufferFormat::R32UI, size);
-      LOG(INFO) << "Has objectid buffer";
     }
     if (!(flags_ & Flag::NoDepthTexture)) {
       depthRenderTexture_.setMinificationFilter(Mn::GL::SamplerFilter::Nearest)
           .setMagnificationFilter(Mn::GL::SamplerFilter::Nearest)
           .setWrapping(Mn::GL::SamplerWrapping::ClampToEdge)
           .setStorage(1, Mn::GL::TextureFormat::DepthComponent32F, size);
-      LOG(INFO) << "Has depth texture";
     } else {
       // we use the unprojectedDepth_ as the depth buffer
       unprojectedDepth_ = Mn::GL::Renderbuffer{};
       unprojectedDepth_.setStorage(Mn::GL::RenderbufferFormat::DepthComponent24,
                                    size);
-      LOG(INFO) << "Has depth buffer";
     }
 
     framebuffer_ = Mn::GL::Framebuffer{{{}, size}};
     if (!(flags_ & Flag::NoRgbaBuffer)) {
       framebuffer_.attachRenderbuffer(RgbaBuffer, colorBuffer_);
-      LOG(INFO) << "Attached rgba buffer";
     }
     if (!(flags_ & Flag::NoObjectIdBuffer)) {
       framebuffer_.attachRenderbuffer(ObjectIdBuffer, objectIdBuffer_);
-      LOG(INFO) << "Attached objectId buffer";
     }
     if (!(flags_ & Flag::NoDepthTexture)) {
       framebuffer_.attachTexture(Mn::GL::Framebuffer::BufferAttachment::Depth,
                                  depthRenderTexture_, 0);
-      LOG(INFO) << "Attached depth texture";
     } else {
       framebuffer_.attachRenderbuffer(
           Mn::GL::Framebuffer::BufferAttachment::Depth, unprojectedDepth_);
-      LOG(INFO) << "Attached depth buffer";
     }
     if (!(flags_ & Flag::NoRgbaBuffer)) {
       framebuffer_.mapForDraw({{0, RgbaBuffer}});
@@ -108,9 +100,6 @@ struct RenderTarget::Impl {
     if (!(flags_ & Flag::NoObjectIdBuffer)) {
       framebuffer_.mapForDraw({{1, ObjectIdBuffer}});
     }
-    // XXX
-    LOG(INFO) << static_cast<int>(
-        framebuffer_.checkStatus(Mn::GL::FramebufferTarget::Draw));
     CORRADE_INTERNAL_ASSERT(
         framebuffer_.checkStatus(Mn::GL::FramebufferTarget::Draw) ==
         Mn::GL::Framebuffer::Status::Complete);

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -27,31 +27,25 @@ class RenderTarget {
  public:
   enum class Flag {
     /**
-     * @brief No textures for the meshes.
-     * Textures take a lot of GPU memory but they are not needed unless we are
-     * doing RGB rendering.
-     * Note: Do NOT set this flag when doing RGB rendering
-     * Currently it is just used to track whether or not @ref readFrameRgba,
-     * @ref blitRgbaToDefault, and @readFrameRgbaGPU are valid calls.
+     * create rgba buffer
+     * No need to set it for depth sensor, semantic sensor etc. as it makes
+     * the rendering slower
      */
-    NoTextures = 1 << 0,
+    RgbaBuffer = 1 << 0,
     /**
-     * @brief Do not create rgba buffer
-     * This can make the rendering faster for depth sensor, semantic sensor
+     * create objectId buffer
+     * No need to set it for color sensor, depth sensor etc. as it makes the
+     * rendering slower
      */
-    NoRgbaBuffer = 1 << 1,
+    ObjectIdBuffer = 1 << 1,
     /**
-     * @brief Do not create rgba buffer
-     * This can make the rendering faster for color sensor, depth sensor
+     * @brief use depth texture, it must be set for the depth sensor.
+     * No need to set it for color sensor, objectId sensor etc. as it makes the
+     * rendering slower
      */
-    NoObjectIdBuffer = 1 << 2,
-    /**
-     * @brief Do not create depth texture, it will use depth buffer instead
-     * This can make the rendering faster for color sensor, semantic sensor
-     * Note: Do NOT set this flag when being used in depth sensor
-     */
-    NoDepthTexture = 1 << 3,
+    DepthTexture = 1 << 2,
   };
+
   typedef Corrade::Containers::EnumSet<Flag> Flags;
   CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
 
@@ -69,7 +63,8 @@ class RenderTarget {
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
                DepthShader* depthShader,
-               Flags flags);
+               Flags flags = {Flag::RgbaBuffer | Flag::ObjectIdBuffer |
+                              Flag::DepthTexture});
 
   /**
    * @brief Constructor

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -5,6 +5,7 @@
 #ifndef ESP_GFX_RENDERTARGET_H_
 #define ESP_GFX_RENDERTARGET_H_
 
+#include <Corrade/Containers/EnumSet.h>
 #include <Magnum/Magnum.h>
 
 #include "esp/core/esp.h"
@@ -24,6 +25,36 @@ namespace gfx {
  */
 class RenderTarget {
  public:
+  enum class Flag {
+    /**
+     * @brief No textures for the meshes.
+     * Textures take a lot of GPU memory but they are not needed unless we are
+     * doing RGB rendering.
+     * Note: Do NOT set this flag when doing RGB rendering
+     * Currently it is just used to track whether or not @ref readFrameRgba,
+     * @ref blitRgbaToDefault, and @readFrameRgbaGPU are valid calls.
+     */
+    NoTextures = 1 << 0,
+    /**
+     * @brief Do not create rgba buffer
+     * This can make the rendering faster for depth sensor, semantic sensor
+     */
+    NoRgbaBuffer = 1 << 1,
+    /**
+     * @brief Do not create rgba buffer
+     * This can make the rendering faster for color sensor, depth sensor
+     */
+    NoObjectIdBuffer = 1 << 2,
+    /**
+     * @brief Do not create depth texture, it will use depth buffer instead
+     * This can make the rendering faster for color sensor, semantic sensor
+     * Note: Do NOT set this flag when being used in depth sensor
+     */
+    NoDepthTexture = 1 << 3,
+  };
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+  CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
+
   /**
    * @brief Constructor
    * @param size               The size of the underlying framebuffers in WxH
@@ -33,16 +64,12 @@ class RenderTarget {
    *                           Unprojects the depth on the CPU if nullptr.
    *                           Must be not nullptr to use @ref
    *                           readFrameDepthGPU()
-   * @param flags              The flags of the renderer that constructed this
-   *                           render target.  Currently just used to track
-   *                           whether or not @ref readFrameRgba,
-   *                           @ref blitRgbaToDefault, and @readFrameRgbaGPU
-   *                           are valid calls.
+   * @param flags              The flags of the renderer target
    */
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
                DepthShader* depthShader,
-               Renderer::Flags flags);
+               Flags flags);
 
   /**
    * @brief Constructor

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -53,10 +53,9 @@ struct Renderer::Impl {
 
   void bindRenderTarget(sensor::VisualSensor& sensor) {
     auto depthUnprojection = sensor.depthUnprojection();
-    if (!depthUnprojection) {
-      throw std::runtime_error(
-          "Sensor does not have a depthUnprojection matrix");
-    }
+    CORRADE_ASSERT(depthUnprojection,
+                   "Renderer::Impl::bindRenderTarget(): Sensor does not have a "
+                   "depthUnprojection matrix", );
 
     if (!depthShader_) {
       depthShader_ = std::make_unique<DepthShader>(
@@ -66,6 +65,11 @@ struct Renderer::Impl {
     RenderTarget::Flags renderTargetFlags_ = {};
     switch (sensor.specification()->sensorType) {
       case sensor::SensorType::Color:
+        CORRADE_ASSERT(
+            !(flags_ & Flag::NoTextures),
+            "Renderer::Impl::bindRenderTarget(): Tried to setup a color "
+            "render buffer while the simulator was initialized with "
+            "requiresTextures = false", );
         renderTargetFlags_ |= RenderTarget::Flag::RgbaBuffer;
         break;
 
@@ -81,10 +85,6 @@ struct Renderer::Impl {
         // I need this default, since sensor type list is long, and without
         // default clang-tidy will complain
         break;
-    }
-    if (flags_ & Flag::NoTextures) {
-      // it means no rgba render buffer
-      renderTargetFlags_ &= ~RenderTarget::Flag::RgbaBuffer;
     }
 
     sensor.bindRenderTarget(RenderTarget::create_unique(

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -64,30 +64,27 @@ struct Renderer::Impl {
     }
 
     RenderTarget::Flags renderTargetFlags_ = {};
-    if (flags_ & Flag::NoTextures) {
-      renderTargetFlags_ |= RenderTarget::Flag::NoTextures;
-    }
-
     switch (sensor.specification()->sensorType) {
       case sensor::SensorType::Color:
-        renderTargetFlags_ |= (RenderTarget::Flag::NoObjectIdBuffer |
-                               RenderTarget::Flag::NoDepthTexture);
+        renderTargetFlags_ |= RenderTarget::Flag::RgbaBuffer;
         break;
 
       case sensor::SensorType::Depth:
-        renderTargetFlags_ |= (RenderTarget::Flag::NoRgbaBuffer |
-                               RenderTarget::Flag::NoObjectIdBuffer);
+        renderTargetFlags_ |= RenderTarget::Flag::DepthTexture;
         break;
 
       case sensor::SensorType::Semantic:
-        renderTargetFlags_ |= (RenderTarget::Flag::NoRgbaBuffer |
-                               RenderTarget::Flag::NoDepthTexture);
+        renderTargetFlags_ |= RenderTarget::Flag::ObjectIdBuffer;
         break;
 
       default:
         // I need this default, since sensor type list is long, and without
         // default clang-tidy will complain
         break;
+    }
+    if (flags_ & Flag::NoTextures) {
+      // it means no rgba render buffer
+      renderTargetFlags_ &= ~RenderTarget::Flag::RgbaBuffer;
     }
 
     sensor.bindRenderTarget(RenderTarget::create_unique(

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -63,9 +63,36 @@ struct Renderer::Impl {
           DepthShader::Flag::UnprojectExistingDepth);
     }
 
+    RenderTarget::Flags renderTargetFlags_ = {};
+    if (flags_ & Flag::NoTextures) {
+      renderTargetFlags_ |= RenderTarget::Flag::NoTextures;
+    }
+
+    switch (sensor.specification()->sensorType) {
+      case sensor::SensorType::Color:
+        renderTargetFlags_ |= (RenderTarget::Flag::NoObjectIdBuffer |
+                               RenderTarget::Flag::NoDepthTexture);
+        break;
+
+      case sensor::SensorType::Depth:
+        renderTargetFlags_ |= (RenderTarget::Flag::NoRgbaBuffer |
+                               RenderTarget::Flag::NoObjectIdBuffer);
+        break;
+
+      case sensor::SensorType::Semantic:
+        renderTargetFlags_ |= (RenderTarget::Flag::NoRgbaBuffer |
+                               RenderTarget::Flag::NoDepthTexture);
+        break;
+
+      default:
+        // I need this default, since sensor type list is long, and without
+        // default clang-tidy will complain
+        break;
+    }
+
     sensor.bindRenderTarget(RenderTarget::create_unique(
         sensor.framebufferSize(), *depthUnprojection, depthShader_.get(),
-        flags_));
+        renderTargetFlags_));
   }
 
  private:

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -16,6 +16,12 @@ namespace gfx {
 class Renderer {
  public:
   enum class Flag {
+    /**
+     * @brief No textures for the meshes.
+     * Textures take a lot of GPU memory but they are not needed unless we are
+     * doing RGB rendering.
+     * Note: Cannot set this flag when doing RGB rendering
+     */
     NoTextures = 1 << 0,
   };
 

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -17,7 +17,7 @@ class Renderer {
  public:
   enum class Flag {
     /**
-     * @brief No textures for the meshes.
+     * No textures for the meshes.
      * Textures take a lot of GPU memory but they are not needed unless we are
      * doing RGB rendering.
      * Note: Cannot set this flag when doing RGB rendering


### PR DESCRIPTION
## Motivation and Context
### Impact
Potential rendering speedup.
**Before:**
The renderTarget will contain 1 rgb buffer, 1 depth texture, 1 objectId Buffer (color attachment) no matter what the sensor type is.

**After:**
The renderTarget will have different combination based on sensor type.
**For rgb sensor**: 1 rgb buffer + 1 depth buffer (no objectId buffer, and No depth texture). 
This is based on the fact that usually depth buffer is faster than the depth texture.

**For depth sensor**: 1 depth texture (No rgb buffer, no objectId buffer).
This will speed up the rendering based on the observation [here](https://github.com/facebookresearch/habitat-sim/pull/1011#discussion_r577347437).

**For ObjectId sensor** 1 objectId buffer + 1 depth buffer (No rgb buffer, and no depth texture).
Reason is the same as above.

More test results are coming.
Here is the viewer with rgb sensor:
Before:
![before](https://user-images.githubusercontent.com/931093/108679661-bfb81100-74a1-11eb-9783-adac2d70ec69.png)

After:
![after](https://user-images.githubusercontent.com/931093/108679674-c3e42e80-74a1-11eb-8c6e-2e40ed0b9a25.png)


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
