### PR TITLE
Support for shader_type specification in stage and object configurations - Part 1 of 2

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -179,7 +179,7 @@ void ResourceManager::initPhysicsManager(
 }  // ResourceManager::initPhysicsManager
 
 bool ResourceManager::loadStage(
-    const StageAttributes::ptr& stageAttributes,
+    StageAttributes::ptr& stageAttributes,
     const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
     esp::scene::SceneManager* sceneManagerPtr,
     std::vector<int>& activeSceneIDs,
@@ -326,8 +326,7 @@ bool ResourceManager::loadStage(
     // Either add with pre-built meshGroup if collision assets are loaded
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
-    bool sceneSuccess =
-        _physicsManager->addStage(stageAttributes->getHandle(), meshGroup);
+    bool sceneSuccess = _physicsManager->addStage(stageAttributes, meshGroup);
     if (!sceneSuccess) {
       LOG(ERROR) << "ResourceManager::loadStage : Adding Stage "
                  << stageAttributes->getHandle()
@@ -1783,10 +1782,8 @@ void ResourceManager::loadTextures(Importer& importer,
 }  // ResourceManager::loadTextures
 
 bool ResourceManager::instantiateAssetsOnDemand(
-    const std::string& objectTemplateHandle) {
-  // Meta data
-  ObjectAttributes::ptr ObjectAttributes =
-      getObjectAttributesManager()->getObjectByHandle(objectTemplateHandle);
+    const metadata::attributes::ObjectAttributes::ptr& ObjectAttributes) {
+  const std::string& objectTemplateHandle = ObjectAttributes->getHandle();
 
   if (!ObjectAttributes) {
     return false;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1785,11 +1785,10 @@ void ResourceManager::loadTextures(Importer& importer,
 
 bool ResourceManager::instantiateAssetsOnDemand(
     const metadata::attributes::ObjectAttributes::ptr& objectAttributes) {
-  const std::string& objectTemplateHandle = objectAttributes->getHandle();
-
-  if (!ObjectAttributes) {
+  if (!objectAttributes) {
     return false;
   }
+  const std::string& objectTemplateHandle = objectAttributes->getHandle();
 
   // if attributes are "dirty" (important values have changed since last
   // registered) then re-register.  Should never return ID_UNDEFINED - this

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2251,8 +2251,17 @@ void ResourceManager::createConvexHullDecomposition(
     const VHACDParameters& params,
     const bool saveChdToObj) {
   if (resourceDict_.count(filename) == 0) {
+    // retrieve existing, or create new, object attributes corresponding to
+    // passed filename
+    auto objAttributes =
+        getObjectAttributesManager()->getObjectCopyByHandle(filename);
+    if (objAttributes == nullptr) {
+      objAttributes =
+          getObjectAttributesManager()->createObject(filename, false);
+    }
+
     // load/check for render MeshMetaData and load assets
-    loadObjectMeshDataFromFile(filename, filename, "render", true);
+    loadObjectMeshDataFromFile(filename, objAttributes, "render", true);
 
   }  // if no render asset exists
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -184,7 +184,7 @@ class ResourceManager {
    * @return Whether or not the scene load succeeded.
    */
   bool loadStage(
-      const metadata::attributes::StageAttributes::ptr& sceneAttributes,
+      metadata::attributes::StageAttributes::ptr& sceneAttributes,
       const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
       esp::scene::SceneManager* sceneManagerPtr,
       std::vector<int>& activeSceneIDs,
@@ -209,12 +209,14 @@ class ResourceManager {
    * collisionMeshGroups_, respectively. Assumes valid render and collisions
    * asset handles have been specified (This is checked/verified during
    * registration.)
-   * @param objTemplateHandle The key for referencing the template in the
-   * @ref esp::metadata::managers::ObjectAttributesManager::objectLibrary_.
+   * @param ObjectAttributes The object template describing the object we wish
+   * to instantiate, copied from an entry in @ref
+   * esp::metadata::managers::ObjectAttributesManager::objectLibrary_.
    * @return whether process succeeded or not - only currently fails if
    * registration call fails.
    */
-  bool instantiateAssetsOnDemand(const std::string& objTemplateHandle);
+  bool instantiateAssetsOnDemand(
+      const metadata::attributes::ObjectAttributes::ptr& ObjectAttributes);
 
   //======== Accessor functions ========
   /**

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -581,20 +581,21 @@ class ResourceManager {
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
-   * specified @ref meshType used by @ref objectTemplateHandle
+   * specified @p assetType used by object described by @p objectAttributes
    *
    * @param filename the name of the file describing this mesh
-   * @param objectTemplateHandle the handle for the object attributes owning
-   * this mesh (for error log output)
-   * @param meshType either "render" or "collision" (for error log output)
+   * @param objectAttributes the object attributes owning
+   * this mesh.
+   * @param assetType either "render" or "collision" (for error log output)
    * @param requiresLighting whether or not this mesh asset responds to
    * lighting
    * @return whether or not the mesh was loaded successfully
    */
-  bool loadObjectMeshDataFromFile(const std::string& filename,
-                                  const std::string& objectTemplateHandle,
-                                  const std::string& meshType,
-                                  const bool requiresLighting);
+  bool loadObjectMeshDataFromFile(
+      const std::string& filename,
+      const metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      const std::string& meshType,
+      const bool requiresLighting);
 
   /**
    * @brief Build a primitive asset based on passed template parameters.  If

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -129,6 +129,10 @@ void initAttributesBindings(py::module& m) {
           R"(Handle of the asset used to calculate collsions for constructions
           built from this template.)")
       .def_property(
+          "shader_type", &AbstractObjectAttributes::getShaderType,
+          &AbstractObjectAttributes::setShaderType,
+          R"(The shader type [0=flat, 1=phong, 2=pbr] to use for this construction)")
+      .def_property(
           "requires_lighting", &AbstractObjectAttributes::getRequiresLighting,
           &AbstractObjectAttributes::setRequiresLighting,
           R"(Whether constructions built from this template should use phong

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -35,6 +35,8 @@ set(
   managers/StageAttributesManager.cpp
   MetadataMediator.h
   MetadataMediator.cpp
+  MetadataUtils.h
+  MetadataUtils.cpp
 )
 find_package(Magnum REQUIRED Primitives)
 

--- a/src/esp/metadata/MetadataUtils.cpp
+++ b/src/esp/metadata/MetadataUtils.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "MetadataUtils.h"
+
+#include <Corrade/Utility/String.h>
+
+#include "esp/io/io.h"
+#include "esp/metadata/attributes/ObjectAttributes.h"
+
+namespace esp {
+namespace metadata {
+namespace attributes {
+enum class ObjectInstanceShaderType;
+}
+namespace Cr = Corrade;
+
+int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc) {
+  // Check for shader type to use.  Default to unknown.
+  int shader_type =
+      static_cast<int>(attributes::ObjectInstanceShaderType::Unknown);
+  std::string tmpShaderType = "";
+  if (io::readMember<std::string>(jsonDoc, "shader_type", tmpShaderType)) {
+    // shader_type tag was found, perform check - first convert to
+    // lowercase
+    std::string strToLookFor = Cr::Utility::String::lowercase(tmpShaderType);
+    auto found = attributes::AbstractObjectAttributes::ShaderTypeNamesMap.find(
+        strToLookFor);
+    if (found !=
+        attributes::AbstractObjectAttributes::ShaderTypeNamesMap.end()) {
+      shader_type = static_cast<int>(found->second);
+    } else {
+      LOG(WARNING) << "getShaderTypeFromJsonDoc : "
+                      "motion_type value in json  : `"
+                   << tmpShaderType << "|" << strToLookFor
+                   << "` does not map to a valid "
+                      "SceneInstanceTranslationOrigin value, so defaulting "
+                      "motion type to SceneInstanceTranslationOrigin::Unknown.";
+    }
+  }
+  return shader_type;
+}  // getShaderTypeFromJsonDoc
+
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/MetadataUtils.h
+++ b/src/esp/metadata/MetadataUtils.h
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_METADATA_METADATAUTILS_H_
+#define ESP_METADATA_METADATAUTILS_H_
+
+#include "esp/io/json.h"
+
+namespace esp {
+namespace metadata {
+
+/**
+ * @brief This function is accessed by object and stage attributes loading, as
+ * well as scene instance loading.  This function will process data held in a
+ * json doc with the tag "shader_type", and return the int value found, or the
+ * int value of @ref
+ * esp::metadata::attributes::ObjectInstanceShaderType::Unknown if no data
+ * found.
+ * @param jsonDoc The json document to query for the tag of interest
+ * @return The shader type specified in the document, or Unknown, casted to an
+ * int.
+ */
+int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc);
+
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_METADATAUTILS_H_

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -16,6 +16,15 @@ const std::map<std::string, esp::assets::AssetType>
         {"semantic", esp::assets::AssetType::INSTANCE_MESH},
         {"suncg", esp::assets::AssetType::SUNCG_SCENE},
 };
+
+// All keys must be lowercase
+const std::map<std::string, ObjectInstanceShaderType>
+    AbstractObjectAttributes::ShaderTypeNamesMap = {
+        {"flat", ObjectInstanceShaderType::Flat},
+        {"phong", ObjectInstanceShaderType::Phong},
+        {"pbr", ObjectInstanceShaderType::PBR},
+};
+
 AbstractObjectAttributes::AbstractObjectAttributes(
     const std::string& attributesClassKey,
     const std::string& handle)
@@ -53,6 +62,9 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);
+  // default to unknown for objects
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+  // TODO remove this once ShaderType support is complete
   setRequiresLighting(true);
   setIsVisible(true);
   setSemanticId(0);
@@ -62,7 +74,9 @@ StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
-
+  // default to unknown for stages
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+  // TODO remove this once ShaderType support is complete
   setRequiresLighting(false);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh
   setCollisionAssetType(0);

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -14,6 +14,31 @@ namespace metadata {
 namespace attributes {
 
 /**
+ * @brief This enum class defines the possible shader options for rendering
+ * instances of objects or stages in Habitat-sim.
+ */
+enum class ObjectInstanceShaderType {
+  /**
+   * Represents an unknown/unspecified value for the shader type to use. Resort
+   * to defaults for object type.
+   */
+  Unknown = -1,
+  /**
+   * Refers to flat shading, pure color and no lighting.  This is often used for
+   * textured objects
+   */
+  Flat = 0,
+  /**
+   * Refers to phong shading with pure diffuse color.
+   */
+  Phong = 1,
+  /**
+   * Refers to using a shader built with physically-based rendering models.
+   */
+  PBR = 2,
+};
+
+/**
  * @brief base attributes object holding attributes shared by all
  * @ref esp::metadata::attributes::ObjectAttributes and @ref
  * esp::metadata::attributes::StageAttributes objects; Should be treated as
@@ -22,11 +47,16 @@ namespace attributes {
 class AbstractObjectAttributes : public AbstractAttributes {
  public:
   /**
-   * @brief Constant static map to provide mappings from string tags to @ref
-   * esp::assets::AssetType values.  This will be used to map values set in json
-   * for mesh type to @ref esp::assets::AssetType.  Keys must be lowercase.
+   * @brief Constant static map to provide mappings from string tags to
+   * @ref esp::assets::AssetType values.  This will be used to map values
+   * set in json for mesh type to @ref esp::assets::AssetType.  Keys must
+   * be lowercase.
    */
   static const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
+
+  static const std::map<std::string, ObjectInstanceShaderType>
+      ShaderTypeNamesMap;
+
   AbstractObjectAttributes(const std::string& classKey,
                            const std::string& handle);
 
@@ -159,6 +189,13 @@ class AbstractObjectAttributes : public AbstractAttributes {
   }
 
   bool getUseMeshCollision() const { return getBool("use_mesh_collision"); }
+
+  /**
+   * @brief Set the default shader to use for an object or stage.  This may be
+   * overridden by a scene instance specification.
+   */
+  void setShaderType(int shader_type) { setInt("shader_type", shader_type); }
+  int getShaderType() const { return getInt("shader_type"); }
 
   // if true use phong illumination model instead of flat shading
   void setRequiresLighting(bool requiresLighting) {

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -18,6 +18,10 @@ const std::map<std::string, esp::physics::MotionType>
 SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     const std::string& handle)
     : AbstractAttributes("SceneObjectInstanceAttributes", handle) {
+  // default to unknown for object instances, to use attributes-specified
+  // defaults
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+
   // defaults to unknown/undefined
   setMotionType(static_cast<int>(esp::physics::MotionType::UNDEFINED));
   // set to no rotation

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -92,6 +92,15 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    */
   int getMotionType() const { return getInt("motion_type"); }
 
+  /**
+   * @brief Set the default shader to use for an object or stage.  Uses values
+   * specified in stage or object attributes if not overridden here.  Uses map
+   * of string values in json to @ref
+   * esp::metadata::atributes::ObjectInstanceShaderType int values.
+   */
+  void setShaderType(int shader_type) { setInt("shader_type", shader_type); }
+  int getShaderType() const { return getInt("shader_type"); }
+
  public:
   ESP_SMART_POINTERS(SceneObjectInstanceAttributes)
 };  // class SceneObjectInstanceAttributes

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -12,6 +12,7 @@
 
 #include "esp/metadata/attributes/ObjectAttributes.h"
 
+#include "esp/metadata/MetadataUtils.h"
 #include "esp/metadata/managers/AttributesManagerBase.h"
 
 namespace Cr = Corrade;
@@ -295,6 +296,17 @@ auto AbstractObjectAttributesManager<T, Access>::
         static_cast<int>(esp::assets::AssetType::UNKNOWN));
     attributes->setUseMeshCollision(true);
   }
+
+  // set attributes shader type to use.  This may be overridden by a scene
+  // instance specification.
+  int shaderTypeVal = getShaderTypeFromJsonDoc(jsonDoc);
+  // if a known shader type val is specified in json, set that value for the
+  // attributes, overriding constructor defaults.
+  if (shaderTypeVal !=
+      static_cast<int>(attributes::ObjectInstanceShaderType::Unknown)) {
+    attributes->setShaderType(shaderTypeVal);
+  }
+
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "SceneAttributesManager.h"
+#include "esp/metadata/MetadataUtils.h"
 #include "esp/physics/RigidBase.h"
 
 #include "esp/io/io.h"
@@ -133,8 +134,12 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
   // to unknown, which will mean use scene instance-level default.
   instanceAttrs->setTranslationOrigin(getTranslationOriginVal(jCell));
 
-  // motion type of object.  Ignored for stage.  TODO : verify is valid motion
-  // type using standard mechanism of static map comparison.
+  // set specified shader type value.  May be Unknown, which means the default
+  // value specified in the stage or object attributes will be used.
+  instanceAttrs->setShaderType(getShaderTypeFromJsonDoc(jCell));
+
+  // motion type of object.  Ignored for stage.  TODO : verify is valid
+  // motion type using standard mechanism of static map comparison.
 
   int motionTypeVal = static_cast<int>(physics::MotionType::UNDEFINED);
   std::string tmpVal = "";

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -34,7 +34,7 @@ PhysicsManager::~PhysicsManager() {
 }
 
 bool PhysicsManager::addStage(
-    const std::string& handle,
+    const metadata::attributes::StageAttributes::ptr& initAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
   for (const assets::CollisionMeshData& meshData : meshGroup) {
@@ -44,41 +44,28 @@ bool PhysicsManager::addStage(
   }
 
   //! Initialize scene
-  bool sceneSuccess = addStageFinalize(handle);
+  bool sceneSuccess = addStageFinalize(initAttributes);
   return sceneSuccess;
 }
 
-bool PhysicsManager::addStageFinalize(const std::string& handle) {
+bool PhysicsManager::addStageFinalize(
+    const metadata::attributes::StageAttributes::ptr& initAttributes) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(handle);
+  bool sceneSuccess = staticStageObject_->initialize(initAttributes);
   return sceneSuccess;
 }
 
-int PhysicsManager::addObject(const int objectLibId,
-                              DrawableGroup* drawables,
-                              scene::SceneNode* attachmentNode,
-                              const std::string& lightSetup) {
-  const std::string& configHandle =
-      resourceManager_.getObjectAttributesManager()->getObjectHandleByID(
-          objectLibId);
-
-  return addObject(configHandle, drawables, attachmentNode, lightSetup);
-}
-
-int PhysicsManager::addObject(const std::string& configFileHandle,
-                              DrawableGroup* drawables,
-                              scene::SceneNode* attachmentNode,
-                              const std::string& lightSetup) {
+int PhysicsManager::addObject(
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    DrawableGroup* drawables,
+    scene::SceneNode* attachmentNode,
+    const std::string& lightSetup) {
   //! Make rigid object and add it to existingObjects
-  int nextObjectID_ = allocateObjectID();
-  scene::SceneNode* objectNode = attachmentNode;
-  if (attachmentNode == nullptr) {
-    objectNode = &staticStageObject_->node().createChild();
-  }
+
   // verify whether necessary assets exist, and if not, instantiate them
   // only make object if asset instantiation succeeds (short circuit)
   bool objectSuccess =
-      resourceManager_.instantiateAssetsOnDemand(configFileHandle);
+      resourceManager_.instantiateAssetsOnDemand(objectAttributes);
   if (!objectSuccess) {
     LOG(ERROR) << "PhysicsManager::addObject : "
                   "ResourceManager::instantiateAssetsOnDemand unsuccessful. "
@@ -86,8 +73,15 @@ int PhysicsManager::addObject(const std::string& configFileHandle,
     return ID_UNDEFINED;
   }
 
+  // derive valid object ID and create new node if necessary
+  int nextObjectID_ = allocateObjectID();
+  scene::SceneNode* objectNode = attachmentNode;
+  if (attachmentNode == nullptr) {
+    objectNode = &staticStageObject_->node().createChild();
+  }
+
   objectSuccess =
-      makeAndAddRigidObject(nextObjectID_, configFileHandle, objectNode);
+      makeAndAddRigidObject(nextObjectID_, objectAttributes, objectNode);
 
   if (!objectSuccess) {
     deallocateObjectID(nextObjectID_);
@@ -167,12 +161,13 @@ int PhysicsManager::deallocateObjectID(int physObjectID) {
   return physObjectID;
 }
 
-bool PhysicsManager::makeAndAddRigidObject(int newObjectID,
-                                           const std::string& handle,
-                                           scene::SceneNode* objectNode) {
+bool PhysicsManager::makeAndAddRigidObject(
+    int newObjectID,
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    scene::SceneNode* objectNode) {
   auto ptr = physics::RigidObject::create_unique(objectNode, newObjectID,
                                                  resourceManager_);
-  bool objSuccess = ptr->initialize(handle);
+  bool objSuccess = ptr->initialize(objectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -61,7 +61,13 @@ int PhysicsManager::addObject(
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
   //! Make rigid object and add it to existingObjects
-
+  if (!objectAttributes) {
+    // should never run, but just in case
+    LOG(ERROR) << "PhysicsManager::addObject : "
+                  "Object creation failed due to nonexistant "
+                  "objectAttributes";
+    return ID_UNDEFINED;
+  }
   // verify whether necessary assets exist, and if not, instantiate them
   // only make object if asset instantiation succeeds (short circuit)
   bool objectSuccess =

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -157,48 +157,79 @@ class PhysicsManager {
    * Only one 'scene' may be initialized per simulated world, but this scene may
    * contain several components (e.g. GLB heirarchy).
    *
-   * @param handle The handle to the attributes structure defining physical
-   * properties of the scene.
+   * @param initAttributes The attributes structure defining physical
+   * properties of the scene.  Must be a copy of the attributes stored in the
+   * Attributes Manager.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
-  bool addStage(const std::string& handle,
-                const std::vector<assets::CollisionMeshData>& meshGroup);
+  bool addStage(
+      const metadata::attributes::StageAttributes::ptr& initAttributes,
+      const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager.
-   *  @anchor addObject_string
-   *  @param configFile The filename of the object's physical properties file
-   * used as the key to query @ref
-   * esp::metadata::managers::ObjectAttributesManager.
-   *  @param drawables Reference to the scene graph drawables group to enable
+   * @anchor addObject_string
+   * @param attributesHandle The handle of the object attributes used as the key
+   * to query @ref esp::metadata::managers::ObjectAttributesManager.
+   * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
+   * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
+   * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObject(const std::string& configFile,
+  int addObject(const std::string& attributesHandle,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    esp::metadata::attributes::ObjectAttributes::ptr attributes =
+        resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
+            attributesHandle);
+
+    return addObject(attributes, drawables, attachmentNode, lightSetup);
+  }
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
    * handle.
-   *  @param objectLibId The ID of the object's template in @ref
+   * @param objectLibId The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
-   *  @param drawables Reference to the scene graph drawables group to enable
+   * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
-   *  @param attachmentNode If supplied, attach the new physical object to an
+   * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
-   *  @return the instanced object's ID, mapping to it in @ref
+   * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
   int addObject(const int objectLibId,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    const esp::metadata::attributes::ObjectAttributes::ptr attributes =
+        resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
+            objectLibId);
+
+    return addObject(attributes, drawables, attachmentNode, lightSetup);
+  }
+
+  /** @brief Instance a physical object from an object properties template in
+   * the @ref esp::metadata::managers::ObjectAttributesManager by template
+   * handle.
+   * @param objectAttributes The object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObject(
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      DrawableGroup* drawables,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref
@@ -1036,29 +1067,30 @@ class PhysicsManager {
   virtual bool initPhysicsFinalize();
 
   /**
-   * @brief Finalize scene initialization for kinematic scenes.  Overidden by
+   * @brief Finalize stage initialization for kinematic stage.  Overidden by
    * instancing class if physics is supported.
    *
-   * @param handle the handle to the attributes structure defining physical
-   * properties of the scene.
+   * @param initAttributes the attributes structure defining physical
+   * properties of the stage.
    * @return true if successful and false otherwise
    */
 
-  virtual bool addStageFinalize(const std::string& handle);
+  virtual bool addStageFinalize(
+      const metadata::attributes::StageAttributes::ptr& initAttributes);
 
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
-   * @param meshGroup The object's mesh.
-   * @param handle The handle to the physical object's template defining its
+   * @param initAttributes The physical object's template defining its
    * physical parameters.
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  virtual bool makeAndAddRigidObject(int newObjectID,
-                                     const std::string& handle,
-                                     scene::SceneNode* objectNode);
+  virtual bool makeAndAddRigidObject(
+      int newObjectID,
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* objectNode);
 
   /** @brief Set the voxelization visualization for a scene node to be true or
    * false.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -186,6 +186,12 @@ class PhysicsManager {
     esp::metadata::attributes::ObjectAttributes::ptr attributes =
         resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
             attributesHandle);
+    if (!attributes) {
+      LOG(ERROR) << "PhysicsManager::addObject : "
+                    "Object creation failed due to unknown attributes "
+                 << attributesHandle;
+      return ID_UNDEFINED;
+    }
 
     return addObject(attributes, drawables, attachmentNode, lightSetup);
   }
@@ -193,7 +199,7 @@ class PhysicsManager {
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
    * handle.
-   * @param objectLibId The ID of the object's template in @ref
+   * @param attributesID The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
    * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object.
@@ -202,14 +208,19 @@ class PhysicsManager {
    * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObject(const int objectLibId,
+  int addObject(const int attributesID,
                 DrawableGroup* drawables,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     const esp::metadata::attributes::ObjectAttributes::ptr attributes =
         resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
-            objectLibId);
-
+            attributesID);
+    if (!attributes) {
+      LOG(ERROR) << "PhysicsManager::addObject : "
+                    "Object creation failed due to unknown attributes ID "
+                 << attributesID;
+      return ID_UNDEFINED;
+    }
     return addObject(attributes, drawables, attachmentNode, lightSetup);
   }
 

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -35,10 +35,10 @@ class AbstractObjectAttributes;
 namespace physics {
 
 /**
-@brief Motion type of a @ref RigidObject.
-Defines its treatment by the simulator and operations which can be performed on
-it.
-*/
+ * @brief Motion type of a @ref RigidObject.
+ * Defines its treatment by the simulator and operations which can be performed
+ * on it.
+ */
 enum class MotionType {
   /**
    * Refers to an error (such as a query to non-existing object) or an
@@ -99,12 +99,12 @@ class RigidBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Initializes the @ref RigidObject or @ref RigidStage that inherits
    * from this class.  This is overridden
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
-   * phyiscal parameters for this object
+   * @param initAttributes The template structure defining relevant phyiscal
+   * parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  virtual bool initialize(const std::string& handle) = 0;
+  virtual bool initialize(
+      metadata::attributes::AbstractObjectAttributes::ptr initAttributes) = 0;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidStage that

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -14,15 +14,16 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode,
   objectId_ = objectId;
 }
 
-bool RigidObject::initialize(const std::string& handle) {
+bool RigidObject::initialize(
+    metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidObject more than once";
     return false;
   }
 
-  // save a copy of the template at initialization time
-  initializationAttributes_ =
-      resMgr_.getObjectAttributesManager()->getObjectCopyByHandle(handle);
+  // save the copy of the template used to create the object at initialization
+  // time
+  initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }  // RigidObject::initialize

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -106,12 +106,12 @@ class RigidObject : public RigidBase {
 
   /**
    * @brief Initializes the @ref RigidObject that inherits from this class
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
+   * @param initAttributes The template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const std::string& handle) override;
+  bool initialize(metadata::attributes::AbstractObjectAttributes::ptr
+                      initAttributes) override;
 
   /**
    * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -11,14 +11,16 @@ RigidStage::RigidStage(scene::SceneNode* rigidBodyNode,
                        const assets::ResourceManager& resMgr)
     : RigidBase(rigidBodyNode, resMgr) {}
 
-bool RigidStage::initialize(const std::string& handle) {
+bool RigidStage::initialize(
+    metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
   if (initializationAttributes_ != nullptr) {
     LOG(ERROR) << "Cannot initialize a RigidStage more than once";
     return false;
   }
   objectMotionType_ = MotionType::STATIC;
-  initializationAttributes_ =
-      resMgr_.getStageAttributesManager()->getObjectCopyByHandle(handle);
+  // save the copy of the template used to create the object at initialization
+  // time
+  initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -25,12 +25,12 @@ class RigidStage : public RigidBase {
   /**
    * @brief Initializes the @ref RigidStage that inherits
    * from this class
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
+   * @param initAttributes The template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
    */
-  bool initialize(const std::string& handle) override;
+  bool initialize(metadata::attributes::AbstractObjectAttributes::ptr
+                      initAttributes) override;
 
   /**
    * @brief Get a copy of the template used to initialize this stage object.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -48,20 +48,22 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
 
 // Bullet Mesh conversion adapted from:
 // https://github.com/mosra/magnum-integration/issues/20
-bool BulletPhysicsManager::addStageFinalize(const std::string& handle) {
+bool BulletPhysicsManager::addStageFinalize(
+    const metadata::attributes::StageAttributes::ptr& initAttributes) {
   //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(handle);
+  bool sceneSuccess = staticStageObject_->initialize(initAttributes);
 
   return sceneSuccess;
 }
 
-bool BulletPhysicsManager::makeAndAddRigidObject(int newObjectID,
-                                                 const std::string& handle,
-                                                 scene::SceneNode* objectNode) {
+bool BulletPhysicsManager::makeAndAddRigidObject(
+    int newObjectID,
+    const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+    scene::SceneNode* objectNode) {
   auto ptr = physics::BulletRigidObject::create_unique(
       objectNode, newObjectID, resourceManager_, bWorld_,
       collisionObjToObjIds_);
-  bool objSuccess = ptr->initialize(handle);
+  bool objSuccess = ptr->initialize(objectAttributes);
   if (objSuccess) {
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -209,7 +209,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * properties of the stage.
    * @return true if successful and false otherwise
    */
-  bool addStageFinalize(const std::string& handle) override;
+  bool addStageFinalize(const metadata::attributes::StageAttributes::ptr&
+                            initAttributes) override;
 
   /** @brief Create and initialize an @ref RigidObject and add
    * it to existingObjects_ map keyed with newObjectID
@@ -221,9 +222,10 @@ class BulletPhysicsManager : public PhysicsManager {
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map
    */
-  bool makeAndAddRigidObject(int newObjectID,
-                             const std::string& handle,
-                             scene::SceneNode* objectNode) override;
+  bool makeAndAddRigidObject(
+      int newObjectID,
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* objectNode) override;
 
   btDbvtBroadphase bBroadphase_;
   btDefaultCollisionConfiguration bCollisionConfig_;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -329,7 +329,18 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       metadataMediator_->getStageAttributesManager()->getObjectCopyByHandle(
           stageAttributesHandle);
 
+  // constant representing unknown shader type
+  const int unknownShaderType =
+      static_cast<int>(metadata::attributes::ObjectInstanceShaderType::Unknown);
+
   // set defaults for stage creation
+
+  // set shader type to use for stage
+  int stageShaderType = stageInstanceAttributes->getShaderType();
+  if (stageShaderType != unknownShaderType) {
+    stageAttributes->setShaderType(stageShaderType);
+  }
+  // set lighting key
   stageAttributes->setLightSetup(lightSetupKey);
   // set frustum culling from simulator config
   stageAttributes->setFrustumCulling(frustumCulling_);
@@ -432,7 +443,19 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
                       "to instance object; skipping. ";
       continue;
     }
-    objID = physicsManager_->addObject(objAttrFullHandle, &drawables,
+
+    // Get ObjectAttributes
+    auto objAttributes =
+        metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
+            objAttrFullHandle);
+    // set shader type to use for stage
+    int objShaderType = objInst->getShaderType();
+    if (objShaderType != unknownShaderType) {
+      objAttributes->setShaderType(objShaderType);
+    }
+
+    // create object using attributes copy.
+    objID = physicsManager_->addObject(objAttributes, &drawables,
                                        attachmentNode, lightSetupKey);
     if (objID == ID_UNDEFINED) {
       // instancing failed for some reason.


### PR DESCRIPTION
## Motivation and Context
[(Replaces this PR which included wrong commit)](https://github.com/facebookresearch/habitat-sim/pull/1134)
This PR is the first of 2 PRs intended to introduce configuration-file level support for independent shader types being specified for the stage and objects in a scene. Supported shader types that the user can specify are Flat, Phong and PBR (case insensitive), and these values can be specified in either stage and object configurations (to specify a default value for a particular stage or object TYPE), or in the scene instance configurations (which, if specified, will override the default values given in stage or object configs for a single instance only).

To support this functionality, stage and object creation had to be slightly modified in order to accept a copy of the appropriate attributes as a parameter, which is then moved to the initialization Attributes of the resultant rigidStage/rigidObject.

Part 1 of 2 : This PR only implements the framework required for this change, but lacks the functionality to consume the configuration-specified shader type in ResourceManager. The lacking functionality will be added in Part 2 of 2.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
