### PR TITLE
New flag to enable a Simulator that doesn't create a Magnum/OpenGL context

### DIFF
--- a/examples/tutorials/colabs/replay_tutorial.ipynb
+++ b/examples/tutorials/colabs/replay_tutorial.ipynb
@@ -82,7 +82,7 @@
    "source": [
     "\n",
     "\n",
-    "def make_configuration():\n",
+    "def make_configuration(make_video_during_simulation=False):\n",
     "    # simulator configuration\n",
     "    backend_cfg = habitat_sim.SimulatorConfiguration()\n",
     "    backend_cfg.scene_id = os.path.join(\n",
@@ -94,6 +94,7 @@
     "    # Enable gfx replay save. See also our call to sim.gfx_replay_manager.save_keyframe()\n",
     "    # below.\n",
     "    backend_cfg.enable_gfx_replay_save = True\n",
+    "    backend_cfg.create_magnum_renderer = make_video_during_simulation\n",
     "\n",
     "    sensor_cfg = habitat_sim.CameraSensorSpec()\n",
     "    sensor_cfg.resolution = [544, 720]\n",
@@ -191,6 +192,7 @@
     "    args, _ = parser.parse_known_args()\n",
     "    show_video = args.show_video\n",
     "    make_video = args.make_video\n",
+    "    make_video_during_simulation = False\n",
     "else:\n",
     "    show_video = False\n",
     "    make_video = False\n",
@@ -198,7 +200,7 @@
     "if make_video and not os.path.exists(output_path):\n",
     "    os.mkdir(output_path)\n",
     "\n",
-    "cfg = make_configuration()\n",
+    "cfg = make_configuration(make_video_during_simulation=make_video_during_simulation)\n",
     "sim = None\n",
     "replay_filepath = \"./replay.json\"\n",
     "\n",
@@ -263,7 +265,7 @@
     "    duration=1.0,\n",
     "    agent_vel=np.array([0.5, 0.0, 0.0]),\n",
     "    look_rotation_vel=25.0,\n",
-    "    get_frames=make_video,\n",
+    "    get_frames=make_video_during_simulation,\n",
     ")"
    ]
   },
@@ -306,7 +308,7 @@
     "    duration=2.0,\n",
     "    agent_vel=np.array([0.0, 0.0, -0.4]),\n",
     "    look_rotation_vel=-5.0,\n",
-    "    get_frames=make_video,\n",
+    "    get_frames=make_video_during_simulation,\n",
     ")"
    ]
   },
@@ -334,7 +336,7 @@
     "    duration=2.0,\n",
     "    agent_vel=np.array([0.4, 0.0, 0.0]),\n",
     "    look_rotation_vel=-10.0,\n",
-    "    get_frames=make_video,\n",
+    "    get_frames=make_video_during_simulation,\n",
     ")"
    ]
   },
@@ -354,7 +356,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "if make_video:\n",
+    "if make_video_during_simulation:\n",
     "    vut.make_video(\n",
     "        observations,\n",
     "        \"rgba_camera\",\n",

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -69,7 +69,7 @@ output_path = os.path.join(dir_path, "examples/tutorials/replay_tutorial_output/
 # %%
 
 
-def make_configuration():
+def make_configuration(make_video_during_simulation=False):
     # simulator configuration
     backend_cfg = habitat_sim.SimulatorConfiguration()
     backend_cfg.scene_id = os.path.join(
@@ -81,6 +81,7 @@ def make_configuration():
     # Enable gfx replay save. See also our call to sim.gfx_replay_manager.save_keyframe()
     # below.
     backend_cfg.enable_gfx_replay_save = True
+    backend_cfg.create_magnum_renderer = make_video_during_simulation
 
     sensor_cfg = habitat_sim.CameraSensorSpec()
     sensor_cfg.resolution = [544, 720]
@@ -154,6 +155,7 @@ if __name__ == "__main__":
     args, _ = parser.parse_known_args()
     show_video = args.show_video
     make_video = args.make_video
+    make_video_during_simulation = False
 else:
     show_video = False
     make_video = False
@@ -161,7 +163,7 @@ else:
 if make_video and not os.path.exists(output_path):
     os.mkdir(output_path)
 
-cfg = make_configuration()
+cfg = make_configuration(make_video_during_simulation=make_video_during_simulation)
 sim = None
 replay_filepath = "./replay.json"
 
@@ -200,7 +202,7 @@ observations += simulate_with_moving_agent(
     duration=1.0,
     agent_vel=np.array([0.5, 0.0, 0.0]),
     look_rotation_vel=25.0,
-    get_frames=make_video,
+    get_frames=make_video_during_simulation,
 )
 
 # %% [markdown]
@@ -230,7 +232,7 @@ observations += simulate_with_moving_agent(
     duration=2.0,
     agent_vel=np.array([0.0, 0.0, -0.4]),
     look_rotation_vel=-5.0,
-    get_frames=make_video,
+    get_frames=make_video_during_simulation,
 )
 
 # %% [markdown]
@@ -245,14 +247,14 @@ observations += simulate_with_moving_agent(
     duration=2.0,
     agent_vel=np.array([0.4, 0.0, 0.0]),
     look_rotation_vel=-10.0,
-    get_frames=make_video,
+    get_frames=make_video_during_simulation,
 )
 
 # %% [markdown]
 # ## End the episode. Render the episode observations to a video.
 # %%
 
-if make_video:
+if make_video_during_simulation:
     vut.make_video(
         observations,
         "rgba_camera",

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -474,7 +474,8 @@ class Sensor:
 
         self._spec = self._sensor_object.specification()
 
-        self._sim.renderer.bind_render_target(self._sensor_object)
+        if self._sim.renderer:
+            self._sim.renderer.bind_render_target(self._sensor_object)
 
         if self._spec.gpu2gpu_transfer:
             assert cuda_enabled, "Must build habitat sim with cuda for gpu2gpu-transfer"
@@ -528,6 +529,8 @@ class Sensor:
         )
 
     def draw_observation(self) -> None:
+        assert self._sim.renderer
+
         # sanity check:
 
         # see if the sensor is attached to a scene graph, otherwise it is invalid,
@@ -541,6 +544,7 @@ class Sensor:
         self._sim.renderer.draw(self._sensor_object, self._sim)
 
     def get_observation(self) -> Union[ndarray, "Tensor"]:
+        assert self._sim.renderer
 
         tgt = self._sensor_object.render_target
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -482,7 +482,7 @@ class ResourceManager {
    * gfx::Drawable.
    */
 
-  void createDrawable(Mn::GL::Mesh& mesh,
+  void createDrawable(Mn::GL::Mesh* mesh,
                       gfx::Drawable::Flags& meshAttributeFlags,
                       scene::SceneNode& node,
                       const Mn::ResourceKey& lightSetupKey,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -46,6 +46,8 @@ void initSimBindings(py::module& m) {
       .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId)
       .def_readwrite("allow_sliding", &SimulatorConfiguration::allowSliding)
       .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
+      .def_readwrite("create_magnum_renderer",
+                     &SimulatorConfiguration::createMagnumRenderer)
       .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling)
       .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
       .def_readwrite(

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -11,7 +11,7 @@ namespace esp {
 namespace gfx {
 uint64_t Drawable::drawableIdCounter = 0;
 Drawable::Drawable(scene::SceneNode& node,
-                   Magnum::GL::Mesh& mesh,
+                   Magnum::GL::Mesh* mesh,
                    DrawableGroup* group /* = nullptr */)
     : Magnum::SceneGraph::Drawable3D{node, group},
       node_(node),

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -52,7 +52,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    * @param group Drawable group this drawable will be added to.
    */
   Drawable(scene::SceneNode& node,
-           Magnum::GL::Mesh& mesh,
+           Magnum::GL::Mesh* mesh,
            DrawableGroup* group = nullptr);
   ~Drawable() override;
 
@@ -74,7 +74,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
   virtual void setLightSetup(
       CORRADE_UNUSED const Magnum::ResourceKey& lightSetup){};
 
-  Magnum::GL::Mesh& getMesh() { return mesh_; }
+  Magnum::GL::Mesh& getMesh() { return *mesh_; }  // todo: assert non-null
 
   /**
    * @brief Get the Magnum GL mesh for visualization, highlighting (e.g., used
@@ -85,7 +85,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    * NOTE: sub-class should override this function if the "visualizer mesh" is
    * different from mesh_ (check the example in the PTexMeshDrawable class)
    */
-  virtual Magnum::GL::Mesh& getVisualizerMesh() { return mesh_; }
+  virtual Magnum::GL::Mesh& getVisualizerMesh() { return *mesh_; }
 
  protected:
   /**
@@ -104,7 +104,7 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
   uint64_t drawableId_;
 
   scene::SceneNode& node_;
-  Magnum::GL::Mesh& mesh_;
+  Magnum::GL::Mesh* mesh_ = nullptr;
 };
 
 CORRADE_ENUMSET_OPERATORS(Drawable::Flags)

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -13,6 +13,8 @@
 
 namespace Mn = Magnum;
 
+extern bool g_createMagnumRenderer;
+
 namespace esp {
 namespace gfx {
 
@@ -113,6 +115,10 @@ void GenericDrawable::updateShaderLightingParameters(
 
 void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
                            Mn::SceneGraph::Camera3D& camera) {
+  if (!g_createMagnumRenderer) {
+    return;
+  }
+
   updateShader();
 
   updateShaderLightingParameters(transformationMatrix, camera);
@@ -152,6 +158,10 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
 
 void GenericDrawable::updateShader() {
   Mn::UnsignedInt lightCount = lightSetup_->size();
+
+  if (!g_createMagnumRenderer) {
+    return;
+  }
 
   if (!shader_ || shader_->lightCount() != lightCount ||
       shader_->flags() != flags_) {

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -19,7 +19,7 @@ namespace esp {
 namespace gfx {
 
 GenericDrawable::GenericDrawable(scene::SceneNode& node,
-                                 Mn::GL::Mesh& mesh,
+                                 Mn::GL::Mesh* mesh,
                                  Drawable::Flags& meshAttributeFlags,
                                  ShaderManager& shaderManager,
                                  const Mn::ResourceKey& lightSetupKey,
@@ -153,7 +153,7 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
     shader_->bindNormalTexture(*(materialData_->normalTexture));
   }
 
-  shader_->draw(mesh_);
+  shader_->draw(*mesh_);
 }
 
 void GenericDrawable::updateShader() {

--- a/src/esp/gfx/GenericDrawable.h
+++ b/src/esp/gfx/GenericDrawable.h
@@ -19,7 +19,7 @@ class GenericDrawable : public Drawable {
   //! Adds drawable to given group and uses provided texture, and
   //! color for textured buffer and color shader output respectively
   explicit GenericDrawable(scene::SceneNode& node,
-                           Magnum::GL::Mesh& mesh,
+                           Magnum::GL::Mesh* mesh,
                            Drawable::Flags& meshAttributeFlags,
                            ShaderManager& shaderManager,
                            const Magnum::ResourceKey& lightSetupKey,

--- a/src/esp/gfx/MeshVisualizerDrawable.cpp
+++ b/src/esp/gfx/MeshVisualizerDrawable.cpp
@@ -16,7 +16,7 @@ MeshVisualizerDrawable::MeshVisualizerDrawable(
     Magnum::Shaders::MeshVisualizerGL3D& shader,
     Magnum::GL::Mesh& mesh,
     DrawableGroup* group)
-    : Drawable{node, mesh, group}, shader_(shader) {}
+    : Drawable{node, &mesh, group}, shader_(shader) {}
 
 void MeshVisualizerDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                                   Magnum::SceneGraph::Camera3D& camera) {
@@ -26,7 +26,7 @@ void MeshVisualizerDrawable::draw(const Magnum::Matrix4& transformationMatrix,
   shader_.setProjectionMatrix(camera.projectionMatrix())
       .setTransformationMatrix(transformationMatrix);
 
-  shader_.draw(mesh_);
+  shader_.draw(*mesh_);
 
   Mn::GL::Renderer::setPolygonOffset(0.0f, 0.0f);
   Mn::GL::Renderer::disable(Mn::GL::Renderer::Feature::PolygonOffsetFill);

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -18,7 +18,7 @@ PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
                                    int submeshID,
                                    ShaderManager& shaderManager,
                                    DrawableGroup* group /* = nullptr */)
-    : Drawable{node, ptexMeshData.getRenderingBuffer(submeshID)->mesh, group},
+    : Drawable{node, &ptexMeshData.getRenderingBuffer(submeshID)->mesh, group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),
 #ifndef CORRADE_TARGET_APPLE
       adjFacesBufferTexture_(
@@ -59,7 +59,7 @@ void PTexMeshDrawable::draw(const Magnum::Matrix4& transformationMatrix,
       .bindAdjFacesBufferTexture(adjFacesBufferTexture_)
 #endif
       .setMVPMatrix(camera.projectionMatrix() * transformationMatrix)
-      .draw(mesh_);
+      .draw(*mesh_);
 }
 
 }  // namespace gfx

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -14,7 +14,7 @@ namespace esp {
 namespace gfx {
 
 PbrDrawable::PbrDrawable(scene::SceneNode& node,
-                         Mn::GL::Mesh& mesh,
+                         Mn::GL::Mesh* mesh,
                          gfx::Drawable::Flags& meshAttributeFlags,
                          ShaderManager& shaderManager,
                          const Mn::ResourceKey& lightSetupKey,
@@ -145,7 +145,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
     shader_->setTextureMatrix(materialData_->textureMatrix);
   }
 
-  shader_->draw(mesh_);
+  shader_->draw(*mesh_);
 }
 
 Mn::ResourceKey PbrDrawable::getShaderKey(Mn::UnsignedInt lightCount,

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -20,7 +20,7 @@ class PbrDrawable : public Drawable {
    * and color for textured buffer and color shader output respectively
    */
   explicit PbrDrawable(scene::SceneNode& node,
-                       Magnum::GL::Mesh& mesh,
+                       Magnum::GL::Mesh* mesh,
                        gfx::Drawable::Flags& meshAttributeFlags,
                        ShaderManager& shaderManager,
                        const Magnum::ResourceKey& lightSetupKey,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -727,7 +727,7 @@ void PhysicsManager::setVoxelizationDraw(const std::string& gridName,
     esp::geo::VoxelWrapper* voxelWrapper_ = rigidBase->voxelWrapper.get();
     gfx::Drawable::Flags meshAttributeFlags{};
     resourceManager_.createDrawable(
-        voxelWrapper_->getVoxelGrid()->getMeshGL(gridName), meshAttributeFlags,
+        &voxelWrapper_->getVoxelGrid()->getMeshGL(gridName), meshAttributeFlags,
         *rigidBase->VoxelNode_, DEFAULT_LIGHTING_KEY,
         PER_VERTEX_OBJECT_ID_MATERIAL_KEY, drawables);
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -28,10 +28,12 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
   bWorld_ = std::make_shared<btMultiBodyDynamicsWorld>(
       &bDispatcher_, &bBroadphase_, &bSolver_, &bCollisionConfig_);
 
-  debugDrawer_.setMode(
-      Magnum::BulletIntegration::DebugDraw::Mode::DrawWireframe |
-      Magnum::BulletIntegration::DebugDraw::Mode::DrawConstraints);
-  bWorld_->setDebugDrawer(&debugDrawer_);
+  if (debugDrawer_) {
+    debugDrawer_->setMode(
+        Magnum::BulletIntegration::DebugDraw::Mode::DrawWireframe |
+        Magnum::BulletIntegration::DebugDraw::Mode::DrawConstraints);
+    bWorld_->setDebugDrawer(debugDrawer_.get());
+  }
 
   // currently GLB meshes are y-up
   bWorld_->setGravity(btVector3(physicsManagerAttributes_->getVec3("gravity")));
@@ -213,8 +215,10 @@ const Magnum::Range3D BulletPhysicsManager::getStageCollisionShapeAabb() const {
 }
 
 void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
-  debugDrawer_.setTransformationProjectionMatrix(projTrans);
-  bWorld_->debugDrawWorld();
+  if (debugDrawer_) {
+    debugDrawer_->setTransformationProjectionMatrix(projTrans);
+    bWorld_->debugDrawWorld();
+  }
 }
 
 bool BulletPhysicsManager::contactTest(const int physObjectID) {

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -23,6 +23,8 @@
 #include "esp/physics/PhysicsManager.h"
 #include "esp/physics/bullet/BulletRigidObject.h"
 
+extern bool g_createMagnumRenderer;
+
 namespace esp {
 namespace physics {
 
@@ -56,6 +58,9 @@ class BulletPhysicsManager : public PhysicsManager {
       : PhysicsManager(_resourceManager, _physicsManagerAttributes) {
     collisionObjToObjIds_ =
         std::make_shared<std::map<const btCollisionObject*, int>>();
+    if (g_createMagnumRenderer) {
+      debugDrawer_ = std::make_unique<Magnum::BulletIntegration::DebugDraw>();
+    }
   };
 
   /** @brief Destructor which destructs necessary Bullet physics structures.*/
@@ -236,7 +241,7 @@ class BulletPhysicsManager : public PhysicsManager {
   /** @brief A pointer to the Bullet world. See @ref btMultiBodyDynamicsWorld.*/
   std::shared_ptr<btMultiBodyDynamicsWorld> bWorld_;
 
-  mutable Magnum::BulletIntegration::DebugDraw debugDrawer_;
+  mutable std::unique_ptr<Magnum::BulletIntegration::DebugDraw> debugDrawer_;
 
   //! keep a map of collision objects to object ids for quick lookups from
   //! Bullet collision checking.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -91,8 +91,10 @@ class Simulator {
    * --headless mode on linux
    */
   int gpuDevice() const {
-    CORRADE_ASSERT(context_ != nullptr,
-                   "Simulator::gpuDevice: no OpenGL context.", 0);
+    if (!context_) {  // todo: be more strict and verbose here. test
+                      // g_createMagnumRenderer.
+      return 0;
+    }
     return context_->gpuDevice();
   }
 

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -23,7 +23,8 @@ struct SimulatorConfiguration {
   unsigned int randomSeed = 0;
   std::string defaultCameraUuid = "rgba_camera";
   bool compressTextures = false;
-  bool createRenderer = true;
+  bool createRenderer = true;  // todo: rename
+  bool createMagnumRenderer = true;
   // Whether or not the agent can slide on collisions
   bool allowSliding = true;
   // enable or disable the frustum culling

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -89,7 +89,7 @@ void DrawableTest::addRemoveDrawables() {
 
   // add a toy box here!
   node.addFeature<esp::gfx::GenericDrawable>(
-      box, meshAttributeFlags, resourceManager_->getShaderManager(),
+      &box, meshAttributeFlags, resourceManager_->getShaderManager(),
       esp::NO_LIGHT_KEY, esp::PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
       drawableGroup_);
   // we already had 5 boxes in the scene, so the id for the above toy box must
@@ -99,7 +99,7 @@ void DrawableTest::addRemoveDrawables() {
   // step 1: basic tests
   esp::gfx::GenericDrawable* dr =
       new esp::gfx::GenericDrawable{node,
-                                    box,
+                                    &box,
                                     meshAttributeFlags,
                                     resourceManager_->getShaderManager(),
                                     esp::NO_LIGHT_KEY,
@@ -114,7 +114,7 @@ void DrawableTest::addRemoveDrawables() {
 
   // step 2: add a single drawable to a group
   dr = new esp::gfx::GenericDrawable{node,
-                                     box,
+                                     &box,
                                      meshAttributeFlags,
                                      resourceManager_->getShaderManager(),
                                      esp::NO_LIGHT_KEY,
@@ -140,7 +140,7 @@ void DrawableTest::addRemoveDrawables() {
 
   // step 5: remove a drawable, that is NOT in the group! should be fine!!
   dr = new esp::gfx::GenericDrawable{node,
-                                     box,
+                                     &box,
                                      meshAttributeFlags,
                                      resourceManager_->getShaderManager(),
                                      esp::NO_LIGHT_KEY,

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -325,6 +325,7 @@ TEST(GfxReplayTest, simulatorIntegration) {
   SimulatorConfiguration simConfig{};
   simConfig.activeSceneName = boxFile;
   simConfig.enableGfxReplaySave = true;
+  simConfig.createMagnumRenderer = false;
 
   auto sim = Simulator::create_unique(simConfig);
   auto& sceneGraph = sim->getActiveSceneGraph();

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -37,11 +37,13 @@ const std::string physicsConfigFile =
 class PhysicsManagerTest : public testing::Test {
  protected:
   void SetUp() override {
+    g_createMagnumRenderer = false;
+
     // set up a default simulation config to initialize MM
     auto cfg = esp::sim::SimulatorConfiguration{};
     metadataMediator_ = MetadataMediator::create(cfg);
     resourceManager_ = std::make_unique<ResourceManager>(metadataMediator_);
-    context_ = esp::gfx::WindowlessContext::create_unique(0);
+    resourceManager_->setRequiresTextures(false);
 
     sceneID_ = sceneManager_.initSceneGraph();
     // get attributes manager for physics world attributes
@@ -72,9 +74,6 @@ class PhysicsManagerTest : public testing::Test {
     bool result = resourceManager_->loadStage(stageAttributes, physicsManager_,
                                               &sceneManager_, tempIDs, false);
   }
-
-  // must declare these in this order due to avoid deallocation errors
-  esp::gfx::WindowlessContext::uptr context_;
 
   std::shared_ptr<MetadataMediator> metadataMediator_ = nullptr;
   std::unique_ptr<ResourceManager> resourceManager_ = nullptr;


### PR DESCRIPTION
## Motivation and Context

I added `SimulatorConfiguration::createMagnumRenderer` to enable creation of a Simulator that doesn't create a Magnum/OpenGL context. This flag can be a useful if you're using the Simulator but not doing rendering, e.g. only querying physics or producing gfx-replay keyframes.

In addition to skipping context creation, I also don't load textures or upload meshes to the GPU, but I do still load all meshes (from disk to CPU memory). I would like to see a related flag in the future that disables loading of render-only meshes (which general aren't needed if you're not rendering), but that's a separate PR.

This is a draft PR and needs some cleanup:
- The hacky use of a global `g_createMagnumRenderer` var.
- Probably not all cases of graphics context use have been properly disabled/guarded, e.g. PbrDrawable.
- Let's add a test of creating a non-renderer sim and using various APIs like `drawObservation`.
- We should handle primitives correctly or at least fail gracefully. If we need to disable primitive-loading/use, we should issue a proper warning to users if they try to use a primitive that's unavailable.
- We need to reconcile with the existing `SimulatorConfiguration::createRenderer`. From discussion with @jturner65 , it sounds like the existing functionality of the existing flag (including disabling physics manager) isn't needed at all. So we instead hook up the `createRenderer` flag to the new functionality introduced in this PR (and discard the no-physics-manager code path altogether?).
- Decide whether to create a stub Renderer object (discussed below).
- reconcile two related features: disabling usage of OpenGL (this PR) and disabling loading of render assets (separate feature). After team discussion on 6/1, we agree this can be implemented separately. However, one suggestion is to have an enum for all the combinations of usage, instead of two independent flags. However, we all agreed that this PR doesn't need to implement the second feature, disabling loading of render assets (that can be a future PR).

I show two example usages here: (1) our `PhysicsTest` unit tests, which no longer require a graphics context, and (2) `replay_tutorial.py`, which uses a non-renderer sim to produce gfx-replay keyframes, then later creates a sim-with-renderer to render the replay.

I made a decision here to not create the Renderer object at all. Thus some fixes are required in Hab python programs, e.g., you have to avoid using sim.renderer if it's `None`. This is a bit more invasive than my other choices and might be wrong. ~It might be better to create Renderer as a stub so that python programs don't have to be modified. E.g. `get_observations` can just return all black pixels or perhaps some debug pattern. If we opted for the stub route, we might rename the flag to `createStubRenderer` or `createNullRenderer`.~ Update: after team discussion on 6/1, we don't need to bother with a stub renderer. So the PR can stay as-is in this respect.

## How Has This Been Tested

See PhysicsTest, GfxReplayTest, and replay_tutorial.py.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
