### PR TITLE
[AO] - convex compound collision shapes

### DIFF
--- a/data/test_assets/urdf/fridge/fridge_static.urdf
+++ b/data/test_assets/urdf/fridge/fridge_static.urdf
@@ -1,0 +1,134 @@
+<?xml version="1.0" ?>
+<robot name="fridge">
+  <link name="root">
+  </link>
+  <joint name="root_rotation" type="fixed">
+    <origin rpy="1.565 0 0" xyz="0 0 0"/>
+    <parent link="root"/>
+    <child link="body"/>
+  </joint>
+  <link name="body">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="70.0"/>
+      <!-- Warning: dummy inertia. Expect that inertia diagonal will be computed during load. -->
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="body.glb" scale="1.0, 1.0, 1.0"/>
+      </geometry>
+    </visual>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 -0.94159"/>
+      <geometry>
+        <box size="0.643 0.691 0.027"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 0.94936"/>
+      <geometry>
+        <box size="0.643 0.691 0.027"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 -0.585528"/>
+      <geometry>
+        <box size="0.643 0.691 0.027"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 -0.226826"/>
+      <geometry>
+        <box size="0.643 0.691 0.027"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 -0.033778"/>
+      <geometry>
+        <box size="0.643 0.691 0.027"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.002765 0.255839"/>
+      <geometry>
+        <box size="0.643 0.691 0.042"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 -0.337538 0.005784"/>
+      <geometry>
+        <box size="0.643 0.03 1.89126"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="0 0.329773 0.005784"/>
+      <geometry>
+        <box size="0.643 0.03 1.89126"/>
+      </geometry>
+    </collision>
+    <collision group="256">
+      <origin rpy="0 0 0" xyz="-0.316502 -0.002765 0"/>
+      <geometry>
+        <box size="0.029014 0.690834 1.91906"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="top_door_hinge" type="revolute">
+    <origin rpy="0 0 0" xyz="0.34 0.326 -0.375"/>
+    <parent link="body"/>
+    <child link="top_door"/>
+    <axis xyz="0 0 1"/>
+    <dynamics damping="0.01" friction="0.01"/>
+    <limit effort="44.4" lower="0.0" upper="2.3" velocity="40"/>
+  </joint>
+  <link name="top_door">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="8"/>
+      <!-- Warning: dummy inertia. Expect that inertia diagonal will be computed during load. -->
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 -0.33 0"/>
+      <geometry>
+        <mesh filename="top_door.glb" scale="1.0, 1.0, 1.0"/>
+      </geometry>
+    </visual>
+    <collision group="2">
+      <origin rpy="0 0 0" xyz="0 -0.33 -0.02"/>
+      <geometry>
+        <box size="0.097 0.712 1.103"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="bottom_door_hinge" type="revolute">
+    <origin rpy="0 0 0" xyz="0.34 0.326 0.546"/>
+    <parent link="body"/>
+    <child link="bottom_door"/>
+    <axis xyz="0 0 1"/>
+    <dynamics damping="0.01" friction="0.01"/>
+    <limit effort="44.4" lower="0.0" upper="2.5" velocity="40"/>
+  </joint>
+  <link name="bottom_door">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="6"/>
+      <!-- Warning: dummy inertia. Expect that inertia diagonal will be computed during load. -->
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0.01, -0.33, 0"/>
+      <geometry>
+        <mesh filename="bottom_door.glb" scale="1.0, 1.0, 1.0"/>
+      </geometry>
+    </visual>
+    <collision group="2">
+      <origin rpy="0 0 0" xyz="0.01, -0.33, 0.01"/>
+      <geometry>
+        <box size="0.08 0.686 0.788"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -134,8 +134,8 @@ bool BulletArticulatedObject::initializeFromURDF(
 
     bFixedObjectShape_ = std::make_unique<btCompoundShape>();
 
-    // By convention, fixed links in the URDF are assigned Noncollidable, and we
-    // then insert corresponding fixed rigid bodies with group Static.
+    // By convention, when fixed links in the URDF are assigned Noncollidable,
+    // we then insert corresponding fixed rigid bodies with group Static.
     // Collisions with a fixed rigid body are cheaper than collisions with a
     // fixed link, due to problems with multibody sleeping behavior.
     {

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -58,19 +58,6 @@ BulletArticulatedObject::~BulletArticulatedObject() {
   collisionObjToObjIds_->erase(baseCollider);
   delete baseCollider;
 
-  // delete children of compound collisionShapes
-  std::map<int, std::unique_ptr<btCollisionShape>>::iterator csIter;
-  for (csIter = linkCollisionShapes_.begin();
-       csIter != linkCollisionShapes_.end(); csIter++) {
-    auto compoundShape = dynamic_cast<btCompoundShape*>(csIter->second.get());
-    if (compoundShape) {
-      for (int i = 0; i < compoundShape->getNumChildShapes(); ++i) {
-        auto childShape = compoundShape->getChildShape(i);
-        compoundShape->removeChildShape(childShape);
-        delete childShape;
-      }
-    }
-  }
   // remove motors from the world
   std::map<int, std::unique_ptr<btMultiBodyJointMotor>>::iterator jmIter;
   for (jmIter = articulatedJointMotors.begin();
@@ -113,7 +100,7 @@ bool BulletArticulatedObject::initializeFromURDF(
   // NOTE: recursive path only
   u2b.ConvertURDF2BulletInternal(cache, urdfLinkIndex,
                                  rootTransformInWorldSpace, bWorld_.get(),
-                                 flags, linkCollisionShapes_);
+                                 flags, linkCompoundShapes_, linkChildShapes_);
 
   if (cache.m_bulletMultiBody) {
     btMultiBody* mb = cache.m_bulletMultiBody;

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -141,7 +141,12 @@ class BulletArticulatedObject : public ArticulatedObject {
   bool supportsJointMotor(int linkIx);
 
   // TODO: should be stored in the link
-  std::map<int, std::unique_ptr<btCollisionShape>> linkCollisionShapes_;
+  // compound parent collision shapes for the links
+  std::map<int, std::unique_ptr<btCompoundShape>> linkCompoundShapes_;
+
+  // child mesh convex and primitive shapes for the link compound shapes
+  std::map<int, std::vector<std::unique_ptr<btCollisionShape>>>
+      linkChildShapes_;
 
   // used to update raycast objectId checks (maps to link ids)
   std::shared_ptr<std::map<const btCollisionObject*, int>>

--- a/src/esp/physics/bullet/BulletBase.cpp
+++ b/src/esp/physics/bullet/BulletBase.cpp
@@ -17,46 +17,29 @@ void BulletBase::constructConvexShapesFromMeshes(
     const Magnum::Matrix4& transformFromParentToWorld,
     const std::vector<assets::CollisionMeshData>& meshGroup,
     const assets::MeshTransformNode& node,
-    bool join,
-    btCompoundShape* bObjectShape) {
+    btCompoundShape* bObjectShape,
+    std::vector<std::unique_ptr<btConvexHullShape>>& bObjectConvexShapes) {
   Magnum::Matrix4 transformFromLocalToWorld =
       transformFromParentToWorld * node.transformFromLocalToParent;
   if (node.meshIDLocal != ID_UNDEFINED) {
     // This node has a mesh, so add it to the compound
-
     const assets::CollisionMeshData& mesh = meshGroup[node.meshIDLocal];
 
-    if (join) {
-      // add all points to a single convex instead of compounding (more
-      // stable)
-      if (bObjectConvexShapes_.empty()) {
-        // create the convex if it does not exist
-        bObjectConvexShapes_.emplace_back(
-            std::make_unique<btConvexHullShape>());
-      }
-
-      // add points
-      for (auto& v : mesh.positions) {
-        bObjectConvexShapes_.back()->addPoint(
-            btVector3(transformFromLocalToWorld.transformPoint(v)), false);
-      }
-    } else {
-      bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>(
-          static_cast<const btScalar*>(mesh.positions.data()->data()),
-          mesh.positions.size(), sizeof(Magnum::Vector3)));
-      bObjectConvexShapes_.back()->setMargin(0.0);
-      bObjectConvexShapes_.back()->recalcLocalAabb();
-      //! Add to compound shape stucture
-      if (bObjectShape != nullptr) {
-        bObjectShape->addChildShape(btTransform{transformFromLocalToWorld},
-                                    bObjectConvexShapes_.back().get());
-      }
+    bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>(
+        static_cast<const btScalar*>(mesh.positions.data()->data()),
+        mesh.positions.size(), sizeof(Magnum::Vector3)));
+    bObjectConvexShapes_.back()->setMargin(0.0);
+    bObjectConvexShapes_.back()->recalcLocalAabb();
+    //! Add to compound shape stucture
+    if (bObjectShape != nullptr) {
+      bObjectShape->addChildShape(btTransform{transformFromLocalToWorld},
+                                  bObjectConvexShapes_.back().get());
     }
   }
 
   for (auto& child : node.children) {
     constructConvexShapesFromMeshes(transformFromLocalToWorld, meshGroup, child,
-                                    join, bObjectShape);
+                                    bObjectShape, bObjectConvexShapes);
   }
 }  // constructConvexShapesFromMeshes
 

--- a/src/esp/physics/bullet/BulletBase.cpp
+++ b/src/esp/physics/bullet/BulletBase.cpp
@@ -25,19 +25,19 @@ void BulletBase::constructConvexShapesFromMeshes(
     // This node has a mesh, so add it to the compound
     const assets::CollisionMeshData& mesh = meshGroup[node.meshIDLocal];
 
-    bObjectConvexShapes_.emplace_back(std::make_unique<btConvexHullShape>());
+    bObjectConvexShapes.emplace_back(std::make_unique<btConvexHullShape>());
     // transform points into world space, including any scale/shear in
     // transformFromLocalToWorld.
     for (auto& v : mesh.positions) {
-      bObjectConvexShapes_.back()->addPoint(
+      bObjectConvexShapes.back()->addPoint(
           btVector3(transformFromLocalToWorld.transformPoint(v)), false);
     }
-    bObjectConvexShapes_.back()->setMargin(0.0);
-    bObjectConvexShapes_.back()->recalcLocalAabb();
+    bObjectConvexShapes.back()->setMargin(0.0);
+    bObjectConvexShapes.back()->recalcLocalAabb();
     //! Add to compound shape stucture
     if (bObjectShape != nullptr) {
       bObjectShape->addChildShape(btTransform::getIdentity(),
-                                  bObjectConvexShapes_.back().get());
+                                  bObjectConvexShapes.back().get());
     }
   }
 
@@ -55,11 +55,8 @@ void BulletBase::constructJoinedConvexShapeFromMeshes(
   Magnum::Matrix4 transformFromLocalToWorld =
       transformFromParentToWorld * node.transformFromLocalToParent;
 
-  if (bConvexShape == nullptr) {
-    Cr::Utility::Debug()
-        << "constructJoinedConvexShapeFromMeshes : E - passed in null shape...";
-    return;
-  }
+  assert(bConvexShape != nullptr);
+
   if (node.meshIDLocal != ID_UNDEFINED) {
     const assets::CollisionMeshData& mesh = meshGroup[node.meshIDLocal];
 

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -124,6 +124,8 @@ class BulletBase {
    * MeshTransformNode tree to the current node.
    * @param meshGroup Access structure for collision mesh data.
    * @param node The current @ref MeshTransformNode in the recursion.
+   * @param bObjectShape The compound shape parent for all generated convexes
+   * @param bObjectConvexShapes Datastructure to cache generated convex shapes
    */
   void constructConvexShapesFromMeshes(
       const Magnum::Matrix4& transformFromParentToWorld,

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -113,7 +113,6 @@ class BulletBase {
       const assets::MeshTransformNode& node,
       btConvexHullShape* bConvexShape);
 
- protected:
   /**
    * @brief Recursively construct a @ref btCompoundShape for collision from
    * loaded mesh assets. A @ref btConvexHullShape is constructed for each
@@ -127,13 +126,14 @@ class BulletBase {
    * @param bObjectShape The compound shape parent for all generated convexes
    * @param bObjectConvexShapes Datastructure to cache generated convex shapes
    */
-  void constructConvexShapesFromMeshes(
+  static void constructConvexShapesFromMeshes(
       const Magnum::Matrix4& transformFromParentToWorld,
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node,
       btCompoundShape* bObjectShape,
       std::vector<std::unique_ptr<btConvexHullShape>>& bObjectConvexShapes);
 
+ protected:
   /** @brief A pointer to the Bullet world to which this object belongs. See
    * @ref btMultiBodyDynamicsWorld.*/
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -124,15 +124,13 @@ class BulletBase {
    * MeshTransformNode tree to the current node.
    * @param meshGroup Access structure for collision mesh data.
    * @param node The current @ref MeshTransformNode in the recursion.
-   * @param join Whether or not to join sub-meshes into a single con convex
-   * shape, rather than creating individual convexes under the compound.
    */
   void constructConvexShapesFromMeshes(
       const Magnum::Matrix4& transformFromParentToWorld,
       const std::vector<assets::CollisionMeshData>& meshGroup,
       const assets::MeshTransformNode& node,
-      bool join,
-      btCompoundShape* bObjectShape = nullptr);
+      btCompoundShape* bObjectShape,
+      std::vector<std::unique_ptr<btConvexHullShape>>& bObjectConvexShapes);
 
   /** @brief A pointer to the Bullet world to which this object belongs. See
    * @ref btMultiBodyDynamicsWorld.*/

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -123,9 +123,19 @@ bool BulletRigidObject::constructCollisionShape() {
         resMgr_.getMeshMetaData(collisionAssetHandle);
 
     if (!usingBBCollisionShape_) {
-      constructConvexShapesFromMeshes(Magnum::Matrix4{}, meshGroup,
-                                      metaData.root, joinCollisionMeshes,
-                                      bObjectShape_.get());
+      if (joinCollisionMeshes) {
+        bObjectConvexShapes_.emplace_back(
+            std::make_unique<btConvexHullShape>());
+        constructJoinedConvexShapeFromMeshes(Magnum::Matrix4{}, meshGroup,
+                                             metaData.root,
+                                             bObjectConvexShapes_.back().get());
+        bObjectShape_->addChildShape(btTransform::getIdentity(),
+                                     bObjectConvexShapes_.back().get());
+      } else {
+        constructConvexShapesFromMeshes(Magnum::Matrix4{}, meshGroup,
+                                        metaData.root, bObjectShape_.get(),
+                                        bObjectConvexShapes_);
+      }
 
       // add the final object after joining meshes
       if (joinCollisionMeshes) {

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -51,6 +51,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
       auto capsuleShape = std::make_unique<btCapsuleShapeZ>(radius, height);
       shape = capsuleShape.get();
       shape->setMargin(gUrdfDefaultCollisionMargin);
+      linkChildShapes.emplace_back(std::move(capsuleShape));
       break;
     }
 
@@ -63,7 +64,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
       btVector3 halfExtents(cylRadius, cylRadius, cylHalfLength);
       auto cylZShape = std::make_unique<btCylinderShapeZ>(halfExtents);
       shape = cylZShape.get();
-
+      linkChildShapes.emplace_back(std::move(cylZShape));
       break;
     }
     case io::URDF::GEOM_BOX: {
@@ -78,6 +79,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
       */
       shape = boxShape.get();
       shape->setMargin(gUrdfDefaultCollisionMargin);
+      linkChildShapes.emplace_back(std::move(boxShape));
       break;
     }
     case io::URDF::GEOM_SPHERE: {
@@ -85,6 +87,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
       auto sphereShape = std::make_unique<btSphereShape>(radius);
       shape = sphereShape.get();
       shape->setMargin(gUrdfDefaultCollisionMargin);
+      linkChildShapes.emplace_back(std::move(sphereShape));
       break;
     }
     case io::URDF::GEOM_MESH: {
@@ -108,6 +111,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
         convexShape->recalcLocalAabb();
         shape = convexShape.get();
         shape->setMargin(gUrdfDefaultCollisionMargin);
+        linkChildShapes.emplace_back(std::move(convexShape));
       } else {
         Mn::Debug{}
             << "BulletURDFImporter::convertURDFToCollisionShape : E - could "

--- a/src/esp/physics/bullet/BulletURDFImporter.h
+++ b/src/esp/physics/bullet/BulletURDFImporter.h
@@ -85,11 +85,13 @@ class BulletURDFImporter : public URDFImporter {
   ~BulletURDFImporter() override = default;
 
   btCollisionShape* convertURDFToCollisionShape(
-      const struct io::URDF::CollisionShape* collision);
+      const struct io::URDF::CollisionShape* collision,
+      std::vector<std::unique_ptr<btCollisionShape>>& linkChildShapes);
 
   btCompoundShape* convertLinkCollisionShapes(
       int linkIndex,
-      const btTransform& localInertiaFrame);
+      const btTransform& localInertiaFrame,
+      std::vector<std::unique_ptr<btCollisionShape>>& linkChildShapes);
 
   int getCollisionGroupAndMask(int linkIndex,
                                int& colGroup,
@@ -111,7 +113,9 @@ class BulletURDFImporter : public URDFImporter {
       const Magnum::Matrix4& parentTransformInWorldSpace,
       btMultiBodyDynamicsWorld* world1,
       int flags,
-      std::map<int, std::unique_ptr<btCollisionShape>>& linkCollisionShapes);
+      std::map<int, std::unique_ptr<btCompoundShape>>& linkCompoundShapes,
+      std::map<int, std::vector<std::unique_ptr<btCollisionShape>>>&
+          linkChildShapes);
 };
 
 void processContactParameters(const io::URDF::LinkContactInfo& contactInfo,

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -136,7 +136,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
             Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
             Magnum::Matrix4::rotationY(Magnum::Math::Rad<float>(-0.25))};
         float boxHeight = 2.0 + (o * 2);
-        Magnum::Vector3 initialPosition{0.0, boxHeight + 1.25f, 0.0};
+        Magnum::Vector3 initialPosition{0.0, boxHeight + 1.5f, 0.0};
         physicsManager_->setRotation(
             objectId, Magnum::Quaternion::fromMatrix(R.rotationNormalized()));
         physicsManager_->setTranslation(objectId, initialPosition);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -2384,10 +2384,20 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       locobotControllers.push_back(std::move(locobotController));
     } break;
     case KeyEvent::Key::Five: {
-      // reset the scene
-      clearAllObjects();
-      Corrade::Utility::Debug() << "done clearing, now generating";
-      setupDemoFurniture();
+      // add the counter in front of the agent with fixed base
+      std::string urdfFilePath = "data/test_assets/URDF/fridge/fridge.urdf";
+      auto fridgeAOId = addArticulatedObject(urdfFilePath, true);
+      simulator_->setAutoClampJointLimits(fridgeAOId, true);
+
+      Mn::Vector3 localFridgeBasePos{0.0f, 0.94f, -2.0f};
+      Mn::Matrix4 T = agentBodyNode_->MagnumObject::transformationMatrix();
+      // rotate the object
+      auto R = Magnum::Matrix4::rotationY(Magnum::Rad(-1.56));
+      Mn::Matrix4 initialFridgeTransform = R * T;
+      initialFridgeTransform.translation() =
+          T.transformPoint(localFridgeBasePos);
+      simulator_->setArticulatedObjectRootState(fridgeAOId,
+                                                initialFridgeTransform);
     } break;
     case KeyEvent::Key::Minus: {
       if (simulator_->getExistingArticulatedObjectIDs().size()) {


### PR DESCRIPTION
## Motivation and Context

Primary changes refactors the convex collision shape generation pipeline to separate joined and compound variants and support compounds for ArticulatedObjects. 

Secondary is a change to default behavior for fixed base ArticulatedObjects. We now only create proxy rigid objects for static links when the URDF explicitly overrides the collision shape filter group with `NonCollidable (256)`. This change prioritizes stability since neighboring links in the kinematic chain often have overlapping collision shapes (see the fridge.urdf asset). Using the rigid object proxy in these cases requires the dynamic links to mask contacts with STATIC objects such as the stage with a manual group override in URDF or they will become unstable in simulation with fixed base. As such, fixed base rigid proxy should be manually configured for specific cases in order to maximize performance for STATIC furniture objects. An example asset `fridge_static.urdf` is provided to demonstrate this option. While cheaper to simulate when the base is touching the stage, the doors will not register collisions with the walls or other STATIC furniture, making it useful only in targeted situations.

Tertiary Changes:
- viewer adds a fixed fridge.urdf facing the agent with '5'
- temporarily adjusted a physics test in which an object just tunneling through the floor. TODO: this test should be modified in master to test functionality rather than resulting stability.

## How Has This Been Tested

Local testing and verification with existing demos in `URDF_robotics_tutorial.py`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
