### PR TITLE
Promote kinematic properties to PhysicsBaseObject

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -46,7 +46,91 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           ("Whether this " + objType + " still exists and is still valid.")
               .c_str())
       .def_property_readonly("template_class", &PhysObjWrapper::getClassKey,
-                             ("Class name of this " + objType).c_str());
+                             ("Class name of this " + objType).c_str())
+      .def("user_attributes", &PhysObjWrapper::userAttributes,
+           ("User-defined " + objType +
+            " attributes.  These are not used internally by Habitat in any "
+            "capacity, but are available for a user to consume how they wish.")
+               .c_str())
+      .def_property(
+          "transformation", &PhysObjWrapper::getTransformation,
+          &PhysObjWrapper::setTransformation,
+          ("Get or set the transformation matrix of this " + objType +
+           "'s root SceneNode. If modified, sim state will be updated.")
+              .c_str())
+      .def_property(
+          "translation", &PhysObjWrapper::getTranslation,
+          &PhysObjWrapper::setTranslation,
+          ("Get or set the translation vector of this " + objType +
+           "'s root SceneNode. If modified, sim state will be updated.")
+              .c_str())
+      .def_property(
+          "rotation", &PhysObjWrapper::getRotation,
+          &PhysObjWrapper::setRotation,
+          ("Get or set the rotation quaternion of this " + objType +
+           "'s root SceneNode. If modified, sim state will be updated.")
+              .c_str())
+      .def_property("rigid_state", &PhysObjWrapper::getRigidState,
+                    &PhysObjWrapper::setRigidState,
+                    ("Get or set this " + objType +
+                     "'s transformation as a Rigid State (i.e. vector, "
+                     "quaternion). If modified, sim state will be updated.")
+                        .c_str())
+      .def_property_readonly("root_scene_node", &PhysObjWrapper::getSceneNode,
+                             ("Get a reference to the root SceneNode of this " +
+                              objType + "'s  SceneGraph subtree.")
+                                 .c_str())
+
+      .def("set_light_setup", &PhysObjWrapper::setLightSetup,
+           ("Set this " + objType +
+            "'s light setup using passed light_setup_key.")
+               .c_str(),
+           "light_setup_key"_a)
+      .def_property("awake", &PhysObjWrapper::isActive,
+                    &PhysObjWrapper::setActive,
+                    ("Get or set whether this " + objType +
+                     " is actively being simulated, or is sleeping.")
+                        .c_str())
+      .def(
+          "translate", &PhysObjWrapper::translate, "vector"_a,
+          ("Move this " + objType + " using passed translation vector").c_str())
+      .def("rotate", &PhysObjWrapper::rotate, "angle_in_rad"_a, "norm_axis"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around passed 3-element normalized "
+            "norm_axis.")
+               .c_str())
+      .def("rotate_local", &PhysObjWrapper::rotateLocal, "angle_in_rad"_a,
+           "norm_axis"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around passed 3-element normalized "
+            "norm_axis in the local frame.")
+               .c_str())
+      .def("rotate_x", &PhysObjWrapper::rotateX, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the x-axis in global frame.")
+               .c_str())
+      .def("rotate_x_local", &PhysObjWrapper::rotateXLocal, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the x-axis in local frame.")
+               .c_str())
+      .def("rotate_y", &PhysObjWrapper::rotateY, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the y-axis in global frame.")
+               .c_str())
+      .def("rotate_y_local", &PhysObjWrapper::rotateYLocal, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the y-axis in local frame.")
+               .c_str())
+      .def("rotate_z", &PhysObjWrapper::rotateZ, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the z-axis in global frame.")
+               .c_str())
+      .def("rotate_z_local", &PhysObjWrapper::rotateZLocal, "angle_in_rad"_a,
+           ("Rotate this " + objType +
+            " by passed angle_in_rad around the z-axis in local frame.")
+               .c_str())
+
+      ;
 }  // declareBasePhysicsObjectWrapper
 
 template <class T>
@@ -60,35 +144,7 @@ void declareRigidBaseWrapper(py::module& m,
              std::shared_ptr<RigidBaseWrapper>>(m, pyclass_name.c_str())
 
       /* --- Geometry & Transformations --- */
-      .def("user_attributes", &RigidBaseWrapper::userAttributes,
-           ("User-defined " + objType +
-            " attributes.  These are not used internally by Habitat in any "
-            "capacity, but are available for a user to consume how they wish.")
-               .c_str())
-      .def_property(
-          "transformation", &RigidBaseWrapper::getTransformation,
-          &RigidBaseWrapper::setTransformation,
-          ("Get or set the transformation matrix of this " + objType +
-           "'s root SceneNode. If modified, sim state will be updated.")
-              .c_str())
-      .def_property(
-          "translation", &RigidBaseWrapper::getTranslation,
-          &RigidBaseWrapper::setTranslation,
-          ("Get or set the translation vector of this " + objType +
-           "'s root SceneNode. If modified, sim state will be updated.")
-              .c_str())
-      .def_property(
-          "rotation", &RigidBaseWrapper::getRotation,
-          &RigidBaseWrapper::setRotation,
-          ("Get or set the rotation quaternion of this " + objType +
-           "'s root SceneNode. If modified, sim state will be updated.")
-              .c_str())
-      .def_property("rigid_state", &RigidBaseWrapper::getRigidState,
-                    &RigidBaseWrapper::setRigidState,
-                    ("Get or set this " + objType +
-                     "'s transformation as a Rigid State (i.e. vector, "
-                     "quaternion). If modified, sim state will be updated.")
-                        .c_str())
+
       .def_property_readonly("scale", &RigidBaseWrapper::getScale,
                              ("Get the scale of the " + objType).c_str())
 
@@ -194,11 +250,7 @@ void declareRigidBaseWrapper(py::module& m,
            "' render assets attached. Use this to manipulate this " + objType +
            "'s visual state. Changes to these nodes will not affect physics "
            "simulation.")
-              .c_str())
-      .def_property_readonly("root_scene_node", &RigidBaseWrapper::getSceneNode,
-                             ("Get a reference to the root SceneNode of this " +
-                              objType + "'s  SceneGraph subtree.")
-                                 .c_str());
+              .c_str());
 
 }  // declareRigidBaseWrapper
 

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -8,6 +8,7 @@
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/Containers/Reference.h>
 #include "esp/assets/ResourceManager.h"
+#include "esp/core/RigidState.h"
 
 /** @file
  * @brief Class @ref esp::physics::PhysicsObjectBase is the base class for any
@@ -113,7 +114,238 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   const scene::SceneNode& getSceneNode() const { return node(); }
 
+  /**
+   * @brief Check whether object is being actively simulated, or sleeping.
+   * Kinematic objects are always active, but derived dynamics implementations
+   * may not be.  NOTE: no active objects without a physics engine...
+   * (kinematics don't count)
+   * @return true if active, false otherwise.
+   */
+  virtual bool isActive() const { return false; }
+
+  /**
+   * @brief Set an object as being actively simulated rather than sleeping.
+   * Kinematic objects are always active, but derived dynamics implementations
+   * may not be.
+   */
+  virtual void setActive() {}
+
+  /**
+   * @brief Set the light setup of this rigid.
+   * @param lightSetupKey @ref gfx::LightSetup key
+   */
+  void setLightSetup(const std::string& lightSetupKey) {
+    gfx::setLightSetupForSubTree(node(), lightSetupKey);
+  }
+
+  // ==== Transformations ===
+
+  /** @brief Set the 4x4 transformation matrix of the object kinematically.
+   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
+   * recommended.
+   * @param transformation The desired 4x4 transform of the object.
+   */
+  virtual void setTransformation(const Magnum::Matrix4& transformation) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().setTransformation(transformation);
+      syncPose();
+    }
+  }
+
+  virtual Magnum::Matrix4 getTransformation() const {
+    return node().transformation();
+  }
+
+  /** @brief Set the 3D position of the object kinematically.
+   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
+   * recommended.
+   * @param vector The desired 3D position of the object.
+   */
+  virtual void setTranslation(const Magnum::Vector3& vector) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().setTranslation(vector);
+      syncPose();
+    }
+  }
+
+  virtual Magnum::Vector3 getTranslation() const {
+    return node().translation();
+  }
+
+  /** @brief Set the orientation of the object kinematically.
+   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
+   * recommended.
+   * @param quaternion The desired orientation of the object.
+   */
+  virtual void setRotation(const Magnum::Quaternion& quaternion) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().setRotation(quaternion);
+      syncPose();
+    }
+  }
+
+  virtual Magnum::Quaternion getRotation() const { return node().rotation(); }
+
+  /**
+   * @brief Get the rotation and translation of the object.
+   */
+  virtual core::RigidState getRigidState() {
+    return core::RigidState(node().rotation(), node().translation());
+  };
+
+  /**
+   * @brief Set the rotation and translation of the object.
+   */
+  virtual void setRigidState(const core::RigidState& rigidState) {
+    setTranslation(rigidState.translation);
+    setRotation(rigidState.rotation);
+  };
+
+  /** @brief Reset the transformation of the object.
+   * !!NOT IMPLEMENTED!!
+   */
+  virtual void resetTransformation() {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().resetTransformation();
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the 3D position of the object kinematically by translation.
+   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
+   * recommended.
+   * @param vector The desired 3D vector by which to translate the object.
+   */
+  virtual void translate(const Magnum::Vector3& vector) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().translate(vector);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the 3D position of the object kinematically by translation
+   * with a vector defined in the object's local coordinate system. Calling this
+   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * @param vector The desired 3D vector in the object's ocal coordiante system
+   * by which to translate the object.
+   */
+  virtual void translateLocal(const Magnum::Vector3& vector) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().translateLocal(vector);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying an
+   * axis-angle rotation to it. Calling this during simulation of a @ref
+   * MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   * @param normalizedAxis The desired unit vector axis of rotation.
+   */
+  virtual void rotate(const Magnum::Rad angleInRad,
+                      const Magnum::Vector3& normalizedAxis) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotate(angleInRad, normalizedAxis);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying an
+   * axis-angle rotation to it in the local coordinate system. Calling this
+   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   * @param normalizedAxis The desired unit vector axis of rotation in the local
+   * coordinate system.
+   */
+  virtual void rotateLocal(const Magnum::Rad angleInRad,
+                           const Magnum::Vector3& normalizedAxis) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateLocal(angleInRad, normalizedAxis);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the global X axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateX(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateX(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the global Y axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateY(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateY(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the global Z axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateZ(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateZ(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the local X axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateXLocal(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateXLocal(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the local Y axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateYLocal(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateYLocal(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Modify the orientation of the object kinematically by applying a
+   * rotation to it about the local Z axis. Calling this during simulation of a
+   * @ref MotionType::DYNAMIC object is not recommended.
+   * @param angleInRad The angle of rotation in radians.
+   */
+  virtual void rotateZLocal(const Magnum::Rad angleInRad) {
+    if (objectMotionType_ != MotionType::STATIC) {
+      node().rotateZLocal(angleInRad);
+      syncPose();
+    }
+  }
+
+  /** @brief Store whatever object attributes you want here! */
+  esp::core::Configuration::ptr attributes_{};
+
  protected:
+  /** @brief Used to synchronize other simulator's notion of the object state
+   * after it was changed kinematically. Must be called automatically on
+   * kinematic updates.*/
+  virtual void syncPose() { return; }
+
   /** @brief An assignable name for this object.
    */
   std::string objectName_;

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -9,7 +9,6 @@
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/GenericInstanceMeshData.h"
 #include "esp/assets/MeshData.h"
-#include "esp/core/RigidState.h"
 #include "esp/core/esp.h"
 #include "esp/geo/VoxelWrapper.h"
 #include "esp/metadata/attributes/AttributesBase.h"
@@ -86,22 +85,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   virtual void setCollidable(CORRADE_UNUSED bool collidable){};
 
   /**
-   * @brief Check whether object is being actively simulated, or sleeping.
-   * Kinematic objects are always active, but derived dynamics implementations
-   * may not be.  NOTE: no active objects without a physics engine...
-   * (kinematics don't count)
-   * @return true if active, false otherwise.
-   */
-  virtual bool isActive() const { return false; }
-
-  /**
-   * @brief Set an object as being actively simulated rather than sleeping.
-   * Kinematic objects are always active, but derived dynamics implementations
-   * may not be.
-   */
-  virtual void setActive() {}
-
-  /**
    * @brief Apply a force to an object through a dervied dynamics
    * implementation. Does nothing for @ref MotionType::STATIC and @ref
    * MotionType::KINEMATIC objects.
@@ -144,205 +127,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    */
   virtual void applyImpulseTorque(
       CORRADE_UNUSED const Magnum::Vector3& impulse) {}
-
-  // ==== Transformations ===
-
-  /** @brief Set the 4x4 transformation matrix of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
-   * @param transformation The desired 4x4 transform of the object.
-   */
-  virtual void setTransformation(const Magnum::Matrix4& transformation) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().setTransformation(transformation);
-      syncPose();
-    }
-  }
-
-  virtual Magnum::Matrix4 getTransformation() const {
-    return node().transformation();
-  }
-
-  /** @brief Set the 3D position of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
-   * @param vector The desired 3D position of the object.
-   */
-  virtual void setTranslation(const Magnum::Vector3& vector) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().setTranslation(vector);
-      syncPose();
-    }
-  }
-
-  virtual Magnum::Vector3 getTranslation() const {
-    return node().translation();
-  }
-
-  /** @brief Set the orientation of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
-   * @param quaternion The desired orientation of the object.
-   */
-  virtual void setRotation(const Magnum::Quaternion& quaternion) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().setRotation(quaternion);
-      syncPose();
-    }
-  }
-
-  virtual Magnum::Quaternion getRotation() const { return node().rotation(); }
-
-  /**
-   * @brief Get the rotation and translation of the object.
-   */
-  virtual core::RigidState getRigidState() {
-    return core::RigidState(node().rotation(), node().translation());
-  };
-
-  /**
-   * @brief Set the rotation and translation of the object.
-   */
-  virtual void setRigidState(const core::RigidState& rigidState) {
-    setTranslation(rigidState.translation);
-    setRotation(rigidState.rotation);
-  };
-
-  /** @brief Reset the transformation of the object.
-   * !!NOT IMPLEMENTED!!
-   */
-  virtual void resetTransformation() {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().resetTransformation();
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the 3D position of the object kinematically by translation.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
-   * @param vector The desired 3D vector by which to translate the object.
-   */
-  virtual void translate(const Magnum::Vector3& vector) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().translate(vector);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the 3D position of the object kinematically by translation
-   * with a vector defined in the object's local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
-   * @param vector The desired 3D vector in the object's ocal coordiante system
-   * by which to translate the object.
-   */
-  virtual void translateLocal(const Magnum::Vector3& vector) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().translateLocal(vector);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying an
-   * axis-angle rotation to it. Calling this during simulation of a @ref
-   * MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   * @param normalizedAxis The desired unit vector axis of rotation.
-   */
-  virtual void rotate(const Magnum::Rad angleInRad,
-                      const Magnum::Vector3& normalizedAxis) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotate(angleInRad, normalizedAxis);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying an
-   * axis-angle rotation to it in the local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   * @param normalizedAxis The desired unit vector axis of rotation in the local
-   * coordinate system.
-   */
-  virtual void rotateLocal(const Magnum::Rad angleInRad,
-                           const Magnum::Vector3& normalizedAxis) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateLocal(angleInRad, normalizedAxis);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the global X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateX(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateX(angleInRad);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the global Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateY(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateY(angleInRad);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the global Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateZ(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateZ(angleInRad);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the local X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateXLocal(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateXLocal(angleInRad);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the local Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateYLocal(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateYLocal(angleInRad);
-      syncPose();
-    }
-  }
-
-  /** @brief Modify the orientation of the object kinematically by applying a
-   * rotation to it about the local Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
-   * @param angleInRad The angle of rotation in radians.
-   */
-  virtual void rotateZLocal(const Magnum::Rad angleInRad) {
-    if (objectMotionType_ != MotionType::STATIC) {
-      node().rotateZLocal(angleInRad);
-      syncPose();
-    }
-  }
 
   // ==== Getter/Setter functions ===
 
@@ -451,14 +235,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
       return nullptr;
     }
     return T::create(*(static_cast<T*>(initializationAttributes_.get())));
-  }
-
-  /**
-   * @brief Set the light setup of this rigid.
-   * @param lightSetupKey @ref gfx::LightSetup key
-   */
-  void setLightSetup(const std::string& lightSetupKey) {
-    gfx::setLightSetupForSubTree(node(), lightSetupKey);
   }
 
   /** @brief Get the scalar linear damping coefficient of the object. Only used
@@ -579,9 +355,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 #endif
 
-  /** @brief Store whatever object attributes you want here! */
-  esp::core::Configuration::ptr attributes_{};
-
   //! The @ref SceneNode of a bounding box debug drawable. If nullptr, BB
   //! drawing is off. See @ref setObjectBBDraw().
   scene::SceneNode* BBNode_ = nullptr;
@@ -625,11 +398,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   void shiftOriginToBBCenter() {
     shiftOrigin(-node().getCumulativeBB().center());
   }
-
-  /** @brief Used to synchronize other simulator's notion of the object state
-   * after it was changed kinematically. Called automatically on kinematic
-   * updates.*/
-  virtual void syncPose() { return; }
 
   /** @brief Flag sepcifying whether or not the object has an active collision
    * shape.

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -36,6 +36,11 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   ~AbstractManagedPhysicsObject() override = default;
 
   /**
+   * @brief Test whether this wrapper's object still exists.
+   */
+  bool isAlive() { return !weakObjRef_.expired(); }
+
+  /**
    * @brief Get this managed object's class.  Should only be set from
    * constructor. Used as key in constructor function pointer maps in Managed
    * Container.
@@ -87,10 +92,166 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
     }
   }
 
-  /**
-   * @brief Test whether this wrapper's object still exists.
-   */
-  bool isAlive() { return !weakObjRef_.expired(); }
+  bool isActive() {
+    if (auto sp = this->getObjectReference()) {
+      return sp->isActive();
+    } else {
+      return false;
+    }
+  }  // isActive()
+
+  void setActive() {
+    if (auto sp = this->getObjectReference()) {
+      sp->setActive();
+    }
+  }  // activate()
+
+  void setLightSetup(const std::string& lightSetupKey) {
+    if (auto sp = this->getObjectReference()) {
+      sp->setLightSetup(lightSetupKey);
+    }
+  }  // setLightSetup
+
+  scene::SceneNode* getSceneNode() {
+    if (auto sp = this->getObjectReference()) {
+      return &const_cast<scene::SceneNode&>(sp->getSceneNode());
+    } else {
+      return nullptr;
+    }
+  }  // getSceneNode
+
+  esp::core::Configuration::ptr userAttributes() {
+    if (auto sp = this->getObjectReference()) {
+      return sp->attributes_;
+    } else {
+      return nullptr;
+    }
+  }
+
+  // ==== Transformations ===
+
+  Magnum::Matrix4 getTransformation() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getTransformation();
+    } else {
+      return Magnum::Matrix4{};
+    }
+  }  // getTransformation
+
+  void setTransformation(const Magnum::Matrix4& transformation) {
+    if (auto sp = this->getObjectReference()) {
+      sp->setTransformation(transformation);
+    }
+  }  // setTransformation
+
+  Magnum::Vector3 getTranslation() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getTranslation();
+    } else {
+      return Magnum::Vector3{};
+    }
+  }  // getTranslation
+
+  void setTranslation(const Magnum::Vector3& vector) {
+    if (auto sp = this->getObjectReference()) {
+      sp->setTranslation(vector);
+    }
+  }  // setTranslation
+
+  Magnum::Quaternion getRotation() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getRotation();
+    } else {
+      return Magnum::Quaternion{};
+    }
+  }  // getTranslation
+  void setRotation(const Magnum::Quaternion& quaternion) {
+    if (auto sp = this->getObjectReference()) {
+      sp->setRotation(quaternion);
+    }
+  }  // setRotation
+
+  core::RigidState getRigidState() {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getRigidState();
+    } else {
+      return core::RigidState{};
+    }
+  }  // getRigidState()
+
+  void setRigidState(const core::RigidState& rigidState) {
+    if (auto sp = this->getObjectReference()) {
+      sp->setRigidState(rigidState);
+    }
+  }  // setRigidState
+
+  void resetTransformation() {
+    if (auto sp = this->getObjectReference()) {
+      sp->resetTransformation();
+    }
+  }  // resetTransformation
+
+  void translate(const Magnum::Vector3& vector) {
+    if (auto sp = this->getObjectReference()) {
+      sp->translate(vector);
+    }
+  }  // translate
+
+  void translateLocal(const Magnum::Vector3& vector) {
+    if (auto sp = this->getObjectReference()) {
+      sp->translateLocal(vector);
+    }
+  }  // translateLocal
+
+  void rotate(const Magnum::Rad angleInRad,
+              const Magnum::Vector3& normalizedAxis) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotate(angleInRad, normalizedAxis);
+    }
+  }  // rotate
+
+  void rotateLocal(const Magnum::Rad angleInRad,
+                   const Magnum::Vector3& normalizedAxis) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateLocal(angleInRad, normalizedAxis);
+    }
+  }  // rotateLocal
+
+  void rotateX(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateX(angleInRad);
+    }
+  }  // rotateX
+
+  void rotateY(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateY(angleInRad);
+    }
+  }  // rotateY
+
+  void rotateZ(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateZ(angleInRad);
+    }
+  }  // rotateZ
+
+  void rotateXLocal(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateXLocal(angleInRad);
+    }
+  }  // rotateXLocal
+
+  void rotateYLocal(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateYLocal(angleInRad);
+    }
+  }  // rotateYLocal
+
+  void rotateZLocal(const Magnum::Rad angleInRad) {
+    if (auto sp = this->getObjectReference()) {
+      sp->rotateZLocal(angleInRad);
+    }
+  }  // rotateZLocal
 
  protected:
   /**

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -27,21 +27,6 @@ class AbstractManagedRigidBase
 
   explicit AbstractManagedRigidBase(const std::string& classKey)
       : AbstractManagedPhysicsObject<T>(classKey) {}
-
-  bool isActive() {
-    if (auto sp = this->getObjectReference()) {
-      return sp->isActive();
-    } else {
-      return false;
-    }
-  }  // isActive()
-
-  void setActive() {
-    if (auto sp = this->getObjectReference()) {
-      sp->setActive();
-    }
-  }  // activate()
-
   void applyForce(const Magnum::Vector3& force, const Magnum::Vector3& relPos) {
     if (auto sp = this->getObjectReference()) {
       sp->applyForce(force, relPos);
@@ -65,131 +50,6 @@ class AbstractManagedRigidBase
       sp->applyImpulseTorque(impulse);
     }
   }  // applyImpulseTorque
-
-  // ==== Transformations ===
-
-  Magnum::Matrix4 getTransformation() const {
-    if (auto sp = this->getObjectReference()) {
-      return sp->getTransformation();
-    } else {
-      return Magnum::Matrix4{};
-    }
-  }  // getTransformation
-
-  void setTransformation(const Magnum::Matrix4& transformation) {
-    if (auto sp = this->getObjectReference()) {
-      sp->setTransformation(transformation);
-    }
-  }  // setTransformation
-
-  Magnum::Vector3 getTranslation() const {
-    if (auto sp = this->getObjectReference()) {
-      return sp->getTranslation();
-    } else {
-      return Magnum::Vector3{};
-    }
-  }  // getTranslation
-
-  void setTranslation(const Magnum::Vector3& vector) {
-    if (auto sp = this->getObjectReference()) {
-      sp->setTranslation(vector);
-    }
-  }  // setTranslation
-
-  Magnum::Quaternion getRotation() const {
-    if (auto sp = this->getObjectReference()) {
-      return sp->getRotation();
-    } else {
-      return Magnum::Quaternion{};
-    }
-  }  // getTranslation
-  void setRotation(const Magnum::Quaternion& quaternion) {
-    if (auto sp = this->getObjectReference()) {
-      sp->setRotation(quaternion);
-    }
-  }  // setRotation
-
-  core::RigidState getRigidState() {
-    if (auto sp = this->getObjectReference()) {
-      return sp->getRigidState();
-    } else {
-      return core::RigidState{};
-    }
-  }  // getRigidState()
-
-  void setRigidState(const core::RigidState& rigidState) {
-    if (auto sp = this->getObjectReference()) {
-      sp->setRigidState(rigidState);
-    }
-  }  // setRigidState
-
-  void resetTransformation() {
-    if (auto sp = this->getObjectReference()) {
-      sp->resetTransformation();
-    }
-  }  // resetTransformation
-
-  void translate(const Magnum::Vector3& vector) {
-    if (auto sp = this->getObjectReference()) {
-      sp->translate(vector);
-    }
-  }  // translate
-
-  void translateLocal(const Magnum::Vector3& vector) {
-    if (auto sp = this->getObjectReference()) {
-      sp->translateLocal(vector);
-    }
-  }  // translateLocal
-
-  void rotate(const Magnum::Rad angleInRad,
-              const Magnum::Vector3& normalizedAxis) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotate(angleInRad, normalizedAxis);
-    }
-  }  // rotate
-
-  void rotateLocal(const Magnum::Rad angleInRad,
-                   const Magnum::Vector3& normalizedAxis) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateLocal(angleInRad, normalizedAxis);
-    }
-  }  // rotateLocal
-
-  void rotateX(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateX(angleInRad);
-    }
-  }  // rotateX
-
-  void rotateY(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateY(angleInRad);
-    }
-  }  // rotateY
-
-  void rotateZ(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateZ(angleInRad);
-    }
-  }  // rotateZ
-
-  void rotateXLocal(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateXLocal(angleInRad);
-    }
-  }  // rotateXLocal
-
-  void rotateYLocal(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateYLocal(angleInRad);
-    }
-  }  // rotateYLocal
-
-  void rotateZLocal(const Magnum::Rad angleInRad) {
-    if (auto sp = this->getObjectReference()) {
-      sp->rotateZLocal(angleInRad);
-    }
-  }  // rotateZLocal
 
   // ==== Getter/Setter functions ===
 
@@ -285,12 +145,6 @@ class AbstractManagedRigidBase
     }
   }  // setInertiaVector
 
-  void setLightSetup(const std::string& lightSetupKey) {
-    if (auto sp = this->getObjectReference()) {
-      sp->setLightSetup(lightSetupKey);
-    }
-  }  // setLightSetup
-
   double getLinearDamping() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getLinearDamping();
@@ -376,22 +230,6 @@ class AbstractManagedRigidBase
       return std::vector<scene::SceneNode*>();
     }
   }  // getVisualSceneNodes
-
-  scene::SceneNode* getSceneNode() {
-    if (auto sp = this->getObjectReference()) {
-      return &const_cast<scene::SceneNode&>(sp->getSceneNode());
-    } else {
-      return nullptr;
-    }
-  }  // getSceneNode
-
-  esp::core::Configuration::ptr userAttributes() {
-    if (auto sp = this->getObjectReference()) {
-      return sp->attributes_;
-    } else {
-      return nullptr;
-    }
-  }
 
  public:
   ESP_SMART_POINTERS(AbstractManagedRigidBase<T>)


### PR DESCRIPTION
## Motivation and Context
This PR makes kinematic node-based transformations available to all PhysicsBaseObjects, promoting the functionality from RigidBase.  This is in preparation for the coming Articulated Object merger, where it was decided that kinematic transformation-based functions should be made available to AO's, operating on their root node.  For standard rigid objects, this change should be transparent.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
