### PR TITLE
Don't enable pedantic warnings for 3rd party dependencies

### DIFF
--- a/src/deps/tinyxml2/CMakeLists.txt
+++ b/src/deps/tinyxml2/CMakeLists.txt
@@ -2,5 +2,3 @@ add_library(tinyxml2 STATIC
   tinyxml2.h
   tinyxml2.cpp
 )
-
-set_directory_properties(PROPERTIES CORRADE_USE_PEDANTIC_FLAGS ON)


### PR DESCRIPTION
## Motivation and Context

Removes a line added in #1137. This one in particular causes many `-Wzero-as-null-pointer-constant`
warnings and as we can't really have control over what's in 3rd party code, we shouldn't be forcing our own warning flags on it. The build was pretty much warning-clear before, which is a good thing, so let's try to keep it that way.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

The build has less spammy output now.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
