### PR TITLE
[AO] - bugfix - BG Thread

### DIFF
--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -117,7 +117,7 @@ class Simulator(SimulatorBackend):
         self._sanitize_config(self.config)
         self.__set_from_config(self.config)
 
-    def close(self, destroy: bool = False) -> None:
+    def close(self, destroy: bool = True) -> None:
         if self.renderer is not None:
             self.renderer.acquire_gl_context()
 

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -257,13 +257,6 @@ struct Renderer::Impl {
       : context_{context}, depthShader_{nullptr}, flags_{flags} {
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);
     Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::FaceCulling);
-
-#if !defined(CORRADE_TARGET_EMSCRIPTEN)
-    if (flags & Flag::BackgroundThread) {
-      CORRADE_INTERNAL_ASSERT(context_ != nullptr);
-      backgroundRenderer_ = std::make_unique<BackgroundRenderThread>(context_);
-    }
-#endif
   }
 
   ~Impl() {
@@ -294,6 +287,12 @@ struct Renderer::Impl {
                  scene::SceneGraph& sceneGraph,
                  const Mn::MutableImageView2D& view,
                  RenderCamera::Flags flags) {
+#if !defined(CORRADE_TARGET_EMSCRIPTEN)
+    if (!backgroundRenderer_ && (flags_ & Flag::BackgroundThread)) {
+      CORRADE_INTERNAL_ASSERT(context_ != nullptr);
+      backgroundRenderer_ = std::make_unique<BackgroundRenderThread>(context_);
+    }
+#endif
     if (!backgroundRenderer_)
       Mn::Fatal{} << "Renderer was not created with a background render "
                      "thread, cannot do async drawing";

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -60,7 +60,7 @@ class Simulator {
    * is not done correctly, the pattern for @ref `close` then @ref `reconfigure`
    * to create a "fresh" instance of the simulator may not work correctly
    */
-  virtual void close(bool destroy = false);
+  virtual void close(bool destroy = true);
 
   virtual void reconfigure(const SimulatorConfiguration& cfg);
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -46,6 +46,11 @@ def powerset(iterable):
             "--no-display",
         ),
         ("examples/tutorials/semantic_id_tutorial.py", "--no-show-images"),
+        (
+            "examples/tutorial/URDF_robotics_tutorial.py",
+            "--no-make-video",
+            "--no-display",
+        ),
     ],
 )
 def test_example_modules(args):


### PR DESCRIPTION
## Motivation and Context

Update `Simulator.close( destroy )` logic (now defaults true) and wait to initialize the background rendering thread until necessary (during draw call) to avoid reconfigure bug where old context was not yet destroyed when new BG thread was initializing. 

Also added `URDF_robotics_tutorial.py` to test_examples unit test.

## How Has This Been Tested

local testing + CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
