### PR TITLE
[BUGFIX] fix bug in string compares in MetadataMediator

### DIFF
--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -143,7 +143,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   }
 
   // Next check if is current activeSceneDataset_, and if so skip with warning
-  if (sceneDatasetName != activeSceneDataset_) {
+  if (sceneDatasetName == activeSceneDataset_) {
     LOG(WARNING) << "MetadataMediator::removeSceneDataset : Cannot remove "
                     "active SceneDatasetAttributes "
                  << sceneDatasetName
@@ -165,7 +165,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     return false;
   }
   // Should always have a default dataset.
-  if (sceneDatasetName != "default") {
+  if (sceneDatasetName == "default") {
     // removing default dataset should still create another, empty, default
     // dataset.
     createSceneDataset("default");


### PR DESCRIPTION
## Motivation and Context
This addresses a bug in MetadataMediator::removeDataset where string comparisons had inverted behavior.[ This bug existed before this PR](https://github.com/facebookresearch/habitat-sim/pull/1250), but became more obvious because of it. So horray expanded clang-tidy checks!
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
