### PR TITLE
bugfix for replay::Player not cleaning up on destruction

### DIFF
--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -41,6 +41,10 @@ void Player::readKeyframesFromFile(const std::string& filepath) {
   }
 }
 
+Player::~Player() {
+  clearFrame();
+}
+
 int Player::getKeyframeIndex() const {
   return frameIndex_;
 }

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -51,6 +51,8 @@ class Player {
    */
   explicit Player(const LoadAndCreateRenderAssetInstanceCallback& callback);
 
+  ~Player();
+
   /**
    * @brief Read keyframes. See also @ref Recorder::writeSavedKeyframesToFile.
    * After calling this, use @ref setKeyframeIndex to set a keyframe.

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -344,6 +344,10 @@ TEST(GfxReplayTest, simulatorIntegration) {
   EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode),
             prevNumberOfChildrenOfRoot + 1);
 
+  player = nullptr;
+  // second copy of box removed when Player is deleted
+  EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode), prevNumberOfChildrenOfRoot);
+
   // remove file created for this test
   bool success = Corrade::Utility::Directory::rm(testFilepath);
   if (!success) {


### PR DESCRIPTION
## Motivation and Context

Bugfix. Player manipulates the scene graph, adding render asset instances as necessary. It should remove everything on destruction.

## How Has This Been Tested

I modified a GfxReplayTest unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
