### PR TITLE
[Sensor] Quick Fix for agent sensorSubType, rename pinholeCameraSpec to cameraSensorSpec

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -523,13 +523,15 @@ Viewer::Viewer(const Arguments& arguments)
        esp::agent::ActionSpec::create(
            "lookDown", esp::agent::ActuationMap{{"amount", lookSensitivity}})},
   };
-  auto pinholeCameraSpec = esp::sensor::CameraSensorSpec::create();
-  pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
-  pinholeCameraSpec->sensorType = esp::sensor::SensorType::Color;
-  pinholeCameraSpec->position = {0.0f, 1.5f, 0.0f};
-  pinholeCameraSpec->orientation = {0, 0, 0};
-  pinholeCameraSpec->resolution = esp::vec2i(viewportSize[1], viewportSize[0]);
-  agentConfig.sensorSpecifications = {pinholeCameraSpec};
+  auto cameraSensorSpec = esp::sensor::CameraSensorSpec::create();
+  cameraSensorSpec->sensorSubType =
+      args.isSet("orthographic") ? esp::sensor::SensorSubType::Orthographic
+                                 : esp::sensor::SensorSubType::Pinhole;
+  cameraSensorSpec->sensorType = esp::sensor::SensorType::Color;
+  cameraSensorSpec->position = {0.0f, 1.5f, 0.0f};
+  cameraSensorSpec->orientation = {0, 0, 0};
+  cameraSensorSpec->resolution = esp::vec2i(viewportSize[1], viewportSize[0]);
+  agentConfig.sensorSpecifications = {cameraSensorSpec};
 
   simulator_->addAgent(agentConfig);
 


### PR DESCRIPTION
## Motivation and Context

@bigbike kindly mentioned that https://github.com/facebookresearch/habitat-sim/pull/1090 forgot to set the sensor's subtype based on whether or not "orthographic" was in agent args. This PR is a quick fix for that. It also renames pinholeCameraSpec to cameraSensorSpec. 

## How Has This Been Tested

Build and run

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
