### PR TITLE
[AO] constraint management and object deactivation state

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -456,6 +456,7 @@ int BulletPhysicsManager::createArticulatedFixedConstraint(
   if (existingObjects_.at(objectId)->getMotionType() == MotionType::DYNAMIC) {
     rb = static_cast<BulletRigidObject*>(existingObjects_.at(objectId).get())
              ->bObjectRigidBody_.get();
+    rb->setActivationState(DISABLE_DEACTIVATION);
   } else {
     Corrade::Utility::Debug()
         << "Cannot create a dynamic fixed constraint for object with "

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -79,6 +79,20 @@ class BulletPhysicsManager : public PhysicsManager {
                                            float massScale = 1.0,
                                            bool forceReload = false) override;
 
+  /**
+   * @brief Override of @ref PhysicsManager::removeObject to also remove any
+   * active Bullet physics constraints for the object.
+   */
+  virtual void removeObject(const int physObjectID,
+                            bool deleteObjectNode = true,
+                            bool deleteVisualNode = true) override;
+
+  /**
+   * @brief Override of @ref PhysicsManager::removeArticulatedObject to also
+   * remove any active Bullet physics constraints for the object.
+   */
+  virtual void removeArticulatedObject(int id) override;
+
   /** @brief Step the physical world forward in time. Time may only advance in
    * increments of @ref fixedTimeStep_. See @ref
    * btMultiBodyDynamicsWorld::stepSimulation.
@@ -337,6 +351,10 @@ class BulletPhysicsManager : public PhysicsManager {
   std::map<int, btMultiBodyPoint2Point*> articulatedP2ps;
   std::map<int, btMultiBodyFixedConstraint*> articulatedFixedConstraints;
   std::map<int, btPoint2PointConstraint*> rigidP2ps;
+
+  //! Maps object ids to a list of active constraints referencing the object for
+  //! use in constraint clean-up and object sleep state management.
+  std::map<int, std::vector<int>> objectConstraints_;
 
   int getNumActiveContactPoints() override {
     return BulletDebugManager::get().getNumActiveContactPoints(bWorld_.get());

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -2054,12 +2054,6 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       float URDFScaling = esp::core::Random().uniform_float_01() + 0.5;
       int objectId = addArticulatedObject(urdfFilePath, false, URDFScaling);
       Mn::Debug{} << "URDF Randomly scaled to " << URDFScaling;
-      Mn::Debug{} << "lower limits = "
-                  << simulator_->getArticulatedObjectPositionLimits(objectId);
-      Mn::Debug{} << "upper limits = "
-                  << simulator_->getArticulatedObjectPositionLimits(objectId,
-                                                                    true);
-
       auto R = Magnum::Matrix4::rotationX(Magnum::Rad(-1.56));
       R.translation() =
           simulator_->getArticulatedObjectRootState(objectId).translation();
@@ -2158,31 +2152,6 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       Corrade::Utility::Debug() << "done clearing, now generating";
       setupDemoFurniture();
     } break;
-    case KeyEvent::Key::Six: {
-      // add the counter in front of the agent with fixed base
-      std::string urdfFilePath =
-          //    "data/test_assets/URDF/fridge/fridge.urdf";
-          "/Users/alexclegg/AndrewObjectRearrangement/p-viz-plan/orp/"
-          "start_data/URDF/fridge/fridge.urdf";
-      auto fridgeAOId = addArticulatedObject(urdfFilePath, true);
-      simulator_->setAutoClampJointLimits(fridgeAOId, true);
-      Mn::Debug{} << "lower limits = "
-                  << simulator_->getArticulatedObjectPositionLimits(fridgeAOId);
-      Mn::Debug{} << "upper limits = "
-                  << simulator_->getArticulatedObjectPositionLimits(fridgeAOId,
-                                                                    true);
-
-      Mn::Vector3 localFridgeBasePos{0.0f, 0.94f, -2.0f};
-      Mn::Matrix4 T = agentBodyNode_->MagnumObject::transformationMatrix();
-      // rotate the object
-      auto R = Magnum::Matrix4::rotationY(Magnum::Rad(-1.56));
-      Mn::Matrix4 initialFridgeTransform = R * T;
-      initialFridgeTransform.translation() =
-          T.transformPoint(localFridgeBasePos);
-      simulator_->setArticulatedObjectRootState(fridgeAOId,
-                                                initialFridgeTransform);
-    } break;
-
     case KeyEvent::Key::Minus: {
       if (simulator_->getExistingArticulatedObjectIDs().size()) {
         for (auto& controller : locobotControllers) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -2054,6 +2054,12 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       float URDFScaling = esp::core::Random().uniform_float_01() + 0.5;
       int objectId = addArticulatedObject(urdfFilePath, false, URDFScaling);
       Mn::Debug{} << "URDF Randomly scaled to " << URDFScaling;
+      Mn::Debug{} << "lower limits = "
+                  << simulator_->getArticulatedObjectPositionLimits(objectId);
+      Mn::Debug{} << "upper limits = "
+                  << simulator_->getArticulatedObjectPositionLimits(objectId,
+                                                                    true);
+
       auto R = Magnum::Matrix4::rotationX(Magnum::Rad(-1.56));
       R.translation() =
           simulator_->getArticulatedObjectRootState(objectId).translation();
@@ -2152,6 +2158,31 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       Corrade::Utility::Debug() << "done clearing, now generating";
       setupDemoFurniture();
     } break;
+    case KeyEvent::Key::Six: {
+      // add the counter in front of the agent with fixed base
+      std::string urdfFilePath =
+          //    "data/test_assets/URDF/fridge/fridge.urdf";
+          "/Users/alexclegg/AndrewObjectRearrangement/p-viz-plan/orp/"
+          "start_data/URDF/fridge/fridge.urdf";
+      auto fridgeAOId = addArticulatedObject(urdfFilePath, true);
+      simulator_->setAutoClampJointLimits(fridgeAOId, true);
+      Mn::Debug{} << "lower limits = "
+                  << simulator_->getArticulatedObjectPositionLimits(fridgeAOId);
+      Mn::Debug{} << "upper limits = "
+                  << simulator_->getArticulatedObjectPositionLimits(fridgeAOId,
+                                                                    true);
+
+      Mn::Vector3 localFridgeBasePos{0.0f, 0.94f, -2.0f};
+      Mn::Matrix4 T = agentBodyNode_->MagnumObject::transformationMatrix();
+      // rotate the object
+      auto R = Magnum::Matrix4::rotationY(Magnum::Rad(-1.56));
+      Mn::Matrix4 initialFridgeTransform = R * T;
+      initialFridgeTransform.translation() =
+          T.transformPoint(localFridgeBasePos);
+      simulator_->setArticulatedObjectRootState(fridgeAOId,
+                                                initialFridgeTransform);
+    } break;
+
     case KeyEvent::Key::Minus: {
       if (simulator_->getExistingArticulatedObjectIDs().size()) {
         for (auto& controller : locobotControllers) {


### PR DESCRIPTION
## Motivation and Context

Object deactivation (sleeping) is disabled when a dynamic constraint is created referencing the object. Since constraints can reference multiple objects and objects can be referenced by multiple constraints, re-enabling object deactivation should wait until all referencing constraints are removed. This PR adds (P2P and fixed) constraint tracking and deactivation state logic.

## How Has This Been Tested

Locally in viewer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
