### PR TITLE
--Save Physics Objects' Scene Instancing attributes on placement

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -110,10 +110,12 @@ int PhysicsManager::addObjectInstance(
     return ID_UNDEFINED;
   }
 
+  // save the scene init attributes used to configure object's initial state
+  this->existingObjects_.at(objID)->setSceneInstanceAttr(objInstAttributes);
   // set object's location, rotation and other pertinent state values based on
-  // scene object instance values
-  this->existingObjects_.at(objID)->setStateFromAttributes(
-      objInstAttributes.get(), defaultCOMCorrection);
+  // scene object instance attributes set in the object above.
+  this->existingObjects_.at(objID)->resetStateFromSceneInstanceAttr(
+      defaultCOMCorrection);
 
   return objID;
 }  // PhysicsManager::addObjectInstance

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -11,7 +11,7 @@
 #include "esp/core/RigidState.h"
 
 /** @file
- * @brief Class @ref esp::physics::PhysicsObjectBase is the base class for any
+ * @brief Class @ref physics::PhysicsObjectBase is the base class for any
  * physics-based construct, and holds basic accounting info and accessors, along
  * with scene node access.
  */
@@ -81,7 +81,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
         Magnum::SceneGraph::AbstractFeature3D::object());
   }
   /**
-   * @brief Get the @ref esp::physics::MotionType of the object. See @ref
+   * @brief Get the @ref physics::MotionType of the object. See @ref
    * setMotionType.
    * @return The object's current @ref MotionType.
    */
@@ -89,12 +89,12 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /**
    * @brief Set the @ref MotionType of the object. If the construct is a @ref
-   * esp::physics::RigidStage, it can only be @ref
-   * esp::physics::MotionType::STATIC. If the object is
-   * @ref esp::physics::RigidObject it can also be set to @ref
-   * esp::physics::MotionType::KINEMATIC. Only if a dervied @ref
-   * esp::physics::PhysicsManager implementing dynamics is in use can the object
-   * be set to @ref esp::physics::MotionType::DYNAMIC.
+   * physics::RigidStage, it can only be @ref
+   * physics::MotionType::STATIC. If the object is
+   * @ref physics::RigidObject it can also be set to @ref
+   * physics::MotionType::KINEMATIC. Only if a dervied @ref
+   * physics::PhysicsManager implementing dynamics is in use can the object
+   * be set to @ref physics::MotionType::DYNAMIC.
    * @param mt The desirved @ref MotionType.
    */
   virtual void setMotionType(MotionType mt) = 0;
@@ -146,7 +146,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   // ==== Transformations ===
 
   /** @brief Set the 4x4 transformation matrix of the object kinematically.
-   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * Calling this during simulation of a @ref physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param transformation The desired 4x4 transform of the object.
    */
@@ -166,7 +166,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /**
    * @brief Set the 3D position of the object kinematically.
-   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * Calling this during simulation of a @ref physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param vector The desired 3D position of the object.
    */
@@ -186,7 +186,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /**
    * @brief Set the orientation of the object kinematically.
-   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * Calling this during simulation of a @ref physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param quaternion The desired orientation of the object.
    */
@@ -228,7 +228,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   }
 
   /** @brief Modify the 3D position of the object kinematically by translation.
-   * Calling this during simulation of a @ref esp::physics::MotionType::DYNAMIC
+   * Calling this during simulation of a @ref physics::MotionType::DYNAMIC
    * object is not recommended.
    * @param vector The desired 3D vector by which to translate the object.
    */
@@ -241,7 +241,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the 3D position of the object kinematically by translation
    * with a vector defined in the object's local coordinate system. Calling this
-   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * during simulation of a @ref physics::MotionType::DYNAMIC object is not
    * recommended.
    * @param vector The desired 3D vector in the object's ocal coordiante system
    * by which to translate the object.
@@ -269,7 +269,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying an
    * axis-angle rotation to it in the local coordinate system. Calling this
-   * during simulation of a @ref esp::physics::MotionType::DYNAMIC object is not
+   * during simulation of a @ref physics::MotionType::DYNAMIC object is not
    * recommended.
    * @param angleInRad The angle of rotation in radians.
    * @param normalizedAxis The desired unit vector axis of rotation in the local
@@ -285,7 +285,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global X axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateX(const Magnum::Rad angleInRad) {
@@ -297,7 +297,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global Y axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateY(const Magnum::Rad angleInRad) {
@@ -309,7 +309,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the global Z axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateZ(const Magnum::Rad angleInRad) {
@@ -321,7 +321,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local X axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateXLocal(const Magnum::Rad angleInRad) {
@@ -333,7 +333,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local Y axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateYLocal(const Magnum::Rad angleInRad) {
@@ -345,7 +345,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Modify the orientation of the object kinematically by applying a
    * rotation to it about the local Z axis. Calling this during simulation of a
-   * @ref esp::physics::MotionType::DYNAMIC object is not recommended.
+   * @ref physics::MotionType::DYNAMIC object is not recommended.
    * @param angleInRad The angle of rotation in radians.
    */
   virtual void rotateZLocal(const Magnum::Rad angleInRad) {
@@ -358,20 +358,30 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Store whatever object attributes you want here!
    */
-  esp::core::Configuration::ptr attributes_{};
+  core::Configuration::ptr attributes_{};
 
   /**
-   * @brief Set the object's state from a @ref
-   * esp::metadata::attributes::SceneObjectInstanceAttributes
-   * @param objInstAttr The attributes that describe the desired state to set
-   * this object.
+   * @brief Set or reset the object's state using the object's specified @p
+   * sceneInstanceAttributes_.
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
    */
-  virtual void setStateFromAttributes(
-      const esp::metadata::attributes::SceneObjectInstanceAttributes* const
-          objInstAttr,
-      bool defaultCOMCorrection = false) = 0;
+  virtual void resetStateFromSceneInstanceAttr(
+      CORRADE_UNUSED bool defaultCOMCorrection = false) = 0;
+
+  /**
+   * @brief Set this object's @ref
+   * metadata::attributes::SceneObjectInstanceAttributes used to place the
+   * object within the scene.
+   * @param instanceAttr The @ref
+   * metadata::attributes::SceneObjectInstanceAttributes used to place this
+   * object in the scene.
+   */
+
+  template <class U>
+  void setSceneInstanceAttr(std::shared_ptr<U> instanceAttr) {
+    _sceneInstanceAttributes = std::move(instanceAttr);
+  }  // setSceneInstanceAttr
 
  protected:
   /**
@@ -400,6 +410,28 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * object's asset data.
    */
   const assets::ResourceManager& resMgr_;
+
+  /** @brief Accessed internally. Get an appropriately cast copy of the @ref
+   * metadata::attributes::SceneObjectInstanceAttributes used to place the
+   * object within the scene.
+   * @return A copy of the initialization template used to create this object
+   * instance or nullptr if no template exists.
+   */
+  template <class T>
+  std::shared_ptr<T> getSceneInstanceAttrInternal() const {
+    if (!_sceneInstanceAttributes) {
+      return nullptr;
+    }
+    return T::create(*(static_cast<T*>(_sceneInstanceAttributes.get())));
+  }
+
+ private:
+  /**
+   * @brief This object's instancing attributes, if any were used during its
+   * creation.
+   */
+  std::shared_ptr<metadata::attributes::SceneObjectInstanceAttributes>
+      _sceneInstanceAttributes = nullptr;
 
  public:
   ESP_SMART_POINTERS(PhysicsObjectBase)

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -236,6 +236,18 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   virtual void setInertiaVector(CORRADE_UNUSED const Magnum::Vector3& inertia) {
   }
 
+  /**
+   * @brief Returns the @ref metadata::attributes::SceneObjectInstanceAttributes
+   * used to place this rigid object in the scene.
+   * @return a copy of the scene instance attributes used to place this object
+   * in the scene.
+   */
+  std::shared_ptr<metadata::attributes::SceneObjectInstanceAttributes>
+  getSceneInstanceAttributes() const {
+    return PhysicsObjectBase::getSceneInstanceAttrInternal<
+        metadata::attributes::SceneObjectInstanceAttributes>();
+  }
+
   /** @brief Get a copy of the template used to initialize this object
    * or scene.
    * @return A copy of the initialization template used to create this object

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -66,37 +66,38 @@ void RigidObject::setMotionType(MotionType mt) {
   }
 }
 
-void RigidObject::setStateFromAttributes(
-    const esp::metadata::attributes::SceneObjectInstanceAttributes* const
-        objInstAttr,
-    bool defaultCOMCorrection) {
+void RigidObject::resetStateFromSceneInstanceAttr(bool defaultCOMCorrection) {
+  auto sceneInstanceAttr = getSceneInstanceAttributes();
+  if (!sceneInstanceAttr) {
+    return;
+  }
   // set object's location and rotation based on translation and rotation
   // params specified in instance attributes
-  auto translate = objInstAttr->getTranslation();
+  auto translate = sceneInstanceAttr->getTranslation();
   // get instance override value, if exists
   auto instanceCOMOrigin =
       static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
-          objInstAttr->getTranslationOrigin());
-  if (((defaultCOMCorrection) &&
+          sceneInstanceAttr->getTranslationOrigin());
+  if ((defaultCOMCorrection &&
        (instanceCOMOrigin !=
         metadata::managers::SceneInstanceTranslationOrigin::COM)) ||
       (instanceCOMOrigin ==
        metadata::managers::SceneInstanceTranslationOrigin::AssetLocal)) {
     // if default COM correction is set and no object-based override, or if
     // Object set to correct for COM.
-    translate -=
-        objInstAttr->getRotation().transformVector(visualNode_->translation());
+    translate -= sceneInstanceAttr->getRotation().transformVector(
+        visualNode_->translation());
   }
 
   setTranslation(translate);
-  setRotation(objInstAttr->getRotation());
+  setRotation(sceneInstanceAttr->getRotation());
   // set object's motion type if different than set value
   const physics::MotionType attrObjMotionType =
-      static_cast<physics::MotionType>(objInstAttr->getMotionType());
+      static_cast<physics::MotionType>(sceneInstanceAttr->getMotionType());
   if (attrObjMotionType != physics::MotionType::UNDEFINED) {
     this->setMotionType(attrObjMotionType);
   }
-}  // RigidObject::setStateFromAttributes
+}  // RigidObject::resetStateFromSceneInstanceAttr
 
 //////////////////
 // VelocityControl

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -178,9 +178,7 @@ class RigidObject : public RigidBase {
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
    */
-  void setStateFromAttributes(
-      const esp::metadata::attributes::SceneObjectInstanceAttributes* const
-          objInstAttr,
+  void resetStateFromSceneInstanceAttr(
       bool defaultCOMCorrection = false) override;
 
  protected:

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -77,18 +77,18 @@ class RigidStage : public RigidBase {
 
  public:
   /**
-   * @brief Currently not supported.  Set the stage's state from a @ref
-   * esp::metadata::attributes::SceneObjectInstanceAttributes
-   * @param stageInstAttr The attributes that describe the desired state to set
-   * this object.
+   * @brief Currently not supported. Set or reset the stages's state using the
+   * object's specified @p sceneInstanceAttributes_.
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
    */
-  void setStateFromAttributes(
-      CORRADE_UNUSED const
-          esp::metadata::attributes::SceneObjectInstanceAttributes* const
-              stageInstAttr,
-      CORRADE_UNUSED bool defaultCOMCorrection = false) override {}
+  void resetStateFromSceneInstanceAttr(
+      CORRADE_UNUSED bool defaultCOMCorrection = false) override {
+    auto sceneInstanceAttr = getSceneInstanceAttributes();
+    if (!sceneInstanceAttr) {
+      return;
+    }
+  }
 
   /**
    * @brief Currently ignored for stage objects.

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -83,12 +83,7 @@ class RigidStage : public RigidBase {
    * translation correction needs to occur.
    */
   void resetStateFromSceneInstanceAttr(
-      CORRADE_UNUSED bool defaultCOMCorrection = false) override {
-    auto sceneInstanceAttr = getSceneInstanceAttributes();
-    if (!sceneInstanceAttr) {
-      return;
-    }
-  }
+      CORRADE_UNUSED bool defaultCOMCorrection = false) override {}
 
   /**
    * @brief Currently ignored for stage objects.


### PR DESCRIPTION
## Motivation and Context
This PR improves how objects are instanced.  It also introduces the ability to save the scene object instance attributes used to place an object to the object itself.  This will make it easier in the future to return an object to its initial position.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
