### PR TITLE
[AO][bugfix] - defer node update for ArticulatedObjects (joint clamping)

### DIFF
--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -271,7 +271,11 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
   virtual Magnum::Matrix4 getRootState() { return {}; };
 
   // update the SceneNode state to match the simulation state
-  virtual void updateNodes(CORRADE_UNUSED bool force = false){};
+  virtual void updateNodes(CORRADE_UNUSED bool force = false) {
+    isDeferringUpdate_ = false;
+  };
+
+  virtual void deferUpdate() { isDeferringUpdate_ = true; }
 
   ArticulatedLink& getLink(int id) {
     CHECK(links_.count(id));
@@ -457,6 +461,10 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
   //! if true, automatically clamp dofs to joint limits before physics
   //! simulation steps
   bool autoClampJointLimits_ = false;
+
+  //! if true visual nodes are not updated from physics simulation such that the
+  //! SceneGraph is not polluted during render
+  bool isDeferringUpdate_ = false;
 
   ESP_SMART_POINTERS(ArticulatedObject)
 };

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -307,7 +307,8 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
 
   virtual std::vector<float> getPositions() { return {}; };
 
-  virtual std::vector<float> getPositionLimits(bool upperLimits = false) {
+  virtual std::vector<float> getPositionLimits(
+      CORRADE_UNUSED bool upperLimits = false) {
     return {};
   };
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -244,6 +244,8 @@ void PhysicsManager::stepPhysics(double dt) {
 void PhysicsManager::deferNodesUpdate() {
   for (auto& o : existingObjects_)
     o.second->deferUpdate();
+  for (auto& ao : existingArticulatedObjects_)
+    ao.second->deferUpdate();
 }
 
 void PhysicsManager::updateNodes() {

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -182,6 +182,8 @@ class RigidObject : public RigidBase {
    */
   VelocityControl::ptr velControl_;
 
+  //! if true visual nodes are not updated from physics simulation such that the
+  //! SceneGraph is not polluted during render
   bool isDeferringUpdate_ = false;
 
  public:

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -352,7 +352,9 @@ void BulletArticulatedObject::setRootState(const Magnum::Matrix4& state) {
     btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
   }
   // sync visual shapes
-  updateNodes(true);
+  if (!isDeferringUpdate_) {
+    updateNodes(true);
+  }
 }
 
 void BulletArticulatedObject::setForces(const std::vector<float>& forces) {
@@ -442,8 +444,10 @@ void BulletArticulatedObject::setPositions(
   btMultiBody_->forwardKinematics(scratch_q, scratch_m);
   btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
 
-  // sync visual shapes
-  updateNodes(true);
+  if (!isDeferringUpdate_) {
+    // sync visual shapes
+    updateNodes(true);
+  }
 }
 
 std::vector<float> BulletArticulatedObject::getPositions() {


### PR DESCRIPTION
## Motivation and Context

Joint clamping occurs during the simulation step phase and calls `setPositions()` which in turn updates the visual nodes on the SceneGraph. This breaks the assumptions of the async renderer that physics step will not touch the SceneGraph. This PR solves the problem by extending the deferred update functionality to include articulated objects.

Includes unrelated minor clang-tidy fix.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
