### PR TITLE
[Sensor] Remove logging on SensorSpec destructor

### DIFF
--- a/src/esp/sensor/Sensor.cpp
+++ b/src/esp/sensor/Sensor.cpp
@@ -11,10 +11,6 @@
 namespace esp {
 namespace sensor {
 
-SensorSpec::~SensorSpec() {
-  LOG(INFO) << "Deconstructing SensorSpec";
-}
-
 bool SensorSpec::operator==(const SensorSpec& a) const {
   return uuid == a.uuid && sensorType == a.sensorType &&
          sensorSubType == a.sensorSubType && position == a.position &&

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -52,7 +52,7 @@ struct SensorSpec {
   vec3f orientation = {0, 0, 0};
   std::string noiseModel = "None";
   SensorSpec() = default;
-  virtual ~SensorSpec();
+  virtual ~SensorSpec() = default;
   virtual bool isVisualSensorSpec() const { return false; }
   virtual void sanityCheck();
   bool operator==(const SensorSpec& a) const;


### PR DESCRIPTION
## Motivation and Context

SensorSpec can't have a print in its destructor since they are created/destroyed on episode swap in habitat-lab.  Having one makes logging really noisy and, as a byproduct, kill perf -- while most of the time training is done with logging off, leaving it on can be useful for debugging, so we should not overly spam INFO.

## How Has This Been Tested

In prod.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

