### PR TITLE
[AO] - recompute_navmesh with STATIC ArticulatedObjects

### DIFF
--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -87,6 +87,12 @@ class ArticulatedLink : public RigidBase {
 
   int getIndex() { return mbIndex_; };
 
+  //! List of visual components attached to this link. Used for NavMesh
+  //! recomputation. Each entry is a child node of this link's node and a string
+  //! key to reference the asset in ResourceManager.
+  std::vector<std::pair<esp::scene::SceneNode*, std::string>>
+      visualAttachments_;
+
   // RigidBase overrides
 
   /**
@@ -262,6 +268,10 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
   virtual void deferUpdate() { isDeferringUpdate_ = true; }
 
   ArticulatedLink& getLink(int id) {
+    // option to get the baseLink_ with id=-1
+    if (id == -1) {
+      return *baseLink_.get();
+    }
     CHECK(links_.count(id));
     return *links_.at(id).get();
   };
@@ -419,17 +429,19 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
 
  protected:
   virtual bool attachGeometry(
-      CORRADE_UNUSED scene::SceneNode& node,
+      CORRADE_UNUSED ArticulatedLink* linkObject,
       CORRADE_UNUSED const std::shared_ptr<io::URDF::Link>& link,
       CORRADE_UNUSED const
-          std::map<std::string, std::shared_ptr<io::URDF::Material> >&
-              materials,
+          std::map<std::string, std::shared_ptr<io::URDF::Material>>& materials,
       CORRADE_UNUSED gfx::DrawableGroup* drawables) {
     return false;
   };
 
   //! map linkId to ArticulatedLink
   std::map<int, ArticulatedLink::uptr> links_;
+
+  //! link object for the AO base
+  ArticulatedLink::uptr baseLink_;
 
   //! map motorId to JointMotor
   std::map<int, JointMotor::uptr> jointMotors_;

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -171,7 +171,7 @@ class BulletArticulatedObject : public ArticulatedObject {
 
  protected:
   virtual bool attachGeometry(
-      scene::SceneNode& node,
+      ArticulatedLink* linkObject,
       const std::shared_ptr<io::URDF::Link>& link,
       const std::map<std::string, std::shared_ptr<io::URDF::Material>>&
           materials,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -956,7 +956,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
         meshComponentStates;
 
     // collect RigidObject mesh components
-    for (auto objectID : physicsManager_->getExistingObjectIDs()) {
+    for (auto& objectID : physicsManager_->getExistingObjectIDs()) {
       if (physicsManager_->getObjectMotionType(objectID) ==
           physics::MotionType::STATIC) {
         auto objectTransform = Magnum::EigenIntegration::cast<
@@ -978,7 +978,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
     }
 
     // collect ArticulatedObject mesh components
-    for (auto objectID : physicsManager_->getExistingArticulatedObjectIDs()) {
+    for (auto& objectID : physicsManager_->getExistingArticulatedObjectIDs()) {
       if (physicsManager_->getArticulatedObjectMotionType(objectID) ==
           physics::MotionType::STATIC) {
         for (int linkIx = -1;
@@ -990,7 +990,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                   physicsManager_->getArticulatedObject(objectID)
                       .getLink(linkIx)
                       .visualAttachments_;
-          for (auto visualAttachment : visualAttachments) {
+          for (auto& visualAttachment : visualAttachments) {
             auto objectTransform = Magnum::EigenIntegration::cast<
                 Eigen::Transform<float, 3, Eigen::Affine>>(
                 visualAttachment.first->absoluteTransformationMatrix());

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -945,11 +945,22 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
 
   // add STATIC collision objects
   if (includeStaticObjects) {
+    // update nodes so SceneNode transforms are up-to-date
+    physicsManager_->updateNodes();
+
+    // collect mesh components from all objects and then merge them.
+    // Each mesh component could be duplicated multiple times w/ different
+    // transforms.
+    std::map<std::string,
+             std::vector<Eigen::Transform<float, 3, Eigen::Affine>>>
+        meshComponentStates;
+
+    // collect RigidObject mesh components
     for (auto objectID : physicsManager_->getExistingObjectIDs()) {
       if (physicsManager_->getObjectMotionType(objectID) ==
           physics::MotionType::STATIC) {
         auto objectTransform = Magnum::EigenIntegration::cast<
-            Eigen::Transform<float, 3, Eigen::Affine> >(
+            Eigen::Transform<float, 3, Eigen::Affine>>(
             physicsManager_->getObjectVisualSceneNode(objectID)
                 .absoluteTransformationMatrix());
         const metadata::attributes::ObjectAttributes::cptr
@@ -962,8 +973,39 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
         if (meshHandle.empty()) {
           meshHandle = initializationTemplate->getRenderAssetHandle();
         }
-        assets::MeshData::uptr joinedObjectMesh =
-            resourceManager_->createJoinedCollisionMesh(meshHandle);
+        meshComponentStates[meshHandle].push_back(objectTransform);
+      }
+    }
+
+    // collect ArticulatedObject mesh components
+    for (auto objectID : physicsManager_->getExistingArticulatedObjectIDs()) {
+      if (physicsManager_->getArticulatedObjectMotionType(objectID) ==
+          physics::MotionType::STATIC) {
+        for (int linkIx = -1;
+             linkIx < physicsManager_->getNumArticulatedLinks(objectID);
+             ++linkIx) {
+          //-1 is baseLink_
+          std::vector<std::pair<esp::scene::SceneNode*, std::string>>
+              visualAttachments =
+                  physicsManager_->getArticulatedObject(objectID)
+                      .getLink(linkIx)
+                      .visualAttachments_;
+          for (auto visualAttachment : visualAttachments) {
+            auto objectTransform = Magnum::EigenIntegration::cast<
+                Eigen::Transform<float, 3, Eigen::Affine>>(
+                visualAttachment.first->absoluteTransformationMatrix());
+            std::string meshHandle = visualAttachment.second;
+            meshComponentStates[meshHandle].push_back(objectTransform);
+          }
+        }
+      }
+    }
+
+    // merge mesh components into the final mesh
+    for (auto& meshComponent : meshComponentStates) {
+      assets::MeshData::uptr joinedObjectMesh =
+          resourceManager_->createJoinedCollisionMesh(meshComponent.first);
+      for (auto& meshTransform : meshComponent.second) {
         int prevNumIndices = joinedMesh->ibo.size();
         int prevNumVerts = joinedMesh->vbo.size();
         joinedMesh->ibo.resize(prevNumIndices + joinedObjectMesh->ibo.size());
@@ -973,7 +1015,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
         }
         joinedMesh->vbo.reserve(joinedObjectMesh->vbo.size() + prevNumVerts);
         for (auto& vert : joinedObjectMesh->vbo) {
-          joinedMesh->vbo.push_back(objectTransform * vert);
+          joinedMesh->vbo.push_back(meshTransform * vert);
         }
       }
     }


### PR DESCRIPTION
## Motivation and Context

Many common navigation obstacles can be represented as `ArticulatedObjects` (e.g. doors, drawers, etc...). Instead of computing 3D collisions with these objects, it can be more efficient to use the NavMesh to constraint agent motion. This PR extends NavMesh re-computation to include `ArticulatedObject`s with `MotionType::STATIC` to enable these use cases.

Supporting changes:
- `ArticulatedObjects` can have `MotionType::STATIC` with equivalent treatment in the simulator to `MotionType::KINEMATIC` except that they are considered in NavMesh re-computation.
- Each 'ArticulatedLink' now caches its visual components for later query during mesh merge process.
- The base for an `ArticulatedObject` is now a stored as an `ArticulatedLink` in `baseLink_` and can be queried with `getLink(-1)` for uniformity.
## How Has This Been Tested

Local testing and demo in URDF_robotics_tutorial.py producing the following video:

https://user-images.githubusercontent.com/1445143/115457663-ac8f9c00-a1d9-11eb-83da-8653961991ed.mp4

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
