### PR TITLE
[AO][bugfix] - Update AABB after setting kinematic state

### DIFF
--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -706,6 +706,7 @@ void BulletArticulatedObject::updateKinematicState() {
   for (size_t linkIx = 0; linkIx < btMultiBody_->getNumLinks(); ++linkIx) {
     bWorld_->updateSingleAabb(btMultiBody_->getLinkCollider(linkIx));
   }
+  bWorld_->updateSingleAabb(btMultiBody_->getBaseCollider());
   if (bFixedObjectRigidBody_) {
     bWorld_->updateSingleAabb(bFixedObjectRigidBody_.get());
   }

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -698,10 +698,8 @@ void BulletArticulatedObject::clampJointLimits() {
 }
 
 void BulletArticulatedObject::updateKinematicState() {
-  btAlignedObjectArray<btQuaternion> scratch_q;
-  btAlignedObjectArray<btVector3> scratch_m;
-  btMultiBody_->forwardKinematics(scratch_q, scratch_m);
-  btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
+  btMultiBody_->forwardKinematics(scratch_q_, scratch_m_);
+  btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q_, scratch_m_);
   // Need to update the aabbs manually also for broadphase collision detection
   for (size_t linkIx = 0; linkIx < btMultiBody_->getNumLinks(); ++linkIx) {
     bWorld_->updateSingleAabb(btMultiBody_->getLinkCollider(linkIx));

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -358,17 +358,7 @@ void BulletArticulatedObject::setRootState(const Magnum::Matrix4& state) {
     bFixedObjectRigidBody_.get()->setWorldTransform(tr);
   }
   // update the simulation state
-  // TODO: make this optional?
-  {
-    btAlignedObjectArray<btQuaternion> scratch_q;
-    btAlignedObjectArray<btVector3> scratch_m;
-    btMultiBody_->forwardKinematics(scratch_q, scratch_m);
-    btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
-  }
-  // sync visual shapes
-  if (!isDeferringUpdate_) {
-    updateNodes(true);
-  }
+  updateKinematicState();
 }
 
 void BulletArticulatedObject::setForces(const std::vector<float>& forces) {
@@ -452,16 +442,7 @@ void BulletArticulatedObject::setPositions(
   }
 
   // update the simulation state
-  // TODO: make this optional?
-  btAlignedObjectArray<btQuaternion> scratch_q;
-  btAlignedObjectArray<btVector3> scratch_m;
-  btMultiBody_->forwardKinematics(scratch_q, scratch_m);
-  btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
-
-  if (!isDeferringUpdate_) {
-    // sync visual shapes
-    updateNodes(true);
-  }
+  updateKinematicState();
 }
 
 std::vector<float> BulletArticulatedObject::getPositions() {
@@ -522,19 +503,13 @@ void BulletArticulatedObject::reset() {
   // clears forces/torques
   // Note: does not update root state TODO:?
   std::vector<float> zeros(btMultiBody_->getNumDofs(), 0);
+
+  // also updates kinematic state
   setPositions(zeros);
-  // btMultiBody_->setPosUpdated(true);
-  {
-    btAlignedObjectArray<btQuaternion> scratch_q;
-    btAlignedObjectArray<btVector3> scratch_m;
-    btMultiBody_->forwardKinematics(scratch_q, scratch_m);
-    btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
-  }
+
   btMultiBody_->clearConstraintForces();
   btMultiBody_->clearVelocities();
   btMultiBody_->clearForcesAndTorques();
-  // sync visual shapes
-  updateNodes(true);
 }
 
 void BulletArticulatedObject::setSleep(bool sleep) {
@@ -719,6 +694,24 @@ void BulletArticulatedObject::clampJointLimits() {
 
   if (poseModified) {
     setPositions(pose);
+  }
+}
+
+void BulletArticulatedObject::updateKinematicState() {
+  btAlignedObjectArray<btQuaternion> scratch_q;
+  btAlignedObjectArray<btVector3> scratch_m;
+  btMultiBody_->forwardKinematics(scratch_q, scratch_m);
+  btMultiBody_->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
+  // Need to update the aabbs manually also for broadphase collision detection
+  for (size_t linkIx = 0; linkIx < btMultiBody_->getNumLinks(); ++linkIx) {
+    bWorld_->updateSingleAabb(btMultiBody_->getLinkCollider(linkIx));
+  }
+  if (bFixedObjectRigidBody_) {
+    bWorld_->updateSingleAabb(bFixedObjectRigidBody_.get());
+  }
+  // update visual shapes
+  if (!isDeferringUpdate_) {
+    updateNodes(true);
   }
 }
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -181,6 +181,10 @@ class BulletArticulatedObject : public ArticulatedObject {
   //! broadphase aabbs for the object. Do this with manual state setters.
   void updateKinematicState();
 
+  // scratch datastrcutures for updateKinematicState
+  btAlignedObjectArray<btQuaternion> scratch_q_;
+  btAlignedObjectArray<btVector3> scratch_m_;
+
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
   std::unique_ptr<btCompoundShape> bFixedObjectShape_;

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -177,6 +177,10 @@ class BulletArticulatedObject : public ArticulatedObject {
           materials,
       gfx::DrawableGroup* drawables) override;
 
+  //! Performs forward kinematics, updates collision object states and
+  //! broadphase aabbs for the object. Do this with manual state setters.
+  void updateKinematicState();
+
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
   std::unique_ptr<btCompoundShape> bFixedObjectShape_;

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -314,6 +314,7 @@ void BulletRigidObject::syncPose() {
   //! For syncing objects
   bObjectRigidBody_->setWorldTransform(
       btTransform(node().transformationMatrix()));
+  bWorld_->updateSingleAabb(bObjectRigidBody_.get());
 }  // syncPose
 
 std::string BulletRigidObject::getCollisionDebugName() {


### PR DESCRIPTION
## Motivation and Context

AO analog of PR #1190. AABBs should be updated for all `btCollisionObjects` when kinematic states are manually set.

## How Has This Been Tested

Locally for AOs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
