### PR TITLE
add ESP_CHECK and one example usage

### DIFF
--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -6,6 +6,7 @@
 
 #include "esp/assets/ResourceManager.h"
 #include "esp/core//random.h"
+#include "esp/core/Check.h"
 #include "esp/core/Configuration.h"
 #include "esp/core/RigidState.h"
 
@@ -126,6 +127,13 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
 #else
       false;
 #endif
+
+  /* This function pointer is used by ESP_CHECK(). If it's null, it
+     std::abort()s, if not, it calls it to cause a Python AssertionError */
+  esp::core::throwInPython = [](const char* const message) {
+    PyErr_SetString(PyExc_AssertionError, message);
+    throw pybind11::error_already_set{};
+  };
 
   m.import("magnum.scenegraph");
 

--- a/src/esp/core/CMakeLists.txt
+++ b/src/esp/core/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(
   AbstractManagedObject.h
   Buffer.cpp
   Buffer.h
+  Check.cpp
+  Check.h
   Configuration.h
   esp.cpp
   esp.h

--- a/src/esp/core/Check.cpp
+++ b/src/esp/core/Check.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "Check.h"
+
+#include <Corrade/Utility/Assert.h>
+
+namespace esp {
+namespace core {
+
+void (*throwInPython)(const char*) = nullptr;
+
+/* NORETURN will help the compiler optimize -- it basically tells it that the
+   condition passed to HABITAT_EXCEPTION() can be assumed to be always true in
+   the following code, because if not then the execution ends in this
+   function. */
+CORRADE_NORETURN void throwIfInPythonOtherwiseAbort(const char* message) {
+  /* The throwInPython function pointer gets filled during Python bindings
+     startup. If it's nullptr, we're in plain C++ code. */
+  if (throwInPython) {
+    throwInPython(message);
+    /* I failed to apply the NORETURN attribute to the throwInPython function
+       pointer so at least this */
+    CORRADE_INTERNAL_ASSERT_UNREACHABLE();
+  }
+
+  /* If it isn't defined, do an abort the same way as CORRADE_ASSERT(). This
+     could be in an `else` block but I like to play with fire, so it's not --
+     the NORETURN above should tell that to the compiler and the function
+     should throw. */
+  Corrade::Utility::Error{Corrade::Utility::Error::defaultOutput()} << message;
+  std::abort();
+}
+
+}  // namespace core
+}  // namespace esp

--- a/src/esp/core/Check.h
+++ b/src/esp/core/Check.h
@@ -1,0 +1,77 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_CORE_CHECK_H_
+#define ESP_CORE_CHECK_H_
+
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/Macros.h>
+#include <sstream>
+
+/** @file
+  @brief ESP_CHECK macro, for use with fatal runtime errors.
+
+  Below is an overview of asserts, ESP_CHECK, exception-throwing, and warnings
+  in Habitat-sim. These are new guidelines as of Feb 2021; not all Habitat code
+  follows these guidelines yet.
+
+  assert
+  - see CORRADE_ASSERT and CORRADE_ASSERT_INTERNAL.
+  - A failed assert represents a Hab programmer error.
+  - It shouldn't depend on Hab-user-provided input or data.
+  - If/when we temporarily disable asserts (e.g. as an optimization), the Hab
+  library should still work correctly.
+
+  runtime error
+  - See fatal and recoverable variants below.
+  - Something outside the Hab programmer's control went wrong.
+  - E.g. bad user input or data, bad OS behavior.
+
+  fatal (non-recoverable) runtime error
+  - see ESP_CHECK.
+  - We consider the error unrecoverable, because it's impossible or inconvenient
+  to handle the error in a recoverable way.
+  - We terminate the program (including the Python user program calling into
+  Hab).
+
+  recoverable (non-fatal) runtime error
+  - See throw std::runtime_error in GfxBindings.cpp and other binding code.
+  - By recover, we mean throw a Python exception or otherwise abort the
+  user-requested operation but still allow the program to continue.
+  - In general, we only throw exceptions in binding code, not elsewhere in the
+  C++.
+
+  warning
+  - see LOG(WARNING)
+  - A message to the user telling her she *probably* did something wrong (e.g.
+  bad input, bad data)
+*/
+
+namespace esp {
+namespace core {
+
+/* The throwInPython function pointer gets filled during Python bindings
+   startup. If it's nullptr, we're in plain C++ code. */
+extern void (*throwInPython)(const char*);
+
+// For use in ESP_CHECK
+CORRADE_NORETURN void throwIfInPythonOtherwiseAbort(const char* message);
+
+}  // namespace core
+}  // namespace esp
+
+/* A runtime check that must pass, otherwise we consider this a fatal runtime
+error. The program terminates with the supplied error message. */
+#define ESP_CHECK(condition, ...)                                 \
+  do {                                                            \
+    if (!(condition)) {                                           \
+      std::ostringstream out;                                     \
+      Corrade::Utility::Debug{                                    \
+          &out, Corrade::Utility::Debug::Flag::NoNewlineAtTheEnd} \
+          << "ESP_CHECK failed:" << __VA_ARGS__;                  \
+      esp::core::throwIfInPythonOtherwiseAbort(out.str().data()); \
+    }                                                             \
+  } while (false)
+
+#endif

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -4,6 +4,8 @@
 
 #include "LightSetup.h"
 
+#include "esp/core/Check.h"
+
 namespace esp {
 namespace gfx {
 
@@ -19,12 +21,11 @@ Magnum::Vector4 getLightPositionRelativeToCamera(
     const LightInfo& light,
     const Magnum::Matrix4& transformationMatrix,
     const Magnum::Matrix4& cameraMatrix) {
-  CORRADE_ASSERT(light.vector.w() == 1 || light.vector.w() == 0,
-                 "Light vector"
-                     << light.vector
+  ESP_CHECK(
+      light.vector.w() == 1 || light.vector.w() == 0,
+      "Light vector" << light.vector
                      << "is expected to have w == 0 for a directional light or "
-                        "w == 1 for a point light",
-                 {});
+                        "w == 1 for a point light");
 
   switch (light.model) {
     case LightPositionModel::OBJECT:


### PR DESCRIPTION
## Motivation and Context

Add ESP_CHECK macro, for use with fatal runtime errors. The Check.h header also gives guidelines on error-handling in Habitat-sim.

Thanks @mosra for providing most of the implementation here.

See [this internal doc](https://docs.google.com/document/d/1v99XKd5EljCGYytdmjZrV20WsyhrcpbLxGSgy4UHlx0/edit?usp=sharing) for more discussion.

I added one example usage of ESP_CHECK in LightSetup.cpp.

## How Has This Been Tested

Ad hoc testing from a Python unit test (causing an AssertionError exception) and a C++ unit test (causing an abort).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
