### PR TITLE
[BUGFIX]Add check to use allowSliding flag for agent move filter function

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1177,17 +1177,17 @@ agent::Agent::ptr Simulator::addAgent(
   agents_.push_back(ag);
   // TODO: just do this once
   if (pathfinder_->isLoaded()) {
+    scene::ObjectControls::MoveFilterFunc moveFilterFunction;
     if (config_.allowSliding) {
-      ag->getControls()->setMoveFilterFunction(
-          [&](const vec3f& start, const vec3f& end) {
-            return pathfinder_->tryStep(start, end);
-          });
+      moveFilterFunction = [&](const vec3f& start, const vec3f& end) {
+        return pathfinder_->tryStep(start, end);
+      };
     } else {
-      ag->getControls()->setMoveFilterFunction(
-          [&](const vec3f& start, const vec3f& end) {
-            return pathfinder_->tryStepNoSliding(start, end);
-          });
+      moveFilterFunction = [&](const vec3f& start, const vec3f& end) {
+        return pathfinder_->tryStepNoSliding(start, end);
+      };
     }
+    ag->getControls()->setMoveFilterFunction(moveFilterFunction);
   }
 
   return ag;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1177,10 +1177,17 @@ agent::Agent::ptr Simulator::addAgent(
   agents_.push_back(ag);
   // TODO: just do this once
   if (pathfinder_->isLoaded()) {
-    ag->getControls()->setMoveFilterFunction(
-        [&](const vec3f& start, const vec3f& end) {
-          return pathfinder_->tryStep(start, end);
-        });
+    if (config_.allowSliding) {
+      ag->getControls()->setMoveFilterFunction(
+          [&](const vec3f& start, const vec3f& end) {
+            return pathfinder_->tryStep(start, end);
+          });
+    } else {
+      ag->getControls()->setMoveFilterFunction(
+          [&](const vec3f& start, const vec3f& end) {
+            return pathfinder_->tryStepNoSliding(start, end);
+          });
+    }
   }
 
   return ag;


### PR DESCRIPTION
## Motivation and Context

This PR will allow disabling agent sliding when executing actions in C++ and JS viewer. 

## How Has This Been Tested

Locally using C++ and JS viewers

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
