### PR TITLE
[AO] - ContactTest for ArticulatedObject

### DIFF
--- a/data/test_assets/URDF/fridge/fridge.urdf
+++ b/data/test_assets/URDF/fridge/fridge.urdf
@@ -20,55 +20,55 @@
         <mesh filename="body.glb" scale="1.0, 1.0, 1.0"/>
       </geometry>
     </visual>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 -0.94159"/>
       <geometry>
         <box size="0.643 0.691 0.027"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 0.94936"/>
       <geometry>
         <box size="0.643 0.691 0.027"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 -0.585528"/>
       <geometry>
         <box size="0.643 0.691 0.027"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 -0.226826"/>
       <geometry>
         <box size="0.643 0.691 0.027"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 -0.033778"/>
       <geometry>
         <box size="0.643 0.691 0.027"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.002765 0.255839"/>
       <geometry>
         <box size="0.643 0.691 0.042"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 -0.337538 0.005784"/>
       <geometry>
         <box size="0.643 0.03 1.89126"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="0 0.329773 0.005784"/>
       <geometry>
         <box size="0.643 0.03 1.89126"/>
       </geometry>
     </collision>
-    <collision>
+    <collision group="256">
       <origin rpy="0 0 0" xyz="-0.316502 -0.002765 0"/>
       <geometry>
         <box size="0.029014 0.690834 1.91906"/>
@@ -96,7 +96,7 @@
         <mesh filename="top_door.glb" scale="1.0, 1.0, 1.0"/>
       </geometry>
     </visual>
-    <collision>
+    <collision group="2">
       <origin rpy="0 0 0" xyz="0 -0.33 -0.02"/>
       <geometry>
         <box size="0.097 0.712 1.103"/>
@@ -124,7 +124,7 @@
         <mesh filename="bottom_door.glb" scale="1.0, 1.0, 1.0"/>
       </geometry>
     </visual>
-    <collision>
+    <collision group="2">
       <origin rpy="0 0 0" xyz="0.01, -0.33, 0.01"/>
       <geometry>
         <box size="0.08 0.686 0.788"/>

--- a/examples/tutorials/URDF_robotics_tutorial.py
+++ b/examples/tutorials/URDF_robotics_tutorial.py
@@ -1,3 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 # [setup]
 
 import os

--- a/examples/tutorials/URDF_robotics_tutorial.py
+++ b/examples/tutorials/URDF_robotics_tutorial.py
@@ -645,7 +645,7 @@ def main(make_video=True, show_video=True):
                 + " friction coefficient = "
                 + str(sim.get_articulated_link_friction(robot_id, link_id))
             )
-            # Note: set this with 'sim.get_articulated_link_friction(robot_id, link_id, friction)'
+            # Note: set this with 'sim.set_articulated_link_friction(robot_id, link_id, friction)'
             observations += simulate(sim, dt=0.5, get_frames=make_video)
         sim.remove_object(cube_id)
 

--- a/examples/tutorials/physics_benchmarking.py
+++ b/examples/tutorials/physics_benchmarking.py
@@ -90,7 +90,7 @@ def box_drop_test(
     useVHACD=False,
     VHACDParams=def_params,
 ):  # take in parameters here
-    """Drops a specified number of objects into a box and returns metrics including the time to simulate each frame, render each frame, and the number of collisions each frame. """
+    """Drops a specified number of objects into a box and returns metrics including the time to simulate each frame, render each frame, and the number of collisions each frame."""
 
     data = {
         "observations": [],

--- a/examples/tutorials/physics_benchmarking.py
+++ b/examples/tutorials/physics_benchmarking.py
@@ -1,4 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 # [setup]
+
 import os
 import time
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -282,7 +282,7 @@ void initSimBindings(py::module& m) {
       .def(
           "contact_test", &Simulator::contactTest, "object_id"_a,
           "static_as_stage"_a = true, "scene_id"_a = 0,
-          R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
+          R"(Run collision detection and return a binary indicator of contact between the specified object and any other collision object. Physics must be enabled. Setting 'static_as_stage' False will override collision filters such that contacts with other STATICs (such as the stage and articulated fixed bases) will be reported.)")
       .def(
           "perform_discrete_collision_detection",
           &Simulator::performDiscreteCollisionDetection,
@@ -465,20 +465,19 @@ void initSimBindings(py::module& m) {
               &Simulator::createArticulatedFixedConstraint),
           "object_id_a"_a, "link_id"_a, "object_id_b"_a, "max_impulse"_a = 2.0,
           R"(add fixed constraint between articulated object a link and an object; the pivot is at the object's origin; the current relative orientation of the link and the object will be fixed)")
-      .def(
-          "create_articulated_fixed_constraint",
-          py::overload_cast<int, int, int, const Magnum::Vector3&,
-                            const Magnum::Vector3&, float>(
-              &Simulator::createArticulatedFixedConstraint),
-          "object_id_a"_a, "link_id"_a, "object_id_b"_a, "pivot_a"_a,
-          "pivot_b"_a, "max_impulse"_a = 2.0,
-          R"(add fixed constraint between articulated object link and rigid object; pivots are specified in the link/object's local space; the current relative orientation of the link and the object will be fixed)")
+      .def("create_articulated_fixed_constraint",
+           py::overload_cast<int, int, int, const Magnum::Vector3&,
+                             const Magnum::Vector3&, float>(
+               &Simulator::createArticulatedFixedConstraint),
+           "object_id_a"_a, "link_id"_a, "object_id_b"_a, "pivot_a"_a,
+           "pivot_b"_a, "max_impulse"_a = 2.0, R"(add fixed constraint between articulated object link and rigid object; pivots are specified in the link/object's local space; the current relative orientation of the link and the object will be fixed)")
       .def("remove_constraint", &Simulator::removeConstraint, "constraint_id"_a,
            R"(Remove a point-2-point or fixed constraint by id.)")
       /* --- Collision information queries --- */
-      .def("get_physics_num_active_contact_points",
-           &Simulator::getPhysicsNumActiveContactPoints,
-           R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
+      .def(
+          "get_physics_num_active_contact_points",
+          &Simulator::getPhysicsNumActiveContactPoints,
+          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
       .def(
           "get_physics_num_active_overlapping_pairs",
           &Simulator::getPhysicsNumActiveOverlappingPairs,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -281,7 +281,7 @@ void initSimBindings(py::module& m) {
            R"(Set whether or not the static stage is collidable.)")
       .def(
           "contact_test", &Simulator::contactTest, "object_id"_a,
-          "scene_id"_a = 0,
+          "static_as_stage"_a = true, "scene_id"_a = 0,
           R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
       .def(
           "perform_discrete_collision_detection",

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1279,10 +1279,14 @@ class PhysicsManager {
    * BulletPhysicsManager.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  virtual bool contactTest(CORRADE_UNUSED const int physObjectID) {
+  virtual bool contactTest(CORRADE_UNUSED const int physObjectID,
+                           CORRADE_UNUSED bool staticAsStage = true) {
     return false;
   };
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -127,10 +127,13 @@ class BulletArticulatedObject : public ArticulatedObject {
    * collision world.
    *
    * See @ref SimulationContactResultCallback
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for articulated fixed base such that contact with other STATICs such as the
+   * stage are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest();
+  bool contactTest(bool staticAsStage = true);
 
   //! Bullet supports vel/pos control joint motors for revolute and prismatic
   //! joints (1 Dof) This is the suggested way to implement friction/damping at

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -122,6 +122,16 @@ class BulletArticulatedObject : public ArticulatedObject {
 
   virtual void setMotionType(MotionType mt) override;
 
+  /**
+   * @brief Return result of a discrete contact test between the object and
+   * collision world.
+   *
+   * See @ref SimulationContactResultCallback
+   * @return Whether or not the object is in contact with any other collision
+   * enabled objects.
+   */
+  bool contactTest();
+
   //! Bullet supports vel/pos control joint motors for revolute and prismatic
   //! joints (1 Dof) This is the suggested way to implement friction/damping at
   //! dof level

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.h"
+#include "BulletDynamics/Featherstone/btMultiBodyLinkCollider.h"
 #include "esp/assets/Asset.h"
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/MeshMetaData.h"
@@ -54,6 +55,21 @@ struct SimulationContactResultCallback
       CORRADE_UNUSED const btCollisionObjectWrapper* colObj1Wrap,
       CORRADE_UNUSED int partId1,
       CORRADE_UNUSED int index1) override {
+    const btMultiBodyLinkCollider* mblc1 =
+        btMultiBodyLinkCollider::upcast(colObj0Wrap->getCollisionObject());
+    const btMultiBodyLinkCollider* mblc2 =
+        btMultiBodyLinkCollider::upcast(colObj1Wrap->getCollisionObject());
+    if (mblc1 && mblc2) {
+      // both multibody links
+      if (mblc1->m_multiBody == mblc2->m_multiBody) {
+        // same parent multibody
+        if (!mblc1->m_multiBody->hasSelfCollision()) {
+          // skip if self collisions not enabled
+          return 0;
+        }
+      }
+    }
+
     bCollision = true;
     return 0;  // not used
   }

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -55,21 +55,6 @@ struct SimulationContactResultCallback
       CORRADE_UNUSED const btCollisionObjectWrapper* colObj1Wrap,
       CORRADE_UNUSED int partId1,
       CORRADE_UNUSED int index1) override {
-    const btMultiBodyLinkCollider* mblc1 =
-        btMultiBodyLinkCollider::upcast(colObj0Wrap->getCollisionObject());
-    const btMultiBodyLinkCollider* mblc2 =
-        btMultiBodyLinkCollider::upcast(colObj1Wrap->getCollisionObject());
-    if (mblc1 && mblc2) {
-      // both multibody links
-      if (mblc1->m_multiBody == mblc2->m_multiBody) {
-        // same parent multibody
-        if (!mblc1->m_multiBody->hasSelfCollision()) {
-          // skip if self collisions not enabled
-          return 0;
-        }
-      }
-    }
-
     bCollision = true;
     return 0;  // not used
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -342,17 +342,18 @@ void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
   bWorld_->debugDrawWorld();
 }
 
-bool BulletPhysicsManager::contactTest(const int physObjectID) {
+bool BulletPhysicsManager::contactTest(const int physObjectID,
+                                       bool staticAsStage) {
   CHECK((existingObjects_.count(physObjectID) > 0) ||
         (existingArticulatedObjects_.count(physObjectID) > 0));
   if (existingObjects_.count(physObjectID) > 0) {
     return static_cast<BulletRigidObject*>(
                existingObjects_.at(physObjectID).get())
-        ->contactTest();
+        ->contactTest(staticAsStage);
   } else {
     return static_cast<BulletArticulatedObject*>(
                existingArticulatedObjects_.at(physObjectID).get())
-        ->contactTest();
+        ->contactTest(staticAsStage);
   }
   return false;
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -343,11 +343,18 @@ void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
 }
 
 bool BulletPhysicsManager::contactTest(const int physObjectID) {
-  assertIDValidity(physObjectID);
-  bWorld_->getCollisionWorld()->performDiscreteCollisionDetection();
-  return static_cast<BulletRigidObject*>(
-             existingObjects_.at(physObjectID).get())
-      ->contactTest();
+  CHECK((existingObjects_.count(physObjectID) > 0) ||
+        (existingArticulatedObjects_.count(physObjectID) > 0));
+  if (existingObjects_.count(physObjectID) > 0) {
+    return static_cast<BulletRigidObject*>(
+               existingObjects_.at(physObjectID).get())
+        ->contactTest();
+  } else {
+    return static_cast<BulletArticulatedObject*>(
+               existingArticulatedObjects_.at(physObjectID).get())
+        ->contactTest();
+  }
+  return false;
 }
 
 void BulletPhysicsManager::overrideCollisionGroup(const int physObjectID,

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -196,10 +196,13 @@ class BulletPhysicsManager : public PhysicsManager {
    *
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(const int physObjectID) override;
+  bool contactTest(const int physObjectID, bool staticAsStage = true) override;
 
   // TODO: document
   void overrideCollisionGroup(const int physObjectID,

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -478,8 +478,19 @@ Magnum::Vector3 BulletRigidObject::getCOM() const {
   return com;
 }  // getCOM
 
-bool BulletRigidObject::contactTest() {
+bool BulletRigidObject::contactTest(bool staticAsStage) {
   SimulationContactResultCallback src;
+  src.m_collisionFilterGroup =
+      bObjectRigidBody_->getBroadphaseHandle()->m_collisionFilterGroup;
+  src.m_collisionFilterMask =
+      bObjectRigidBody_->getBroadphaseHandle()->m_collisionFilterMask;
+  if (!staticAsStage && objectMotionType_ == MotionType::STATIC) {
+    // override collision filter for STATIC object to include other STATICs such
+    // as the stage
+    src.m_collisionFilterGroup = int(CollisionGroup::FreeObject);
+    src.m_collisionFilterMask =
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::FreeObject);
+  }
   bWorld_->getCollisionWorld()->contactTest(bObjectRigidBody_.get(), src);
   return src.bCollision;
 }  // contactTest

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -416,10 +416,13 @@ class BulletRigidObject : public BulletBase,
    * collision world.
    *
    * See @ref SimulationContactResultCallback
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects such that contact with other STATICs such as the stage
+   * are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest();
+  bool contactTest(bool staticAsStage = true);
 
   /**
    * @brief Query the Aabb from bullet physics for the root compound shape of

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -842,9 +842,11 @@ Magnum::Vector3 Simulator::getAngularVelocity(const int objectID,
   return Magnum::Vector3();
 }
 
-bool Simulator::contactTest(const int objectID, const int sceneID) {
+bool Simulator::contactTest(const int objectID,
+                            bool staticAsStage,
+                            const int sceneID) {
   if (sceneHasPhysics(sceneID)) {
-    return physicsManager_->contactTest(objectID);
+    return physicsManager_->contactTest(objectID, staticAsStage);
   }
   return false;
 }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -959,12 +959,15 @@ class Simulator {
    * collision world.
    * @param objectID The object ID and key identifying the object in @ref
    * esp::physics::PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @param sceneID !! Not used currently !! Specifies which physical scene of
    * the object.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(int objectID, int sceneID = 0);
+  bool contactTest(int objectID, bool staticAsStage = true, int sceneID = 0);
 
   /**
    * @brief Perform discrete collision detection for the scene.

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -276,6 +276,22 @@ TEST_F(PhysicsManagerTest, DiscreteContactTest) {
     ASSERT_TRUE(physicsManager_->contactTest(objectId0));
     ASSERT_FALSE(physicsManager_->contactTest(objectId1));
 
+    // set box 0 to KINEMATIC
+    physicsManager_->setObjectMotionType(objectId0,
+                                         esp::physics::MotionType::KINEMATIC);
+    ASSERT_TRUE(physicsManager_->contactTest(objectId0));
+    ASSERT_FALSE(physicsManager_->contactTest(objectId1));
+
+    // set box 0 to STATIC
+    physicsManager_->setObjectMotionType(objectId0,
+                                         esp::physics::MotionType::STATIC);
+    ASSERT_FALSE(physicsManager_->contactTest(objectId0));
+    ASSERT_TRUE(physicsManager_->contactTest(objectId0, false));
+    ASSERT_FALSE(physicsManager_->contactTest(objectId1));
+    // reset MotionType
+    physicsManager_->setObjectMotionType(objectId0,
+                                         esp::physics::MotionType::DYNAMIC);
+
     // set stage to non-collidable
     ASSERT_TRUE(physicsManager_->getStageIsCollidable());
     physicsManager_->setStageIsCollidable(false);


### PR DESCRIPTION
## Motivation and Context

Extends `contactTest` function to support `ArticulatedObjects` by id. Individually checks each link and base collision shape against the world and screens self collisions if necessary returning a boolean indicator of whether or not any multibody collision shape is in contact with any other collision object in the scene.

Also modified the `contactTest` setup to use configured collision group and mask filters by default. A side-effect of this change is that `STATIC` objects (including articulated fixed base) will not report contact with other `STATICs` (such as the stage). An option override is provided by setting `static_as_stage` to false which then treats the queried `STATIC` as a dynamic object.

## How Has This Been Tested

Local testing of AO. Modified some tests for rigids.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
