### PR TITLE
address some doc warnings

### DIFF
--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -80,7 +80,7 @@
     :summary: Samples a navigable point uniformly at random from the navmesh
 
     :param max_tries: The maximum number of times to retry sampling if it fails and the navmesh
-    seems fine.  Setting this higher can sometimes be warranted, but needing to typically
+    seems fine. Setting this higher can sometimes be warranted, but needing to typically
     indicates an error with the navmesh.
     :return: A navigable point or ``{NAN, NAN, NAN}`` if this fails
 

--- a/habitat_sim/simulator.py
+++ b/habitat_sim/simulator.py
@@ -47,7 +47,8 @@ class Configuration:
 
     :property sim_cfg: The configuration of the backend of the simulator
     :property agents: A list of agent configurations
-    :property metadata_mediator: (optional) The metadata mediator to build the simulator from
+    :property metadata_mediator: (optional) The metadata mediator to build the simulator from.
+
     Ties together a backend config, `sim_cfg` and a list of agent
     configurations `agents`.
     """

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -173,8 +173,8 @@ class ResourceManager {
    * @param _physicsManager The currently defined @ref physics::PhysicsManager.
    * @param sceneManagerPtr Pointer to scene manager, to fetch drawables and
    * parent node.
-   * @param [out] Current active scene ID is in idx 0, if semantic scene is
-   * made, its activeID should be pushed onto vector
+   * @param [out] activeSceneIDs active scene ID is in idx 0, if semantic scene
+   * is made, its activeID should be pushed onto vector
    * @param createSemanticMesh If the semantic mesh should be created, based on
    * @ref SimulatorConfiguration
    * @param forceSeparateSemanticSceneGraph Force creation of a separate
@@ -336,8 +336,8 @@ class ResourceManager {
   /**
    * @brief Registers a given VoxelGrid pointer under the given handle in the
    * voxelGridDict_ if no such VoxelGrid has been registered.
-   * @param VoxelGrid The pointer to the VoxelGrid
    * @param voxelGridHandle The key to register the VoxelGrid under.
+   * @param VoxelGridPtr The pointer to the VoxelGrid
    * @return Whether or not the registration succeeded.
    */
   bool registerVoxelGrid(
@@ -353,6 +353,9 @@ class ResourceManager {
 
   /**
    * @brief Get a named @ref LightSetup
+   *
+   * @param key The key identifying the light setup in shaderManager_.
+   * @return The LightSetup object.
    */
   Mn::Resource<gfx::LightSetup> getLightSetup(
       const Mn::ResourceKey& key = Mn::ResourceKey{DEFAULT_LIGHTING_KEY}) {
@@ -699,7 +702,8 @@ class ResourceManager {
    * identifying its mesh, material, transformation, and children.
    * @param[out] visNodeCache Cache for pointers to all nodes created as the
    * result of this recursive process.
-   * @param computeAABBs whether absolute bounding boxes should be computed
+   * @param computeAbsoluteAABBs whether absolute bounding boxes should be
+   * computed
    * @param staticDrawableInfo structure holding the drawable infos for aabbs
    */
   void addComponent(const MeshMetaData& metaData,
@@ -826,8 +830,7 @@ class ResourceManager {
    * @param drawables The @ref DrawableGroup with which the mesh will be
    * rendered. See also creation->isRGBD and creation->isSemantic. nullptr if
    * not instancing.
-   * @param splitSemanticMesh Split the semantic mesh by objectID, used for A/B
-   * testing
+   * @return Whether or not the load was successful.
    */
   bool loadStageInternal(const AssetInfo& info,
                          const RenderAssetInstanceCreationInfo* creation,
@@ -968,12 +971,12 @@ class ResourceManager {
    */
   Mn::Range3D computeMeshBB(BaseMesh* meshDataGL);
 
+#ifdef ESP_BUILD_PTEX_SUPPORT
   /**
    * @brief Compute the absolute AABBs for drawables in PTex mesh in world
    * space
-   * @param baseMesh: ptex mesh
+   * @param baseMesh ptex mesh
    */
-#ifdef ESP_BUILD_PTEX_SUPPORT
   void computePTexMeshAbsoluteAABBs(
       BaseMesh& baseMesh,
       const std::vector<StaticDrawableInfo>& staticDrawableInfo);

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -163,7 +163,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    * extension(s) with the passed @p fileTypeExt, if it is missing.  NOTE : this
    * does not verify that file exists.
    * @param filename The original file name
-   * @param fileTypeExt The extension to use for the new filename.
+   * @param jsonTypeExt The extension to use for the new filename.
    * @return The file name changed so that it has the correct @p fileTypeExt if
    * it was missing.
    */

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -163,12 +163,12 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    * extension(s) with the passed @p fileTypeExt, if it is missing.  NOTE : this
    * does not verify that file exists.
    * @param filename The original file name
-   * @param jsonTypeExt The extension to use for the new filename.
+   * @param fileTypeExt The extension to use for the new filename.
    * @return The file name changed so that it has the correct @p fileTypeExt if
    * it was missing.
    */
   std::string convertFilenameToPassedExt(const std::string& filename,
-                                         const std::string& jsonTypeExt);
+                                         const std::string& fileTypeExt);
 
   /**
    * @brief Get directory component of managed object handle and call @ref

--- a/src/esp/geo/VoxelGrid.cpp
+++ b/src/esp/geo/VoxelGrid.cpp
@@ -146,7 +146,7 @@ void VoxelGrid::fillBoolGridNeighborhood(std::vector<bool>& neighbors,
 void VoxelGrid::addVoxelToMeshPrimitives(
     Cr::Containers::Array<VoxelVertex>& vertexData,
     Cr::Containers::Array<Mn::UnsignedInt>& indexData,
-    const Mn::Vector3i& local_coords,
+    const Mn::Vector3i& localCoords,
     const std::vector<bool>& neighbors,
     const Mn::Color3& color) {
   // Using the data of a cubeSolid to create the voxel cube
@@ -155,7 +155,7 @@ void VoxelGrid::addVoxelToMeshPrimitives(
 
   // add cube to mesh
   // midpoint of a voxel
-  Mn::Vector3 mid = getGlobalCoords(local_coords);
+  Mn::Vector3 mid = getGlobalCoords(localCoords);
   unsigned int sz = vertexData.size();
   Corrade::Containers::StridedArrayView1D<const Magnum::Vector3> cubePositions =
       cubeData.attribute<Mn::Vector3>(Mn::Trade::MeshAttribute::Position);
@@ -183,12 +183,12 @@ void VoxelGrid::addVoxelToMeshPrimitives(
 void VoxelGrid::addVectorToMeshPrimitives(
     Cr::Containers::Array<VoxelVertex>& vertexData,
     Cr::Containers::Array<Mn::UnsignedInt>& indexData,
-    const Mn::Vector3i& local_coords,
+    const Mn::Vector3i& localCoords,
     const Mn::Vector3& vec) {
   Mn::Trade::MeshData coneData = Mn::Primitives::coneSolid(1, 4, 1.0f);
 
   // midpoint of a voxel
-  Mn::Vector3 mid = getGlobalCoords(local_coords);
+  Mn::Vector3 mid = getGlobalCoords(localCoords);
   // add cone to mesh (tip of arrow)
   unsigned int sz = vertexData.size();
   Corrade::Containers::StridedArrayView1D<const Magnum::Vector3> conePositions =

--- a/src/esp/geo/VoxelGrid.h
+++ b/src/esp/geo/VoxelGrid.h
@@ -52,7 +52,7 @@ class VoxelGrid {
   /**
    * @brief Generates a Boundary voxel grid using VHACD's voxelization
    * framework.
-   * @param MeshData The mesh that will be voxelized
+   * @param meshData The mesh that will be voxelized
    * @param renderAssetHandle The handle for the render asset.
    * @param resolution The approximate number of voxels in the voxel grid.
    */
@@ -65,7 +65,7 @@ class VoxelGrid {
    * @brief Generates an empty voxel grid given some voxel size and voxel
    * dimensions..
    * @param voxelSize The size of a single voxel
-   * @param VoxelGridDimensions The dimensions of the voxel grid.
+   * @param voxelGridDimensions The dimensions of the voxel grid.
    */
   VoxelGrid(const Magnum::Vector3& voxelSize,
             const Magnum::Vector3i& voxelGridDimensions);
@@ -151,7 +151,7 @@ class VoxelGrid {
 
   /**
    * @brief Removes a grid and frees up memory.
-   * @param name The name of the grid to be removed.
+   * @param gridName The name of the grid to be removed.
    */
   void removeGrid(const std::string& gridName) {
     assert(grids_.find(gridName) != grids_.end());
@@ -362,8 +362,8 @@ class VoxelGrid {
    * @param vertexData A Corrade Array of VoxelVertex which each contain a
    * vertex's position, normal, and color
    * @param indexData A Corrade Array of indicies for the faces on the mesh.
-   * @param local_coords A voxel index specifying the location of the voxel.
-   * @param voxel_neighbors A boolean with 6 booleans representing whether the
+   * @param localCoords A voxel index specifying the location of the voxel.
+   * @param neighbors A boolean with 6 booleans representing whether the
    * voxel on the top (y+1), bottom (x+1), right (y+1), left (y-1), back (z-1)
    * and front (x-1) are filled.
    * @param color A Magnum::Color3 object specifying the color for a particular
@@ -372,8 +372,8 @@ class VoxelGrid {
   void addVoxelToMeshPrimitives(
       Corrade::Containers::Array<VoxelVertex>& vertexData,
       Corrade::Containers::Array<Mn::UnsignedInt>& indexData,
-      const Magnum::Vector3i& local_coords,
-      const std::vector<bool>& voxel_neighbors,
+      const Magnum::Vector3i& localCoords,
+      const std::vector<bool>& neighbors,
       const Magnum::Color3& color = Magnum::Color3(.4, .8, 1));
 
   /**
@@ -382,13 +382,13 @@ class VoxelGrid {
    * @param vertexData A Corrade Array of VoxelVertex which each contain a
    * vertex's position, normal, and color
    * @param indexData A Corrade Array of indicies for the faces on the mesh.
-   * @param local_coords A voxel index specifying the location of the voxel.
+   * @param localCoords A voxel index specifying the location of the voxel.
    * @param vec The vector to be converted into a mesh.
    */
   void addVectorToMeshPrimitives(
       Corrade::Containers::Array<VoxelVertex>& vertexData,
       Corrade::Containers::Array<Mn::UnsignedInt>& indexData,
-      const Magnum::Vector3i& local_coords,
+      const Magnum::Vector3i& localCoords,
       const Magnum::Vector3& vec);
 
  private:

--- a/src/esp/geo/VoxelWrapper.h
+++ b/src/esp/geo/VoxelWrapper.h
@@ -29,12 +29,12 @@ class VoxelWrapper {
    * @param renderAssetHandle The handle for the render asset to which the voxel
    * grid corresponds.
    * @param sceneNode The scene node the voxel wrapper will be pointing to.
-   * @param resourceManager_ Used for retrieving or registering the voxel grid.
+   * @param resourceManager Used for retrieving or registering the voxel grid.
    * @param resolution The approximate number of voxels for the voxelization.
    */
   VoxelWrapper(const std::string& renderAssetHandle,
                esp::scene::SceneNode* sceneNode,
-               esp::assets::ResourceManager& resourceManager_,
+               esp::assets::ResourceManager& resourceManager,
                int resolution);
 #endif
 
@@ -45,13 +45,13 @@ class VoxelWrapper {
    * @param renderAssetHandle The handle for the render asset to which the voxel
    * grid corresponds.
    * @param sceneNode The scene node the voxel wrapper will be pointing to.
-   * @param resourceManager_ Used for registering the voxel grid.
+   * @param resourceManager Used for registering the voxel grid.
    * @param voxelSize The size of an individual voxel cell.
    * @param voxelDimensions The dimensions of the voxel grid.
    */
-  VoxelWrapper(const std::string& handle,
+  VoxelWrapper(const std::string& renderAssetHandle,
                esp::scene::SceneNode* sceneNode,
-               esp::assets::ResourceManager& resourceManager_,
+               esp::assets::ResourceManager& resourceManager,
                Mn::Vector3& voxelSize,
                Mn::Vector3i& voxelDimensions);
 
@@ -98,7 +98,8 @@ class VoxelWrapper {
   // --== FUNCTIONS FROM VOXELGRID ==--
   /**
    * @brief Generates a new empty voxel grid of a specified type.
-   * @param name The key underwhich the grid will be registered and accessed.
+   * @param gridName The key underwhich the grid will be registered and
+   * accessed.
    * @return a StridedArrayView3D for the newly created grid.
    */
   template <typename T>
@@ -108,7 +109,7 @@ class VoxelWrapper {
 
   /**
    * @brief Removes a grid and frees up memory.
-   * @param name The name of the grid to be removed.
+   * @param gridName The name of the grid to be removed.
    */
   void removeGrid(const std::string& gridName) {
     voxelGrid->removeGrid(gridName);

--- a/src/esp/gfx/CubeMap.h
+++ b/src/esp/gfx/CubeMap.h
@@ -73,7 +73,7 @@ class CubeMap {
 
   /**
    * @brief, Constructor
-   * @param size, the size of the cubemap texture (each face is size x size)
+   * @param imageSize the size of the cubemap texture (each face is size x size)
    */
   explicit CubeMap(int imageSize, Flags flags = Flags{Flag::ColorTexture});
 
@@ -103,8 +103,8 @@ class CubeMap {
    * ```
    * NOTE: +Y is top
    * @brief save the cubemap texture based on the texture type
-   * @param type, texture type
-   * @param imageFilePrefix, the filename prefix
+   * @param type texture type
+   * @param imageFilePrefix the filename prefix
    * The 6 image files then would be:
    * {imageFilePrefix}.{texType}.+X.png
    * {imageFilePrefix}.{texType}.-X.png
@@ -139,8 +139,8 @@ class CubeMap {
    * NOTE: +Y is top
    * @brief load cubemap texture from external images
    * @param type can be "rgba", "depth", or "objectId" (TODO)
-   * @param imageFilePrefix, the prefix of the image filename
-   * @param imageFileExtension, the image filename extension (such as "png",
+   * @param imageFilePrefix the prefix of the image filename
+   * @param imageFileExtension the image filename extension (such as "png",
    * "jpg")
    * @return true if succeeded, otherwise false
    * The 6 image files then would be:
@@ -157,7 +157,7 @@ class CubeMap {
 
   /**
    * @brief Render to cubemap texture using the camera
-   * @param camera, a cubemap camera
+   * @param camera a cubemap camera
    * NOTE: It will NOT automatically generate the mipmap for the user
    */
   void renderToTexture(CubeMapCamera& camera,
@@ -201,9 +201,9 @@ class CubeMap {
 
   /**
    * @brief Prepare to draw to the texture
-   * @param[in] cubeSideIndex, the index of the cube side, can be 0,
+   * @param[in] cubeSideIndex the index of the cube side, can be 0,
    * 1, 2, 3, 4, or 5
-   * @param[in] flags, the flags to control the rendering
+   * @param[in] flags the flags to control the rendering
    */
   void prepareToDraw(unsigned int cubeSideIndex,
                      RenderCamera::Flags flags = {
@@ -213,7 +213,7 @@ class CubeMap {
 
   /**
    * @brief Map shader output to attachments.
-   * @param cubeSideIndex, the index of the cube side, can be 0,
+   * @param cubeSideIndex the index of the cube side, can be 0,
    * 1, 2, 3, 4, or 5
    */
   void mapForDraw(unsigned int cubeSideIndex);

--- a/src/esp/gfx/CubeMapCamera.h
+++ b/src/esp/gfx/CubeMapCamera.h
@@ -17,15 +17,15 @@ class CubeMapCamera : public RenderCamera {
  public:
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
+   * @param node the scene node to which the camera is attached
    */
   explicit CubeMapCamera(scene::SceneNode& node);
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
-   * @param eye, the eye position (parent node space)
-   * @param target, the target position (parent node space)
-   * @param up, the up direction (parent node space)
+   * @param node the scene node to which the camera is attached
+   * @param eye the eye position (parent node space)
+   * @param target the target position (parent node space)
+   * @param up the up direction (parent node space)
    */
   explicit CubeMapCamera(scene::SceneNode& node,
                          const vec3f& eye,
@@ -33,10 +33,10 @@ class CubeMapCamera : public RenderCamera {
                          const vec3f& up);
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
-   * @param eye, the eye position (parent node space)
-   * @param target, the target position (parent node space)
-   * @param up, the up direction (parent node space)
+   * @param node the scene node to which the camera is attached
+   * @param eye the eye position (parent node space)
+   * @param target the target position (parent node space)
+   * @param up the up direction (parent node space)
    */
   explicit CubeMapCamera(scene::SceneNode& node,
                          const Magnum::Vector3& eye,
@@ -54,7 +54,7 @@ class CubeMapCamera : public RenderCamera {
    *           | +Y |
    *           +----+
    * ```
-   * @param cubeSide, the cube map coordinate, see the following pictures
+   * @param cubeSide the cube map coordinate, see the following pictures
    * NOTE: +Y is top
    * CAREFUL! the local transformation of the camera node will be set after
    * calling this function.
@@ -72,7 +72,7 @@ class CubeMapCamera : public RenderCamera {
    *           | +Y |
    *           +----+
    * ```
-   * @param cubSideIndex, the index of the cube map coordinate.
+   * @param cubSideIndex the index of the cube map coordinate.
    * 0: +X
    * 1: -X
    * 2: +Y
@@ -94,7 +94,7 @@ class CubeMapCamera : public RenderCamera {
                                     float hfov) = delete;
   /**
    * @brief Set the projection matrix
-   * @param width, the width of the square image plane
+   * @param width the width of the square image plane
    * @param znear the near clipping plane
    * @param znear the far clipping plane
    */

--- a/src/esp/gfx/DoubleSphereCameraShader.h
+++ b/src/esp/gfx/DoubleSphereCameraShader.h
@@ -19,13 +19,13 @@ class DoubleSphereCameraShader : public CubeMapShaderBase {
 
   /**
    *  @brief Set the focal length of the fisheye camera
-   *  @param focalLength, the focal length x, y directions
+   *  @param focalLength the focal length x, y directions
    *  @return Reference to self (for method chaining)
    */
   DoubleSphereCameraShader& setFocalLength(Magnum::Vector2 focalLength);
   /**
    *  @brief Set the offset of the principal point of the fisheye camera
-   *  @param offset, the offset of the principal point in pixels
+   *  @param offset the offset of the principal point in pixels
    *  @return Reference to self (for method chaining)
    */
   DoubleSphereCameraShader& setPrincipalPointOffset(Magnum::Vector2 offset);
@@ -34,7 +34,7 @@ class DoubleSphereCameraShader : public CubeMapShaderBase {
    * See details in:
    * Vladyslav Usenko, Nikolaus Demmel and Daniel Cremers: The Double Sphere
    * Camera Model, The International Conference on 3D Vision (3DV), 2018
-   *  @param alpha, the alpha value (0.0 <= alpha < 1.0)
+   *  @param alpha the alpha value (0.0 <= alpha < 1.0)
    *  @return Reference to self (for method chaining)
    */
   DoubleSphereCameraShader& setAlpha(float alpha);
@@ -44,7 +44,7 @@ class DoubleSphereCameraShader : public CubeMapShaderBase {
    * See details in:
    * Vladyslav Usenko, Nikolaus Demmel and Daniel Cremers: The Double Sphere
    * Camera Model, The International Conference on 3D Vision (3DV), 2018
-   * @param xi, the Xi value
+   * @param xi the Xi value
    * @return Reference to self (for method chaining)
    */
   DoubleSphereCameraShader& setXi(float xi);

--- a/src/esp/gfx/DrawableGroup.h
+++ b/src/esp/gfx/DrawableGroup.h
@@ -43,7 +43,7 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
 
   /**
    * @brief Given drawable id, returns if drawable is in the group
-   * @param id, drawable id
+   * @param id drawable id
    * @return true if the drawable is in the group, otherwise false
    */
   bool hasDrawable(uint64_t id) const;
@@ -52,7 +52,7 @@ class DrawableGroup : public Magnum::SceneGraph::DrawableGroup3D {
    * @brief Given drawable id, returns nullptr if the id is not in this
    * drawable group, otherwise the raw pointer to the object
    *
-   * @param id, drawable id
+   * @param id drawable id
    * @return raw pointer to the drawable, or nullptr
    */
   Drawable* getDrawable(uint64_t id) const;

--- a/src/esp/gfx/EquirectangularShader.h
+++ b/src/esp/gfx/EquirectangularShader.h
@@ -29,7 +29,7 @@ class EquirectangularShader : public CubeMapShaderBase {
 
   /**
    * @brief Set ViewportSize for calculations in vertex shader
-   * @param[in] Vector2i the size of the viewport
+   * @param[in] viewportSize the size of the viewport
    * @return itself for method chaining
    */
   EquirectangularShader& setViewportSize(esp::vec2i viewportSize);

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -29,10 +29,9 @@ class PbrDrawable : public Drawable {
 
   /**
    *  @brief Set the light info
-   *  @param lightSetupKey, the key value for the light resource
-   *  @param color, the color of the light
+   *  @param lightSetupKey the key value for the light resource
    */
-  void setLightSetup(const Magnum::ResourceKey& lightSetupkey) override;
+  void setLightSetup(const Magnum::ResourceKey& lightSetupKey) override;
 
   static constexpr const char* SHADER_KEY_TEMPLATE = "PBR-lights={}-flags={}";
 
@@ -40,9 +39,9 @@ class PbrDrawable : public Drawable {
   /**
    * @brief overload draw function, see here for more details:
    * https://doc.magnum.graphics/magnum/classMagnum_1_1SceneGraph_1_1Drawable.html#aca0d0a219aa4d7712316de55d67f2134
-   * @param transformationMatrix, the transformation of the object (to which the
+   * @param transformationMatrix the transformation of the object (to which the
    *        drawable is attached) relative to camera
-   * @param camera, the camera that views and renders the world
+   * @param camera the camera that views and renders the world
    */
   void draw(const Magnum::Matrix4& transformationMatrix,
             Magnum::SceneGraph::Camera3D& camera) override;
@@ -63,9 +62,9 @@ class PbrDrawable : public Drawable {
   /**
    *  @brief Update light direction (or position) in *camera* space to the
    * shader
-   *  @param transformationMatrix, describes a tansformation from object (model)
+   *  @param transformationMatrix describes a tansformation from object (model)
    *         space to camera space
-   *  @param camera, the camera, which views and renders the world
+   *  @param camera the camera, which views and renders the world
    *  @return Reference to self (for method chaining)
    */
   PbrDrawable& updateShaderLightDirectionParameters(
@@ -74,8 +73,8 @@ class PbrDrawable : public Drawable {
 
   /**
    * @brief get the key for the shader
-   * @param lightCount, the number of the lights;
-   * @param flags, flags that defines the shader features
+   * @param lightCount the number of the lights;
+   * @param flags flags that defines the shader features
    */
   Magnum::ResourceKey getShaderKey(Magnum::UnsignedInt lightCount,
                                    PbrShader::Flags flags) const;

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -305,7 +305,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    * @brief Set light positions or directions
-   * @param vectors, an array of the light vectors
+   * @param vectors an array of the light vectors
    * @return Reference to self (for method chaining)
    *
    * when vec.w == 0, it means vec.xyz is the light direction;
@@ -323,9 +323,9 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
   /**
    *  @brief Set the position or direction of a specific light See @ref vec for
    *  details
-   *  @param lightIndex, the index of the light, MUST be smaller than
+   *  @param lightIndex the index of the light, MUST be smaller than
    *                     lightCount_
-   *  @param vec, the direction (or position) of the light in *camera* space;
+   *  @param vec the direction (or position) of the light in *camera* space;
    *              when vec.w == 0, it means vec.xyz is the light direction;
    *              when vec.w == 1, it means vec.xyz is the light position;
    *  @return Reference to self (for method chaining)
@@ -338,9 +338,9 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    *  @brief Set the position of a specific light.
-   *  @param lightIndex, the index of the light, MUST be smaller than
+   *  @param lightIndex the index of the light, MUST be smaller than
    * lightCount_
-   *  @param pos, the position of the light in *camera* space
+   *  @param pos the position of the light in *camera* space
    *  @return Reference to self (for method chaining)
    *  Note:
    *  If the light was a directional light, it will be overrided as a point
@@ -351,9 +351,9 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    *  @brief Set the direction of a specific light.
-   *  @param lightIndex, the index of the light, MUST be smaller than
+   *  @param lightIndex the index of the light, MUST be smaller than
    * lightCount_
-   *  @param dir, the direction of the light in *camera* space
+   *  @param dir the direction of the light in *camera* space
    *  @return Reference to self (for method chaining)
    *  NOTE:
    *  If the light was a point light, it will be overrided as a direction
@@ -364,19 +364,19 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    *  @brief Set the range of a specific light.
-   *  @param lightIndex, the index of the light, MUST be smaller than
+   *  @param lightIndex the index of the light, MUST be smaller than
    * lightCount_
-   *  @param range, the range of the light
+   *  @param range the range of the light
    *  @return Reference to self (for method chaining)
    */
   PbrShader& setLightRange(unsigned int lightIndex, float range);
 
   /**
    *  @brief Set the color of a specific light.
-   *  @param lightIndex, the index of the light, MUST be smaller than
+   *  @param lightIndex the index of the light, MUST be smaller than
    * lightCount_
-   *  @param color, the color of the light
-   *  @param intensity, the intensity of the light
+   *  @param color the color of the light
+   *  @param intensity the intensity of the light
    *  @return Reference to self (for method chaining)
    */
   PbrShader& setLightColor(unsigned int lightIndex,
@@ -385,7 +385,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    *  @brief Set the colors of the lights
-   *  @param color, the colors of the lights
+   *  @param colors the colors of the lights
    *  NOTE: the intensity MUST be included in the color
    *  @return Reference to self (for method chaining)
    */
@@ -399,7 +399,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
 
   /**
    *  @brief Set the ranges of the lights
-   *  @param ranges, the ranges of the lights
+   *  @param ranges the ranges of the lights
    *  @return Reference to self (for method chaining)
    */
   PbrShader& setLightRanges(Corrade::Containers::ArrayView<const float> ranges);

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -59,15 +59,15 @@ class RenderCamera : public MagnumCamera {
   CORRADE_ENUMSET_FRIEND_OPERATORS(Flags)
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
+   * @param node the scene node to which the camera is attached
    */
   explicit RenderCamera(scene::SceneNode& node);
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
-   * @param eye, the eye position (in PARENT node space)
-   * @param target, the target position (in PARENT node space)
-   * @param up, the up direction (in PARENT node space)
+   * @param node the scene node to which the camera is attached
+   * @param eye the eye position (in PARENT node space)
+   * @param target the target position (in PARENT node space)
+   * @param up the up direction (in PARENT node space)
    * NOTE: it will override any relative transformation w.r.t its parent node
    */
   RenderCamera(scene::SceneNode& node,
@@ -76,10 +76,10 @@ class RenderCamera : public MagnumCamera {
                const vec3f& up);
   /**
    * @brief Constructor
-   * @param node, the scene node to which the camera is attached
-   * @param eye, the eye position (in PARENT node space)
-   * @param target, the target position (in PARENT node space)
-   * @param up, the up direction (in PARENT node space)
+   * @param node the scene node to which the camera is attached
+   * @param eye the eye position (in PARENT node space)
+   * @param target the target position (in PARENT node space)
+   * @param up the up direction (in PARENT node space)
    * NOTE: it will override any relative transformation w.r.t its parent node
    */
   RenderCamera(scene::SceneNode& node,
@@ -88,9 +88,9 @@ class RenderCamera : public MagnumCamera {
                const Magnum::Vector3& up);
   /**
    * @brief Reset the initial viewing parameters of the camera
-   * @param eye, the eye position (in PARENT node space)
-   * @param target, the target position (in PARENT node space)
-   * @param up, the up direction (in PARENT node space)
+   * @param eye the eye position (in PARENT node space)
+   * @param target the target position (in PARENT node space)
+   * @param up the up direction (in PARENT node space)
    * @return Reference to self (for method chaining)
    * NOTE: it will override any relative transformation w.r.t its parent node
    */
@@ -150,7 +150,7 @@ class RenderCamera : public MagnumCamera {
    * @param height The height of the viewport
    * @param znear The location of the near clipping plane
    * @param zfar The location of the far clipping plane
-   * @param projMat The projection matrix to use.
+   * @param hfov The horizontal field of view.
    * @return A reference to this RenderCamera
    */
   RenderCamera& setProjectionMatrix(int width,

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -45,8 +45,9 @@ class Renderer {
 
   /**
    * @brief draw the scene graph with the camera specified by user
-   * @param[in] camera, the render camera to render the scene
-   * @param[in] flags, flags to control the rendering
+   * @param[in] camera the render camera to render the scene
+   * @param[in] sceneGraph the scene to render
+   * @param[in] flags flags to control the rendering
    */
   void draw(RenderCamera& camera,
             scene::SceneGraph& sceneGraph,

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -100,7 +100,7 @@ class AttributesManager
    *
    * @param path A global path to configuration files or a directory containing
    * such files.
-   * @param exttype The extension of files to be attempted to be loaded as
+   * @param extType The extension of files to be attempted to be loaded as
    * templates.
    * @param saveAsDefaults Set the templates loaded as undeleteable default
    * templates.
@@ -131,7 +131,7 @@ class AttributesManager
    * then will load all the configs it finds at each path.
    * @param configDir The directory to use as a root to search in - may be
    * different than the config dir already listed in this manager.
-   * @param saveAsDefaults Set the templates loaded as undeleteable default
+   * @param extType The extension of files to be attempted to be loaded as
    * templates.
    * @param jsonPaths The json array element
    */

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -182,7 +182,7 @@ class PathFinder {
   /**
    * @brief Returns a random navigable point
    *
-   * @param maxTries[in] The maximum number of tries sampling will be retried if
+   * @param[in] maxTries The maximum number of tries sampling will be retried if
    * it fails.
    *
    * @return A random navigable point.

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -177,7 +177,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @brief Initialization: load physical properties and setup the world.
    * @param node  The scene graph node which will act as the parent of all
    * physical scene and object nodes.
-   * @param physMgr Simulator's shared pointer referencing this physics manager.
    */
   bool initPhysics(scene::SceneNode* node);
 
@@ -253,8 +252,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    *
    * @param attributesID The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -486,7 +483,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * object is not recommended.
    * @param  physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
-   * @param trans The desired @ref esp::core::RigidState of the object.
+   * @param rigidState The desired @ref esp::core::RigidState of the object.
    */
   void setRigidState(const int physObjectID,
                      const esp::core::RigidState& rigidState);
@@ -629,7 +626,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * PhysicsManager::existingObjects_.
    * @return The @ref esp::core::RigidState of the object.
    */
-  esp::core::RigidState getRigidState(const int objectID) const;
+  esp::core::RigidState getRigidState(const int physObjectID) const;
 
   /** @brief Get the current 3D position of an object.
    * @param  physObjectID The object ID and key identifying the object in @ref
@@ -801,14 +798,14 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Get the scalar angular damping coefficient of an object.
    * See @ref RigidObject::getAngularDamping.
-   * @param  physObjectID The object ID and key identifying the object in @ref
+   * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @return The scalar angular damping coefficient of the object
    */
   double getAngularDamping(const int physObjectID) const;
 
   /** @brief Gets the VoxelWrapper associated with a rigid object.
-   * @param  physObjectID The object ID and key identifying the object in @ref
+   * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @return A pointer to the object's Voxel Wrapper.
    */
@@ -824,7 +821,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /** @brief Get the scalar collision margin of an object.
    * See @ref BulletRigidObject::getMargin.
-   * @param  physObjectID The object ID and key identifying the object in @ref
+   * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @return The scalar collision margin of the object.
    */
@@ -835,7 +832,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   /** @brief Set the scalar collision margin of an object.
    * See @ref BulletRigidObject::setMargin. Nothing is set if no implementation
    * using a collision margin is in use.
-   * @param  physObjectID The object ID and key identifying the object in @ref
+   * @param physObjectID The object ID and key identifying the object in @ref
    * PhysicsManager::existingObjects_.
    * @param  margin The desired collision margin for the object.
    */
@@ -1133,7 +1130,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * existingObjects_.
    * @param semanticId The desired semantic id for the object.
    */
-  void setSemanticId(int physObjectID, uint32_t semanticId);
+  void setSemanticId(int objectID, uint32_t semanticId);
 
   /**
    * @brief Get a copy of the template used to initialize an object.
@@ -1261,8 +1258,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   /** @brief Create and initialize a @ref RigidObject, assign it an ID and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
-   * @param initAttributes The physical object's template defining its
-   * physical parameters.
+   * @param objectAttributes The physical object's template
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -40,7 +40,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Constructor for a @ref RigidBase.
    * @param rigidBodyNode Pointer to the node to be used for this rigid.
-   * @param objectID the desired ID for this rigid construct.
+   * @param objectId the desired ID for this rigid construct.
    * @param resMgr a reference to @ref esp::assets::ResourceManager
    */
   RigidBase(scene::SceneNode* rigidBodyNode,

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -173,8 +173,6 @@ class RigidObject : public RigidBase {
   /**
    * @brief Set the object's state from a @ref
    * esp::metadata::attributes::SceneObjectInstanceAttributes
-   * @param objInstAttr The attributes that describe the desired state to set
-   * this object.
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
    */

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -61,8 +61,6 @@ class RigidStage : public RigidBase {
    * geometry.  This is overridden by inheriting class specific to certain
    * physics libraries.Necessary to support kinematic objects without any
    * dynamics support.
-   * @param resMgr Reference to resource manager, to access relevant components
-   * pertaining to the stage object
    * @return true if initialized successfully, false otherwise.
    */
   bool initialization_LibSpecific() override { return true; }

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -235,7 +235,7 @@ class BulletPhysicsManager : public PhysicsManager {
    * mesh can be used by Bullet. See @ref BulletRigidObject::initializeStage.
    * Bullet mesh conversion adapted from:
    * https://github.com/mosra/magnum-integration/issues/20
-   * @param handle The handle of the attributes structure defining physical
+   * @param initAttributes The attributes structure defining physical
    * properties of the stage.
    * @return true if successful and false otherwise
    */
@@ -245,9 +245,7 @@ class BulletPhysicsManager : public PhysicsManager {
   /** @brief Create and initialize an @ref RigidObject and add
    * it to existingObjects_ map keyed with newObjectID
    * @param newObjectID valid object ID for the new object
-   * @param meshGroup The object's mesh.
-   * @param handle The handle to the physical object's template defining its
-   * physical parameters.
+   * @param objectAttributes The object's template
    * @param objectNode Valid, existing scene node
    * @return whether the object has been successfully initialized and added to
    * existingObjects_ map

--- a/src/esp/physics/bullet/BulletRigidStage.h
+++ b/src/esp/physics/bullet/BulletRigidStage.h
@@ -36,8 +36,6 @@ class BulletRigidStage : public BulletBase, public RigidStage {
   /**
    * @brief Finalize the initialization of this @ref RigidScene
    * geometry.  This holds bullet-specific functionality for stages.
-   * @param resMgr Reference to resource manager, to access relevant components
-   * pertaining to the stage object
    * @return true if initialized successfully, false otherwise.
    */
   bool initialization_LibSpecific() override;

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -47,10 +47,9 @@ class RigidObjectManager
    * that queries for a DrawableGroup from Simulator.
    * @param attributesID The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
+   * @param lightSetup An optional custom lightsetup for the object.
    * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -145,7 +145,7 @@ class SemanticScene {
  protected:
   /**
    * @brief Verify a requested file exists.
-   * @param houseFile the file to attempt to load
+   * @param filename the file to attempt to load
    * @param srcFunc calling function name to be displayed in failure message
    * @return whether found or not
    */

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -181,8 +181,8 @@ class CameraSensor : public VisualSensor {
 
   /**
    * @brief Draw the scene graph with the specified camera flag
-   * @param[in] sceneGraph, scene graph to be drawn
-   * @param[in] flags, flag for the render camera
+   * @param[in] sceneGraph scene graph to be drawn
+   * @param[in] flags flag for the render camera
    */
   void draw(scene::SceneGraph& sceneGraph, gfx::RenderCamera::Flags flags);
 

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -198,7 +198,6 @@ class SensorSuite : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Return reference to Sensor with key uuid in existing sensors_
    * @param[in] uuid of Sensor to be found in sensors_
-   * @param[out] reference to Sensor with key uuid
    */
   sensor::Sensor& get(const std::string& uuid) const;
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -382,7 +382,7 @@ class Simulator {
 
   /**
    * @brief Set the @ref esp::core::RigidState of an object kinematically.
-   * @param transform The desired @ref esp::core::RigidState of the object.
+   * @param rigidState The desired @ref esp::core::RigidState of the object.
    * @param  objectID The object ID and key identifying the object in @ref
    * esp::physics::PhysicsManager::existingObjects_.
    * @param sceneID !! Not used currently !! Specifies which physical scene of


### PR DESCRIPTION
## Motivation and Context

Address some doc build warnings, mostly related to `@param` use in function doc-strings.

## How Has This Been Tested

Existing tests, no functionality changed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

