### PR TITLE
Derived class able to use base class's shared_from_this properly

### DIFF
--- a/src/esp/core/esp.h
+++ b/src/esp/core/esp.h
@@ -122,6 +122,24 @@ inline std::ostream& operator<<(std::ostream& os, const box3f& bbox) {
     return std::make_unique<__VA_ARGS__>(std::forward<Targs>(args)...); \
   }
 
+/**
+ * shim function helper for derived class of std::enable_shared_from_this<Base>
+ */
+template <typename Base>
+inline std::shared_ptr<Base> shared_from_base(
+    std::enable_shared_from_this<Base>* base) {
+  return base->shared_from_this();
+}
+
+/**
+ * shared_from_this access for inheriting classes of Base classes that inherit
+ * std::enable_shared_from_this<Base>
+ */
+template <typename Derived>
+inline std::shared_ptr<Derived> shared_from(Derived* derived) {
+  return std::static_pointer_cast<Derived>(shared_from_base(derived));
+}
+
 // pimpl macro backed by unique_ptr pointer
 #define ESP_UNIQUE_PTR_PIMPL() \
  protected:                    \

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -214,6 +214,13 @@ class BulletPhysicsManager : public PhysicsManager {
     recentNumSubStepsTaken_ = -1;  // TODO: handle this more gracefully
   }
 
+  /**
+   * @brief utilize PhysicsManager's enable shared
+   */
+  BulletPhysicsManager::ptr shared_from_this() {
+    return esp::shared_from(this);
+  }
+
  protected:
   //============ Initialization =============
   /**


### PR DESCRIPTION
## Motivation and Context
Small PR that adds functionality so that a derived class's shared_from_this is appropriately downcast when the parent class inherits from std::enable_shared_from_this<parent>.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes
All c++ and python tests pass locally

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
