### PR TITLE
[BugFix] Add wrapper for bullet rigid objects

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -7,7 +7,9 @@
 #include "esp/physics/RigidBase.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/physics/RigidStage.h"
+#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
+#endif
 #include "esp/physics/objectWrappers/ManagedPhysicsObjectBase.h"
 #include "esp/physics/objectWrappers/ManagedRigidBase.h"
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
@@ -329,6 +331,7 @@ void initPhysicsObjectBindings(py::module& m) {
   // ==== ManagedRigidObject ====
   declareRigidObjectWrapper(m, "Rigid Object", "ManagedRigidObject");
 
+#ifdef ESP_BUILD_WITH_BULLET
   // ==== ManagedBulletRigidObject ====
   py::class_<ManagedBulletRigidObject, ManagedRigidObject,
              std::shared_ptr<ManagedBulletRigidObject>>(
@@ -340,7 +343,7 @@ void initPhysicsObjectBindings(py::module& m) {
           "collision_shape_aabb",
           &ManagedBulletRigidObject::getCollisionShapeAabb,
           R"(The bounds of the axis-aligned bounding box from Bullet Physics, in its local coordinate frame.)");
-
+#endif
 }  // initPhysicsObjectBindings
 
 }  // namespace physics

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -297,10 +297,9 @@ void declareRigidBaseWrapper(py::module& m,
 void declareRigidObjectWrapper(py::module& m,
                                const std::string& objType,
                                const std::string& classStrPrefix) {
-  std::string pyclass_name = classStrPrefix;
   // ==== ManagedRigidObject ====
   py::class_<ManagedRigidObject, AbstractManagedRigidBase<RigidObject>,
-             std::shared_ptr<ManagedRigidObject>>(m, pyclass_name.c_str())
+             std::shared_ptr<ManagedRigidObject>>(m, classStrPrefix.c_str())
       .def_property_readonly(
           "creation_attributes",
           &ManagedRigidObject::getInitializationAttributes,

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -29,7 +29,7 @@ namespace physics {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <class T>
+template <typename T>
 void declareBaseWrapperManager(py::module& m,
                                const std::string& objType,
                                const std::string& classStrPrefix) {
@@ -151,7 +151,7 @@ void declareBaseWrapperManager(py::module& m,
            "handle"_a);
 }  // declareBaseWrapperManager
 
-template <class T>
+template <typename T>
 void declareRigidBaseWrapperManager(py::module& m,
                                     CORRADE_UNUSED const std::string& objType,
                                     const std::string& classStrPrefix) {

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -247,9 +247,9 @@ int PhysicsManager::addObject(
                << newObjectHandle;
 
   existingObjects_.at(nextObjectID_)->setObjectName(newObjectHandle);
+
   // 2.0 Get wrapper - name is irrelevant, do not register.
-  ManagedRigidObject::ptr objWrapper =
-      rigidObjectManager_->createObject("No Name Yet");
+  ManagedRigidObject::ptr objWrapper = getRigidObjectWrapper();
 
   // 3.0 Put object in wrapper
   objWrapper->setObjectRef(existingObjects_.at(nextObjectID_));
@@ -259,6 +259,10 @@ int PhysicsManager::addObject(
 
   return nextObjectID_;
 }  // PhysicsManager::addObject
+
+esp::physics::ManagedRigidObject::ptr PhysicsManager::getRigidObjectWrapper() {
+  return rigidObjectManager_->createObject("ManagedRigidObject");
+}
 
 void PhysicsManager::removeObject(const int physObjectID,
                                   bool deleteObjectNode,

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -27,6 +27,7 @@
 #include "esp/assets/MeshMetaData.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/DrawableGroup.h"
+#include "esp/physics/objectWrappers/ManagedRigidObject.h"
 #include "esp/scene/SceneNode.h"
 
 namespace esp {
@@ -342,6 +343,12 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       DrawableGroup* drawables,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Create an object wrapper appropriate for this physics manager.
+   * Overridden if called by dynamics-library-enabled PhysicsManager
+   */
+  virtual esp::physics::ManagedRigidObject::ptr getRigidObjectWrapper();
 
   /** @brief Remove an object instance from the pysical scene by ID, destroying
    * its scene graph node and removing it from @ref

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -8,6 +8,7 @@
 #include "BulletPhysicsManager.h"
 #include "BulletRigidObject.h"
 #include "esp/assets/ResourceManager.h"
+#include "esp/physics/objectManagers/RigidObjectManager.h"
 
 namespace esp {
 namespace physics {
@@ -67,6 +68,12 @@ bool BulletPhysicsManager::makeAndAddRigidObject(
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }
   return objSuccess;
+}
+
+esp::physics::ManagedRigidObject::ptr
+BulletPhysicsManager::getRigidObjectWrapper() {
+  // TODO make sure this is appropriately cast
+  return rigidObjectManager_->createObject("ManagedBulletRigidObject");
 }
 
 //! Check if mesh primitive is compatible with physics

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -229,6 +229,12 @@ class BulletPhysicsManager : public PhysicsManager {
    */
   bool initPhysicsFinalize() override;
 
+  /**
+   * @brief Create an object wrapper appropriate for this physics manager.
+   * Overridden if called by dynamics-library-enabled PhysicsManager
+   */
+  esp::physics::ManagedRigidObject::ptr getRigidObjectWrapper() override;
+
   //============ Object/Stage Instantiation =============
   /**
    * @brief Finalize stage initialization. Checks that the collision

--- a/src/esp/physics/bullet/CMakeLists.txt
+++ b/src/esp/physics/bullet/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   BulletRigidObject.h
   BulletRigidStage.cpp
   BulletRigidStage.h
+  objectWrappers/ManagedBulletRigidObject.h
 )
 
 target_link_libraries(

--- a/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
+++ b/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
@@ -1,0 +1,65 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_PHYSICS_MANAGEDBULLETRIGIDOBJECT_H_
+#define ESP_PHYSICS_MANAGEDBULLETRIGIDOBJECT_H_
+
+#include "esp/physics/bullet/BulletRigidObject.h"
+#include "esp/physics/objectWrappers/ManagedRigidObject.h"
+
+namespace esp {
+namespace physics {
+
+/**
+ * @brief Class describing wrapper for RigidObject constructions.
+ * Provides bindings for all RigidObject-specific functionality.
+ */
+class ManagedBulletRigidObject : public esp::physics::ManagedRigidObject {
+ public:
+  ManagedBulletRigidObject() : ManagedRigidObject("ManagedBulletRigidObject") {}
+
+  double getMargin() const {
+    if (auto sp = this->getBulletObjectReference()) {
+      return sp->getMargin();
+    } else {
+      return 0.0;
+    }
+  }  // getMargin
+
+  void setMargin(const double margin) {
+    if (auto sp = this->getBulletObjectReference()) {
+      sp->setMargin(margin);
+    }
+  }  // setMass
+
+  Magnum::Range3D getCollisionShapeAabb() {
+    if (auto sp = this->getBulletObjectReference()) {
+      return sp->getCollisionShapeAabb();
+    } else {
+      return {};
+    }
+  }  // getCollisionShapeAabb
+
+ protected:
+  /**
+   * @brief Templated version of obj ref getter. This function accesses the
+   * underlying shared pointer of this object's @p weakObjRef_ if it exists,
+   * and casts it to the specified template parameter; if it the ptr does not
+   * exist, it provides a message.
+   * @return Either a shared pointer of this wrapper's object, or nullptr if
+   * dne.
+   */
+  std::shared_ptr<BulletRigidObject> getBulletObjectReference() const {
+    return std::static_pointer_cast<BulletRigidObject>(
+        this->getObjectReference());
+  }
+
+ public:
+  ESP_SMART_POINTERS(ManagedBulletRigidObject)
+};  // namespace physics
+
+}  // namespace physics
+}  // namespace esp
+
+#endif  // ESP_PHYSICS_MANAGEDBULLETRIGIDOBJECT_H_

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -50,7 +50,8 @@ class PhysicsObjectBaseManager
    * @brief Creates an empty @ref esp::physics::AbstractManagedPhysicsObject of
    * the type managed by this manager.
    *
-   * @param objectHandle Unused.  Object being wrapped will provide its name.
+   * @param objectTypeName Class name of the wrapper to create.  This will be
+   * looked up against
    * @param registerObject whether to add this managed object to the
    * library or not. If the user is going to edit this managed object, this
    * should be false. Defaults to true. If specified as true, then this function
@@ -58,7 +59,7 @@ class PhysicsObjectBaseManager
    * @return a reference to the desired managed object.
    */
   ObjWrapperPtr createObject(
-      const std::string& objectHandle,
+      const std::string& objectTypeName,
       CORRADE_UNUSED bool registerObject = false) override;
 
  protected:
@@ -85,6 +86,54 @@ class PhysicsObjectBaseManager
       }
     }
   }  // updateObjectHandleLists
+  /**
+   * @brief Build a shared pointer to a ManagedRigidObject wrapper around an
+   * appropriately cast @ref esp::physics::RigidObject, either the base
+   * kinematic verison, or one built to support a dynamic library.
+   * @tparam The type of the underlying wrapped object to create
+   */
+  template <typename U>
+  ObjWrapperPtr createPhysicsObjectWrapper() {
+    return U::create();
+  }
+
+  /**
+   * @brief Used Internally.  Create and configure newly-created managed object
+   * with any default values, before any specific values are set.
+   *
+   * @param objectTypeName Used to determine what kind of Rigid Object wrapper
+   * to make (either kinematic or dynamic-library-specific)
+   * @param builtFromConfig Unused for wrapper objects.  All wrappers are
+   * constructed from scratch.
+   * @return Newly created but unregistered ManagedObject pointer, with only
+   * default values set.
+   */
+  ObjWrapperPtr initNewObjectInternal(
+      const std::string& objectTypeName,
+      CORRADE_UNUSED bool builtFromConfig) override {
+    // construct a new wrapper based on the passed object
+    auto newWrapper = (*this.*managedObjTypeConstructorMap_[objectTypeName])();
+
+    return newWrapper;
+  }  // RigidObjectManager::initNewObjectInternal(
+
+  /**
+   * @brief Define a map type referencing function pointers to @ref
+   * createRigidObjectWrapper() keyed by string names of classes being
+   * instanced, as defined in @ref PrimitiveNames3DMap
+   */
+  typedef std::map<std::string,
+                   ObjWrapperPtr (PhysicsObjectBaseManager<T>::*)()>
+      Map_Of_ManagedObjTypeCtors;
+
+  /**
+   * @brief Map of function pointers to instantiate a @ref
+   * esp::physics::AbstractManagedPhysicsObject wrapper object, keyed by the
+   * wrapper's class name. A ManagedRigidObject wrapper of the appropriate type
+   * is instanced by accessing the constructor map with the appropriate
+   * classname.
+   */
+  Map_Of_ManagedObjTypeCtors managedObjTypeConstructorMap_;
 
   /**
    * @brief implementation of managed object type-specific registration
@@ -133,7 +182,7 @@ class PhysicsObjectBaseManager
 
 template <class T>
 auto PhysicsObjectBaseManager<T>::createObject(
-    const std::string& objectWrapperHandle,
+    const std::string& objectTypeName,
     CORRADE_UNUSED bool registerTemplate) -> ObjWrapperPtr {
   // This creates and returns an empty object wrapper.  The shared_ptr to the
   // actual @ref esp::physics::PhysicsObjectBase needs to be passed into this
@@ -142,8 +191,7 @@ auto PhysicsObjectBaseManager<T>::createObject(
   // object being wrapped to be set separately.
   // NO default object will exist for wrappers, since they have no independent
   // data outside of the wrapped object.
-  ObjWrapperPtr objWrapper =
-      this->initNewObjectInternal(objectWrapperHandle, false);
+  ObjWrapperPtr objWrapper = this->initNewObjectInternal(objectTypeName, false);
 
   return objWrapper;
 }  // PhysicsObjectBaseManager<T>::createObject

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -6,6 +6,24 @@
 namespace esp {
 namespace physics {
 
+RigidObjectManager::RigidObjectManager()
+    : esp::physics::RigidBaseManager<ManagedRigidObject>::RigidBaseManager(
+          "RigidObject") {
+  // build this manager's copy constructor map, keyed by the type name of the
+  // wrappers it will manage
+  this->copyConstructorMap_["ManagedRigidObject"] =
+      &RigidObjectManager::createObjectCopy<ManagedRigidObject>;
+  this->copyConstructorMap_["ManagedBulletRigidObject"] =
+      &RigidObjectManager::createObjectCopy<ManagedBulletRigidObject>;
+
+  // build the function pointers to proper wrapper construction methods, keyed
+  // by the wrapper names
+  managedObjTypeConstructorMap_["ManagedRigidObject"] =
+      &RigidObjectManager::createPhysicsObjectWrapper<ManagedRigidObject>;
+  managedObjTypeConstructorMap_["ManagedBulletRigidObject"] =
+      &RigidObjectManager::createPhysicsObjectWrapper<ManagedBulletRigidObject>;
+}
+
 std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByHandle(
     const std::string& attributesHandle,
     scene::SceneNode* attachmentNode,

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -3,6 +3,11 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "RigidObjectManager.h"
+
+#ifdef ESP_BUILD_WITH_BULLET
+#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
+#endif
+
 namespace esp {
 namespace physics {
 
@@ -13,15 +18,18 @@ RigidObjectManager::RigidObjectManager()
   // wrappers it will manage
   this->copyConstructorMap_["ManagedRigidObject"] =
       &RigidObjectManager::createObjectCopy<ManagedRigidObject>;
-  this->copyConstructorMap_["ManagedBulletRigidObject"] =
-      &RigidObjectManager::createObjectCopy<ManagedBulletRigidObject>;
 
   // build the function pointers to proper wrapper construction methods, keyed
   // by the wrapper names
   managedObjTypeConstructorMap_["ManagedRigidObject"] =
       &RigidObjectManager::createPhysicsObjectWrapper<ManagedRigidObject>;
+
+#ifdef ESP_BUILD_WITH_BULLET
+  this->copyConstructorMap_["ManagedBulletRigidObject"] =
+      &RigidObjectManager::createObjectCopy<ManagedBulletRigidObject>;
   managedObjTypeConstructorMap_["ManagedBulletRigidObject"] =
       &RigidObjectManager::createPhysicsObjectWrapper<ManagedBulletRigidObject>;
+#endif
 }
 
 std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByHandle(

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -6,6 +6,7 @@
 #define ESP_PHYSICS_RIGIDOBJECTMANAGER_H
 
 #include "RigidBaseManager.h"
+#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
 namespace esp {
 namespace physics {
@@ -17,13 +18,7 @@ namespace physics {
 class RigidObjectManager
     : public esp::physics::RigidBaseManager<ManagedRigidObject> {
  public:
-  RigidObjectManager()
-      : esp::physics::RigidBaseManager<ManagedRigidObject>::RigidBaseManager(
-            "RigidObject") {
-    // build this manager's copy constructor map
-    this->copyConstructorMap_["ManagedRigidObject"] =
-        &RigidObjectManager::createObjectCopy<ManagedRigidObject>;
-  }
+  RigidObjectManager();
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager.  This method
@@ -52,7 +47,8 @@ class RigidObjectManager
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   * PhysicsManager::existingObjects_ if successful, or @ref
+   * esp::ID_UNDEFINED.
    */
   std::shared_ptr<ManagedRigidObject> addObjectByID(
       const int attributesID,
@@ -61,18 +57,18 @@ class RigidObjectManager
 
   /**
    * @brief Overload of standard @ref
-   * esp::core::ManagedContainer::removeObjectByID to allow for the retention of
-   * scene node or visual node of the underlying RigidObject after it and its
-   * wrapper's removal.
+   * esp::core::ManagedContainer::removeObjectByID to allow for the retention
+   * of scene node or visual node of the underlying RigidObject after it and
+   * its wrapper's removal.
    *
    * @param objectID The ID of the managed object to be deleted.
-   * @param deleteObjectNode If true, deletes the object's scene node. Otherwise
-   * detaches the object from simulation.
+   * @param deleteObjectNode If true, deletes the object's scene node.
+   * Otherwise detaches the object from simulation.
    * @param deleteVisualNode If true, deletes the object's visual node.
    * Otherwise detaches the object from simulation. Is not considered if
    * deleteObjectNode==true.
-   * @return this always returns a nullptr, since a wrapper of a deleted object
-   * is unusable.
+   * @return this always returns a nullptr, since a wrapper of a deleted
+   * object is unusable.
    */
 
   std::shared_ptr<ManagedRigidObject> removePhysObjectByID(
@@ -83,17 +79,17 @@ class RigidObjectManager
   /**
    * @brief Overload of standard @ref
    * esp::core::ManagedContainer::removeObjectByHandle to allow for the
-   * retention of scene node or visual node of the underlying RigidObject after
-   * it and its wrapper's removal.
+   * retention of scene node or visual node of the underlying RigidObject
+   * after it and its wrapper's removal.
    *
    * @param objectHandle The handle of the managed object to be deleted.
-   * @param deleteObjectNode If true, deletes the object's scene node. Otherwise
-   * detaches the object from simulation.
+   * @param deleteObjectNode If true, deletes the object's scene node.
+   * Otherwise detaches the object from simulation.
    * @param deleteVisualNode If true, deletes the object's visual node.
    * Otherwise detaches the object from simulation. Is not considered if
    * deleteObjectNode==true.
-   * @return this always returns a nullptr, since a wrapper of a deleted object
-   * is unusable.
+   * @return this always returns a nullptr, since a wrapper of a deleted
+   * object is unusable.
    */
   std::shared_ptr<ManagedRigidObject> removePhysObjectByHandle(
       const std::string& objectHandle,
@@ -101,23 +97,6 @@ class RigidObjectManager
       bool deleteVisualNode = true);
 
  protected:
-  /**
-   * @brief Used Internally.  Create and configure newly-created managed object
-   * with any default values, before any specific values are set.
-   *
-   * @param objectHandle Unused for wrapper objects.  All wrappers use the name
-   * of their underlying objects.
-   * @param builtFromConfig Unused for wrapper objects.  All wrappers are
-   * constructed from scratch.
-   * @return Newly created but unregistered ManagedObject pointer, with only
-   * default values set.
-   */
-  std::shared_ptr<ManagedRigidObject> initNewObjectInternal(
-      CORRADE_UNUSED const std::string& objectHandle,
-      CORRADE_UNUSED bool builtFromConfig) override {
-    return ManagedRigidObject::create();
-  }  // RigidObjectManager::initNewObjectInternal(
-
  public:
   ESP_SMART_POINTERS(RigidObjectManager)
 };

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -6,7 +6,6 @@
 #define ESP_PHYSICS_RIGIDOBJECTMANAGER_H
 
 #include "RigidBaseManager.h"
-#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
 namespace esp {
 namespace physics {

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -49,9 +49,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   std::string getHandle() const override {
     if (auto sp = getObjectReference()) {
       return sp->getObjectName();
-    } else {
-      return "";
     }
+    return "";
   }
 
   /**
@@ -66,9 +65,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   int getID() const override {
     if (auto sp = getObjectReference()) {
       return sp->getObjectID();
-    } else {
-      return ID_UNDEFINED;
     }
+    return ID_UNDEFINED;
   }  // getID()
 
   /**
@@ -80,9 +78,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   MotionType getMotionType() const {
     if (auto sp = getObjectReference()) {
       return sp->getMotionType();
-    } else {
-      return MotionType::UNDEFINED;
     }
+    return MotionType::UNDEFINED;
   }
 
   void setMotionType(MotionType mt) {
@@ -94,9 +91,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   bool isActive() {
     if (auto sp = this->getObjectReference()) {
       return sp->isActive();
-    } else {
-      return false;
     }
+    return false;
   }  // isActive()
 
   void setActive(const bool active) {
@@ -114,17 +110,15 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   scene::SceneNode* getSceneNode() {
     if (auto sp = this->getObjectReference()) {
       return &const_cast<scene::SceneNode&>(sp->getSceneNode());
-    } else {
-      return nullptr;
     }
+    return nullptr;
   }  // getSceneNode
 
   esp::core::Configuration::ptr userAttributes() {
     if (auto sp = this->getObjectReference()) {
       return sp->attributes_;
-    } else {
-      return nullptr;
     }
+    return nullptr;
   }
 
   // ==== Transformations ===
@@ -132,9 +126,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   Magnum::Matrix4 getTransformation() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getTransformation();
-    } else {
-      return Magnum::Matrix4{};
     }
+    return Magnum::Matrix4{};
   }  // getTransformation
 
   void setTransformation(const Magnum::Matrix4& transformation) {
@@ -146,9 +139,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   Magnum::Vector3 getTranslation() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getTranslation();
-    } else {
-      return Magnum::Vector3{};
     }
+    return Magnum::Vector3{};
   }  // getTranslation
 
   void setTranslation(const Magnum::Vector3& vector) {
@@ -160,9 +152,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   Magnum::Quaternion getRotation() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getRotation();
-    } else {
-      return Magnum::Quaternion{};
     }
+    return Magnum::Quaternion{};
   }  // getTranslation
   void setRotation(const Magnum::Quaternion& quaternion) {
     if (auto sp = this->getObjectReference()) {
@@ -173,9 +164,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   core::RigidState getRigidState() {
     if (auto sp = this->getObjectReference()) {
       return sp->getRigidState();
-    } else {
-      return core::RigidState{};
     }
+    return core::RigidState{};
   }  // getRigidState()
 
   void setRigidState(const core::RigidState& rigidState) {

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -27,9 +27,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
 
   typedef std::weak_ptr<T> WeakObjRef;
 
-  explicit AbstractManagedPhysicsObject(const std::string& classKey) {
-    setClassKey(classKey);
-  }
+  explicit AbstractManagedPhysicsObject(const std::string& classKey)
+      : classKey_(classKey) {}
 
   void setObjectRef(const std::shared_ptr<T>& objRef) { weakObjRef_ = objRef; }
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -256,9 +256,7 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
  protected:
   /**
    * @brief This function accesses the underlying shared pointer of this
-   * object's
-   * @p weakObjRef_ if it exists; if not, it provides a message and executes
-   * appropriate cleanup code.
+   * object's @p weakObjRef_ if it exists; if not, it provides a message.
    * @return Either a shared pointer of this wrapper's object, or nullptr if
    * dne.
    */

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -56,9 +56,8 @@ class AbstractManagedRigidBase
   double getAngularDamping() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getAngularDamping();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getAngularDamping
 
   void setAngularDamping(const double angDamping) {
@@ -70,9 +69,8 @@ class AbstractManagedRigidBase
   Magnum::Vector3 getAngularVelocity() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getAngularVelocity();
-    } else {
-      return Magnum::Vector3();
     }
+    return Magnum::Vector3();
   }  // getAngularVelocity
 
   void setAngularVelocity(const Magnum::Vector3& angVel) {
@@ -84,9 +82,8 @@ class AbstractManagedRigidBase
   bool getCollidable() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getCollidable();
-    } else {
-      return false;
     }
+    return false;
   }  // getCollidable()
 
   void setCollidable(bool collidable) {
@@ -98,9 +95,8 @@ class AbstractManagedRigidBase
   Magnum::Vector3 getCOM() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getCOM();
-    } else {
-      return Magnum::Vector3();
     }
+    return Magnum::Vector3();
   }  // getCOM
 
   void setCOM(const Magnum::Vector3& COM) {
@@ -112,9 +108,8 @@ class AbstractManagedRigidBase
   double getFrictionCoefficient() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getFrictionCoefficient();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getFrictionCoefficient
 
   void setFrictionCoefficient(const double frictionCoefficient) {
@@ -126,17 +121,15 @@ class AbstractManagedRigidBase
   Magnum::Matrix3 getInertiaMatrix() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getInertiaMatrix();
-    } else {
-      return Magnum::Matrix3();
     }
+    return Magnum::Matrix3();
   }  // getInertiaMatrix
 
   Magnum::Vector3 getInertiaVector() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getInertiaVector();
-    } else {
-      return Magnum::Vector3();
     }
+    return Magnum::Vector3();
   }  // getInertiaVector
 
   void setInertiaVector(const Magnum::Vector3& inertia) {
@@ -148,9 +141,8 @@ class AbstractManagedRigidBase
   double getLinearDamping() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getLinearDamping();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getLinearDamping
 
   void setLinearDamping(const double linDamping) {
@@ -162,9 +154,8 @@ class AbstractManagedRigidBase
   Magnum::Vector3 getLinearVelocity() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getLinearVelocity();
-    } else {
-      return Magnum::Vector3();
     }
+    return Magnum::Vector3();
   }  // getLinearVelocity
 
   void setLinearVelocity(const Magnum::Vector3& linVel) {
@@ -176,9 +167,8 @@ class AbstractManagedRigidBase
   double getMass() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getMass();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getMass
 
   void setMass(const double mass) {
@@ -190,9 +180,8 @@ class AbstractManagedRigidBase
   double getRestitutionCoefficient() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getRestitutionCoefficient();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getRestitutionCoefficient
 
   void setRestitutionCoefficient(const double restitutionCoefficient) {
@@ -204,17 +193,15 @@ class AbstractManagedRigidBase
   Magnum::Vector3 getScale() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getScale();
-    } else {
-      return Magnum::Vector3();
     }
+    return Magnum::Vector3();
   }  // getScale
 
   int getSemanticId() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getSemanticId();
-    } else {
-      return 0;
     }
+    return 0;
   }  // getSemanticId
 
   void setSemanticId(uint32_t semanticId) {
@@ -226,9 +213,8 @@ class AbstractManagedRigidBase
   std::vector<scene::SceneNode*> getVisualSceneNodes() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getVisualSceneNodes();
-    } else {
-      return std::vector<scene::SceneNode*>();
     }
+    return std::vector<scene::SceneNode*>();
   }  // getVisualSceneNodes
 
  public:

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -28,17 +28,15 @@ class ManagedRigidObject
   getInitializationAttributes() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getInitializationAttributes();
-    } else {
-      return nullptr;
     }
+    return nullptr;
   }  // getInitializationAttributes()
 
   VelocityControl::ptr getVelocityControl() {
     if (auto sp = this->getObjectReference()) {
       return sp->getVelocityControl();
-    } else {
-      return nullptr;
     }
+    return nullptr;
   }  // getVelocityControl()
 
  public:

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -15,12 +15,14 @@ namespace physics {
  * @brief Class describing wrapper for RigidObject constructions.
  * Provides bindings for all RigidObject-specific functionality.
  */
+
 class ManagedRigidObject
     : public esp::physics::AbstractManagedRigidBase<esp::physics::RigidObject> {
  public:
-  ManagedRigidObject()
-      : AbstractManagedRigidBase<esp::physics::RigidObject>(
-            "ManagedRigidObject") {}
+  explicit ManagedRigidObject(
+      const std::string& classKey = "ManagedRigidObject")
+      : AbstractManagedRigidBase<
+            esp::physics::RigidObject>::AbstractManagedRigidBase(classKey) {}
 
   std::shared_ptr<metadata::attributes::ObjectAttributes>
   getInitializationAttributes() const {

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -15,6 +15,7 @@
 #include "esp/physics/objectManagers/RigidObjectManager.h"
 #ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/BulletPhysicsManager.h"
+#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
 #endif
 
 #include "configure.h"

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -289,6 +289,7 @@ def test_velocity_control():
         object_template.linear_damping = 0.0
         object_template.angular_damping = 0.0
         obj_template_mgr.register_template(object_template)
+        obj_attr_margin = object_template.margin
 
         obj_handle = obj_template_mgr.get_template_handle_by_id(template_ids[0])
 
@@ -303,6 +304,8 @@ def test_velocity_control():
                     # Non-dynamic simulator in use. Skip 1st pass.
                     rigid_obj_mgr.remove_object_by_id(box_object.object_id)
                     continue
+                # verify bullet wrapper is being accessed
+                assert np.allclose(box_object.margin, obj_attr_margin)
             elif iteration == 1:
                 # test KINEMATIC
                 box_object.motion_type = habitat_sim.physics.MotionType.KINEMATIC


### PR DESCRIPTION
## Motivation and Context
This PR adds the ability for the rigidObjectManager to manage either ManagedRigidObjects or ManagedBulletRigidObjects, depending on whether bullet is available or not.  Without this, Bullet-specific object functionality would not be accessible through the wrappers.

PhysicsTest was also modified to conduct many of the tests through the wrappers instead of by accessing individual objects through PhysicsManager.   test_physics.py's dynamics test also has a small check that verifies that the proper wrapper is being served.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
C++ and python tests passed. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
