### PR TITLE
Scene Instance : Improve Object instancing process

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -92,7 +92,7 @@ int PhysicsManager::addObjectInstance(
           metadata::attributes::ObjectInstanceShaderType::Unknown)) {
     objAttributes->setShaderType(objShaderType);
   }
-  int objID;
+  int objID = 0;
   if (simulator_ != nullptr) {
     auto& drawables = simulator_->getDrawableGroup();
     objID = addObject(objAttributes, &drawables, attachmentNode, lightSetup);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -65,6 +65,59 @@ bool PhysicsManager::addStageFinalize(
   return sceneSuccess;
 }  // PhysicsManager::addStageFinalize
 
+int PhysicsManager::addObjectInstance(
+    const esp::metadata::attributes::SceneObjectInstanceAttributes::ptr&
+        objInstAttributes,
+    const std::string& attributesHandle,
+    bool defaultCOMCorrection,
+    scene::SceneNode* attachmentNode,
+    const std::string& lightSetup) {
+  const std::string errMsgTmplt = "PhysicsManager::addObjectInstance : ";
+  // Get ObjectAttributes
+  auto objAttributes =
+      resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
+          attributesHandle);
+  if (!objAttributes) {
+    LOG(ERROR) << errMsgTmplt
+               << "Missing/improperly configured objectAttributes "
+               << attributesHandle << ", whose handle contains "
+               << objInstAttributes->getHandle()
+               << " as specified in object instance attributes.";
+    return false;
+  }
+  // set shader type to use for stage
+  int objShaderType = objInstAttributes->getShaderType();
+  if (objShaderType !=
+      static_cast<int>(
+          metadata::attributes::ObjectInstanceShaderType::Unknown)) {
+    objAttributes->setShaderType(objShaderType);
+  }
+  int objID;
+  if (simulator_ != nullptr) {
+    auto& drawables = simulator_->getDrawableGroup();
+    objID = addObject(objAttributes, &drawables, attachmentNode, lightSetup);
+  } else {
+    // support creation when simulator DNE
+    objID = addObject(objAttributes, nullptr, attachmentNode, lightSetup);
+  }
+
+  if (objID == ID_UNDEFINED) {
+    // instancing failed for some reason.
+    LOG(ERROR) << errMsgTmplt << "Object create failed for objectAttributes "
+               << attributesHandle << ", whose handle contains "
+               << objInstAttributes->getHandle()
+               << " as specified in object instance attributes.";
+    return ID_UNDEFINED;
+  }
+
+  // set object's location, rotation and other pertinent state values based on
+  // scene object instance values
+  this->existingObjects_.at(objID)->setStateFromAttributes(
+      objInstAttributes.get(), defaultCOMCorrection);
+
+  return objID;
+}  // PhysicsManager::addObjectInstance
+
 int PhysicsManager::addObject(const std::string& attributesHandle,
                               scene::SceneNode* attachmentNode,
                               const std::string& lightSetup) {

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -180,6 +180,29 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       const metadata::attributes::StageAttributes::ptr& initAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
+  /**
+   * @brief Instance and place a physics object from a @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes file.
+   * @param objInstAttributes The attributes that describe the desired state to
+   * set this object.
+   * @param attributesHandle The handle of the object attributes used as the key
+   * to query @ref esp::metadata::managers::ObjectAttributesManager.
+   * @param defaultCOMCorrection The default value of whether COM-based
+   * translation correction needs to occur.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObjectInstance(
+      const esp::metadata::attributes::SceneObjectInstanceAttributes::ptr&
+          objInstAttributes,
+      const std::string& attributesHandle,
+      bool defaultCOMCorrection = false,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager.  This method
    * will query for a drawable group from simulator.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -155,11 +155,15 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     }
   }
 
+  /**
+   * @brief Get the 4x4 transformation matrix of the object
+   */
   virtual Magnum::Matrix4 getTransformation() const {
     return node().transformation();
   }
 
-  /** @brief Set the 3D position of the object kinematically.
+  /**
+   * @brief Set the 3D position of the object kinematically.
    * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param vector The desired 3D position of the object.
@@ -171,11 +175,15 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     }
   }
 
+  /**
+   * @brief Get the 3D position of the object.
+   */
   virtual Magnum::Vector3 getTranslation() const {
     return node().translation();
   }
 
-  /** @brief Set the orientation of the object kinematically.
+  /**
+   * @brief Set the orientation of the object kinematically.
    * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param quaternion The desired orientation of the object.
@@ -187,6 +195,9 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     }
   }
 
+  /**
+   * @brief Get the orientation of the object.
+   */
   virtual Magnum::Quaternion getRotation() const { return node().rotation(); }
 
   /**
@@ -342,28 +353,48 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     }
   }
 
-  /** @brief Store whatever object attributes you want here! */
+  /**
+   * @brief Store whatever object attributes you want here!
+   */
   esp::core::Configuration::ptr attributes_{};
 
+  /**
+   * @brief Set the object's state from a @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes
+   * @param objInstAttr The attributes that describe the desired state to set
+   * this object.
+   * @param defaultCOMCorrection The default value of whether COM-based
+   * translation correction needs to occur.
+   */
+  virtual void setStateFromAttributes(
+      const esp::metadata::attributes::SceneObjectInstanceAttributes* const
+          objInstAttr,
+      bool defaultCOMCorrection = false) = 0;
+
  protected:
-  /** @brief Used to synchronize other simulator's notion of the object state
+  /**
+   * @brief Used to synchronize other simulator's notion of the object state
    * after it was changed kinematically. Must be called automatically on
    * kinematic updates.*/
   virtual void syncPose() { return; }
 
-  /** @brief An assignable name for this object.
+  /**
+   * @brief An assignable name for this object.
    */
   std::string objectName_;
 
-  /** @brief The @ref MotionType of the object. Determines what operations can
+  /**
+   * @brief The @ref MotionType of the object. Determines what operations can
    * be performed on this object. */
   MotionType objectMotionType_{MotionType::UNDEFINED};
 
-  /** @brief Access for the object to its own PhysicsManager id.
+  /**
+   * @brief Access for the object to its own PhysicsManager id.
    */
   int objectId_;
 
-  /** @brief Reference to the ResourceManager for internal access to the
+  /**
+   * @brief Reference to the ResourceManager for internal access to the
    * object's asset data.
    */
   const assets::ResourceManager& resMgr_;

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -367,12 +367,16 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 #endif
 
-  //! The @ref SceneNode of a bounding box debug drawable. If nullptr, BB
-  //! drawing is off. See @ref setObjectBBDraw().
+  /**
+   * @brief The @ref SceneNode of a bounding box debug drawable. If nullptr, BB
+   * drawing is off. See @ref setObjectBBDraw().
+   */
   scene::SceneNode* BBNode_ = nullptr;
 
-  //! The @ref SceneNode of the voxel drawable. If nullptr, Voxel
-  //! drawing is off. See @ref setObjectVoxelizationDraw().
+  /**
+   * @brief  The @ref SceneNode of the voxel drawable. If nullptr, Voxel drawing
+   * is off. See @ref setObjectVoxelizationDraw().
+   */
   scene::SceneNode* VoxelNode_ = nullptr;
 
   /**
@@ -383,11 +387,15 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    */
   scene::SceneNode* visualNode_ = nullptr;
 
-  //! all nodes created when this object's render asset was added to the
-  //! SceneGraph
+  /**
+   * @brief all nodes created when this object's render asset was added to the
+   * SceneGraph
+   */
   std::vector<esp::scene::SceneNode*> visualNodes_;
 
-  //! ptr to the VoxelWrapper associated with this RigidBase
+  /**
+   * @brief ptr to the VoxelWrapper associated with this RigidBase
+   */
   std::shared_ptr<esp::geo::VoxelWrapper> voxelWrapper = nullptr;
 
  protected:

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -66,6 +66,38 @@ void RigidObject::setMotionType(MotionType mt) {
   }
 }
 
+void RigidObject::setStateFromAttributes(
+    const esp::metadata::attributes::SceneObjectInstanceAttributes* const
+        objInstAttr,
+    bool defaultCOMCorrection) {
+  // set object's location and rotation based on translation and rotation
+  // params specified in instance attributes
+  auto translate = objInstAttr->getTranslation();
+  // get instance override value, if exists
+  auto instanceCOMOrigin =
+      static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
+          objInstAttr->getTranslationOrigin());
+  if (((defaultCOMCorrection) &&
+       (instanceCOMOrigin !=
+        metadata::managers::SceneInstanceTranslationOrigin::COM)) ||
+      (instanceCOMOrigin ==
+       metadata::managers::SceneInstanceTranslationOrigin::AssetLocal)) {
+    // if default COM correction is set and no object-based override, or if
+    // Object set to correct for COM.
+    translate -=
+        objInstAttr->getRotation().transformVector(visualNode_->translation());
+  }
+
+  setTranslation(translate);
+  setRotation(objInstAttr->getRotation());
+  // set object's motion type if different than set value
+  const physics::MotionType attrObjMotionType =
+      static_cast<physics::MotionType>(objInstAttr->getMotionType());
+  if (attrObjMotionType != physics::MotionType::UNDEFINED) {
+    this->setMotionType(attrObjMotionType);
+  }
+}  // RigidObject::setStateFromAttributes
+
 //////////////////
 // VelocityControl
 

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -170,6 +170,19 @@ class RigidObject : public RigidBase {
    */
   VelocityControl::ptr getVelocityControl() { return velControl_; };
 
+  /**
+   * @brief Set the object's state from a @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes
+   * @param objInstAttr The attributes that describe the desired state to set
+   * this object.
+   * @param defaultCOMCorrection The default value of whether COM-based
+   * translation correction needs to occur.
+   */
+  void setStateFromAttributes(
+      const esp::metadata::attributes::SceneObjectInstanceAttributes* const
+          objInstAttr,
+      bool defaultCOMCorrection = false) override;
+
  protected:
   /**
    * @brief Convenience variable: specifies a constant control velocity (linear

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -77,6 +77,20 @@ class RigidStage : public RigidBase {
 
  public:
   /**
+   * @brief Currently not supported.  Set the stage's state from a @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes
+   * @param stageInstAttr The attributes that describe the desired state to set
+   * this object.
+   * @param defaultCOMCorrection The default value of whether COM-based
+   * translation correction needs to occur.
+   */
+  void setStateFromAttributes(
+      CORRADE_UNUSED const
+          esp::metadata::attributes::SceneObjectInstanceAttributes* const
+              stageInstAttr,
+      CORRADE_UNUSED bool defaultCOMCorrection = false) override {}
+
+  /**
    * @brief Currently ignored for stage objects.
    * @param mt The desirved @ref MotionType.
    */

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -412,7 +412,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   }  // if ID has changed - needs to be reset
 
   // 5. Load object instances as spceified by Scene Instance Attributes.
-  bool success = setAllObjectsForCurrentScene();
+  bool success = instanceObjectsForActiveScene();
 
   // TODO : reset may eventually have all the scene instance instantiation
   // code so that scenes can be reset
@@ -423,7 +423,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   return success;
 }  // Simulator::createSceneInstance
 
-bool Simulator::setAllObjectsForCurrentScene() {
+bool Simulator::instanceObjectsForActiveScene() {
   // Get scene instance attributes corresponding to current active scene name
   // This should always just retrieve an existing, appropriately configured
   // scene instance attributes, depending on what exists in the Scene Dataset
@@ -479,7 +479,7 @@ bool Simulator::setAllObjectsForCurrentScene() {
   }  // for each object attributes
   // objectsAdded holds all ids of added objects.
   return true;
-}  // Simulator::setAllObjectsForCurrentScene()
+}  // Simulator::instanceObjectsForActiveScene()
 
 bool Simulator::createSceneInstanceNoRenderer(
     const std::string& activeSceneName) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -412,13 +412,36 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   }  // if ID has changed - needs to be reset
 
   // 5. Load object instances as spceified by Scene Instance Attributes.
+  bool success = setAllObjectsForCurrentScene();
+
+  // TODO : reset may eventually have all the scene instance instantiation
+  // code so that scenes can be reset
+  if (success) {
+    reset();
+  }
+
+  return success;
+}  // Simulator::createSceneInstance
+
+bool Simulator::setAllObjectsForCurrentScene() {
+  // Get scene instance attributes corresponding to current active scene name
+  // This should always just retrieve an existing, appropriately configured
+  // scene instance attributes, depending on what exists in the Scene Dataset
+  // library for the current dataset.
+  const std::string activeSceneName = config_.activeSceneName;
+  metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
+      metadataMediator_->getSceneAttributesByName(activeSceneName);
+
+  // get lightSetupKey from the value set when stage was created.
+  const std::string lightSetupKey =
+      physicsManager_->getStageInitAttributes()->getLightSetup();
+
+  // Load object instances as spceified by Scene Instance Attributes.
 
   // Get all instances of objects described in scene
   const std::vector<SceneObjectInstanceAttributes::ptr> objectInstances =
       curSceneInstanceAttributes->getObjectInstances();
 
-  // current scene graph's drawables
-  auto& drawables = sceneGraph.getDrawables();
   // node to attach object to
   scene::SceneNode* attachmentNode = nullptr;
   // vector holding all objects added
@@ -427,7 +450,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   // whether or not to correct for COM shift - only do for blender-sourced
   // scene attributes
-  bool Default_COM_Correction =
+  bool defaultCOMCorrection =
       (static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
            curSceneInstanceAttributes->getTranslationOrigin()) ==
        metadata::managers::SceneInstanceTranslationOrigin::AssetLocal);
@@ -448,71 +471,15 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       return false;
     }
 
-    // Get ObjectAttributes
-    auto objAttributes =
-        metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
-            objAttrFullHandle);
-    if (!objAttributes) {
-      LOG(ERROR) << errMsgTmplt
-                 << "Missing/improperly configured objectAttributes "
-                 << objAttrFullHandle << ", whose handle contains "
-                 << objInst->getHandle()
-                 << " as specified in object instance attributes.";
-      return false;
-    }
-    // set shader type to use for stage
-    int objShaderType = objInst->getShaderType();
-    if (objShaderType != unknownShaderType) {
-      objAttributes->setShaderType(objShaderType);
-    }
+    objID = physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
+                                               defaultCOMCorrection,
+                                               attachmentNode, lightSetupKey);
 
-    // create object using attributes copy.
-    objID = physicsManager_->addObject(objAttributes, &drawables,
-                                       attachmentNode, lightSetupKey);
-    if (objID == ID_UNDEFINED) {
-      // instancing failed for some reason.
-      LOG(ERROR) << errMsgTmplt << "Object create failed for objectAttributes "
-                 << objAttrFullHandle << ", whose handle contains "
-                 << objInst->getHandle()
-                 << " as specified in object instance attributes.";
-      return false;
-    }
-    // set object's location and rotation based on translation and rotation
-    // params specified in instance attributes
-    auto translate = objInst->getTranslation();
-    // get instance override value, if exists
-    auto Instance_COM_Origin =
-        static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
-            objInst->getTranslationOrigin());
-    if (((Default_COM_Correction) &&
-         (Instance_COM_Origin !=
-          metadata::managers::SceneInstanceTranslationOrigin::COM)) ||
-        (Instance_COM_Origin ==
-         metadata::managers::SceneInstanceTranslationOrigin::AssetLocal)) {
-      // if default COM correction is set and no object-based override, or if
-      // Object set to correct for COM.
-
-      translate -= objInst->getRotation().transformVector(
-          physicsManager_->getObjectVisualSceneNodes(objID)[0]->translation());
-    }
-    physicsManager_->setTranslation(objID, translate);
-    physicsManager_->setRotation(objID, objInst->getRotation());
-    // set object's motion type if different than set value
-    const physics::MotionType attrObjMotionType =
-        static_cast<physics::MotionType>(objInst->getMotionType());
-    if (attrObjMotionType != physics::MotionType::UNDEFINED) {
-      physicsManager_->setObjectMotionType(objID, attrObjMotionType);
-    }
     objectsAdded.push_back(objID);
   }  // for each object attributes
   // objectsAdded holds all ids of added objects.
-
-  // TODO : reset may eventually have all the scene instance instantiation
-  // code so that scenes can be reset
-  reset();
-
   return true;
-}  // Simulator::createSceneInstance
+}  // Simulator::setAllObjectsForCurrentScene()
 
 bool Simulator::createSceneInstanceNoRenderer(
     const std::string& activeSceneName) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -312,6 +312,8 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
                                       Mn::ResourceKey{lightSetupKey});
     }
   }
+  config_.sceneLightSetup = lightSetupKey;
+  metadataMediator_->setSimulatorConfiguration(config_);
 
   // 4. Load stage specified by Scene Instance Attributes
   // Get Stage Instance Attributes - contains name of stage and initial
@@ -433,8 +435,7 @@ bool Simulator::instanceObjectsForActiveScene() {
       metadataMediator_->getSceneAttributesByName(activeSceneName);
 
   // get lightSetupKey from the value set when stage was created.
-  const std::string lightSetupKey =
-      physicsManager_->getStageInitAttributes()->getLightSetup();
+  const std::string lightSetupKey = config_.sceneLightSetup;
 
   // Load object instances as spceified by Scene Instance Attributes.
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1060,7 +1060,7 @@ class Simulator {
    * schene's scene instance configuration.
    * @return whether object creation and placement is completed succesfully
    */
-  bool setAllObjectsForCurrentScene();
+  bool instanceObjectsForActiveScene();
 
   /**
    * @brief sample a random valid AgentState in passed agentState

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1056,6 +1056,13 @@ class Simulator {
       const std::string& activeSceneName);
 
   /**
+   * @brief Instance all the objects in the scene based on the current active
+   * schene's scene instance configuration.
+   * @return whether object creation and placement is completed succesfully
+   */
+  bool setAllObjectsForCurrentScene();
+
+  /**
    * @brief sample a random valid AgentState in passed agentState
    * @param agentState [out] The placeholder for the sampled agent state.
    */


### PR DESCRIPTION
## Motivation and Context
This PR moves the code to instantiate an object from a [scene object instance attributes](https://aihabitat.org/docs/habitat-sim/classesp_1_1metadata_1_1attributes_1_1SceneObjectInstanceAttributes.html) (which describes the initial state an object should be in) to PhysicsManager from Simulator.  It also moves the object instancing functionality from Simulator::createSceneInstance to a separate function that can be called at any time to create the objects at their initial locations.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
