### PR TITLE
[Bugfix]Remove virtual function call from manager specialization ctors

### DIFF
--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -552,14 +552,6 @@ class ManagedContainer : public ManagedContainerBase {
   }  // ManagedContainer::
 
   /**
-   * @brief This function will build the appropriate @p copyConstructorMap_
-   * copy constructor function pointer map for this container's managed object,
-   * keyed on the managed object's class type.  This MUST be called in the
-   * constructor of the -instancing- class.
-   */
-  virtual void buildCtorFuncPtrMaps() = 0;
-
-  /**
    * @brief Build an @ref esp::core::AbstractManagedObject object of type
    * associated with passed object.
    * @param origAttr The ptr to the original AbstractManagedObject object to
@@ -630,7 +622,7 @@ class ManagedContainer : public ManagedContainerBase {
   /**
    * @brief Map of function pointers to instantiate a copy of a managed
    * object. A managed object is instanced by accessing the approrpiate
-   * function pointer.
+   * function pointer.  THIS MUST BE INSTANCED IN SPECIALIZATION CONSTRUCTOR.
    */
   Map_Of_CopyCtors copyConstructorMap_;
 

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -36,7 +36,10 @@ const std::map<PrimObjTypes, const char*>
         {PrimObjTypes::UVSPHERE_WF, "uvSphereWireframe"},
         {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
 
-void AssetAttributesManager::buildCtorFuncPtrMaps() {
+AssetAttributesManager::AssetAttributesManager()
+    : AttributesManager<attributes::AbstractPrimitiveAttributes,
+                        core::ManagedObjectAccess::Copy>::
+          AttributesManager("Primitive Asset", "prim_config.json") {
   // function pointers to asset attributes constructors
   primTypeConstructorMap_["capsule3DSolid"] =
       &AssetAttributesManager::createPrimAttributes<
@@ -102,10 +105,10 @@ void AssetAttributesManager::buildCtorFuncPtrMaps() {
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
 
-  LOG(INFO) << "AssetAttributesManager::buildCtorFuncPtrMaps : Built default "
+  LOG(INFO) << "AssetAttributesManager::constructor : Built default "
                "primitive asset templates : "
             << std::to_string(defaultPrimAttributeHandles_.size());
-}  // AssetAttributesManager::buildMapOfPrimTypeConstructors
+}  // AssetAttributesManager::ctor
 
 AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
     const std::string& primClassName,

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -86,12 +86,7 @@ class AssetAttributesManager
    */
   static const std::map<PrimObjTypes, const char*> PrimitiveNames3DMap;
 
-  AssetAttributesManager()
-      : AttributesManager<attributes::AbstractPrimitiveAttributes,
-                          core::ManagedObjectAccess::Copy>::
-            AttributesManager("Primitive Asset", "prim_config.json") {
-    buildCtorFuncPtrMaps();
-  }  // AssetAttributesManager::ctor
+  AssetAttributesManager();
 
   /**
    * @brief Should only be called internally. Creates an instance of a primtive
@@ -521,14 +516,6 @@ class AssetAttributesManager
       createObject(elem.second, true);
     }
   }  // AssetAttributesManager::resetFinalize()
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointers for @ref createPrimAttributes calls for each type of
-   * supported primitive to the @ref primTypeConstructorMap_, keyed by type of
-   * primtive
-   */
-  void buildCtorFuncPtrMaps() override;
 
   // ======== Typedefs and Instance Variables ========
 

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -23,7 +23,10 @@ class LightLayoutAttributesManager
       : AttributesManager<attributes::LightLayoutAttributes,
                           core::ManagedObjectAccess::Copy>::
             AttributesManager("Lighting Layout", "lighting_config.json") {
-    buildCtorFuncPtrMaps();
+    // build this manager's copy constructor map
+    this->copyConstructorMap_["LightLayoutAttributes"] =
+        &LightLayoutAttributesManager::createObjectCopy<
+            attributes::LightLayoutAttributes>;
   }
 
   /**
@@ -126,17 +129,6 @@ class LightLayoutAttributesManager
    * reset.
    */
   void resetFinalize() override {}
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as required by
-   * AttributesManager<LightLayoutAttributes::ptr>
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["LightLayoutAttributes"] =
-        &LightLayoutAttributesManager::createObjectCopy<
-            attributes::LightLayoutAttributes>;
-  }  // LightLayoutAttributesManager::buildCtorFuncPtrMaps
 
   /**
    * @brief Light Attributes has no reason to check this value

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -25,10 +25,11 @@ class ObjectAttributesManager
   ObjectAttributesManager()
       : AbstractObjectAttributesManager<attributes::ObjectAttributes,
                                         core::ManagedObjectAccess::Copy>::
-            AbstractObjectAttributesManager(
-                "Object",
-                "object_config.json") {  // was phys_properties.json
-    buildCtorFuncPtrMaps();
+            AbstractObjectAttributesManager("Object", "object_config.json") {
+    // build this manager's copy constructor map
+    this->copyConstructorMap_["ObjectAttributes"] =
+        &ObjectAttributesManager::createObjectCopy<
+            attributes::ObjectAttributes>;
   }
 
   void setAssetAttributesManager(
@@ -243,17 +244,6 @@ class ObjectAttributesManager
     physicsFileObjTmpltLibByID_.clear();
     physicsSynthObjTmpltLibByID_.clear();
   }
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as defined in
-   * AttributesManager<ObjectAttributes::ptr>
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["ObjectAttributes"] =
-        &ObjectAttributesManager::createObjectCopy<
-            attributes::ObjectAttributes>;
-  }  // ObjectAttributesManager::buildCtorFuncPtrMaps()
 
   // ======== Typedefs and Instance Variables ========
 

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -25,8 +25,10 @@ class PhysicsAttributesManager
       : AttributesManager<attributes::PhysicsManagerAttributes,
                           core::ManagedObjectAccess::Copy>::
             AttributesManager("Physics Manager", "physics_config.json") {
-    buildCtorFuncPtrMaps();
-  }
+    this->copyConstructorMap_["PhysicsManagerAttributes"] =
+        &PhysicsAttributesManager::createObjectCopy<
+            attributes::PhysicsManagerAttributes>;
+  }  // ctor
 
   /**
    * @brief Creates an instance of a physics world template described by passed
@@ -138,17 +140,6 @@ class PhysicsAttributesManager
    * reset.
    */
   void resetFinalize() override {}
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as required by
-   * AttributesManager<PhysicsSceneAttributes::ptr>
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["PhysicsManagerAttributes"] =
-        &PhysicsAttributesManager::createObjectCopy<
-            attributes::PhysicsManagerAttributes>;
-  }  // PhysicsAttributesManager::buildCtorFuncPtrMaps
 
   // instance vars
 

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -50,7 +50,9 @@ class SceneAttributesManager
       : AttributesManager<attributes::SceneAttributes,
                           core::ManagedObjectAccess::Copy>::
             AttributesManager("Scene Instance", "scene_instance.json") {
-    buildCtorFuncPtrMaps();
+    // build this manager's copy constructor map
+    this->copyConstructorMap_["SceneAttributes"] =
+        &SceneAttributesManager::createObjectCopy<attributes::SceneAttributes>;
   }
 
   /**
@@ -166,19 +168,6 @@ class SceneAttributesManager
   int registerObjectFinalize(attributes::SceneAttributes::ptr sceneAttributes,
                              const std::string& sceneAttributesHandle,
                              CORRADE_UNUSED bool forceRegistration) override;
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as required by
-   * AttributesManager<PhysicsSceneAttributes::ptr>
-   *
-   * NOTE : currently this will only perform a shallow copy of the
-   * SceneAttributes.
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["SceneAttributes"] =
-        &SceneAttributesManager::createObjectCopy<attributes::SceneAttributes>;
-  }  // SceneAttributesManager::buildCtorFuncPtrMaps
 
   /**
    * @brief This function is meaningless for this manager's ManagedObjects.

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -12,6 +12,19 @@ namespace metadata {
 
 using attributes::SceneDatasetAttributes;
 namespace managers {
+
+SceneDatasetAttributesManager::SceneDatasetAttributesManager(
+    PhysicsAttributesManager::ptr physicsAttributesMgr)
+    : AttributesManager<attributes::SceneDatasetAttributes,
+                        core::ManagedObjectAccess::Share>::
+          AttributesManager("Dataset", "scene_dataset_config.json"),
+      physicsAttributesManager_(std::move(physicsAttributesMgr)) {
+  // build this manager's copy ctor map
+  this->copyConstructorMap_["SceneDatasetAttributes"] =
+      &SceneDatasetAttributesManager::createObjectCopy<
+          attributes::SceneDatasetAttributes>;
+}  // SceneDatasetAttributesManager ctor
+
 SceneDatasetAttributes::ptr SceneDatasetAttributesManager::createObject(
     const std::string& datasetHandle,
     bool registerTemplate) {

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -20,14 +20,7 @@ class SceneDatasetAttributesManager
                                core::ManagedObjectAccess::Share> {
  public:
   explicit SceneDatasetAttributesManager(
-      PhysicsAttributesManager::ptr physicsAttributesMgr)
-      : AttributesManager<attributes::SceneDatasetAttributes,
-                          core::ManagedObjectAccess::Share>::
-            AttributesManager("Dataset", "scene_dataset_config.json"),
-        physicsAttributesManager_(std::move(physicsAttributesMgr)) {
-    buildCtorFuncPtrMaps();
-  }
-
+      PhysicsAttributesManager::ptr physicsAttributesMgr);
   /**
    * @brief Creates an instance of a dataset template described by passed
    * string. For dataset templates, this a file name.
@@ -193,17 +186,6 @@ class SceneDatasetAttributesManager
       attributes::SceneDatasetAttributes::ptr SceneDatasetAttributes,
       const std::string& SceneDatasetAttributesHandle,
       CORRADE_UNUSED bool forceRegistration) override;
-
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as required by
-   * AttributesManager<PhysicsSceneAttributes::ptr>
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["SceneDatasetAttributes"] =
-        &SceneDatasetAttributesManager::createObjectCopy<
-            attributes::SceneDatasetAttributes>;
-  }  // SceneDatasetAttributesManager::buildCtorFuncPtrMaps
 
   /**
    * @brief This function is meaningless for this manager's ManagedObjects.

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -31,10 +31,7 @@ StageAttributesManager::StageAttributesManager(
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),
       cfgLightSetup_(NO_LIGHT_KEY) {
-  buildCtorFuncPtrMaps();
-}  // StageAttributesManager ctor
-
-void StageAttributesManager::buildCtorFuncPtrMaps() {
+  // build this manager's copy constructor map
   this->copyConstructorMap_["StageAttributes"] =
       &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
   // create none-type stage attributes and set as undeletable
@@ -42,7 +39,7 @@ void StageAttributesManager::buildCtorFuncPtrMaps() {
   auto tmplt = this->createDefaultObject("NONE", true);
   std::string tmpltHandle = tmplt->getHandle();
   this->undeletableObjectNames_.insert(tmpltHandle);
-}  // StageAttributesManager::buildCtorFuncPtrMaps
+}  // StageAttributesManager::ctor
 
 int StageAttributesManager::registerObjectFinalize(
     StageAttributes::ptr stageAttributes,

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -165,13 +165,6 @@ class StageAttributesManager
    */
   void resetFinalize() override {}
 
-  /**
-   * @brief This function will assign the appropriately configured function
-   * pointer for the copy constructor as required by
-   * AttributesManager<StageAttributes::ptr>
-   */
-  void buildCtorFuncPtrMaps() override;
-
   // instance vars
 
   /**

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -20,7 +20,9 @@ class RigidObjectManager
   RigidObjectManager()
       : esp::physics::RigidBaseManager<ManagedRigidObject>::RigidBaseManager(
             "RigidObject") {
-    this->buildCtorFuncPtrMaps();
+    // build this manager's copy constructor map
+    this->copyConstructorMap_["ManagedRigidObject"] =
+        &RigidObjectManager::createObjectCopy<ManagedRigidObject>;
   }
 
   /** @brief Instance a physical object from an object properties template in
@@ -115,17 +117,6 @@ class RigidObjectManager
       CORRADE_UNUSED bool builtFromConfig) override {
     return ManagedRigidObject::create();
   }  // RigidObjectManager::initNewObjectInternal(
-
-  /**
-   * @brief This function will build the appropriate @ref copyConstructorMap_
-   * copy constructor function pointer map for this container's managed object,
-   * keyed on the managed object's class type.  This MUST be called in the
-   * constructor of the -instancing- class.
-   */
-  void buildCtorFuncPtrMaps() override {
-    this->copyConstructorMap_["ManagedRigidObject"] =
-        &RigidObjectManager::createObjectCopy<ManagedRigidObject>;
-  }  // ObjectAttributesManager::buildCtorFuncPtrMaps()
 
  public:
   ESP_SMART_POINTERS(RigidObjectManager)


### PR DESCRIPTION
## Motivation and Context
The Managed Containers have a virtual function which instances a map of copy constructors for the objects being managed (this is so we can have one manager manage all the different types of attributes for related types, such as primitives). Unfortunately, this function was being called from the specialization class's constructor (Which is very bad - function does not act virtual if called from ctor, so if any class ever inherits from these existing managers, they would experience difficult to diagnose bugs).  This PR removes this function and moves the functionality from it to the various constructors.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
