### PR TITLE
fix for Simulator::reconfigureReplayManager; added a replay unit test

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -91,10 +91,10 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   if (!resourceManager_) {
     resourceManager_ =
         std::make_unique<assets::ResourceManager>(metadataMediator_);
-    if (config_.createRenderer) {
+    if (cfg.createRenderer) {
       // needs to be called after ResourceManager exists but before any assets
       // have been loaded
-      reconfigureReplayManager();
+      reconfigureReplayManager(cfg.enableGfxReplaySave);
     }
   } else {
     resourceManager_->setMetadataMediator(metadataMediator_);
@@ -511,11 +511,11 @@ void Simulator::seed(uint32_t newSeed) {
   pathfinder_->seed(newSeed);
 }
 
-void Simulator::reconfigureReplayManager() {
+void Simulator::reconfigureReplayManager(bool enableGfxReplaySave) {
   gfxReplayMgr_ = std::make_shared<gfx::replay::ReplayManager>();
 
   // construct Recorder instance if requested
-  gfxReplayMgr_->setRecorder(config_.enableGfxReplaySave
+  gfxReplayMgr_->setRecorder(enableGfxReplaySave
                                  ? std::make_shared<gfx::replay::Recorder>()
                                  : nullptr);
   // assign Recorder to ResourceManager

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -934,7 +934,7 @@ class Simulator {
     return isValidScene(sceneID) && physicsManager_ != nullptr;
   }
 
-  void reconfigureReplayManager();
+  void reconfigureReplayManager(bool enableGfxReplaySave);
 
   gfx::WindowlessContext::uptr context_ = nullptr;
   std::shared_ptr<gfx::Renderer> renderer_ = nullptr;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(DrawableTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 test(PhysicsTest physics)
 target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(GfxReplayTest assets gfx)
+test(GfxReplayTest assets gfx sim)
 target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(ResourceManagerTest assets)

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -10,7 +10,9 @@
 #include "esp/gfx/WindowlessContext.h"
 #include "esp/gfx/replay/Player.h"
 #include "esp/gfx/replay/Recorder.h"
+#include "esp/gfx/replay/ReplayManager.h"
 #include "esp/scene/SceneManager.h"
+#include "esp/sim/Simulator.h"
 
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Utility/Directory.h>
@@ -27,6 +29,8 @@ namespace Mn = Magnum;
 using esp::assets::ResourceManager;
 using esp::metadata::MetadataMediator;
 using esp::scene::SceneManager;
+using esp::sim::Simulator;
+using esp::sim::SimulatorConfiguration;
 
 // Helper function to get numberOfChildrenOfRoot
 int getNumberOfChildrenOfRoot(esp::scene::SceneNode& rootNode) {
@@ -306,6 +310,44 @@ TEST(GfxReplayTest, playerReadInvalidFile) {
   bool success = Corrade::Utility::Directory::rm(testFilepath);
   if (!success) {
     LOG(WARNING) << "GfxReplayTest::playerReadInvalidFile : unable to remove "
+                    "temporary test JSON file "
+                 << testFilepath;
+  }
+}
+
+// test recording and playback through the simulator interface
+TEST(GfxReplayTest, simulatorIntegration) {
+  std::string boxFile =
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+  auto testFilepath =
+      Corrade::Utility::Directory::join(DATA_DIR, "./gfx_replay_test.json");
+
+  SimulatorConfiguration simConfig{};
+  simConfig.activeSceneName = boxFile;
+  simConfig.enableGfxReplaySave = true;
+
+  auto sim = Simulator::create_unique(simConfig);
+  auto& sceneGraph = sim->getActiveSceneGraph();
+  auto& rootNode = sceneGraph.getRootNode();
+  auto prevNumberOfChildrenOfRoot = getNumberOfChildrenOfRoot(rootNode);
+
+  const auto recorder = sim->getGfxReplayManager()->getRecorder();
+  EXPECT_TRUE(recorder);
+  recorder->saveKeyframe();
+  recorder->writeSavedKeyframesToFile(testFilepath);
+
+  auto player = sim->getGfxReplayManager()->readKeyframesFromFile(testFilepath);
+  EXPECT_TRUE(player);
+  EXPECT_EQ(player->getNumKeyframes(), 1);
+  player->setKeyframeIndex(0);
+  // second copy of box was loaded
+  EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode),
+            prevNumberOfChildrenOfRoot + 1);
+
+  // remove file created for this test
+  bool success = Corrade::Utility::Directory::rm(testFilepath);
+  if (!success) {
+    LOG(WARNING) << "GfxReplayTest::simulatorIntegration : unable to remove "
                     "temporary test JSON file "
                  << testFilepath;
   }


### PR DESCRIPTION
## Motivation and Context

This is a fix for a bug that caused replay recording to not get enabled. I also added a test for simulator replay integration which will catch this kind of bug in the future.

## How Has This Been Tested

See new unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
