### PR TITLE
[CIRCLECI] Enforce Clang-Tidy on headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat;
               cd habitat-sim
-              python tools/run-clang-tidy.py src/esp
+              python tools/run-clang-tidy.py -header-filter=src/esp src/esp
       - run:
           name: Ccache stats
           when: always

--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -169,7 +169,8 @@ class ManagedContainerBase {
       LOG(ERROR) << "ManagedContainerBase::getObjectHandleByID : Unknown "
                  << objectType_ << " managed object ID:" << objectID
                  << ". Aborting";
-      return "";
+      // never will have registered object with registration handle == ""
+	  return "";
     }
     return objectLibKeyByID_.at(objectID);
   }  // ManagedContainer::getObjectHandleByID

--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -169,7 +169,7 @@ class ManagedContainerBase {
       LOG(ERROR) << "ManagedContainerBase::getObjectHandleByID : Unknown "
                  << objectType_ << " managed object ID:" << objectID
                  << ". Aborting";
-      return nullptr;
+      return "";
     }
     return objectLibKeyByID_.at(objectID);
   }  // ManagedContainer::getObjectHandleByID

--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -170,7 +170,7 @@ class ManagedContainerBase {
                  << objectType_ << " managed object ID:" << objectID
                  << ". Aborting";
       // never will have registered object with registration handle == ""
-	  return "";
+      return "";
     }
     return objectLibKeyByID_.at(objectID);
   }  // ManagedContainer::getObjectHandleByID


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* There have been several PRs recently to get our headers compliant with clang-tidy. This change allows clang-tidy to enforce style on all our headers.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and in CircleCI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
