### PR TITLE
[AO] joint limit query and clamping

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -366,6 +366,13 @@ void initSimBindings(py::module& m) {
            &Simulator::getArticulatedObjectVelocities, "object_id"_a)
       .def("get_articulated_object_forces",
            &Simulator::getArticulatedObjectForces, "object_id"_a)
+      .def("get_articulated_object_position_limits",
+           &Simulator::getArticulatedObjectPositionLimits, "object_id"_a,
+           "upper_limits"_a = false)
+      .def("get_auto_clamp_joint_limits", &Simulator::getAutoClampJointLimits,
+           "object_id"_a)
+      .def("set_auto_clamp_joint_limits", &Simulator::setAutoClampJointLimits,
+           "object_id"_a, "auto_clamp"_a)
       .def("reset_articulated_object", &Simulator::resetArticulatedObject,
            "object_id"_a)
       .def("set_articulated_object_sleep",

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -303,9 +303,9 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual std::vector<float> getPositions() { return {}; };
 
-  virtual std::vector<float> getPositionLowerLimits() { return {}; };
-
-  virtual std::vector<float> getPositionUpperLimits() { return {}; };
+  virtual std::vector<float> getPositionLimits(bool upperLimits = false) {
+    return {};
+  };
 
   virtual void addArticulatedLinkForce(CORRADE_UNUSED int linkId,
                                        CORRADE_UNUSED Magnum::Vector3 force){};
@@ -401,6 +401,28 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
     return std::map<int, int>();
   };
 
+  /**
+   * @brief Set whether articulated object state is automatically clamped to
+   * configured joint limits before physics simulation.
+   */
+  void setAutoClampJointLimits(bool autoClamp) {
+    autoClampJointLimits_ = autoClamp;
+  }
+
+  /**
+   * @brief Query whether articulated object state is automatically clamped to
+   * configured joint limits before physics simulation.
+   */
+  bool getAutoClampJointLimits() { return autoClampJointLimits_; }
+
+  /**
+   * @brief Clamp current pose to joint limits.
+   * See derived implementations.
+   */
+  virtual void clampJointLimits() {
+    Magnum::Debug{} << "No base implementation of \"clampJointLimits\". ";
+  };
+
   //=========== END - Joint Motor API ===========
 
   //! map PhysicsManager objectId to local multibody linkId
@@ -431,6 +453,10 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
 
   //! This ArticulatedObject's id in PhysicsManager::existingArticulatedObjects
   int objectId_;
+
+  //! if true, automatically clamp dofs to joint limits before physics
+  //! simulation steps
+  bool autoClampJointLimits_ = false;
 
   ESP_SMART_POINTERS(ArticulatedObject)
 };

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1363,6 +1363,24 @@ class PhysicsManager {
     existingArticulatedObjects_.at(objectId)->setPositions(positions);
   };
 
+  std::vector<float> getArticulatedObjectPositionLimits(
+      int objectId,
+      bool upperLimits = false) {
+    CHECK(existingArticulatedObjects_.count(objectId));
+    return existingArticulatedObjects_.at(objectId)->getPositionLimits(
+        upperLimits);
+  };
+
+  void setAutoClampJointLimits(int objectId, bool autoClamp) {
+    CHECK(existingArticulatedObjects_.count(objectId));
+    existingArticulatedObjects_.at(objectId)->setAutoClampJointLimits(
+        autoClamp);
+  };
+
+  bool getAutoClampJointLimits(int objectId) {
+    CHECK(existingArticulatedObjects_.count(objectId));
+    return existingArticulatedObjects_.at(objectId)->getAutoClampJointLimits();
+  };
   std::vector<float> getArticulatedObjectPositions(int objectId) {
     CHECK(existingArticulatedObjects_.count(objectId));
     return existingArticulatedObjects_.at(objectId)->getPositions();

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -97,10 +97,8 @@ class BulletArticulatedObject : public ArticulatedObject {
 
   virtual std::vector<float> getPositions() override;
 
-  // TODO: This is tough in Bullet. We'll need to construct a map from link
-  // indices to MultiBody constraint pointers in the world to track these...
-  // virtual std::vector<float> getPositionLowerLimits() override;
-  // virtual std::vector<float> getPositionUpperLimits() override;
+  virtual std::vector<float> getPositionLimits(
+      bool upperLimits = false) override;
 
   virtual void addArticulatedLinkForce(int linkId,
                                        Magnum::Vector3 force) override;
@@ -165,7 +163,11 @@ class BulletArticulatedObject : public ArticulatedObject {
 
   std::map<int, std::unique_ptr<btMultiBodyJointMotor>> articulatedJointMotors;
 
+  //! maps local link id to parent joint's limit constraint
   std::map<int, JointLimitConstraintInfo> jointLimitConstraints;
+
+  //! clamp current pose to joint limits
+  void clampJointLimits() override;
 
  protected:
   virtual bool attachGeometry(

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -223,6 +223,14 @@ void BulletPhysicsManager::stepPhysics(double dt) {
     }
   }
 
+  // extra step to validate joint states against limits for corrective clamping
+  for (auto& objectItr : existingArticulatedObjects_) {
+    if (objectItr.second->getAutoClampJointLimits()) {
+      static_cast<BulletArticulatedObject*>(objectItr.second.get())
+          ->clampJointLimits();
+    }
+  }
+
   // ==== Physics stepforward ======
   // NOTE: worldTime_ will always be a multiple of sceneMetaData_.timestep
   int numSubStepsTaken =

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1383,6 +1383,29 @@ std::vector<float> Simulator::getArticulatedObjectForces(int objectId) {
   return std::vector<float>();
 };
 
+std::vector<float> Simulator::getArticulatedObjectPositionLimits(
+    int objectId,
+    bool upperLimits) {
+  if (sceneHasPhysics(0)) {
+    return physicsManager_->getArticulatedObjectPositionLimits(objectId,
+                                                               upperLimits);
+  }
+  return std::vector<float>();
+}
+
+void Simulator::setAutoClampJointLimits(int objectId, bool autoClamp) {
+  if (sceneHasPhysics(0)) {
+    physicsManager_->setAutoClampJointLimits(objectId, autoClamp);
+  }
+}
+
+bool Simulator::getAutoClampJointLimits(int objectId) {
+  if (sceneHasPhysics(0)) {
+    return physicsManager_->getAutoClampJointLimits(objectId);
+  }
+  return false;
+}
+
 void Simulator::resetArticulatedObject(int objectId) {
   if (sceneHasPhysics(0)) {
     physicsManager_->resetArticulatedObject(objectId);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -573,6 +573,38 @@ class Simulator {
 
   std::vector<float> getArticulatedObjectForces(int objectId);
 
+  /**
+   * @brief Get the joint limits for all dofs of an articulated object.
+   *
+   * Note: Dofs with no limits will return inf or -inf for upper and lower
+   * limits.
+   *
+   * @param objectID The object ID and key identifying the object in the
+   * simulator.
+   * @param upperLimits If true, get the upper joints limits, otherwise get
+   * lower limits.
+   * @return vector of requesteed upper or lower joint limits for all dofs
+   */
+  std::vector<float> getArticulatedObjectPositionLimits(
+      int objectId,
+      bool upperLimits = false);
+
+  /**
+   * @brief Set whether articulated object state is automatically clamped to
+   * configured joint limits before physics simulation.
+   * @param objectID The object ID and key identifying the object in the
+   * simulator.
+   */
+  void setAutoClampJointLimits(int objectId, bool autoClamp);
+
+  /**
+   * @brief Query whether articulated object state is automatically clamped to
+   * configured joint limits before physics simulation.
+   * @param objectID The object ID and key identifying the object in the
+   * simulator.
+   */
+  bool getAutoClampJointLimits(int objectId);
+
   void resetArticulatedObject(int objectId);
 
   void setArticulatedObjectSleep(int objectId, bool sleep);


### PR DESCRIPTION
## Motivation and Context
Joint limit constraints in Bullet do not rectify error occurring from DoF setters or infeasible constraint solves. Pose clamping appears to be a practical solution to this issues for some objects (such as fixed base articulated furniture). This PR implements automated joint limit clamping for cases such as theses.
Note: clamping pose for fully dynamic articulated objects (e.g. robots) may result in artifacts due to the nature of warring constraints and discrete collision detection/response.

Added Simulator API to:
- query joint limits: `get_articulated_object_position_limits`
- get/set automated joint limit clamping for each articulated object: `set_auto_clamp_joint_limits` and `get_auto_clamp_joint_limits`

Notes:
- Automated clamping occurs before every call to physics simulation step (smaller steps in higher frequency will likely produce better results).
- DoFs with no configured limits return inf or -inf
- API is subject to change.

## How Has This Been Tested
Local testing.

