### PR TITLE
[BUGFIX/Improvement] Make sure appropriate light vec is set based on specified light type

### DIFF
--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -142,10 +142,10 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
       posMdleVal = static_cast<int>(esp::gfx::LightPositionModel::Global);
     }
     lightAttribs->setPositionModel(posMdleVal);
-  }
+  }  // position model
 
   // type of light - should map to enum values in esp::gfx::LightType
-  int typeVal = -1;
+  int specifiedTypeVal = -1;
   std::string tmpTypeVal = "";
   if (io::readMember<std::string>(jsonConfig, "type", tmpTypeVal)) {
     std::string strToLookFor = Cr::Utility::String::lowercase(tmpTypeVal);
@@ -155,10 +155,10 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           << "LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc : "
              "Type spotlight specified in JSON not currently supported, so "
              "defaulting LightInfo type to esp::gfx::LightType::Point.";
-      typeVal = static_cast<int>(esp::gfx::LightType::Point);
+      specifiedTypeVal = static_cast<int>(esp::gfx::LightType::Point);
     } else if (LightInstanceAttributes::LightTypeNamesMap.count(strToLookFor) !=
                0u) {
-      typeVal = static_cast<int>(
+      specifiedTypeVal = static_cast<int>(
           LightInstanceAttributes::LightTypeNamesMap.at(strToLookFor));
     } else {
       LOG(WARNING)
@@ -168,9 +168,9 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           << "` does not map to a valid "
              "LightInstanceAttributes::LightTypeNamesMap value, so "
              "defaulting LightInfo type to esp::gfx::LightType::Point.";
-      typeVal = static_cast<int>(esp::gfx::LightType::Point);
+      specifiedTypeVal = static_cast<int>(esp::gfx::LightType::Point);
     }
-    lightAttribs->setType(typeVal);
+    lightAttribs->setType(specifiedTypeVal);
   } else if (posIsSet) {
     // if no value found in attributes, attempt to infer desired type based on
     // whether position or direction were set from JSON.
@@ -178,6 +178,22 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
   } else if (dirIsSet) {
     lightAttribs->setType(static_cast<int>(esp::gfx::LightType::Directional));
   }  // if nothing set by here, will default to constructor defaults
+
+  // if the user specifies a type, we will assume that type overrides any
+  // inferred light type based on vector position/direction provided.  If the
+  // vector provided does not match the type specified, we copy the vector into
+  // the appropriate location.
+  if ((specifiedTypeVal ==
+       static_cast<int>(esp::gfx::LightType::Directional)) &&
+      (posIsSet) && !(dirIsSet)) {
+    // position set, direction absent, but directional type explicitly specified
+    lightAttribs->setDirection(lightAttribs->getPosition());
+  } else if ((specifiedTypeVal ==
+              static_cast<int>(esp::gfx::LightType::Point)) &&
+             (dirIsSet) && !(posIsSet)) {
+    // direction set, position absent, but point type explicitly specified
+    lightAttribs->setPosition(lightAttribs->getDirection());
+  }
 
   // read spotlight params
   if (jsonConfig.HasMember("spot")) {
@@ -187,7 +203,8 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           << "LightLayoutAttributesManager::setValsFromJSONDoc : \"spot\" "
              "cell in JSON config unable to be parsed to set "
              "spotlight parameters so skipping.  NOTE : Spotlights not "
-             "currently supported, so cone anble values are ignored and light "
+             "currently supported, so cone anble values are ignored and "
+             "light "
              "will be created as a point light.";
     } else {
       const auto& spotArea = jsonConfig["spot"];
@@ -272,12 +289,13 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
             break;
           }
           default: {
-            LOG(INFO)
-                << "LightLayoutAttributesManager::"
-                   "createLightSetupFromAttributes : Enum gfx::LightType with "
-                   "val "
-                << type
-                << " is not supported, so defaulting to gfx::LightType::Point";
+            LOG(INFO) << "LightLayoutAttributesManager::"
+                         "createLightSetupFromAttributes : Enum "
+                         "gfx::LightType with "
+                         "val "
+                      << type
+                      << " is not supported, so defaulting to "
+                         "gfx::LightType::Point";
             lightVector = {lightAttr->getPosition(), 1.0f};
           }
         }  // switch on type


### PR DESCRIPTION
## Motivation and Context
If the user specifies a type of light explicitly in their lighting attributes, that lighting type overrides any type inferred by whether the vector value provided is "position" or "direction".   However, if an inappropriate vector value is provided (position for explicitly specified directional lights, or direction for explicitly specified point lights) there will be a disconnect and the light will be given a default value for its vector.

This PR copies the value given for position (if given) into direction (if not given) for directional lights, and copies the value given for direction (if given) into position (if not given) for positional lights.  

This may not be a bugfix per se (specifying the wrong vector for a given type is really user error), but since we are trumping inferred type from vector given by explicit type specified by the user, the behavior without this PR's functionality seems kinda buggy.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
