### PR TITLE
[AO Prototype] Fix leak in BG renderer

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -117,7 +117,7 @@ class Simulator(SimulatorBackend):
         self._sanitize_config(self.config)
         self.__set_from_config(self.config)
 
-    def close(self) -> None:
+    def close(self, destroy: bool = False) -> None:
         if self.renderer is not None:
             self.renderer.acquire_gl_context()
 
@@ -136,7 +136,7 @@ class Simulator(SimulatorBackend):
 
         self.__last_state.clear()
 
-        super().close()
+        super().close(destroy)
 
     def __enter__(self) -> "Simulator":
         return self
@@ -506,7 +506,7 @@ class Simulator(SimulatorBackend):
         return end_pos
 
     def __del__(self) -> None:
-        self.close()
+        self.close(destroy=True)
 
     def step_physics(self, dt: float, scene_id: int = 0) -> None:
         self.step_world(dt)

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -99,7 +99,7 @@ void initSimBindings(py::module& m) {
       .def("seed", &Simulator::seed, "new_seed"_a)
       .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
       .def("reset", &Simulator::reset)
-      .def("close", &Simulator::close)
+      .def("close", &Simulator::close, "destroy"_a=false)
       .def_property("pathfinder", &Simulator::getPathFinder,
                     &Simulator::setPathFinder)
       .def_property(

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -51,10 +51,10 @@ Simulator::Simulator(const SimulatorConfiguration& cfg,
 
 Simulator::~Simulator() {
   LOG(INFO) << "Deconstructing Simulator";
-  close();
+  close(true);
 }
 
-void Simulator::close() {
+void Simulator::close(const bool destroy) {
   if (renderer_)
     renderer_->acquireGlContext();
 
@@ -72,8 +72,10 @@ void Simulator::close() {
 
   resourceManager_ = nullptr;
 
-  renderer_ = nullptr;
-  context_ = nullptr;
+  if (destroy) {
+    renderer_ = nullptr;
+    context_ = nullptr;
+  }
 
   activeSceneID_ = ID_UNDEFINED;
   activeSemanticSceneID_ = ID_UNDEFINED;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -60,7 +60,7 @@ class Simulator {
    * is not done correctly, the pattern for @ref `close` then @ref `reconfigure`
    * to create a "fresh" instance of the simulator may not work correctly
    */
-  virtual void close();
+  virtual void close(bool destroy=false);
 
   virtual void reconfigure(const SimulatorConfiguration& cfg);
 


### PR DESCRIPTION
## Motivation and Context

Something somewhere is leaking GPU memory because we create and destroy the background render thread all the time.  Ideally we'd fix that, but we currently have no idea how.  This is a workaround to not destroy the context or renderer on a close call.

Just putting this here for visibility and to note the caveats: If you change flags related to the renderer, those won't be propagated.  This is fine ATM and fixable in the long run, but not needed currently.

## How Has This Been Tested

Ran the training script for a long time with lots of scene swaps and no leaks!

Planning to land if the CI is happy

## Types of changes

 Bug fix (non-breaking change which fixes an issue)
