### PR TITLE
Material ID refactor

### DIFF
--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -28,8 +28,8 @@ struct MeshTransformNode {
   /** @brief Local mesh index within @ref MeshMetaData::meshIndex. */
   int meshIDLocal;
 
-  /** @brief Local material index within @ref MeshMetaData::materialIndex */
-  int materialIDLocal;
+  /** @brief Material key within global material manager. */
+  std::string materialID;
 
   /** @brief Object index of asset component in the original file. */
   int componentID;
@@ -44,7 +44,7 @@ struct MeshTransformNode {
   /** @brief Default constructor. */
   MeshTransformNode() {
     meshIDLocal = ID_UNDEFINED;
-    materialIDLocal = ID_UNDEFINED;
+    materialID = "";  // default material
     componentID = ID_UNDEFINED;
   };
 };
@@ -76,11 +76,6 @@ struct MeshMetaData {
   std::pair<start, end> textureIndex =
       std::make_pair(ID_UNDEFINED, ID_UNDEFINED);
 
-  /** @brief Index range (inclusive) of material data for the asset in the
-   * global asset datastructure. */
-  std::pair<start, end> materialIndex =
-      std::make_pair(ID_UNDEFINED, ID_UNDEFINED);
-
   /** @brief The root of the mesh component transformation heirarchy tree which
    * stores the relationship between components of the asset.*/
   MeshTransformNode root;
@@ -92,12 +87,9 @@ struct MeshMetaData {
   MeshMetaData(int meshStart,
                int meshEnd,
                int textureStart = ID_UNDEFINED,
-               int textureEnd = ID_UNDEFINED,
-               int materialStart = ID_UNDEFINED,
-               int materialEnd = ID_UNDEFINED) {
+               int textureEnd = ID_UNDEFINED) {
     meshIndex = std::make_pair(meshStart, meshEnd);
     textureIndex = std::make_pair(textureStart, textureEnd);
-    materialIndex = std::make_pair(materialStart, materialEnd);
   }
 
   /**
@@ -124,19 +116,6 @@ struct MeshMetaData {
   void setTextureIndices(int textureStart, int textureEnd) {
     textureIndex.first = textureStart;
     textureIndex.second = textureEnd;
-  }
-
-  /**
-   * @brief Sets the material indices for the asset. See @ref
-   * ResourceManager::materials_.
-   * @param materialStart First index for asset material data in the global
-   * material datastructure.
-   * @param materialEnd Final index for asset material data in the global
-   * material datastructure.
-   */
-  void setMaterialIndices(int materialStart, int materialEnd) {
-    materialIndex.first = materialStart;
-    materialIndex.second = materialEnd;
   }
 };
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1428,9 +1428,6 @@ int ResourceManager::loadNavMeshVisualization(esp::nav::PathFinder& pathFinder,
 
 void ResourceManager::loadMaterials(Importer& importer,
                                     LoadedAssetData& loadedAssetData) {
-  int materialStart = nextMaterialID_;
-  int materialEnd = materialStart + importer.materialCount() - 1;
-
   for (int iMaterial = 0; iMaterial < importer.materialCount(); ++iMaterial) {
     int currentMaterialID = nextMaterialID_++;
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -880,12 +880,11 @@ void ResourceManager::buildPrimitiveAssetData(
   std::unique_ptr<gfx::MaterialData> phongMaterial =
       gfx::PhongMaterialData::create_unique();
 
-  meshMetaData.setMaterialIndices(nextMaterialID_, nextMaterialID_);
-  shaderManager_.set(std::to_string(nextMaterialID_++),
-                     phongMaterial.release());
+  shaderManager_.set(std::to_string(nextMaterialID_), phongMaterial.release());
 
   meshMetaData.root.meshIDLocal = 0;
   meshMetaData.root.componentID = 0;
+  meshMetaData.root.materialID = std::to_string(nextMaterialID_++);
   // store the rotation to world frame upon load - currently superfluous
   const quatf transform = info.frame.rotationFrameToWorld();
   Magnum::Matrix4 R = Magnum::Matrix4::from(
@@ -1343,13 +1342,13 @@ bool ResourceManager::buildTrajectoryVisualization(
   phongMaterial->ambientColor = color;
   phongMaterial->diffuseColor = color;
 
-  meshMetaData.setMaterialIndices(nextMaterialID_, nextMaterialID_);
-  shaderManager_.set(std::to_string(nextMaterialID_++),
+  shaderManager_.set(std::to_string(nextMaterialID_),
                      static_cast<gfx::MaterialData*>(phongMaterial.release()));
 
   meshMetaData.root.meshIDLocal = 0;
   meshMetaData.root.componentID = 0;
-  meshMetaData.root.materialIDLocal = 0;
+  meshMetaData.root.materialID = std::to_string(nextMaterialID_++);
+
   // store the rotation to world frame upon load - currently superfluous
   const quatf transform = info.frame.rotationFrameToWorld();
   Magnum::Matrix4 R = Magnum::Matrix4::from(
@@ -1431,7 +1430,6 @@ void ResourceManager::loadMaterials(Importer& importer,
                                     LoadedAssetData& loadedAssetData) {
   int materialStart = nextMaterialID_;
   int materialEnd = materialStart + importer.materialCount() - 1;
-  loadedAssetData.meshMetaData.setMaterialIndices(materialStart, materialEnd);
 
   for (int iMaterial = 0; iMaterial < importer.materialCount(); ++iMaterial) {
     int currentMaterialID = nextMaterialID_++;
@@ -1691,11 +1689,14 @@ void ResourceManager::loadMeshHierarchy(Importer& importer,
       meshIDLocal != ID_UNDEFINED) {
     parent.children.back().meshIDLocal = meshIDLocal;
     if (requiresTextures_) {
-      parent.children.back().materialIDLocal =
-          static_cast<Magnum::Trade::MeshObjectData3D*>(objectData.get())
-              ->material();
-    } else {
-      parent.children.back().materialIDLocal = ID_UNDEFINED;
+      auto mod3D =
+          static_cast<Magnum::Trade::MeshObjectData3D*>(objectData.get());
+      if (mod3D->material() != ID_UNDEFINED) {
+        // we've already loaded the materials, so we can get the global index
+        // from the material count
+        parent.children.back().materialID = std::to_string(
+            mod3D->material() + nextMaterialID_ - importer.materialCount());
+      }
     }
   }
 
@@ -1923,17 +1924,9 @@ void ResourceManager::addComponent(
 
   // Add a drawable if the object has a mesh and the mesh is loaded
   if (meshIDLocal != ID_UNDEFINED) {
-    const int materialIDLocal = meshTransformNode.materialIDLocal;
     const int meshID = metaData.meshIndex.first + meshIDLocal;
     Magnum::GL::Mesh& mesh = *meshes_.at(meshID)->getMagnumGLMesh();
-    Mn::ResourceKey materialKey;
-    if (materialIDLocal == ID_UNDEFINED ||
-        metaData.materialIndex.second == ID_UNDEFINED) {
-      materialKey = DEFAULT_MATERIAL_KEY;
-    } else {
-      materialKey =
-          std::to_string(metaData.materialIndex.first + materialIDLocal);
-    }
+    Mn::ResourceKey materialKey = meshTransformNode.materialID;
 
     gfx::Drawable::Flags meshAttributeFlags{};
     const auto& meshData = meshes_.at(meshID)->getMeshData();
@@ -2342,16 +2335,8 @@ void ResourceManager::createConvexHullDecomposition(
     MeshTransformNode transformNode;
     transformNode.meshIDLocal = p;
     transformNode.componentID = componentID;
-    transformNode.materialIDLocal = 0;
     meshMetaData.root.children.push_back(transformNode);
   }
-
-  // default material for now
-  auto phongMaterial = gfx::PhongMaterialData::create_unique();
-
-  meshMetaData.setMaterialIndices(nextMaterialID_, nextMaterialID_);
-  shaderManager_.set(std::to_string(nextMaterialID_++),
-                     static_cast<gfx::MaterialData*>(phongMaterial.release()));
 
   // make assetInfo
   AssetInfo info{AssetType::PRIMITIVE};


### PR DESCRIPTION
## Motivation and Context

`ResourceManager::shaderManager_` holds materials keyed by `Magnum::ResourceKey`. The current data import pipeline assumes these materials are keyed by int and that all materials for an asset are keyed contiguously. This is a limiting paradigm as it does not allow us to use arbitrary string keying for programmatic or user-defined materials.

Concretely an example of this case is material overriding in URDF requiring on-the-fly material registration and editing existing MeshMetaData.

This change refactors away from int ids for material keys and the notion of local material ids in `MeshMetaData` to instead directly store global string keys. The previous method of creating new unique ids during import by incrementing a counter remains.

## How Has This Been Tested

All current tests pass after the refactor.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
