### PR TITLE
Tidy mesh transform node

### DIFF
--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -26,13 +26,13 @@ namespace assets {
  */
 struct MeshTransformNode {
   /** @brief Local mesh index within @ref MeshMetaData::meshIndex. */
-  int meshIDLocal;
+  int meshIDLocal{ID_UNDEFINED};
 
   /** @brief Material key within global material manager. */
-  std::string materialID;
+  std::string materialID{};  // initializes to default material;
 
   /** @brief Object index of asset component in the original file. */
-  int componentID;
+  int componentID{ID_UNDEFINED};
 
   /** @brief The component transformation subtrees with this node as the root.
    */
@@ -42,10 +42,7 @@ struct MeshTransformNode {
   Magnum::Matrix4 transformFromLocalToParent;
 
   /** @brief Default constructor. */
-  MeshTransformNode()
-      : meshIDLocal(ID_UNDEFINED),
-        materialID(""),  // default material id
-        componentID(ID_UNDEFINED){};
+  MeshTransformNode() = default;
 };
 
 /**


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Tidying up some code to use default member inits. This should clean up the constructor and make it more readable and may allow the compiler to do some further optimization by marking the constructor as trivial.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
