### PR TITLE
[BUGFIX] Add hfov to CameraSensor config settings

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -13,6 +13,7 @@ default_sim_settings = {
     "height": 480,
     "default_agent": 0,
     "sensor_height": 1.5,
+    "hfov": 90,
     "color_sensor": True,  # RGB sensor (default: ON)
     "semantic_sensor": False,  # semantic sensor (default: OFF)
     "depth_sensor": False,  # depth sensor (default: OFF)
@@ -68,6 +69,7 @@ def make_cfg(settings):
         color_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         color_sensor_spec.resolution = [settings["height"], settings["width"]]
         color_sensor_spec.position = [0, settings["sensor_height"], 0]
+        color_sensor_spec.hfov = mn.Deg(settings["hfov"])
         color_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(color_sensor_spec)
 
@@ -77,6 +79,7 @@ def make_cfg(settings):
         depth_sensor_spec.sensor_type = habitat_sim.SensorType.DEPTH
         depth_sensor_spec.resolution = [settings["height"], settings["width"]]
         depth_sensor_spec.position = [0, settings["sensor_height"], 0]
+        depth_sensor_spec.hfov = mn.Deg(settings["hfov"])
         depth_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(depth_sensor_spec)
 
@@ -86,6 +89,7 @@ def make_cfg(settings):
         semantic_sensor_spec.sensor_type = habitat_sim.SensorType.SEMANTIC
         semantic_sensor_spec.resolution = [settings["height"], settings["width"]]
         semantic_sensor_spec.position = [0, settings["sensor_height"], 0]
+        semantic_sensor_spec.hfov = mn.Deg(settings["hfov"])
         semantic_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(semantic_sensor_spec)
 

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -69,7 +69,7 @@ def make_cfg(settings):
         color_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         color_sensor_spec.resolution = [settings["height"], settings["width"]]
         color_sensor_spec.position = [0, settings["sensor_height"], 0]
-        color_sensor_spec.hfov = mn.Deg(settings["hfov"])
+        color_sensor_spec.hfov = settings["hfov"]
         color_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(color_sensor_spec)
 
@@ -79,7 +79,7 @@ def make_cfg(settings):
         depth_sensor_spec.sensor_type = habitat_sim.SensorType.DEPTH
         depth_sensor_spec.resolution = [settings["height"], settings["width"]]
         depth_sensor_spec.position = [0, settings["sensor_height"], 0]
-        depth_sensor_spec.hfov = mn.Deg(settings["hfov"])
+        depth_sensor_spec.hfov = settings["hfov"]
         depth_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(depth_sensor_spec)
 
@@ -89,7 +89,7 @@ def make_cfg(settings):
         semantic_sensor_spec.sensor_type = habitat_sim.SensorType.SEMANTIC
         semantic_sensor_spec.resolution = [settings["height"], settings["width"]]
         semantic_sensor_spec.position = [0, settings["sensor_height"], 0]
-        semantic_sensor_spec.hfov = mn.Deg(settings["hfov"])
+        semantic_sensor_spec.hfov = settings["hfov"]
         semantic_sensor_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
         sensor_specs.append(semantic_sensor_spec)
 

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -101,7 +101,11 @@ void initSensorBindings(py::module& m) {
   py::class_<CameraSensorSpec, CameraSensorSpec::ptr, VisualSensorSpec>(
       m, "CameraSensorSpec", py::dynamic_attr())
       .def(py::init(&CameraSensorSpec::create<>))
-      .def_readwrite("hfov", &CameraSensorSpec::hfov)
+      .def_property(
+          "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
+          [](CameraSensorSpec& self, Mn::Degd angle) {
+            self.hfov = Mn::Deg(angle);
+          })
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
 
   // ====FisheyeSensorSpec ====

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -104,6 +104,7 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
           [](CameraSensorSpec& self, Mn::Degd angle) {
+	    //TODO use Python bindings for Mn::Deg for nicer conversion
             self.hfov = Mn::Deg(angle);
           })
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -101,6 +101,7 @@ void initSensorBindings(py::module& m) {
   py::class_<CameraSensorSpec, CameraSensorSpec::ptr, VisualSensorSpec>(
       m, "CameraSensorSpec", py::dynamic_attr())
       .def(py::init(&CameraSensorSpec::create<>))
+      .def_readwrite("hfov", &CameraSensorSpec::hfov)
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
 
   // ====FisheyeSensorSpec ====

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -9,6 +9,7 @@
 
 #include <Magnum/PythonBindings.h>
 #include <Magnum/SceneGraph/PythonBindings.h>
+#include <pybind11/pytypes.h>
 
 #include <utility>
 
@@ -213,7 +214,7 @@ void initSensorBindings(py::module& m) {
           R"(Set the height of the resolution in the SensorSpec for this CameraSensor.)")
       .def_property(
           "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
-          [](CameraSensor& self, Mn::Degd angle) {
+          [](CameraSensor& self, py::object angle) {
             py::object deg = py::module_::import("magnum").attr("Deg");
             self.setFOV(Mn::Deg(deg(angle).cast<Mn::Degd>()));
           },

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -105,7 +105,7 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
           [](CameraSensorSpec& self, py::object angle) {
-            py::object PyDeg = py::module_::import("magnum").attr("Deg");
+            auto PyDeg = py::module_::import("magnum").attr("Deg");
             self.hfov = Mn::Deg(PyDeg(angle).cast<Mn::Degd>());
           })
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
@@ -215,7 +215,7 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
           [](CameraSensor& self, py::object angle) {
-            py::object PyDeg = py::module_::import("magnum").attr("Deg");
+            auto PyDeg = py::module_::import("magnum").attr("Deg");
             self.setFOV(Mn::Deg(PyDeg(angle).cast<Mn::Degd>()));
           },
           R"(Set the field of view to use for this CameraSensor.  Only applicable to

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -103,9 +103,9 @@ void initSensorBindings(py::module& m) {
       .def(py::init(&CameraSensorSpec::create<>))
       .def_property(
           "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
-          [](CameraSensorSpec& self, Mn::Degd angle) {
-	    //TODO use Python bindings for Mn::Deg for nicer conversion
-            self.hfov = Mn::Deg(angle);
+          [](CameraSensorSpec& self, py::object angle) {
+            py::object deg = py::module_::import("magnum").attr("Deg");
+            self.hfov = Mn::Deg(deg(angle).cast<Mn::Degd>());
           })
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
 
@@ -214,7 +214,8 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
           [](CameraSensor& self, Mn::Degd angle) {
-            self.setFOV(Mn::Deg(angle));
+            py::object deg = py::module_::import("magnum").attr("Deg");
+            self.setFOV(Mn::Deg(deg(angle).cast<Mn::Degd>()));
           },
           R"(Set the field of view to use for this CameraSensor.  Only applicable to
           Pinhole Camera Types)")

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -104,7 +104,7 @@ void initSensorBindings(py::module& m) {
       .def(py::init(&CameraSensorSpec::create<>))
       .def_property(
           "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
-          [](CameraSensorSpec& self, py::object angle) {
+          [](CameraSensorSpec& self, const py::object& angle) {
             auto PyDeg = py::module_::import("magnum").attr("Deg");
             self.hfov = Mn::Deg(PyDeg(angle).cast<Mn::Degd>());
           })
@@ -214,7 +214,7 @@ void initSensorBindings(py::module& m) {
           R"(Set the height of the resolution in the SensorSpec for this CameraSensor.)")
       .def_property(
           "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
-          [](CameraSensor& self, py::object angle) {
+          [](CameraSensor& self, const py::object& angle) {
             auto PyDeg = py::module_::import("magnum").attr("Deg");
             self.setFOV(Mn::Deg(PyDeg(angle).cast<Mn::Degd>()));
           },

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -105,8 +105,8 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "hfov", [](CameraSensorSpec& self) { return Mn::Degd(self.hfov); },
           [](CameraSensorSpec& self, py::object angle) {
-            py::object deg = py::module_::import("magnum").attr("Deg");
-            self.hfov = Mn::Deg(deg(angle).cast<Mn::Degd>());
+            py::object PyDeg = py::module_::import("magnum").attr("Deg");
+            self.hfov = Mn::Deg(PyDeg(angle).cast<Mn::Degd>());
           })
       .def_readwrite("ortho_scale", &CameraSensorSpec::orthoScale);
 
@@ -215,8 +215,8 @@ void initSensorBindings(py::module& m) {
       .def_property(
           "fov", [](CameraSensor& self) { return Mn::Degd(self.getFOV()); },
           [](CameraSensor& self, py::object angle) {
-            py::object deg = py::module_::import("magnum").attr("Deg");
-            self.setFOV(Mn::Deg(deg(angle).cast<Mn::Degd>()));
+            py::object PyDeg = py::module_::import("magnum").attr("Deg");
+            self.setFOV(Mn::Deg(PyDeg(angle).cast<Mn::Degd>()));
           },
           R"(Set the field of view to use for this CameraSensor.  Only applicable to
           Pinhole Camera Types)")

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -56,6 +56,8 @@ CameraSensor::CameraSensor(scene::SceneNode& cameraNode,
       Mn::SceneGraph::AspectRatioPolicy::Extend);
   recomputeProjectionMatrix();
   renderCamera_->setViewport(this->framebufferSize());
+  // Set initial hFOV
+  setFOV(cameraSensorSpec_->hfov);
 }  // ctor
 
 void CameraSensor::setProjectionParameters(const CameraSensorSpec& spec) {

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -14,6 +14,7 @@ namespace sensor {
 
 struct CameraSensorSpec : public VisualSensorSpec {
   float orthoScale = 0.1f;
+  Mn::Deg hfov = 90.0_degf;
   CameraSensorSpec();
   void sanityCheck() override;
   bool operator==(const CameraSensorSpec& a) const;

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -277,7 +277,7 @@ def test_smoke_redwood_noise(scene, gpu2gpu, make_cfg_settings):
 def test_initial_hfov(scene, sensor_type, make_cfg_settings):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
-    make_cfg_settings["hfov"] = mn.Deg(70)
+    make_cfg_settings["hfov"] = 70
     with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
         assert sim.agents[0]._sensors[sensor_type].hfov == mn.Deg(
             70

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -235,6 +235,8 @@ def test_smoke_no_sensors(make_cfg_settings):
         cfg = make_cfg(make_cfg_settings)
         cfg.agents[0].sensor_specifications = []
         sims.append(habitat_sim.Simulator(cfg))
+    for sim in sims:
+        sim.close()
 
 
 @pytest.mark.gfxtest
@@ -267,6 +269,19 @@ def test_smoke_redwood_noise(scene, gpu2gpu, make_cfg_settings):
         ), "Incorrect depth_sensor output"
 
     sim.close()
+
+
+@pytest.mark.gfxtest
+@pytest.mark.parametrize("scene", _test_scenes)
+@pytest.mark.parametrize("sensor_type", all_base_sensor_types[:2])
+def test_initial_hfov(scene, sensor_type, make_cfg_settings):
+    if not osp.exists(scene):
+        pytest.skip("Skipping {}".format(scene))
+    make_cfg_settings["hfov"] = mn.Deg(70)
+    with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
+        assert sim.agents[0]._sensors[sensor_type].hfov == mn.Deg(
+            70
+        ), "HFOV was not properly set"
 
 
 @pytest.mark.gfxtest


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During a refactor, we lost the ability to set the initial hfov via a sensor config. This restores the ability to do that via the CameraSensorSpec. See the corresponding Habitat-Lab bug: https://github.com/facebookresearch/habitat-lab/issues/627. This should add the necessary bindings to set the initial hfov of a CameraSensorSpec.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
