### PR TITLE
--[Bug Fix]Remake activateCollisionIsland with bitset

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -43,9 +43,6 @@ BulletRigidObject::BulletRigidObject(
       RigidObject(rigidBodyNode, objectId, resMgr),
       MotionState(*rigidBodyNode) {}
 
-// clang-tidy assumes that the set insert in activateCollisionIsland() may
-// potentially throw an exception
-// NOLINTNEXTLINE(bugprone-exception-escape)
 BulletRigidObject::~BulletRigidObject() {
   if (!isActive()) {
     // This object may be supporting other sleeping objects, so wake them
@@ -459,20 +456,22 @@ void BulletRigidObject::activateCollisionIsland() {
   // first query overlapping pairs of the current object from the most recent
   // broadphase to collect relevant simulation islands.
 
-  std::set<int> overlappingSimulationIslands = {thisColObj->getIslandTag()};
+  // each index represents an island tag present - default is -1, so add one.
+  std::bitset<65536> overlappingSimIslands;
+  overlappingSimIslands[thisColObj->getIslandTag() + 1] = true;
   auto* bColWorld = bWorld_->getCollisionWorld();
   auto& pairCache = bColWorld->getPairCache()->getOverlappingPairArray();
   for (int i = 0; i < pairCache.size(); ++i) {
     if (pairCache.at(i).m_pProxy0->m_clientObject == thisColObj) {
-      overlappingSimulationIslands.insert(
-          static_cast<btCollisionObject*>(
-              pairCache.at(i).m_pProxy1->m_clientObject)
-              ->getIslandTag());
+      overlappingSimIslands[static_cast<btCollisionObject*>(
+                                pairCache.at(i).m_pProxy1->m_clientObject)
+                                ->getIslandTag() +
+                            1] = true;
     } else if (pairCache.at(i).m_pProxy1->m_clientObject == thisColObj) {
-      overlappingSimulationIslands.insert(
-          static_cast<btCollisionObject*>(
-              pairCache.at(i).m_pProxy0->m_clientObject)
-              ->getIslandTag());
+      overlappingSimIslands[static_cast<btCollisionObject*>(
+                                pairCache.at(i).m_pProxy0->m_clientObject)
+                                ->getIslandTag() +
+                            1] = true;
     }
   }
 
@@ -480,8 +479,7 @@ void BulletRigidObject::activateCollisionIsland() {
   // previous collision detection pass
   auto& colObjs = bColWorld->getCollisionObjectArray();
   for (auto objIx = 0; objIx < colObjs.size(); ++objIx) {
-    if (overlappingSimulationIslands.count(colObjs[objIx]->getIslandTag()) >
-        0) {
+    if (overlappingSimIslands[colObjs[objIx]->getIslandTag() + 1]) {
       colObjs[objIx]->activate();
     }
   }

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -456,8 +456,12 @@ void BulletRigidObject::activateCollisionIsland() {
   // first query overlapping pairs of the current object from the most recent
   // broadphase to collect relevant simulation islands.
 
-  // each index represents an island tag present - default is -1, so add one.
+  // bitset template argument specifies reasonable allocation size at compile
+  // time - it is not expected that we would require more than 65536 different
+  // islands; if we do, this number should be increased.
   std::bitset<65536> overlappingSimIslands;
+  // each index represents an island tag present - default in bullet is -1, so
+  // add one.
   overlappingSimIslands[thisColObj->getIslandTag() + 1] = true;
   auto* bColWorld = bWorld_->getCollisionWorld();
   auto& pairCache = bColWorld->getPairCache()->getOverlappingPairArray();

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -459,23 +459,25 @@ void BulletRigidObject::activateCollisionIsland() {
   // bitset template argument specifies reasonable allocation size at compile
   // time - it is not expected that we would require more than 65536 different
   // islands; if we do, this number should be increased.
-  std::bitset<65536> overlappingSimIslands;
+  Magnum::Math::BoolVector<65536> overlappingSimIslands;
   // each index represents an island tag present - default in bullet is -1, so
   // add one.
-  overlappingSimIslands[thisColObj->getIslandTag() + 1] = true;
+  overlappingSimIslands.set(thisColObj->getIslandTag() + 1, true);
   auto* bColWorld = bWorld_->getCollisionWorld();
   auto& pairCache = bColWorld->getPairCache()->getOverlappingPairArray();
   for (int i = 0; i < pairCache.size(); ++i) {
     if (pairCache.at(i).m_pProxy0->m_clientObject == thisColObj) {
-      overlappingSimIslands[static_cast<btCollisionObject*>(
-                                pairCache.at(i).m_pProxy1->m_clientObject)
-                                ->getIslandTag() +
-                            1] = true;
+      overlappingSimIslands.set(static_cast<btCollisionObject*>(
+                                    pairCache.at(i).m_pProxy1->m_clientObject)
+                                        ->getIslandTag() +
+                                    1,
+                                true);
     } else if (pairCache.at(i).m_pProxy1->m_clientObject == thisColObj) {
-      overlappingSimIslands[static_cast<btCollisionObject*>(
-                                pairCache.at(i).m_pProxy0->m_clientObject)
-                                ->getIslandTag() +
-                            1] = true;
+      overlappingSimIslands.set(static_cast<btCollisionObject*>(
+                                    pairCache.at(i).m_pProxy0->m_clientObject)
+                                        ->getIslandTag() +
+                                    1,
+                                true);
     }
   }
 

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -59,9 +59,6 @@ class BulletRigidObject : public BulletBase,
   /**
    * @brief Destructor cleans up simulation structures for the object.
    */
-  // clang-tidy assumes that the set insert in activateCollisionIsland() may
-  // potentially throw an exception
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~BulletRigidObject() override;
 
   /**


### PR DESCRIPTION
This PR changes BulletRigidObject::activateCollisionIsland() to use a Magnum::BoolVector instead of a std::set.  The std::set.insert function can throw an exception due to allocation, but BulletRigidObject::activateCollisionIsland is called from the BulletRigidObject destructor, which cannot allow exceptions.  Instead of bypassing a useful clang-tidy check, this uses a Magnum::BoolVector that does not throw exceptions.

Magnum::BoolVector also has a smaller memory footprint per element ([an integer set requires approximately 32 bytes per 32 bit element](https://lemire.me/blog/2016/09/15/the-memory-usage-of-stl-containers-can-be-surprising/)); the BoolVector<65536> requires 8kb storage space, which is equivalent to a std::set<int> containing approx 200 elements.

A potential issue is if we have more than 65536 island ids, this will overflow unless the template param size is increased.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
