### PR TITLE
tol 1e-5 too tight for checking normalized quaternions

### DIFF
--- a/habitat_sim/utils/validators.py
+++ b/habitat_sim/utils/validators.py
@@ -38,7 +38,7 @@ def all_is_finite(instance, attribute, value) -> None:
         )
 
 
-def is_unit_length(instance, attribute, value, tol=1e-5) -> None:
+def is_unit_length(instance, attribute, value, tol=1e-4) -> None:
     if isinstance(value, mn.Quaternion):
         if not value.is_normalized():
             raise ValueError(


### PR DESCRIPTION
Magnum requires normalized quaternions, but I've found that a tol of 1e-5 is too tight. The quaternion returned by agent_state.rotation has a norm that is off by at most 1e-4. In some cases, I get errors from this function because the norm is really something like 0.9995 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
