### PR TITLE
[BUGFIX] - add dummy function mappings for no-bullet compilation

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -7,10 +7,8 @@
 #include "esp/physics/RigidBase.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/physics/RigidStage.h"
-#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
 #include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
-#endif
 #include "esp/physics/objectWrappers/ManagedArticulatedObject.h"
 #include "esp/physics/objectWrappers/ManagedPhysicsObjectBase.h"
 #include "esp/physics/objectWrappers/ManagedRigidBase.h"
@@ -460,7 +458,6 @@ void initPhysicsObjectBindings(py::module& m) {
   // ==== ManagedRigidObject ====
   declareRigidObjectWrapper(m, "Rigid Object", "ManagedRigidObject");
 
-#ifdef ESP_BUILD_WITH_BULLET
   // ==== ManagedBulletRigidObject ====
   py::class_<ManagedBulletRigidObject, ManagedRigidObject,
              std::shared_ptr<ManagedBulletRigidObject>>(
@@ -474,19 +471,6 @@ void initPhysicsObjectBindings(py::module& m) {
           &ManagedBulletRigidObject::getCollisionShapeAabb,
           R"(REQUIRES BULLET TO BE INSTALLED. The bounds of the axis-aligned bounding box from Bullet Physics, in its local coordinate frame.)");
 
-#else
-  // ==== non-bullet dummy ManagedBulletRigidObject ====
-  py::class_<ManagedRigidObject, AbstractManagedRigidBase<RigidObject>,
-             std::shared_ptr<ManagedRigidObject>>(m, "ManagedBulletRigidObject")
-      .def_property(
-          "margin", [](ManagedRigidObject& self) { return 0.0; },
-          [](ManagedRigidObject& self, double margin) {},
-          R"(REQUIRES BULLET TO BE INSTALLED. Get or set this object's collision margin.)")
-      .def_property_readonly(
-          "collision_shape_aabb",
-          [](ManagedRigidObject& self) { return Magnum::Range3D{}; },
-          R"(REQUIRES BULLET TO BE INSTALLED. The bounds of the axis-aligned bounding box from Bullet Physics, in its local coordinate frame.)");
-#endif
   // create bindings for ArticulatedObjects
   // physics object base instance for articulated object
   declareBasePhysicsObjectWrapper<ArticulatedObject>(m, "Articulated Object",
@@ -496,7 +480,6 @@ void initPhysicsObjectBindings(py::module& m) {
   declareArticulatedObjectWrapper(m, "Articulated Object",
                                   "ManagedArticulatedObject");
 
-#ifdef ESP_BUILD_WITH_BULLET
   // ==== ManagedBulletArticulatedObject ====
   py::class_<ManagedBulletArticulatedObject, ManagedArticulatedObject,
              std::shared_ptr<ManagedBulletArticulatedObject>>(
@@ -515,33 +498,6 @@ void initPhysicsObjectBindings(py::module& m) {
           &ManagedBulletArticulatedObject::getJointMotorMaxImpulse,
           R"(REQUIRES BULLET TO BE INSTALLED. Get the maximum impulse for the joint motor specified by the given motor_id)",
           "motor_id"_a);
-
-#else
-  // ==== non-bullet dummy ManagedBulletArticulatedObject ====
-  py::class_<ManagedArticulatedObject,
-             AbstractManagedPhysicsObject<ArticulatedObject>,
-             std::shared_ptr<ManagedArticulatedObject>>(
-      m, "ManagedBulletArticulatedObject")
-      .def(
-          "contact_test",
-          [](ManagedArticulatedObject& self, bool staticAsStage) {
-            return false;
-          },
-          // TODO need to describe what 'static_as_stage' is intended for in
-          // appropriate terms.
-          R"(REQUIRES BULLET TO BE INSTALLED. Returns the result of a discrete collision test between this object and the world.)",
-          "static_as_stage"_a)
-      .def(
-          "supports_joint_motor",
-          [](ManagedArticulatedObject& self, int linkIx) { return false; },
-          R"(REQUIRES BULLET TO BE INSTALLED. )", "link_id"_a)
-      .def(
-          "get_joint_motor_max_impulse",
-          [](ManagedArticulatedObject& self, int motorId) { return 0.0; },
-          R"(REQUIRES BULLET TO BE INSTALLED. Get the maximum impulse for the joint motor specified by the given motor_id)",
-          "motor_id"_a);
-
-#endif
 
 }  // initPhysicsObjectBindings
 

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -191,7 +191,12 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
   py::class_<RigidObjectManager, RigidBaseManager<ManagedRigidObject>,
              std::shared_ptr<RigidObjectManager>>(m, "RigidObjectManager")
       .def(
-          "add_object_by_template_id", &RigidObjectManager::addObjectByID,
+          "add_object_by_template_id",
+#ifdef ESP_BUILD_WITH_BULLET
+          &RigidObjectManager::addBulletObjectByID,
+#else
+          &RigidObjectManager::addObjectByID,
+#endif
           "object_lib_id"_a, "attachment_node"_a = nullptr,
           "light_setup_key"_a = DEFAULT_LIGHTING_KEY,
           R"(Instance an object into the scene via a template referenced by library id.
@@ -199,8 +204,12 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
           LightSetup key. Returns a reference to the created object.)")
       .def(
           "add_object_by_template_handle",
-          &RigidObjectManager::addObjectByHandle, "object_lib_handle"_a,
-          "attachment_node"_a = nullptr,
+#ifdef ESP_BUILD_WITH_BULLET
+          &RigidObjectManager::addBulletObjectByHandle,
+#else
+          &RigidObjectManager::addObjectByHandle,
+#endif
+          "object_lib_handle"_a, "attachment_node"_a = nullptr,
           "light_setup_key"_a = DEFAULT_LIGHTING_KEY,
           R"(Instance an object into the scene via a template referenced by its handle.
           Optionally attach the object to an existing SceneNode and assign its initial
@@ -237,10 +246,15 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
       m, "ArticulatedObjectManager")
 
       .def(
-          "add_articulated_object_from_urdf",
-          &ArticulatedObjectManager::addArticulatedObjectFromURDF, "filepath"_a,
-          "fixed_base"_a = false, "global_scale"_a = 1.0, "mass_scale"_a = 1.0,
-          "froce_reload"_a = false,
+          "add_articulated_object_from_URDF",
+#ifdef ESP_BUILD_WITH_BULLET
+          &ArticulatedObjectManager::addBulletArticulatedObjectFromURDF,
+#else
+          &ArticulatedObjectManager::addArticulatedObjectFromURDF,
+#endif
+
+          "filepath"_a, "fixed_base"_a = false, "global_scale"_a = 1.0,
+          "mass_scale"_a = 1.0, "force_reload"_a = false,
           R"(Load and parse a URDF file using the given 'filepath' into a model,
           then use this model to instantiate an Articulated Object in the world.
           Returns a reference to the created object.)");

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -4,24 +4,21 @@
 
 #include "esp/bindings/bindings.h"
 
+#include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
+#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
 #include "esp/physics/objectManagers/ArticulatedObjectManager.h"
 #include "esp/physics/objectManagers/PhysicsObjectBaseManager.h"
 #include "esp/physics/objectManagers/RigidBaseManager.h"
 #include "esp/physics/objectManagers/RigidObjectManager.h"
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
-#ifdef ESP_BUILD_WITH_BULLET
-#include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
-#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
-#endif
+
 namespace py = pybind11;
 using py::literals::operator""_a;
 
 namespace PhysWraps = esp::physics;
-#ifdef ESP_BUILD_WITH_BULLET
+using PhysWraps::ArticulatedObjectManager;
 using PhysWraps::ManagedBulletArticulatedObject;
 using PhysWraps::ManagedBulletRigidObject;
-#endif
-using PhysWraps::ArticulatedObjectManager;
 using PhysWraps::ManagedRigidObject;
 using PhysWraps::PhysicsObjectBaseManager;
 using PhysWraps::RigidBaseManager;
@@ -161,7 +158,7 @@ void declareBaseWrapperManager(py::module& m,
            "handle"_a);
 }  // declareBaseWrapperManager
 
-template <typename T, typename U>
+template <typename T>
 void declareRigidBaseWrapperManager(py::module& m,
                                     CORRADE_UNUSED const std::string& objType,
                                     const std::string& classStrPrefix) {
@@ -179,16 +176,16 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
   declareBaseWrapperManager<ManagedRigidObject, ManagedBulletRigidObject>(
       m, "BulletRigidObject", "BulletRigidObject");
 
-  declareRigidBaseWrapperManager<ManagedRigidObject, ManagedBulletRigidObject>(
-      m, "BulletRigidObject", "BulletRigidObject");
+  declareRigidBaseWrapperManager<ManagedRigidObject>(m, "BulletRigidObject",
+                                                     "BulletRigidObject");
 
 #else
   // if dynamics library not being used, just use base rigid object
   declareBaseWrapperManager<ManagedRigidObject, ManagedRigidObject>(
       m, "RigidObject", "RigidObject");
 
-  declareRigidBaseWrapperManager<ManagedRigidObject, ManagedRigidObject>(
-      m, "RigidObject", "RigidObject");
+  declareRigidBaseWrapperManager<ManagedRigidObject>(m, "RigidObject",
+                                                     "RigidObject");
 #endif
   // RigidObject wrapper manager
   py::class_<RigidObjectManager, RigidBaseManager<ManagedRigidObject>,

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -38,7 +38,7 @@ namespace physics {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <typename T, typename U = ManagedRigidObject>
+template <typename T, typename U>
 void declareBaseWrapperManager(py::module& m,
                                const std::string& objType,
                                const std::string& classStrPrefix) {
@@ -161,7 +161,7 @@ void declareBaseWrapperManager(py::module& m,
            "handle"_a);
 }  // declareBaseWrapperManager
 
-template <typename T, typename U = ManagedRigidObject>
+template <typename T, typename U>
 void declareRigidBaseWrapperManager(py::module& m,
                                     CORRADE_UNUSED const std::string& objType,
                                     const std::string& classStrPrefix) {
@@ -184,11 +184,11 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
 
 #else
   // if dynamics library not being used, just use base rigid object
-  declareBaseWrapperManager<ManagedRigidObject>(m, "RigidObject",
-                                                "RigidObject");
+  declareBaseWrapperManager<ManagedRigidObject, ManagedRigidObject>(
+      m, "RigidObject", "RigidObject");
 
-  declareRigidBaseWrapperManager<ManagedRigidObject>(m, "RigidObject",
-                                                     "RigidObject");
+  declareRigidBaseWrapperManager<ManagedRigidObject, ManagedRigidObject>(
+      m, "RigidObject", "RigidObject");
 #endif
   // RigidObject wrapper manager
   py::class_<RigidObjectManager, RigidBaseManager<ManagedRigidObject>,
@@ -230,8 +230,8 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
 
 #else
   // if dynamics library not being used, just use base rigid object
-  declareBaseWrapperManager<ManagedArticulatedObject>(m, "ArticulatedObject",
-                                                      "ArticulatedObject");
+  declareBaseWrapperManager<ManagedArticulatedObject, ManagedArticulatedObject>(
+      m, "ArticulatedObject", "ArticulatedObject");
 
 #endif
   py::class_<ArticulatedObjectManager,

--- a/src/esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h
+++ b/src/esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h
@@ -5,7 +5,9 @@
 #ifndef ESP_PHYSICS_MANAGEDBULLETARTICULATEDOBJECT_H_
 #define ESP_PHYSICS_MANAGEDBULLETARTICULATEDOBJECT_H_
 
+#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/BulletArticulatedObject.h"
+#endif
 #include "esp/physics/objectWrappers/ManagedArticulatedObject.h"
 
 namespace esp {
@@ -22,6 +24,7 @@ class ManagedBulletArticulatedObject
   ManagedBulletArticulatedObject()
       : ManagedArticulatedObject("ManagedBulletArticulatedObject") {}
 
+#ifdef ESP_BUILD_WITH_BULLET
   bool contactTest(bool staticAsStage = true) {
     if (auto sp = getBulletObjectReference()) {
       return sp->contactTest(staticAsStage);
@@ -52,10 +55,38 @@ class ManagedBulletArticulatedObject
    * @return Either a shared pointer of this wrapper's object, or nullptr if
    * dne.
    */
+
   std::shared_ptr<BulletArticulatedObject> getBulletObjectReference() const {
     return std::static_pointer_cast<BulletArticulatedObject>(
         this->getObjectReference());
   }
+#else
+  //! no bullet version
+  bool contactTest(CORRADE_UNUSED bool staticAsStage = true) {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+    return false;
+  }
+
+  bool supportsJointMotor(CORRADE_UNUSED int linkIx) {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+    return false;
+  }
+
+  float getJointMotorMaxImpulse(CORRADE_UNUSED int motorId) {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+    return 0.0;
+  }
+
+  std::shared_ptr<ArticulatedObject> getBulletObjectReference() const {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+
+    return nullptr;
+  }
+#endif
 
  public:
   ESP_SMART_POINTERS(ManagedBulletArticulatedObject)

--- a/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
+++ b/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
@@ -5,7 +5,9 @@
 #ifndef ESP_PHYSICS_MANAGEDBULLETRIGIDOBJECT_H_
 #define ESP_PHYSICS_MANAGEDBULLETRIGIDOBJECT_H_
 
+#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/BulletRigidObject.h"
+#endif
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
 
 namespace esp {
@@ -19,12 +21,12 @@ class ManagedBulletRigidObject : public esp::physics::ManagedRigidObject {
  public:
   ManagedBulletRigidObject() : ManagedRigidObject("ManagedBulletRigidObject") {}
 
+#ifdef ESP_BUILD_WITH_BULLET
   double getMargin() const {
     if (auto sp = this->getBulletObjectReference()) {
       return sp->getMargin();
-    } else {
-      return 0.0;
     }
+    return 0.0;
   }  // getMargin
 
   void setMargin(const double margin) {
@@ -36,9 +38,8 @@ class ManagedBulletRigidObject : public esp::physics::ManagedRigidObject {
   Magnum::Range3D getCollisionShapeAabb() {
     if (auto sp = this->getBulletObjectReference()) {
       return sp->getCollisionShapeAabb();
-    } else {
-      return {};
     }
+    return {};
   }  // getCollisionShapeAabb
 
  protected:
@@ -54,6 +55,30 @@ class ManagedBulletRigidObject : public esp::physics::ManagedRigidObject {
     return std::static_pointer_cast<BulletRigidObject>(
         this->getObjectReference());
   }
+
+#else
+  //! no bullet version
+  double getMargin() const {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+
+    return 0.0;
+  }  // getMargin
+
+  void setMargin(CORRADE_UNUSED const double margin) {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+
+  }  // setMass
+
+  Magnum::Range3D getCollisionShapeAabb() {
+    LOG(WARNING) << "This functionaliy requires Habitat-Sim to be compiled "
+                    "with Bullet enabled..";
+
+    return {};
+  }  // getCollisionShapeAabbb
+
+#endif
 
  public:
   ESP_SMART_POINTERS(ManagedBulletRigidObject)

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -4,9 +4,7 @@
 
 #include "ArticulatedObjectManager.h"
 
-#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
-#endif
 
 namespace esp {
 namespace physics {
@@ -24,14 +22,13 @@ ArticulatedObjectManager::ArticulatedObjectManager()
       &ArticulatedObjectManager::createPhysicsObjectWrapper<
           ManagedArticulatedObject>;
 
-#ifdef ESP_BUILD_WITH_BULLET
   this->copyConstructorMap_["ManagedBulletArticulatedObject"] =
       &ArticulatedObjectManager::createObjectCopy<
           ManagedBulletArticulatedObject>;
   managedObjTypeConstructorMap_["ManagedBulletArticulatedObject"] =
       &ArticulatedObjectManager::createPhysicsObjectWrapper<
           ManagedBulletArticulatedObject>;
-#endif
+
 }  // ctor
 
 std::shared_ptr<ManagedArticulatedObject>

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -4,8 +4,6 @@
 
 #include "ArticulatedObjectManager.h"
 
-#include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
-
 namespace esp {
 namespace physics {
 

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.h
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.h
@@ -6,6 +6,7 @@
 #define ESP_PHYSICS_ARTICULATEDOBJECTMANAGER_H
 
 #include "PhysicsObjectBaseManager.h"
+#include "esp/physics/bullet/objectWrappers/ManagedBulletArticulatedObject.h"
 #include "esp/physics/objectWrappers/ManagedArticulatedObject.h"
 
 namespace esp {
@@ -44,6 +45,34 @@ class ArticulatedObjectManager
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false);
+
+  /**
+   * @brief Cast to BulletArticulatedObject version.  Load, parse, and import a
+   * URDF file instantiating an @ref BulletArticulatedObject in the world.  This
+   * version does not require drawables to be specified.
+   * @param filepath The fully-qualified filename for the URDF file describing
+   * the model the articulated object is to be built from.
+   * @param fixedBase Whether the base of the @ref ArticulatedObject should be
+   * fixed.
+   * @param globalScale A scale multiplier to be applied uniformly in 3
+   * dimensions to the entire @ref ArticulatedObject.
+   * @param massScale A scale multiplier to be applied to the mass of the all
+   * the components of the @ref ArticulatedObject.
+   * @param forceReload If true, reload the source URDF from file, replacing the
+   * cached model.
+   *
+   * @return A reference to the created ArticulatedObject
+   */
+  std::shared_ptr<ManagedBulletArticulatedObject>
+  addBulletArticulatedObjectFromURDF(const std::string& filepath,
+                                     bool fixedBase = false,
+                                     float globalScale = 1.0,
+                                     float massScale = 1.0,
+                                     bool forceReload = false) {
+    return std::static_pointer_cast<ManagedBulletArticulatedObject>(
+        addArticulatedObjectFromURDF(filepath, fixedBase, globalScale,
+                                     massScale, forceReload));
+  }
 
   /**
    * @brief Load, parse, and import a URDF file instantiating an @ref

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -3,9 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "RigidObjectManager.h"
-
-#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
-
 namespace esp {
 namespace physics {
 

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -4,9 +4,7 @@
 
 #include "RigidObjectManager.h"
 
-#ifdef ESP_BUILD_WITH_BULLET
 #include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
-#endif
 
 namespace esp {
 namespace physics {
@@ -24,12 +22,10 @@ RigidObjectManager::RigidObjectManager()
   managedObjTypeConstructorMap_["ManagedRigidObject"] =
       &RigidObjectManager::createPhysicsObjectWrapper<ManagedRigidObject>;
 
-#ifdef ESP_BUILD_WITH_BULLET
   this->copyConstructorMap_["ManagedBulletRigidObject"] =
       &RigidObjectManager::createObjectCopy<ManagedBulletRigidObject>;
   managedObjTypeConstructorMap_["ManagedBulletRigidObject"] =
       &RigidObjectManager::createPhysicsObjectWrapper<ManagedBulletRigidObject>;
-#endif
 }
 
 std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByHandle(

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -6,6 +6,7 @@
 #define ESP_PHYSICS_RIGIDOBJECTMANAGER_H
 
 #include "RigidBaseManager.h"
+#include "esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h"
 #include "esp/physics/objectWrappers/ManagedRigidObject.h"
 namespace esp {
 namespace physics {
@@ -27,13 +28,29 @@ class RigidObjectManager
    * to query @ref esp::metadata::managers::ObjectAttributesManager.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   * @return a copy of the instanced object, or nullptr.
    */
   std::shared_ptr<ManagedRigidObject> addObjectByHandle(
       const std::string& attributesHandle,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Templated version of addObjectByHandle. Will cast result to
+   * appropriate dynamics library wrapper.
+   * @param attributesHandle The handle of the object attributes used as the key
+   * to query @ref esp::metadata::managers::ObjectAttributesManager.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @return a copy of the instanced object, appropriately cast, or nullptr.
+   */
+  std::shared_ptr<ManagedBulletRigidObject> addBulletObjectByHandle(
+      const std::string& attributesHandle,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    return std::static_pointer_cast<ManagedBulletRigidObject>(
+        addObjectByHandle(attributesHandle, attachmentNode, lightSetup));
+  }
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
@@ -44,14 +61,29 @@ class RigidObjectManager
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup An optional custom lightsetup for the object.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref
-   * esp::ID_UNDEFINED.
+   * @return a copy of the instanced object, or nullptr.
    */
   std::shared_ptr<ManagedRigidObject> addObjectByID(
       const int attributesID,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Templated version of addObjectByID. Will cast result to
+   * appropriate dynamics library wrapper.
+   * @param attributesID The ID of the object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @return a copy of the instanced object, appropriately cast, or nullptr.
+   */
+  std::shared_ptr<ManagedBulletRigidObject> addBulletObjectByID(
+      const int attributesID,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    return std::static_pointer_cast<ManagedBulletRigidObject>(
+        addObjectByID(attributesID, attachmentNode, lightSetup));
+  }
 
   /**
    * @brief Overload of standard @ref


### PR DESCRIPTION
## Motivation and Context
This adds dummy python bindings for the BulletRigidObject and BulletArticulatedObject constructs when bullet is not included in compilation, so that the python derivations can be included regardless of bullet state.  The bindings provide default values but otherwise act as no ops, similar to how such methods in physicsManager used to work.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes
C++ and python tests pass 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
