### PR TITLE
[AO] ArticulatedLink|Object SceneNode query

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2092,12 +2092,12 @@ std::string ResourceManager::setupMaterialModifiedAsset(
 
 bool ResourceManager::attachAsset(const std::string& filename,
                                   scene::SceneNode& node,
+                                  std::vector<scene::SceneNode*>& visNodeCache,
                                   DrawableGroup* drawables) {
   if (drawables != nullptr && resourceDict_.count(filename)) {
     MeshMetaData& meshMetaData = resourceDict_[filename].meshMetaData;
 
     std::vector<StaticDrawableInfo> staticDrawableInfo;
-    std::vector<scene::SceneNode*> visNodeCache;
     addComponent(meshMetaData, node, DEFAULT_LIGHTING_KEY, drawables,
                  meshMetaData.root, visNodeCache, false, staticDrawableInfo);
     // compute the full BB hierarchy for the new tree.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -573,6 +573,7 @@ class ResourceManager {
   //! Attach a visual asset to a SceneNode as part of a DrawableGroup
   bool attachAsset(const std::string& filename,
                    scene::SceneNode& node,
+                   std::vector<scene::SceneNode*>& visNodeCache,
                    DrawableGroup* drawables);
   /**
    * @brief Set a replay recorder so that ResourceManager can notify it about

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -40,7 +40,8 @@ void initSceneBindings(py::module& m) {
       .value("EMPTY", SceneNodeType::EMPTY)
       .value("SENSOR", SceneNodeType::SENSOR)
       .value("AGENT", SceneNodeType::AGENT)
-      .value("CAMERA", SceneNodeType::CAMERA);
+      .value("CAMERA", SceneNodeType::CAMERA)
+      .value("OBJECT", SceneNodeType::OBJECT);
 
   // ==== SceneNode ====
   py::class_<SceneNode, Magnum::SceneGraph::PyObject<SceneNode>, MagnumObject,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -349,6 +349,12 @@ void initSimBindings(py::module& m) {
            "object_id"_a)
       .def("get_existing_articulated_object_ids",
            &Simulator::getExistingArticulatedObjectIDs, "scene_id"_a = 0)
+      .def("get_articulated_link_scene_node",
+           &Simulator::getArticulatedLinkSceneNode, "object_id"_a,
+           "link_id"_a = -1)
+      .def("get_articulated_link_visual_scene_nodes",
+           &Simulator::getArticulatedLinkVisualSceneNodes, "object_id"_a,
+           "link_id"_a = -1)
       .def("set_articulated_object_root_state",
            &Simulator::setArticulatedObjectRootState, "object_id"_a, "state"_a)
       .def("get_articulated_object_root_state",

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -255,6 +255,55 @@ class ArticulatedObject : public Magnum::SceneGraph::AbstractFeature3D {
         Magnum::SceneGraph::AbstractFeature3D::object());
   }
 
+  /**
+   * @brief Get a const reference to an ArticulatedLink SceneNode for
+   * info query purposes.
+   * @param linkId The ArticulatedLink ID or -1 for the baseLink.
+   * @return Const reference to the SceneNode.
+   */
+  virtual const scene::SceneNode& getLinkSceneNode(int linkId = -1) const {
+    if (linkId == ID_UNDEFINED) {
+      // base link
+      return baseLink_->node();
+    }
+    CHECK(links_.count(linkId));
+    return links_.at(linkId)->node();
+  }
+
+  /**
+   * @brief Get pointers to a link's visual SceneNodes.
+   * @param linkId The ArticulatedLink ID or -1 for the baseLink.
+   * @return vector of pointers to the link's visual scene nodes.
+   */
+  std::vector<scene::SceneNode*> getLinkVisualSceneNodes(
+      int linkId = -1) const {
+    if (linkId == ID_UNDEFINED) {
+      // base link
+      return baseLink_->visualNodes_;
+    }
+    CHECK(links_.count(linkId));
+    return links_.at(linkId)->visualNodes_;
+  }
+
+  /**
+   * @brief Get pointers to all visual SceneNodes associated to this
+   * ArticulatedObject.
+   * @return vector of pointers to base and all links' visual scene nodes.
+   */
+  std::vector<scene::SceneNode*> getVisualSceneNodes() const {
+    std::vector<scene::SceneNode*> allVisualNodes;
+    // base link
+    allVisualNodes.insert(allVisualNodes.end(), baseLink_->visualNodes_.begin(),
+                          baseLink_->visualNodes_.end());
+    // other links
+    for (auto& link : links_) {
+      allVisualNodes.insert(allVisualNodes.end(),
+                            link.second->visualNodes_.begin(),
+                            link.second->visualNodes_.end());
+    }
+    return allVisualNodes;
+  }
+
   virtual bool initializeFromURDF(
       CORRADE_UNUSED URDFImporter& urdfImporter,
       CORRADE_UNUSED const Magnum::Matrix4& worldTransform,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -640,14 +640,39 @@ void PhysicsManager::setVoxelizationDraw(const std::string& gridName,
 
 const scene::SceneNode& PhysicsManager::getObjectSceneNode(
     int physObjectID) const {
-  assertIDValidity(physObjectID);
-  return existingObjects_.at(physObjectID)->getSceneNode();
+  CHECK(existingObjects_.count(physObjectID) > 0 ||
+        existingArticulatedObjects_.count(physObjectID) > 0);
+  if (existingObjects_.count(physObjectID) > 0) {
+    return existingObjects_.at(physObjectID)->getSceneNode();
+  } else {
+    return existingArticulatedObjects_.at(physObjectID)->node();
+  }
 }
 
 scene::SceneNode& PhysicsManager::getObjectSceneNode(int physObjectID) {
-  assertIDValidity(physObjectID);
+  CHECK(existingObjects_.count(physObjectID) > 0 ||
+        existingArticulatedObjects_.count(physObjectID) > 0);
+  if (existingObjects_.count(physObjectID) > 0) {
+    return const_cast<scene::SceneNode&>(
+        existingObjects_.at(physObjectID)->getSceneNode());
+  } else {
+    return const_cast<scene::SceneNode&>(
+        existingArticulatedObjects_.at(physObjectID)->node());
+  }
+}
+
+const scene::SceneNode& PhysicsManager::getArticulatedLinkSceneNode(
+    int physObjectID,
+    int linkId) const {
+  CHECK(existingArticulatedObjects_.count(physObjectID) > 0);
+  return existingArticulatedObjects_.at(physObjectID)->getLinkSceneNode(linkId);
+}
+
+scene::SceneNode& PhysicsManager::getArticulatedLinkSceneNode(int physObjectID,
+                                                              int linkId) {
+  CHECK(existingArticulatedObjects_.count(physObjectID) > 0);
   return const_cast<scene::SceneNode&>(
-      existingObjects_.at(physObjectID)->getSceneNode());
+      existingArticulatedObjects_.at(physObjectID)->getLinkSceneNode(linkId));
 }
 
 const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
@@ -658,8 +683,21 @@ const scene::SceneNode& PhysicsManager::getObjectVisualSceneNode(
 
 std::vector<scene::SceneNode*> PhysicsManager::getObjectVisualSceneNodes(
     const int physObjectID) const {
-  assertIDValidity(physObjectID);
-  return existingObjects_.at(physObjectID)->visualNodes_;
+  CHECK(existingObjects_.count(physObjectID) > 0 ||
+        existingArticulatedObjects_.count(physObjectID) > 0);
+  if (existingObjects_.count(physObjectID) > 0) {
+    return existingObjects_.at(physObjectID)->visualNodes_;
+  } else {
+    return existingArticulatedObjects_.at(physObjectID)->getVisualSceneNodes();
+  }
+}
+
+std::vector<scene::SceneNode*>
+PhysicsManager::getArticulatedLinkVisualSceneNodes(const int objectID,
+                                                   const int linkID) const {
+  CHECK(existingArticulatedObjects_.count(objectID) > 0);
+  return existingArticulatedObjects_.at(objectID)->getLinkVisualSceneNodes(
+      linkID);
 }
 
 void PhysicsManager::setSemanticId(const int physObjectID,

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1225,7 +1225,8 @@ class PhysicsManager {
    * @brief Get a const reference to the specified object's SceneNode for info
    * query purposes.
    * @param physObjectID The object ID and key identifying the object in @ref
-   * PhysicsManager::existingObjects_.
+   * PhysicsManager::existingObjects_ or @ref
+   * PhysicsManager::existingArticulatedObjects_.
    * @return Const reference to the object scene node.
    */
   const scene::SceneNode& getObjectSceneNode(int physObjectID) const;
@@ -1234,14 +1235,19 @@ class PhysicsManager {
   scene::SceneNode& getObjectSceneNode(int physObjectID);
 
   /**
-   * @brief Set the desired light setup by name for the passed object
-   * @param objectID The id of the object to set
-   * @param lightSetupKey The string name of the desired lighting setup to use.
+   * @brief Get a const reference to the specified ArticulatedLink SceneNode for
+   * info query purposes. Default (-1) returns baseLink SceneNode.
+   * @param physObjectID The object ID and key identifying the object in @ref
+   * PhysicsManager::existingArticulatedObjects_.
+   * @param linkId The ArticulatedLink ID or -1 for the base.
+   * @return Const reference to the object scene node.
    */
-  void setObjectLightSetup(const int objectID,
-                           const std::string& lightSetupKey) {
-    existingObjects_.at(objectID)->setLightSetup(lightSetupKey);
-  }
+  const scene::SceneNode& getArticulatedLinkSceneNode(int physObjectID,
+                                                      int linkId = -1) const;
+
+  /** @overload */
+  scene::SceneNode& getArticulatedLinkSceneNode(int physObjectID,
+                                                int linkId = -1);
 
   /**
    * @brief Get a const reference to the specified object's visual SceneNode for
@@ -1261,6 +1267,27 @@ class PhysicsManager {
    */
   std::vector<scene::SceneNode*> getObjectVisualSceneNodes(
       const int objectID) const;
+
+  /**
+   * @brief Get pointers to an ArticulatedLink's visual SceneNodes.
+   *
+   * @param physObjectID The object ID and key identifying the object in @ref
+   * PhysicsManager::existingArticulatedObjects_.
+   * @return pointers to an ArticulatedLink's visual scene nodes.
+   */
+  std::vector<scene::SceneNode*> getArticulatedLinkVisualSceneNodes(
+      const int objectID,
+      const int linkID = -1) const;
+
+  /**
+   * @brief Set the desired light setup by name for the passed object
+   * @param objectID The id of the object to set
+   * @param lightSetupKey The string name of the desired lighting setup to use.
+   */
+  void setObjectLightSetup(const int objectID,
+                           const std::string& lightSetupKey) {
+    existingObjects_.at(objectID)->setLightSetup(lightSetupKey);
+  }
 
   /** @brief Render any debugging visualizations provided by the underlying
    * physics simulator implementation. By default does nothing. See @ref

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1454,6 +1454,17 @@ void Simulator::removeArticulatedObject(int objectId) {
   }
 }
 
+scene::SceneNode* Simulator::getArticulatedLinkSceneNode(int objectID,
+                                                         int linkId) {
+  return &physicsManager_->getArticulatedLinkSceneNode(objectID, linkId);
+}
+
+std::vector<scene::SceneNode*> Simulator::getArticulatedLinkVisualSceneNodes(
+    int objectID,
+    int linkId) {
+  return physicsManager_->getArticulatedLinkVisualSceneNodes(objectID, linkId);
+}
+
 std::vector<int> Simulator::getExistingArticulatedObjectIDs(
     CORRADE_UNUSED const int sceneID) {
   if (sceneHasPhysics(0)) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -636,6 +636,24 @@ class Simulator {
    */
   std::vector<int> getExistingArticulatedObjectIDs(int sceneID = 0);
 
+  /**
+   * @brief Get a reference to the specified ArticulatedLink SceneNode for info
+   * query purposes. Default (-1) returns baseLink SceneNode.
+   * @param physObjectID The object ID and key identifying the object.
+   * @param linkId The ArticulatedLink ID or -1 for the base.
+   * @return the object scene node or nullptr if failed.
+   */
+  scene::SceneNode* getArticulatedLinkSceneNode(int objectID, int linkId = -1);
+
+  /**
+   * @brief Get references to a link's visual scene nodes or empty if
+   * failed.
+   * @param linkId The ArticulatedLink ID or -1 for the base.
+   */
+  std::vector<scene::SceneNode*> getArticulatedLinkVisualSceneNodes(
+      int objectID,
+      int linkId = -1);
+
   void setArticulatedObjectRootState(int objectId,
                                      const Magnum::Matrix4& state);
 


### PR DESCRIPTION
## Motivation and Context

Add query API for ArticulatedObject and ArticulatedLink SceneNode and visual SceneNodes (created to hold render asset Drawables).

New functions:
- `get_articulated_link_scene_node` and `get_articulated_link_visual_scene_nodes` which take a link id (or -1 for base link) and return a node or vector of nodes.

Modified functions:
- `get_object_scene_node` and `get_object_visual_scene_nodes` which now accept ArticulatedObject id and return root AO SceneNode and all AO visual SceneNodes respectively.

## How Has This Been Tested

Local testing. 
**Example: query visual nodes and set semantic_id for semantic mask render:**

https://user-images.githubusercontent.com/1445143/116758981-196b1900-a9c6-11eb-92f9-4cf30891f1a7.mov



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)