### PR TITLE
[GFX][FisheyeBindings] Allow principal point to default to center of sensor

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import magnum as mn
 
 import habitat_sim
 import habitat_sim.agent
@@ -153,10 +152,8 @@ def make_cfg(settings):
 
         fisheye_sensor_spec.resolution = [settings["height"], settings["width"]]
         # The default principal_point_offset is the middle of the image
-        fisheye_sensor_spec.principal_point_offset = mn.Vector2(
-            settings["height"] // 2,
-            settings["width"] // 2,
-        )
+        fisheye_sensor_spec.principal_point_offset = None
+        # default: fisheye_sensor_spec.principal_point_offset = [i/2 for i in fisheye_sensor_spec.resolution]
         fisheye_sensor_spec.position = [0, settings["sensor_height"], 0]
         for k in kw_args:
             setattr(fisheye_sensor_spec, k, kw_args[k])

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -4,6 +4,7 @@
 
 #include "esp/bindings/bindings.h"
 
+#include <Corrade/Containers/OptionalPythonBindings.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/SceneGraph/SceneGraph.h>
 

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 #include "FisheyeSensor.h"
+#include "Corrade/Containers/Containers.h"
 #include "esp/core/Check.h"
 #include "esp/gfx/DoubleSphereCameraShader.h"
 
@@ -48,6 +49,14 @@ void specSanityCheck(FisheyeSensorSpec* spec) {
   actualSpec->sanityCheck();
 }
 
+Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec spec) {
+  if (spec.principalPointOffset != Corrade::Containers::NullOpt) {
+    return *spec.principalPointOffset;
+  }
+  auto res = spec.resolution;
+  return Magnum::Vector2(res[0] * 0.5f, res[1] * 0.5f);
+}
+
 FisheyeSensor::FisheyeSensor(scene::SceneNode& cameraNode,
                              const FisheyeSensorSpec::ptr& spec)
     : CubeMapSensorBase(cameraNode, spec) {
@@ -88,7 +97,7 @@ bool FisheyeSensor::drawObservation(sim::Simulator& sim) {
           static_cast<FisheyeSensorDoubleSphereSpec&>(*fisheyeSensorSpec_);
       (*shader)
           .setFocalLength(actualSpec.focalLength)
-          .setPrincipalPointOffset(actualSpec.principalPointOffset)
+          .setPrincipalPointOffset(computePrincipalPointOffset(actualSpec))
           .setAlpha(actualSpec.alpha)
           .setXi(actualSpec.xi);
       drawWith(*shader);

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -52,9 +52,8 @@ Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
   if (bool(spec.principalPointOffset)) {
     return *spec.principalPointOffset;
   }
-  auto res = spec.resolution;
-  return Mn::Vector2(static_cast<float>(res[0]), static_cast<float>(res[1])) *
-         0.5f;
+  auto res = spec.resolution.cast<float>();
+  return Mn::Vector2(res[0], res[1]) * 0.5f;
 }
 
 FisheyeSensor::FisheyeSensor(scene::SceneNode& cameraNode,

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -2,10 +2,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 #include "FisheyeSensor.h"
-#include "Corrade/Containers/Containers.h"
 #include "esp/core/Check.h"
 #include "esp/gfx/DoubleSphereCameraShader.h"
 
+#include <Corrade/Containers/Containers.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/FormatStl.h>
 

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -49,7 +49,7 @@ void specSanityCheck(FisheyeSensorSpec* spec) {
   actualSpec->sanityCheck();
 }
 
-Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec spec) {
+Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
   if (spec.principalPointOffset != Corrade::Containers::NullOpt) {
     return *spec.principalPointOffset;
   }

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -8,7 +8,6 @@
 #include <Corrade/Containers/Containers.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/FormatStl.h>
-#include <Magnum/EigenIntegration/Integration.h>
 
 namespace Mn = Magnum;
 namespace Cr = Corrade;
@@ -55,7 +54,7 @@ Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
     return *spec.principalPointOffset;
   }
   auto res = spec.resolution;
-  return Mn::Vector2{Mn::Vector2i{res}} * 0.5f;
+  return Mn::Vector2(res[0], res[1]) * 0.5f;
 }
 
 FisheyeSensor::FisheyeSensor(scene::SceneNode& cameraNode,

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -8,6 +8,7 @@
 #include <Corrade/Containers/Containers.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/FormatStl.h>
+#include <Magnum/EigenIntegration/Integration.h>
 
 namespace Mn = Magnum;
 namespace Cr = Corrade;
@@ -54,7 +55,7 @@ Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
     return *spec.principalPointOffset;
   }
   auto res = spec.resolution;
-  return Magnum::Vector2(res[0] * 0.5f, res[1] * 0.5f);
+  return Mn::Vector2{Mn::Vector2i{res}} * 0.5f;
 }
 
 FisheyeSensor::FisheyeSensor(scene::SceneNode& cameraNode,

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -53,7 +53,8 @@ Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
     return *spec.principalPointOffset;
   }
   auto res = spec.resolution;
-  return Mn::Vector2(res[0], res[1]) * 0.5f;
+  return Mn::Vector2(static_cast<float>(res[0]), static_cast<float>(res[1])) *
+         0.5f;
 }
 
 FisheyeSensor::FisheyeSensor(scene::SceneNode& cameraNode,

--- a/src/esp/sensor/FisheyeSensor.cpp
+++ b/src/esp/sensor/FisheyeSensor.cpp
@@ -5,7 +5,6 @@
 #include "esp/core/Check.h"
 #include "esp/gfx/DoubleSphereCameraShader.h"
 
-#include <Corrade/Containers/Containers.h>
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/FormatStl.h>
 
@@ -50,7 +49,7 @@ void specSanityCheck(FisheyeSensorSpec* spec) {
 }
 
 Magnum::Vector2 computePrincipalPointOffset(const FisheyeSensorSpec& spec) {
-  if (spec.principalPointOffset != Corrade::Containers::NullOpt) {
+  if (bool(spec.principalPointOffset)) {
     return *spec.principalPointOffset;
   }
   auto res = spec.resolution;

--- a/src/esp/sensor/FisheyeSensor.h
+++ b/src/esp/sensor/FisheyeSensor.h
@@ -46,7 +46,8 @@ struct FisheyeSensorSpec : public CubeMapSensorBaseSpec {
   Magnum::Vector2 focalLength;
   /**
    * @brief Principal Point Offset in pixel, cx, cy, location of the principal
-   * point relative to the image plane's origin.
+   * point relative to the image plane's origin. None will place it in the
+   * middle of the image (height/2, width/2).
    */
   Corrade::Containers::Optional<Magnum::Vector2> principalPointOffset =
       Corrade::Containers::NullOpt;

--- a/src/esp/sensor/FisheyeSensor.h
+++ b/src/esp/sensor/FisheyeSensor.h
@@ -49,8 +49,7 @@ struct FisheyeSensorSpec : public CubeMapSensorBaseSpec {
    * point relative to the image plane's origin. None will place it in the
    * middle of the image (height/2, width/2).
    */
-  Corrade::Containers::Optional<Magnum::Vector2> principalPointOffset =
-      Corrade::Containers::NullOpt;
+  Corrade::Containers::Optional<Magnum::Vector2> principalPointOffset;
 
   /**
    * @brief Constructor

--- a/src/esp/sensor/FisheyeSensor.h
+++ b/src/esp/sensor/FisheyeSensor.h
@@ -48,7 +48,8 @@ struct FisheyeSensorSpec : public CubeMapSensorBaseSpec {
    * @brief Principal Point Offset in pixel, cx, cy, location of the principal
    * point relative to the image plane's origin.
    */
-  Magnum::Vector2 principalPointOffset;
+  Corrade::Containers::Optional<Magnum::Vector2> principalPointOffset =
+      Corrade::Containers::NullOpt;
 
   /**
    * @brief Constructor
@@ -79,7 +80,7 @@ struct FisheyeSensorDoubleSphereSpec : public FisheyeSensorSpec {
   /**
    * @brief constructor
    */
-  FisheyeSensorDoubleSphereSpec() : FisheyeSensorSpec() {}
+  FisheyeSensorDoubleSphereSpec() : FisheyeSensorSpec(){};
   /**
    * @brief check if the specification is legal
    */

--- a/src/esp/sensor/FisheyeSensor.h
+++ b/src/esp/sensor/FisheyeSensor.h
@@ -80,7 +80,7 @@ struct FisheyeSensorDoubleSphereSpec : public FisheyeSensorSpec {
   /**
    * @brief constructor
    */
-  FisheyeSensorDoubleSphereSpec() : FisheyeSensorSpec(){};
+  FisheyeSensorDoubleSphereSpec() : FisheyeSensorSpec() {}
   /**
    * @brief check if the specification is legal
    */


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* We currently have to specify the Principal Point which is a big annoyance on the Habitat-Lab side. Most of the time, the principal point should lie in the center of the image. If not, the user can still specify it. Using the new fixed Corrade::Optional bindings to make this a sensible and easy to compute default.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* PyTest and locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
 