### PR TITLE
Attributes Managers python bindings more descriptive help text.

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -4,7 +4,6 @@
 
 #include "esp/bindings/bindings.h"
 
-#include <Magnum/Magnum.h>
 #include <Magnum/PythonBindings.h>
 
 #include "esp/core/managedContainers/AbstractManagedObject.h"

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -44,11 +44,13 @@ namespace managers {
  * @tparam The type used to specialize class template for each attributes
  * manager. Will be an attributes instance
  * @param m pybind module reference.
+ * @param attrType type of attributes being managed, for better help docs
  * @param classStrPrefix string prefix for python class name specification.
  */
 
 template <class T, core::ManagedObjectAccess Access>
 void declareBaseAttributesManager(py::module& m,
+                                  const std::string& attrType,
                                   const std::string& classStrPrefix) {
   using MgrClass = AttributesManager<T, Access>;
   using AttribsPtr = std::shared_ptr<T>;
@@ -58,118 +60,162 @@ void declareBaseAttributesManager(py::module& m,
   // documentation.
   std::string pyclass_name = classStrPrefix + std::string("AttributesManager");
   py::class_<MgrClass, std::shared_ptr<MgrClass>>(m, pyclass_name.c_str())
-      .def(
-          "get_template_handle_by_ID", &MgrClass::getObjectHandleByID,
-          R"(Returns string handle for the template corresponding to passed ID.)",
-          "ID"_a)
+      .def("get_template_handle_by_ID", &MgrClass::getObjectHandleByID,
+           ("Returns string handle for the " + attrType +
+            " corresponding to passed ID.")
+               .c_str(),
+           "ID"_a)
       .def(
           "get_template_ID_by_handle",
           py::overload_cast<const std::string&>(&MgrClass::getObjectIDByHandle),
-          R"(Returns integer ID for the template with the passed handle.)",
+          ("Returns integer ID for the " + attrType +
+           " template with the passed handle.")
+              .c_str(),
           "handle"_a)
-      .def(
-          "get_template_handles",
-          static_cast<std::vector<std::string> (MgrClass::*)(const std::string&,
-                                                             bool) const>(
-              &MgrClass::getObjectHandlesBySubstring),
-          R"(Returns a list of template handles that either contain or explicitly do not
-            contain the passed search_str, based on the value of boolean contains.)",
-          "search_str"_a = "", "contains"_a = true)
+      .def("get_template_handles",
+           static_cast<std::vector<std::string> (MgrClass::*)(
+               const std::string&, bool) const>(
+               &MgrClass::getObjectHandlesBySubstring),
+           ("Returns a list of " + attrType +
+            " template handles that either contain or "
+            "explicitly do not contain the passed search_str, based on the "
+            "value of boolean contains.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true)
       .def(
           "load_configs",
           static_cast<std::vector<int> (MgrClass::*)(const std::string&, bool)>(
               &MgrClass::loadAllConfigsFromPath),
-          R"(Build templates for all JSON files with appropriate extension
-            that exist in the provided file or directory path. If save_as_defaults
-            is true, then these templates will be unable to be deleted)",
+          ("Build " + attrType +
+           " templates for all JSON files with appropriate extension "
+           "that exist in the provided file or directory path. If "
+           "save_as_defaults is true, "
+           "then these " +
+           attrType + " templates will be unable to be deleted")
+              .c_str(),
           "path"_a, "save_as_defaults"_a = false)
       .def("create_template",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&, bool)>(
                &MgrClass::createObject),
-           R"(Creates a template based on passed handle, and registers it in
-            the library if register_template is True.)",
+           ("Creates a " + attrType +
+            " template based on passed handle, and registers it "
+            "in the library if register_template is True.")
+               .c_str(),
            "handle"_a, "register_template"_a = true)
       .def("create_new_template",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&, bool)>(
                &MgrClass::createDefaultObject),
-           R"(Creates a template built with default values, and registers it in
-            the library if register_template is True.)",
+           ("Creates a " + attrType +
+            " template built with default values, and registers "
+            "it in the library if register_template is True.")
+               .c_str(),
            "handle"_a, "register_template"_a = false)
       .def("is_valid_filename", &MgrClass::isValidFileName, R"(
              Returns whether the passed handle exists and the user has access.)",
            "handle"_a)
-      .def("get_num_templates", &MgrClass::getNumObjects, R"(
-             Returns the number of existing templates being managed.)")
+      .def("get_num_templates", &MgrClass::getNumObjects,
+           ("Returns the number of existing " + attrType +
+            " templates being managed.")
+               .c_str())
       .def("get_random_template_handle", &MgrClass::getRandomObjectHandle,
-           R"(Returns the handle for a random template chosen from the
-             existing templates being managed.)")
-      .def(
-          "get_undeletable_handles", &MgrClass::getUndeletableObjectHandles,
-          R"(Returns a list of template handles for templates that have been marked
-            undeletable by the system. These templates can still be edited.)")
+           ("Returns the handle for a random " + attrType +
+            " template chosen"
+            " from the existing " +
+            attrType + " templates being managed.")
+               .c_str())
+      .def("get_undeletable_handles", &MgrClass::getUndeletableObjectHandles,
+           ("Returns a list of " + attrType + " template handles for " +
+            attrType +
+            " templates that have been marked undeletable by the system. "
+            "These " +
+            attrType + " templates can still be edited.")
+               .c_str())
       .def(
           "get_user_locked_handles", &MgrClass::getUserLockedObjectHandles,
-          R"(Returns a list of template handles for templates that have been marked
-            locked by the user. These will be undeletable until unlocked by the user.
-            These templates can still be edited.)")
+          ("Returns a list of " + attrType + " template handles for " +
+           attrType +
+           " templates that have been marked locked by the user. These will be "
+           "undeletable until unlocked by the user. These " +
+           attrType + " templates can still be edited.")
+              .c_str())
       .def("get_library_has_handle", &MgrClass::getObjectLibHasHandle,
-           R"(Returns whether the passed handle describes an existing template
-             in the library.)",
+           ("Returns whether the passed handle describes an existing " +
+            attrType + " template in the library.")
+               .c_str(),
            "handle"_a)
-      .def(
-          "set_template_lock", &MgrClass::setLock,
-          R"(This sets the lock state for the template that has the passed name.
-             Lock == True makes the template unable to be deleted.
-             Note : Locked templates can still be edited.)",
-          "handle"_a, "lock"_a)
+      .def("set_template_lock", &MgrClass::setLock,
+           ("This sets the lock state for the " + attrType +
+            " template that has the passed name. Lock == True makes the " +
+            attrType + " template unable to be deleted.  Note : Locked " +
+            attrType + " templates can still be edited.")
+               .c_str(),
+           "handle"_a, "lock"_a)
       .def("set_lock_by_substring", &MgrClass::setLockBySubstring,
-           R"(This sets the lock state for all templates whose handles either
-             contain or explictly do not contain the passed search_str.
-             Returns a list of handles for templates locked by this function
-             call. Lock == True makes the template unable to be deleted.
-             Note : Locked templates can still be edited.)",
+           ("This sets the lock state for all " + attrType +
+            " templates whose handles either contain or explictly do not "
+            "contain the passed search_str. Returns a list of handles for " +
+            attrType +
+            " templates locked by this function call. Lock == True makes the " +
+            attrType + " template unable to be deleted. Note : Locked " +
+            attrType + " templates can still be edited.")
+               .c_str(),
            "lock"_a, "search_str"_a = "", "contains"_a = true)
       .def("set_template_list_lock", &MgrClass::setLockByHandles,
-           R"(This sets the lock state for all templates whose handles
-             are passed in list. Returns a list of handles for templates
-             locked by this function call. Lock == True makes the template unable
-             to be deleted. Note : Locked templates can still be edited.)",
+           ("This sets the lock state for all " + attrType +
+            " templates whose handles are passed "
+            "in list. Returns a list of handles for templates locked by this "
+            "function call. "
+            "Lock == True makes the " +
+            attrType +
+            " template unable to be deleted. Note : "
+            "Locked " +
+            attrType + " templates can still be edited.")
+               .c_str(),
            "handles"_a, "lock"_a)
       .def("remove_all_templates", &MgrClass::removeAllObjects,
-           R"(This removes, and returns, a list of all the templates referenced
-             in the library that have not been marked undeletable by the system
-             or read-only by the user.)")
+           ("This removes, and returns, a list of all the " + attrType +
+            " templates referenced in the library that have not been marked "
+            "undeletable by the system or read-only by the user.")
+               .c_str())
       .def("remove_templates_by_str", &MgrClass::removeObjectsBySubstring,
-           R"(This removes, and returns, a list of all the templates referenced
-             in the library that have not been marked undeletable by the system
-             or read-only by the user and whose handles either contain or explictly
-             do not contain the passed search_str.)",
+           ("This removes, and returns, a list of all the " + attrType +
+            " templates referenced in the library that have not been marked "
+            "undeletable by the system or read-only by the user and whose "
+            "handles either contain or explictly do not contain the passed "
+            "search_str.")
+               .c_str(),
            "search_str"_a = "", "contains"_a = true)
       .def("remove_template_by_ID", &MgrClass::removeObjectByID,
-           R"(This removes, and returns the template referenced by the passed ID
-             from the library.)",
+           ("This removes, and returns the " + attrType +
+            " template referenced by the passed ID from the library.")
+               .c_str(),
            "ID"_a)
-      .def(
-          "remove_template_by_handle", &MgrClass::removeObjectByHandle,
-          R"(This removes, and returns the template referenced by the passed handle
-             from the library.)",
-          "handle"_a)
+      .def("remove_template_by_handle", &MgrClass::removeObjectByHandle,
+           ("This removes, and returns the " + attrType +
+            " template referenced by the passed handle from the library.")
+               .c_str(),
+           "handle"_a)
       .def("register_template", &MgrClass::registerObject,
-           R"(This registers a copy of the passed template in the library, and
-             returns the template's integer ID.)",
+           ("This registers a copy of the passed " + attrType +
+            " template in the library, and returns the template's integer ID.")
+               .c_str(),
            "template"_a, "specified_handle"_a = "",
            "force_registration"_a = false)
       .def("get_template_by_ID",
            static_cast<AttribsPtr (MgrClass::*)(int)>(
                &MgrClass::getObjectOrCopyByID),
-           R"(This returns a copy of the template specified by the passed
-             ID if it exists, and NULL if it does not.)",
+           ("This returns a copy of the " + attrType +
+            " template specified by the passed ID if it exists, and NULL if it "
+            "does not.")
+               .c_str(),
            "ID"_a)
       .def("get_template_by_handle",
            static_cast<AttribsPtr (MgrClass::*)(const std::string&)>(
                &MgrClass::getObjectOrCopyByHandle),
-           R"(This returns a copy of the template specified by the passed
-             handle if it exists, and NULL if it does not.)",
+           ("This returns a copy of the " + attrType +
+            " template specified by the passed handle if it exists, and NULL "
+            "if it does not.")
+               .c_str(),
            "handle"_a);
 }  // declareBaseAttributesManager
 
@@ -192,7 +238,8 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Primitive Asset Attributes Template manager ====
   declareBaseAttributesManager<AbstractPrimitiveAttributes,
-                               core::ManagedObjectAccess::Copy>(m, "BaseAsset");
+                               core::ManagedObjectAccess::Copy>(
+      m, "Primitive Asset", "BaseAsset");
   py::class_<AssetAttributesManager,
              AttributesManager<AbstractPrimitiveAttributes,
                                core::ManagedObjectAccess::Copy>,
@@ -277,7 +324,7 @@ void initAttributesManagersBindings(py::module& m) {
   // ==== Light Layout Attributes Template manager ====
   declareBaseAttributesManager<LightLayoutAttributes,
                                core::ManagedObjectAccess::Copy>(
-      m, "BaseLightLayout");
+      m, "LightLayout", "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       LightLayoutAttributesManager,
@@ -285,8 +332,8 @@ void initAttributesManagersBindings(py::module& m) {
       LightLayoutAttributesManager::ptr>(m, "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
   declareBaseAttributesManager<ObjectAttributes,
-                               core::ManagedObjectAccess::Copy>(m,
-                                                                "BaseObject");
+                               core::ManagedObjectAccess::Copy>(
+      m, "ObjectAttributes", "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       ObjectAttributesManager,
@@ -297,22 +344,22 @@ void initAttributesManagersBindings(py::module& m) {
       .def("load_object_configs",
            &ObjectAttributesManager::loadAllConfigsFromPath,
            R"(DEPRECATED : use "load_configs" instead.
-            Build templates for all files with ".object_config.json" extension
+            Build ObjectAttributes templates for all files with ".object_config.json" extension
             that exist in the provided file or directory path. If save_as_defaults
-            is true, then these templates will be unable to be deleted)",
+            is true, then these ObjectAttributes templates will be unable to be deleted)",
            "path"_a, "save_as_defaults"_a = false)
 
       // manage file-based templates access
       .def(
           "get_num_file_templates",
           &ObjectAttributesManager::getNumFileTemplateObjects,
-          R"(Returns the number of existing file-based templates being managed.)")
+          R"(Returns the number of existing file-based ObjectAttributes templates being managed.)")
       .def(
           "get_file_template_handles",
           static_cast<std::vector<std::string> (ObjectAttributesManager::*)(
               const std::string&, bool) const>(
               &ObjectAttributesManager::getFileTemplateHandlesBySubstring),
-          R"(Returns a list of file-based template handles that either contain or
+          R"(Returns a list of file-based ObjectAttributes template handles that either contain or
           explicitly do not contain the passed search_str, based on the value of
           contains.)",
           "search_str"_a = "", "contains"_a = true)
@@ -320,30 +367,31 @@ void initAttributesManagersBindings(py::module& m) {
           "get_random_file_template_handle",
           &ObjectAttributesManager::getRandomFileTemplateHandle,
           R"(Returns the handle for a random file-based template chosen from the
-             existing templates being managed.)")
+             existing ObjectAttributes templates being managed.)")
 
       // manage synthesized/primitive asset-based templates access
       .def("get_num_synth_templates",
            &ObjectAttributesManager::getNumSynthTemplateObjects, R"(
-             Returns the number of existing synthesized(primitive asset)-based
+             Returns the number of existing synthesized(primitive asset)-based ObjectAttributes
              templates being managed.)")
       .def(
           "get_synth_template_handles",
           static_cast<std::vector<std::string> (ObjectAttributesManager::*)(
               const std::string&, bool) const>(
               &ObjectAttributesManager::getSynthTemplateHandlesBySubstring),
-          R"(Returns a list of synthesized(primitive asset)-based template handles
+          R"(Returns a list of synthesized(primitive asset)-based ObjectAttributes template handles
             that either contain or explicitly do not contain the passed search_str,
             based on the value of contains.)",
           "search_str"_a = "", "contains"_a = true)
       .def("get_random_synth_template_handle",
            &ObjectAttributesManager::getRandomSynthTemplateHandle,
            R"(Returns the handle for a random synthesized(primitive asset)-based
-          template chosen from the existing templates being managed.)");
+          template chosen from the existing ObjectAttributes templates being managed.)");
 
   // ==== Stage Attributes Template manager ====
   declareBaseAttributesManager<StageAttributes,
-                               core::ManagedObjectAccess::Copy>(m, "BaseStage");
+                               core::ManagedObjectAccess::Copy>(
+      m, "StageAttributes", "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       StageAttributesManager,
@@ -353,8 +401,8 @@ void initAttributesManagersBindings(py::module& m) {
   // ==== Physics World/Manager Template manager ====
 
   declareBaseAttributesManager<PhysicsManagerAttributes,
-                               core::ManagedObjectAccess::Copy>(m,
-                                                                "BasePhysics");
+                               core::ManagedObjectAccess::Copy>(
+      m, "PhysicsAttributes", "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<PhysicsAttributesManager,
              AttributesManager<PhysicsManagerAttributes,

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -62,7 +62,7 @@ void declareBaseAttributesManager(py::module& m,
   py::class_<MgrClass, std::shared_ptr<MgrClass>>(m, pyclass_name.c_str())
       .def("get_template_handle_by_ID", &MgrClass::getObjectHandleByID,
            ("Returns string handle for the " + attrType +
-            " corresponding to passed ID.")
+            " template corresponding to passed ID.")
                .c_str(),
            "ID"_a)
       .def(

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -39,8 +39,9 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
 
   AbstractObjectAttributesManager(const std::string& attrType,
                                   const std::string& JSONTypeExt)
-      : AttributesManager<T, Access>::AttributesManager(attrType, JSONTypeExt) {
-  }
+      : AttributesManager<T, Access>::AttributesManager(
+            (attrType + " Template"),
+            JSONTypeExt) {}
   ~AbstractObjectAttributesManager() override = default;
 
   /**


### PR DESCRIPTION
## Motivation and Context
This PR modifies the help text for the attributes managers' various python bindings to include the type of the object template being managed, instead of just referencing an ambiguous "template".

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
