### PR TITLE
addObjectByHandle polish

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1790,6 +1790,10 @@ bool ResourceManager::instantiateAssetsOnDemand(
   ObjectAttributes::ptr ObjectAttributes =
       getObjectAttributesManager()->getObjectByHandle(objectTemplateHandle);
 
+  if (!ObjectAttributes) {
+    return false;
+  }
+
   // if attributes are "dirty" (important values have changed since last
   // registered) then re-register.  Should never return ID_UNDEFINED - this
   // would mean something has corrupted the library.

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -125,6 +125,7 @@ struct SimTest : Cr::TestSuite::Tester {
   void recomputeNavmeshWithStaticObjects();
   void loadingObjectTemplates();
   void buildingPrimAssetObjectTemplates();
+  void addObjectByHandle();
   void addSensorToObject();
 
   // TODO: remove outlier pixels from image and lower maxThreshold
@@ -164,6 +165,7 @@ SimTest::SimTest() {
             &SimTest::recomputeNavmeshWithStaticObjects,
             &SimTest::loadingObjectTemplates,
             &SimTest::buildingPrimAssetObjectTemplates,
+            &SimTest::addObjectByHandle,
             &SimTest::addSensorToObject}, Cr::Containers::arraySize(SimulatorBuilder) );
   // clang-format on
 }
@@ -717,6 +719,22 @@ void SimTest::buildingPrimAssetObjectTemplates() {
   primObjAssetHandles.clear();
 
 }  // SimTest::buildingPrimAssetObjectTemplates
+
+void SimTest::addObjectByHandle() {
+  Corrade::Utility::Debug() << "Starting Test : addObject ";
+  auto&& data = SimulatorBuilder[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+  auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
+
+  int objectId = simulator->addObjectByHandle("invalid_handle");
+  CORRADE_VERIFY(objectId == esp::ID_UNDEFINED);
+
+  // pass valid object_config.json filepath as handle to addObjectByHandle
+  const auto validHandle = Cr::Utility::Directory::join(
+      TEST_ASSETS, "objects/nested_box.object_config.json");
+  objectId = simulator->addObjectByHandle(validHandle);
+  CORRADE_VERIFY(objectId != esp::ID_UNDEFINED);
+}
 
 void SimTest::addSensorToObject() {
   Corrade::Utility::Debug() << "Starting Test : addSensorToObject ";

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -482,7 +482,7 @@ Viewer::Viewer(const Arguments& arguments)
       .addOption("physics-config", ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH)
       .setHelp("physics-config",
                "Provide a non-default PhysicsManager config file.")
-      .addOption("object-dir", "./data/objects")
+      .addOption("object-dir", "data/objects")
       .setHelp("object-dir",
                "Provide a directory to search for object config files "
                "(relative to habitat-sim directory).")
@@ -555,8 +555,7 @@ Viewer::Viewer(const Arguments& arguments)
   simulator_ = esp::sim::Simulator::create_unique(simConfig);
 
   objectAttrManager_ = simulator_->getObjectAttributesManager();
-  objectAttrManager_->loadAllConfigsFromPath(Cr::Utility::Directory::join(
-      Corrade::Utility::Directory::current(), args.value("object-dir")));
+  objectAttrManager_->loadAllConfigsFromPath(args.value("object-dir"));
   assetAttrManager_ = simulator_->getAssetAttributesManager();
   stageAttrManager_ = simulator_->getStageAttributesManager();
   physAttrManager_ = simulator_->getPhysicsAttributesManager();


### PR DESCRIPTION
## Motivation and Context

- avoid crash in addObjectByHandle for invalid object handle
- Change C++ viewer default object-dir to be relative path. This will make it easier to directly load objects, e.g. you can write `simulator_->addObjectByHandle("data/objects/my_object.object_config.json");`
- add unit test for addObjectByHandle

## How Has This Been Tested

I added a unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
