### PR TITLE
[WIP][AO migration] collision groups and modified contactTest

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -91,6 +91,10 @@ void declareBasePhysicsObjectWrapper(py::module& m,
                     ("Get or set whether this " + objType +
                      " is actively being simulated, or is sleeping.")
                         .c_str())
+      .def("contact_test", &PhysObjWrapper::contactTest, "static_as_stage"_a,
+           ("Discrete collision check for contact between an object and the "
+            "collision world. Optionally treat STATICs as stage or free "
+            "objects."))
       .def(
           "translate", &PhysObjWrapper::translate, "vector"_a,
           ("Move this " + objType + " using passed translation vector").c_str())

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -364,7 +364,7 @@ void initSimBindings(py::module& m) {
       .def(
           "contact_test", &Simulator::contactTest, "object_id"_a,
           "static_as_stage"_a = true, "scene_id"_a = 0,
-          R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
+          R"(DEPRECATED AND WILL BE REMOVED IN HABITAT-SIM 2.0. Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
       .def(
           "perform_discrete_collision_detection",
           &Simulator::performDiscreteCollisionDetection,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -363,7 +363,7 @@ void initSimBindings(py::module& m) {
            R"(Set whether or not the static stage is collidable.)")
       .def(
           "contact_test", &Simulator::contactTest, "object_id"_a,
-          "scene_id"_a = 0,
+          "static_as_stage"_a = true, "scene_id"_a = 0,
           R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
       .def(
           "perform_discrete_collision_detection",

--- a/src/esp/physics/CMakeLists.txt
+++ b/src/esp/physics/CMakeLists.txt
@@ -10,6 +10,8 @@ configure_file(
 
 add_library(
   physics STATIC
+  CollisionGroupHelper.cpp
+  CollisionGroupHelper.h
   objectManagers/PhysicsObjectBaseManager.h
   objectManagers/RigidBaseManager.h
   objectManagers/RigidObjectManager.cpp

--- a/src/esp/physics/CollisionGroupHelper.cpp
+++ b/src/esp/physics/CollisionGroupHelper.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "CollisionGroupHelper.h"
+#include <Corrade/Utility/Assert.h>
+#include "esp/core/logging.h"
+
+namespace esp {
+namespace physics {
+
+/*
+  enum class CollisionGroup {
+    Default = 1,
+    Static = 2,
+    Kinematic = 4,
+    FreeObject = 8,
+    GraspedObject = 16,
+    Robot = 32,
+  };
+*/
+
+int CollisionGroupHelper::getMaskForGroup(CollisionGroup group) {
+  // TODO: refactor this in terms of enabling collision between specific pairs
+  // of groups
+  switch (group) {
+    case CollisionGroup::Default:
+      // everything
+      return -1 & ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::Static:
+    case CollisionGroup::Kinematic:
+      // everything but [kinematic, static]
+      return int(-1) & ~int(CollisionGroup::Kinematic) &
+             ~int(CollisionGroup::Static) & ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::FreeObject:
+      // everything
+      return int(-1) & ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::GraspedObject:
+      // everything but robot
+      return int(-1) & ~int(CollisionGroup::Robot) &
+             ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::Robot:
+      // everything but grasped object
+      return int(-1) & ~int(CollisionGroup::GraspedObject) &
+             ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::EeMargin:
+      // everything but grasped object or the robot
+      return int(-1) & ~int(CollisionGroup::GraspedObject) &
+             ~int(CollisionGroup::Robot) & ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::SelObj:
+      // everything but the ee margin
+      return int(-1) & ~(int(CollisionGroup::EeMargin)) &
+             ~int(CollisionGroup::Noncollidable);
+
+    case CollisionGroup::Noncollidable:
+      // nothing
+      return 0;
+
+    default:
+      CORRADE_ASSERT(
+          false,
+          "Collision group specified does not exist or no mask configured.", 0);
+      return 0;
+  }
+}
+
+}  // namespace physics
+}  // namespace esp

--- a/src/esp/physics/CollisionGroupHelper.h
+++ b/src/esp/physics/CollisionGroupHelper.h
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_PHYSICS_COLLISIONGROUPHELPER_H_
+#define ESP_PHYSICS_COLLISIONGROUPHELPER_H_
+
+namespace esp {
+namespace physics {
+
+/*
+  For reference, here are the standard Bullet groups. It's probably good to
+  stay somewhat consistent with them, in case users are already using them.
+        enum CollisionFilterGroups
+        {
+                DefaultFilter = 1,
+                StaticFilter = 2,
+                KinematicFilter = 4,
+                DebrisFilter = 8,
+                SensorTrigger = 16,
+                CharacterFilter = 32,
+                AllFilter = -1  //all bits sets: DefaultFilter | StaticFilter |
+  KinematicFilter | DebrisFilter | SensorTrigger
+        };
+*/
+
+enum class CollisionGroup {
+  Default = 1,
+  Static = 2,
+  Kinematic = 4,
+  FreeObject = 8,
+  GraspedObject = 16,
+  Robot = 32,
+  EeMargin = 64,
+  SelObj = 128,
+  Noncollidable = 256
+};
+
+class CollisionGroupHelper {
+ public:
+  static int getMaskForGroup(CollisionGroup group);
+};
+
+}  // end namespace physics
+}  // end namespace esp
+
+#endif  // ESP_PHYSICS_COLLISIONGROUPHELPER_H_

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1015,8 +1015,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @brief Check whether an object is in contact with any other objects or the
    * scene.
    *
-   * Not implemented for default @ref PhysicsManager. See @ref
-   * BulletPhysicsManager.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param staticAsStage When false, override configured collision groups|masks
@@ -1025,8 +1023,10 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  virtual bool contactTest(CORRADE_UNUSED const int physObjectID,
-                           CORRADE_UNUSED bool staticAsStage = true) {
+  virtual bool contactTest(const int physObjectID, bool staticAsStage = true) {
+    if (existingObjects_.count(physObjectID) > 0) {
+      return existingObjects_.at(physObjectID)->contactTest(staticAsStage);
+    }
     return false;
   };
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -17,6 +17,7 @@
 
 /* Bullet Physics Integration */
 
+#include "CollisionGroupHelper.h"
 #include "RigidObject.h"
 #include "RigidStage.h"
 #include "esp/assets/Asset.h"
@@ -1018,10 +1019,14 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * BulletPhysicsManager.
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  virtual bool contactTest(CORRADE_UNUSED const int physObjectID) {
+  virtual bool contactTest(CORRADE_UNUSED const int physObjectID,
+                           CORRADE_UNUSED bool staticAsStage = true) {
     return false;
   };
 

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -146,7 +146,9 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(CORRADE_UNUSED bool staticAsStage = true) { return false; }
+  virtual bool contactTest(CORRADE_UNUSED bool staticAsStage = true) {
+    return false;
+  }
 
   /**
    * @brief Set the light setup of this rigid.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -136,6 +136,19 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   virtual void setActive(CORRADE_UNUSED bool active) {}
 
   /**
+   * @brief Return result of a discrete contact test between the object and
+   * collision world.
+   *
+   * See @ref SimulationContactResultCallback
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects such that contact with other STATICs such as the stage
+   * are considered.
+   * @return Whether or not the object is in contact with any other collision
+   * enabled objects.
+   */
+  bool contactTest(CORRADE_UNUSED bool staticAsStage = true) { return false; }
+
+  /**
    * @brief Set the light setup of this rigid.
    * @param lightSetupKey @ref gfx::LightSetup key
    */

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -215,12 +215,13 @@ void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
   bWorld_->debugDrawWorld();
 }
 
-bool BulletPhysicsManager::contactTest(const int physObjectID) {
+bool BulletPhysicsManager::contactTest(const int physObjectID,
+                                       bool staticAsStage) {
   assertIDValidity(physObjectID);
   bWorld_->getCollisionWorld()->performDiscreteCollisionDetection();
   return static_cast<BulletRigidObject*>(
              existingObjects_.at(physObjectID).get())
-      ->contactTest();
+      ->contactTest(staticAsStage);
 }
 
 RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -215,15 +215,6 @@ void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
   bWorld_->debugDrawWorld();
 }
 
-bool BulletPhysicsManager::contactTest(const int physObjectID,
-                                       bool staticAsStage) {
-  assertIDValidity(physObjectID);
-  bWorld_->getCollisionWorld()->performDiscreteCollisionDetection();
-  return static_cast<BulletRigidObject*>(
-             existingObjects_.at(physObjectID).get())
-      ->contactTest(staticAsStage);
-}
-
 RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
                                              double maxDistance) {
   RaycastResults results;

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -166,10 +166,13 @@ class BulletPhysicsManager : public PhysicsManager {
    *
    * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(const int physObjectID) override;
+  bool contactTest(const int physObjectID, bool staticAsStage = true) override;
 
   /**
    * @brief Cast a ray into the collision world and return a @ref RaycastResults

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -161,20 +161,6 @@ class BulletPhysicsManager : public PhysicsManager {
   void debugDraw(const Magnum::Matrix4& projTrans) const override;
 
   /**
-   * @brief Check whether an object is in contact with any other objects or the
-   * stage.
-   *
-   * @param physObjectID The object ID and key identifying the object in @ref
-   * PhysicsManager::existingObjects_.
-   * @param staticAsStage When false, override configured collision groups|masks
-   * for STATIC objects and articulated fixed base such that contact with other
-   * STATICs such as the stage are considered.
-   * @return Whether or not the object is in contact with any other collision
-   * enabled objects.
-   */
-  bool contactTest(const int physObjectID, bool staticAsStage = true) override;
-
-  /**
    * @brief Cast a ray into the collision world and return a @ref RaycastResults
    * with hit information.
    *

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -394,11 +394,12 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
   if (mt == MotionType::STATIC) {
     CORRADE_INTERNAL_ASSERT(bObjectRigidBody_->isStaticObject());
     bWorld_->addRigidBody(
-        bObjectRigidBody_.get(),
-        2,       // collisionFilterGroup (2 == StaticFilter)
-        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
+        bObjectRigidBody_.get(), int(CollisionGroup::Static),
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::Static));
   } else {
-    bWorld_->addRigidBody(bObjectRigidBody_.get());
+    bWorld_->addRigidBody(
+        bObjectRigidBody_.get(), int(CollisionGroup::FreeObject),
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::FreeObject));
     setActive(true);
   }
 }
@@ -461,11 +462,33 @@ Magnum::Vector3 BulletRigidObject::getCOM() const {
   return com;
 }  // getCOM
 
-bool BulletRigidObject::contactTest() {
+bool BulletRigidObject::contactTest(bool staticAsStage) {
   SimulationContactResultCallback src;
+  src.m_collisionFilterGroup =
+      bObjectRigidBody_->getBroadphaseHandle()->m_collisionFilterGroup;
+  src.m_collisionFilterMask =
+      bObjectRigidBody_->getBroadphaseHandle()->m_collisionFilterMask;
+  if (!staticAsStage && objectMotionType_ == MotionType::STATIC) {
+    // override collision filter for STATIC object to include other STATICs such
+    // as the stage
+    src.m_collisionFilterGroup = int(CollisionGroup::FreeObject);
+    src.m_collisionFilterMask =
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::FreeObject);
+  }
   bWorld_->getCollisionWorld()->contactTest(bObjectRigidBody_.get(), src);
   return src.bCollision;
 }  // contactTest
+
+void BulletRigidObject::overrideCollisionGroup(CollisionGroup group) {
+  if (!bObjectRigidBody_->isInWorld()) {
+    LOG(ERROR) << "BulletRigidObject::overrideCollisionGroup failed because "
+                  "the Bullet body hasn't yet been added to the Bullet world.";
+  }
+
+  bWorld_->removeRigidBody(bObjectRigidBody_.get());
+  bWorld_->addRigidBody(bObjectRigidBody_.get(), int(group),
+                        CollisionGroupHelper::getMaskForGroup(group));
+}
 
 const Magnum::Range3D BulletRigidObject::getCollisionShapeAabb() const {
   if (!bObjectShape_) {

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -420,7 +420,7 @@ class BulletRigidObject : public BulletBase,
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(bool staticAsStage = true);
+  virtual bool contactTest(bool staticAsStage = true) override;
 
   /**
    * @brief Manually set the collision group for an object.

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -20,6 +20,7 @@
 
 #include "esp/core/esp.h"
 
+#include "esp/physics/CollisionGroupHelper.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/physics/bullet/BulletBase.h"
 
@@ -413,10 +414,19 @@ class BulletRigidObject : public BulletBase,
    * collision world.
    *
    * See @ref SimulationContactResultCallback
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects such that contact with other STATICs such as the stage
+   * are considered.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest();
+  bool contactTest(bool staticAsStage = true);
+
+  /**
+   * @brief Manually set the collision group for an object.
+   * @param group The desired CollisionGroup for the object.
+   */
+  void overrideCollisionGroup(CollisionGroup group);
 
   /**
    * @brief Query the Aabb from bullet physics for the root compound shape of

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -13,6 +13,7 @@
 #include "BulletCollision/Gimpact/btGImpactShape.h"
 #include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
 #include "BulletRigidStage.h"
+#include "esp/physics/CollisionGroupHelper.h"
 
 namespace esp {
 namespace physics {
@@ -87,9 +88,8 @@ void BulletRigidStage::constructAndAddCollisionObjects() {
   // add the objects to the world
   for (auto& object : bStaticCollisionObjects_) {
     bWorld_->addRigidBody(
-        object.get(),
-        2,       // collisionFilterGroup (2 == StaticFilter)
-        1 + 2);  // collisionFilterMask (1 == DefaultFilter, 2==StaticFilter)
+        object.get(), int(CollisionGroup::Static),
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::Static));
   }
 }
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -112,6 +112,23 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
     }
   }  // setLightSetup
 
+  /**
+   * @brief Discrete collision check for contact between an object and the
+   * collision world.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
+   * @return Whether or not the object is in contact with any other collision
+   * enabled objects.
+   */
+  bool contactTest(bool staticAsStage = true) {
+    if (auto sp = this->getObjectReference()) {
+      return sp->contactTest(staticAsStage);
+    } else {
+      return false;
+    }
+  }
+
   scene::SceneNode* getSceneNode() {
     if (auto sp = this->getObjectReference()) {
       return &const_cast<scene::SceneNode&>(sp->getSceneNode());

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -790,9 +790,11 @@ Magnum::Vector3 Simulator::getAngularVelocity(const int objectID,
   return Magnum::Vector3();
 }
 
-bool Simulator::contactTest(const int objectID, const int sceneID) {
+bool Simulator::contactTest(const int objectID,
+                            bool staticAsStage,
+                            const int sceneID) {
   if (sceneHasPhysics(sceneID)) {
-    return physicsManager_->contactTest(objectID);
+    return physicsManager_->contactTest(objectID, staticAsStage);
   }
   return false;
 }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -599,12 +599,15 @@ class Simulator {
    * collision world.
    * @param objectID The object ID and key identifying the object in @ref
    * esp::physics::PhysicsManager::existingObjects_.
+   * @param staticAsStage When false, override configured collision groups|masks
+   * for STATIC objects and articulated fixed base such that contact with other
+   * STATICs such as the stage are considered.
    * @param sceneID !! Not used currently !! Specifies which physical scene of
    * the object.
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  bool contactTest(int objectID, int sceneID = 0);
+  bool contactTest(int objectID, bool staticAsStage = true, int sceneID = 0);
 
   /**
    * @brief Perform discrete collision detection for the scene.

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -136,7 +136,7 @@ TEST_F(PhysicsManagerTest, JoinCompound) {
             Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
             Magnum::Matrix4::rotationY(Magnum::Math::Rad<float>(-0.25))};
         float boxHeight = 2.0 + (o * 2);
-        Magnum::Vector3 initialPosition{0.0, boxHeight + 1.25f, 0.0};
+        Magnum::Vector3 initialPosition{0.0, boxHeight + 1.5f, 0.0};
         physicsManager_->setRotation(
             objectId, Magnum::Quaternion::fromMatrix(R.rotationNormalized()));
         physicsManager_->setTranslation(objectId, initialPosition);


### PR DESCRIPTION
## Motivation and Context

ArticulatedObject migration PR split from #1226.
Contains collision group related changes from #1247 originally implemented by @eundersander.

WIP: adapt to provide better user-end behavior with some default protected behaviors (e.g. STATIC, KINEMATIC, and free objects with locked behaviors). 

## How Has This Been Tested

TODO: add some specific tests for group filter behavior

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
