### PR TITLE
MetadataManager: Add binding to remove dataset functionality.

### DIFF
--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -28,7 +28,7 @@ void initMetadataMediatorBindings(py::module& m) {
       /* --- Methods --- */
       .def(
           "dataset_exists", &MetadataMediator::sceneDatasetExists,
-          R"(Checks whether the passed name references an existing scene dataset)",
+          R"(Returns whether the passed name references an existing scene dataset or not.)",
           "dataset_name"_a)
       .def(
           "remove_dataset", &MetadataMediator::removeSceneDataset,

--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -25,6 +25,11 @@ void initMetadataMediatorBindings(py::module& m) {
           R"(The currently active dataset being used.  Will attempt to load
             configuration files specified if does not already exist.)")
 
+      /* --- Methods --- */
+      .def(
+          "remove_dataset", &MetadataMediator::removeSceneDataset,
+          R"(Remove the given dataset from MetadataMediator.  If specified dataset is currently active, this will fail.)",
+          "dataset_name"_a)
       /* --- Template Manager accessors --- */
       .def_property_readonly(
           "asset_template_manager",

--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -27,6 +27,10 @@ void initMetadataMediatorBindings(py::module& m) {
 
       /* --- Methods --- */
       .def(
+          "dataset_exists", &MetadataMediator::sceneDatasetExists,
+          R"(Checks whether the passed name references an existing scene dataset)",
+          "dataset_name"_a)
+      .def(
           "remove_dataset", &MetadataMediator::removeSceneDataset,
           R"(Remove the given dataset from MetadataMediator.  If specified dataset is currently active, this will fail.)",
           "dataset_name"_a)

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -22,7 +22,9 @@ void MetadataMediator::buildAttributesManagers() {
       managers::SceneDatasetAttributesManager::create(
           physicsAttributesManager_);
 
-  // should always have default dataset
+  // should always have default dataset, but this is managed by MM instead of
+  // made undeletable in SceneDatasetManager, so that it can be easily "reset"
+  // by deleting and remaking.
   createSceneDataset("default");
   // should always have default physicsManagerAttributesPath
   createPhysicsManagerAttributes(ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH);
@@ -211,10 +213,10 @@ bool MetadataMediator::setActiveSceneDatasetName(
   // first check if dataset exists/is loaded, if so then set as default
   if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName)) {
     if (activeSceneDataset_ != sceneDatasetName) {
-      LOG(INFO)
-          << "MetadataMediator::setActiveSceneDatasetName : Old active dataset "
-          << activeSceneDataset_ << " changed to " << sceneDatasetName
-          << " successfully.";
+      LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Previous "
+                   "active dataset "
+                << activeSceneDataset_ << " changed to " << sceneDatasetName
+                << " successfully.";
       activeSceneDataset_ = sceneDatasetName;
     }
     return true;
@@ -231,8 +233,8 @@ bool MetadataMediator::setActiveSceneDatasetName(
   }
   LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Attempt to "
                "create new dataset "
-            << sceneDatasetName << " "
-            << (success ? " succeeded." : " failed.");
+            << sceneDatasetName << " " << (success ? " succeeded." : " failed.")
+            << " Currently active dataset : " << activeSceneDataset_;
   return success;
 }  // MetadataMediator::setActiveSceneDatasetName
 

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -11,7 +11,7 @@ MetadataMediator::MetadataMediator(const sim::SimulatorConfiguration& cfg) {
   buildAttributesManagers();
   // sets simConfig_, activeSceneDataset_ and currPhysicsManagerAttributes_
   // based on config
-  setSimulatorConfiguration(simConfig_);
+  setSimulatorConfiguration(cfg);
 }  // MetadataMediator ctor (SimulatorConfiguration)
 
 void MetadataMediator::buildAttributesManagers() {

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -7,11 +7,10 @@
 namespace esp {
 namespace metadata {
 
-MetadataMediator::MetadataMediator(const sim::SimulatorConfiguration& cfg)
-    : activeSceneDataset_(cfg.sceneDatasetConfigFile),
-      currPhysicsManagerAttributes_(cfg.physicsConfigFile),
-      simConfig_(cfg) {
+MetadataMediator::MetadataMediator(const sim::SimulatorConfiguration& cfg) {
   buildAttributesManagers();
+  // sets simConfig_, activeSceneDataset_ and currPhysicsManagerAttributes_
+  // based on config
   setSimulatorConfiguration(simConfig_);
 }  // MetadataMediator ctor (SimulatorConfiguration)
 
@@ -138,7 +137,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   if (!sceneDatasetAttributesManager_->getObjectLibHasHandle(
           sceneDatasetName)) {
     // DNE, do nothing
-    LOG(INFO)
+    LOG(WARNING)
         << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
         << sceneDatasetName << " does not exist. Aborting.";
     return false;
@@ -166,7 +165,8 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
         << sceneDatasetName << " unable to be deleted. Aborting.";
     return false;
   }
-  // Should always have a default dataset.
+  // Should always have a default dataset. Use this process to remove extraneous
+  // configs in default Scene Dataset
   if (sceneDatasetName == "default") {
     // removing default dataset should still create another, empty, default
     // dataset.

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -100,8 +100,7 @@ bool MetadataMediator::createPhysicsManagerAttributes(
 bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
                                           bool overwrite) {
   // see if exists
-  bool exists =
-      sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName);
+  bool exists = sceneDatasetExists(sceneDatasetName);
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
@@ -134,8 +133,7 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
 
 bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // First check if SceneDatasetAttributes exists
-  if (!sceneDatasetAttributesManager_->getObjectLibHasHandle(
-          sceneDatasetName)) {
+  if (!sceneDatasetExists(sceneDatasetName)) {
     // DNE, do nothing
     LOG(WARNING)
         << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
@@ -211,7 +209,7 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
 bool MetadataMediator::setActiveSceneDatasetName(
     const std::string& sceneDatasetName) {
   // first check if dataset exists/is loaded, if so then set as default
-  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDatasetName)) {
+  if (sceneDatasetExists(sceneDatasetName)) {
     if (activeSceneDataset_ != sceneDatasetName) {
       LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Previous "
                    "active dataset "

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -481,6 +481,8 @@ class MetadataMediator {
     // do not get copy of dataset attributes
     auto datasetAttr =
         sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
+    // this should never happen - there will always be a dataset with the name
+    // activeSceneDataset_
     if (datasetAttr == nullptr) {
       LOG(ERROR) << "MetadataMediator::getActiveDSAttribs : Unable to set "
                     "active dataset due to Unknown dataset named "
@@ -496,7 +498,7 @@ class MetadataMediator {
    * @brief Current Simulator Configuration. A copy (not a ref) so that it can
    * exceed the lifespan of the source config from, for example, Simulator.
    */
-  sim::SimulatorConfiguration simConfig_;
+  sim::SimulatorConfiguration simConfig_{};
 
   /**
    * @brief String name of current, default dataset.

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -420,6 +420,16 @@ class MetadataMediator {
    */
   bool removeSceneDataset(const std::string& sceneDatasetName);
 
+  /**
+   * @brief Checks if passed handle exists as scene dataset.
+   * @param sceneDatasetName The name of the SceneDatasetAttributes to remove.
+   * @return whether successful or not.
+   */
+  inline bool sceneDatasetExists(const std::string& sceneDatasetName) const {
+    return sceneDatasetAttributesManager_->getObjectLibHasHandle(
+        sceneDatasetName);
+  }
+
  protected:
   /**
    * @brief Return the file path corresponding to the passed handle in the

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -455,4 +455,29 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   ASSERT_EQ(semanticMap.size(), 3);
   // testLoadSemanticScene
 }  // testDataset1
+
+TEST_F(MetadataMediatorTest, testDatasetDelete) {
+  // load dataset 1 and make active
+  initDataset1();
+  const std::string nameDS1 = MM_->getActiveSceneDatasetName();
+  // verify the dataset has been added
+  ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), true);
+  // verify the active dataset is the expected name
+  ASSERT_EQ(nameDS1, sceneDatasetConfigFile_1);
+  // load datsaet 0 and make active
+  initDataset0();
+  // get new active dataset
+  const std::string nameDS0 = MM_->getActiveSceneDatasetName();
+  // verify the dataset has been added
+  ASSERT_EQ(MM_->sceneDatasetExists(nameDS0), true);
+  // verify the active dataset is the expected name
+  ASSERT_EQ(nameDS0, sceneDatasetConfigFile_0);
+
+  // delete dataset 1 and verify delete
+  ASSERT_EQ(MM_->removeSceneDataset(nameDS1), true);
+  // verify the dataset does not exist anymore
+  ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), false);
+
+}  // testDatasetDelete
+
 }  // namespace


### PR DESCRIPTION
## Motivation and Context
This PR adds a python binding to the existing remove dataset functionality, as well as a c++ test to verify functionality.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing c++ and python tests pass. C++ test added to verify functionality.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
