### PR TITLE
[BUGFIX] Fix Voxel grid test failing when --vhacd not enabled.

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -57,18 +57,20 @@ target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 test(ResourceManagerTest assets)
 target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-corrade_add_test(
-  VoxelGridTest
-  VoxelGridTest.cpp
-  LIBRARIES
-  sim
-  assets
-  geo
-  Magnum::DebugTools
-  Magnum::AnyImageConverter
-  MagnumPlugins::StbImageImporter
-)
-target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+if(BUILD_WITH_VHACD)
+  corrade_add_test(
+    VoxelGridTest
+    VoxelGridTest.cpp
+    LIBRARIES
+    sim
+    assets
+    geo
+    Magnum::DebugTools
+    Magnum::AnyImageConverter
+    MagnumPlugins::StbImageImporter
+  )
+  target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 corrade_add_test(CullingTest CullingTest.cpp LIBRARIES gfx)
 target_include_directories(CullingTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/tests/VoxelGridTest.cpp
+++ b/src/tests/VoxelGridTest.cpp
@@ -14,22 +14,20 @@
 namespace Cr = Corrade;
 namespace Mn = Magnum;
 
-struct VoxelGrid : Cr::TestSuite::Tester {
-  explicit VoxelGrid();
+// Test is not compiled if --vhacd is not enabled
+struct VoxelGridTest : Cr::TestSuite::Tester {
+  explicit VoxelGridTest();
 
   void testVoxelGridWithVHACD();
   void testVoxelUtilityFunctions();
 };
 
-VoxelGrid::VoxelGrid() {
-#ifdef ESP_BUILD_WITH_VHACD
-  addTests({&VoxelGrid::testVoxelGridWithVHACD});
-  addTests({&VoxelGrid::testVoxelUtilityFunctions});
-#endif
+VoxelGridTest::VoxelGridTest() {
+  addTests({&VoxelGridTest::testVoxelGridWithVHACD});
+  addTests({&VoxelGridTest::testVoxelUtilityFunctions});
 }
 
-#ifdef ESP_BUILD_WITH_VHACD
-void VoxelGrid::testVoxelGridWithVHACD() {
+void VoxelGridTest::testVoxelGridWithVHACD() {
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
   simConfig.activeSceneName = Cr::Utility::Directory::join(
@@ -108,7 +106,7 @@ void VoxelGrid::testVoxelGridWithVHACD() {
   simulator_->setStageVoxelizationDraw(false, "Boundary");
 }
 
-void VoxelGrid::testVoxelUtilityFunctions() {
+void VoxelGridTest::testVoxelUtilityFunctions() {
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
   simConfig.activeSceneName = Cr::Utility::Directory::join(
@@ -182,6 +180,4 @@ void VoxelGrid::testVoxelUtilityFunctions() {
   CORRADE_VERIFY(valuesAreInRange);
 }
 
-#endif
-
-CORRADE_TEST_MAIN(VoxelGrid)
+CORRADE_TEST_MAIN(VoxelGridTest)


### PR DESCRIPTION
## Motivation and Context
VoxelGridTest was failing if --vhacd was not enabled (with no actual tests to run, the test suite considers this a failure), so this PR does not compile the test unless it has --vhacd is enabled.  All compiler directives in the test file were removed as well, since they were not necessary.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests with and without flag passed.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
