### PR TITLE
[Sensor] Use texture instead of render buffer for semantic info rendering

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -299,6 +299,8 @@ struct RenderTarget::Impl {
         "RenderTarget::Impl::readFrameObjectIdGPU(): this render target "
         "was not created with objectId render texture enabled.", );
 
+    // We replaced the render buffer by the render texture in #1203, and
+    // expected NO performance loss. Let us know if it is not the case.
     if (objecIdBufferCugl_ == nullptr)
       checkCudaErrors(cudaGraphicsGLRegisterImage(
           &objecIdBufferCugl_, objectIdTexture_.id(), GL_TEXTURE_2D,

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -226,8 +226,12 @@ struct RenderTarget::Impl {
         flags_ & Flag::ObjectIdTexture,
         "RenderTarget::Impl::readFrameObjectId(): this render target "
         "was not created with objectId render texture enabled.", );
-
+#ifdef MAGNUM_TARGET_WEBGL
+    framebuffer_.mapForRead(ObjectIdTextureColorAttachment)
+        .read(framebuffer_.viewport(), view);
+#else
     objectIdTexture_.image(0, view);
+#endif
   }
 
   Mn::Vector2i framebufferSize() const {

--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -102,14 +102,16 @@ struct RenderTarget::Impl {
       framebuffer_.attachRenderbuffer(
           Mn::GL::Framebuffer::BufferAttachment::Depth, unprojectedDepth_);
     }
-    if (flags_ & Flag::RgbaAttachment) {
-      framebuffer_.mapForDraw(
-          {{Mn::Shaders::Generic3D::ColorOutput, RgbaBufferAttachment}});
-    }
-    if (flags_ & Flag::ObjectIdAttachment) {
-      framebuffer_.mapForDraw({{Mn::Shaders::Generic3D::ObjectIdOutput,
-                                ObjectIdTextureColorAttachment}});
-    }
+
+    framebuffer_.mapForDraw(
+        {{Mn::Shaders::Generic3D::ColorOutput,
+          (flags_ & Flag::RgbaAttachment
+               ? RgbaBufferAttachment
+               : Mn::GL::Framebuffer::DrawAttachment::None)},
+         {Mn::Shaders::Generic3D::ObjectIdOutput,
+          (flags_ & Flag::ObjectIdAttachment
+               ? ObjectIdTextureColorAttachment
+               : Mn::GL::Framebuffer::DrawAttachment::None)}});
 
     CORRADE_INTERNAL_ASSERT(
         framebuffer_.checkStatus(Mn::GL::FramebufferTarget::Draw) ==

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -38,11 +38,11 @@ class RenderTarget {
      */
     RgbaBuffer = 1 << 0,
     /**
-     * create objectId buffer
+     * create objectId texture
      * No need to set it for color sensor, depth sensor etc. as it makes the
      * rendering slower
      */
-    ObjectIdBuffer = 1 << 1,
+    ObjectIdTexture = 1 << 1,
     /**
      * @brief use depth texture, it must be set for the depth sensor.
      * No need to set it for color sensor, objectId sensor etc. as it makes the
@@ -70,7 +70,7 @@ class RenderTarget {
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
                DepthShader* depthShader,
-               Flags flags = {Flag::RgbaBuffer | Flag::ObjectIdBuffer |
+               Flags flags = {Flag::RgbaBuffer | Flag::ObjectIdTexture |
                               Flag::DepthTexture},
                const sensor::VisualSensor* visualSensor = nullptr);
 
@@ -154,6 +154,11 @@ class RenderTarget {
    * @brief get the depth texture
    */
   Magnum::GL::Texture2D& getDepthTexture();
+
+  /**
+   * @brief get the object id texture
+   */
+  Magnum::GL::Texture2D& getObjectIdTexture();
 
   // @brief Delete copy Constructor
   RenderTarget(const RenderTarget&) = delete;

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -32,23 +32,24 @@ class RenderTarget {
  public:
   enum class Flag {
     /**
-     * create rgba buffer
+     * create a color attachment for the rgba render buffer
      * No need to set it for depth sensor, semantic sensor etc. as it makes
      * the rendering slower
      */
-    RgbaBuffer = 1 << 0,
+    RgbaAttachment = 1 << 0,
     /**
-     * create objectId texture
+     * create a color attachment for the objectId texture
      * No need to set it for color sensor, depth sensor etc. as it makes the
      * rendering slower
      */
-    ObjectIdTexture = 1 << 1,
+    ObjectIdAttachment = 1 << 1,
     /**
-     * @brief use depth texture, it must be set for the depth sensor.
+     * @brief create a depth attachment for the depth texture, it MUST be set
+     * for the depth sensor.
      * No need to set it for color sensor, objectId sensor etc. as it makes the
-     * rendering slower
+     * rendering slower (default depth buffer will be used in this case.)
      */
-    DepthTexture = 1 << 2,
+    DepthTextureAttachment = 1 << 2,
   };
 
   typedef Corrade::Containers::EnumSet<Flag> Flags;
@@ -70,8 +71,8 @@ class RenderTarget {
   RenderTarget(const Magnum::Vector2i& size,
                const Magnum::Vector2& depthUnprojection,
                DepthShader* depthShader,
-               Flags flags = {Flag::RgbaBuffer | Flag::ObjectIdTexture |
-                              Flag::DepthTexture},
+               Flags flags = {Flag::RgbaAttachment | Flag::ObjectIdAttachment |
+                              Flag::DepthTextureAttachment},
                const sensor::VisualSensor* visualSensor = nullptr);
 
   /**

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -127,12 +127,7 @@ struct Renderer::Impl {
         tgt.renderReEnter();
         shader->draw(*mesh_);
         tgt.renderExit();
-      } else if (type == sensor::SensorType::Semantic) {
-        Magnum::Resource<Mn::GL::AbstractShaderProgram, TextureVisualizerShader>
-            shader = getShader<TextureVisualizerShader>(
-                esp::gfx::Renderer::Impl::RendererShaderType::
-                    DepthTextureVisualizer);
-      }
+      };
 
       // TODO object id
       Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);
@@ -200,7 +195,7 @@ struct Renderer::Impl {
   enum class RendererShaderType : uint8_t {
     DepthShader = 0,
     DepthTextureVisualizer = 1,
-    ObjectIdTextureVisualizer = 2,
+    // ObjectIdTextureVisualizer = 2,
   };
   template <typename T>
   Mn::Resource<Mn::GL::AbstractShaderProgram, T> getShader(

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -127,7 +127,7 @@ struct Renderer::Impl {
         tgt.renderReEnter();
         shader->draw(*mesh_);
         tgt.renderExit();
-      };
+      }
 
       // TODO object id
       Mn::GL::Renderer::enable(Mn::GL::Renderer::Feature::DepthTest);

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -153,21 +153,21 @@ struct Renderer::Impl {
             "Renderer::Impl::bindRenderTarget(): Tried to setup a color "
             "render buffer while the simulator was initialized with "
             "requiresTextures = false", );
-        renderTargetFlags |= RenderTarget::Flag::RgbaBuffer;
+        renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
         break;
 
       case sensor::SensorType::Depth:
         if (bindingFlags & Flag::VisualizeTexture) {
-          renderTargetFlags |= RenderTarget::Flag::RgbaBuffer;
+          renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
         }
-        renderTargetFlags |= RenderTarget::Flag::DepthTexture;
+        renderTargetFlags |= RenderTarget::Flag::DepthTextureAttachment;
         break;
 
       case sensor::SensorType::Semantic:
         if (bindingFlags & Flag::VisualizeTexture) {
-          renderTargetFlags |= RenderTarget::Flag::RgbaBuffer;
+          renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
         }
-        renderTargetFlags |= RenderTarget::Flag::ObjectIdTexture;
+        renderTargetFlags |= RenderTarget::Flag::ObjectIdAttachment;
         break;
 
       default:

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -127,6 +127,11 @@ struct Renderer::Impl {
         tgt.renderReEnter();
         shader->draw(*mesh_);
         tgt.renderExit();
+      } else if (type == sensor::SensorType::Semantic) {
+        Magnum::Resource<Mn::GL::AbstractShaderProgram, TextureVisualizerShader>
+            shader = getShader<TextureVisualizerShader>(
+                esp::gfx::Renderer::Impl::RendererShaderType::
+                    DepthTextureVisualizer);
       }
 
       // TODO object id
@@ -167,7 +172,7 @@ struct Renderer::Impl {
         if (bindingFlags & Flag::VisualizeTexture) {
           renderTargetFlags |= RenderTarget::Flag::RgbaBuffer;
         }
-        renderTargetFlags |= RenderTarget::Flag::ObjectIdBuffer;
+        renderTargetFlags |= RenderTarget::Flag::ObjectIdTexture;
         break;
 
       default:
@@ -195,7 +200,7 @@ struct Renderer::Impl {
   enum class RendererShaderType : uint8_t {
     DepthShader = 0,
     DepthTextureVisualizer = 1,
-    // ObjectIdTextureVisualizer = 2,
+    ObjectIdTextureVisualizer = 2,
   };
   template <typename T>
   Mn::Resource<Mn::GL::AbstractShaderProgram, T> getShader(


### PR DESCRIPTION
## Motivation and Context
As titled.
The benefit:
The texture is much easier to be visualized.

Should have no performance lose.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
