### PR TITLE
[Bugfix] Set Stage Instance default lighting appropriately.

### DIFF
--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -34,8 +34,8 @@ const std::map<std::string, managers::SceneInstanceTranslationOrigin>
 };
 SceneAttributes::SceneAttributes(const std::string& handle)
     : AbstractAttributes("SceneAttributes", handle) {
-  // defaults to no lights
-  setLightingHandle(NO_LIGHT_KEY);
+  // defaults to default lighting
+  setLightingHandle(DEFAULT_LIGHTING_KEY);
   // defaults to asset local
   setTranslationOrigin(
       static_cast<int>(managers::SceneInstanceTranslationOrigin::AssetLocal));


### PR DESCRIPTION
This small bugfix sets the Scene Instance default lighting to be "DEFAULT_LIGHTING_KEY" instead of "NO_LIGHT_KEY", so that unspecified scenes, particularly those constructed internally to support the direct loading of a stage, will have reasonable light setups.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
