### PR TITLE
[Sensor][viewer] Save/load agent and sensors' transformations to/from disk

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -20,6 +20,7 @@
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/GL/RenderbufferFormat.h>
 #include <Magnum/Image.h>
+#include <Magnum/Math/Tags.h>
 #include <Magnum/PixelFormat.h>
 #include <Magnum/SceneGraph/Camera.h>
 #include <Magnum/Shaders/Generic.h>
@@ -168,12 +169,8 @@ class Viewer : public Mn::Platform::Application {
   void switchCameraType();
   Mn::Vector3 randomDirection();
 
-  void saveCameraTransformToFile();
-  void saveNodeTransformToFile(esp::scene::SceneNode& node,
-                               const std::string& filename);
-  void loadCameraTransformFromFile();
-  void loadNodeTransformFromFile(esp::scene::SceneNode& node,
-                                 const std::string& filename);
+  void saveAgentAndSensorTransformToFile();
+  void loadAgentAndSensorTransformFromFile();
 
   //! string rep of time when viewer application was started
   std::string viewerStartTimeString = getCurrentTimeString();
@@ -365,10 +362,13 @@ Key Commands:
   bool drawObjectBBs = false;
   std::string gfxReplayRecordFilepath_;
 
-  std::string cameraLoadPath_;
-  // bool cameraSaved_ = false;
-  // Mn::Matrix4 lastCameraSave_;
-  Cr::Containers::Optional<Mn::Matrix4> lastCameraSave_;
+  std::string agentTransformLoadPath_;
+  Cr::Containers::Optional<Mn::Matrix4> savedAgentTransform_ =
+      Cr::Containers::NullOpt;
+  // there could be a couple of sensors, just save the rgb CameraSensor's
+  // transformation
+  Cr::Containers::Optional<Mn::Matrix4> savedSensorTransform_ =
+      Cr::Containers::NullOpt;
 
   Mn::Timeline timeline_;
 
@@ -537,7 +537,7 @@ Viewer::Viewer(const Arguments& arguments)
     debugBullet_ = true;
   }
 
-  cameraLoadPath_ = args.value("camera-transform-filepath");
+  agentTransformLoadPath_ = args.value("camera-transform-filepath");
   gfxReplayRecordFilepath_ = args.value("gfx-replay-record-filepath");
 
   // configure and intialize Simulator
@@ -704,51 +704,9 @@ void Viewer::switchCameraType() {
   }
 }
 
-void Viewer::saveCameraTransformToFile() {
-  const char* saved_transformations_directory = "saved_transformations/";
-  if (!Cr::Utility::Directory::exists(saved_transformations_directory)) {
-    Cr::Utility::Directory::mkpath(saved_transformations_directory);
-  }
-
-  // update temporary save
-  lastCameraSave_ = renderCamera_->node().absoluteTransformation();
-
-  // update save in file system
-  saveNodeTransformToFile(
-      renderCamera_->node(),
-      Cr::Utility::formatString("{}camera.{}.txt",
-                                saved_transformations_directory,
-                                getCurrentTimeString()));
-}
-
-void Viewer::loadCameraTransformFromFile() {
-  if (!cameraLoadPath_.empty()) {
-    // loading from file system
-    loadNodeTransformFromFile(renderCamera_->node(), cameraLoadPath_);
-  } else {
-    // attempting to load from last temporary save
-    LOG(WARNING)
-        << "Camera transform file not specified, attempting to load from "
-           "current instance. Use --camera-transform-filepath to specify file "
-           "to load from.";
-    if (!lastCameraSave_) {
-      LOG(ERROR) << "No transformation saved in current instance.";
-      return;
-    }
-
-    renderCamera_->node().setTransformation(*lastCameraSave_);
-    LOG(INFO) << "Transformation matrix loaded from current instance : "
-              << Eigen::Map<esp::mat4f>(lastCameraSave_->data());
-  }
-
-  if (!flyingCameraMode_) {
-    LOG(INFO) << "Note: The flying camera mode is currently OFF. You may not "
-                 "see any view change.";
-  }
-}
-
-void Viewer::saveNodeTransformToFile(esp::scene::SceneNode& node,
-                                     const std::string& filename) {
+void saveTransformToFile(const std::string& filename,
+                         const Mn::Matrix4 agentTransform,
+                         const Mn::Matrix4 sensorTransform) {
   std::ofstream file(filename);
   if (!file.good()) {
     LOG(ERROR) << "Cannot open " << filename << " to output data.";
@@ -756,45 +714,98 @@ void Viewer::saveNodeTransformToFile(esp::scene::SceneNode& node,
   }
 
   // saving transformation into file system
-  Mn::Matrix4 transform = node.absoluteTransformation();
-  float* t = transform.data();
-  for (int i = 0; i < 16; ++i) {
-    file << t[i] << " ";
-  }
-  file.close();
+  auto save = [&](const Mn::Matrix4 transform) {
+    const float* t = transform.data();
+    for (int i = 0; i < 16; ++i) {
+      file << t[i] << " ";
+    }
+    LOG(INFO) << "Transformation matrix saved to " << filename << " : "
+              << Eigen::Map<const esp::mat4f>(transform.data());
+  };
+  save(agentTransform);
+  save(sensorTransform);
 
-  LOG(INFO) << "Transformation matrix saved to " << filename << " : "
-            << Eigen::Map<esp::mat4f>(transform.data());
+  file.close();
+}
+void Viewer::saveAgentAndSensorTransformToFile() {
+  const char* saved_transformations_directory = "saved_transformations/";
+  if (!Cr::Utility::Directory::exists(saved_transformations_directory)) {
+    Cr::Utility::Directory::mkpath(saved_transformations_directory);
+  }
+
+  // update temporary save
+  savedAgentTransform_ = defaultAgent_->node().transformation();
+  savedSensorTransform_ = getAgentCamera().node().transformation();
+
+  // update save in file system
+  saveTransformToFile(Cr::Utility::formatString("{}camera.{}.txt",
+                                                saved_transformations_directory,
+                                                getCurrentTimeString()),
+                      *savedAgentTransform_, *savedSensorTransform_);
 }
 
-void Viewer::loadNodeTransformFromFile(esp::scene::SceneNode& node,
-                                       const std::string& filename) {
+bool loadTransformFromFile(const std::string& filename,
+                           Mn::Matrix4& agentTransform,
+                           Mn::Matrix4& sensorTransform) {
   std::ifstream file(filename);
   if (!file.good()) {
     LOG(ERROR) << "Cannot open " << filename << " to load data.";
-    return;
+    return false;
   }
 
   // reading file system data into matrix as transformation
-  Mn::Vector4 cols[4];
-  for (int col = 0; col < 4; ++col) {
-    for (int row = 0; row < 4; ++row) {
-      file >> cols[col][row];
+  auto load = [&](Mn::Matrix4& transform) {
+    Mn::Vector4 cols[4];
+    for (int col = 0; col < 4; ++col) {
+      for (int row = 0; row < 4; ++row) {
+        file >> cols[col][row];
+      }
+    }
+    Mn::Matrix4 temp{cols[0], cols[1], cols[2], cols[3]};
+    if (!temp.isRigidTransformation()) {
+      LOG(WARNING) << "Data loaded from " << filename
+                   << " is not a valid rigid transformation.";
+      return false;
+    }
+    transform = temp;
+    LOG(INFO) << "Transformation matrix loaded from " << filename << " : "
+              << Eigen::Map<esp::mat4f>(transform.data());
+    return true;
+  };
+  // NOTE: load Agent first!!
+  bool status = load(agentTransform) && load(sensorTransform);
+  file.close();
+  return status;
+}
+
+void Viewer::loadAgentAndSensorTransformFromFile() {
+  if (!agentTransformLoadPath_.empty()) {
+    // loading from file system
+    Mn::Matrix4 agentMtx;
+    Mn::Matrix4 sensorMtx;
+    if (!loadTransformFromFile(agentTransformLoadPath_, agentMtx, sensorMtx))
+      return;
+    savedAgentTransform_ = agentMtx;
+    savedSensorTransform_ = sensorMtx;
+  } else {
+    // attempting to load from last temporary save
+    LOG(INFO)
+        << "Camera transform file not specified, attempting to load from "
+           "current instance. Use --camera-transform-filepath to specify file "
+           "to load from.";
+    if (!savedAgentTransform_ || !savedSensorTransform_) {
+      LOG(INFO) << "Well, no transformation saved in current instance. nothing "
+                   "is changed.";
+      return;
     }
   }
-  Mn::Matrix4 transform{cols[0], cols[1], cols[2], cols[3]};
-  file.close();
 
-  // checking for corruption
-  if (!transform.isRigidTransformation()) {
-    LOG(WARNING) << "Data loaded from " << filename
-                 << " is not a valid transformation.";
-    return;
+  defaultAgent_->node().setTransformation(*savedAgentTransform_);
+  for (const auto& p : getAgentCamera().node().getNodeSensors()) {
+    p.second.get().object().setTransformation(*savedSensorTransform_);
   }
-
-  node.setTransformation(transform);
-  LOG(INFO) << "Transformation matrix loaded from " << filename << " : "
-            << Eigen::Map<esp::mat4f>(transform.data());
+  LOG(INFO)
+      << "Transformation matrices are loaded to the agent and the sensors.";
 }
 
 int Viewer::addObject(int ID) {
@@ -1520,10 +1531,10 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       }
       break;
     case KeyEvent::Key::LeftBracket:
-      saveCameraTransformToFile();
+      saveAgentAndSensorTransformToFile();
       break;
     case KeyEvent::Key::RightBracket:
-      loadCameraTransformFromFile();
+      loadAgentAndSensorTransformFromFile();
       break;
 
     case KeyEvent::Key::Equal: {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -505,8 +505,8 @@ Viewer::Viewer(const Arguments& arguments)
       .addBooleanOption("recompute-navmesh")
       .setHelp("recompute-navmesh",
                "Programmatically re-generate the scene navmesh.")
-      .addOption("camera-transform-filepath")
-      .setHelp("camera-transform-filepath",
+      .addOption("agent-transform-filepath")
+      .setHelp("agent-transform-filepath",
                "Specify path to load camera transform from.")
       .parse(arguments.argc, arguments.argv);
 
@@ -535,7 +535,7 @@ Viewer::Viewer(const Arguments& arguments)
     debugBullet_ = true;
   }
 
-  agentTransformLoadPath_ = args.value("camera-transform-filepath");
+  agentTransformLoadPath_ = args.value("agent-transform-filepath");
   gfxReplayRecordFilepath_ = args.value("gfx-replay-record-filepath");
 
   // configure and intialize Simulator
@@ -789,7 +789,7 @@ void Viewer::loadAgentAndSensorTransformFromFile() {
     // attempting to load from last temporary save
     LOG(INFO)
         << "Camera transform file not specified, attempting to load from "
-           "current instance. Use --camera-transform-filepath to specify file "
+           "current instance. Use --agent-transform-filepath to specify file "
            "to load from.";
     if (!savedAgentTransform_ || !savedSensorTransform_) {
       LOG(INFO) << "Well, no transformation saved in current instance. nothing "

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -20,7 +20,6 @@
 #include <Magnum/GL/Renderbuffer.h>
 #include <Magnum/GL/RenderbufferFormat.h>
 #include <Magnum/Image.h>
-#include <Magnum/Math/Tags.h>
 #include <Magnum/PixelFormat.h>
 #include <Magnum/SceneGraph/Camera.h>
 #include <Magnum/Shaders/Generic.h>


### PR DESCRIPTION
## Motivation and Context
When the viewer works with a new stage, the view usually starts from a random position and orientation. We need a functionality to quickly set the agent and its sensors to some desired (previously saved) transformations. This diff is to address this problem.
(NOTE: it assumes all the sensors are at the same position on the agent, which is the current setting.)
 
 This diff includes:
- Fix: Previously, the camera save/load functions are outdated (as we deprecated the "default" renderCamera in the scene graph). It is fixed in this diff.
- It saves 2 relative transformations -- one is the default agent's and the other one is the rgb camera sensor's.
- It loads and sets the agent's transformation, and load the sensor's transformation and sets it to **all the sensors.** 
- It deprecates the `flyingCameraMode`.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
On my machine.
I saved the file to the disk and load them later. Performed as expected. Very handy.
I can load for example using:
```
./build/utils/viewer/viewer --magnum-gpu-validation on --enable-physics --dataset '/home/user/models/frl_apartment_stage_pvizplan_empty.scene_dataset_config.json' frl_apartment_stage_pvizplan_empty --agent-transform-filepath '/home/user/habitat-sim/saved_transformations/camera.2021_4_19_19-2-51.txt' 

```

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
