### PR TITLE
pvizplan replay and light tuning

### DIFF
--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -531,6 +531,14 @@ class ResourceManager {
       esp::scene::SceneManager* sceneManagerPtr,
       const std::vector<int>& activeSceneIDs);
 
+  /**
+   * @brief Temporary interface for URDF branch to create render asset instances
+   */
+  scene::SceneNode* hackTryCreateRenderAssetInstance(
+      const RenderAssetInstanceCreationInfo& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables);
+
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
@@ -557,6 +565,13 @@ class ResourceManager {
    * primitive to instantiate
    */
   void buildPrimitiveAssetData(const std::string& primTemplateHandle);
+
+  /**
+   * @brief Replace references to runtime-created assets with reasonable
+   * fallback persistent assets.
+   */
+  RenderAssetInstanceCreationInfo hackReplaceRuntimeAssets(
+      const RenderAssetInstanceCreationInfo& creation);
 
  protected:
   // ======== Structs and Types only used locally ========

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -113,6 +113,15 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     }
     ASSERT(assetInfos_.count(creation.filepath));
 
+    if (creation.filepath.find("bellows_link.STL") != std::string::npos) {
+      if (!failedFilepaths_.count(creation.filepath)) {
+        LOG(WARNING) << "Player: disabling display for bellows_link.STL "
+                        "because we don't want to display it.";
+        failedFilepaths_.insert(creation.filepath);
+      }
+      continue;
+    }
+
     // "filepath":
     // "data/objects/ycb/002_master_chef_can/google_16k/textured.obj",
 

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -112,8 +112,18 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
       continue;
     }
     ASSERT(assetInfos_.count(creation.filepath));
+
+    // "filepath":
+    // "data/objects/ycb/002_master_chef_can/google_16k/textured.obj",
+
+    // temp hack assign "ycb" lightSetupKey if filepath contains "objects/ycb"
+    auto adjustedCreation = creation;
+    if (adjustedCreation.filepath.find("objects/ycb") != std::string::npos) {
+      adjustedCreation.lightSetupKey = "ycb";
+    }
+
     auto node = loadAndCreateRenderAssetInstanceCallback(
-        assetInfos_[creation.filepath], creation);
+        assetInfos_[adjustedCreation.filepath], adjustedCreation);
     if (!node) {
       if (!failedFilepaths_.count(creation.filepath)) {
         LOG(WARNING) << "Player: load failed for asset [" << creation.filepath

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -166,7 +166,10 @@ void Recorder::writeSavedKeyframesToFile(const std::string& filepath) {
   auto document = writeKeyframesToJsonDocument();
   esp::io::writeJsonToFile(document, filepath);
 
-  consolidateSavedKeyframes();
+  // temp disable consolidate, such that each writeSavedKeyframesToFile writes
+  // all saved keyframes since step 0
+
+  // consolidateSavedKeyframes();
 }
 
 std::string Recorder::writeSavedKeyframesToString() {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -864,6 +864,20 @@ double Simulator::stepWorld(const double dt) {
 #endif
     physicsManager_->updateNodes();
   }
+
+  // temp force replay recording and periodic writing to disk
+  {
+    const auto recorder = getGfxReplayManager()->getRecorder();
+    if (recorder) {
+      recorder->saveKeyframe();
+      static int count = 0;
+      count++;
+      if (count > 500) {
+        count = 0;
+        recorder->writeSavedKeyframesToFile("./default.replay.json");
+      }
+    }
+  }
   return getWorldTime();
 }
 

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -36,7 +36,7 @@ struct SimulatorConfiguration {
   /**
    * @brief todo
    */
-  bool enableGfxReplaySave = false;
+  bool enableGfxReplaySave = true;  // temp enable replay recording by default
   /**
    * @brief Whether or not to load the semantic mesh
    */

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -756,6 +756,7 @@ Key Commands:
   Mn::DebugTools::GLFrameProfiler profiler_{};
 
   std::shared_ptr<esp::gfx::replay::Player> player_;
+  float ycbLightColorScale_ = 4.f;
 };
 
 Viewer::Viewer(const Arguments& arguments)
@@ -2323,6 +2324,12 @@ void Viewer::reloadLights() {
     }
   }
   simulator_->setLightSetup(lightInfos);
+
+  for (auto& info : lightInfos) {
+    info.color *= ycbLightColorScale_;
+  }
+
+  simulator_->setLightSetup(lightInfos, "ycb");
 }
 
 }  // namespace


### PR DESCRIPTION
Do not merge. This PR documents this branch.

# Overview
This branch supports three intended pvizplan workflows:
1. Record a gfx replay while running orp/play.py
2. Play a gfx replay in the C++ viewer
3. Tune lighting for a scene in the C++ viewer (this is mostly unrelated to 1 and 2 above)

## Record a gfx replay while running orp/play.py
1. Build this branch and make sure your python imports habitat-sim from where you built. See [building from source](https://github.com/facebookresearch/habitat-sim/blob/master/BUILD_FROM_SOURCE.md)
2. Run pvizplan orp/play.py or otherwise invoke habitat-sim. Beware that replay recording is enabled by default regardless of whether you're running play.py, training a model, or using habitat-sim for something else.
3. Look for default.replay.json generated in your current working directory. A replay keyframe is saved on every Simulator::stepWorld and the json is re-written periodically (every 500 steps).
4. Take care to rename default.replay.json later so it doesn't get overwritten by the next run of habitat-sim.

## Play a gfx replay in the C++ viewer
1. Find/produce a gfx replay JSON file. It starts like this:
```
{
    "keyframes": [
        {
            "loads": [
                {
                    "type": 3,
                    "filepath": "./orp/start_data/frl_apartment_stage_pvizplan_empty.glb",
```
2. Inspect the GLB/dae filepaths in the replay JSON. Make sure you have these model assets on your local machine. If your replay was generated from pvizplan, you should probably clone the pvizplan repo to get the model assets onto your local machine.
4. Build the C++ viewer (./build/utils/viewer/viewer).
5. Find a working directory from which to run the viewer. Make sure the GLB filepaths referenced in your replay file are valid for your working directory. If your replay was generated from pvizplan, then use pvizplan working directory. If necessary, find/replace the filepaths in the JSON, for example, to remap their locations on disk.
6. Invoke the C++ viewer like so. Note "NONE" for the stage; the gfx replay includes all visuals including the stage.
```
>cd /data/projects/p-viz-plan
>/data/projects/habitat-sim/build/utils/viewer/viewer NONE --gfx-replay-playback-filepath "/data/projects/p-viz-plan/1.replay.json"
```
7. Look for warnings like this that indicate that model filepaths weren't resolved: `Player: load failed for asset [./orp/robots/opt_fetch/robots/../meshes/wrist_roll_link.dae]`
8. Use [ and ] keys to advance/rewind one keyframe at a time. Hold shift to advance/rewind by 60 keyframes.
9. Note that this branch doesn't currently have a "play" button for smooth realtime playback. You can hold down the ] key to approximate that. Let Eric U know if you need this, or implement it in viewer.cpp with appropriate calls to player_->getKeyframeIndex.

## Tune lighting for a scene in the C++ viewer
1. Find a scene to load into the viewer. Or, follow instructions above to play a replay in the viewer.
2a. Ensure lighting is enabled. If loading a scene, pass `--stage-requires-lighting` when launching the viewer.
2b. If playing a replay, inspect the replay JSON. For the relevant model asset, look for `"requiresLighting": true` and also `"lightSetupKey": ""`.
3. Pass a lights JSON filepath to the viewer:
`--lights-filepath "my_lights.json"`
Here's an example lights JSON file:
```
{"lights": [
  {"position": [-0.91, 2.3, 2.53, 1.0], "color_scale": 1.0, "color": [0.93, 0.98, 1]}, 
  {"position": [-0.91, 2.3, 0.9, 1.0], "color_scale": 1.0, "color": [0.93, 0.98, 1]}, 
  {"position": [-1.15, 2.5, -3.6, 1.0], "color_scale": 1, "color": [0.93, 0.98, 1]}, 
  {"position": [2.8, 4.5, 2.6, 1.0], "color_scale": 4, "color": [1, 1, 1]}, 
  {"position": [1.0, 4.5, 6.4, 1.0], "color_scale": 4, "color": [1, 1, 1]}, 
  {"position": [2.0, 4.5, 2.0, 1.0], "color_scale": 0, "color": [1, 1, 1]}, 
  {"position": [3.2, 6.5, -2.0, 1.0], "color_scale": 15, "color": [1, 1, 1]}, 
  {"position": [1.0, 4.5, -3.6, 1.0], "color_scale": -4, "color": [1, 1, 1]}   
]}
```
4. Check for a `[filepath] parse failed` message. You may hit this if the file is missing or has syntax errors.
5. Modify the lights JSON file and observe real-time lighting changes in the viewer. The file is hot-reloaded at 1Hz.
6. Here's an [old PR that discusses lighting concepts and includes screenshots](https://github.com/facebookresearch/habitat-sim/pull/792).
7. The 4th component of a light position should be 1 for a point light, or 0 for a directional light.
8. The color_scale can be negative to approximate a soft shadow, but beware this is a hack. You can easily create ugly solid-black artifacts on objects if you mis-place a negative light.

## Brighter ycb objects
See cefebe9330bfaf02a7ce8bf1d651bf6672ca2911 . This hack is based on finding "objects/ycb" substring in a GLB filepath. To get brighter ycb objects, you must be playing a gfx replay, and you must have specified `--lights-filepath`. See `viewer.cpp ycbLightColorScale_ = 4.f`. You can tune this value through the debugger, by modifying and re-building the source, or by adding keyboard controls to viewer.cpp.

## Hack disable display of bellows_link.STL in gfx replay playback
See 60b282480ba9f20af567527300b6558fe3af2ba0.
