### PR TITLE
Refactor core bindings to their own file.

### DIFF
--- a/src/esp/bindings/CMakeLists.txt
+++ b/src/esp/bindings/CMakeLists.txt
@@ -2,9 +2,11 @@ find_package(MagnumBindings REQUIRED Python)
 
 pybind11_add_module(
   habitat_sim_bindings
+  bindings.h
   bindings.cpp
   AttributesBindings.cpp
   AttributesManagersBindings.cpp
+  CoreBindings.cpp
   GeoBindings.cpp
   GfxBindings.cpp
   MetadataMediatorBindings.cpp

--- a/src/esp/bindings/CoreBindings.cpp
+++ b/src/esp/bindings/CoreBindings.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "esp/bindings/bindings.h"
+#include "esp/core/ManagedContainer.h"
+#include "esp/core/random.h"
+
+namespace py = pybind11;
+using py::literals::operator""_a;
+
+namespace esp {
+namespace core {
+
+void initCoreBindings(py::module& m) {
+  py::class_<Configuration, Configuration::ptr>(m, "ConfigurationGroup")
+      .def(py::init(&Configuration::create<>))
+      .def("get_bool", &Configuration::getBool)
+      .def("get_string", &Configuration::getString)
+      .def("get_int", &Configuration::getInt)
+      .def("get_double", &Configuration::getDouble)
+      .def("get_vec3", &Configuration::getVec3)
+      .def("get", &Configuration::getString)
+      .def("set", &Configuration::set<std::string>)
+      .def("set", &Configuration::set<int>)
+      .def("set", &Configuration::set<double>)
+      .def("set", &Configuration::set<bool>)
+      .def("set", &Configuration::set<Magnum::Vector3>)
+      .def("add_string_to_group", &Configuration::addStringToGroup)
+      .def("get_string_group", &Configuration::getStringGroup)
+      .def("has_value", &Configuration::hasValue)
+      .def("remove_value", &Configuration::removeValue);
+
+  // ==== struct RigidState ===
+  py::class_<RigidState, RigidState::ptr>(m, "RigidState")
+      .def(py::init(&RigidState::create<>))
+      .def(py::init(&RigidState::create<const Magnum::Quaternion&,
+                                        const Magnum::Vector3&>))
+      .def_readwrite("rotation", &RigidState::rotation)
+      .def_readwrite("translation", &RigidState::translation);
+
+  py::class_<Random, Random::ptr>(m, "Random")
+      .def(py::init(&Random::create<>))
+      .def("seed", &Random::seed)
+      .def("uniform_float_01", &Random::uniform_float_01)
+      .def("uniform_float", &Random::uniform_float)
+      .def("uniform_int", py::overload_cast<>(&Random::uniform_int))
+      .def("uniform_int", py::overload_cast<int, int>(&Random::uniform_int))
+      .def("uniform_uint", &Random::uniform_uint)
+      .def("normal_float_01", &Random::normal_float_01);
+}
+
+}  // namespace core
+
+}  // namespace esp

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -5,7 +5,6 @@
 #include "esp/bindings/bindings.h"
 
 #include "esp/assets/ResourceManager.h"
-#include "esp/core//random.h"
 #include "esp/core/Check.h"
 #include "esp/core/Configuration.h"
 #include "esp/core/RigidState.h"
@@ -70,47 +69,6 @@ void initEspBindings(py::module& m) {
 #endif
 }
 
-namespace core {
-
-void initCoreBindings(py::module& m) {
-  py::class_<Configuration, Configuration::ptr>(m, "ConfigurationGroup")
-      .def(py::init(&Configuration::create<>))
-      .def("get_bool", &Configuration::getBool)
-      .def("get_string", &Configuration::getString)
-      .def("get_int", &Configuration::getInt)
-      .def("get_double", &Configuration::getDouble)
-      .def("get_vec3", &Configuration::getVec3)
-      .def("get", &Configuration::getString)
-      .def("set", &Configuration::set<std::string>)
-      .def("set", &Configuration::set<int>)
-      .def("set", &Configuration::set<double>)
-      .def("set", &Configuration::set<bool>)
-      .def("set", &Configuration::set<Magnum::Vector3>)
-      .def("add_string_to_group", &Configuration::addStringToGroup)
-      .def("get_string_group", &Configuration::getStringGroup)
-      .def("has_value", &Configuration::hasValue)
-      .def("remove_value", &Configuration::removeValue);
-
-  // ==== struct RigidState ===
-  py::class_<RigidState, RigidState::ptr>(m, "RigidState")
-      .def(py::init(&RigidState::create<>))
-      .def(py::init(&RigidState::create<const Magnum::Quaternion&,
-                                        const Magnum::Vector3&>))
-      .def_readwrite("rotation", &RigidState::rotation)
-      .def_readwrite("translation", &RigidState::translation);
-
-  py::class_<Random, Random::ptr>(m, "Random")
-      .def(py::init(&Random::create<>))
-      .def("seed", &Random::seed)
-      .def("uniform_float_01", &Random::uniform_float_01)
-      .def("uniform_float", &Random::uniform_float)
-      .def("uniform_int", py::overload_cast<>(&Random::uniform_int))
-      .def("uniform_int", py::overload_cast<int, int>(&Random::uniform_int))
-      .def("uniform_uint", &Random::uniform_uint)
-      .def("normal_float_01", &Random::normal_float_01);
-}
-
-}  // namespace core
 }  // namespace esp
 
 PYBIND11_MODULE(habitat_sim_bindings, m) {

--- a/src/esp/bindings/bindings.h
+++ b/src/esp/bindings/bindings.h
@@ -7,16 +7,15 @@
 
 #include <pybind11/pybind11.h>
 #include "esp/bindings/OpaqueTypes.h"
+#include "esp/core/ManagedContainer.h"
 
 namespace esp {
 
-namespace metadata {
-void initAttributesBindings(pybind11::module& m);
-void initMetadataMediatorBindings(pybind11::module& m);
-namespace managers {
-void initAttributesManagersBindings(pybind11::module& m);
-}  // namespace managers
-}  // namespace metadata
+namespace core {
+
+void initCoreBindings(pybind11::module& m);
+
+}  // namespace core
 
 namespace geo {
 void initGeoBindings(pybind11::module& m);
@@ -26,8 +25,16 @@ namespace gfx {
 void initGfxBindings(pybind11::module& m);
 namespace replay {
 void initGfxReplayBindings(pybind11::module& m);
-}
+}  // namespace replay
 }  // namespace gfx
+
+namespace metadata {
+void initAttributesBindings(pybind11::module& m);
+void initMetadataMediatorBindings(pybind11::module& m);
+namespace managers {
+void initAttributesManagersBindings(pybind11::module& m);
+}  // namespace managers
+}  // namespace metadata
 
 namespace nav {
 void initShortestPathBindings(pybind11::module& m);


### PR DESCRIPTION
## Motivation and Context
This PR has a minor refactor to move the core namespace bindings to their own file from "bindings.cpp".  New bindings of core namespace classes are pending as part of the ongoing work making physics constructs managed objects, which will be placed in these files.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
