### PR TITLE
[Bugfix] Scene Dataset Attributes Managers access enforcement

### DIFF
--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -112,10 +112,8 @@ class MetadataMediator {
    * @return The current dataset's @ref managers::AssetAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
-  managers::AssetAttributesManager::ptr getAssetAttributesManager() const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    return (datasetAttr == nullptr) ? nullptr
-                                    : datasetAttr->getAssetAttributesManager();
+  const managers::AssetAttributesManager::ptr& getAssetAttributesManager() {
+    return getActiveDSAttribs()->getAssetAttributesManager();
   }
 
   /**
@@ -125,12 +123,9 @@ class MetadataMediator {
    * managers::LightLayoutAttributesManager::ptr, or nullptr if no current
    * dataset.
    */
-  managers::LightLayoutAttributesManager::ptr getLightLayoutAttributesManager()
-      const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    return (datasetAttr == nullptr)
-               ? nullptr
-               : datasetAttr->getLightLayoutAttributesManager();
+  const managers::LightLayoutAttributesManager::ptr&
+  getLightLayoutAttributesManager() {
+    return getActiveDSAttribs()->getLightLayoutAttributesManager();
   }
 
   /**
@@ -139,17 +134,16 @@ class MetadataMediator {
    * @return The current dataset's @ref managers::ObjectAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
-  managers::ObjectAttributesManager::ptr getObjectAttributesManager() const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    return (datasetAttr == nullptr) ? nullptr
-                                    : datasetAttr->getObjectAttributesManager();
+  const managers::ObjectAttributesManager::ptr& getObjectAttributesManager() {
+    return getActiveDSAttribs()->getObjectAttributesManager();
   }
 
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
    */
-  managers::PhysicsAttributesManager::ptr getPhysicsAttributesManager() const {
+  const managers::PhysicsAttributesManager::ptr& getPhysicsAttributesManager()
+      const {
     return physicsAttributesManager_;
   }  // getPhysicsAttributesManager
 
@@ -159,10 +153,8 @@ class MetadataMediator {
    * @return The current dataset's @ref managers::SceneAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
-  managers::SceneAttributesManager::ptr getSceneAttributesManager() const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    return (datasetAttr == nullptr) ? nullptr
-                                    : datasetAttr->getSceneAttributesManager();
+  const managers::SceneAttributesManager::ptr& getSceneAttributesManager() {
+    return getActiveDSAttribs()->getSceneAttributesManager();
   }  // MetadataMediator::getSceneAttributesManager
 
   /**
@@ -171,10 +163,8 @@ class MetadataMediator {
    * @return The current dataset's @ref managers::StageAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
-  managers::StageAttributesManager::ptr getStageAttributesManager() const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    return (datasetAttr == nullptr) ? nullptr
-                                    : datasetAttr->getStageAttributesManager();
+  const managers::StageAttributesManager::ptr& getStageAttributesManager() {
+    return getActiveDSAttribs()->getStageAttributesManager();
   }  // MetadataMediator::getStageAttributesManager
 
   /**
@@ -189,13 +179,9 @@ class MetadataMediator {
   /**
    * @brief Return copy of map of current active dataset's navmesh handles.
    */
-  std::map<std::string, std::string> getActiveNavmeshMap() const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-
-    if (datasetAttr == nullptr) {
-      return std::map<std::string, std::string>();
-    }
-    return std::map<std::string, std::string>(datasetAttr->getNavmeshMap());
+  const std::map<std::string, std::string> getActiveNavmeshMap() {
+    return std::map<std::string, std::string>(
+        getActiveDSAttribs()->getNavmeshMap());
   }  // getActiveNavmeshMap
 
   /**
@@ -204,16 +190,9 @@ class MetadataMediator {
    * @param navMeshHandle The dataset library handle of the navmesh
    * @return The file path of the navmesh.
    */
-  std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    if (datasetAttr == nullptr) {
-      LOG(ERROR)
-          << "MetadataMediator::getNavmeshPathByHandle : No active "
-             "dataset has been specified so unable to determine path for "
-          << navMeshHandle;
-      return "";
-    }
-    return getFilePathForHandle(navMeshHandle, datasetAttr->getNavmeshMap(),
+  const std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
+    return getFilePathForHandle(navMeshHandle,
+                                getActiveDSAttribs()->getNavmeshMap(),
                                 "MetadataMediator::getNavmeshPathByHandle");
 
   }  // MetadataMediator::getNavmeshPathByHandle
@@ -222,15 +201,10 @@ class MetadataMediator {
    * @brief Return copy of map of current active dataset's semantic scene
    * descriptor handles.
    */
-  std::map<std::string, std::string> getActiveSemanticSceneDescriptorMap()
-      const {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-
-    if (datasetAttr == nullptr) {
-      return std::map<std::string, std::string>();
-    }
+  const std::map<std::string, std::string>
+  getActiveSemanticSceneDescriptorMap() {
     return std::map<std::string, std::string>(
-        datasetAttr->getSemanticSceneDescrMap());
+        getActiveDSAttribs()->getSemanticSceneDescrMap());
   }  // getActiveSemanticSceneDescriptorMap
 
   /**
@@ -242,17 +216,8 @@ class MetadataMediator {
    */
   std::string getSemanticSceneDescriptorPathByHandle(
       const std::string& ssDescrHandle) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    if (datasetAttr == nullptr) {
-      LOG(ERROR)
-          << "MetadataMediator::getSemanticSceneDescriptorPathByHandle : No "
-             "active dataset has been specified so unable to determine path "
-             "for "
-          << ssDescrHandle;
-      return "";
-    }
     return getFilePathForHandle(
-        ssDescrHandle, datasetAttr->getSemanticSceneDescrMap(),
+        ssDescrHandle, getActiveDSAttribs()->getSemanticSceneDescrMap(),
         "MetadataMediator::getSemanticSceneDescriptorPathByHandle");
 
   }  // MetadataMediator::getNavMeshPathByHandle
@@ -284,15 +249,7 @@ class MetadataMediator {
    */
   attributes::StageAttributes::ptr getNamedStageAttributesCopy(
       const std::string& stageAttrName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedStageAttributesCopy : No "
-                    "current active dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
-      return nullptr;
-    }
-    return datasetAttr->getNamedStageAttributesCopy(stageAttrName);
+    return getActiveDSAttribs()->getNamedStageAttributesCopy(stageAttrName);
   }  // getNamedStageAttributesCopy
 
   /**
@@ -307,15 +264,7 @@ class MetadataMediator {
    */
   attributes::ObjectAttributes::ptr getNamedObjectAttributesCopy(
       const std::string& objAttrName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedObjectAttributesCopy : No "
-                    "current active dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
-      return nullptr;
-    }
-    return datasetAttr->getNamedObjectAttributesCopy(objAttrName);
+    return getActiveDSAttribs()->getNamedObjectAttributesCopy(objAttrName);
   }  // getNamedObjectAttributesCopy
 
   /**
@@ -328,15 +277,7 @@ class MetadataMediator {
    * @return the lightsetup corresponding to @p lightSetupName.
    */
   esp::gfx::LightSetup getNamedLightSetup(const std::string& lightSetupName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getNamedLightSetup : No current active "
-                    "dataset specified/exists named :"
-                 << activeSceneDataset_ << ".";
-      return esp::gfx::LightSetup{};
-    }
-    return datasetAttr->getNamedLightSetup(lightSetupName);
+    return getActiveDSAttribs()->getNamedLightSetup(lightSetupName);
   }  // getNamedLightSetup
 
   /**
@@ -350,17 +291,8 @@ class MetadataMediator {
    * @return name of stage attributes with handle containing @p stageAttrName ,
    * or empty string if none.
    */
-  std::string getStageAttrFullHandle(const std::string& stageAttrName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR)
-          << "MetadataMediator::getStageAttrFullHandle : No current active "
-             "dataset specified/exists named :"
-          << activeSceneDataset_ << ".";
-      return "";
-    }
-    return datasetAttr->getStageAttrFullHandle(stageAttrName);
+  const std::string getStageAttrFullHandle(const std::string& stageAttrName) {
+    return getActiveDSAttribs()->getStageAttrFullHandle(stageAttrName);
   }  // getStageAttrFullHandle
 
   /**
@@ -374,17 +306,8 @@ class MetadataMediator {
    * @return name of object attributes with handle containing @p objAttrName or
    * empty string if none.
    */
-  std::string getObjAttrFullHandle(const std::string& objAttrName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR)
-          << "MetadataMediator::getObjAttrFullHandle : No current active "
-             "dataset specified/exists named :"
-          << activeSceneDataset_ << ".";
-      return "";
-    }
-    return datasetAttr->getObjAttrFullHandle(objAttrName);
+  const std::string getObjAttrFullHandle(const std::string& objAttrName) {
+    return getActiveDSAttribs()->getObjAttrFullHandle(objAttrName);
   }  // getObjAttrFullHandle
 
   /**
@@ -396,17 +319,8 @@ class MetadataMediator {
    * @return the full attributes name corresponding to @p lightSetupName , or
    * the empty string.
    */
-  std::string getLightSetupFullHandle(const std::string& lightSetupName) {
-    attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-    // this should never happen
-    if (datasetAttr == nullptr) {
-      LOG(ERROR)
-          << "MetadataMediator::getLightSetupFullHandle : No current active "
-             "dataset specified/exists named :"
-          << activeSceneDataset_ << ".";
-      return "";
-    }
-    return datasetAttr->getLightSetupFullHandle(lightSetupName);
+  const std::string getLightSetupFullHandle(const std::string& lightSetupName) {
+    return getActiveDSAttribs()->getLightSetupFullHandle(lightSetupName);
   }  // getLightSetupFullHandle
 
   /**
@@ -487,7 +401,7 @@ class MetadataMediator {
    * @brief Retrieve the current default dataset object.  Currently only for
    * internal use.
    */
-  attributes::SceneDatasetAttributes::ptr getActiveDSAttribs() const {
+  attributes::SceneDatasetAttributes::ptr getActiveDSAttribs() {
     // do not get copy of dataset attributes
     auto datasetAttr =
         sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
@@ -496,8 +410,12 @@ class MetadataMediator {
     if (datasetAttr == nullptr) {
       LOG(ERROR) << "MetadataMediator::getActiveDSAttribs : Unable to set "
                     "active dataset due to Unknown dataset named "
-                 << activeSceneDataset_ << ". Aborting";
-      return nullptr;
+                 << activeSceneDataset_
+                 << " so changing dataset to \"default\".";
+      activeSceneDataset_ = "default";
+
+      datasetAttr = sceneDatasetAttributesManager_->getObjectByHandle(
+          activeSceneDataset_);
     }
     return datasetAttr;
   }  // MetadataMediator::getActiveDSAttribs

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -179,7 +179,7 @@ class MetadataMediator {
   /**
    * @brief Return copy of map of current active dataset's navmesh handles.
    */
-  const std::map<std::string, std::string> getActiveNavmeshMap() {
+  std::map<std::string, std::string> getActiveNavmeshMap() {
     return std::map<std::string, std::string>(
         getActiveDSAttribs()->getNavmeshMap());
   }  // getActiveNavmeshMap
@@ -190,7 +190,7 @@ class MetadataMediator {
    * @param navMeshHandle The dataset library handle of the navmesh
    * @return The file path of the navmesh.
    */
-  const std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
+  std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
     return getFilePathForHandle(navMeshHandle,
                                 getActiveDSAttribs()->getNavmeshMap(),
                                 "MetadataMediator::getNavmeshPathByHandle");
@@ -201,8 +201,7 @@ class MetadataMediator {
    * @brief Return copy of map of current active dataset's semantic scene
    * descriptor handles.
    */
-  const std::map<std::string, std::string>
-  getActiveSemanticSceneDescriptorMap() {
+  std::map<std::string, std::string> getActiveSemanticSceneDescriptorMap() {
     return std::map<std::string, std::string>(
         getActiveDSAttribs()->getSemanticSceneDescrMap());
   }  // getActiveSemanticSceneDescriptorMap
@@ -291,7 +290,7 @@ class MetadataMediator {
    * @return name of stage attributes with handle containing @p stageAttrName ,
    * or empty string if none.
    */
-  const std::string getStageAttrFullHandle(const std::string& stageAttrName) {
+  std::string getStageAttrFullHandle(const std::string& stageAttrName) {
     return getActiveDSAttribs()->getStageAttrFullHandle(stageAttrName);
   }  // getStageAttrFullHandle
 
@@ -306,7 +305,7 @@ class MetadataMediator {
    * @return name of object attributes with handle containing @p objAttrName or
    * empty string if none.
    */
-  const std::string getObjAttrFullHandle(const std::string& objAttrName) {
+  std::string getObjAttrFullHandle(const std::string& objAttrName) {
     return getActiveDSAttribs()->getObjAttrFullHandle(objAttrName);
   }  // getObjAttrFullHandle
 
@@ -319,7 +318,7 @@ class MetadataMediator {
    * @return the full attributes name corresponding to @p lightSetupName , or
    * the empty string.
    */
-  const std::string getLightSetupFullHandle(const std::string& lightSetupName) {
+  std::string getLightSetupFullHandle(const std::string& lightSetupName) {
     return getActiveDSAttribs()->getLightSetupFullHandle(lightSetupName);
   }  // getLightSetupFullHandle
 

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -28,7 +28,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
     AbstractAttributes::setHandle(handle);
   }
 
-  virtual ~AbstractAttributes() override = default;
+  ~AbstractAttributes() override = default;
   /**
    * @brief Get this attributes' class.  Should only be set from constructor.
    * Used as key in constructor function pointer maps in AttributesManagers.

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -28,7 +28,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
     AbstractAttributes::setHandle(handle);
   }
 
-  ~AbstractAttributes() override = default;
+  virtual ~AbstractAttributes() override = default;
   /**
    * @brief Get this attributes' class.  Should only be set from constructor.
    * Used as key in constructor function pointer maps in AttributesManagers.

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -27,6 +27,19 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& datasetName,
       const managers::PhysicsAttributesManager::ptr& physAttrMgr);
 
+  ~SceneDatasetAttributes() override {
+    // These are to clear any external refs persisting after this scene dataset
+    // is deleted.  Accessing these refs should result in errors instead of
+    // leaks/undefined behavior.
+    assetAttributesManager_ = nullptr;
+    lightLayoutAttributesManager_ = nullptr;
+    objectAttributesManager_ = nullptr;
+    sceneAttributesManager_ = nullptr;
+    stageAttributesManager_ = nullptr;
+    navmeshMap_.clear();
+    semanticSceneDescrMap_.clear();
+  }
+
   /**
    * @brief Return manager for construction and access to asset attributes.
    */

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -30,36 +30,40 @@ class SceneDatasetAttributes : public AbstractAttributes {
   /**
    * @brief Return manager for construction and access to asset attributes.
    */
-  managers::AssetAttributesManager::ptr getAssetAttributesManager() const {
+  const managers::AssetAttributesManager::ptr& getAssetAttributesManager()
+      const {
     return assetAttributesManager_;
   }
 
   /**
    * @brief Return manager for construction and access to object attributes.
    */
-  managers::ObjectAttributesManager::ptr getObjectAttributesManager() const {
+  const managers::ObjectAttributesManager::ptr& getObjectAttributesManager()
+      const {
     return objectAttributesManager_;
   }
 
   /**
    * @brief Return manager for construction and access to light attributes.
    */
-  managers::LightLayoutAttributesManager::ptr getLightLayoutAttributesManager()
-      const {
+  const managers::LightLayoutAttributesManager::ptr&
+  getLightLayoutAttributesManager() const {
     return lightLayoutAttributesManager_;
   }
 
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
-  managers::SceneAttributesManager::ptr getSceneAttributesManager() const {
+  const managers::SceneAttributesManager::ptr& getSceneAttributesManager()
+      const {
     return sceneAttributesManager_;
   }
 
   /**
    * @brief Return manager for construction and access to stage attributes.
    */
-  managers::StageAttributesManager::ptr getStageAttributesManager() const {
+  const managers::StageAttributesManager::ptr& getStageAttributesManager()
+      const {
     return stageAttributesManager_;
   }
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -103,15 +103,15 @@ class Simulator {
    * @brief Return manager for construction and access to asset attributes for
    * the current dataset.
    */
-  metadata::managers::AssetAttributesManager::ptr getAssetAttributesManager()
-      const {
+  const metadata::managers::AssetAttributesManager::ptr&
+  getAssetAttributesManager() const {
     return metadataMediator_->getAssetAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to light attributes and
    * layouts for the current dataset.
    */
-  metadata::managers::LightLayoutAttributesManager::ptr
+  const metadata::managers::LightLayoutAttributesManager::ptr&
   getLightLayoutAttributesManager() const {
     return metadataMediator_->getLightLayoutAttributesManager();
   }
@@ -120,15 +120,15 @@ class Simulator {
    * @brief Return manager for construction and access to object attributes and
    * layouts for the current dataset.
    */
-  metadata::managers::ObjectAttributesManager::ptr getObjectAttributesManager()
-      const {
+  const metadata::managers::ObjectAttributesManager::ptr&
+  getObjectAttributesManager() const {
     return metadataMediator_->getObjectAttributesManager();
   }
   /**
    * @brief Return manager for construction and access to physics world
    * attributes.
    */
-  metadata::managers::PhysicsAttributesManager::ptr
+  const metadata::managers::PhysicsAttributesManager::ptr&
   getPhysicsAttributesManager() const {
     return metadataMediator_->getPhysicsAttributesManager();
   }
@@ -136,8 +136,8 @@ class Simulator {
    * @brief Return manager for construction and access to scene attributes for
    * the current dataset.
    */
-  metadata::managers::StageAttributesManager::ptr getStageAttributesManager()
-      const {
+  const metadata::managers::StageAttributesManager::ptr&
+  getStageAttributesManager() const {
     return metadataMediator_->getStageAttributesManager();
   }
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -466,6 +466,11 @@ TEST_F(MetadataMediatorTest, testDatasetDelete) {
   ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), true);
   // verify the active dataset is the expected name
   ASSERT_EQ(nameDS1, sceneDatasetConfigFile_1);
+  // get the stage attributes manager for the scene dataset
+  const auto& stageAttrMgr_DS1 = MM_->getStageAttributesManager();
+  // verify not nullptr
+  ASSERT_NE(stageAttrMgr_DS1, nullptr);
+
   // load datsaet 0 and make active
   initDataset0();
   // get new active dataset
@@ -479,6 +484,9 @@ TEST_F(MetadataMediatorTest, testDatasetDelete) {
   ASSERT_EQ(MM_->removeSceneDataset(nameDS1), true);
   // verify the dataset does not exist anymore
   ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), false);
+
+  // verify deleted scene dataset's stage manager is nullptr
+  ASSERT_EQ(stageAttrMgr_DS1, nullptr);
 
 }  // testDatasetDelete
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -67,7 +67,7 @@ TEST_F(MetadataMediatorTest, testDataset0) {
 
   LOG(INFO) << "Starting "
                "MetadataMediatorTest::testDataset0 : test LoadStages";
-  const auto stageAttributesMgr = MM_->getStageAttributesManager();
+  const auto& stageAttributesMgr = MM_->getStageAttributesManager();
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // should be 7 - one for default NONE stage, one original JSON, one based on
   // original but changed, and one new, and 3 built from .glb files
@@ -151,7 +151,7 @@ TEST_F(MetadataMediatorTest, testDataset0) {
 
   LOG(INFO) << "Starting test LoadObjects";
 
-  const auto objectAttributesMgr = MM_->getObjectAttributesManager();
+  const auto& objectAttributesMgr = MM_->getObjectAttributesManager();
   int numObjHandles = objectAttributesMgr->getNumFileTemplateObjects();
   // should be 6 file-based templates - 4 original, one based on an original
   // but changed, and one new
@@ -231,7 +231,8 @@ TEST_F(MetadataMediatorTest, testDataset0) {
 
   LOG(INFO) << "Starting test LoadLights";
 
-  const auto lightsLayoutAttributesMgr = MM_->getLightLayoutAttributesManager();
+  const auto& lightsLayoutAttributesMgr =
+      MM_->getLightLayoutAttributesManager();
   // get # of loaded light layout attributes.
   int numLightAttrHandles = lightsLayoutAttributesMgr->getNumObjects();
   // Should be 3 : file based, copy and new
@@ -283,7 +284,7 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   // SHOULD NOT BE REFERENCED DIRECTLY IN USER CODE, but rather desired scene
   // instance should be acquired through MM.
   //
-  const auto sceneAttributesMgr = MM_->getSceneAttributesManager();
+  const auto& sceneAttributesMgr = MM_->getSceneAttributesManager();
   // get # of loaded scene attributes.
   int numSceneHandles = sceneAttributesMgr->getNumObjects();
   // should be 1
@@ -403,7 +404,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
 
   LOG(INFO) << "Starting "
                "MetadataMediatorTest::testDataset1 : test LoadStages";
-  const auto stageAttributesMgr = MM_->getStageAttributesManager();
+  const auto& stageAttributesMgr = MM_->getStageAttributesManager();
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // shoudld be 6 : one for default NONE stage, glob lookup yields 2 stages + 2
   // modified and 1 new stage in scene dataset config
@@ -411,14 +412,15 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // end test LoadStages
 
   LOG(INFO) << "Starting test LoadObjects";
-  const auto objectAttributesMgr = MM_->getObjectAttributesManager();
+  const auto& objectAttributesMgr = MM_->getObjectAttributesManager();
   int numObjHandles = objectAttributesMgr->getNumFileTemplateObjects();
   // glob lookup yields 4 files + 2 modified in config
   ASSERT_EQ(numObjHandles, 6);
   // end test LoadObjects
 
   LOG(INFO) << "Starting test LoadLights";
-  const auto lightsLayoutAttributesMgr = MM_->getLightLayoutAttributesManager();
+  const auto& lightsLayoutAttributesMgr =
+      MM_->getLightLayoutAttributesManager();
   // get # of loaded light layout attributes.
   int numLightAttrHandles = lightsLayoutAttributesMgr->getNumObjects();
   // Should be 4 : 2 file based, copy and new
@@ -431,7 +433,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // SHOULD NOT BE REFERENCED DIRECTLY IN USER CODE, but rather desired scene
   // instance should be acquired through MM.
   //
-  const auto sceneAttributesMgr = MM_->getSceneAttributesManager();
+  const auto& sceneAttributesMgr = MM_->getSceneAttributesManager();
   // get # of loaded scene attributes.
   int numSceneHandles = sceneAttributesMgr->getNumObjects();
   // should be 2 - 2 file based


### PR DESCRIPTION
## Motivation and Context
This PR makes all scene dataset attributes managers accessed by const refs.  This required a slight change to how the current active dataset is queried - now there will never be an occasion for a null ptr return for any of the managers - if somehow a non-existent dataset has become active (which is not currently possible) then the default dataset will be called upon to provide the managers.  

The scene dataset attributes also has been changed so that its destructor will kill its various managers.  This is so that any persistent external references to the managers will give an error, and not leak, if the dataset they reference has been removed, addressing an extant possible bug in the scene dataset removal process.

Ideally these managers would be accessed by weak pointers, which would address this issue more politely, but such support would necessitate a substantial refactor of how the managers work; this can be addressed at a later date.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
