### PR TITLE
add --no-web-apps for JS build; update JS build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ This feature is built by when Habitat-Sim is compiled with CUDA, i.e. built with
 This is implemented in a way that is reasonably agnostic to the exact GPU-Tensor library being used, but we currently have only implemented support for PyTorch.
 
 
-## Experimental: Emscripten, WebGL,find  and Web Apps
+## Experimental: Emscripten, WebGL, and Web Apps
 
 Build `hsim_bindings.wasm`, our experimental Emscripten-compiled webassembly binary for use in WebGL html/Javascript apps. See the available Javascript bindings at `src/esp/bindings_js/bindings_js.cpp`. Check out our `bindings.html` demo app:
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ This feature is built by when Habitat-Sim is compiled with CUDA, i.e. built with
 This is implemented in a way that is reasonably agnostic to the exact GPU-Tensor library being used, but we currently have only implemented support for PyTorch.
 
 
-## WebGL
+## Experimental: Emscripten, WebGL,find  and Web Apps
+
+Build `hsim_bindings.wasm`, our experimental Emscripten-compiled webassembly binary for use in WebGL html/Javascript apps. See the available Javascript bindings at `src/esp/bindings_js/bindings_js.cpp`. Check out our `bindings.html` demo app:
 
 1. Download the [test scenes](http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip) and extract locally to habitat-sim creating habitat-sim/data.
 1. Download and install [emscripten](https://emscripten.org/docs/getting_started/downloads.html) (you need at least version 1.38.48, newer versions such as 2.0.6 work too)
@@ -296,6 +298,9 @@ This is implemented in a way that is reasonably agnostic to the exact GPU-Tensor
    python -m http.server 8000 --bind 127.0.0.1
    ```
 1. Open <http://127.0.0.1:8000/build_js/esp/bindings_js/bindings.html>
+
+You can build `hsim_bindings.wasm` without the demo web apps like so:
+- `./build_js.sh --no-web-apps [--bullet]`
 
 ## Datasets
 

--- a/build_js.sh
+++ b/build_js.sh
@@ -4,10 +4,12 @@
 set -e
 
 BULLET=false
+WEB_APPS=true
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --bullet) BULLET=true ;;
+        --no-web-apps) WEB_APPS=false ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -32,7 +34,7 @@ cd build_js
 EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
 cmake ../src \
     -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/RelWithDebInfo/bin/corrade-rc \
-    -DBUILD_GUI_VIEWERS=ON \
+    -DBUILD_GUI_VIEWERS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )" \
     -DBUILD_PYTHON_BINDINGS=OFF \
     -DBUILD_ASSIMP_SUPPORT=OFF \
     -DBUILD_DATATOOL=OFF \
@@ -41,19 +43,24 @@ cmake ../src \
     -DCMAKE_PREFIX_PATH="$EMSCRIPTEN" \
     -DCMAKE_TOOLCHAIN_FILE="../src/deps/corrade/toolchains/generic/Emscripten-wasm.cmake" \
     -DCMAKE_INSTALL_PREFIX="." \
-    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1" \
+    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=0" \
     -DCMAKE_EXE_LINKER_FLAGS="${EXE_LINKER_FLAGS}" \
-    -DBUILD_WITH_BULLET="$( if ${BULLET} ; then echo ON ; else echo OFF; fi )"
+    -DBUILD_WITH_BULLET="$( if ${BULLET} ; then echo ON ; else echo OFF; fi )" \
+    -DBUILD_WEB_APPS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )"
 
 cmake --build . -- -j 8 #TODO: Set to 8 cores only on CirelcCI
-cmake --build . --target install -- -j 8
-
 echo "Done building."
-echo "Run:"
-echo "python2 -m SimpleHTTPServer 8000"
-echo "Or:"
-echo "python3 -m http.server"
-echo "Then open in a browser:"
-echo "http://0.0.0.0:8000/build_js/esp/bindings_js/bindings.html?scene=skokloster-castle.glb"
-echo "Or open in a VR-capable browser:"
-echo "http://0.0.0.0:8000/build_js/esp/bindings_js/webvr.html?scene=skokloster-castle.glb"
+
+if [ -o ${WEB_APPS} ]
+  then
+    cmake --build . --target install -- -j 8
+    echo "Run:"
+    echo "python2 -m SimpleHTTPServer 8000"
+    echo "Or:"
+    echo "python3 -m http.server"
+    echo "Then open in a browser:"
+    echo "http://0.0.0.0:8000/build_js/esp/bindings_js/bindings.html?scene=skokloster-castle.glb"
+    echo "Or open in a VR-capable browser:"
+    echo "http://0.0.0.0:8000/build_js/esp/bindings_js/webvr.html?scene=skokloster-castle.glb"
+fi
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,11 @@ option(BUILD_WITH_BULLET
        "Build Habitat-Sim with Bullet physics enabled -- Requires Bullet" OFF
 )
 option(
+  BUILD_WEB_APPS
+  "(Emscripten-build-only) build and bundle our html/Javascript demo web apps including test_page.html and bindings.html"
+  ON
+)
+option(
   BUILD_WITH_VHACD
   "Build Habitat-Sim with VHACD convex hull decomposition and voxelization engine enabled -- Requires VHACD"
   OFF

--- a/src/esp/bindings_js/CMakeLists.txt
+++ b/src/esp/bindings_js/CMakeLists.txt
@@ -22,69 +22,73 @@ set_target_properties(
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-# Create symlinks for specific files as well as the entire data directory.
-set(
-  resources
-  ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.glb
-  ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.navmesh
-  ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.glb
-  ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.navmesh
-  ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
-  ${MAGNUM_WEBAPPLICATION_CSS}
-  ${DATA_DIR}
-)
-
-foreach(resource ${resources})
-  get_filename_component(filename ${resource} NAME)
-  get_filename_component(path ${resource} ABSOLUTE)
-  add_custom_command(
-    TARGET hsim_bindings POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink ${path}
-                                            ${CMAKE_CURRENT_BINARY_DIR}/${filename}
+if(BUILD_WEB_APPS)
+  message("Building demo web apps")
+  # Create symlinks for specific files as well as the entire data directory.
+  set(
+    resources
+    ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.glb
+    ${SCENE_DATASETS}/habitat-test-scenes/skokloster-castle.navmesh
+    ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.glb
+    ${SCENE_DATASETS}/habitat-test-scenes/van-gogh-room.navmesh
+    ${MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS}
+    ${MAGNUM_WEBAPPLICATION_CSS}
+    ${DATA_DIR}
   )
-endforeach()
 
-set(package_files ${PROJECT_SOURCE_DIR}/../package.json)
+  foreach(resource ${resources})
+    get_filename_component(filename ${resource} NAME)
+    get_filename_component(path ${resource} ABSOLUTE)
+    add_custom_command(
+      TARGET hsim_bindings POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E create_symlink ${path}
+              ${CMAKE_CURRENT_BINARY_DIR}/${filename}
+    )
+  endforeach()
 
-add_custom_command(
-  OUTPUT empty.stamp
-  COMMAND npm install
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/empty.stamp
-  DEPENDS ${package_files}
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  COMMENT "Trying npm install"
-)
+  set(package_files ${PROJECT_SOURCE_DIR}/../package.json)
 
-set(
-  bundle_files
-  bindings.html
-  test_page.html
-  webvr.html
-  viewer.html
-  bindings.css
-  viewer.css
-  webpack.config.js
-  index.js
-  modules/object_sensor.js
-  modules/navigate.js
-  modules/simenv_embind.js
-  modules/topdown.js
-  modules/web_demo.js
-  modules/viewer_demo.js
-  modules/defaults.js
-  modules/test_page.js
-  modules/vr_demo.js
-  modules/utils.js
-)
+  add_custom_command(
+    OUTPUT empty.stamp
+    COMMAND npm install
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/empty.stamp
+    DEPENDS ${package_files}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Trying npm install"
+  )
 
-add_custom_command(
-  OUTPUT bundle.js
-  COMMAND npm run lint-fix
-  COMMAND npm run build -- --build_dir ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS hsim_bindings ${bundle_files} empty.stamp
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  COMMENT "Building JS files now"
-)
+  set(
+    bundle_files
+    bindings.html
+    test_page.html
+    webvr.html
+    viewer.html
+    bindings.css
+    viewer.css
+    webpack.config.js
+    index.js
+    modules/object_sensor.js
+    modules/navigate.js
+    modules/simenv_embind.js
+    modules/topdown.js
+    modules/web_demo.js
+    modules/viewer_demo.js
+    modules/defaults.js
+    modules/test_page.js
+    modules/vr_demo.js
+    modules/utils.js
+  )
 
-add_custom_target(hsim_bundle ALL DEPENDS bundle.js)
+  add_custom_command(
+    OUTPUT bundle.js
+    COMMAND npm run lint-fix
+    COMMAND npm run build -- --build_dir ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS hsim_bindings ${bundle_files} empty.stamp
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Building JS files now"
+  )
 
-add_dependencies(hsim_bundle hsim_bindings)
+  add_custom_target(hsim_bundle ALL DEPENDS bundle.js)
+
+  add_dependencies(hsim_bundle hsim_bindings)
+endif()


### PR DESCRIPTION
## Motivation and Context

This flag helps define the division between the Emscripten-built `hsim_bindings.wasm` binary and the demo web apps that showcase it. I also updated documentation to convey this.

The flag simplifies and speeds up the build if you're just building the binary and not using the demo web apps.

This is a small change but there's a lot of diff spam due to indenting changes.

## How Has This Been Tested

I built locally with `--no-web-apps`. (Is a new CI step warranted? To build with this flag?)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
