### PR TITLE
--[Bugfix]Const specifier added to functions that do not change internal state.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1516,7 +1516,7 @@ gfx::PhongMaterialData::uptr ResourceManager::buildFlatShadedMaterialData(
 
 gfx::PhongMaterialData::uptr ResourceManager::buildPhongShadedMaterialData(
     const Mn::Trade::PhongMaterialData& material,
-    int textureBaseIndex) {
+    int textureBaseIndex) const {
   // NOLINTNEXTLINE(google-build-using-namespace)
   using namespace Mn::Math::Literals;
 
@@ -1557,7 +1557,7 @@ gfx::PhongMaterialData::uptr ResourceManager::buildPhongShadedMaterialData(
 
 gfx::PbrMaterialData::uptr ResourceManager::buildPbrShadedMaterialData(
     const Mn::Trade::PbrMetallicRoughnessMaterialData& material,
-    int textureBaseIndex) {
+    int textureBaseIndex) const {
   // NOLINTNEXTLINE(google-build-using-namespace)
   using namespace Mn::Math::Literals;
 
@@ -2201,7 +2201,7 @@ std::unique_ptr<MeshData> ResourceManager::createJoinedCollisionMesh(
 bool ResourceManager::outputMeshMetaDataToObj(
     const std::string& MeshMetaDataFile,
     const std::string& new_filename,
-    const std::string& filepath) {
+    const std::string& filepath) const {
   bool success = Cr::Utility::Directory::mkpath(filepath);
 
   const MeshMetaData& metaData = getMeshMetaData(MeshMetaDataFile);
@@ -2246,7 +2246,8 @@ bool ResourceManager::outputMeshMetaDataToObj(
   return success;
 }
 
-bool ResourceManager::isAssetDataRegistered(const std::string& resourceName) {
+bool ResourceManager::isAssetDataRegistered(
+    const std::string& resourceName) const {
   return (resourceDict_.count(resourceName) > 0);
 }
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2161,7 +2161,7 @@ void ResourceManager::joinHeirarchy(
     MeshData& mesh,
     const MeshMetaData& metaData,
     const MeshTransformNode& node,
-    const Magnum::Matrix4& transformFromParentToWorld) {
+    const Magnum::Matrix4& transformFromParentToWorld) const {
   Magnum::Matrix4 transformFromLocalToWorld =
       transformFromParentToWorld * node.transformFromLocalToParent;
 
@@ -2185,7 +2185,7 @@ void ResourceManager::joinHeirarchy(
 }
 
 std::unique_ptr<MeshData> ResourceManager::createJoinedCollisionMesh(
-    const std::string& filename) {
+    const std::string& filename) const {
   std::unique_ptr<MeshData> mesh = std::make_unique<MeshData>();
 
   CHECK(resourceDict_.count(filename) > 0);

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -341,7 +341,7 @@ class ResourceManager {
    * @return The unified @ref MeshData object for the asset.
    */
   std::unique_ptr<MeshData> createJoinedCollisionMesh(
-      const std::string& filename);
+      const std::string& filename) const;
 
   /**
    * @brief Converts a MeshMetaData into a obj file.
@@ -657,7 +657,7 @@ class ResourceManager {
   void joinHeirarchy(MeshData& mesh,
                      const MeshMetaData& metaData,
                      const MeshTransformNode& node,
-                     const Mn::Matrix4& transformFromParentToWorld);
+                     const Mn::Matrix4& transformFromParentToWorld) const;
 
   /**
    * @brief Load materials from importer into assets, and update metaData for

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -352,7 +352,7 @@ class ResourceManager {
    */
   bool outputMeshMetaDataToObj(const std::string& filename,
                                const std::string& new_filename,
-                               const std::string& filepath);
+                               const std::string& filepath) const;
 
   /**
    * @brief Returns the number of resources registered under a given resource
@@ -360,7 +360,7 @@ class ResourceManager {
    *
    * @param resourceName The name of the resource.
    */
-  bool isAssetDataRegistered(const std::string& resourceName);
+  bool isAssetDataRegistered(const std::string& resourceName) const;
 
 #ifdef ESP_BUILD_WITH_VHACD
   /**
@@ -692,7 +692,7 @@ class ResourceManager {
    */
   gfx::PhongMaterialData::uptr buildPhongShadedMaterialData(
       const Mn::Trade::PhongMaterialData& material,
-      int textureBaseIndex);
+      int textureBaseIndex) const;
 
   /**
    * @brief Build a @ref PbrMaterialData for use with PBR shading
@@ -704,7 +704,7 @@ class ResourceManager {
    */
   gfx::PbrMaterialData::uptr buildPbrShadedMaterialData(
       const Mn::Trade::PbrMetallicRoughnessMaterialData& material,
-      int textureBaseIndex);
+      int textureBaseIndex) const;
 
   /**
    * @brief Load a mesh describing some scene asset based on the passed

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -647,7 +647,7 @@ class ResourceManager {
    * @brief Recursively build a unified @ref MeshData from loaded assets via a
    * tree of @ref MeshTransformNode.
    *
-   * @param mesh The @ref MeshData being constructed.
+   * @param[in,out] mesh The @ref MeshData being constructed.
    * @param metaData The @ref MeshMetaData for the object heirarchy being
    * joined.
    * @param node The current @ref MeshTransformNode in the recursion.


### PR DESCRIPTION
## Motivation and Context
These two functions in ResourceManager do not change any internal RM variables' states, so this small PR specifies them as const.  This will open them up 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
