### PR TITLE
Support specifying position model/frame of reference for lighting instances

### DIFF
--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -230,3 +230,6 @@ The Light Setup attributes JSON should contain a single cell named "lights" that
 "type"
 	- string
 	- The type of the light.  "point" and "directional" are currently supported.
+"position_model"
+  - string
+  - They origin to use to place the light. "global", meaning stage's origin, and "camera" meaning place relative to a (potentially moving) camera, are currently supported.

--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -232,4 +232,4 @@ The Light Setup attributes JSON should contain a single cell named "lights" that
 	- The type of the light.  "point" and "directional" are currently supported.
 "position_model"
   - string
-  - They origin to use to place the light. "global", meaning stage's origin, and "camera" meaning place relative to a (potentially moving) camera, are currently supported.
+  - They frame to use to place the light. "global", meaning stage's origin, and "camera", meaning place relative to a (potentially moving) camera, are currently supported.

--- a/examples/tutorials/lighting_tutorial.py
+++ b/examples/tutorials/lighting_tutorial.py
@@ -99,7 +99,7 @@ def main(show_imgs=True, save_imgs=False):
 
     # create and register new light setup:
     my_scene_lighting_setup = [
-        LightInfo(vector=[0.0, 2.0, 0.6, 0.0], model=LightPositionModel.GLOBAL)
+        LightInfo(vector=[0.0, 2.0, 0.6, 0.0], model=LightPositionModel.Global)
     ]
     sim.set_light_setup(my_scene_lighting_setup, "my_scene_lighting")
 
@@ -142,7 +142,7 @@ def main(show_imgs=True, save_imgs=False):
 
     # create a custom light setup
     my_default_lighting = [
-        LightInfo(vector=[2.0, 2.0, 1.0, 0.0], model=LightPositionModel.CAMERA)
+        LightInfo(vector=[2.0, 2.0, 1.0, 0.0], model=LightPositionModel.Camera)
     ]
     # overwrite the default DEFAULT_LIGHTING_KEY light setup
     sim.set_light_setup(my_default_lighting)
@@ -165,7 +165,7 @@ def main(show_imgs=True, save_imgs=False):
         LightInfo(
             vector=[2.0, 1.5, 5.0, 1.0],
             color=[0.0, 100.0, 100.0],
-            model=LightPositionModel.GLOBAL,
+            model=LightPositionModel.Global,
         )
     ]
     sim.set_light_setup(light_setup_2, "my_custom_lighting")
@@ -196,7 +196,7 @@ def main(show_imgs=True, save_imgs=False):
         LightInfo(
             vector=[0.0, 0.0, 1.0, 0.0],
             color=[1.6, 1.6, 1.4],
-            model=LightPositionModel.CAMERA,
+            model=LightPositionModel.Camera,
         )
     ]
 

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -161,9 +161,9 @@ void initGfxBindings(py::module& m) {
   py::enum_<LightPositionModel>(
       m, "LightPositionModel",
       R"(Defines the coordinate frame of a light source.)")
-      .value("CAMERA", LightPositionModel::CAMERA)
-      .value("GLOBAL", LightPositionModel::GLOBAL)
-      .value("OBJECT", LightPositionModel::OBJECT);
+      .value("CAMERA", LightPositionModel::Camera)
+      .value("GLOBAL", LightPositionModel::Global)
+      .value("OBJECT", LightPositionModel::Object);
 
   py::enum_<LightType>(
       m, "LightType", R"(Defines the type of light described by the LightInfo)")
@@ -178,7 +178,7 @@ void initGfxBindings(py::module& m) {
       .def(py::init())
       .def(py::init<Magnum::Vector4, Magnum::Color3, LightPositionModel>(),
            "vector"_a, "color"_a = Magnum::Color3{1},
-           "model"_a = LightPositionModel::GLOBAL)
+           "model"_a = LightPositionModel::Global)
       .def_readwrite("vector", &LightInfo::vector)
       .def_readwrite("color", &LightInfo::color)
       .def_readwrite("model", &LightInfo::model)

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -161,9 +161,9 @@ void initGfxBindings(py::module& m) {
   py::enum_<LightPositionModel>(
       m, "LightPositionModel",
       R"(Defines the coordinate frame of a light source.)")
-      .value("CAMERA", LightPositionModel::Camera)
-      .value("GLOBAL", LightPositionModel::Global)
-      .value("OBJECT", LightPositionModel::Object);
+      .value("Camera", LightPositionModel::Camera)
+      .value("Global", LightPositionModel::Global)
+      .value("Object", LightPositionModel::Object);
 
   py::enum_<LightType>(
       m, "LightType", R"(Defines the type of light described by the LightInfo)")

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -28,11 +28,11 @@ Magnum::Vector4 getLightPositionRelativeToCamera(
                         "w == 1 for a point light");
 
   switch (light.model) {
-    case LightPositionModel::OBJECT:
+    case LightPositionModel::Object:
       return transformationMatrix * light.vector;
-    case LightPositionModel::GLOBAL:
+    case LightPositionModel::Global:
       return cameraMatrix * light.vector;
-    case LightPositionModel::CAMERA:
+    case LightPositionModel::Camera:
       return light.vector;
   }
 

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -17,11 +17,11 @@ namespace gfx {
 
 enum class LightPositionModel {
   /** @brief Light position is relative to the camera */
-  CAMERA = 0,
+  Camera = 0,
   /** @brief Light position is relative to scene */
-  GLOBAL = 1,
+  Global = 1,
   /** @brief Light position is relative to the object being rendered */
-  OBJECT = 2,
+  Object = 2,
 };
 
 enum class LightType {
@@ -40,7 +40,7 @@ struct LightInfo {
   // directional light with no distance attenuation.
   Magnum::Vector4 vector;
   Magnum::Color3 color{1};
-  LightPositionModel model = LightPositionModel::GLOBAL;
+  LightPositionModel model = LightPositionModel::Global;
 };
 
 bool operator==(const LightInfo& a, const LightInfo& b);

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -13,7 +13,13 @@ const std::map<std::string, esp::gfx::LightType>
     LightInstanceAttributes::LightTypeNamesMap = {
         {"point", esp::gfx::LightType::Point},
         {"directional", esp::gfx::LightType::Directional},
-};
+        {"spot", esp::gfx::LightType::Spot}};
+
+const std::map<std::string, esp::gfx::LightPositionModel>
+    LightInstanceAttributes::LightPositionNamesMap = {
+        {"global", esp::gfx::LightPositionModel::Global},
+        {"camera", esp::gfx::LightPositionModel::Camera},
+        {"object", esp::gfx::LightPositionModel::Object}};
 
 LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
     : AbstractAttributes("LightInstanceAttributes", handle) {
@@ -22,6 +28,7 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
   setColor({1.0, 1.0, 1.0});
   setIntensity(1.0);
   setType(static_cast<int>(esp::gfx::LightType::Point));
+  setPositionModel(static_cast<int>(esp::gfx::LightPositionModel::Global));
   // ignored for all but spot lights
   setInnerConeAngle(0.0_radf);
   setOuterConeAngle(90.0_degf);

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -22,9 +22,19 @@ class LightInstanceAttributes : public AbstractAttributes {
   /**
    * @brief Constant static map to provide mappings from string tags to @ref
    * esp::gfx::LightType values.  This will be used to map values set in json
-   * for light type to @ref esp::gfx::LightType.  Keys must be lowercase.
+   * for light type to @ref esp::gfx::LightType.  Keys must be lowercase - will
+   * support any case values in JSON.
    */
   static const std::map<std::string, esp::gfx::LightType> LightTypeNamesMap;
+
+  /**
+   * @brief Constant static map to provide mappings from string tags to @ref
+   * esp::gfx::LightPositionModel values.  This will be used to map values set
+   * in json to specify what translations are measured from for a lighting
+   * instance.
+   */
+  static const std::map<std::string, esp::gfx::LightPositionModel>
+      LightPositionNamesMap;
   explicit LightInstanceAttributes(const std::string& handle = "");
 
   /**
@@ -60,6 +70,16 @@ class LightInstanceAttributes : public AbstractAttributes {
    */
   void setType(int type) { setInt("type", type); }
   int getType() const { return getInt("type"); }
+
+  /**
+   * @brief Get/Set the position model to use when placing the light - whether
+   * the lights translation should be relative to the camera, the global scene
+   * origin, or some object.
+   */
+  void setPositionModel(int position_model) {
+    setInt("position_model", position_model);
+  }
+  int getPositionModel() const { return getInt("position_model"); }
 
   /**
    * @brief Get/Set inner cone angle for spotlights.  Should be ignored for

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -459,6 +459,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
         "intensity": -0.1,
         "color": [2,1,-1],
         "type": "directional",
+        "position_model" : "camera",
         "spot": {
           "innerConeAngle": -0.75,
           "outerConeAngle": -1.57
@@ -486,6 +487,8 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
   ASSERT_EQ(lightAttr->getIntensity(), -0.1);
   ASSERT_EQ(lightAttr->getType(),
             static_cast<int>(esp::gfx::LightType::Directional));
+  ASSERT_EQ(lightAttr->getPositionModel(),
+            static_cast<int>(esp::gfx::LightPositionModel::Camera));
   ASSERT_EQ(lightAttr->getInnerConeAngle(), -0.75_radf);
   ASSERT_EQ(lightAttr->getOuterConeAngle(), -1.57_radf);
 }  // AttributesManagers_LightJSONLoadTest

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -133,10 +133,10 @@ struct SimTest : Cr::TestSuite::Tester {
 
   LightSetup lightSetup1{{Magnum::Vector4{1.0f, 1.5f, 0.5f, 0.0f},
                           {5.0, 5.0, 0.0},
-                          LightPositionModel::CAMERA}};
+                          LightPositionModel::Camera}};
   LightSetup lightSetup2{{Magnum::Vector4{0.0f, 0.5f, 1.0f, 0.0f},
                           {0.0, 5.0, 5.0},
-                          LightPositionModel::CAMERA}};
+                          LightPositionModel::Camera}};
 };
 struct {
   // display name for sim being tested

--- a/tests/test_light_setup.py
+++ b/tests/test_light_setup.py
@@ -22,7 +22,7 @@ def test_set_default_light_setup(make_cfg_settings):
         assert sim.get_light_setup() == light_setup
 
         # ensure modifications to local light setup variable are not reflected in sim
-        light_setup[0].model = LightPositionModel.CAMERA
+        light_setup[0].model = LightPositionModel.Camera
         assert sim.get_light_setup() != light_setup
 
         sim.set_light_setup(light_setup, DEFAULT_LIGHTING_KEY)


### PR DESCRIPTION
## Motivation and Context
This PR introduces JSON support, and appropriate testing and documentation, for setting the desired position model/frame of reference for a lighting instance.  With this setting, the user can specify whether they wish for a particular light info/instance to be placed in the scene relative to the global origin or the camera.  Object-relative positioning is also fully supported in the configuration, but only as a stub currently in the underlying lighting code.

The enum describing the position model value has also been refactored to follow our naming conventions, from  ALL_CAPS to pascal case, in the c++ and python code.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing and added c++ and python test cases pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
