### PR TITLE
[Sensor] VisualSensor and CameraSensor updates for Hierarchical SensorSpec

### DIFF
--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -94,7 +94,7 @@ void initSensorBindings(py::module& m) {
   py::class_<CameraSensorSpec, CameraSensorSpec::ptr, VisualSensorSpec,
              SensorSpec>(m, "CameraSensorSpec", py::dynamic_attr())
       .def(py::init(&CameraSensorSpec::create<>))
-      .def_readwrite("ortho_scale", &CameraSensorSpec::ortho_scale);
+      .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
 
   // ==== Sensor ====
   py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -84,17 +84,17 @@ void initSensorBindings(py::module& m) {
   py::class_<VisualSensorSpec, VisualSensorSpec::ptr, SensorSpec>(
       m, "VisualSensorSpec", py::dynamic_attr())
       .def(py::init(&VisualSensorSpec::create<>))
-      .def_readwrite("ortho_scale", &VisualSensorSpec::ortho_scale)
+      .def_readwrite("near", &VisualSensorSpec::near)
+      .def_readwrite("far", &VisualSensorSpec::far)
       .def_readwrite("resolution", &VisualSensorSpec::resolution)
-      .def_readwrite("encoding", &VisualSensorSpec::encoding)
-      .def_readwrite("gpu2gpu_transfer", &VisualSensorSpec::gpu2gpuTransfer);
+      .def_readwrite("gpu2gpu_transfer", &VisualSensorSpec::gpu2gpuTransfer)
+      .def_readwrite("channels", &VisualSensorSpec::channels);
 
   // ====CameraSensorSpec ====
   py::class_<CameraSensorSpec, CameraSensorSpec::ptr, VisualSensorSpec,
              SensorSpec>(m, "CameraSensorSpec", py::dynamic_attr())
       .def(py::init(&CameraSensorSpec::create<>))
-      .def_readwrite("channels", &CameraSensorSpec::channels)
-      .def_readwrite("observation_space", &CameraSensorSpec::observationSpace);
+      .def_readwrite("ortho_scale", &CameraSensorSpec::ortho_scale);
 
   // ==== Sensor ====
   py::class_<Sensor, Magnum::SceneGraph::PyFeature<Sensor>,

--- a/src/esp/bindings_js/bindings_js.cpp
+++ b/src/esp/bindings_js/bindings_js.cpp
@@ -196,7 +196,7 @@ EMSCRIPTEN_BINDINGS(habitat_sim_bindings_js) {
 
   em::class_<CameraSensorSpec, em::base<VisualSensorSpec>>("CameraSensorSpec")
       .smart_ptr_constructor("CameraSensorSpec", &CameraSensorSpec::create<>)
-      .property("ortho_scale", &CameraSensorSpec::ortho_scale);
+      .property("ortho_scale", &CameraSensorSpec::orthoScale);
 
   em::class_<Sensor>("Sensor")
       .smart_ptr<Sensor::ptr>("Sensor::ptr")

--- a/src/esp/bindings_js/bindings_js.cpp
+++ b/src/esp/bindings_js/bindings_js.cpp
@@ -188,15 +188,15 @@ EMSCRIPTEN_BINDINGS(habitat_sim_bindings_js) {
 
   em::class_<VisualSensorSpec, em::base<SensorSpec>>("VisualSensorSpec")
       .smart_ptr_constructor("VisualSensorSpec", &VisualSensorSpec::create<>)
-      .property("ortho_scale", &VisualSensorSpec::ortho_scale)
       .property("resolution", &VisualSensorSpec::resolution)
-      .property("encoding", &VisualSensorSpec::encoding)
+      .property("channels", &VisualSensorSpec::channels)
+      .property("near", &VisualSensorSpec::near)
+      .property("far", &VisualSensorSpec::far)
       .property("gpu2gpu_transfer", &VisualSensorSpec::gpu2gpuTransfer);
 
   em::class_<CameraSensorSpec, em::base<VisualSensorSpec>>("CameraSensorSpec")
       .smart_ptr_constructor("CameraSensorSpec", &CameraSensorSpec::create<>)
-      .property("channels", &CameraSensorSpec::channels)
-      .property("observation_space", &CameraSensorSpec::observationSpace);
+      .property("ortho_scale", &CameraSensorSpec::ortho_scale);
 
   em::class_<Sensor>("Sensor")
       .smart_ptr<Sensor::ptr>("Sensor::ptr")

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -28,12 +28,12 @@ void CameraSensorSpec::sanityCheck() {
                  "SensorSubType "
                  "Pinhole or Orthographic", );
   CORRADE_ASSERT(
-      ortho_scale > 0,
-      "CameraSensorSpec::sanityCheck(): ortho_scale must be greater than 0", );
+      orthoScale > 0,
+      "CameraSensorSpec::sanityCheck(): orthoScale must be greater than 0", );
 }
 
 bool CameraSensorSpec::operator==(const CameraSensorSpec& a) const {
-  return VisualSensorSpec::operator==(a) && ortho_scale == a.ortho_scale;
+  return VisualSensorSpec::operator==(a) && orthoScale == a.orthoScale;
 }
 
 CameraSensor::CameraSensor(scene::SceneNode& cameraNode,
@@ -84,7 +84,7 @@ void CameraSensor::recomputeBaseProjectionMatrix() {
       Mn::Vector2{1.0f, static_cast<float>(cameraSensorSpec_->resolution[0]) /
                             cameraSensorSpec_->resolution[1]};
   if (cameraSensorSpec_->sensorSubType == SensorSubType::Orthographic) {
-    nearPlaneSize_ /= cameraSensorSpec_->ortho_scale;
+    nearPlaneSize_ /= cameraSensorSpec_->orthoScale;
     baseProjMatrix_ = Mn::Matrix4::orthographicProjection(
         nearPlaneSize_, cameraSensorSpec_->near, cameraSensorSpec_->far);
   } else {

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -27,11 +27,13 @@ void CameraSensorSpec::sanityCheck() {
                  "CameraSensorSpec::sanityCheck(): sensorSpec does not have "
                  "SensorSubType "
                  "Pinhole or Orthographic", );
+  CORRADE_ASSERT(
+      ortho_scale > 0,
+      "CameraSensorSpec::sanityCheck(): ortho_scale must be greater than 0", );
 }
 
 bool CameraSensorSpec::operator==(const CameraSensorSpec& a) const {
-  return VisualSensorSpec::operator==(a) && channels == a.channels &&
-         observationSpace == a.observationSpace;
+  return VisualSensorSpec::operator==(a) && ortho_scale == a.ortho_scale;
 }
 
 CameraSensor::CameraSensor(scene::SceneNode& cameraNode,
@@ -83,49 +85,23 @@ void CameraSensor::recomputeBaseProjectionMatrix() {
                             cameraSensorSpec_->resolution[1]};
   if (cameraSensorSpec_->sensorSubType == SensorSubType::Orthographic) {
     nearPlaneSize_ /= cameraSensorSpec_->ortho_scale;
-    baseProjMatrix_ =
-        Mn::Matrix4::orthographicProjection(nearPlaneSize_, near_, far_);
+    baseProjMatrix_ = Mn::Matrix4::orthographicProjection(
+        nearPlaneSize_, cameraSensorSpec_->near, cameraSensorSpec_->far);
   } else {
     // cameraSensorSpec_ is subtype Pinhole
     Magnum::Deg halfHFovRad{Magnum::Deg(.5 * hfov_)};
-    float scale = 1.0f / (2.0f * near_ * Magnum::Math::tan(halfHFovRad));
+    float scale = 1.0f / (2.0f * cameraSensorSpec_->near *
+                          Magnum::Math::tan(halfHFovRad));
     nearPlaneSize_ /= scale;
-    baseProjMatrix_ =
-        Mn::Matrix4::perspectiveProjection(nearPlaneSize_, near_, far_);
+    baseProjMatrix_ = Mn::Matrix4::perspectiveProjection(
+        nearPlaneSize_, cameraSensorSpec_->near, cameraSensorSpec_->far);
   }
   // build projection matrix
   recomputeProjectionMatrix();
 }  // CameraSensor::recomputeNearPlaneSize
 
-bool CameraSensor::getObservationSpace(ObservationSpace& space) {
-  space.spaceType = ObservationSpaceType::Tensor;
-  space.shape = {static_cast<size_t>(cameraSensorSpec_->resolution[0]),
-                 static_cast<size_t>(cameraSensorSpec_->resolution[1]),
-                 static_cast<size_t>(cameraSensorSpec_->channels)};
-  space.dataType = core::DataType::DT_UINT8;
-  if (cameraSensorSpec_->sensorType == SensorType::Semantic) {
-    space.dataType = core::DataType::DT_UINT32;
-  } else if (cameraSensorSpec_->sensorType == SensorType::Depth) {
-    space.dataType = core::DataType::DT_FLOAT;
-  }
-  return true;
-}
-
 gfx::RenderCamera* CameraSensor::getRenderCamera() const {
   return renderCamera_;
-}
-
-bool CameraSensor::getObservation(sim::Simulator& sim, Observation& obs) {
-  // TODO: check if sensor is valid?
-  // TODO: have different classes for the different types of sensors
-  //
-  if (!hasRenderTarget())
-    return false;
-
-  drawObservation(sim);
-  readObservation(obs);
-
-  return true;
 }
 
 bool CameraSensor::drawObservation(sim::Simulator& sim) {
@@ -155,33 +131,6 @@ bool CameraSensor::drawObservation(sim::Simulator& sim) {
   renderTarget().renderExit();
 
   return true;
-}
-
-void CameraSensor::readObservation(Observation& obs) {
-  // Make sure we have memory
-  if (buffer_ == nullptr) {
-    // TODO: check if our sensor was resized and resize our buffer if needed
-    ObservationSpace space;
-    getObservationSpace(space);
-    buffer_ = core::Buffer::create(space.shape, space.dataType);
-  }
-  obs.buffer = buffer_;
-
-  // TODO: have different classes for the different types of sensors
-  // TODO: do we need to flip axis?
-  if (cameraSensorSpec_->sensorType == SensorType::Semantic) {
-    renderTarget().readFrameObjectId(Magnum::MutableImageView2D{
-        Magnum::PixelFormat::R32UI, renderTarget().framebufferSize(),
-        obs.buffer->data});
-  } else if (cameraSensorSpec_->sensorType == SensorType::Depth) {
-    renderTarget().readFrameDepth(Magnum::MutableImageView2D{
-        Magnum::PixelFormat::R32F, renderTarget().framebufferSize(),
-        obs.buffer->data});
-  } else {
-    renderTarget().readFrameRgba(Magnum::MutableImageView2D{
-        Magnum::PixelFormat::RGBA8Unorm, renderTarget().framebufferSize(),
-        obs.buffer->data});
-  }
 }
 
 Corrade::Containers::Optional<Magnum::Vector2> CameraSensor::depthUnprojection()

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -13,7 +13,7 @@ namespace esp {
 namespace sensor {
 
 struct CameraSensorSpec : public VisualSensorSpec {
-  float ortho_scale = 0.1f;
+  float orthoScale = 0.1f;
   CameraSensorSpec();
   void sanityCheck() override;
   bool operator==(const CameraSensorSpec& a) const;

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -13,9 +13,7 @@ namespace esp {
 namespace sensor {
 
 struct CameraSensorSpec : public VisualSensorSpec {
-  int channels = 4;
-  // description of Sensor observation space as gym.spaces.Dict()
-  std::string observationSpace = "";
+  float ortho_scale = 0.1f;
   CameraSensorSpec();
   void sanityCheck() override;
   bool operator==(const CameraSensorSpec& a) const;
@@ -42,27 +40,6 @@ class CameraSensor : public VisualSensor {
    * for rendering
    */
   gfx::RenderCamera* getRenderCamera() const override;
-
-  /**
-   * @brief Draws an observation to the frame buffer using simulator's renderer,
-   * then reads the observation to the sensor's memory buffer
-   * @return true if success, otherwise false (e.g., failed to draw or read
-   * observation)
-   * @param[in] sim Instance of Simulator class for which the observation needs
-   *                to be drawn, obs Instance of Observation class in which the
-   * observation will be stored
-   */
-  bool getObservation(sim::Simulator& sim, Observation& obs) override;
-
-  /**
-   * @brief Updates ObservationSpace space with spaceType, shape, and dataType
-   * of this sensor. The information in space is later used to resize the
-   * sensor's memory buffer if sensor is resized.
-   * @return true if success, otherwise false
-   * @param[in] space Instance of ObservationSpace class which will be updated
-   * with information from this sensor
-   */
-  bool getObservationSpace(ObservationSpace& space) override;
 
   /**
    * @brief Returns the parameters needed to unproject depth for this sensor's
@@ -167,10 +144,9 @@ class CameraSensor : public VisualSensor {
     CORRADE_ASSERT(_near > 0,
                    "CameraSensor::setNear(): near plane distance must be "
                    "greater than 0", );
-    near_ = _near;
+    cameraSensorSpec_->near = _near;
     recomputeBaseProjectionMatrix();
   }
-  float getNear() const { return near_; }
 
   /**
    * @brief Sets far plane distance.
@@ -179,10 +155,9 @@ class CameraSensor : public VisualSensor {
     CORRADE_ASSERT(
         _far > 0,
         "CameraSensor::setFar(): Far plane distance must be greater than 0", );
-    far_ = _far;
+    cameraSensorSpec_->far = _far;
     recomputeBaseProjectionMatrix();
   }
-  float getFar() const { return far_; }
 
  protected:
   /**
@@ -198,13 +173,6 @@ class CameraSensor : public VisualSensor {
    * change.
    */
   void recomputeProjectionMatrix();
-
-  /**
-   * @brief Read the observation that was rendered by the simulator
-   * @param[in,out] obs Instance of Observation class in which the observation
-   * will be stored
-   */
-  virtual void readObservation(Observation& obs);
 
   /**
    * @brief This camera's projection matrix. Should be recomputeulated every

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -24,7 +24,8 @@ using Mn::Math::Literals::operator""_degf;
 
 struct VisualSensorSpec : public SensorSpec {
   vec2i resolution = {128, 128};  // height x width
-  int channels = 4;
+  int channels =
+      4;  // Number of components in buffer values, eg. 4 channels for RGBA
   bool gpu2gpuTransfer = false;  // True for pytorch tensor support
   /**
    * @brief near clipping plane


### PR DESCRIPTION
## Motivation and Context

This PR introduces changes to VisualSensor, CameraSensor, VisualSensorSpec, and CameraSensorSpec in order for 
 the hierarchical SensorSpec to be correct when new Sensors are introduced.
 
 In this PR: 

- Lift getObservation, getObservationSpace, and readObservation from CameraSensor to Visual Sensor
- Deprecate observationSpace and encoding in SensorSpec
- Move channels, near, and far to VisualSensorSpec, move ortho_scale to CameraSensorSpec

See https://github.com/facebookresearch/habitat-sim/pull/1090/files#r588849042 for context

## How Has This Been Tested

Build and run tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
