### PR TITLE
--Refactor : Change pragma once to full header guard

### DIFF
--- a/src/esp/bindings/OpaqueTypes.h
+++ b/src/esp/bindings/OpaqueTypes.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_BINDINGS_OPAQUETYPES_H_
+#define ESP_BINDINGS_OPAQUETYPES_H_
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -17,3 +18,5 @@
 
 PYBIND11_MAKE_OPAQUE(std::map<std::string, std::string>);
 PYBIND11_MAKE_OPAQUE(std::vector<esp::nav::GreedyGeodesicFollowerImpl::CODES>);
+
+#endif  //  ESP_BINDINGS_OPAQUETYPES_H_

--- a/src/esp/core/configure.h.cmake
+++ b/src/esp/core/configure.h.cmake
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_CORE_CONFIGURE_H_
+#define ESP_CORE_CONFIGURE_H_
 
 #cmakedefine ESP_BUILD_ASSIMP_SUPPORT
 
@@ -17,3 +18,5 @@
 #cmakedefine ESP_BUILD_WITH_BULLET
 
 #cmakedefine ESP_BUILD_WITH_VHACD
+
+#endif //  ESP_CORE_CONFIGURE_H_

--- a/src/esp/geo/CoordinateFrame.h
+++ b/src/esp/geo/CoordinateFrame.h
@@ -2,7 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GEO_COORDINATEFRAME_H_
+#define ESP_GEO_COORDINATEFRAME_H_
 
 #include "esp/core/esp.h"
 #include "esp/geo/geo.h"
@@ -70,3 +71,5 @@ inline std::ostream& operator<<(std::ostream& os, const CoordinateFrame& c) {
 
 }  // namespace geo
 }  // namespace esp
+
+#endif  // ESP_GEO_COORDINATEFRAME_H_

--- a/src/esp/gfx/MaterialUtil.h
+++ b/src/esp/gfx/MaterialUtil.h
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
+#ifndef ESP_GFX_MATERIALUTIL_H_
+#define ESP_GFX_MATERIALUTIL_H_
 
 #include <Magnum/Trade/Trade.h>
 #include "esp/gfx/MaterialData.h"
@@ -31,3 +32,5 @@ gfx::PhongMaterialData::uptr buildPhongFromPbrMetallicRoughness(
 
 }  // namespace gfx
 }  // namespace esp
+
+#endif  // ESP_GFX_MATERIALUTIL_H_

--- a/src/esp/gfx/cuda_helpers/helper_cuda.h
+++ b/src/esp/gfx/cuda_helpers/helper_cuda.h
@@ -12,10 +12,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 // These are CUDA Helper functions for initialization and error checking
 
-#ifndef HELPER_CUDA_H
-#define HELPER_CUDA_H
-
-#pragma once
+#ifndef ESP_GFX_CUDA_HELPERS_HELPER_CUDA_H
+#define ESP_GFX_CUDA_HELPERS_HELPER_CUDA_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1221,4 +1219,4 @@ inline bool checkCudaCapabilities(int major_version, int minor_version) {
 
 // end of CUDA Helper Functions
 
-#endif
+#endif  // ESP_GFX_CUDA_HELPERS_HELPER_

--- a/src/esp/gfx/cuda_helpers/helper_string.h
+++ b/src/esp/gfx/cuda_helpers/helper_string.h
@@ -10,8 +10,8 @@
  */
 
 // These are helper functions for the SDK samples (string parsing, timers, etc)
-#ifndef STRING_HELPER_H
-#define STRING_HELPER_H
+#ifndef ESP_GFX_CUDA_HELPERS_HELPER_STRING_H
+#define ESP_GFX_CUDA_HELPERS_HELPER_STRING_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -687,4 +687,4 @@ inline char* sdkFindFilePath(const char* filename,
   return 0;
 }
 
-#endif
+#endif  // ESP_GFX_CUDA_HELPERS_HELPER_STRING_H


### PR DESCRIPTION
## Motivation and Context
We decided with [PR 806 to make Habitat-Sim c++ headers use #defines, as per google c++ code guidelines](https://github.com/facebookresearch/habitat-sim/pull/806).  This PR refactors a few pragmas that got missed, or introduced, since then.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
all c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
