### PR TITLE
[Bugfix] Refactor virtual function calls in ctors and dtors.

### DIFF
--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -24,7 +24,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
   AbstractAttributes(const std::string& attributesClassKey,
                      const std::string& handle)
       : Configuration() {
-    setClassKey(attributesClassKey);
+    AbstractAttributes::setClassKey(attributesClassKey);
     AbstractAttributes::setHandle(handle);
   }
 

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -99,7 +99,7 @@ AssetAttributesManager::AssetAttributesManager()
     if (elem.first == PrimObjTypes::END_PRIM_OBJ_TYPES) {
       continue;
     }
-    auto tmplt = this->createObject(elem.second, true);
+    auto tmplt = AssetAttributesManager::createObject(elem.second, true);
     std::string tmpltHandle = tmplt->getHandle();
     defaultPrimAttributeHandles_[elem.second] = tmpltHandle;
     this->undeletableObjectNames_.insert(tmpltHandle);

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -36,7 +36,8 @@ StageAttributesManager::StageAttributesManager(
       &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
   // create none-type stage attributes and set as undeletable
   // based on default
-  auto tmplt = this->createDefaultObject("NONE", true);
+  auto tmplt = this->postCreateRegister(
+      StageAttributesManager::initNewObjectInternal("NONE", false), true);
   std::string tmpltHandle = tmplt->getHandle();
   this->undeletableObjectNames_.insert(tmpltHandle);
 }  // StageAttributesManager::ctor
@@ -59,7 +60,7 @@ int StageAttributesManager::registerObjectFinalize(
   std::string collisionAssetHandle = stageAttributes->getCollisionAssetHandle();
 
   // verify these represent legitimate assets
-  if (this->isValidPrimitiveAttributes(renderAssetHandle)) {
+  if (StageAttributesManager::isValidPrimitiveAttributes(renderAssetHandle)) {
     // If renderAssetHandle corresponds to valid/existing primitive attributes
     // then setRenderAssetIsPrimitive to true and set map of IDs->Names to
     // physicsSynthObjTmpltLibByID_
@@ -94,7 +95,8 @@ int StageAttributesManager::registerObjectFinalize(
     return ID_UNDEFINED;
   }
 
-  if (this->isValidPrimitiveAttributes(collisionAssetHandle)) {
+  if (StageAttributesManager::isValidPrimitiveAttributes(
+          collisionAssetHandle)) {
     // If collisionAssetHandle corresponds to valid/existing primitive
     // attributes then setCollisionAssetIsPrimitive to true
     stageAttributes->setCollisionAssetIsPrimitive(true);
@@ -137,7 +139,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
     const std::string& primAssetHandle,
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
-  if (!this->isValidPrimitiveAttributes(primAssetHandle)) {
+  if (!StageAttributesManager::isValidPrimitiveAttributes(primAssetHandle)) {
     LOG(ERROR)
         << "StageAttributesManager::createPrimBasedAttributesTemplate : No "
            "primitive with handle '"
@@ -219,13 +221,13 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
     // set default origin and orientation values based on file name
     // from AssetInfo::fromPath
     // set defaults for passed render asset handles
-    this->setDefaultAssetNameBasedAttributes(
+    StageAttributesManager::setDefaultAssetNameBasedAttributes(
         newAttributes, true, newAttributes->getRenderAssetHandle(),
         [newAttributes](auto&& PH1) {
           newAttributes->setRenderAssetType(std::forward<decltype(PH1)>(PH1));
         });
     // set defaults for passed collision asset handles
-    this->setDefaultAssetNameBasedAttributes(
+    StageAttributesManager::setDefaultAssetNameBasedAttributes(
         newAttributes, false, newAttributes->getCollisionAssetHandle(),
         [newAttributes](auto&& PH1) {
           newAttributes->setCollisionAssetType(
@@ -233,7 +235,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
         });
 
     // set defaults for passed semantic asset handles
-    this->setDefaultAssetNameBasedAttributes(
+    StageAttributesManager::setDefaultAssetNameBasedAttributes(
         newAttributes, false, newAttributes->getSemanticAssetHandle(),
         [newAttributes](auto&& PH1) {
           newAttributes->setSemanticAssetType(std::forward<decltype(PH1)>(PH1));
@@ -283,7 +285,7 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
     // coordinate frame to -Z gravity
     up = up2;
     fwd = fwd2;
-  } else if (this->isValidPrimitiveAttributes(fileName)) {
+  } else if (StageAttributesManager::isValidPrimitiveAttributes(fileName)) {
     assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
   } else {
     assetTypeSetter(static_cast<int>(AssetType::UNKNOWN));

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -44,7 +44,7 @@ BulletRigidObject::BulletRigidObject(
       MotionState{*rigidBodyNode} {}
 
 BulletRigidObject::~BulletRigidObject() {
-  if (!isActive()) {
+  if (!BulletRigidObject::isActive()) {
     // This object may be supporting other sleeping objects, so wake them
     // before removing.
     activateCollisionIsland();

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -27,8 +27,9 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
 
   typedef std::weak_ptr<T> WeakObjRef;
 
-  explicit AbstractManagedPhysicsObject(const std::string& classKey)
-      : classKey_(classKey) {}
+  explicit AbstractManagedPhysicsObject(const std::string& classKey) {
+    AbstractManagedPhysicsObject::setClassKey(classKey);
+  }
 
   void setObjectRef(const std::shared_ptr<T>& objRef) { weakObjRef_ = objRef; }
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -60,7 +60,7 @@ class Simulator {
    * is not done correctly, the pattern for @ref `close` then @ref `reconfigure`
    * to create a "fresh" instance of the simulator may not work correctly
    */
-  virtual void close();
+  void close();
 
   virtual void reconfigure(const SimulatorConfiguration& cfg);
 


### PR DESCRIPTION
## Motivation and Context
Numerous virtual function calls were being called from constructors or destructors.  This is bad in that it bypasses virtual dispatch (i.e. the functions do not behave as virtual anymore).  This PR addresses these situations by either specifying the owning class in the call (in effect manually bypassing virtual dispatch) or changing function to no longer be virtual (Note : close() in Simulator was marked as virtual, but is no longer).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
