### PR TITLE
[AO] Decouple URDF::Model and URDF::Parser + tests

### DIFF
--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -229,7 +229,7 @@ bool Parser::parseMaterial(Material& material, XMLElement* config) const {
   return true;
 }
 
-bool Parser::parseLink(std::shared_ptr<Model> model,
+bool Parser::parseLink(const std::shared_ptr<Model>& model,
                        Link& link,
                        XMLElement* config) {
   Mn::Debug silence{logMessages ? &std::cout : nullptr};
@@ -454,7 +454,7 @@ bool Parser::parseCollision(CollisionShape& collision, XMLElement* config) {
   return true;
 }
 
-bool Parser::parseVisual(std::shared_ptr<Model> model,
+bool Parser::parseVisual(const std::shared_ptr<Model>& model,
                          VisualShape& visual,
                          XMLElement* config) {
   Mn::Debug silence{logMessages ? &std::cout : nullptr};
@@ -750,7 +750,7 @@ bool Parser::validateMeshFile(std::string& meshFilename) {
   return meshSuccess;
 }
 
-bool Parser::initTreeAndRoot(std::shared_ptr<Model> model) const {
+bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
   Mn::Debug silence{logMessages ? &std::cout : nullptr};
   // every link has children links and joints, but no parents, so we create a
   // local convenience data structure for keeping child->parent relations

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -327,10 +327,6 @@ class Model {
 };
 
 class Parser {
-  // datastructures
-  std::shared_ptr<Model> m_urdfModel;
-  float m_urdfScaling = 1.0;
-
   // URDF file path of last load call
   std::string sourceFilePath_;
 
@@ -338,19 +334,19 @@ class Parser {
   bool parseTransform(Magnum::Matrix4& tr, tinyxml2::XMLElement* xml) const;
   bool parseInertia(Inertia& inertia, tinyxml2::XMLElement* config);
   bool parseGeometry(Geometry& geom, tinyxml2::XMLElement* g);
-  bool parseVisual(std::shared_ptr<Model>& model,
+  bool parseVisual(std::shared_ptr<Model> model,
                    VisualShape& visual,
                    tinyxml2::XMLElement* config);
   bool parseCollision(CollisionShape& collision, tinyxml2::XMLElement* config);
-  bool initTreeAndRoot(std::shared_ptr<Model>& model) const;
+  bool initTreeAndRoot(std::shared_ptr<Model> model) const;
   bool parseMaterial(Material& material, tinyxml2::XMLElement* config) const;
   bool parseJointLimits(Joint& joint, tinyxml2::XMLElement* config) const;
   bool parseJointDynamics(Joint& joint, tinyxml2::XMLElement* config) const;
   bool parseJoint(Joint& joint, tinyxml2::XMLElement* config);
-  bool parseLink(std::shared_ptr<Model>&,
+  bool parseLink(std::shared_ptr<Model>,
                  Link& link,
                  tinyxml2::XMLElement* config);
-  bool parseSensor(CORRADE_UNUSED std::shared_ptr<Model>&,
+  bool parseSensor(CORRADE_UNUSED std::shared_ptr<Model>,
                    CORRADE_UNUSED Link& link,
                    CORRADE_UNUSED Joint& joint,
                    CORRADE_UNUSED tinyxml2::XMLElement* config) {
@@ -365,17 +361,8 @@ class Parser {
 
   // parse a loaded URDF string into relevant general data structures
   // return false if the string is not a valid urdf or other error causes abort
-  bool parseURDF(const std::string& meshFilename);
-
-  //! Set the global scale for future parsing and modify the cached model if
-  //! applicable.
-  void setGlobalScaling(float scaling) {
-    m_urdfScaling = scaling;
-    m_urdfModel->setGlobalScaling(m_urdfScaling);
-  }
-  float getGlobalScaling() const { return m_urdfScaling; }
-
-  std::shared_ptr<Model> getModel() const { return m_urdfModel; }
+  bool parseURDF(std::shared_ptr<Model>& model,
+                 const std::string& meshFilename);
 
   bool logMessages = false;
 };

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -334,19 +334,19 @@ class Parser {
   bool parseTransform(Magnum::Matrix4& tr, tinyxml2::XMLElement* xml) const;
   bool parseInertia(Inertia& inertia, tinyxml2::XMLElement* config);
   bool parseGeometry(Geometry& geom, tinyxml2::XMLElement* g);
-  bool parseVisual(std::shared_ptr<Model> model,
+  bool parseVisual(const std::shared_ptr<Model>& model,
                    VisualShape& visual,
                    tinyxml2::XMLElement* config);
   bool parseCollision(CollisionShape& collision, tinyxml2::XMLElement* config);
-  bool initTreeAndRoot(std::shared_ptr<Model> model) const;
+  bool initTreeAndRoot(const std::shared_ptr<Model>& model) const;
   bool parseMaterial(Material& material, tinyxml2::XMLElement* config) const;
   bool parseJointLimits(Joint& joint, tinyxml2::XMLElement* config) const;
   bool parseJointDynamics(Joint& joint, tinyxml2::XMLElement* config) const;
   bool parseJoint(Joint& joint, tinyxml2::XMLElement* config);
-  bool parseLink(std::shared_ptr<Model>,
+  bool parseLink(const std::shared_ptr<Model>&,
                  Link& link,
                  tinyxml2::XMLElement* config);
-  bool parseSensor(CORRADE_UNUSED std::shared_ptr<Model>,
+  bool parseSensor(CORRADE_UNUSED const std::shared_ptr<Model>&,
                    CORRADE_UNUSED Link& link,
                    CORRADE_UNUSED Joint& joint,
                    CORRADE_UNUSED tinyxml2::XMLElement* config) {

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -29,7 +29,8 @@ bool URDFImporter::loadURDF(const std::string& filename,
 
     // parse the URDF from file
     urdfParser_.logMessages = logMessages;
-    bool success = urdfParser_.parseURDF(filename);
+    std::shared_ptr<io::URDF::Model> urdfModel;
+    bool success = urdfParser_.parseURDF(urdfModel, filename);
     if (!success) {
       Mn::Debug{} << "Failed to parse URDF: " << filename << ", aborting.";
       return false;
@@ -37,7 +38,7 @@ bool URDFImporter::loadURDF(const std::string& filename,
 
     if (logMessages) {
       Mn::Debug{} << "Done parsing URDF model: ";
-      urdfParser_.getModel()->printKinematicChain();
+      urdfModel->printKinematicChain();
     }
 
     // if reloading, clear the old model
@@ -46,7 +47,7 @@ bool URDFImporter::loadURDF(const std::string& filename,
     }
 
     // register the new model
-    modelCache_.emplace(filename, urdfParser_.getModel());
+    modelCache_.emplace(filename, urdfModel);
   }
   activeModel_ = modelCache_.at(filename);
 


### PR DESCRIPTION
## Motivation and Context

`URDF::Model` is no longer owned by `URDF:Parser` and is instead created externally and passed in to be filled. All parser internal model scaling is removed in favor of a model post-process. 

## How Has This Been Tested

Added tests for model scaling and parser overwriting an existing model variable. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
