### PR TITLE
[CircleCI] Optimize CI Tests (6X speed up on test suite)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,12 +346,13 @@ jobs:
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
+              git submodule update --init --recursive --jobs 16
               cd habitat-sim
+              while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
               conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils
-              git submodule update --init --recursive --jobs 16
               while [ ! -f ~/cuda_installed ]; do sleep 2; done # wait for CUDA
               sudo apt install --allow-change-held-packages \
                   texlive-base \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,11 +381,6 @@ jobs:
               pip install -r requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed
-      - save_cache:
-          key: conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
-          background: true
-          paths:
-            - ~/miniconda
       - run:
           name: Run Habitat Lab tests
           no_output_timeout: 25m
@@ -412,6 +407,11 @@ jobs:
               conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils
               ./build-public.sh
+      - save_cache:
+          key: conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
+          background: true
+          paths:
+            - ~/miniconda
       - save_cache:
           key: docs-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-sugar pytest-xdist typeguard
+                pip install pytest-sugar pytest-xdist
               fi
       - run:
           name: Install emscripten
@@ -447,7 +447,7 @@ jobs:
               cd habitat-sim
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
-              git submodule update --init --recursive --jobs 4
+              git submodule update --init --recursive --jobs 16
               python -u setup.py install --headless --vhacd
       - run:
           name: run clang-tidy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,12 +521,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest -n auto --durations=10 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
+              pytest -n auto --durations=10 --cov-report=xml --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
-              pytest -n auto --durations=10 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
+              pytest -n auto --durations=10 --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               . ~/emsdk/emsdk_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,8 +346,8 @@ jobs:
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
-              git submodule update --init --recursive --jobs 16
               cd habitat-sim
+              git submodule update --init --recursive --jobs 16
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,12 +521,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest -n 4 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
+              pytest -n auto --cov-report=xml --typeguard-packages=habitat_sim --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
               ./build.sh --headless
-              pytest -n 4 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
+              pytest -n auto --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               . ~/emsdk/emsdk_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
               pip install imageio imageio-ffmpeg
               conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils
-              git submodule update --init --recursive --jobs 4
+              git submodule update --init --recursive --jobs 16
               while [ ! -f ~/cuda_installed ]; do sleep 2; done # wait for CUDA
               sudo apt install --allow-change-held-packages \
                   texlive-base \
@@ -521,12 +521,12 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest -n auto --cov-report=xml --typeguard-packages=habitat_sim --cov=./
+              pytest -n auto --durations=10 --cov-report=xml --typeguard-packages=habitat_sim --cov=./
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration
-              ./build.sh --headless
-              pytest -n auto --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
+              ./build.sh --headless --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
+              pytest -n auto --durations=10 --cov-report=xml --cov=./ --cov-append --typeguard-packages=habitat_sim tests/test_physics.py tests/test_sensors.py
 
               . ~/.bashrc
               . ~/emsdk/emsdk_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,8 +178,8 @@ commands:
             - habitat-lab-{{ checksum "./hablab_sha" }}
       - restore_cache:
           keys:
-            - ccache-{{ arch }}-master
             - ccache-{{ arch }}-{{ .Branch }}
+            - ccache-{{ arch }}-master
           paths:
             - /home/circleci/.ccache
       - run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
     rev: 0.4.0
     hooks:
     -   id: nbstripout
-        files: '.ipynb'
 
 -   repo: https://github.com/mwouts/jupytext
     rev: v1.11.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         additional_dependencies: [toml]
 
 -   repo: https://github.com/ambv/black
-    rev: 21.4b2
+    rev: 21.5b1
     hooks:
     - id: black
       exclude: ^examples/tutorials/(nb_python|colabs)
@@ -55,7 +55,7 @@ repos:
         exclude: docs/
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 3.9.2
     hooks:
     -   id: flake8
         exclude: docs/
@@ -84,7 +84,7 @@ repos:
         files: '.ipynb'
 
 -   repo: https://github.com/mwouts/jupytext
-    rev: v1.11.1
+    rev: v1.11.2
     hooks:
     -   id: jupytext
         files: '^examples/tutorials/(colabs|nb_python)/(.*\.py|.*\.ipynb)$'
@@ -111,7 +111,7 @@ repos:
         exclude: (^src/(cmake/Find|deps)|configure\.h\.cmake$)
 
 -   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.25.0
+    rev: v7.26.0
     hooks:
     -   id: eslint
         args: [--fix, --ext .html,.js]
@@ -129,6 +129,6 @@ repos:
         exclude: ^conda-build/ #TODO fix these scripts
 
 -   repo: https://github.com/AleksaC/circleci-cli-py
-    rev: v0.1.15195
+    rev: v0.1.15224
     hooks:
     -   id: circle-ci-validator

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -18,7 +18,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -13,7 +13,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/ECCV_2020_Navigation.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Navigation.py
@@ -13,7 +13,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/rigid_object_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3


### PR DESCRIPTION
## Motivation and Context
* This speed up the CI by: Making it More Parallel
* Removing typeguard which gives a 50X speedup on some tests.
* Fix a bug the CircleCI cache loading (will now build a lot faster for subsequent builds on PR branches).
Total testing cut by more than half! Build times from 4 minutes -> 2 minutes on CI Cache. PyTest suite speed up from 30 minutes to just 5 minutes!
<!--- Why is this change required? What problem does it solve? -->
* CI Tests were very slow (taking 30 minutes to run the whole suite)
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
