### PR TITLE
1 version of retention for nightly packages

### DIFF
--- a/conda-build/common/delete_old_night_packages.py
+++ b/conda-build/common/delete_old_night_packages.py
@@ -9,10 +9,7 @@ import re
 import subprocess
 import sys
 
-# We currently can't have any retention as our average binary
-# size is ~150 MB, so even 1 day of retention would require
-# storing 24 binaries, which is over the 3 GB limit
-MAX_NUMBER_OF_PACKAGES = 0
+MAX_NUMBER_OF_VERSIONS = 1
 
 parser = argparse.ArgumentParser(
     "A tool for removing conda nightly builds in chronical order to reduce conda repo storage usage"
@@ -41,7 +38,8 @@ result = subprocess.run(
 versions = re.findall(
     r"\d\.\d\.\d\.\d{4}\.\d\d\.\d\d", str(result.stdout) + str(result.stderr)
 )
-remove_versions = versions[:-MAX_NUMBER_OF_PACKAGES]
+# Using len(versions) - MAX_NUMBER_OF_VERSIONS to support MAX_NUMBER_OF_VERSIONS == 0
+remove_versions = versions[: len(versions) - MAX_NUMBER_OF_VERSIONS]
 print(
     f"anaconda remove {' '.join(list(map(lambda x: f'aihabitat-nightly/habitat-sim/{x}', remove_versions)))}"
 )

--- a/conda-build/common/delete_old_night_packages.py
+++ b/conda-build/common/delete_old_night_packages.py
@@ -9,7 +9,10 @@ import re
 import subprocess
 import sys
 
-MAX_NUMBER_OF_PACKAGES = 30
+# We currently can't have any retention as our average binary
+# size is ~150 MB, so even 1 day of retention would require
+# storing 24 binaries, which is over the 3 GB limit
+MAX_NUMBER_OF_PACKAGES = 0
 
 parser = argparse.ArgumentParser(
     "A tool for removing conda nightly builds in chronical order to reduce conda repo storage usage"


### PR DESCRIPTION
## Motivation and Context

Given our average binary size of ~150 MB and building 12 different binaries on the CI, we can't retain any and stay under the 3 GB limit.

## How Has This Been Tested

Just changing a number


