### PR TITLE
Support for shader_type specification in stage and object configurations - Part 1 of 2

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -179,7 +179,7 @@ void ResourceManager::initPhysicsManager(
 }  // ResourceManager::initPhysicsManager
 
 bool ResourceManager::loadStage(
-    const StageAttributes::ptr& stageAttributes,
+    StageAttributes::ptr& stageAttributes,
     const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
     esp::scene::SceneManager* sceneManagerPtr,
     std::vector<int>& activeSceneIDs,
@@ -326,8 +326,7 @@ bool ResourceManager::loadStage(
     // Either add with pre-built meshGroup if collision assets are loaded
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
-    bool sceneSuccess =
-        _physicsManager->addStage(stageAttributes->getHandle(), meshGroup);
+    bool sceneSuccess = _physicsManager->addStage(stageAttributes, meshGroup);
     if (!sceneSuccess) {
       LOG(ERROR) << "ResourceManager::loadStage : Adding Stage "
                  << stageAttributes->getHandle()
@@ -1783,10 +1782,8 @@ void ResourceManager::loadTextures(Importer& importer,
 }  // ResourceManager::loadTextures
 
 bool ResourceManager::instantiateAssetsOnDemand(
-    const std::string& objectTemplateHandle) {
-  // Meta data
-  ObjectAttributes::ptr ObjectAttributes =
-      getObjectAttributesManager()->getObjectByHandle(objectTemplateHandle);
+    const metadata::attributes::ObjectAttributes::ptr& ObjectAttributes) {
+  const std::string& objectTemplateHandle = ObjectAttributes->getHandle();
 
   if (!ObjectAttributes) {
     return false;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1785,11 +1785,10 @@ void ResourceManager::loadTextures(Importer& importer,
 
 bool ResourceManager::instantiateAssetsOnDemand(
     const metadata::attributes::ObjectAttributes::ptr& objectAttributes) {
-  const std::string& objectTemplateHandle = objectAttributes->getHandle();
-
-  if (!ObjectAttributes) {
+  if (!objectAttributes) {
     return false;
   }
+  const std::string& objectTemplateHandle = objectAttributes->getHandle();
 
   // if attributes are "dirty" (important values have changed since last
   // registered) then re-register.  Should never return ID_UNDEFINED - this

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2251,8 +2251,17 @@ void ResourceManager::createConvexHullDecomposition(
     const VHACDParameters& params,
     const bool saveChdToObj) {
   if (resourceDict_.count(filename) == 0) {
+    // retrieve existing, or create new, object attributes corresponding to
+    // passed filename
+    auto objAttributes =
+        getObjectAttributesManager()->getObjectCopyByHandle(filename);
+    if (objAttributes == nullptr) {
+      objAttributes =
+          getObjectAttributesManager()->createObject(filename, false);
+    }
+
     // load/check for render MeshMetaData and load assets
-    loadObjectMeshDataFromFile(filename, filename, "render", true);
+    loadObjectMeshDataFromFile(filename, objAttributes, "render", true);
 
   }  // if no render asset exists
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -184,7 +184,7 @@ class ResourceManager {
    * @return Whether or not the scene load succeeded.
    */
   bool loadStage(
-      const metadata::attributes::StageAttributes::ptr& sceneAttributes,
+      metadata::attributes::StageAttributes::ptr& sceneAttributes,
       const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
       esp::scene::SceneManager* sceneManagerPtr,
       std::vector<int>& activeSceneIDs,
@@ -209,12 +209,14 @@ class ResourceManager {
    * collisionMeshGroups_, respectively. Assumes valid render and collisions
    * asset handles have been specified (This is checked/verified during
    * registration.)
-   * @param objTemplateHandle The key for referencing the template in the
-   * @ref esp::metadata::managers::ObjectAttributesManager::objectLibrary_.
+   * @param ObjectAttributes The object template describing the object we wish
+   * to instantiate, copied from an entry in @ref
+   * esp::metadata::managers::ObjectAttributesManager::objectLibrary_.
    * @return whether process succeeded or not - only currently fails if
    * registration call fails.
    */
-  bool instantiateAssetsOnDemand(const std::string& objTemplateHandle);
+  bool instantiateAssetsOnDemand(
+      const metadata::attributes::ObjectAttributes::ptr& ObjectAttributes);
 
   //======== Accessor functions ========
   /**

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -581,20 +581,21 @@ class ResourceManager {
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
-   * specified @ref meshType used by @ref objectTemplateHandle
+   * specified @p assetType used by object described by @p objectAttributes
    *
    * @param filename the name of the file describing this mesh
-   * @param objectTemplateHandle the handle for the object attributes owning
-   * this mesh (for error log output)
-   * @param meshType either "render" or "collision" (for error log output)
+   * @param objectAttributes the object attributes owning
+   * this mesh.
+   * @param assetType either "render" or "collision" (for error log output)
    * @param requiresLighting whether or not this mesh asset responds to
    * lighting
    * @return whether or not the mesh was loaded successfully
    */
-  bool loadObjectMeshDataFromFile(const std::string& filename,
-                                  const std::string& objectTemplateHandle,
-                                  const std::string& meshType,
-                                  const bool requiresLighting);
+  bool loadObjectMeshDataFromFile(
+      const std::string& filename,
+      const metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      const std::string& meshType,
+      const bool requiresLighting);
 
   /**
    * @brief Build a primitive asset based on passed template parameters.  If

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -129,6 +129,10 @@ void initAttributesBindings(py::module& m) {
           R"(Handle of the asset used to calculate collsions for constructions
           built from this template.)")
       .def_property(
+          "shader_type", &AbstractObjectAttributes::getShaderType,
+          &AbstractObjectAttributes::setShaderType,
+          R"(The shader type [0=flat, 1=phong, 2=pbr] to use for this construction)")
+      .def_property(
           "requires_lighting", &AbstractObjectAttributes::getRequiresLighting,
           &AbstractObjectAttributes::setRequiresLighting,
           R"(Whether constructions built from this template should use phong

--- a/src/esp/core/ManagedContainer.h
+++ b/src/esp/core/ManagedContainer.h
@@ -117,10 +117,10 @@ class ManagedContainer : public ManagedContainerBase {
     io::JsonDocument docConfig = nullptr;
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
-      LOG(ERROR) << "ManagedContainer::createObjectFromFile ("
-                 << this->objectType_
-                 << ") : Failure reading document as JSON : " << filename
-                 << ". Aborting.";
+      !Cr::Utility::Error{}
+          << "ManagedContainer::createObjectFromFile (" << this->objectType_
+          << ") : Failure reading document as JSON : " << filename
+          << ". Aborting.";
       return nullptr;
     }
     // convert doc to const value
@@ -141,7 +141,7 @@ class ManagedContainer : public ManagedContainerBase {
   template <typename U>
   ManagedPtr buildManagedObjectFromDoc(const std::string& filename,
                                        CORRADE_UNUSED const U& config) {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "ManagedContainer::buildManagedObjectFromDoc (" << this->objectType_
         << ") : Failure loading attributes from document of unknown type : "
         << filename << ". Aborting.";
@@ -188,8 +188,9 @@ class ManagedContainer : public ManagedContainerBase {
                      const std::string& objectHandle = "",
                      bool forceRegistration = false) {
     if (nullptr == managedObject) {
-      LOG(ERROR) << "ManagedContainer::registerObject : Invalid "
-                    "(null) managed object passed to registration. Aborting.";
+      !Cr::Utility::Error{}
+          << "ManagedContainer::registerObject : Invalid "
+             "(null) managed object passed to registration. Aborting.";
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
@@ -198,9 +199,10 @@ class ManagedContainer : public ManagedContainerBase {
     }
     std::string handleToSet = managedObject->getHandle();
     if ("" == handleToSet) {
-      LOG(ERROR) << "ManagedContainer::registerObject : No "
-                    "valid handle specified for "
-                 << objectType_ << " managed object to register. Aborting.";
+      !Cr::Utility::Error{} << "ManagedContainer::registerObject : No "
+                               "valid handle specified for "
+                            << objectType_
+                            << " managed object to register. Aborting.";
       return ID_UNDEFINED;
     }
     return registerObjectFinalize(managedObject, handleToSet,
@@ -579,9 +581,10 @@ class ManagedContainer : public ManagedContainerBase {
       return getObjectInternal<T>(objectHandle)->getID();
     } else {
       if (!getNext) {
-        LOG(ERROR) << "ManagedContainer::getObjectIDByHandleOrNew : No "
-                   << objectType_ << " managed object with handle "
-                   << objectHandle << "exists. Aborting";
+        !Cr::Utility::Error{}
+            << "ManagedContainer::getObjectIDByHandleOrNew : No " << objectType_
+            << " managed object with handle " << objectHandle
+            << "exists. Aborting";
         return ID_UNDEFINED;
       } else {
         return getUnusedObjectID();
@@ -733,8 +736,9 @@ auto ManagedContainer<T, Access>::removeObjectInternal(
     const std::string& objectHandle,
     const std::string& sourceStr) -> ManagedPtr {
   if (!checkExistsWithMessage(objectHandle, sourceStr)) {
-    LOG(INFO) << sourceStr << " : Unable to remove " << objectType_
-              << " managed object " << objectHandle << " : Does not exist.";
+    !Cr::Utility::Debug{} << sourceStr << " : Unable to remove " << objectType_
+                          << " managed object " << objectHandle
+                          << " : Does not exist.";
     return nullptr;
   }
   std::string msg;
@@ -744,8 +748,9 @@ auto ManagedContainer<T, Access>::removeObjectInternal(
     msg = "User-locked Object.  To delete managed object, unlock it";
   }
   if (msg.length() != 0) {
-    LOG(INFO) << sourceStr << " : Unable to remove " << objectType_
-              << " managed object " << objectHandle << " : " << msg << ".";
+    !Cr::Utility::Debug{} << sourceStr << " : Unable to remove " << objectType_
+                          << " managed object " << objectHandle << " : " << msg
+                          << ".";
     return nullptr;
   }
 

--- a/src/esp/core/ManagedContainerBase.cpp
+++ b/src/esp/core/ManagedContainerBase.cpp
@@ -16,13 +16,14 @@ std::string ManagedContainerBase::convertFilenameToJSON(
       strHandle.find(Cr::Utility::String::lowercase(jsonTypeExt))) {
     resHandle = Cr::Utility::Directory::splitExtension(filename).first + "." +
                 jsonTypeExt;
-    LOG(INFO) << "ManagedContainerBase::convertFilenameToJSON : Filename : "
-              << filename
-              << " changed to proposed JSON configuration filename : "
-              << resHandle;
+    !Cr::Utility::Debug{}
+        << "ManagedContainerBase::convertFilenameToJSON : Filename : "
+        << filename
+        << " changed to proposed JSON configuration filename : " << resHandle;
   } else {
-    LOG(INFO) << "ManagedContainerBase::convertFilenameToJSON : Filename : "
-              << filename << " is appropriate JSON configuration filename.";
+    !Cr::Utility::Debug{}
+        << "ManagedContainerBase::convertFilenameToJSON : Filename : "
+        << filename << " is appropriate JSON configuration filename.";
   }
   return resHandle;
 }  // ManagedContainerBase::convertFilenameToJSON
@@ -47,8 +48,9 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
     const std::string& type) const {
   std::size_t numVals = mapOfHandles.size();
   if (numVals == 0) {
-    LOG(ERROR) << "Attempting to get a random " << type << objectType_
-               << " managed object handle but none are loaded; Aboring";
+    !Cr::Utility::Error{}
+        << "Attempting to get a random " << type << objectType_
+        << " managed object handle but none are loaded; Aboring";
     return "";
   }
   int randIDX = rand() % numVals;
@@ -150,7 +152,7 @@ bool ManagedContainerBase::verifyLoadDocument(const std::string& filename,
     try {
       jsonDoc = io::parseJsonFile(filename);
     } catch (...) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << objectType_
           << "ManagedContainerBase::verifyLoadDocument : Failed to parse "
           << filename << " as JSON.";
@@ -159,9 +161,9 @@ bool ManagedContainerBase::verifyLoadDocument(const std::string& filename,
     return true;
   } else {
     // by here always fail
-    LOG(ERROR) << objectType_
-               << "ManagedContainerBase::verifyLoadDocument : File " << filename
-               << " does not exist";
+    !Cr::Utility::Error{} << objectType_
+                          << "ManagedContainerBase::verifyLoadDocument : File "
+                          << filename << " does not exist";
     return false;
   }
 }  // ManagedContainerBase::verifyLoadDocument

--- a/src/esp/core/ManagedContainerBase.h
+++ b/src/esp/core/ManagedContainerBase.h
@@ -237,9 +237,9 @@ class ManagedContainerBase {
   bool verifyLoadDocument(const std::string& filename,
                           CORRADE_UNUSED U& resDoc) {
     // by here always fail
-    LOG(ERROR) << objectType_
-               << "ManagedContainerBase::verifyLoadDocument : File " << filename
-               << " failed due to unknown file type.";
+    !Cr::Utility::Error{} << objectType_
+                          << "ManagedContainerBase::verifyLoadDocument : File "
+                          << filename << " failed due to unknown file type.";
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
   /**
@@ -285,8 +285,9 @@ class ManagedContainerBase {
   bool checkExistsWithMessage(const std::string& objectHandle,
                               const std::string& src) const {
     if (!getObjectLibHasHandle(objectHandle)) {
-      LOG(ERROR) << src << " : Unknown " << objectType_
-                 << " managed object handle :" << objectHandle << ". Aborting";
+      !Cr::Utility::Error{} << src << " : Unknown " << objectType_
+                            << " managed object handle :" << objectHandle
+                            << ". Aborting";
       return false;
     }
     return true;

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -35,6 +35,8 @@ set(
   managers/StageAttributesManager.cpp
   MetadataMediator.h
   MetadataMediator.cpp
+  MetadataUtils.h
+  MetadataUtils.cpp
 )
 find_package(Magnum REQUIRED Primitives)
 

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -37,9 +37,10 @@ bool MetadataMediator::setSimulatorConfiguration(
   bool success = setActiveSceneDatasetName(simConfig_.sceneDatasetConfigFile);
   if (!success) {
     // something failed about setting up active scene dataset
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : Some error "
-                  "prevented current scene dataset name to be changed to "
-               << simConfig_.sceneDatasetConfigFile;
+    !Cr::Utility::Error{}
+        << "MetadataMediator::setSimulatorConfiguration : Some error "
+           "prevented current scene dataset name to be changed to "
+        << simConfig_.sceneDatasetConfigFile;
     return false;
   }
 
@@ -47,9 +48,10 @@ bool MetadataMediator::setSimulatorConfiguration(
   success = setCurrPhysicsAttributesHandle(simConfig_.physicsConfigFile);
   if (!success) {
     // something failed about setting up physics attributes
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : Some error "
-                  "prevented current physics attributes to "
-               << simConfig_.physicsConfigFile;
+    !Cr::Utility::Error{}
+        << "MetadataMediator::setSimulatorConfiguration : Some error "
+           "prevented current physics attributes to "
+        << simConfig_.physicsConfigFile;
     return false;
   }
 
@@ -60,19 +62,19 @@ bool MetadataMediator::setSimulatorConfiguration(
     datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetup,
                                 simConfig_.frustumCulling);
   } else {
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : No active "
-                  "dataset exists or has been specified. Aborting";
+    !Cr::Utility::Error{}
+        << "MetadataMediator::setSimulatorConfiguration : No active "
+           "dataset exists or has been specified. Aborting";
     return false;
   }
-  LOG(INFO) << "MetadataMediator::setSimulatorConfiguration : Set new "
-               "simulator config for scene/stage : "
-            << simConfig_.activeSceneName
-            << " and dataset : " << simConfig_.sceneDatasetConfigFile
-            << " which "
-            << (activeSceneDataset_.compare(
-                    simConfig_.sceneDatasetConfigFile) == 0
-                    ? "is currently active dataset."
-                    : "is NOT active dataset (THIS IS PROBABLY AN ERROR.)");
+  !Cr::Utility::Debug{}
+      << "MetadataMediator::setSimulatorConfiguration : Set new "
+         "simulator config for scene/stage : "
+      << simConfig_.activeSceneName
+      << " and dataset : " << simConfig_.sceneDatasetConfigFile << " which "
+      << (activeSceneDataset_.compare(simConfig_.sceneDatasetConfigFile) == 0
+              ? "is currently active dataset."
+              : "is NOT active dataset (THIS IS PROBABLY AN ERROR.)");
   return true;
 }  // MetadataMediator::setSimulatorConfiguration
 
@@ -86,7 +88,7 @@ bool MetadataMediator::createPhysicsManagerAttributes(
 
     if (physAttrs == nullptr) {
       // something failed during creation process.
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "MetadataMediator::createPhysicsManagerAttributes : Unknown  "
              "physics manager configuration file : "
           << _physicsManagerAttributesPath
@@ -105,10 +107,11 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
-      LOG(WARNING) << "MetadataMediator::createSceneDataset : Scene Dataset "
-                   << sceneDatasetName
-                   << " already exists.  To reload and overwrite existing "
-                      "data, set overwrite to true. Aborting.";
+      !Cr::Utility::Warning{}
+          << "MetadataMediator::createSceneDataset : Scene Dataset "
+          << sceneDatasetName
+          << " already exists.  To reload and overwrite existing "
+             "data, set overwrite to true. Aborting.";
       return false;
     }
     // overwrite specified, make sure not locked
@@ -119,14 +122,15 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
       sceneDatasetAttributesManager_->createObject(sceneDatasetName, true);
   if (datasetAttribs == nullptr) {
     // not created, do not set name
-    LOG(WARNING) << "MetadataMediator::createSceneDataset : Unknown dataset "
-                 << sceneDatasetName
-                 << " does not exist and is not able to be created.  Aborting.";
+    !Cr::Utility::Warning{}
+        << "MetadataMediator::createSceneDataset : Unknown dataset "
+        << sceneDatasetName
+        << " does not exist and is not able to be created.  Aborting.";
     return false;
   }
   // if not null then successfully created
-  LOG(INFO) << "MetadataMediator::createSceneDataset : Dataset "
-            << sceneDatasetName << " successfully created.";
+  !Cr::Utility::Debug{} << "MetadataMediator::createSceneDataset : Dataset "
+                        << sceneDatasetName << " successfully created.";
   // lock dataset to prevent accidental deletion
   sceneDatasetAttributesManager_->setLock(sceneDatasetName, true);
   return true;
@@ -137,7 +141,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   if (!sceneDatasetAttributesManager_->getObjectLibHasHandle(
           sceneDatasetName)) {
     // DNE, do nothing
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
         << sceneDatasetName << " does not exist. Aborting.";
     return false;
@@ -145,10 +149,10 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
 
   // Next check if is current activeSceneDataset_, and if so skip with warning
   if (sceneDatasetName.compare(activeSceneDataset_)) {
-    LOG(WARNING) << "MetadataMediator::removeSceneDataset : Cannot remove "
-                    "active SceneDatasetAttributes "
-                 << sceneDatasetName
-                 << ".  Switch to another dataset before removing.";
+    !Cr::Utility::Warning{}
+        << "MetadataMediator::removeSceneDataset : Cannot remove "
+           "active SceneDatasetAttributes "
+        << sceneDatasetName << ".  Switch to another dataset before removing.";
     return false;
   }
 
@@ -160,7 +164,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // if failed here, probably means SceneDatasetAttributes was set to
   // undeletable, return message and false
   if (delDataset == nullptr) {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
         << sceneDatasetName << " unable to be deleted. Aborting.";
     return false;
@@ -171,8 +175,9 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     // dataset.
     createSceneDataset("default");
   }
-  LOG(INFO) << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
-            << sceneDatasetName << " successfully removed.";
+  !Cr::Utility::Debug{}
+      << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
+      << sceneDatasetName << " successfully removed.";
   return true;
 
 }  // MetadataMediator::removeSceneDataset
@@ -184,10 +189,11 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
           _physicsManagerAttributesPath)) {
     if (currPhysicsManagerAttributes_.compare(_physicsManagerAttributesPath) !=
         0) {
-      LOG(INFO) << "MetadataMediator::setCurrPhysicsAttributesHandle : Old "
-                   "physics manager attributes "
-                << currPhysicsManagerAttributes_ << " changed to "
-                << _physicsManagerAttributesPath << " successfully.";
+      !Cr::Utility::Debug{}
+          << "MetadataMediator::setCurrPhysicsAttributesHandle : Old "
+             "physics manager attributes "
+          << currPhysicsManagerAttributes_ << " changed to "
+          << _physicsManagerAttributesPath << " successfully.";
       currPhysicsManagerAttributes_ = _physicsManagerAttributesPath;
     }
     sceneDatasetAttributesManager_->setCurrPhysicsManagerAttributesHandle(
@@ -213,7 +219,7 @@ bool MetadataMediator::setActiveSceneDatasetName(
   // first check if dataset exists/is loaded, if so then set as default
   if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName)) {
     if (activeSceneDataset_.compare(sceneDatasetName) != 0) {
-      LOG(INFO)
+      !Cr::Utility::Debug{}
           << "MetadataMediator::setActiveSceneDatasetName : Old active dataset "
           << activeSceneDataset_ << " changed to " << sceneDatasetName
           << " successfully.";
@@ -222,19 +228,20 @@ bool MetadataMediator::setActiveSceneDatasetName(
     return true;
   }
   // if does not exist, attempt to create it
-  LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Attempting to "
-               "create new dataset "
-            << sceneDatasetName;
+  !Cr::Utility::Debug{}
+      << "MetadataMediator::setActiveSceneDatasetName : Attempting to "
+         "create new dataset "
+      << sceneDatasetName;
   bool success = createSceneDataset(sceneDatasetName);
   // if successfully created, set default name to access dataset attributes in
   // SceneDatasetAttributesManager
   if (success) {
     activeSceneDataset_ = sceneDatasetName;
   }
-  LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Attempt to "
-               "create new dataset "
-            << sceneDatasetName << " "
-            << (success ? " succeeded." : " failed.");
+  !Cr::Utility::Debug{}
+      << "MetadataMediator::setActiveSceneDatasetName : Attempt to "
+         "create new dataset "
+      << sceneDatasetName << " " << (success ? " succeeded." : " failed.");
   return success;
 }  // MetadataMediator::setActiveSceneDatasetName
 
@@ -244,8 +251,9 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // this should never happen
   if (datasetAttr == nullptr) {
-    LOG(ERROR) << "MetadataMediator::getSceneAttributesByName : No dataset "
-                  "specified/exists.";
+    !Cr::Utility::Error{}
+        << "MetadataMediator::getSceneAttributesByName : No dataset "
+           "specified/exists.";
     return nullptr;
   }
   // directory to look for attributes for this dataset
@@ -263,11 +271,11 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   if (sceneList.size() > 0) {
     // 1.  Existing, registered SceneAttributes in current active dataset.
     //    In this case the SceneAttributes is returned.
-    LOG(INFO) << "MetadataMediator::getSceneAttributesByName : Query dataset : "
-              << activeSceneDataset_
-              << " for SceneAttributes named : " << sceneName << " yields "
-              << sceneList.size() << " candidates.  Using " << sceneList[0]
-              << ".";
+    !Cr::Utility::Debug{}
+        << "MetadataMediator::getSceneAttributesByName : Query dataset : "
+        << activeSceneDataset_ << " for SceneAttributes named : " << sceneName
+        << " yields " << sceneList.size() << " candidates.  Using "
+        << sceneList[0] << ".";
     sceneAttributes = dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
   } else {
     const std::string sceneFilenameCandidate =
@@ -277,13 +285,13 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
       // 2.  Existing, valid SceneAttributes file on disk, but not in dataset.
       //    If this is the case, then the SceneAttributes should be loaded,
       //    registered, added to the dataset and returned.
-      LOG(INFO) << "MetadataMediator::getSceneAttributesByName : Dataset : "
-                << activeSceneDataset_
-                << " does not reference a SceneAttributes named  " << sceneName
-                << " but a SceneAttributes config named "
-                << sceneFilenameCandidate
-                << " was found on disk, so "
-                   "loading.";
+      !Cr::Utility::Debug{}
+          << "MetadataMediator::getSceneAttributesByName : Dataset : "
+          << activeSceneDataset_
+          << " does not reference a SceneAttributes named  " << sceneName
+          << " but a SceneAttributes config named " << sceneFilenameCandidate
+          << " was found on disk, so "
+             "loading.";
       sceneAttributes = dsSceneAttrMgr->createObjectFromJSONFile(
           sceneFilenameCandidate, true);
     } else {
@@ -295,13 +303,14 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         //    In this case, a SceneAttributes is created amd registered using
         //    sceneName, referencing the StageAttributes of the same name; This
         //    sceneAttributes is returned.
-        LOG(INFO) << "MetadataMediator::getSceneAttributesByName : No existing "
-                     "scene instance attributes containing name "
-                  << sceneName << " found in Dataset : " << activeSceneDataset_
-                  << " but " << stageList.size()
-                  << " StageAttributes found.  Using " << stageList[0]
-                  << " as stage and to construct a SceneAttributes with same "
-                     "name that will be added to Dataset.";
+        !Cr::Utility::Debug{}
+            << "MetadataMediator::getSceneAttributesByName : No existing "
+               "scene instance attributes containing name "
+            << sceneName << " found in Dataset : " << activeSceneDataset_
+            << " but " << stageList.size() << " StageAttributes found.  Using "
+            << stageList[0]
+            << " as stage and to construct a SceneAttributes with same "
+               "name that will be added to Dataset.";
         // create a new SceneAttributes, and give it a
         // SceneObjectInstanceAttributes for the stage with the same name.
         sceneAttributes = makeSceneAndReferenceStage(
@@ -312,7 +321,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         // 4.  Existing stage config/asset on disk, but not in current dataset.
         //    In this case, a stage attributes is loaded and registered, then
         //    added to current dataset, and then 3. is performed.
-        LOG(INFO)
+        !Cr::Utility::Debug{}
             << "MetadataMediator::getSceneAttributesByName : Dataset : "
             << activeSceneDataset_
             << " has no preloaded SceneAttributes or StageAttributes named : "

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -212,7 +212,7 @@ class MetadataMediator {
   const std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     if (datasetAttr == nullptr) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "MetadataMediator::getNavmeshPathByHandle : No active "
              "dataset has been specified so unable to determine path for "
           << navMeshHandle;
@@ -249,7 +249,7 @@ class MetadataMediator {
       const std::string& ssDescrHandle) {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     if (datasetAttr == nullptr) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "MetadataMediator::getSemanticSceneDescriptorPathByHandle : No "
              "active dataset has been specified so unable to determine path "
              "for "
@@ -292,9 +292,10 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedStageAttributesCopy : No "
-                    "current active dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
+      !Cr::Utility::Error{}
+          << "MetadataMediator::getNamedStageAttributesCopy : No "
+             "current active dataset specified/exists named :"
+          << activeSceneDataset_ << ".";
       return nullptr;
     }
     return datasetAttr->getNamedStageAttributesCopy(stageAttrName);
@@ -315,9 +316,10 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedObjectAttributesCopy : No "
-                    "current active dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
+      !Cr::Utility::Error{}
+          << "MetadataMediator::getNamedObjectAttributesCopy : No "
+             "current active dataset specified/exists named :"
+          << activeSceneDataset_ << ".";
       return nullptr;
     }
     return datasetAttr->getNamedObjectAttributesCopy(objAttrName);
@@ -336,9 +338,10 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedLightSetup : No current active "
-                    "dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
+      !Cr::Utility::Error{}
+          << "MetadataMediator::getNamedLightSetup : No current active "
+             "dataset specified/exists named :"
+          << activeSceneDataset_ << ".";
       return esp::gfx::LightSetup{};
     }
     return datasetAttr->getNamedLightSetup(lightSetupName);
@@ -359,7 +362,7 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "MetadataMediator::getStageAttrFullHandle : No current active "
              "dataset specified/exists named :"
           << activeSceneDataset_ << ".";
@@ -383,7 +386,7 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "MetadataMediator::getObjAttrFullHandle : No current active "
              "dataset specified/exists named :"
           << activeSceneDataset_ << ".";
@@ -405,7 +408,7 @@ class MetadataMediator {
     attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
     // this should never happen
     if (datasetAttr == nullptr) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "MetadataMediator::getLightSetupFullHandle : No current active "
              "dataset specified/exists named :"
           << activeSceneDataset_ << ".";
@@ -440,8 +443,9 @@ class MetadataMediator {
       const std::map<std::string, std::string>& assetMapping,
       const std::string& msgString) {
     if (assetMapping.count(assetHandle) == 0) {
-      LOG(WARNING) << msgString << " (getAsset) : Unable to find file path for "
-                   << assetHandle << ".  Aborting.";
+      !Cr::Utility::Warning{} << msgString
+                              << " (getAsset) : Unable to find file path for "
+                              << assetHandle << ".  Aborting.";
       return "";
     }
     return assetMapping.at(assetHandle);
@@ -487,9 +491,10 @@ class MetadataMediator {
     auto datasetAttr =
         sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
     if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getActiveDSAttribs : Unable to set "
-                    "active dataset due to Unknown dataset named "
-                 << activeSceneDataset_ << ". Aborting";
+      !Cr::Utility::Error{}
+          << "MetadataMediator::getActiveDSAttribs : Unable to set "
+             "active dataset due to Unknown dataset named "
+          << activeSceneDataset_ << ". Aborting";
       return nullptr;
     }
     return datasetAttr;

--- a/src/esp/metadata/MetadataUtils.cpp
+++ b/src/esp/metadata/MetadataUtils.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "MetadataUtils.h"
+
+#include <Corrade/Utility/String.h>
+
+#include "esp/io/io.h"
+#include "esp/metadata/attributes/ObjectAttributes.h"
+
+namespace esp {
+namespace metadata {
+namespace attributes {
+enum class ObjectInstanceShaderType;
+}
+namespace Cr = Corrade;
+
+int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc) {
+  // Check for shader type to use.  Default to unknown.
+  int shader_type =
+      static_cast<int>(attributes::ObjectInstanceShaderType::Unknown);
+  std::string tmpShaderType = "";
+  if (io::readMember<std::string>(jsonDoc, "shader_type", tmpShaderType)) {
+    // shader_type tag was found, perform check - first convert to
+    // lowercase
+    std::string strToLookFor = Cr::Utility::String::lowercase(tmpShaderType);
+    auto found = attributes::AbstractObjectAttributes::ShaderTypeNamesMap.find(
+        strToLookFor);
+    if (found !=
+        attributes::AbstractObjectAttributes::ShaderTypeNamesMap.end()) {
+      shader_type = static_cast<int>(found->second);
+    } else {
+      LOG(WARNING) << "getShaderTypeFromJsonDoc : "
+                      "motion_type value in json  : `"
+                   << tmpShaderType << "|" << strToLookFor
+                   << "` does not map to a valid "
+                      "SceneInstanceTranslationOrigin value, so defaulting "
+                      "motion type to SceneInstanceTranslationOrigin::Unknown.";
+    }
+  }
+  return shader_type;
+}  // getShaderTypeFromJsonDoc
+
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/MetadataUtils.h
+++ b/src/esp/metadata/MetadataUtils.h
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_METADATA_METADATAUTILS_H_
+#define ESP_METADATA_METADATAUTILS_H_
+
+#include "esp/io/json.h"
+
+namespace esp {
+namespace metadata {
+
+/**
+ * @brief This function is accessed by object and stage attributes loading, as
+ * well as scene instance loading.  This function will process data held in a
+ * json doc with the tag "shader_type", and return the int value found, or the
+ * int value of @ref
+ * esp::metadata::attributes::ObjectInstanceShaderType::Unknown if no data
+ * found.
+ * @param jsonDoc The json document to query for the tag of interest
+ * @return The shader type specified in the document, or Unknown, casted to an
+ * int.
+ */
+int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc);
+
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_METADATAUTILS_H_

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -16,6 +16,15 @@ const std::map<std::string, esp::assets::AssetType>
         {"semantic", esp::assets::AssetType::INSTANCE_MESH},
         {"suncg", esp::assets::AssetType::SUNCG_SCENE},
 };
+
+// All keys must be lowercase
+const std::map<std::string, ObjectInstanceShaderType>
+    AbstractObjectAttributes::ShaderTypeNamesMap = {
+        {"flat", ObjectInstanceShaderType::Flat},
+        {"phong", ObjectInstanceShaderType::Phong},
+        {"pbr", ObjectInstanceShaderType::PBR},
+};
+
 AbstractObjectAttributes::AbstractObjectAttributes(
     const std::string& attributesClassKey,
     const std::string& handle)
@@ -53,6 +62,9 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);
+  // default to unknown for objects
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+  // TODO remove this once ShaderType support is complete
   setRequiresLighting(true);
   setIsVisible(true);
   setSemanticId(0);
@@ -62,7 +74,9 @@ StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
-
+  // default to unknown for stages
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+  // TODO remove this once ShaderType support is complete
   setRequiresLighting(false);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh
   setCollisionAssetType(0);

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -14,6 +14,31 @@ namespace metadata {
 namespace attributes {
 
 /**
+ * @brief This enum class defines the possible shader options for rendering
+ * instances of objects or stages in Habitat-sim.
+ */
+enum class ObjectInstanceShaderType {
+  /**
+   * Represents an unknown/unspecified value for the shader type to use. Resort
+   * to defaults for object type.
+   */
+  Unknown = -1,
+  /**
+   * Refers to flat shading, pure color and no lighting.  This is often used for
+   * textured objects
+   */
+  Flat = 0,
+  /**
+   * Refers to phong shading with pure diffuse color.
+   */
+  Phong = 1,
+  /**
+   * Refers to using a shader built with physically-based rendering models.
+   */
+  PBR = 2,
+};
+
+/**
  * @brief base attributes object holding attributes shared by all
  * @ref esp::metadata::attributes::ObjectAttributes and @ref
  * esp::metadata::attributes::StageAttributes objects; Should be treated as
@@ -22,11 +47,16 @@ namespace attributes {
 class AbstractObjectAttributes : public AbstractAttributes {
  public:
   /**
-   * @brief Constant static map to provide mappings from string tags to @ref
-   * esp::assets::AssetType values.  This will be used to map values set in json
-   * for mesh type to @ref esp::assets::AssetType.  Keys must be lowercase.
+   * @brief Constant static map to provide mappings from string tags to
+   * @ref esp::assets::AssetType values.  This will be used to map values
+   * set in json for mesh type to @ref esp::assets::AssetType.  Keys must
+   * be lowercase.
    */
   static const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
+
+  static const std::map<std::string, ObjectInstanceShaderType>
+      ShaderTypeNamesMap;
+
   AbstractObjectAttributes(const std::string& classKey,
                            const std::string& handle);
 
@@ -159,6 +189,13 @@ class AbstractObjectAttributes : public AbstractAttributes {
   }
 
   bool getUseMeshCollision() const { return getBool("use_mesh_collision"); }
+
+  /**
+   * @brief Set the default shader to use for an object or stage.  This may be
+   * overridden by a scene instance specification.
+   */
+  void setShaderType(int shader_type) { setInt("shader_type", shader_type); }
+  int getShaderType() const { return getInt("shader_type"); }
 
   // if true use phong illumination model instead of flat shading
   void setRequiresLighting(bool requiresLighting) {

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -18,6 +18,10 @@ const std::map<std::string, esp::physics::MotionType>
 SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     const std::string& handle)
     : AbstractAttributes("SceneObjectInstanceAttributes", handle) {
+  // default to unknown for object instances, to use attributes-specified
+  // defaults
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+
   // defaults to unknown/undefined
   setMotionType(static_cast<int>(esp::physics::MotionType::UNDEFINED));
   // set to no rotation

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -92,6 +92,15 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    */
   int getMotionType() const { return getInt("motion_type"); }
 
+  /**
+   * @brief Set the default shader to use for an object or stage.  Uses values
+   * specified in stage or object attributes if not overridden here.  Uses map
+   * of string values in json to @ref
+   * esp::metadata::atributes::ObjectInstanceShaderType int values.
+   */
+  void setShaderType(int shader_type) { setInt("shader_type", shader_type); }
+  int getShaderType() const { return getInt("shader_type"); }
+
  public:
   ESP_SMART_POINTERS(SceneObjectInstanceAttributes)
 };  // class SceneObjectInstanceAttributes

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -37,14 +37,15 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
   const std::string fullStageName =
       getFullAttrNameFromStr(stageHandle, stageAttributesManager_);
   if (fullStageName.compare("") == 0) {
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << infoPrefix << " Stage Attributes '" << stageHandle
         << "' specified in Scene Attributes but does not exist in dataset, so "
            "creating.";
     stageAttributesManager_->createObject(stageHandle, true);
   } else {
-    LOG(INFO) << infoPrefix << " Stage Attributes '" << stageHandle
-              << "' specified in Scene Attributes exists in dataset library.";
+    !Cr::Utility::Debug{}
+        << infoPrefix << " Stage Attributes '" << stageHandle
+        << "' specified in Scene Attributes exists in dataset library.";
   }
 
   // verify each object in sceneInstance exists in SceneDatasetAttributes
@@ -54,13 +55,15 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const std::string fullObjHandle =
         getFullAttrNameFromStr(objHandle, objectAttributesManager_);
     if (fullObjHandle.compare("") == 0) {
-      LOG(INFO) << infoPrefix << " Object Attributes '" << objHandle
-                << "' specified in Scene Attributes but does not exist in "
-                   "dataset, so creating.";
+      !Cr::Utility::Debug{}
+          << infoPrefix << " Object Attributes '" << objHandle
+          << "' specified in Scene Attributes but does not exist in "
+             "dataset, so creating.";
       objectAttributesManager_->createObject(objHandle, true);
     } else {
-      LOG(INFO) << infoPrefix << " Object Attributes '" << objHandle
-                << "' specified in Scene Attributes exists in dataset library.";
+      !Cr::Utility::Debug{}
+          << infoPrefix << " Object Attributes '" << objHandle
+          << "' specified in Scene Attributes exists in dataset library.";
     }
   }
 
@@ -77,14 +80,15 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
   const std::string fullLightLayoutAttrName =
       getFullAttrNameFromStr(lightHandle, lightLayoutAttributesManager_);
   if (fullLightLayoutAttrName.compare("") == 0) {
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << infoPrefix << "Lighting Layout Attributes '" << lightHandle
         << "' specified in Scene Attributes but does not exist in dataset, so "
            "creating.";
     lightLayoutAttributesManager_->createObject(lightHandle, true);
   } else {
-    LOG(INFO) << infoPrefix << " Lighting Layout Attributes " << lightHandle
-              << " specified in Scene Attributes exists in dataset library.";
+    !Cr::Utility::Debug{}
+        << infoPrefix << " Lighting Layout Attributes " << lightHandle
+        << " specified in Scene Attributes exists in dataset library.";
   }
 
   const std::string fullSceneInstanceName =
@@ -92,8 +96,9 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
 
   // add scene attributes to scene attributes manager
   if (fullSceneInstanceName.compare("") == 0) {
-    LOG(INFO) << infoPrefix << " Scene Attributes " << sceneInstanceName
-              << " does not exist in dataset so adding.";
+    !Cr::Utility::Debug{} << infoPrefix << " Scene Attributes "
+                          << sceneInstanceName
+                          << " does not exist in dataset so adding.";
     sceneAttributesManager_->registerObject(sceneInstance);
   }
   return true;
@@ -126,17 +131,17 @@ std::pair<std::string, std::string> SceneDatasetAttributes::addNewValToMap(
           ss << key << "_" << iter++;
           newKey = ss.str();
         } while (map.count(newKey) > 0);
-        LOG(WARNING)
+        !Cr::Utility::Warning{}
             << descString << " : Provided key '" << key
             << "' already references a different value in "
                "map. Modifying key to be "
             << newKey
             << ". Set overwrite to true to overwrite existing entries.";
       } else {  // overwrite entry
-        LOG(WARNING) << descString
-                     << " : Warning : Overwriting existing map entry "
-                     << map.at(newKey) << " at key " << newKey << " with value "
-                     << path << ".";
+        !Cr::Utility::Warning{}
+            << descString << " : Warning : Overwriting existing map entry "
+            << map.at(newKey) << " at key " << newKey << " with value " << path
+            << ".";
       }  // overwrite or not
     }    // found entry is desired or not
   }      // key is found

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -12,6 +12,7 @@
 
 #include "esp/metadata/attributes/ObjectAttributes.h"
 
+#include "esp/metadata/MetadataUtils.h"
 #include "esp/metadata/managers/AttributesManagerBase.h"
 
 namespace Cr = Corrade;
@@ -297,6 +298,17 @@ auto AbstractObjectAttributesManager<T, Access>::
         static_cast<int>(esp::assets::AssetType::UNKNOWN));
     attributes->setUseMeshCollision(true);
   }
+
+  // set attributes shader type to use.  This may be overridden by a scene
+  // instance specification.
+  int shaderTypeVal = getShaderTypeFromJsonDoc(jsonDoc);
+  // if a known shader type val is specified in json, set that value for the
+  // attributes, overriding constructor defaults.
+  if (shaderTypeVal !=
+      static_cast<int>(attributes::ObjectInstanceShaderType::Unknown)) {
+    attributes->setShaderType(shaderTypeVal);
+  }
+
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -173,21 +173,23 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
                                                     registerTemplate);
     msg = "Primitive Asset (" + attributesTemplateHandle + ") Based";
   } else {
-    LOG(INFO) << "AbstractObjectAttributesManager<T>::createObject  ("
-              << this->objectType_ << ") : Making attributes with handle : "
-              << attributesTemplateHandle;
+    !Cr::Utility::Debug{}
+        << "AbstractObjectAttributesManager<T>::createObject  ("
+        << this->objectType_
+        << ") : Making attributes with handle : " << attributesTemplateHandle;
     attrs = this->createFromJsonOrDefaultInternal(attributesTemplateHandle, msg,
                                                   registerTemplate);
 
-    LOG(INFO) << "AbstractObjectAttributesManager<T>::createObject  ("
-              << this->objectType_
-              << ") : Done making attributes with handle : "
-              << attributesTemplateHandle;
+    !Cr::Utility::Debug{}
+        << "AbstractObjectAttributesManager<T>::createObject  ("
+        << this->objectType_ << ") : Done making attributes with handle : "
+        << attributesTemplateHandle;
 
   }  // if this is prim else
   if (nullptr != attrs) {
-    LOG(INFO) << msg << " " << this->objectType_ << " attributes created"
-              << (registerTemplate ? " and registered." : ".");
+    !Cr::Utility::Debug{} << msg << " " << this->objectType_
+                          << " attributes created"
+                          << (registerTemplate ? " and registered." : ".");
   }
   return attrs;
 
@@ -325,7 +327,7 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     if (T::AssetTypeNamesMap.count(strToLookFor)) {
       typeVal = static_cast<int>(T::AssetTypeNamesMap.at(strToLookFor));
     } else {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "AbstractObjectAttributesManager::setJSONAssetHandleAndType : "
              "Value in json @ tag : "
           << jsonMeshTypeTag << " : `" << tmpVal

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -102,9 +102,10 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
 
-  LOG(INFO) << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "
-               "primitive asset templates : "
-            << std::to_string(defaultPrimAttributeHandles_.size());
+  !Cr::Utility::Debug{}
+      << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "
+         "primitive asset templates : "
+      << std::to_string(defaultPrimAttributeHandles_.size());
 }  // AssetAttributesManager::buildMapOfPrimTypeConstructors
 
 AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
@@ -114,9 +115,9 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
   if (nullptr == primAssetAttributes) {
     return primAssetAttributes;
   }
-  LOG(INFO) << "Asset attributes (" << primClassName << " : "
-            << primAssetAttributes->getHandle() << ") created"
-            << (registerTemplate ? " and registered." : ".");
+  !Cr::Utility::Debug{} << "Asset attributes (" << primClassName << " : "
+                        << primAssetAttributes->getHandle() << ") created"
+                        << (registerTemplate ? " and registered." : ".");
 
   return this->postCreateRegister(primAssetAttributes, registerTemplate);
 }  // AssetAttributesManager::createObject
@@ -128,12 +129,12 @@ int AssetAttributesManager::registerObjectFinalize(
   std::string primAttributesHandle = primAttributesTemplate->getHandle();
   // verify that attributes has been edited in a legal manner
   if (!primAttributesTemplate->isValidTemplate()) {
-    LOG(ERROR) << "AssetAttributesManager::registerObjectFinalize "
-                  ": Primitive asset attributes template named"
-               << primAttributesHandle
-               << "is not configured properly for specified prmitive"
-               << primAttributesTemplate->getPrimObjClassName()
-               << ". Aborting.";
+    !Cr::Utility::Error{} << "AssetAttributesManager::registerObjectFinalize "
+                             ": Primitive asset attributes template named"
+                          << primAttributesHandle
+                          << "is not configured properly for specified prmitive"
+                          << primAttributesTemplate->getPrimObjClassName()
+                          << ". Aborting.";
     return ID_UNDEFINED;
   }
 
@@ -158,10 +159,11 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   // if not legal primitive asset attributes file name, have message and return
   // default sphere attributes.
   if (defaultPrimAttributeHandles_.count(primClassName) == 0) {
-    LOG(ERROR) << "AssetAttributesManager::buildObjectFromJSONDoc :Unknown "
-                  "primitive class type : "
-               << primClassName
-               << " so returning default attributes for solid uvSphere.";
+    !Cr::Utility::Error{}
+        << "AssetAttributesManager::buildObjectFromJSONDoc :Unknown "
+           "primitive class type : "
+        << primClassName
+        << " so returning default attributes for solid uvSphere.";
     return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         defaultPrimAttributeHandles_.at("uvSphereSolid"));
   }
@@ -169,7 +171,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   // create attributes for the primitive described in the JSON file
   auto primAssetAttributes = this->initNewObjectInternal(primClassName, true);
   if (nullptr == primAssetAttributes) {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "AssetAttributesManager::buildObjectFromJSONDoc : unable to "
            "create default primitive asset attributes from primClassName "
         << primClassName

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -154,9 +154,10 @@ class AssetAttributesManager
       PrimObjTypes primObjType,
       bool registerTemplate = true) {
     if (primObjType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR) << "AssetAttributesManager::createObject : Illegal "
-                    "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
-                    "Aborting.";
+      !Cr::Utility::Error{}
+          << "AssetAttributesManager::createObject : Illegal "
+             "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
+             "Aborting.";
       return nullptr;
     }
     return this->createObject(PrimitiveNames3DMap.at(primObjType),
@@ -177,9 +178,10 @@ class AssetAttributesManager
       PrimObjTypes primType,
       bool contains = true) const {
     if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR) << "AssetAttributesManager::getTemplateHandlesByPrimType : "
-                    "Illegal primtitive type "
-                    "name PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
+      !Cr::Utility::Error{}
+          << "AssetAttributesManager::getTemplateHandlesByPrimType : "
+             "Illegal primtitive type "
+             "name PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return {};
     }
     std::string subStr = PrimitiveNames3DMap.at(primType);
@@ -397,9 +399,10 @@ class AssetAttributesManager
   void setDefaultObject(
       CORRADE_UNUSED attributes::AbstractPrimitiveAttributes::ptr& _defaultObj)
       override {
-    LOG(WARNING) << "AssetAttributesManager::setDefaultObject : Overriding "
-                    "defualt objects for PrimitiveAssetAttributes not "
-                    "currently supported.  Aborting.";
+    !Cr::Utility::Warning{}
+        << "AssetAttributesManager::setDefaultObject : Overriding "
+           "defualt objects for PrimitiveAssetAttributes not "
+           "currently supported.  Aborting.";
     this->defaultObj_ = nullptr;
   }  // AssetAttributesManager::setDefaultObject
 
@@ -439,9 +442,10 @@ class AssetAttributesManager
   bool verifyTemplateHandle(const std::string& templateHandle,
                             const std::string& attrType) {
     if (std::string::npos == templateHandle.find(attrType)) {
-      LOG(ERROR) << "AssetAttributesManager::verifyTemplateHandle : Handle : "
-                 << templateHandle << " is not of appropriate type for desired "
-                 << attrType << " primitives. Aborting.";
+      !Cr::Utility::Error{}
+          << "AssetAttributesManager::verifyTemplateHandle : Handle : "
+          << templateHandle << " is not of appropriate type for desired "
+          << attrType << " primitives. Aborting.";
       return false;
     }
     return true;
@@ -477,9 +481,10 @@ class AssetAttributesManager
       const std::string& primClassName,
       CORRADE_UNUSED bool builtFromConfig) override {
     if (primTypeConstructorMap_.count(primClassName) == 0) {
-      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : No "
-                    "primitive class"
-                 << primClassName << "exists in Magnum::Primitives. Aborting.";
+      !Cr::Utility::Error{}
+          << "AssetAttributesManager::buildPrimAttributes : No "
+             "primitive class"
+          << primClassName << "exists in Magnum::Primitives. Aborting.";
       return nullptr;
     }
     // these attributes ignore any default setttings.
@@ -495,7 +500,7 @@ class AssetAttributesManager
   template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
   attributes::AbstractPrimitiveAttributes::ptr createPrimAttributes() {
     if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
              "attributes::AbstractPrimitiveAttributes object for "
              "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -180,14 +180,16 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
   if (paths.size() > 0) {
     std::string dir = Cr::Utility::Directory::path(paths[0]);
-    LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Loading "
-              << paths.size() << " " << this->objectType_
-              << " templates found in " << dir;
+    !Cr::Utility::Debug{}
+        << "AttributesManager::loadAllFileBasedTemplates : Loading "
+        << paths.size() << " " << this->objectType_ << " templates found in "
+        << dir;
     for (int i = 0; i < paths.size(); ++i) {
       auto attributesFilename = paths[i];
-      LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Load "
-                << this->objectType_ << " template: "
-                << Cr::Utility::Directory::filename(attributesFilename);
+      !Cr::Utility::Debug{}
+          << "AttributesManager::loadAllFileBasedTemplates : Load "
+          << this->objectType_ << " template: "
+          << Cr::Utility::Directory::filename(attributesFilename);
       auto tmplt = this->createObjectFromJSONFile(attributesFilename, true);
 
       // save handles in list of defaults, so they are not removed, if desired.
@@ -198,7 +200,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
       templateIndices[i] = tmplt->getID();
     }
   }
-  LOG(INFO)
+  !Cr::Utility::Debug{}
       << "AttributesManager::loadAllFileBasedTemplates : Loaded file-based "
       << this->objectType_ << " templates: " << std::to_string(paths.size());
   return templateIndices;
@@ -215,8 +217,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllConfigsFromPath(
   // Check if directory
   const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
-    LOG(INFO) << "AttributesManager::loadAllConfigsFromPath : Parsing "
-              << this->objectType_ << " library directory: " + path;
+    !Cr::Utility::Debug{}
+        << "AttributesManager::loadAllConfigsFromPath : Parsing "
+        << this->objectType_ << " library directory: " + path;
     for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
       std::string absoluteSubfilePath = Dir::join(path, file);
       if (Cr::Utility::String::endsWith(absoluteSubfilePath,
@@ -232,10 +235,11 @@ std::vector<int> AttributesManager<T, Access>::loadAllConfigsFromPath(
     if (fileExists) {
       paths.push_back(attributesFilepath);
     } else {  // neither a directory or a file
-      LOG(WARNING) << "AttributesManager::loadAllConfigsFromPath : Parsing "
-                   << this->objectType_ << " : Cannot find " << path
-                   << " as directory or " << attributesFilepath
-                   << " as config file. Aborting parse.";
+      !Cr::Utility::Warning{}
+          << "AttributesManager::loadAllConfigsFromPath : Parsing "
+          << this->objectType_ << " : Cannot find " << path
+          << " as directory or " << attributesFilepath
+          << " as config file. Aborting parse.";
       return templateIndices;
     }  // if fileExists else
   }    // if dirExists else
@@ -252,7 +256,7 @@ void AttributesManager<T, Access>::buildCfgPathsFromJSONAndLoad(
     const io::JsonGenericValue& jsonPaths) {
   for (rapidjson::SizeType i = 0; i < jsonPaths.Size(); ++i) {
     if (!jsonPaths[i].IsString()) {
-      LOG(ERROR)
+      !Cr::Utility::Error{}
           << "AttributesManager::buildCfgPathsFromJSONAndLoad : Invalid path "
              "value in file path array element @ idx "
           << i << ". Skipping.";
@@ -272,10 +276,10 @@ void AttributesManager<T, Access>::buildCfgPathsFromJSONAndLoad(
       LOG(WARNING) << "No Glob path result for " << absolutePath;
     }
   }
-  LOG(INFO) << "AttributesManager::buildCfgPathsFromJSONAndLoad : "
-            << std::to_string(jsonPaths.Size())
-            << " paths specified in JSON doc for " << this->objectType_
-            << " templates.";
+  !Cr::Utility::Debug{} << "AttributesManager::buildCfgPathsFromJSONAndLoad : "
+                        << std::to_string(jsonPaths.Size())
+                        << " paths specified in JSON doc for "
+                        << this->objectType_ << " templates.";
 }  // AttributesManager<T>::buildCfgPathsFromJSONAndLoad
 
 template <class T, core::ManagedObjectAccess Access>
@@ -293,11 +297,11 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   // Check if this configuration file exists and if so use it to build
   // attributes
   bool jsonFileExists = (this->isValidFileName(jsonAttrFileName));
-  LOG(INFO) << "AttributesManager<T>::createFromJsonOrDefaultInternal  ("
-            << this->objectType_
-            << ") : Proposing JSON name : " << jsonAttrFileName
-            << " from original name : " << filename << " | This file "
-            << (jsonFileExists ? " exists." : " does not exist.");
+  !Cr::Utility::Debug{}
+      << "AttributesManager<T>::createFromJsonOrDefaultInternal  ("
+      << this->objectType_ << ") : Proposing JSON name : " << jsonAttrFileName
+      << " from original name : " << filename << " | This file "
+      << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
     attrs = this->createObjectFromJSONFile(jsonAttrFileName, registerObj);

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -31,8 +31,8 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::createObject(
       this->createFromJsonOrDefaultInternal(lightConfigName, msg, doRegister);
 
   if (nullptr != attrs) {
-    LOG(INFO) << msg << " light layout attributes created"
-              << (doRegister ? " and registered." : ".");
+    !Cr::Utility::Debug{} << msg << " light layout attributes created"
+                          << (doRegister ? " and registered." : ".");
   }
   return attrs;
 }  // PhysicsAttributesManager::createObject
@@ -74,11 +74,12 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
       lightAttribs->addLightInstance(lightInstanceAttribs);
       ++count;
     }
-    LOG(INFO) << "LightLayoutAttributesManager::setValsFromJSONDoc : " << count
-              << " of " << numLightConfigs
-              << " LightInstanceAttributes created successfully and added to "
-                 "LightLayoutAttributes "
-              << layoutName << ".";
+    !Cr::Utility::Debug{}
+        << "LightLayoutAttributesManager::setValsFromJSONDoc : " << count
+        << " of " << numLightConfigs
+        << " LightInstanceAttributes created successfully and added to "
+           "LightLayoutAttributes "
+        << layoutName << ".";
 
     // register
     this->postCreateRegister(lightAttribs, true);
@@ -129,7 +130,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
       typeVal = static_cast<int>(
           LightInstanceAttributes::LightTypeNamesMap.at(strToLookFor));
     } else {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc : "
              "Type Value in json : `"
           << tmpVal
@@ -150,7 +151,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
   // read spotlight params
   if (jsonConfig.HasMember("spot")) {
     if (!jsonConfig["spot"].IsObject()) {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "LightLayoutAttributesManager::setValsFromJSONDoc : \"spot\" "
              "cell in JSON config unable to be parsed to set "
              "spotlight parameters so skipping.";
@@ -231,7 +232,7 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
             break;
           }
           default: {
-            LOG(INFO)
+            !Cr::Utility::Debug{}
                 << "LightLayoutAttributesManager::"
                    "createLightSetupFromAttributes : Enum gfx::LightType with "
                    "val "

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -28,7 +28,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "ObjectAttributesManager::createPrimBasedAttributesTemplate : No "
            "primitive with handle '"
         << primAttrTemplateHandle
@@ -186,7 +186,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     const std::string& objectTemplateHandle,
     bool forceRegistration) {
   if (objectTemplate->getRenderAssetHandle() == "") {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "ObjectAttributesManager::registerObjectFinalize : "
            "Attributes template named "
         << objectTemplateHandle
@@ -213,7 +213,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     mapToUse = &physicsFileObjTmpltLibByID_;
   } else if (forceRegistration) {
     // Forcing registration in case of computationaly generated assets
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "ObjectAttributesManager::registerObjectFinalize "
            ": Render asset template handle : "
         << renderAssetHandle << " specified in object template with handle : "
@@ -225,7 +225,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     // If renderAssetHandle is neither valid file name nor existing primitive
     // attributes template hande, fail
     // by here always fail
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "ObjectAttributesManager::registerObjectFinalize "
            ": Render asset template handle : "
         << renderAssetHandle << " specified in object template with handle : "
@@ -245,7 +245,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     objectTemplate->setCollisionAssetIsPrimitive(false);
   } else {
     // Else, means no collision data specified, use specified render data
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << "ObjectAttributesManager::registerObjectFinalize "
            ": Collision asset template handle : "
         << collisionAssetHandle

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -23,8 +23,8 @@ PhysicsManagerAttributes::ptr PhysicsAttributesManager::createObject(
       physicsFilename, msg, registerTemplate);
 
   if (nullptr != attrs) {
-    LOG(INFO) << msg << " physics manager attributes created"
-              << (registerTemplate ? " and registered." : ".");
+    !Cr::Utility::Debug{} << msg << " physics manager attributes created"
+                          << (registerTemplate ? " and registered." : ".");
   }
   return attrs;
 }  // PhysicsAttributesManager::createObject

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "SceneAttributesManager.h"
+#include "esp/metadata/MetadataUtils.h"
 #include "esp/physics/RigidBase.h"
 
 #include "esp/io/io.h"
@@ -137,8 +138,12 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
   // to unknown, which will mean use scene instance-level default.
   instanceAttrs->setTranslationOrigin(getTranslationOriginVal(jCell));
 
-  // motion type of object.  Ignored for stage.  TODO : verify is valid motion
-  // type using standard mechanism of static map comparison.
+  // set specified shader type value.  May be Unknown, which means the default
+  // value specified in the stage or object attributes will be used.
+  instanceAttrs->setShaderType(getShaderTypeFromJsonDoc(jCell));
+
+  // motion type of object.  Ignored for stage.  TODO : verify is valid
+  // motion type using standard mechanism of static map comparison.
 
   int motionTypeVal = static_cast<int>(physics::MotionType::UNDEFINED);
   std::string tmpVal = "";

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -24,8 +24,8 @@ SceneAttributes::ptr SceneAttributesManager::createObject(
       sceneInstanceHandle, msg, registerTemplate);
 
   if (nullptr != attrs) {
-    LOG(INFO) << msg << " scene instance attributes created"
-              << (registerTemplate ? " and registered." : ".");
+    !Cr::Utility::Debug{} << msg << " scene instance attributes created"
+                          << (registerTemplate ? " and registered." : ".");
   }
   return attrs;
 }  // SceneAttributesManager::createObject
@@ -58,9 +58,10 @@ void SceneAttributesManager::setValsFromJSONDoc(
     attribs->setStageInstance(
         createInstanceAttributesFromJSON(jsonConfig["stage_instance"]));
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Stage "
-                    "specified for scene "
-                 << attribsDispName << ", or specification error.";
+    !Cr::Utility::Warning{}
+        << "SceneAttributesManager::setValsFromJSONDoc : No Stage "
+           "specified for scene "
+        << attribsDispName << ", or specification error.";
   }
   // Check for object instances existance
   if ((jsonConfig.HasMember("object_instances")) &&
@@ -71,15 +72,17 @@ void SceneAttributesManager::setValsFromJSONDoc(
       if (objCell.IsObject()) {
         attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
       } else {
-        LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : Object "
-                        "specification error in scene "
-                     << attribsDispName << " at idx : " << i << ".";
+        !Cr::Utility::Warning{}
+            << "SceneAttributesManager::setValsFromJSONDoc : Object "
+               "specification error in scene "
+            << attribsDispName << " at idx : " << i << ".";
       }
     }
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Objects "
-                    "specified for scene "
-                 << attribsDispName << ", or specification error.";
+    !Cr::Utility::Warning{}
+        << "SceneAttributesManager::setValsFromJSONDoc : No Objects "
+           "specified for scene "
+        << attribsDispName << ", or specification error.";
   }
   std::string dfltLighting = "";
   if (io::readMember<std::string>(jsonConfig, "default_lighting",
@@ -87,7 +90,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "default lighting" is specified in scene json set value.
     attribs->setLightingHandle(dfltLighting);
   } else {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "SceneAttributesManager::setValsFromJSONDoc : No default_lighting "
            "specified for scene "
         << attribsDispName << ".";
@@ -99,7 +102,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "navmesh_instance" is specified in scene json set value.
     attribs->setNavmeshHandle(navmeshName);
   } else {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "SceneAttributesManager::setValsFromJSONDoc : No navmesh_instance "
            "specified for scene "
         << attribsDispName << ".";
@@ -111,9 +114,10 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "semantic scene instance" is specified in scene json set value.
     attribs->setSemanticSceneHandle(semanticDesc);
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No "
-                    "semantic_scene_instance specified for scene "
-                 << attribsDispName << ".";
+    !Cr::Utility::Warning{}
+        << "SceneAttributesManager::setValsFromJSONDoc : No "
+           "semantic_scene_instance specified for scene "
+        << attribsDispName << ".";
   }
 }  // SceneAttributesManager::setValsFromJSONDoc
 
@@ -146,7 +150,7 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
     if (found != SceneObjectInstanceAttributes::MotionTypeNamesMap.end()) {
       motionTypeVal = static_cast<int>(found->second);
     } else {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "SceneAttributesManager::createInstanceAttributesFromJSON : "
              "motion_type value in json  : `"
           << tmpVal << "|" << strToLookFor
@@ -189,12 +193,13 @@ int SceneAttributesManager::getTranslationOriginVal(
     if (found != SceneAttributes::InstanceTranslationOriginMap.end()) {
       transOrigin = static_cast<int>(found->second);
     } else {
-      LOG(WARNING) << "SceneAttributesManager::getTranslationOriginVal : "
-                      "motion_type value in json  : `"
-                   << tmpTransOriginVal << "|" << strToLookFor
-                   << "` does not map to a valid "
-                      "SceneInstanceTranslationOrigin value, so defaulting "
-                      "motion type to SceneInstanceTranslationOrigin::Unknown.";
+      !Cr::Utility::Warning{}
+          << "SceneAttributesManager::getTranslationOriginVal : "
+             "motion_type value in json  : `"
+          << tmpTransOriginVal << "|" << strToLookFor
+          << "` does not map to a valid "
+             "SceneInstanceTranslationOrigin value, so defaulting "
+             "motion type to SceneInstanceTranslationOrigin::Unknown.";
     }
   }
   return transOrigin;

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -20,8 +20,8 @@ SceneDatasetAttributes::ptr SceneDatasetAttributesManager::createObject(
       datasetHandle, msg, registerTemplate);
 
   if (nullptr != attrs) {
-    LOG(INFO) << msg << " dataset attributes created"
-              << (registerTemplate ? " and registered." : ".");
+    !Cr::Utility::Debug{} << msg << " dataset attributes created"
+                          << (registerTemplate ? " and registered." : ".");
   }
   return attrs;
 }  // SceneDatasetAttributesManager::createObject
@@ -93,10 +93,10 @@ void SceneDatasetAttributesManager::loadAndValidateMap(
     if (!Cr::Utility::Directory::exists(loc)) {
       std::string newLoc = Cr::Utility::Directory::join(dsDir, loc);
       if (!Cr::Utility::Directory::exists(newLoc)) {
-        LOG(WARNING) << "SceneDatasetAttributesManager::loadAndValidateMap : "
-                     << jsonTag << " Value : " << loc
-                     << " not found on disk as absolute path or relative to "
-                     << dsDir;
+        !Cr::Utility::Warning{}
+            << "SceneDatasetAttributesManager::loadAndValidateMap : " << jsonTag
+            << " Value : " << loc
+            << " not found on disk as absolute path or relative to " << dsDir;
       } else {
         // replace value with dataset-augmented absolute path
         map[entry.first] = newLoc;
@@ -122,7 +122,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // type.
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
-          LOG(WARNING)
+          !Cr::Utility::Warning{}
               << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
               << tag
               << ".default attributes\" cell in JSON config unable to "
@@ -132,7 +132,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           auto attr = attrMgr->buildObjectFromJSONDoc(
               "default_attributes", jCell["default_attributes"]);
           if (nullptr == attr) {
-            LOG(WARNING)
+            !Cr::Utility::Warning{}
                 << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
                 << tag
                 << ".default attributes\" cell failed to successfully "
@@ -140,7 +140,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
-            LOG(INFO)
+            !Cr::Utility::Debug{}
                 << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
                 << tag
                 << ".default attributes\" set in Attributes Manager from JSON.";
@@ -152,7 +152,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // files.
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
-          LOG(WARNING)
+          !Cr::Utility::Warning{}
               << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
               << tag
               << ".paths\" cell in JSON config unable to be parsed as "
@@ -184,7 +184,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // existing attributes.
       if (jCell.HasMember("configs")) {
         if (!jCell["configs"].IsArray()) {
-          LOG(WARNING)
+          !Cr::Utility::Warning{}
               << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
               << tag
               << ".configs\" cell in JSON config unable to be parsed "
@@ -209,7 +209,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     const U& attrMgr) {
   // every cell within configs array must have an attributes tag
   if ((!jCell.HasMember("attributes")) || (!jCell["attributes"].IsObject())) {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
         << tag
         << ".configs\" cell element in JSON config lacks required data to "
@@ -234,7 +234,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     std::vector<std::string> handles =
         attrMgr->getObjectHandlesBySubstring(originalFile, true);
     if (handles.size() == 0) {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
           << tag
           << ".configs\" cell element in JSON config specified source file : "
@@ -257,7 +257,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   }
   // if neither handle is specified, cell will fail
   if (!validCell) {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
         << tag
         << ".configs\" cell element in JSON config lacks required data to "
@@ -282,14 +282,14 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // is known to be legitimate file
     auto attr = attrMgr->getObjectCopyByHandle(origObjHandle);
     if (nullptr == attr) {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : "
           << attrMgr->getObjectType() << " : Attempting to make a copy of "
           << origObjHandle
           << " failing so creating and registering a new object.";
       attr = attrMgr->createObject(origObjHandle, true);
       if (nullptr == attr) {
-        LOG(WARNING)
+        !Cr::Utility::Warning{}
             << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
             << tag << ".configs\" cell element's original file ("
             << originalFile
@@ -309,7 +309,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     auto attr = attrMgr->createDefaultObject(newTemplateHandle, false);
     // if null then failed for some reason to create a new default object.
     if (nullptr == attr) {
-      LOG(WARNING)
+      !Cr::Utility::Warning{}
           << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
           << tag
           << ".configs\" cell element failed to successfully create an "

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -135,7 +135,7 @@ class SceneDatasetAttributesManager
    * @param tag the name of the cell
    */
   void dispCellConfigError(const std::string& tag) {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "SceneDatasetAttributesManager::readDatasetJSONCell : \"" << tag
         << "\" cell in JSON config not appropriately configured. Skipping.";
   }

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -49,7 +49,7 @@ int StageAttributesManager::registerObjectFinalize(
     const std::string& stageAttributesHandle,
     bool forceRegistration) {
   if (stageAttributes->getRenderAssetHandle() == "") {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "StageAttributesManager::registerObjectFinalize : "
            "Attributes template named "
         << stageAttributesHandle
@@ -78,7 +78,7 @@ int StageAttributesManager::registerObjectFinalize(
     stageAttributes->setRenderAssetType(static_cast<int>(AssetType::UNKNOWN));
     stageAttributes->setRenderAssetIsPrimitive(false);
   } else if (forceRegistration) {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "StageAttributesManager::registerObjectFinalize "
            ": Render asset template handle : "
         << renderAssetHandle << " specified in stage template with handle : "
@@ -87,7 +87,7 @@ int StageAttributesManager::registerObjectFinalize(
            "asset. This attributes is not in a valid state.";
   } else {
     // If renderAssetHandle is not valid file name needs to  fail
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "StageAttributesManager::registerObjectFinalize "
            ": Render asset template handle : "
         << renderAssetHandle << " specified in stage template with handle : "
@@ -112,7 +112,7 @@ int StageAttributesManager::registerObjectFinalize(
     stageAttributes->setCollisionAssetIsPrimitive(false);
   } else {
     // Else, means no collision data specified, use specified render data
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << "StageAttributesManager::registerObjectFinalize "
            ": Collision asset template handle : "
         << collisionAssetHandle << " specified in stage template with handle : "
@@ -141,7 +141,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAssetHandle)) {
-    LOG(ERROR)
+    !Cr::Utility::Error{}
         << "StageAttributesManager::createPrimBasedAttributesTemplate : No "
            "primitive with handle '"
         << primAssetHandle
@@ -360,7 +360,7 @@ void StageAttributesManager::setValsFromJSONDoc(
     const auto& paths = jsonConfig["rigid object paths"];
     for (rapidjson::SizeType i = 0; i < paths.Size(); ++i) {
       if (!paths[i].IsString()) {
-        LOG(ERROR)
+        !Cr::Utility::Error{}
             << "StageAttributesManager::setValsFromJSONDoc "
                ":Invalid value in stage config 'rigid object paths'- array "
             << i;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -34,7 +34,7 @@ PhysicsManager::~PhysicsManager() {
 }
 
 bool PhysicsManager::addStage(
-    const std::string& handle,
+    const metadata::attributes::StageAttributes::ptr& initAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
   for (const assets::CollisionMeshData& meshData : meshGroup) {
@@ -44,41 +44,28 @@ bool PhysicsManager::addStage(
   }
 
   //! Initialize scene
-  bool sceneSuccess = addStageFinalize(handle);
+  bool sceneSuccess = addStageFinalize(initAttributes);
   return sceneSuccess;
 }
 
-bool PhysicsManager::addStageFinalize(const std::string& handle) {
+bool PhysicsManager::addStageFinalize(
+    const metadata::attributes::StageAttributes::ptr& initAttributes) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(handle);
+  bool sceneSuccess = staticStageObject_->initialize(initAttributes);
   return sceneSuccess;
 }
 
-int PhysicsManager::addObject(const int objectLibId,
-                              DrawableGroup* drawables,
-                              scene::SceneNode* attachmentNode,
-                              const std::string& lightSetup) {
-  const std::string& configHandle =
-      resourceManager_.getObjectAttributesManager()->getObjectHandleByID(
-          objectLibId);
-
-  return addObject(configHandle, drawables, attachmentNode, lightSetup);
-}
-
-int PhysicsManager::addObject(const std::string& configFileHandle,
-                              DrawableGroup* drawables,
-                              scene::SceneNode* attachmentNode,
-                              const std::string& lightSetup) {
+int PhysicsManager::addObject(
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    DrawableGroup* drawables,
+    scene::SceneNode* attachmentNode,
+    const std::string& lightSetup) {
   //! Make rigid object and add it to existingObjects
-  int nextObjectID_ = allocateObjectID();
-  scene::SceneNode* objectNode = attachmentNode;
-  if (attachmentNode == nullptr) {
-    objectNode = &staticStageObject_->node().createChild();
-  }
+
   // verify whether necessary assets exist, and if not, instantiate them
   // only make object if asset instantiation succeeds (short circuit)
   bool objectSuccess =
-      resourceManager_.instantiateAssetsOnDemand(configFileHandle);
+      resourceManager_.instantiateAssetsOnDemand(objectAttributes);
   if (!objectSuccess) {
     LOG(ERROR) << "PhysicsManager::addObject : "
                   "ResourceManager::instantiateAssetsOnDemand unsuccessful. "
@@ -86,8 +73,15 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     return ID_UNDEFINED;
   }
 
+  // derive valid object ID and create new node if necessary
+  int nextObjectID_ = allocateObjectID();
+  scene::SceneNode* objectNode = attachmentNode;
+  if (attachmentNode == nullptr) {
+    objectNode = &staticStageObject_->node().createChild();
+  }
+
   objectSuccess =
-      makeAndAddRigidObject(nextObjectID_, configFileHandle, objectNode);
+      makeAndAddRigidObject(nextObjectID_, objectAttributes, objectNode);
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);
@@ -167,12 +161,13 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
   return physObjectID;
 }
 
-bool PhysicsManager::makeAndAddRigidObject(int newObjectID,
-                                           const std::string& handle,
-                                           scene::SceneNode* objectNode) {
+bool PhysicsManager::makeAndAddRigidObject(
+    int newObjectID,
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    scene::SceneNode* objectNode) {
   auto ptr = physics::RigidObject::create_unique(objectNode, newObjectID,
                                                  resourceManager_);
-  bool objSuccess = ptr->initialize(handle);
+  bool objSuccess = ptr->initialize(objectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -61,7 +61,13 @@ int PhysicsManager::addObject(
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
   //! Make rigid object and add it to existingObjects
-
+  if (!objectAttributes) {
+    // should never run, but just in case
+    LOG(ERROR) << "PhysicsManager::addObject : "
+                  "Object creation failed due to nonexistant "
+                  "objectAttributes";
+    return ID_UNDEFINED;
+  }
   // verify whether necessary assets exist, and if not, instantiate them
   // only make object if asset instantiation succeeds (short circuit)
   bool objectSuccess =

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -157,48 +157,79 @@ class PhysicsManager {
    * Only one 'scene' may be initialized per simulated world, but this scene may
    * contain several components (e.g. GLB heirarchy).
    *
-   * @param handle The handle to the attributes structure defining physical
-   * properties of the scene.
+   * @param initAttributes The attributes structure defining physical
+   * properties of the scene.  Must be a copy of the attributes stored in the
+   * Attributes Manager.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
-  bool addStage(const std::string& handle,
-                const std::vector<assets::CollisionMeshData>& meshGroup);
+  bool addStage(
+      const metadata::attributes::StageAttributes::ptr& initAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager.
-   *  @anchor addObject_string
-   *  @param configFile The filename of the object's physical properties file
-   * used as the key to query @ref
-   * esp::metadata::managers::ObjectAttributesManager.
-   *  @param drawables Reference to the scene graph drawables group to enable
+   * @anchor addObject_string
+   * @param attributesHandle The handle of the object attributes used as the key
+   * to query @ref esp::metadata::managers::ObjectAttributesManager.
+   * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
+   * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
+   * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObject(const std::string& configFile,
+  int addObject(const std::string& attributesHandle,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    esp::metadata::attributes::ObjectAttributes::ptr attributes =
+        resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
+            attributesHandle);
+
+    return addObject(attributes, drawables, attachmentNode, lightSetup);
+  }
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
    * handle.
-   *  @param objectLibId The ID of the object's template in @ref
+   * @param objectLibId The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
-   *  @param drawables Reference to the scene graph drawables group to enable
+   * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
+   * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
+   * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
   int addObject(const int objectLibId,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    const esp::metadata::attributes::ObjectAttributes::ptr attributes =
+        resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
+            objectLibId);
+
+    return addObject(attributes, drawables, attachmentNode, lightSetup);
+  }
+
+  /** @brief Instance a physical object from an object properties template in
+   * the @ref esp::metadata::managers::ObjectAttributesManager by template
+   * handle.
+   * @param objectAttributes The object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObject(
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      DrawableGroup* drawables,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref
@@ -1036,29 +1067,30 @@ class PhysicsManager {
   virtual bool initPhysicsFinalize();
 
   /**
-   * @brief Finalize scene initialization for kinematic scenes.  Overidden by
+   * @brief Finalize stage initialization for kinematic stage.  Overidden by
    * instancing class if physics is supported.
    *
-   * @param handle the handle to the attributes structure defining physical
-   * properties of the scene.
+   * @param initAttributes the attributes structure defining physical
+   * properties of the stage.
    * @return true if successful and false otherwise
    */
 
-  virtual bool addStageFinalize(const std::string& handle);
+  virtual bool addStageFinalize(
+      const metadata::attributes::StageAttributes::ptr& initAttributes);
 
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
-   * @param meshGroup The object's mesh.
-   * @param handle The handle to the physical object's template defining its
+   * @param initAttributes The physical object's template defining its
    * physical parameters.
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  virtual bool makeAndAddRigidObject(int newObjectID,
-                                     const std::string& handle,
-                                     scene::SceneNode* objectNode);
+  virtual bool makeAndAddRigidObject(
+      int newObjectID,
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* objectNode);
 
   /** @brief Set the voxelization visualization for a scene node to be true or
    * false.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -186,6 +186,12 @@ class PhysicsManager {
     esp::metadata::attributes::ObjectAttributes::ptr attributes =
         resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
             attributesHandle);
+    if (!attributes) {
+      LOG(ERROR) << "PhysicsManager::addObject : "
+                    "Object creation failed due to unknown attributes "
+                 << attributesHandle;
+      return ID_UNDEFINED;
+    }
 
     return addObject(attributes, drawables, attachmentNode, lightSetup);
   }
@@ -193,7 +199,7 @@ class PhysicsManager {
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
    * handle.
-   * @param objectLibId The ID of the object's template in @ref
+   * @param attributesID The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
    * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
@@ -202,14 +208,19 @@ class PhysicsManager {
    * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObject(const int objectLibId,
+  int addObject(const int attributesID,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     const esp::metadata::attributes::ObjectAttributes::ptr attributes =
         resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
-            objectLibId);
-
+            attributesID);
+    if (!attributes) {
+      LOG(ERROR) << "PhysicsManager::addObject : "
+                    "Object creation failed due to unknown attributes ID "
+                 << attributesID;
+      return ID_UNDEFINED;
+    }
     return addObject(attributes, drawables, attachmentNode, lightSetup);
   }
 

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -35,10 +35,10 @@ class AbstractObjectAttributes;
 namespace physics {
 
 /**
-@brief Motion type of a @ref RigidObject.
-Defines its treatment by the simulator and operations which can be performed on
-it.
-*/
+ * @brief Motion type of a @ref RigidObject.
+ * Defines its treatment by the simulator and operations which can be performed
+ * on it.
+ */
 enum class MotionType {
   /**
    * Refers to an error (such as a query to non-existing object) or an
@@ -99,12 +99,12 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Initializes the @ref RigidObject or @ref RigidStage that inherits
    * from this class.  This is overridden
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
-   * phyiscal parameters for this object
+   * @param initAttributes The template structure defining relevant phyiscal
+   * parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialize(const std::string& handle) = 0;
+  virtual bool initialize(
+      metadata::attributes::AbstractObjectAttributes::ptr initAttributes) = 0;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidStage that

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -14,15 +14,16 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode,
   objectId_ = objectId;
 }
 
-bool RigidObject::initialize(const std::string& handle) {
+bool RigidObject::initialize(
+    metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidObject more than once";
     return false;
   }
 
-  // save a copy of the template at initialization time
-  initializationAttributes_ =
-      resMgr_.getObjectAttributesManager()->getObjectCopyByHandle(handle);
+  // save the copy of the template used to create the object at initialization
+  // time
+  initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }  // RigidObject::initialize

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -106,12 +106,12 @@ class RigidObject : public RigidBase {
 
   /**
    * @brief Initializes the @ref RigidObject that inherits from this class
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
+   * @param initAttributes The template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const std::string& handle) override;
+  bool initialize(metadata::attributes::AbstractObjectAttributes::ptr
+                      initAttributes) override;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -11,14 +11,16 @@ RigidStage::RigidStage(scene::SceneNode* rigidBodyNode,
                        const assets::ResourceManager& resMgr)
     : RigidBase(rigidBodyNode, resMgr) {}
 
-bool RigidStage::initialize(const std::string& handle) {
+bool RigidStage::initialize(
+    metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidStage more than once";
     return false;
   }
   objectMotionType_ = MotionType::STATIC;
-  initializationAttributes_ =
-      resMgr_.getStageAttributesManager()->getObjectCopyByHandle(handle);
+  // save the copy of the template used to create the object at initialization
+  // time
+  initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -25,12 +25,12 @@ class RigidStage : public RigidBase {
   /**
    * @brief Initializes the @ref RigidStage that inherits
    * from this class
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
+   * @param initAttributes The template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const std::string& handle) override;
+  bool initialize(metadata::attributes::AbstractObjectAttributes::ptr
+                      initAttributes) override;
 
   /**
    * @brief Get a copy of the template used to initialize this stage object.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -48,20 +48,22 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
 
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
-bool BulletPhysicsManager::addStageFinalize(const std::string& handle) {
+bool BulletPhysicsManager::addStageFinalize(
+    const metadata::attributes::StageAttributes::ptr& initAttributes) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(handle);
+  bool sceneSuccess = staticStageObject_->initialize(initAttributes);
 
   return sceneSuccess;
 }
 
-bool BulletPhysicsManager::makeAndAddRigidObject(int newObjectID,
-                                                 const std::string& handle,
-                                                 scene::SceneNode* objectNode) {
+bool BulletPhysicsManager::makeAndAddRigidObject(
+    int newObjectID,
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    scene::SceneNode* objectNode) {
   auto ptr = physics::BulletRigidObject::create_unique(
       objectNode, newObjectID, resourceManager_, bWorld_,
       collisionObjToObjIds_);
-  bool objSuccess = ptr->initialize(handle);
+  bool objSuccess = ptr->initialize(objectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -209,7 +209,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * properties of the stage.
    * @return true if successful and false otherwise
    */
-  bool addStageFinalize(const std::string& handle) override;
+  bool addStageFinalize(const metadata::attributes::StageAttributes::ptr&
+                            initAttributes) override;
 
   /** @brief Create and initialize an @ref RigidObject and add
    * it to existingObjects_ map keyed with newObjectID
@@ -221,9 +222,10 @@ class BulletPhysicsManager : public PhysicsManager {
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  bool makeAndAddRigidObject(int newObjectID,
-                             const std::string& handle,
-                             scene::SceneNode* objectNode) override;
+  bool makeAndAddRigidObject(
+      int newObjectID,
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* objectNode) override;
 
   btDbvtBroadphase bBroadphase_;
   btDefaultCollisionConfiguration bCollisionConfig_;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -329,7 +329,18 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       metadataMediator_->getStageAttributesManager()->getObjectCopyByHandle(
           stageAttributesHandle);
 
+  // constant representing unknown shader type
+  const int unknownShaderType =
+      static_cast<int>(metadata::attributes::ObjectInstanceShaderType::Unknown);
+
   // set defaults for stage creation
+
+  // set shader type to use for stage
+  int stageShaderType = stageInstanceAttributes->getShaderType();
+  if (stageShaderType != unknownShaderType) {
+    stageAttributes->setShaderType(stageShaderType);
+  }
+  // set lighting key
   stageAttributes->setLightSetup(lightSetupKey);
   // set frustum culling from simulator config
   stageAttributes->setFrustumCulling(frustumCulling_);
@@ -432,7 +443,19 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
                       "to instance object; skipping. ";
       continue;
     }
-    objID = physicsManager_->addObject(objAttrFullHandle, &drawables,
+
+    // Get ObjectAttributes
+    auto objAttributes =
+        metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
+            objAttrFullHandle);
+    // set shader type to use for stage
+    int objShaderType = objInst->getShaderType();
+    if (objShaderType != unknownShaderType) {
+      objAttributes->setShaderType(objShaderType);
+    }
+
+    // create object using attributes copy.
+    objID = physicsManager_->addObject(objAttributes, &drawables,
                                        attachmentNode, lightSetupKey);
     if (objID == ID_UNDEFINED) {
       // instancing failed for some reason.

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -122,8 +122,9 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
         "requiresTextures was changed to True from False.  Must call close() "
         "before changing this value.");
   } else if ((*requiresTextures_) && !config_.requiresTextures) {
-    LOG(WARNING) << "Not changing requiresTextures as the simulator was "
-                    "initialized with True.  Call close() to change this.";
+    !Cr::Utility::Warning{}
+        << "Not changing requiresTextures as the simulator was "
+           "initialized with True.  Call close() to change this.";
   }
 
   bool success = false;
@@ -150,10 +151,11 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     success = createSceneInstanceNoRenderer(config_.activeSceneName);
   }
 
-  LOG(INFO) << "Simulator::reconfigure : createSceneInstance success == "
-            << (success ? "true" : "false")
-            << " for active scene name : " << config_.activeSceneName
-            << (config_.createRenderer ? " with" : " without") << " renderer.";
+  !Cr::Utility::Debug{}
+      << "Simulator::reconfigure : createSceneInstance success == "
+      << (success ? "true" : "false")
+      << " for active scene name : " << config_.activeSceneName
+      << (config_.createRenderer ? " with" : " without") << " renderer.";
 
 }  // Simulator::reconfigure
 
@@ -177,7 +179,7 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   const std::string& navmeshFileLoc = metadataMediator_->getNavmeshPathByHandle(
       curSceneInstanceAttributes->getNavmeshHandle());
 
-  LOG(INFO)
+  !Cr::Utility::Debug{}
       << "Simulator::setSceneInstanceAttributes : Navmesh file location in "
          "scene instance : "
       << navmeshFileLoc;
@@ -185,13 +187,15 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   // create pathfinder and load navmesh if available
   pathfinder_ = nav::PathFinder::create();
   if (FileUtil::exists(navmeshFileLoc)) {
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : Loading navmesh from "
-              << navmeshFileLoc;
+    !Cr::Utility::Debug{}
+        << "Simulator::setSceneInstanceAttributes : Loading navmesh from "
+        << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : "
-              << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
+    !Cr::Utility::Debug{} << "Simulator::setSceneInstanceAttributes : "
+                          << (pfSuccess ? "Navmesh Loaded."
+                                        : "Navmesh load error.");
   } else {
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "Simulator::setSceneInstanceAttributes : Navmesh file not found, "
            "checked at filename : '"
         << navmeshFileLoc << "'";
@@ -224,10 +228,10 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
     // semantic scene descriptor might not exist, so
     semanticScene_ = nullptr;
     semanticScene_ = scene::SemanticScene::create();
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : SceneInstance : "
-              << activeSceneName
-              << " proposed Semantic Scene Descriptor filename : "
-              << semanticSceneDescFilename;
+    !Cr::Utility::Debug{}
+        << "Simulator::setSceneInstanceAttributes : SceneInstance : "
+        << activeSceneName << " proposed Semantic Scene Descriptor filename : "
+        << semanticSceneDescFilename;
 
     // Attempt to load semantic scene descriptor specified in scene instance
     // file, agnostic to file type inferred by name,
@@ -242,13 +246,13 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
       if (FileUtil::exists(tmpFName)) {
         success =
             scene::SemanticScene::loadReplicaHouse(tmpFName, *semanticScene_);
-        LOG(INFO) << msgPrefix
-                  << "Replica w/existing constructed file : " << tmpFName
-                  << " in directory with " << semanticSceneDescFilename << " : "
-                  << (success ? "" : "not ") << "successful";
+        !Cr::Utility::Debug{}
+            << msgPrefix << "Replica w/existing constructed file : " << tmpFName
+            << " in directory with " << semanticSceneDescFilename << " : "
+            << (success ? "" : "not ") << "successful";
       }
     }  // if given SSD file name specifiedd exists
-    LOG(WARNING)
+    !Cr::Utility::Warning{}
         << "Simulator::setSceneInstanceAttributes : All attempts to load "
            "SSD with SceneAttributes-provided name "
         << semanticSceneDescFilename << " : exist : " << fileExists
@@ -289,13 +293,14 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   if (config_.overrideSceneLightDefaults) {
     lightSetupKey = config_.sceneLightSetup;
-    LOG(INFO) << "Simulator::createSceneInstance : Using config-specified "
-                 "Light key : -"
-              << lightSetupKey << "-";
+    !Cr::Utility::Debug{}
+        << "Simulator::createSceneInstance : Using config-specified "
+           "Light key : -"
+        << lightSetupKey << "-";
   } else {
     lightSetupKey = metadataMediator_->getLightSetupFullHandle(
         curSceneInstanceAttributes->getLightingHandle());
-    LOG(INFO)
+    !Cr::Utility::Debug{}
         << "Simulator::createSceneInstance : Using scene instance-specified "
            "Light key : -"
         << lightSetupKey << "-";
@@ -348,11 +353,12 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // create a structure to manage active scene and active semantic scene ID
   // passing to and from loadStage
   std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};
-  LOG(INFO) << "Simulator::createSceneInstance : Start to load stage named : "
-            << stageAttributes->getHandle() << " with render asset : "
-            << stageAttributes->getRenderAssetHandle()
-            << " and collision asset : "
-            << stageAttributes->getCollisionAssetHandle();
+  !Cr::Utility::Debug{}
+      << "Simulator::createSceneInstance : Start to load stage named : "
+      << stageAttributes->getHandle()
+      << " with render asset : " << stageAttributes->getRenderAssetHandle()
+      << " and collision asset : "
+      << stageAttributes->getCollisionAssetHandle();
 
   // Load stage
   bool loadSuccess = resourceManager_->loadStage(
@@ -360,16 +366,18 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       config_.loadSemanticMesh, config_.forceSeparateSemanticSceneGraph);
 
   if (!loadSuccess) {
-    LOG(ERROR) << "Simulator::createSceneInstance : Cannot load stage : "
-               << stageAttributesHandle;
+    !Cr::Utility::Error{}
+        << "Simulator::createSceneInstance : Cannot load stage : "
+        << stageAttributesHandle;
     // Pass the error to the python through pybind11 allowing graceful exit
     throw std::invalid_argument(
         "Simulator::createSceneInstance : Cannot load: " +
         stageAttributesHandle);
   } else {
-    LOG(INFO) << "Simulator::createSceneInstance : Successfully loaded stage "
-                 "named : "
-              << stageAttributes->getHandle();
+    !Cr::Utility::Debug{}
+        << "Simulator::createSceneInstance : Successfully loaded stage "
+           "named : "
+        << stageAttributes->getHandle();
   }
 
   // refresh the NavMesh visualization if necessary after loading a new
@@ -402,9 +410,9 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
             stageAttributesHandle.compare(assets::EMPTY_SCENE) == 0)) {
         // TODO: programmatic generation of semantic meshes when no
         // annotations are provided.
-        LOG(WARNING) << "\n---\nSimulator::createSceneInstance : The active "
-                        "scene does not contain semantic "
-                        "annotations. \n---";
+        !Cr::Utility::Warning{}
+            << "Simulator::createSceneInstance : The active "
+               "scene does not contain semantic annotations.";
       }
     }
   }  // if ID has changed - needs to be reset
@@ -439,10 +447,11 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
     const std::string objAttrFullHandle =
         metadataMediator_->getObjAttrFullHandle(objInst->getHandle());
     if (objAttrFullHandle == "") {
-      LOG(ERROR) << errMsgTmplt
-                 << "Unable to find objectAttributes whose handle contains "
-                 << objInst->getHandle()
-                 << " as specified in object instance attributes.";
+      !Cr::Utility::Error{}
+          << errMsgTmplt
+          << "Unable to find objectAttributes whose handle contains "
+          << objInst->getHandle()
+          << " as specified in object instance attributes.";
       return false;
     }
 
@@ -451,11 +460,11 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
         metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
             objAttrFullHandle);
     if (!objAttributes) {
-      LOG(ERROR) << errMsgTmplt
-                 << "Missing/improperly configured objectAttributes "
-                 << objAttrFullHandle << ", whose handle contains "
-                 << objInst->getHandle()
-                 << " as specified in object instance attributes.";
+      !Cr::Utility::Error{} << errMsgTmplt
+                            << "Missing/improperly configured objectAttributes "
+                            << objAttrFullHandle << ", whose handle contains "
+                            << objInst->getHandle()
+                            << " as specified in object instance attributes.";
       return false;
     }
     // set shader type to use for stage
@@ -469,10 +478,11 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
                                        attachmentNode, lightSetupKey);
     if (objID == ID_UNDEFINED) {
       // instancing failed for some reason.
-      LOG(ERROR) << errMsgTmplt << "Object create failed for objectAttributes "
-                 << objAttrFullHandle << ", whose handle contains "
-                 << objInst->getHandle()
-                 << " as specified in object instance attributes.";
+      !Cr::Utility::Error{} << errMsgTmplt
+                            << "Object create failed for objectAttributes "
+                            << objAttrFullHandle << ", whose handle contains "
+                            << objInst->getHandle()
+                            << " as specified in object instance attributes.";
       return false;
     }
     // set object's location and rotation based on translation and rotation
@@ -1063,9 +1073,10 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
     // using trajVisName
     return ID_UNDEFINED;
   }
-  LOG(INFO) << "Simulator::showTrajectoryVisualization : Trajectory "
-               "visualization object created with ID "
-            << trajVisID;
+  !Cr::Utility::Debug{}
+      << "Simulator::showTrajectoryVisualization : Trajectory "
+         "visualization object created with ID "
+      << trajVisID;
   physicsManager_->setObjectMotionType(trajVisID,
                                        esp::physics::MotionType::KINEMATIC);
   // add to internal references of object ID and resourceDict name


### PR DESCRIPTION
## Motivation and Context
This PR is the first of 2 PRs intended to introduce configuration-file level support for independent shader types being specified for the stage and objects in a scene. Supported shader types that the user can specify are Flat, Phong and PBR (case insensitive), and these values can be specified in either stage and object configurations (to specify a default value for a particular stage or object TYPE), or in the scene instance configurations (which, if specified, will override the default values given in stage or object configs for a single instance only).

To support this functionality, stage and object creation had to be slightly modified in order to accept a copy of the appropriate attributes as a parameter, which is then moved to the initialization Attributes of the resultant rigidStage/rigidObject.

Part 1 of 2 : This PR only implements the framework required for this change, but lacks the functionality to consume the configuration-specified shader type in ResourceManager.  The lacking functionality will be added in Part 2 of 2.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and Python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
