### PR TITLE
[bugfix] Modify python bindings to cast mn.Degd

### DIFF
--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -58,12 +58,13 @@ void initGfxBindings(py::module& m) {
   render_camera
       .def(py::init_alias<std::reference_wrapper<scene::SceneNode>,
                           const vec3f&, const vec3f&, const vec3f&>())
-      .def("set_projection_matrix",
-           static_cast<RenderCamera& (RenderCamera::*)(int, int, float, float,
-                                                       Mn::Deg)>(
-               &RenderCamera::setProjectionMatrix),
-           R"(Set this `Camera`'s projection matrix.)", "width"_a, "height"_a,
-           "znear"_a, "zfar"_a, "hfov"_a)
+      .def(
+          "set_projection_matrix",
+          [](RenderCamera& self, int w, int h, float n, float f, Mn::Degd fov) {
+            self.setProjectionMatrix(w, h, n, f, Mn::Deg(fov));
+          },
+          R"(Set this `Camera`'s projection matrix.)", "width"_a, "height"_a,
+          "znear"_a, "zfar"_a, "hfov"_a)
       .def("set_orthographic_projection_matrix",
            &RenderCamera::setOrthoProjectionMatrix,
            R"(Set this `Orthographic Camera`'s projection matrix.)", "width"_a,

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -146,8 +146,9 @@ void initSensorBindings(py::module& m) {
       .def_property_readonly(
           "far", &VisualSensor::getFar,
           R"(The distance to the far clipping plane this VisualSensor uses.)")
-      .def_property_readonly("hfov", &VisualSensor::getFOV,
-                             R"(The Field of View this VisualSensor uses.)")
+      .def_property_readonly(
+          "hfov", [](VisualSensor& self) { return Mn::Degd(self.getFOV()); },
+          R"(The Field of View this VisualSensor uses.)")
       .def_property_readonly("framebuffer_size", &VisualSensor::framebufferSize)
       .def_property_readonly("render_target", &VisualSensor::renderTarget);
 
@@ -175,9 +176,10 @@ void initSensorBindings(py::module& m) {
           "set_height", &CameraSensor::setHeight,
           R"(Set the height of the resolution in the SensorSpec for this CameraSensor.)")
       .def_property(
-          "fov",
-          static_cast<Mn::Deg (CameraSensor::*)() const>(&CameraSensor::getFOV),
-          static_cast<void (CameraSensor::*)(Mn::Deg)>(&CameraSensor::setFOV),
+          "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
+          [](CameraSensor& self, Mn::Degd angle) {
+            self.setFOV(Mn::Deg(angle));
+          },
           R"(Set the field of view to use for this CameraSensor.  Only applicable to
           Pinhole Camera Types)")
       .def_property(

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -8,6 +8,7 @@ import itertools
 import json
 from os import path as osp
 
+import magnum as mn
 import numpy as np
 import pytest
 import quaternion  # noqa: F401
@@ -36,6 +37,15 @@ def _render_and_load_gt(sim, scene, sensor_type, gpu2gpu):
     obs = sim.step("move_forward")
 
     assert sensor_type in obs, f"{sensor_type} not in obs"
+
+    # now that sensors are constructed, test some getter/setters
+    sim.get_agent(0)._sensors[sensor_type].fov = mn.Deg(80)
+    assert sim.get_agent(0)._sensors[sensor_type].fov == mn.Deg(
+        80
+    ), "fov not set correctly"
+    assert sim.get_agent(0)._sensors[sensor_type].hfov == mn.Deg(
+        80
+    ), "hfov not set correctly"
 
     gt_obs_file = osp.abspath(
         osp.join(


### PR DESCRIPTION
## Motivation and Context

Magnum bindings define a single Deg type, Degd(64-bit), for rotation. Some Habitat functions return/expect the 32-bit variant (Deg) which fail to convert to/from python. This PR casts the type for known bindings with this issue.

## How Has This Been Tested

Local testing in python:
e.g.
- `render_camera.set_projection_matrix(100,100,-1.0,1.0,mn.Deg(80.0))`
- `sim._sensors[sensor_name]._sensor_object.fov = mn.Deg(80.0)`
- `print(sim._sensors[sensor_name]._sensor_object.fov)`
- `print(sim._sensors[sensor_name]._sensor_object.hfov)`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
