### PR TITLE
DebugRender class for line rendering

### DIFF
--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -2,6 +2,8 @@ set(
   gfx_SOURCES
   CubeMap.cpp
   CubeMap.h
+  DebugRender.cpp
+  DebugRender.h
   DepthUnprojection.cpp
   DepthUnprojection.h
   Drawable.cpp

--- a/src/esp/gfx/DebugRender.cpp
+++ b/src/esp/gfx/DebugRender.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "DebugRender.h"
+
+#include <Corrade/Containers/GrowableArray.h>
+#include <Magnum/Math/Color.h>
+
+namespace Cr = Corrade;
+namespace Mn = Magnum;
+
+namespace esp {
+namespace gfx {
+
+DebugRender::DebugRender(const std::size_t initialBufferCapacity)
+    : _mesh{Mn::GL::MeshPrimitive::Lines} {
+  _mesh.addVertexBuffer(_buffer, 0, Mn::Shaders::VertexColor3D::Position{},
+                        Mn::Shaders::VertexColor3D::Color3{});
+  arrayReserve(_bufferData, initialBufferCapacity * 4);
+}
+
+void DebugRender::drawLine(const Mn::Vector3& from,
+                           const Mn::Vector3& to,
+                           const Mn::Color3& color) {
+  drawLine(from, to, color, color);
+}
+
+void DebugRender::drawLine(const Mn::Vector3& from,
+                           const Mn::Vector3& to,
+                           const Mn::Color3& fromColor,
+                           const Mn::Color3& toColor) {
+  arrayAppend(_bufferData,
+              {from, Mn::Vector3(fromColor), to, Mn::Vector3(toColor)});
+}
+
+void DebugRender::flushLines() {
+  /* Update buffer with new data */
+  _buffer.setData(_bufferData, Mn::GL::BufferUsage::DynamicDraw);
+
+  /* Update shader and draw */
+  _mesh.setCount(_bufferData.size() / 2);
+  _shader.setTransformationProjectionMatrix(_transformationProjectionMatrix)
+      .draw(_mesh);
+
+  /* Clear buffer to receive new data */
+  arrayResize(_bufferData, 0);
+}
+
+void DebugRender::pushInputTransform(const Magnum::Matrix4& transform) {
+  _inputTransformStack.push_back(transform);
+  updateCachedInputTransform();
+}
+
+void DebugRender::popInputTransform() {
+  CORRADE_INTERNAL_ASSERT(!_inputTransformStack.empty());
+  _inputTransformStack.pop_back();
+  updateCachedInputTransform();
+}
+
+void DebugRender::drawTransformedLine(const Magnum::Vector3& from,
+                                      const Magnum::Vector3& to,
+                                      const Magnum::Color3& color) {
+  drawTransformedLine(from, to, color, color);
+}
+
+void DebugRender::drawTransformedLine(const Magnum::Vector3& from,
+                                      const Magnum::Vector3& to,
+                                      const Magnum::Color3& fromColor,
+                                      const Magnum::Color3& toColor) {
+  Mn::Vector3 fromTransformed = _cachedInputTransform.transformPoint(from);
+  Mn::Vector3 toTransformed = _cachedInputTransform.transformPoint(to);
+  drawLine(fromTransformed, toTransformed, fromColor, toColor);
+}
+
+void DebugRender::updateCachedInputTransform() {
+  _cachedInputTransform = Mn::Matrix4{Magnum::Math::IdentityInit};
+  for (const auto& item : _inputTransformStack) {
+    _cachedInputTransform = _cachedInputTransform * item;
+  }
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/DebugRender.h
+++ b/src/esp/gfx/DebugRender.h
@@ -1,0 +1,87 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_GFX_DEBUGRENDER_H_
+#define ESP_GFX_DEBUGRENDER_H_
+
+/** @file
+ * Utility for on-the-fly rendering of lines (e.g. every frame). This is
+ * intended for debugging. The API prioritizes ease-of-use over maximum runtime
+ * performance.
+ */
+
+#include <Corrade/Containers/Array.h>
+#include <Corrade/Utility/Macros.h>
+#include <Magnum/GL/Buffer.h>
+#include <Magnum/GL/Mesh.h>
+#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Shaders/VertexColor.h>
+
+#include <vector>
+namespace esp {
+namespace gfx {
+
+/**
+@brief todo
+*/
+class DebugRender {
+ public:
+  /**
+   * @brief Constructor
+   * @param initialBufferCapacity     Amount of lines for which to
+   *      reserve memory in the buffer vector.
+   *
+   * Sets up @ref Shaders::VertexColor3D, @ref GL::Buffer and
+   * @ref GL::Mesh for physics debug rendering.
+   */
+  explicit DebugRender(std::size_t initialBufferCapacity = 0);
+
+  /** @brief Copying is not allowed */
+  DebugRender(const DebugRender&) = delete;
+
+  /** @brief Copying is not allowed */
+  DebugRender& operator=(const DebugRender&) = delete;
+
+  /** @brief Set transformation projection matrix used for rendering */
+  DebugRender& setTransformationProjectionMatrix(
+      const Magnum::Matrix4& matrix) {
+    _transformationProjectionMatrix = matrix;
+    return *this;
+  }
+
+  void drawLine(const Magnum::Vector3& from,
+                const Magnum::Vector3& to,
+                const Magnum::Color3& color);
+  void drawLine(const Magnum::Vector3& from,
+                const Magnum::Vector3& to,
+                const Magnum::Color3& fromColor,
+                const Magnum::Color3& toColor);
+  void flushLines();
+
+  void pushInputTransform(const Magnum::Matrix4& transform);
+  void popInputTransform();
+  void drawTransformedLine(const Magnum::Vector3& from,
+                           const Magnum::Vector3& to,
+                           const Magnum::Color3& color);
+  void drawTransformedLine(const Magnum::Vector3& from,
+                           const Magnum::Vector3& to,
+                           const Magnum::Color3& fromColor,
+                           const Magnum::Color3& toColor);
+
+ private:
+  void updateCachedInputTransform();
+
+  std::vector<Magnum::Matrix4> _inputTransformStack;
+  Magnum::Matrix4 _cachedInputTransform{Magnum::Math::IdentityInit};
+  Magnum::Matrix4 _transformationProjectionMatrix{Magnum::Math::IdentityInit};
+  Magnum::Shaders::VertexColor3D _shader;
+  Magnum::GL::Buffer _buffer;
+  Magnum::GL::Mesh _mesh;
+  Magnum::Containers::Array<Magnum::Vector3> _bufferData;
+};
+
+}  // namespace gfx
+}  // namespace esp
+
+#endif


### PR DESCRIPTION
## Motivation and Context

**Updated: I see a group of reviewers were added to this PR. Just a reminder, I have no plans to merge this to master so don't feel obligated to review this.**

Do not merge. I'm using this PR to document this branch. Let's wait and see if this is useful before merging to master.

DebugRender is a utility for "on-the-fly" rendering of lines (e.g. every frame). This is intended for debugging. The API prioritizes ease-of-use over maximum runtime performance. The implementation is mostly borrowed from `src/deps/magnum-integration/src/Magnum/BulletIntegration/DebugDraw.h`.

The example usage in viewer.cpp draws object coordinate frames as RGB axes.

Some possible future directions:
- python bindings
- helpers for line-based primitives like axes, boxes, and arrows
- on-the-fly triangle rendering and triangle-based primitives

![debug_render_object_coord_frames](https://user-images.githubusercontent.com/6557808/116452411-8fc71a00-a812-11eb-8673-3d1aded1e1e6.png)

## How Has This Been Tested

Todo: unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

