### PR TITLE
prototype navmesh snapPoint to single island

### DIFF
--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -250,6 +250,9 @@ class PathFinder {
   template <typename T>
   T snapPoint(const T& pt);
 
+  template <typename T>
+  T snapPointWithBase(const T& pt, const T& basePt);
+
   /**
    * @brief Loads a navigation meshed saved by @ref saveNavMesh
    *


### PR DESCRIPTION
Prototype, do not merge.

Instead of snapping to any point on the navmesh, snapPointWithBase first does a snap with the base point (e.g. the agent) to find a base navmesh poly. Then, we snap the query point to the nearest navmesh poly in the same island as the base navmesh poly.

As an example usage, consider snapping an object position to the nearest position that an agent can actually navigate to (remember that you can't navigate to a separate navmesh island, by definition).

https://user-images.githubusercontent.com/6557808/113487851-47187d00-946f-11eb-8bd5-8a6e792f23b5.mp4



