### PR TITLE
Fix some documentation warnings and issues

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -94,41 +94,80 @@ void declareBasePhysicsObjectWrapper(py::module& m,
       .def(
           "translate", &PhysObjWrapper::translate, "vector"_a,
           ("Move this " + objType + " using passed translation vector").c_str())
-      .def("rotate", &PhysObjWrapper::rotate, "angle_in_rad"_a, "norm_axis"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around passed 3-element normalized "
-            "norm_axis.")
-               .c_str())
-      .def("rotate_local", &PhysObjWrapper::rotateLocal, "angle_in_rad"_a,
-           "norm_axis"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around passed 3-element normalized "
-            "norm_axis in the local frame.")
-               .c_str())
-      .def("rotate_x", &PhysObjWrapper::rotateX, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the x-axis in global frame.")
-               .c_str())
-      .def("rotate_x_local", &PhysObjWrapper::rotateXLocal, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the x-axis in local frame.")
-               .c_str())
-      .def("rotate_y", &PhysObjWrapper::rotateY, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the y-axis in global frame.")
-               .c_str())
-      .def("rotate_y_local", &PhysObjWrapper::rotateYLocal, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the y-axis in local frame.")
-               .c_str())
-      .def("rotate_z", &PhysObjWrapper::rotateZ, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the z-axis in global frame.")
-               .c_str())
-      .def("rotate_z_local", &PhysObjWrapper::rotateZLocal, "angle_in_rad"_a,
-           ("Rotate this " + objType +
-            " by passed angle_in_rad around the z-axis in local frame.")
-               .c_str())
+      .def(
+          "rotate",
+          [](PhysObjWrapper& self, Mn::Radd angle, Mn::Vector3& normAxis) {
+            self.rotate(Mn::Rad(angle), normAxis);
+          },
+          "angle_in_rad"_a, "norm_axis"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around passed 3-element normalized "
+           "norm_axis.")
+              .c_str())
+      .def(
+          "rotate_local",
+          [](PhysObjWrapper& self, Mn::Radd angle, Mn::Vector3& normAxis) {
+            self.rotateLocal(Mn::Rad(angle), normAxis);
+          },
+          "angle_in_rad"_a, "norm_axis"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around passed 3-element normalized "
+           "norm_axis in the local frame.")
+              .c_str())
+      .def(
+          "rotate_x",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateX(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the x-axis in global frame.")
+              .c_str())
+      .def(
+          "rotate_x_local",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateXLocal(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the x-axis in local frame.")
+              .c_str())
+      .def(
+          "rotate_y",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateY(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the y-axis in global frame.")
+              .c_str())
+      .def(
+          "rotate_y_local",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateYLocal(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the y-axis in local frame.")
+              .c_str())
+      .def(
+          "rotate_z",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateZ(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the z-axis in global frame.")
+              .c_str())
+      .def(
+          "rotate_z_local",
+          [](PhysObjWrapper& self, Mn::Radd angle) {
+            self.rotateZLocal(Mn::Rad(angle));
+          },
+          "angle_in_rad"_a,
+          ("Rotate this " + objType +
+           " by passed angle_in_rad around the z-axis in local frame.")
+              .c_str())
 
       ;
 }  // declareBasePhysicsObjectWrapper

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -102,17 +102,17 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   // TODO(msb) sim and sensor should not cross-depend
   esp::initEspBindings(m);
   esp::core::initCoreBindings(m);
-  esp::metadata::initAttributesBindings(m);
-  esp::metadata::initMetadataMediatorBindings(m);
-  esp::metadata::managers::initAttributesManagersBindings(m);
   esp::geo::initGeoBindings(m);
-  esp::physics::initPhysicsBindings(m);
-  esp::physics::initPhysicsObjectBindings(m);
-  esp::physics::initPhysicsWrapperManagerBindings(m);
   esp::scene::initSceneBindings(m);
   esp::gfx::initGfxBindings(m);
   esp::gfx::replay::initGfxReplayBindings(m);
   esp::sensor::initSensorBindings(m);
   esp::nav::initShortestPathBindings(m);
+  esp::metadata::initAttributesBindings(m);
+  esp::metadata::initMetadataMediatorBindings(m);
+  esp::metadata::managers::initAttributesManagersBindings(m);
+  esp::physics::initPhysicsBindings(m);
+  esp::physics::initPhysicsObjectBindings(m);
+  esp::physics::initPhysicsWrapperManagerBindings(m);
   esp::sim::initSimBindings(m);
 }

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -111,6 +111,7 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
   esp::metadata::initAttributesBindings(m);
   esp::metadata::initMetadataMediatorBindings(m);
   esp::metadata::managers::initAttributesManagersBindings(m);
+  // These depend on SceneNode bindings
   esp::physics::initPhysicsBindings(m);
   esp::physics::initPhysicsObjectBindings(m);
   esp::physics::initPhysicsWrapperManagerBindings(m);

--- a/src/esp/core/managedContainers/AbstractManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractManagedObject.h
@@ -34,12 +34,22 @@ class AbstractManagedObject {
    * @param handle the handle to set.
    */
   virtual void setHandle(const std::string& handle) = 0;
+
+  /**
+   * @brief Retrieve this object's unique handle
+   * @return The handle of the object
+   */
   virtual std::string getHandle() const = 0;
 
   /**
-   *  @brief Unique ID referencing ManagedObject
+   * @brief Set the unique ID referencing ManagedObject
+   * @param ID the ID for this object.
    */
   virtual void setID(int ID) = 0;
+  /**
+   * @brief Retrieve this object's unique ID.
+   * @return Unique ID for this object.
+   */
   virtual int getID() const = 0;
 
  protected:

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -51,8 +51,16 @@ class ManagedContainer : public ManagedContainerBase {
                 "ManagedContainer :: Managed object type must be derived from "
                 "AbstractManagedObject");
 
+  /**
+   * @brief Alias for shared pointer to the @ref
+   * esp::core::AbstractManagedObject this container manages.
+   */
   typedef std::shared_ptr<T> ManagedPtr;
 
+  /**
+   * @brief Constructor
+   * @param metadataType The name of the managed object type.
+   */
   explicit ManagedContainer(const std::string& metadataType)
       : ManagedContainerBase(metadataType) {}
 
@@ -221,7 +229,7 @@ class ManagedContainer : public ManagedContainerBase {
   }
 
   /**
-   * @brief  Remove the managed object referenced by the passed string handle.
+   * @brief Remove the managed object referenced by the passed string handle.
    * Will emplace managed object ID within deque of usable IDs and return the
    * managed object being removed.
    * @param objectHandle the string key of the managed object desired.
@@ -282,7 +290,7 @@ class ManagedContainer : public ManagedContainerBase {
 
   /**
    * @brief Get a reference to, or a copy of, the managed object identified by
-   * the @p managedObjectID, depending on @ref Access value.  This is the
+   * the @p managedObjectID, depending on @p Access value.  This is the
    * function that should be be accessed by the user for general object
    * consumption by ID.
    *
@@ -298,7 +306,7 @@ class ManagedContainer : public ManagedContainerBase {
 
   /**
    * @brief Get a reference to, or a copy of, the managed object identified by
-   * the @p objectHandle, depending on @ref Access value.  This is the function
+   * the @p objectHandle, depending on @p Access value.  This is the function
    * that should be be accessed by the user for general object consumption by
    * Handle.
    *
@@ -316,7 +324,7 @@ class ManagedContainer : public ManagedContainerBase {
 
   /**
    * @brief Get a reference to, or a copy of, the managed object identified by
-   * the @p managedObjectID, depending on @ref Access value, and casted to the
+   * the @p managedObjectID, depending on @p Access value, and casted to the
    * appropriate derived managed object class. This is the version that should
    * be accessed by the user for type-casted object consumption by ID.
    *
@@ -333,7 +341,7 @@ class ManagedContainer : public ManagedContainerBase {
 
   /**
    * @brief Get a reference to, or a copy of, the managed object identified by
-   * the @p managedObjectID, depending on @ref Access value, and casted to the
+   * the @p managedObjectID, depending on @p Access value, and casted to the
    * appropriate derived managed object class. This is the version that should
    * be accessed by the user for type-casted object consumption by
    * Handle.
@@ -544,7 +552,7 @@ class ManagedContainer : public ManagedContainerBase {
   }  // ManagedContainer::
 
   /**
-   * @brief This function will build the appropriate @ref copyConstructorMap_
+   * @brief This function will build the appropriate @p copyConstructorMap_
    * copy constructor function pointer map for this container's managed object,
    * keyed on the managed object's class type.  This MUST be called in the
    * constructor of the -instancing- class.
@@ -563,7 +571,7 @@ class ManagedContainer : public ManagedContainerBase {
   }  // ManagedContainer::copyObject
 
   /**
-   * @brief Create a new object as a copy of @ref defaultObject_  if it exists,
+   * @brief Create a new object as a copy of @p defaultObject_  if it exists,
    * otherwise return nullptr.
    * @param newHandle the name for the copy of the default.
    * @return New object or nullptr

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -106,28 +106,20 @@ class RenderCamera : public MagnumCamera {
 
   /**
    * @brief Get the scene node being attached to.
-   * @return the current scene node
    */
   scene::SceneNode& node() { return object(); }
 
   /**
    * @brief Get a const ref to the scene node being attached to.
-   * @return the current scene node
    */
   const scene::SceneNode& node() const { return object(); }
 
-  /**
-   * @brief Overloads to avoid confusion
-   * @return ref to current scene node
-   */
+  /** @overload */
   scene::SceneNode& object() {
     return static_cast<scene::SceneNode&>(MagnumCamera::object());
   }
 
-  /**
-   * @brief Overloads to avoid confusion
-   * @return ref to current scene node
-   */
+  /** @overload */
   const scene::SceneNode& object() const {
     return static_cast<const scene::SceneNode&>(MagnumCamera::object());
   }
@@ -179,7 +171,7 @@ class RenderCamera : public MagnumCamera {
 
   /**
    * @brief Overload function to render the drawables
-   * @param drawables, a drawable group containing all the drawables
+   * @param drawables a drawable group containing all the drawables
    * @param flags state flags to direct drawing
    * @return the number of drawables that are drawn
    */
@@ -187,7 +179,7 @@ class RenderCamera : public MagnumCamera {
 
   /**
    * @brief performs the frustum culling
-   * @param drawableTransforms, a vector of pairs of Drawable3D object and its
+   * @param drawableTransforms a vector of pairs of Drawable3D object and its
    * absolute transformation
    * @return the number of drawables that are not culled
    *
@@ -202,7 +194,7 @@ class RenderCamera : public MagnumCamera {
   /**
    * @brief Cull Drawables for SceneNodes which are not OBJECT type.
    *
-   * @param drawableTransforms, a vector of pairs of Drawable3D object and its
+   * @param drawableTransforms a vector of pairs of Drawable3D object and its
    * absolute transformation
    * @return the number of drawables that are not culled
    */

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -104,14 +104,30 @@ class RenderCamera : public MagnumCamera {
    */
   ~RenderCamera() override = default;
 
-  // Get the scene node being attached to.
+  /**
+   * @brief Get the scene node being attached to.
+   * @return the current scene node
+   */
   scene::SceneNode& node() { return object(); }
+
+  /**
+   * @brief Get a const ref to the scene node being attached to.
+   * @return the current scene node
+   */
   const scene::SceneNode& node() const { return object(); }
 
-  // Overloads to avoid confusion
+  /**
+   * @brief Overloads to avoid confusion
+   * @return ref to current scene node
+   */
   scene::SceneNode& object() {
     return static_cast<scene::SceneNode&>(MagnumCamera::object());
   }
+
+  /**
+   * @brief Overloads to avoid confusion
+   * @return ref to current scene node
+   */
   const scene::SceneNode& object() const {
     return static_cast<const scene::SceneNode&>(MagnumCamera::object());
   }
@@ -120,6 +136,7 @@ class RenderCamera : public MagnumCamera {
    * @brief Set precalculated projection matrix for this RenderCamera
    * @param width The width of the viewport
    * @param height The height of the viewport
+   * @param projMat The projection matrix to use.
    * @return A reference to this RenderCamera
    */
   RenderCamera& setProjectionMatrix(int width,
@@ -130,6 +147,15 @@ class RenderCamera : public MagnumCamera {
     return *this;
   }
 
+  /**
+   * @brief Set precalculated projection matrix for this RenderCamera
+   * @param width The width of the viewport
+   * @param height The height of the viewport
+   * @param znear The location of the near clipping plane
+   * @param zfar The location of the far clipping plane
+   * @param projMat The projection matrix to use.
+   * @return A reference to this RenderCamera
+   */
   RenderCamera& setProjectionMatrix(int width,
                                     int height,
                                     float znear,
@@ -154,7 +180,7 @@ class RenderCamera : public MagnumCamera {
   /**
    * @brief Overload function to render the drawables
    * @param drawables, a drawable group containing all the drawables
-   * @param frustumCulling, whether do frustum culling or not, default: false
+   * @param flags state flags to direct drawing
    * @return the number of drawables that are drawn
    */
   uint32_t draw(MagnumDrawableGroup& drawables, Flags flags = {});

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -100,9 +100,9 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
     /**
      * The default implemenation of kineamtics through the base @ref
-     * PhysicsManager class. Supports @ref MotionType::STATIC and @ref
-     * MotionType::KINEMATIC objects of base class @ref RigidObject. If the
-     * derived @ref PhysicsManager class for a desired @ref
+     * PhysicsManager class. Supports @ref esp::physics::MotionType::STATIC and
+     * @ref esp::physics::MotionType::KINEMATIC objects of base class @ref
+     * RigidObject. If the derived @ref PhysicsManager class for a desired @ref
      * PhysicsSimulationLibrary fails to initialize, it will default to @ref
      * PhysicsSimulationLibrary::NONE.
      */
@@ -110,9 +110,11 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
     /**
      * An implemenation of dynamics through the Bullet Physics library.
-     * Supports @ref MotionType::STATIC, @ref MotionType::KINEMATIC, and @ref
-     * MotionType::DYNAMIC objects of @ref RigidObject derived class @ref
-     * BulletRigidObject. Suggests the use of @ref PhysicsManager derived class
+     * Supports @ref esp::physics::MotionType::STATIC, @ref
+     * esp::physics::MotionType::KINEMATIC, and @ref
+     * esp::physics::MotionType::DYNAMIC objects of @ref RigidObject derived
+     * class @ref BulletRigidObject. Suggests the use of @ref PhysicsManager
+     * derived class
      * @ref BulletPhysicsManager
      */
     BULLET
@@ -420,8 +422,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   // ============ Object Transformation functions =============
 
   /** @brief Set the 4x4 transformation matrix of an object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param trans The desired 4x4 transform of the object.
@@ -429,8 +431,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   void setTransformation(const int physObjectID, const Magnum::Matrix4& trans);
 
   /** @brief Set the @ref esp::core::RigidState of an object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param trans The desired @ref esp::core::RigidState of the object.
@@ -439,8 +441,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
                      const esp::core::RigidState& rigidState);
 
   /** @brief Set the 3D position of an object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param vector The desired 3D position of the object.
@@ -448,8 +450,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   void setTranslation(const int physObjectID, const Magnum::Vector3& vector);
 
   /** @brief Set the orientation of an object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param quaternion The desired orientation of the object.
@@ -465,8 +467,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   void resetTransformation(const int physObjectID);
 
   /** @brief Modify the 3D position of an object kinematically by translation.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param vector The desired 3D vector by which to translate the object.
@@ -475,7 +477,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the 3D position of an object kinematically by translation
    * with a vector defined in the object's local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param vector The desired 3D vector in the object's ocal coordiante system
@@ -497,7 +500,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying an
    * axis-angle rotation to it in the local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -510,7 +514,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the global X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -519,7 +523,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the global Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -528,7 +532,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the global Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -537,7 +541,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the local X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -546,7 +550,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the local Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -555,7 +559,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Modify the orientation of an object kinematically by applying a
    * rotation to it about the local Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angleInRad The angle of rotation in radians.
@@ -850,10 +854,11 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
                           const Magnum::Vector3& impulse);
 
   /**
-   * @brief Set linear velocity for an object with @ref MotionType::DYNAMIC.
+   * @brief Set linear velocity for an object with @ref
+   * esp::physics::MotionType::DYNAMIC.
    *
-   * Does nothing for @ref MotionType::KINEMATIC or @ref MotionType::STATIC
-   * objects.
+   * Does nothing for @ref esp::physics::MotionType::KINEMATIC or @ref
+   * esp::physics::MotionType::STATIC objects.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param linVel Linear velocity to set.
@@ -861,10 +866,11 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   void setLinearVelocity(const int physObjectID, const Magnum::Vector3& linVel);
 
   /**
-   * @brief Set angular velocity for an object with @ref MotionType::DYNAMIC.
+   * @brief Set angular velocity for an object with @ref
+   * esp::physics::MotionType::DYNAMIC.
    *
-   * Does nothing for @ref MotionType::KINEMATIC or @ref MotionType::STATIC
-   * objects.
+   * Does nothing for @ref esp::physics::MotionType::KINEMATIC or @ref
+   * esp::physics::MotionType::STATIC objects.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param angVel Angular velocity vector corresponding to world unit axis
@@ -874,10 +880,11 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
                           const Magnum::Vector3& angVel);
 
   /**
-   * @brief Get linear velocity of an object with @ref MotionType::DYNAMIC.
+   * @brief Get linear velocity of an object with @ref
+   * esp::physics::MotionType::DYNAMIC.
    *
-   * Always zero for @ref MotionType::KINEMATIC or @ref MotionType::STATIC
-   * objects.
+   * Always zero for @ref esp::physics::MotionType::KINEMATIC or @ref
+   * esp::physics::MotionType::STATIC objects.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @return Linear velocity of the object.
@@ -885,10 +892,11 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   Magnum::Vector3 getLinearVelocity(const int physObjectID) const;
 
   /**
-   * @brief Get angular velocity of an object with @ref MotionType::DYNAMIC.
+   * @brief Get angular velocity of an object with @ref
+   * esp::physics::MotionType::DYNAMIC.
    *
-   * Always zero for @ref MotionType::KINEMATIC or @ref MotionType::STATIC
-   * objects.
+   * Always zero for @ref esp::physics::MotionType::KINEMATIC or @ref
+   * esp::physics::MotionType::STATIC objects.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @return Angular velocity vector corresponding to world unit axis angles.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -89,7 +89,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /**
    * @brief Set the @ref MotionType of the object. If the construct is a @ref
-   * esp::physics::RigidScene, it can only be @ref
+   * esp::physics::RigidStage, it can only be @ref
    * esp::physics::MotionType::STATIC. If the object is
    * @ref esp::physics::RigidObject it can also be set to @ref
    * esp::physics::MotionType::KINEMATIC. Only if a dervied @ref

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -81,17 +81,20 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
         Magnum::SceneGraph::AbstractFeature3D::object());
   }
   /**
-   * @brief Get the @ref MotionType of the object. See @ref setMotionType.
+   * @brief Get the @ref esp::physics::MotionType of the object. See @ref
+   * setMotionType.
    * @return The object's current @ref MotionType.
    */
   MotionType getMotionType() const { return objectMotionType_; }
 
   /**
-   * @brief Set the @ref MotionType of the object. If the object is @ref
-   * ObjectType::SCENE it can only be @ref MotionType::STATIC. If the object is
-   * @ref ObjectType::OBJECT is can also be set to @ref MotionType::KINEMATIC.
-   * Only if a dervied @ref PhysicsManager implementing dynamics is in use can
-   * the object be set to @ref MotionType::DYNAMIC.
+   * @brief Set the @ref MotionType of the object. If the construct is a @ref
+   * esp::physics::RigidScene, it can only be @ref
+   * esp::physics::MotionType::STATIC. If the object is
+   * @ref esp::physics::RigidObject it can also be set to @ref
+   * esp::physics::MotionType::KINEMATIC. Only if a dervied @ref
+   * esp::physics::PhysicsManager implementing dynamics is in use can the object
+   * be set to @ref esp::physics::MotionType::DYNAMIC.
    * @param mt The desirved @ref MotionType.
    */
   virtual void setMotionType(MotionType mt) = 0;
@@ -141,8 +144,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   // ==== Transformations ===
 
   /** @brief Set the 4x4 transformation matrix of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param transformation The desired 4x4 transform of the object.
    */
   virtual void setTransformation(const Magnum::Matrix4& transformation) {
@@ -157,8 +160,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   }
 
   /** @brief Set the 3D position of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param vector The desired 3D position of the object.
    */
   virtual void setTranslation(const Magnum::Vector3& vector) {
@@ -173,8 +176,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   }
 
   /** @brief Set the orientation of the object kinematically.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param quaternion The desired orientation of the object.
    */
   virtual void setRotation(const Magnum::Quaternion& quaternion) {
@@ -212,8 +215,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   }
 
   /** @brief Modify the 3D position of the object kinematically by translation.
-   * Calling this during simulation of a @ref MotionType::DYNAMIC object is not
-   * recommended.
+   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * object is not recommended.
    * @param vector The desired 3D vector by which to translate the object.
    */
   virtual void translate(const Magnum::Vector3& vector) {
@@ -225,7 +228,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the 3D position of the object kinematically by translation
    * with a vector defined in the object's local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * recommended.
    * @param vector The desired 3D vector in the object's ocal coordiante system
    * by which to translate the object.
    */
@@ -252,7 +256,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying an
    * axis-angle rotation to it in the local coordinate system. Calling this
-   * during simulation of a @ref MotionType::DYNAMIC object is not recommended.
+   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * recommended.
    * @param angleInRad The angle of rotation in radians.
    * @param normalizedAxis The desired unit vector axis of rotation in the local
    * coordinate system.
@@ -267,7 +272,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateX(const Magnum::Rad angleInRad) {
@@ -279,7 +284,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateY(const Magnum::Rad angleInRad) {
@@ -291,7 +296,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateZ(const Magnum::Rad angleInRad) {
@@ -303,7 +308,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local X axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateXLocal(const Magnum::Rad angleInRad) {
@@ -315,7 +320,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local Y axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateYLocal(const Magnum::Rad angleInRad) {
@@ -327,7 +332,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local Z axis. Calling this during simulation of a
-   * @ref MotionType::DYNAMIC object is not recommended.
+   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateZLocal(const Magnum::Rad angleInRad) {

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -32,6 +32,12 @@ namespace physics {
 
 class RigidBase : public esp::physics::PhysicsObjectBase {
  public:
+  /**
+   * @brief Constructor for a @ref esp::physics::RigidBase.
+   * @param rigidBodyNode Pointer to the node to be used for this rigid.
+   * @param objectID the desired ID for this rigid construct.
+   * @param resMgr a reference to @ref esp::assets::ResourceManager
+   */
   RigidBase(scene::SceneNode* rigidBodyNode,
             int objectId,
             const assets::ResourceManager& resMgr)
@@ -39,13 +45,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
         visualNode_(&rigidBodyNode->createChild()) {}
 
   /**
-   * @brief Virtual destructor for a @ref RigidBase.
+   * @brief Virtual destructor for a @ref esp::physics::RigidBase.
    */
   ~RigidBase() override = default;
 
   /**
-   * @brief Initializes the @ref RigidObject or @ref RigidStage that inherits
-   * from this class.  This is overridden
+   * @brief Initializes the @ref esp::physics::RigidObject or @ref
+   * esp::physics::RigidStage that inherits from this class.  This is overridden
    * @param initAttributes The template structure defining relevant phyiscal
    * parameters for this object
    * @return true if initialized successfully, false otherwise.
@@ -54,24 +60,23 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
       metadata::attributes::AbstractObjectAttributes::ptr initAttributes) = 0;
 
   /**
-   * @brief Finalize the creation of @ref RigidObject or @ref RigidStage that
-   * inherits from this class.
+   * @brief Finalize the creation of @ref esp::physics::RigidObject or @ref
+   * esp::physics::RigidStage that inherits from this class.
    * @return whether successful finalization.
    */
   virtual bool finalizeObject() = 0;
 
  private:
   /**
-   * @brief Finalize the initialization of this @ref RigidBase. This is
-   * overridden by inheriting objects
-   * @param resMgr Reference to resource manager, to access relevant components
-   * pertaining to the object
+   * @brief Finalize the initialization of this @ref esp::physics::RigidBase.
+   * This is overridden by inheriting objects
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initialization_LibSpecific() = 0;
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
-   * after @ref RigidObject or @ref RigidStage is created.
+   * after @ref esp::physics::RigidObject or @ref esp::physics::RigidStage is
+   * created.
    * @return whether successful finalization.
    */
   virtual bool finalizeObject_LibSpecific() = 0;
@@ -136,13 +141,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   //! implemented in physics-engine specific ways
 
   /** @brief Get the scalar angular damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref RigidObject.
+   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @return The scalar angular damping coefficient of the object.
    */
   virtual double getAngularDamping() const { return 0.0; }
 
   /** @brief Set the scalar angular damping coefficient for the object. Only
-   * used for dervied dynamic implementations of @ref RigidObject.
+   * used for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @param angDamping The new scalar angular damping coefficient for the
    * object.
    */
@@ -152,7 +157,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual angular velocity getter for an object.
    *
    * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * MotionType::STATIC objects.
+   * esp::physics::MotionType::::STATIC objects.
    * @return Angular velocity vector corresponding to world unit axis angles.
    */
   virtual Magnum::Vector3 getAngularVelocity() const {
@@ -162,7 +167,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /** @brief Virtual angular velocity setter for an object.
    *
    * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * MotionType::STATIC objects.
+   * esp::physics::MotionType::::STATIC objects.
    * @param angVel Angular velocity vector corresponding to world unit axis
    * angles.
    */
@@ -184,13 +189,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   virtual void setCOM(CORRADE_UNUSED const Magnum::Vector3& COM) {}
 
   /** @brief Get the scalar friction coefficient of the object. Only used for
-   * dervied dynamic implementations of @ref RigidObject.
+   * dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @return The scalar friction coefficient of the object.
    */
   virtual double getFrictionCoefficient() const { return 0.0; }
 
   /** @brief Set the scalar friction coefficient of the object. Only used for
-   * dervied dynamic implementations of @ref RigidObject.
+   * dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @param frictionCoefficient The new scalar friction coefficient of the
    * object.
    */
@@ -240,13 +245,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 
   /** @brief Get the scalar linear damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref RigidObject.
+   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @return The scalar linear damping coefficient of the object.
    */
   virtual double getLinearDamping() const { return 0.0; }
 
   /** @brief Set the scalar linear damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref RigidObject.
+   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @param linDamping The new scalar linear damping coefficient of the object.
    */
   virtual void setLinearDamping(CORRADE_UNUSED const double linDamping) {}
@@ -255,7 +260,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual linear velocity getter for an object.
    *
    * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * MotionType::STATIC objects.
+   * esp::physics::MotionType::::STATIC objects.
    * @return Linear velocity of the object.
    */
   virtual Magnum::Vector3 getLinearVelocity() const {
@@ -266,32 +271,32 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual linear velocity setter for an object.
    *
    * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * MotionType::STATIC objects.
+   * esp::physics::MotionType::::STATIC objects.
    * @param linVel Linear velocity to set.
    */
   virtual void setLinearVelocity(CORRADE_UNUSED const Magnum::Vector3& linVel) {
   }
 
   /** @brief Get the mass of the object. Only used for dervied dynamic
-   * implementations of @ref RigidObject.
+   * implementations of @ref esp::physics::RigidObject.
    * @return The mass of the object.
    */
   virtual double getMass() const { return 0.0; }
 
   /** @brief Set the mass of the object. Only used for dervied dynamic
-   * implementations of @ref RigidObject.
+   * implementations of @ref esp::physics::RigidObject.
    * @param mass The new mass of the object.
    */
   virtual void setMass(CORRADE_UNUSED const double mass) {}
 
   /** @brief Get the scalar coefficient of restitution  of the object. Only used
-   * for dervied dynamic implementations of @ref RigidObject.
+   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @return The scalar coefficient of restitution  of the object.
    */
   virtual double getRestitutionCoefficient() const { return 0.0; }
 
   /** @brief Set the scalar coefficient of restitution of the object. Only used
-   * for dervied dynamic implementations of @ref RigidObject.
+   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
    * @param restitutionCoefficient The new scalar coefficient of restitution of
    * the object.
    */

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -30,6 +30,11 @@ class AbstractObjectAttributes;
 
 namespace physics {
 
+/**
+ * @brief This class specifies the functionality expected of rigid objects and
+ * stages, particularly with regard to dynamic simulation, if such a library,
+ * such as bullet, is available.
+ */
 class RigidBase : public esp::physics::PhysicsObjectBase {
  public:
   /**

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -86,8 +86,8 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
 
   /**
    * @brief Apply a force to an object through a dervied dynamics
-   * implementation. Does nothing for @ref MotionType::STATIC and @ref
-   * MotionType::KINEMATIC objects.
+   * implementation. Does nothing for @ref esp::physics::MotionType::STATIC and
+   * @ref esp::physics::MotionType::KINEMATIC objects.
    * @param force The desired force on the object in the global coordinate
    * system.
    * @param relPos The desired location of force application in the global
@@ -99,8 +99,9 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Apply an impulse to an object through a dervied dynamics
    * implementation. Directly modifies the object's velocity without requiring
-   * integration through simulation. Does nothing for @ref MotionType::STATIC
-   * and @ref MotionType::KINEMATIC objects.
+   * integration through simulation. Does nothing for @ref
+   * esp::physics::MotionType::STATIC and @ref
+   * esp::physics::MotionType::KINEMATIC objects.
    * @param impulse The desired impulse on the object in the global coordinate
    * system.
    * @param relPos The desired location of impulse application in the global
@@ -111,16 +112,17 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
 
   /**
    * @brief Apply an internal torque to an object through a dervied dynamics
-   * implementation. Does nothing for @ref MotionType::STATIC and @ref
-   * MotionType::KINEMATIC objects.
+   * implementation. Does nothing for @ref esp::physics::MotionType::STATIC and
+   * @ref esp::physics::MotionType::KINEMATIC objects.
    * @param torque The desired torque on the object in the local coordinate
    * system.
    */
   virtual void applyTorque(CORRADE_UNUSED const Magnum::Vector3& torque) {}
   /**
    * @brief Apply an internal impulse torque to an object through a dervied
-   * dynamics implementation. Does nothing for @ref MotionType::STATIC and @ref
-   * MotionType::KINEMATIC objects.
+   * dynamics implementation. Does nothing for @ref
+   * esp::physics::MotionType::STATIC and @ref
+   * esp::physics::MotionType::KINEMATIC objects.
    * @param impulse The desired impulse torque on the object in the local
    * coordinate system. Directly modifies the object's angular velocity without
    * requiring integration through simulation.
@@ -149,7 +151,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Virtual angular velocity getter for an object.
    *
-   * Returns zero for default @ref MotionType::KINEMATIC or @ref
+   * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
    * MotionType::STATIC objects.
    * @return Angular velocity vector corresponding to world unit axis angles.
    */
@@ -159,7 +161,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
 
   /** @brief Virtual angular velocity setter for an object.
    *
-   * Does nothing for default @ref MotionType::KINEMATIC or @ref
+   * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
    * MotionType::STATIC objects.
    * @param angVel Angular velocity vector corresponding to world unit axis
    * angles.
@@ -169,7 +171,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
 
   /** @brief Get the center of mass (COM) of the object.
    * @return Object 3D center of mass in the global coordinate system.
-   * @todo necessary for @ref MotionType::KINEMATIC?
+   * @todo necessary for @ref esp::physics::MotionType::KINEMATIC?
    */
   virtual Magnum::Vector3 getCOM() const {
     const Magnum::Vector3 com = Magnum::Vector3();
@@ -177,7 +179,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
   /** @brief Set the center of mass (COM) of the object.
    * @param COM Object 3D center of mass in the local coordinate system.
-   * @todo necessary for @ref MotionType::KINEMATIC?
+   * @todo necessary for @ref esp::physics::MotionType::KINEMATIC?
    */
   virtual void setCOM(CORRADE_UNUSED const Magnum::Vector3& COM) {}
 
@@ -252,7 +254,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Virtual linear velocity getter for an object.
    *
-   * Returns zero for default @ref MotionType::KINEMATIC or @ref
+   * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
    * MotionType::STATIC objects.
    * @return Linear velocity of the object.
    */
@@ -263,7 +265,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Virtual linear velocity setter for an object.
    *
-   * Does nothing for default @ref MotionType::KINEMATIC or @ref
+   * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
    * MotionType::STATIC objects.
    * @param linVel Linear velocity to set.
    */

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -15,7 +15,7 @@
 #include "esp/physics/PhysicsObjectBase.h"
 
 /** @file
- * @brief Class @ref esp::physics::Rigidbase
+ * @brief Class @ref Rigidbase
  */
 
 namespace esp {
@@ -33,7 +33,7 @@ namespace physics {
 class RigidBase : public esp::physics::PhysicsObjectBase {
  public:
   /**
-   * @brief Constructor for a @ref esp::physics::RigidBase.
+   * @brief Constructor for a @ref RigidBase.
    * @param rigidBodyNode Pointer to the node to be used for this rigid.
    * @param objectID the desired ID for this rigid construct.
    * @param resMgr a reference to @ref esp::assets::ResourceManager
@@ -45,12 +45,12 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
         visualNode_(&rigidBodyNode->createChild()) {}
 
   /**
-   * @brief Virtual destructor for a @ref esp::physics::RigidBase.
+   * @brief Virtual destructor for a @ref RigidBase.
    */
   ~RigidBase() override = default;
 
   /**
-   * @brief Initializes the @ref esp::physics::RigidObject or @ref
+   * @brief Initializes the @ref RigidObject or @ref
    * esp::physics::RigidStage that inherits from this class.  This is overridden
    * @param initAttributes The template structure defining relevant phyiscal
    * parameters for this object
@@ -60,7 +60,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
       metadata::attributes::AbstractObjectAttributes::ptr initAttributes) = 0;
 
   /**
-   * @brief Finalize the creation of @ref esp::physics::RigidObject or @ref
+   * @brief Finalize the creation of @ref RigidObject or @ref
    * esp::physics::RigidStage that inherits from this class.
    * @return whether successful finalization.
    */
@@ -68,14 +68,14 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
 
  private:
   /**
-   * @brief Finalize the initialization of this @ref esp::physics::RigidBase.
+   * @brief Finalize the initialization of this @ref RigidBase.
    * This is overridden by inheriting objects
    * @return true if initialized successfully, false otherwise.
    */
   virtual bool initialization_LibSpecific() = 0;
   /**
    * @brief any physics-lib-specific finalization code that needs to be run
-   * after @ref esp::physics::RigidObject or @ref esp::physics::RigidStage is
+   * after @ref RigidObject or @ref RigidStage is
    * created.
    * @return whether successful finalization.
    */
@@ -141,13 +141,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   //! implemented in physics-engine specific ways
 
   /** @brief Get the scalar angular damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * for dervied dynamic implementations of @ref RigidObject.
    * @return The scalar angular damping coefficient of the object.
    */
   virtual double getAngularDamping() const { return 0.0; }
 
   /** @brief Set the scalar angular damping coefficient for the object. Only
-   * used for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * used for dervied dynamic implementations of @ref RigidObject.
    * @param angDamping The new scalar angular damping coefficient for the
    * object.
    */
@@ -157,7 +157,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual angular velocity getter for an object.
    *
    * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * esp::physics::MotionType::::STATIC objects.
+   * esp::physics::MotionType::STATIC objects.
    * @return Angular velocity vector corresponding to world unit axis angles.
    */
   virtual Magnum::Vector3 getAngularVelocity() const {
@@ -167,7 +167,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /** @brief Virtual angular velocity setter for an object.
    *
    * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * esp::physics::MotionType::::STATIC objects.
+   * esp::physics::MotionType::STATIC objects.
    * @param angVel Angular velocity vector corresponding to world unit axis
    * angles.
    */
@@ -189,13 +189,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   virtual void setCOM(CORRADE_UNUSED const Magnum::Vector3& COM) {}
 
   /** @brief Get the scalar friction coefficient of the object. Only used for
-   * dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * dervied dynamic implementations of @ref RigidObject.
    * @return The scalar friction coefficient of the object.
    */
   virtual double getFrictionCoefficient() const { return 0.0; }
 
   /** @brief Set the scalar friction coefficient of the object. Only used for
-   * dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * dervied dynamic implementations of @ref RigidObject.
    * @param frictionCoefficient The new scalar friction coefficient of the
    * object.
    */
@@ -245,13 +245,13 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 
   /** @brief Get the scalar linear damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * for dervied dynamic implementations of @ref RigidObject.
    * @return The scalar linear damping coefficient of the object.
    */
   virtual double getLinearDamping() const { return 0.0; }
 
   /** @brief Set the scalar linear damping coefficient of the object. Only used
-   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * for dervied dynamic implementations of @ref RigidObject.
    * @param linDamping The new scalar linear damping coefficient of the object.
    */
   virtual void setLinearDamping(CORRADE_UNUSED const double linDamping) {}
@@ -260,7 +260,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual linear velocity getter for an object.
    *
    * Returns zero for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * esp::physics::MotionType::::STATIC objects.
+   * esp::physics::MotionType::STATIC objects.
    * @return Linear velocity of the object.
    */
   virtual Magnum::Vector3 getLinearVelocity() const {
@@ -271,32 +271,32 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @brief Virtual linear velocity setter for an object.
    *
    * Does nothing for default @ref esp::physics::MotionType::KINEMATIC or @ref
-   * esp::physics::MotionType::::STATIC objects.
+   * esp::physics::MotionType::STATIC objects.
    * @param linVel Linear velocity to set.
    */
   virtual void setLinearVelocity(CORRADE_UNUSED const Magnum::Vector3& linVel) {
   }
 
   /** @brief Get the mass of the object. Only used for dervied dynamic
-   * implementations of @ref esp::physics::RigidObject.
+   * implementations of @ref RigidObject.
    * @return The mass of the object.
    */
   virtual double getMass() const { return 0.0; }
 
   /** @brief Set the mass of the object. Only used for dervied dynamic
-   * implementations of @ref esp::physics::RigidObject.
+   * implementations of @ref RigidObject.
    * @param mass The new mass of the object.
    */
   virtual void setMass(CORRADE_UNUSED const double mass) {}
 
   /** @brief Get the scalar coefficient of restitution  of the object. Only used
-   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * for dervied dynamic implementations of @ref RigidObject.
    * @return The scalar coefficient of restitution  of the object.
    */
   virtual double getRestitutionCoefficient() const { return 0.0; }
 
   /** @brief Set the scalar coefficient of restitution of the object. Only used
-   * for dervied dynamic implementations of @ref esp::physics::RigidObject.
+   * for dervied dynamic implementations of @ref RigidObject.
    * @param restitutionCoefficient The new scalar coefficient of restitution of
    * the object.
    */

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -115,8 +115,7 @@ class RigidObject : public RigidBase {
                       initAttributes) override;
 
   /**
-   * @brief Finalize the creation of @ref esp::physics::RigidObject or @ref
-   * esp::physics::RigidScene that inherits from this class.
+   * @brief Finalize the creation of the RigidObject.
    * @return whether successful finalization.
    */
   bool finalizeObject() override;

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -80,7 +80,7 @@ struct VelocityControl {
 };
 
 /**
- * @brief An AbstractFeature3D representing an individual rigid object instance
+ * @brief A @ref RigidBase representing an individual rigid object instance
  * attached to a SceneNode, updating its state through simulation. This may be a
  * @ref esp::physics::MotionType::STATIC scene collision geometry or an object
  * of any @ref MotionType which can interact with other members of a physical

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -67,7 +67,7 @@ struct VelocityControl {
    *
    * Default implementation uses explicit Euler integration.
    * @param dt The discrete timestep over which to integrate.
-   * @param objectRotationTranslation The initial state of the object before
+   * @param rigidState The initial state of the object before
    * applying velocity control.
    * @return The new state of the object after applying velocity control over
    * dt.
@@ -91,7 +91,7 @@ struct VelocityControl {
 class RigidObject : public RigidBase {
  public:
   /**
-   * @brief Constructor for a @ref RigidObject.
+   * @brief Constructor for a @ref esp::physics::RigidObject.
    * @param rigidBodyNode The @ref scene::SceneNode this feature will be
    * attached to.
    */
@@ -100,12 +100,13 @@ class RigidObject : public RigidBase {
               const assets::ResourceManager& resMgr);
 
   /**
-   * @brief Virtual destructor for a @ref RigidObject.
+   * @brief Virtual destructor for a @ref esp::physics::RigidObject.
    */
   ~RigidObject() override = default;
 
   /**
-   * @brief Initializes the @ref RigidObject that inherits from this class
+   * @brief Initializes the @ref esp::physics::RigidObject that inherits from
+   * this class
    * @param initAttributes The template structure defining relevant
    * phyiscal parameters for this object
    * @return true if initialized successfully, false otherwise.
@@ -114,8 +115,8 @@ class RigidObject : public RigidBase {
                       initAttributes) override;
 
   /**
-   * @brief Finalize the creation of @ref RigidObject or @ref RigidScene that
-   * inherits from this class.
+   * @brief Finalize the creation of @ref esp::physics::RigidObject or @ref
+   * esp::physics::RigidScene that inherits from this class.
    * @return whether successful finalization.
    */
   bool finalizeObject() override;
@@ -134,12 +135,10 @@ class RigidObject : public RigidBase {
 
  private:
   /**
-   * @brief Finalize the initialization of this @ref RigidScene
+   * @brief Finalize the initialization of this @ref esp::physics::RigidObject's
    * geometry. This is overridden by inheriting class specific to certain
    * physics libraries. Necessary to support kinematic objects without any
    * dynamics support.
-   * @param resMgr Reference to resource manager, to access relevant
-   * components pertaining to the scene object
    * @return true if initialized successfully, false otherwise.
    */
   bool initialization_LibSpecific() override;

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -82,9 +82,9 @@ struct VelocityControl {
 /**
  * @brief An AbstractFeature3D representing an individual rigid object instance
  * attached to a SceneNode, updating its state through simulation. This may be a
- * @ref MotionType::STATIC scene collision geometry or an object of any @ref
- * MotionType which can interact with other members of a physical world. Must
- * have a collision mesh. By default, a RigidObject is @ref
+ * @ref esp::physics::MotionType::STATIC scene collision geometry or an object
+ * of any @ref MotionType which can interact with other members of a physical
+ * world. Must have a collision mesh. By default, a RigidObject is @ref
  * MotionType::KINEMATIC without an underlying simulator implementation. Derived
  * classes can be used to introduce specific implementations of dynamics.
  */
@@ -156,10 +156,12 @@ class RigidObject : public RigidBase {
  public:
   /**
    * @brief Set the @ref MotionType of the object. If the object is @ref
-   * ObjectType::SCENE it can only be @ref MotionType::STATIC. If the object is
-   * @ref ObjectType::OBJECT is can also be set to @ref MotionType::KINEMATIC.
-   * Only if a dervied @ref PhysicsManager implementing dynamics is in use can
-   * the object be set to @ref MotionType::DYNAMIC.
+   * ObjectType::SCENE it can only be @ref esp::physics::MotionType::STATIC. If
+   * the object is
+   * @ref ObjectType::OBJECT is can also be set to @ref
+   * esp::physics::MotionType::KINEMATIC. Only if a dervied @ref PhysicsManager
+   * implementing dynamics is in use can the object be set to @ref
+   * esp::physics::MotionType::DYNAMIC.
    * @param mt The desirved @ref MotionType.
    * @return true if successfully set, false otherwise.
    */

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -12,6 +12,12 @@
  */
 namespace esp {
 namespace physics {
+
+/**
+ * @brief A @ref RigidBase representing an individual rigid stage instance
+ * attached to a SceneNode. This construction currently may only be
+ * @ref esp::physics::MotionType::STATIC.
+ */
 class RigidStage : public RigidBase {
  public:
   RigidStage(scene::SceneNode* rigidBodyNode,


### PR DESCRIPTION
## Motivation and Context
The new documentation for the object wrappers was incorrectly marking certain functions as static.  This PR addresses this.

Also, there are nearly 4 thousand warnings indicative of missing docstrings, improper references, or other issues with the documentation when the docs are built.  This PR attempts to address some of these, although many thousand issues still remain.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass local. Docs build locally (with thousands of warnings).
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
