### PR TITLE
[clang-tidy]Tweak clang-tidy config and optimize RenderCamera

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ modernize-avoid-bind,
 modernize-deprecated-headers,
 modernize-make-shared,
 modernize-make-unique,
+modernize-pass-by-value,
 modernize-redundant-void-arg,
 modernize-replace-disallow-copy-and-assign-macro,
 modernize-replace-random-shuffle,
@@ -64,6 +65,10 @@ readability-uniqueptr-delete-release,
 
 CheckOptions:
 - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+  value:           true
+- key:             modernize-pass-by-value.ValuesOnly
+  value:           true
+- key:             performance-for-range-copy.WarnOnAllAutoCopies
   value:           true
 - key:             readability-implicit-bool-conversion.AllowPointerConditions
   value:           true

--- a/src/esp/physics/bullet/BulletBase.h
+++ b/src/esp/physics/bullet/BulletBase.h
@@ -31,12 +31,12 @@ struct SimulationContactResultCallback
   /**
    * @brief Set when a contact is detected.
    */
-  bool bCollision;
+  bool bCollision{false};
 
   /**
    * @brief Constructor.
    */
-  SimulationContactResultCallback() { bCollision = false; }
+  SimulationContactResultCallback() = default;
 
   /**
    * @brief Called when a contact is detected.

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -11,7 +11,6 @@
 
 #include "CameraSensor.h"
 #include "esp/gfx/DepthUnprojection.h"
-#include "esp/gfx/RenderCamera.h"
 #include "esp/sim/Simulator.h"
 
 namespace esp {

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -11,6 +11,7 @@
 
 #include "CameraSensor.h"
 #include "esp/gfx/DepthUnprojection.h"
+#include "esp/gfx/RenderCamera.h"
 #include "esp/sim/Simulator.h"
 
 namespace esp {
@@ -41,16 +42,15 @@ CameraSensor::CameraSensor(scene::SceneNode& cameraNode,
                            const CameraSensorSpec::ptr& spec)
     : VisualSensor(cameraNode, spec),
       baseProjMatrix_(Magnum::Math::IdentityInit),
-      zoomMatrix_(Magnum::Math::IdentityInit) {
+      zoomMatrix_(Magnum::Math::IdentityInit),
+      renderCamera_(new gfx::RenderCamera(cameraNode)) {
   // Sanity check
   CORRADE_ASSERT(
       cameraSensorSpec_,
       "CameraSensor::CameraSensor(): The input sensorSpec is illegal", );
   cameraSensorSpec_->sanityCheck();
 
-  // Initialize renderCamera_ first to avoid segfaults
-  // NOLINTNEXTLINE(cplusplus.NewDeleteLeaks)
-  renderCamera_ = new gfx::RenderCamera(cameraNode);
+  // RenderCamera initialized in member list
   setProjectionParameters(*spec);
   renderCamera_->setAspectRatioPolicy(
       Mn::SceneGraph::AspectRatioPolicy::Extend);

--- a/src/esp/sensor/CubeMapSensorBase.cpp
+++ b/src/esp/sensor/CubeMapSensorBase.cpp
@@ -40,7 +40,9 @@ int computeCubemapSize(const esp::vec2i& resolution,
 
 CubeMapSensorBase::CubeMapSensorBase(scene::SceneNode& cameraNode,
                                      const CubeMapSensorBaseSpec::ptr& spec)
-    : VisualSensor(cameraNode, spec) {
+    : VisualSensor(cameraNode, spec),
+      cubeMapCamera_(new gfx::CubeMapCamera(cameraNode)),
+      mesh_(Mn::GL::Mesh()) {
   // initialize a cubemap
   int size = computeCubemapSize(cubeMapSensorBaseSpec_->resolution,
                                 cubeMapSensorBaseSpec_->cubemapSize);
@@ -61,10 +63,9 @@ CubeMapSensorBase::CubeMapSensorBase(scene::SceneNode& cameraNode,
   }
   cubeMap_ = esp::gfx::CubeMap{size, cubeMapFlags};
 
-  // initialize the cubemap camera, it attaches to the same node as the sensor
+  // Sets the cubemap camera, it attaches to the same node as the sensor
   // You do not have to release it in the dtor since magnum scene graph will
-  // handle it
-  cubeMapCamera_ = new gfx::CubeMapCamera(cameraNode);
+  // handle it. The cubemap is initialized in the member list above.
   cubeMapCamera_->setProjectionMatrix(size, cubeMapSensorBaseSpec_->near,
                                       cubeMapSensorBaseSpec_->far);
 
@@ -86,7 +87,7 @@ CubeMapSensorBase::CubeMapSensorBase(scene::SceneNode& cameraNode,
   }
 
   // prepare a big triangle mesh to cover the screen
-  mesh_ = Mn::GL::Mesh{};
+  // initialied in member initializer list
   mesh_.setCount(3);
 }
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Tweaks the clang-tidy config slightly  .
* Cleans up the BulletBase to use a default member initializer. This will help the ctor get optimized away and make it more readable.
* Most notable, moves the initializer of the RenderCamera into a member initializer list. This prevents a move and temporary variable from being created in the constructor and should yield performance gains as well as make the code more readable. It also remove the clang-tidy false positive that existed there before.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* CI Tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
