### PR TITLE
[CMake][Bullet] Let Sim be built without Bullet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,11 +462,6 @@ jobs:
             export PATH=$HOME/miniconda/bin:$PATH
             . activate habitat;
             ccache --show-stats
-      - save_cache:
-          key: ccache-{{ arch }}-{{ .Branch }}
-          background: true
-          paths:
-            - /home/circleci/.ccache
       - run: *download_test_data
       - run:
           name: Build Javascript bindings
@@ -537,6 +532,11 @@ jobs:
               nvm use v11.9.0
               # Generate JS CodeConv
               npm run test_with_coverage
+      - save_cache:
+          key: ccache-{{ arch }}-{{ .Branch }}
+          background: true
+          paths:
+            - /home/circleci/.ccache
       - run:
           name: Upload test coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
                   libjpeg-dev \
                   libglm-dev \
                   libegl1-mesa-dev \
-                  ninja-build \ 
+                  ninja-build \
                   xorg-dev \
                   freeglut3-dev \
                   pkg-config \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ commands:
                   libjpeg-dev \
                   libglm-dev \
                   libegl1-mesa-dev \
+                  ninja-build \ 
                   xorg-dev \
                   freeglut3-dev \
                   pkg-config \
@@ -478,7 +479,7 @@ jobs:
               . activate habitat
               nvm use v11.9.0
               . ~/emsdk/emsdk_env.sh
-              ./build_js.sh --bullet
+              CMAKE_GENERATOR=Ninja ./build_js.sh --bullet
               # switch back to cmake 3.10
               sudo rm /usr/local/bin/cmake
               sudo ln -s /opt/cmake310/bin/cmake /usr/local/bin/cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ commands:
                   pkg-config \
                   wget \
                   zip \
-                  libbullet-dev\
                   lcov\
                   libhdf5-dev \
                   unzip || true

--- a/build_js.sh
+++ b/build_js.sh
@@ -45,8 +45,8 @@ cmake ../src \
     -DCMAKE_EXE_LINKER_FLAGS="${EXE_LINKER_FLAGS}" \
     -DBUILD_WITH_BULLET="$( if ${BULLET} ; then echo ON ; else echo OFF; fi )"
 
-cmake --build . -- -j 4 #TODO: Set to 4 cores only on CirelcCI
-cmake --build . --target install -- -j 4
+cmake --build . -- -j 8 #TODO: Set to 8 cores only on CirelcCI
+cmake --build . --target install -- -j 8
 
 echo "Done building."
 echo "Run:"

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -232,6 +232,8 @@ if(NOT USE_SYSTEM_MAGNUM)
   if(BUILD_WITH_BULLET)
     # Build Magnum's BulletIntegration
     set(WITH_BULLET ON CACHE BOOL "" FORCE)
+  else()
+    set(WITH_BULLET OFF CACHE BOOL "" FORCE)
   endif()
 
   if(BUILD_GUI_VIEWERS)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Habitat-Sim could not be built without Bullet if Bullet wasn't installed due to a CMake issue.
Without having Bullet installed on your system, if you tried to build Habitat-Sim without Bullet, you would get this error:
```
CMake Error at /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find Bullet (missing: Bullet_Dynamics_LIBRARY
  Bullet_Collision_LIBRARY Bullet_LinearMath_LIBRARY Bullet_SoftBody_LIBRARY
  Bullet_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  deps/magnum-integration/modules/FindBullet.cmake:193 (find_package_handle_standard_args)
  deps/magnum-integration/src/Magnum/BulletIntegration/CMakeLists.txt:31 (find_packag
```
This solves that issue.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* I removed the system wide Bullet from CircleCI since we don't need it anymore. This way this issue should repro on CI. I tested it locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
