### PR TITLE
Access semantic scene mesh directly

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -55,7 +55,6 @@
 #endif
 
 #include "CollisionMeshData.h"
-#include "GenericInstanceMeshData.h"
 #include "GenericMeshData.h"
 #include "MeshData.h"
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -275,35 +275,58 @@ class ResourceManager {
   /**
    * @brief Return a vector of the vertex position in a given mesh.
    *
-   * Given the integer ID of a mesh, get the vertex positions in that mesh.
+   * Given the integer ID of a semantic mesh, get the vertex positions in that
+   * mesh.
    * @param id The number index of a mesh.
    * @return A vector of vertex positions.
    */
   std::vector<vec3f> getVertices(int id) {
-    const std::vector<vec3f> vertexPositions =
-          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
-              .getVertexBufferObjectCPU();
-    return vertexPositions;
+    BaseMesh &mesh = *meshes_.at(id);
+    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+      // It is an instance mesh and it is possible to return the vertex data
+      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<vec3f> vertexPositions = instMesh.getVertexBufferObjectCPU();
+      return vertexPositions;
+
+    } else {
+      // The mesh is not an instance mesh
+      throw "Error in getVertices. The mesh is not an instance mesh.";
+      const std::vector<vec3f> vertexPositions;
+    }
   }
 
   /**
    * @brief Return a vector of the surface indexes for a specific mesh in the scene.
    */
   std::vector<uint32_t> getSurfIndexes(int id) {
-    const std::vector<uint32_t> surfIndexes =
-          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
-              .getIndexBufferObjectCPU();
-    return surfIndexes;
+    BaseMesh &mesh = *meshes_.at(id);
+    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+      // It is an instance mesh and it is possible to return the vertex data
+      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<uint32_t> surfIndexes = instMesh.getIndexBufferObjectCPU();
+      return surfIndexes;
+
+    } else {
+      // The mesh is not an instance mesh
+      throw "Error in getSurfIndexes. The mesh is not an instance mesh.";
+    }
   }
 
   /**
    * @brief Return a vector of color per vertex for a specific mesh in the scene.
    */
   std::vector<vec3uc> getVerticesColor(int id) {
-    const std::vector<vec3uc> colors =
-          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
-              .getColorBufferObjectCPU();
-    return colors;
+    BaseMesh &mesh = *meshes_.at(id);
+    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+      // It is an instance mesh and it is possible to return the vertex data
+      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<vec3uc> colors = instMesh.getColorBufferObjectCPU();
+      return colors;
+
+    } else {
+      // The mesh is not an instance mesh
+      throw "Error in getSurfIndexes. The mesh is not an instance mesh.";
+    }
   }
 
   /**
@@ -315,10 +338,17 @@ class ResourceManager {
    * @return A vector of object IDs.
    */
   std::vector<uint16_t> getObjectIds(int id) {
-    const std::vector<uint16_t> objIds =
-          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
-              .getObjectIdsBufferObjectCPU();
-    return objIds;
+    BaseMesh &mesh = *meshes_.at(id);
+    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+      // It is an instance mesh and it is possible to return the vertex data
+      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<uint16_t> objIds = instMesh.getObjectIdsBufferObjectCPU();
+      return objIds;
+
+    } else {
+      // The mesh is not an instance mesh
+      throw "Error in getSurfIndexes. The mesh is not an instance mesh.";
+    }
   }
 
    /**
@@ -330,7 +360,7 @@ class ResourceManager {
    std::vector<int> getMeshKeys() {
      std::vector<int> r;
      for (auto const& m : meshes_){
-       auto id = m.first;
+       int id = m.first;
        r.push_back(id);
      }
      return r;

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -28,10 +28,10 @@
 #include "Asset.h"
 #include "BaseMesh.h"
 #include "CollisionMeshData.h"
+#include "GenericInstanceMeshData.h"
 #include "GenericMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
-#include "GenericInstanceMeshData.h"
 #include "RenderAssetInstanceCreationInfo.h"
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
@@ -281,11 +281,13 @@ class ResourceManager {
    * @return A vector of vertex positions.
    */
   std::vector<vec3f> getVertices(int id) {
-    BaseMesh &mesh = *meshes_.at(id);
-    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+    BaseMesh& mesh = *meshes_.at(id);
+    if (mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH) {
       // It is an instance mesh and it is possible to return the vertex data
-      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
-      const std::vector<vec3f> vertexPositions = instMesh.getVertexBufferObjectCPU();
+      const GenericInstanceMeshData& instMesh =
+          dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<vec3f> vertexPositions =
+          instMesh.getVertexBufferObjectCPU();
       return vertexPositions;
 
     } else {
@@ -296,14 +298,17 @@ class ResourceManager {
   }
 
   /**
-   * @brief Return a vector of the surface indexes for a specific mesh in the scene.
+   * @brief Return a vector of the surface indexes for a specific mesh in the
+   * scene.
    */
   std::vector<uint32_t> getSurfIndexes(int id) {
-    BaseMesh &mesh = *meshes_.at(id);
-    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+    BaseMesh& mesh = *meshes_.at(id);
+    if (mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH) {
       // It is an instance mesh and it is possible to return the vertex data
-      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
-      const std::vector<uint32_t> surfIndexes = instMesh.getIndexBufferObjectCPU();
+      const GenericInstanceMeshData& instMesh =
+          dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<uint32_t> surfIndexes =
+          instMesh.getIndexBufferObjectCPU();
       return surfIndexes;
 
     } else {
@@ -313,13 +318,15 @@ class ResourceManager {
   }
 
   /**
-   * @brief Return a vector of color per vertex for a specific mesh in the scene.
+   * @brief Return a vector of color per vertex for a specific mesh in the
+   * scene.
    */
   std::vector<vec3uc> getVerticesColor(int id) {
-    BaseMesh &mesh = *meshes_.at(id);
-    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+    BaseMesh& mesh = *meshes_.at(id);
+    if (mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH) {
       // It is an instance mesh and it is possible to return the vertex data
-      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const GenericInstanceMeshData& instMesh =
+          dynamic_cast<GenericInstanceMeshData&>(mesh);
       const std::vector<vec3uc> colors = instMesh.getColorBufferObjectCPU();
       return colors;
 
@@ -338,11 +345,13 @@ class ResourceManager {
    * @return A vector of object IDs.
    */
   std::vector<uint16_t> getObjectIds(int id) {
-    BaseMesh &mesh = *meshes_.at(id);
-    if(mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH){
+    BaseMesh& mesh = *meshes_.at(id);
+    if (mesh.getMeshType() == SupportedMeshType::INSTANCE_MESH) {
       // It is an instance mesh and it is possible to return the vertex data
-      const GenericInstanceMeshData &instMesh = dynamic_cast<GenericInstanceMeshData&>(mesh);
-      const std::vector<uint16_t> objIds = instMesh.getObjectIdsBufferObjectCPU();
+      const GenericInstanceMeshData& instMesh =
+          dynamic_cast<GenericInstanceMeshData&>(mesh);
+      const std::vector<uint16_t> objIds =
+          instMesh.getObjectIdsBufferObjectCPU();
       return objIds;
 
     } else {
@@ -351,20 +360,20 @@ class ResourceManager {
     }
   }
 
-   /**
-    * @brief Return a vector of the integer IDs of existing meshes.
-    *
-    * Return a vector of the integer IDs of existing meshes.
-    * @return a vector of existing mesh IDs.
-    */
-   std::vector<int> getMeshKeys() {
-     std::vector<int> r;
-     for (auto const& m : meshes_){
-       int id = m.first;
-       r.push_back(id);
-     }
-     return r;
-   }
+  /**
+   * @brief Return a vector of the integer IDs of existing meshes.
+   *
+   * Return a vector of the integer IDs of existing meshes.
+   * @return a vector of existing mesh IDs.
+   */
+  std::vector<int> getMeshKeys() {
+    std::vector<int> r;
+    for (auto const& m : meshes_) {
+      int id = m.first;
+      r.push_back(id);
+    }
+    return r;
+  }
 
   /**
    * @brief Set a reference to the current @ref metadataMediator_.  Perform any

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -308,6 +308,26 @@ class ResourceManager {
   }
 
   /**
+   * @brief Return a vector of what I believe are the surface indexes for a specific mesh in the scene.
+   */
+  std::vector<uint32_t> getSurfIndexes(int id) {
+    const std::vector<uint32_t> surfIndexes =
+          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
+              .getIndexBufferObjectCPU();
+    return surfIndexes;
+  }
+
+  /**
+   * @brief Return a vector of color per vertex for a specific mesh in the scene.
+   */
+  std::vector<vec3uc> getVerticesColor(int id) {
+    const std::vector<vec3uc> colors =
+          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
+              .getColorBufferObjectCPU();
+    return colors;
+  }
+
+  /**
    * @brief Return a vector of object IDs for each vertex in a given mesh.
    *
    * Given the integer ID of a mesh, get the object IDs of each vertex in

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -308,7 +308,7 @@ class ResourceManager {
   }
 
   /**
-   * @brief Return a vector of what I believe are the surface indexes for a specific mesh in the scene.
+   * @brief Return a vector of the surface indexes for a specific mesh in the scene.
    */
   std::vector<uint32_t> getSurfIndexes(int id) {
     const std::vector<uint32_t> surfIndexes =

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -273,7 +273,11 @@ class ResourceManager {
   }
 
   /**
-   * @brief
+   * @brief Return a vector of all vertex positions in the mesh
+   *
+   * Constructs a vector of all vertex positions the vertex positions in each
+   * separate mesh.
+   * @return A nested vector of vertex positions (level 1) in meshes (level 2).
    */
   std::vector<std::vector<vec3f>> getVertices() {
     std::vector<std::vector<vec3f>> r;
@@ -290,7 +294,11 @@ class ResourceManager {
   }
 
   /**
-   * @brief
+   * @brief Return a vector of the vertex position in a given mesh.
+   *
+   * Given the integer ID of a mesh, get the vertex positions in that mesh.
+   * @param id The number index of a mesh.
+   * @return A vector of vertex positions.
    */
   std::vector<vec3f> getVertices(int id) {
     const std::vector<vec3f> vertexPositions =
@@ -300,7 +308,12 @@ class ResourceManager {
   }
 
   /**
-   * @brief
+   * @brief Return a vector of object IDs for each vertex in a given mesh.
+   *
+   * Given the integer ID of a mesh, get the object IDs of each vertex in
+   * the mesh.
+   * @param id The number index of a mesh.
+   * @return A vector of object IDs.
    */
   std::vector<uint16_t> getObjectIds(int id) {
     const std::vector<uint16_t> objIds =
@@ -310,7 +323,10 @@ class ResourceManager {
   }
 
    /**
-    * @brief
+    * @brief Return a vector of the integer IDs of existing meshes.
+    *
+    * Return a vector of the integer IDs of existing meshes.
+    * @return a vector of existing mesh IDs.
     */
    std::vector<int> getMeshKeys() {
      std::vector<int> r;

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -273,27 +273,6 @@ class ResourceManager {
   }
 
   /**
-   * @brief Return a vector of all vertex positions in the mesh
-   *
-   * Constructs a vector of all vertex positions the vertex positions in each
-   * separate mesh.
-   * @return A nested vector of vertex positions (level 1) in meshes (level 2).
-   */
-  std::vector<std::vector<vec3f>> getVertices() {
-    std::vector<std::vector<vec3f>> r;
-    for (auto const& m : meshes_){
-      auto id = m.first;
-      printf("Getting mesh number %d\n", id);
-      auto mesh = m.second;
-      const std::vector<vec3f> vertexPositions =
-            dynamic_cast<GenericInstanceMeshData&>(*mesh)
-                .getVertexBufferObjectCPU();
-      r.push_back(vertexPositions);
-    }
-    return r;
-  }
-
-  /**
    * @brief Return a vector of the vertex position in a given mesh.
    *
    * Given the integer ID of a mesh, get the vertex positions in that mesh.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -31,6 +31,7 @@
 #include "GenericMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
+#include "GenericInstanceMeshData.h"
 #include "RenderAssetInstanceCreationInfo.h"
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/DrawableGroup.h"
@@ -270,6 +271,55 @@ class ResourceManager {
   getStageAttributesManager() const {
     return metadataMediator_->getStageAttributesManager();
   }
+
+  /**
+   * @brief
+   */
+  std::vector<std::vector<vec3f>> getVertices() {
+    std::vector<std::vector<vec3f>> r;
+    for (auto const& m : meshes_){
+      auto id = m.first;
+      printf("Getting mesh number %d\n", id);
+      auto mesh = m.second;
+      const std::vector<vec3f> vertexPositions =
+            dynamic_cast<GenericInstanceMeshData&>(*mesh)
+                .getVertexBufferObjectCPU();
+      r.push_back(vertexPositions);
+    }
+    return r;
+  }
+
+  /**
+   * @brief
+   */
+  std::vector<vec3f> getVertices(int id) {
+    const std::vector<vec3f> vertexPositions =
+          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
+              .getVertexBufferObjectCPU();
+    return vertexPositions;
+  }
+
+  /**
+   * @brief
+   */
+  std::vector<uint16_t> getObjectIds(int id) {
+    const std::vector<uint16_t> objIds =
+          dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(id))
+              .getObjectIdsBufferObjectCPU();
+    return objIds;
+  }
+
+   /**
+    * @brief
+    */
+   std::vector<int> getMeshKeys() {
+     std::vector<int> r;
+     for (auto const& m : meshes_){
+       auto id = m.first;
+       r.push_back(id);
+     }
+     return r;
+   }
 
   /**
    * @brief Set a reference to the current @ref metadataMediator_.  Perform any

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -323,23 +323,22 @@ void initSimBindings(py::module& m) {
           "set_object_light_setup", &Simulator::setObjectLightSetup,
           "object_id"_a, "light_setup_key"_a, "scene_id"_a = 0,
           R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)")
-
       .def(
           "get_num_active_contact_points",
           &Simulator::getNumActiveContactPoints,
           R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)")
       .def("get_vertices",
-           &Simulator::getVertices,
-           pybind11::return_value_policy::reference,
-           R"()")
+          &Simulator::getVertices,
+          pybind11::return_value_policy::reference,
+          R"(Return a vector of the vertex locations on a given mesh.)")
       .def("get_object_ids",
-           &Simulator::getObjectIds,
-           pybind11::return_value_policy::reference,
-           R"()")
+          &Simulator::getObjectIds,
+          pybind11::return_value_policy::reference,
+          R"(Return the object IDs for each vertex in a given mesh.)")
       .def("get_mesh_keys",
-           &Simulator::getMeshKeys,
-           pybind11::return_value_policy::reference,
-           R"()")
+          &Simulator::getMeshKeys,
+          pybind11::return_value_policy::reference,
+          R"(Return a list of the IDs of existing meshes.)")
   ;
 }
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -333,13 +333,15 @@ void initSimBindings(py::module& m) {
           pybind11::return_value_policy::reference,
           R"(Return a vector of the vertex locations on a given mesh.)")
       .def("get_vertices_color",
-           &Simulator::getVerticesColor,
-           pybind11::return_value_policy::reference,
-           R"()")
+          &Simulator::getVerticesColor,
+          "ID"_a,
+          pybind11::return_value_policy::reference,
+          R"(Return a vector of color per vertex for a specific mesh in the scene.)")
       .def("get_surface_ids",
-           &Simulator::getSurfIndexes,
-           pybind11::return_value_policy::reference,
-           R"()")
+          &Simulator::getSurfIndexes,
+          "ID"_a,
+          pybind11::return_value_policy::reference,
+          R"(Return a vector of the surface indexes for a specific mesh in the scene.)")
       .def("get_object_ids",
           &Simulator::getObjectIds,
           "ID"_a,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -327,7 +327,19 @@ void initSimBindings(py::module& m) {
       .def(
           "get_num_active_contact_points",
           &Simulator::getNumActiveContactPoints,
-          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)");
+          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)")
+      .def("get_vertices",
+           &Simulator::getVertices,
+           pybind11::return_value_policy::reference,
+           R"()")
+      .def("get_object_ids",
+           &Simulator::getObjectIds,
+           pybind11::return_value_policy::reference,
+           R"()")
+      .def("get_mesh_keys",
+           &Simulator::getMeshKeys,
+           pybind11::return_value_policy::reference,
+           R"()")
   ;
 }
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -327,31 +327,23 @@ void initSimBindings(py::module& m) {
           "get_num_active_contact_points",
           &Simulator::getNumActiveContactPoints,
           R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)")
-      .def("get_vertices",
-          &Simulator::getVertices,
-          "ID"_a,
-          pybind11::return_value_policy::reference,
-          R"(Return a vector of the vertex locations on a given mesh.)")
-      .def("get_vertices_color",
-          &Simulator::getVerticesColor,
-          "ID"_a,
+      .def("get_vertices", &Simulator::getVertices, "ID"_a,
+           pybind11::return_value_policy::reference,
+           R"(Return a vector of the vertex locations on a given mesh.)")
+      .def(
+          "get_vertices_color", &Simulator::getVerticesColor, "ID"_a,
           pybind11::return_value_policy::reference,
           R"(Return a vector of color per vertex for a specific mesh in the scene.)")
-      .def("get_surface_ids",
-          &Simulator::getSurfIndexes,
-          "ID"_a,
+      .def(
+          "get_surface_ids", &Simulator::getSurfIndexes, "ID"_a,
           pybind11::return_value_policy::reference,
           R"(Return a vector of the surface indexes for a specific mesh in the scene.)")
-      .def("get_object_ids",
-          &Simulator::getObjectIds,
-          "ID"_a,
-          pybind11::return_value_policy::reference,
-          R"(Return the object IDs for each vertex in a given mesh.)")
-      .def("get_mesh_keys",
-          &Simulator::getMeshKeys,
-          pybind11::return_value_policy::reference,
-          R"(Return a list of the IDs of existing meshes.)")
-      ;
+      .def("get_object_ids", &Simulator::getObjectIds, "ID"_a,
+           pybind11::return_value_policy::reference,
+           R"(Return the object IDs for each vertex in a given mesh.)")
+      .def("get_mesh_keys", &Simulator::getMeshKeys,
+           pybind11::return_value_policy::reference,
+           R"(Return a list of the IDs of existing meshes.)");
 }
 
 }  // namespace sim

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -329,17 +329,19 @@ void initSimBindings(py::module& m) {
           R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.)")
       .def("get_vertices",
           &Simulator::getVertices,
+          "ID"_a,
           pybind11::return_value_policy::reference,
           R"(Return a vector of the vertex locations on a given mesh.)")
       .def("get_object_ids",
           &Simulator::getObjectIds,
+          "ID"_a,
           pybind11::return_value_policy::reference,
           R"(Return the object IDs for each vertex in a given mesh.)")
       .def("get_mesh_keys",
           &Simulator::getMeshKeys,
           pybind11::return_value_policy::reference,
           R"(Return a list of the IDs of existing meshes.)")
-  ;
+      ;
 }
 
 }  // namespace sim

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -332,6 +332,14 @@ void initSimBindings(py::module& m) {
           "ID"_a,
           pybind11::return_value_policy::reference,
           R"(Return a vector of the vertex locations on a given mesh.)")
+      .def("get_vertices_color",
+           &Simulator::getVerticesColor,
+           pybind11::return_value_policy::reference,
+           R"()")
+      .def("get_surface_ids",
+           &Simulator::getSurfIndexes,
+           pybind11::return_value_policy::reference,
+           R"()")
       .def("get_object_ids",
           &Simulator::getObjectIds,
           "ID"_a,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -888,21 +888,33 @@ class Simulator {
 #endif
 
   /**
-   * @brief
+   * @brief Return a vector of the vertex locations of a given mesh.
+   *
+   * Given the integer ID of a mesh, return vector of the associated vertex
+   * locations.
+   * @param id The integer ID of a mesh.
+   * @return A vector of vertex locations in the given mesh.
    */
   std::vector<vec3f> getVertices(int id) {
     return resourceManager_->getVertices(id);
   }
 
   /**
-   * @brief
+   * @brief Return a vector of the object IDs for each vertex location of a
+   * given mesh.
+   *
+   * Given the integer ID of a mesh, return a vector of the object IDs for
+   * each vertex location of the mesh
+   * @param id The integer ID of a mesh.
+   * @return A vector of object IDs in the given mesh.
    */
   std::vector<uint16_t> getObjectIds(int id){
     return resourceManager_->getObjectIds(id);
   }
 
   /**
-   * @brief
+   * @brief Return a vector of the integer IDs of existing meshes.
+   * @return a vector of existing mesh IDs.
    */
   std::vector<int> getMeshKeys() {
     return resourceManager_->getMeshKeys();

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -898,18 +898,21 @@ class Simulator {
   std::vector<vec3f> getVertices(int id) {
     return resourceManager_->getVertices(id);
   }
+
   /**
-   * @brief
+   * @brief Return a vector of color per vertex for a specific mesh in the scene.
    */
   std::vector<vec3uc> getVerticesColor(int id) {
     return resourceManager_->getVerticesColor(id);
   }
+
   /**
-   * @brief
+   * @brief Return a vector of the surface indexes for a specific mesh in the scene.
    */
   std::vector<uint32_t> getSurfIndexes(int id) {
     return resourceManager_->getSurfIndexes(id);
   }
+
   /**
    * @brief Return a vector of the object IDs for each vertex location of a
    * given mesh.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -887,6 +887,28 @@ class Simulator {
       bool saveChdToObj = false);
 #endif
 
+  /**
+   * @brief
+   */
+  std::vector<vec3f> getVertices(int id) {
+    return resourceManager_->getVertices(id);
+  }
+
+  /**
+   * @brief
+   */
+  std::vector<uint16_t> getObjectIds(int id){
+    return resourceManager_->getObjectIds(id);
+  }
+
+  /**
+   * @brief
+   */
+  std::vector<int> getMeshKeys() {
+    return resourceManager_->getMeshKeys();
+  }
+
+
  protected:
   Simulator() = default;
   /**

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -900,14 +900,16 @@ class Simulator {
   }
 
   /**
-   * @brief Return a vector of color per vertex for a specific mesh in the scene.
+   * @brief Return a vector of color per vertex for a specific mesh in the
+   * scene.
    */
   std::vector<vec3uc> getVerticesColor(int id) {
     return resourceManager_->getVerticesColor(id);
   }
 
   /**
-   * @brief Return a vector of the surface indexes for a specific mesh in the scene.
+   * @brief Return a vector of the surface indexes for a specific mesh in the
+   * scene.
    */
   std::vector<uint32_t> getSurfIndexes(int id) {
     return resourceManager_->getSurfIndexes(id);
@@ -922,7 +924,7 @@ class Simulator {
    * @param id The integer ID of a mesh.
    * @return A vector of object IDs in the given mesh.
    */
-  std::vector<uint16_t> getObjectIds(int id){
+  std::vector<uint16_t> getObjectIds(int id) {
     return resourceManager_->getObjectIds(id);
   }
 
@@ -930,10 +932,7 @@ class Simulator {
    * @brief Return a vector of the integer IDs of existing meshes.
    * @return a vector of existing mesh IDs.
    */
-  std::vector<int> getMeshKeys() {
-    return resourceManager_->getMeshKeys();
-  }
-
+  std::vector<int> getMeshKeys() { return resourceManager_->getMeshKeys(); }
 
  protected:
   Simulator() = default;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -898,7 +898,18 @@ class Simulator {
   std::vector<vec3f> getVertices(int id) {
     return resourceManager_->getVertices(id);
   }
-
+  /**
+   * @brief
+   */
+  std::vector<vec3uc> getVerticesColor(int id) {
+    return resourceManager_->getVerticesColor(id);
+  }
+  /**
+   * @brief
+   */
+  std::vector<uint32_t> getSurfIndexes(int id) {
+    return resourceManager_->getSurfIndexes(id);
+  }
   /**
    * @brief Return a vector of the object IDs for each vertex location of a
    * given mesh.

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -252,8 +252,7 @@ def test_object_template_editing():
 
 @pytest.mark.skip(reason="the test requires data not present on the repository")
 def test_mesh_point_extraction():
-    ''' Test the interface for retrieving mesh data from instance meshes
-    '''
+    """Test the interface for retrieving mesh data from instance meshes"""
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "office_0/habitat/mesh_semantic.ply"
     hab_cfg = examples.settings.make_cfg(cfg_settings)
@@ -261,22 +260,22 @@ def test_mesh_point_extraction():
 
     # Try getting a list of mesh IDs
     keys = sim.get_mesh_keys()
-    assert(len(keys) == 68)
+    assert len(keys) == 68
 
     # Test getting information on mesh 0
     vertices = sim.get_vertices(0)
-    assert(len(vertices) == 13431)
+    assert len(vertices) == 13431
     vertices_color = sim.get_vertices_color(0)
-    assert(len(vertices_color) == 13431)
+    assert len(vertices_color) == 13431
     vertices = sim.get_object_ids(0)
-    assert(len(vertices) == 13431)
+    assert len(vertices) == 13431
     surface_ids = sim.get_surface_ids(0)
-    assert(len(surface_ids) == 76908)
+    assert len(surface_ids) == 76908
 
 
 def test_mesh_point_extraction_when_not_instance():
-    ''' Run the mesh extraction methods when the mesh is not
-        an instance mesh. This should result in an exception. '''
+    """Run the mesh extraction methods when the mesh is not
+    an instance mesh. This should result in an exception."""
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "data/test_assets/scenes/simple_room.glb"
     hab_cfg = examples.settings.make_cfg(cfg_settings)
@@ -284,7 +283,7 @@ def test_mesh_point_extraction_when_not_instance():
 
     # The scene has 6 meshes
     keys = sim.get_mesh_keys()
-    assert(len(keys) == 7)
+    assert len(keys) == 7
 
     # The other mesh data extraction methods should throw an exception
     with pytest.raises(Exception):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -2,6 +2,8 @@ import random
 from copy import copy
 from os import path as osp
 
+import pytest
+
 import magnum as mn
 import numpy as np
 
@@ -246,3 +248,26 @@ def test_object_template_editing():
 
             obj_init_template = sim.get_object_initialization_template(object_id)
             assert obj_init_template.render_asset_handle.endswith("sphere.glb")
+
+
+@pytest.mark.skip(reason="the test requires data not present on the repository")
+def test_mesh_point_extraction():
+    ''' Test the interface for retrieving mesh data '''
+    cfg_settings = examples.settings.default_sim_settings.copy()
+    cfg_settings["scene"] = "office_0/habitat/mesh_semantic.ply"
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim = habitat_sim.Simulator(hab_cfg)
+
+    # Try getting a list of mesh IDs
+    keys = sim.get_mesh_keys()
+    assert(len(keys) == 68)
+
+    # Test getting information on mesh 0
+    vertices = sim.get_vertices(0)
+    assert(len(vertices) == 13431)
+    vertices_color = sim.get_vertices_color(0)
+    assert(len(vertices_color) == 13431)
+    vertices = sim.get_object_ids(0)
+    assert(len(vertices) == 13431)
+    surface_ids = sim.get_surface_ids(0)
+    assert(len(surface_ids) == 76908)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -252,7 +252,8 @@ def test_object_template_editing():
 
 @pytest.mark.skip(reason="the test requires data not present on the repository")
 def test_mesh_point_extraction():
-    ''' Test the interface for retrieving mesh data '''
+    ''' Test the interface for retrieving mesh data from instance meshes
+    '''
     cfg_settings = examples.settings.default_sim_settings.copy()
     cfg_settings["scene"] = "office_0/habitat/mesh_semantic.ply"
     hab_cfg = examples.settings.make_cfg(cfg_settings)
@@ -271,3 +272,26 @@ def test_mesh_point_extraction():
     assert(len(vertices) == 13431)
     surface_ids = sim.get_surface_ids(0)
     assert(len(surface_ids) == 76908)
+
+
+def test_mesh_point_extraction_when_not_instance():
+    ''' Run the mesh extraction methods when the mesh is not
+        an instance mesh. This should result in an exception. '''
+    cfg_settings = examples.settings.default_sim_settings.copy()
+    cfg_settings["scene"] = "data/test_assets/scenes/simple_room.glb"
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    sim = habitat_sim.Simulator(hab_cfg)
+
+    # The scene has 6 meshes
+    keys = sim.get_mesh_keys()
+    assert(len(keys) == 7)
+
+    # The other mesh data extraction methods should throw an exception
+    with pytest.raises(Exception):
+        vertices = sim.get_vertices(0)
+    with pytest.raises(Exception):
+        vertices = sim.get_vertices_color(0)
+    with pytest.raises(Exception):
+        vertices = sim.get_object_ids(0)
+    with pytest.raises(Exception):
+        vertices = sim.get_surface_ids(0)


### PR DESCRIPTION
## Motivation and Context

We have implemented the ability to directly access mesh data as discussed in issue #1081.

This required adding methods to the ResourceManager class and the Simulator class. We added python bindings
to the methods in the Simulator class.

## How Has This Been Tested

We added two new tests to tests/test_simulator.py, test_mesh_point_extraction and 
test_mesh_point_extraction_when_not_instance. The first one uses a datafile not 
present in the repository and is marked as skipped. It tests that the methods run and
return vectors with the correct length.

The other test check that the methods throw an exception when the meshes are not
of the GenericInstanceMeshData type.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
