### PR TITLE
[AO][bugfix] - URDF force reload

### DIFF
--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -40,6 +40,11 @@ bool URDFImporter::loadURDF(const std::string& filename,
       urdfParser_.getModel()->printKinematicChain();
     }
 
+    // if reloading, clear the old model
+    if (modelCache_.count(filename)) {
+      modelCache_.erase(filename);
+    }
+
     // register the new model
     modelCache_.emplace(filename, urdfParser_.getModel());
   }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1312,7 +1312,7 @@ int Viewer::addArticulatedObject(std::string urdfFilename,
                                  bool fixedBase,
                                  float globalScale) {
   int articulatedObjectId = simulator_->addArticulatedObjectFromURDF(
-      urdfFilename, fixedBase, globalScale);
+      urdfFilename, fixedBase, globalScale, 1.0, true);
   placeArticulatedObjectAgentFront(articulatedObjectId);
   return articulatedObjectId;
 }


### PR DESCRIPTION
## Motivation and Context

Force reload URDF was not clearing old cached entry before attempting to cache the newly parsed model.

Viewer now always forces reload for convenience when iterating on URDF files.

## How Has This Been Tested

Local

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
