### PR TITLE
[bugfix] - set bounds_ for recomputed NavMesh

### DIFF
--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -645,6 +645,8 @@ bool PathFinder::Impl::build(const NavMeshSettings& bs,
     }
   }
 
+  bounds_ = std::make_pair(vec3f(bmin), vec3f(bmax));
+
   // Added as we also need to remove these on navmesh recomputation
   removeZeroAreaPolys();
 


### PR DESCRIPTION
## Motivation and Context

`bounds_ ` was not being set for PathFinder during NavMesh recomputation. If a previous NavMesh was loaded with bounds, querying would produce the old bounds instead of updating.

## How Has This Been Tested

local testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
