### PR TITLE
fix for replay tutorial; add replay tutorial to test_examples.py

### DIFF
--- a/examples/tutorials/colabs/replay_tutorial.ipynb
+++ b/examples/tutorials/colabs/replay_tutorial.ipynb
@@ -205,7 +205,7 @@
     "\n",
     "cfg = make_configuration()\n",
     "sim = None\n",
-    "replay_filepath = output_path + \"replay.json\"\n",
+    "replay_filepath = \"./replay.json\"\n",
     "\n",
     "if not sim:\n",
     "    sim = habitat_sim.Simulator(cfg)\n",
@@ -384,6 +384,7 @@
    "source": [
     "\n",
     "sim.gfx_replay_manager.write_saved_keyframes_to_file(replay_filepath)\n",
+    "assert os.path.exists(replay_filepath)\n",
     "\n",
     "remove_all_objects(sim)"
    ]
@@ -657,7 +658,10 @@
     "\n",
     "# clean up the players\n",
     "for other_player in other_players:\n",
-    "    other_player.close()"
+    "    other_player.close()\n",
+    "\n",
+    "# clean up replay file\n",
+    "os.remove(replay_filepath)"
    ]
   }
  ],

--- a/examples/tutorials/colabs/replay_tutorial.ipynb
+++ b/examples/tutorials/colabs/replay_tutorial.ipynb
@@ -413,6 +413,8 @@
     "    cfg.agents,\n",
     ")\n",
     "\n",
+    "sim.close()\n",
+    "\n",
     "if not sim:\n",
     "    sim = habitat_sim.Simulator(playback_cfg)\n",
     "else:\n",
@@ -599,7 +601,10 @@
     "    )\n",
     "\n",
     "sim.remove_object(agent_viz_id)\n",
-    "sim.remove_object(sensor_viz_id)"
+    "sim.remove_object(sensor_viz_id)\n",
+    "\n",
+    "# clean up the player\n",
+    "player.close()"
    ]
   },
   {
@@ -621,10 +626,14 @@
     "\n",
     "observations = []\n",
     "num_copies = 30\n",
+    "other_players = []\n",
     "for i in range(num_copies):\n",
     "    other_player = sim.gfx_replay_manager.read_keyframes_from_file(replay_filepath)\n",
     "    assert other_player\n",
-    "    other_player.set_keyframe_index(player.get_num_keyframes() // (num_copies - 1) * i)\n",
+    "    other_player.set_keyframe_index(\n",
+    "        other_player.get_num_keyframes() // (num_copies - 1) * i\n",
+    "    )\n",
+    "    other_players.append(other_player)\n",
     "\n",
     "# place a third-person camera\n",
     "sensor_node.translation = [1.0, -0.9, -0.3]\n",
@@ -644,7 +653,11 @@
     "        \"color\",\n",
     "        output_path + \"replay_playback4\",\n",
     "        open_vid=show_video,\n",
-    "    )"
+    "    )\n",
+    "\n",
+    "# clean up the players\n",
+    "for other_player in other_players:\n",
+    "    other_player.close()"
    ]
   }
  ],

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -285,6 +285,8 @@ playback_cfg = habitat_sim.Configuration(
     cfg.agents,
 )
 
+sim.close()
+
 if not sim:
     sim = habitat_sim.Simulator(playback_cfg)
 else:
@@ -408,6 +410,9 @@ if make_video:
 sim.remove_object(agent_viz_id)
 sim.remove_object(sensor_viz_id)
 
+# clean up the player
+player.close()
+
 # %% [markdown]
 # ## Load multiple replays and create a "sequence" image.
 # In this tutorial, we only recorded one replay. In general, you can load and play multiple replays and they are rendered "additively" (all objects from all replays are visualized on top of each other). Here, let's load multiple copies of our replay and create a single image showing different snapshots in time.
@@ -415,10 +420,14 @@ sim.remove_object(sensor_viz_id)
 
 observations = []
 num_copies = 30
+other_players = []
 for i in range(num_copies):
     other_player = sim.gfx_replay_manager.read_keyframes_from_file(replay_filepath)
     assert other_player
-    other_player.set_keyframe_index(player.get_num_keyframes() // (num_copies - 1) * i)
+    other_player.set_keyframe_index(
+        other_player.get_num_keyframes() // (num_copies - 1) * i
+    )
+    other_players.append(other_player)
 
 # place a third-person camera
 sensor_node.translation = [1.0, -0.9, -0.3]
@@ -439,3 +448,7 @@ if make_video:
         output_path + "replay_playback4",
         open_vid=show_video,
     )
+
+# clean up the players
+for other_player in other_players:
+    other_player.close()

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -168,7 +168,7 @@ if make_video and not os.path.exists(output_path):
 
 cfg = make_configuration()
 sim = None
-replay_filepath = output_path + "replay.json"
+replay_filepath = "./replay.json"
 
 if not sim:
     sim = habitat_sim.Simulator(cfg)
@@ -269,6 +269,7 @@ if make_video:
 # %%
 
 sim.gfx_replay_manager.write_saved_keyframes_to_file(replay_filepath)
+assert os.path.exists(replay_filepath)
 
 remove_all_objects(sim)
 
@@ -452,3 +453,6 @@ if make_video:
 # clean up the players
 for other_player in other_players:
     other_player.close()
+
+# clean up replay file
+os.remove(replay_filepath)

--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -39,7 +39,11 @@ void initGfxReplayBindings(py::module& m) {
                                py::make_tuple(translation, rotation))
                          : py::cast<py::object>(Py_None);
           },
-          R"(Get a previously-added user transform. See also ReplayManager.add_user_transform_to_keyframe.)");
+          R"(Get a previously-added user transform. See also ReplayManager.add_user_transform_to_keyframe.)")
+
+      .def(
+          "close", &Player::close,
+          R"(Unload all keyframes. The Player is unusable after it is closed.)");
 
   py::class_<ReplayManager, ReplayManager::ptr>(m, "ReplayManager")
       .def(

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -23,8 +23,7 @@ Player::Player(const LoadAndCreateRenderAssetInstanceCallback& callback)
     : loadAndCreateRenderAssetInstanceCallback(callback) {}
 
 void Player::readKeyframesFromFile(const std::string& filepath) {
-  clearFrame();
-  keyframes_.clear();
+  close();
 
   if (!Corrade::Utility::Directory::exists(filepath)) {
     LOG(ERROR) << "Player::readKeyframesFromFile: file " << filepath
@@ -83,8 +82,16 @@ bool Player::getUserTransform(const std::string& name,
   }
 }
 
+void Player::close() {
+  clearFrame();
+  keyframes_.clear();
+}
+
 void Player::clearFrame() {
   for (const auto& pair : createdInstances_) {
+    // TODO: use NodeDeletionHelper to safely delete nodes owned by the Player.
+    // the deletion here is unsafe because a Player may persist beyond the
+    // lifetime of these nodes.
     delete pair.second;
   }
   createdInstances_.clear();

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -85,6 +85,11 @@ class Player {
                         Magnum::Quaternion* rotation) const;
 
   /**
+   * @brief Unload all keyframes.
+   */
+  void close();
+
+  /**
    * @brief Reserved for unit-testing.
    */
   void debugSetKeyframes(std::vector<Keyframe>&& keyframes) {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -45,6 +45,11 @@ def powerset(iterable):
             "--no-make-video",
             "--no-display",
         ),
+        (
+            "examples/tutorials/nb_python/replay_tutorial.py",
+            "--no-show-video",
+            "--no-make-video",
+        ),
         ("examples/tutorials/semantic_id_tutorial.py", "--no-show-images"),
     ],
 )


### PR DESCRIPTION
## Motivation and Context

A recent change to replay::Player cleanup logic broke the visual output of this replay (replay video #4).

I've also added this tutorial to test_examples.py to catch regressions.

On doing this, I encountered a crash during shutdown which I avoid here by explicitly closing Players before closing the sim. I also added a TODO for a better long-term fix.

## How Has This Been Tested

I added replay tutorial to test_examples.py. I ran this test locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
