### PR TITLE
[AO] pytest-benchmark integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-sugar pytest-xdist
+                pip install pytest-sugar pytest-xdist pytest-benchmark
               fi
       - run:
           name: Install emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,9 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
+
+              #run the marked pytest-benchmark tests and print the results
+              pytest -m sim_benchmarks
       - run:
           name: Run JavaScript tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,6 +478,7 @@ jobs:
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
 
               #run the marked pytest-benchmark tests and print the results
+              export PYTHONPATH=$(pwd):$PYTHONPATH
               pytest -m sim_benchmarks
       - run:
           name: Run JavaScript tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,10 +476,6 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
-
-              #run the marked pytest-benchmark tests and print the results
-              export PYTHONPATH=$(pwd):$PYTHONPATH
-              pytest -m sim_benchmarks
       - run:
           name: Run JavaScript tests
           command: |
@@ -514,6 +510,9 @@ jobs:
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pytest -n auto --durations=10 --cov-report=xml --cov=./
+
+              #run the marked pytest-benchmark tests and print the results
+              pytest -m sim_benchmarks
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration

--- a/habitat_sim/__init__.py
+++ b/habitat_sim/__init__.py
@@ -58,6 +58,7 @@ if not getattr(builtins, "__HSIM_SETUP__", False):
         SceneNode,
         SceneNodeType,
         SimulatorConfiguration,
+        built_with_bullet,
         cuda_enabled,
         vhacd_enabled,
     )

--- a/habitat_sim/bindings/__init__.py
+++ b/habitat_sim/bindings/__init__.py
@@ -38,6 +38,7 @@ from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
 from habitat_sim._ext.habitat_sim_bindings import (
     SimulatorConfiguration,
     VisualSensorSpec,
+    built_with_bullet,
     cuda_enabled,
     vhacd_enabled,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,3 @@ exclude = '''
 skip_glob = ["*/deps/*", "*/build/*", "*/obselete/*"]
 profile = 'black'
 treat_comments_as_code = "# %%"
-
-[tool.pytest.ini_options]
-markers = [
-    "sim_benchmarks: marks tests which use pytest-benchmark for perf tracking of simulator features so they can be easily run together.)",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ exclude = '''
 skip_glob = ["*/deps/*", "*/build/*", "*/obselete/*"]
 profile = 'black'
 treat_comments_as_code = "# %%"
+
+[tool.pytest.ini_options]
+markers = [
+    "sim_benchmarks: marks tests which use pytest-benchmark for perf tracking of simulator features so they can be easily run together.)",
+]

--- a/setup.py
+++ b/setup.py
@@ -420,7 +420,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         install_requires=requirements,
         setup_requires=setup_requires,
-        tests_require=["hypothesis", "pytest-cov", "pytest"],
+        tests_require=["hypothesis", "pytest-benchmark", "pytest"],
         python_requires=">=3.6",
         # add extension module
         ext_modules=[CMakeExtension("habitat_sim._ext.habitat_sim_bindings", "src")],

--- a/src/esp/bindings/bindings.cpp
+++ b/src/esp/bindings/bindings.cpp
@@ -86,6 +86,13 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
       false;
 #endif
 
+  m.attr("built_with_bullet") =
+#ifdef ESP_BUILD_WITH_BULLET
+      true;
+#else
+      false;
+#endif
+
   /* This function pointer is used by ESP_CHECK(). If it's null, it
      std::abort()s, if not, it calls it to cause a Python AssertionError */
   esp::core::throwInPython = [](const char* const message) {

--- a/tests/test_physics_benchmarking.py
+++ b/tests/test_physics_benchmarking.py
@@ -1,10 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import pytest
 
+import examples.settings
+import habitat_sim
 import utils
-from habitat_sim import vhacd_enabled
 
 
-@pytest.mark.skipif(not vhacd_enabled, reason="Test requires vhacd")
+# run the benchmarking script
+@pytest.mark.skipif(not habitat_sim.vhacd_enabled, reason="Test requires vhacd")
 @pytest.mark.parametrize(
     "args",
     [
@@ -18,3 +26,33 @@ from habitat_sim import vhacd_enabled
 )
 def test_example_modules(args):
     utils.run_main_subproc(args)
+
+
+# benchmark adding/removing articulated objects from URDF files
+@pytest.mark.skipif(
+    not habitat_sim.built_with_bullet,
+    reason="ArticulatedObject API requires Bullet physics.",
+)
+@pytest.mark.benchmark(group="URDF load->remove iterations|force_reload")
+@pytest.mark.parametrize("iterations", [1, 10, 100, 200])
+@pytest.mark.parametrize("force_reload", [False, True])
+def test_benchmark_urdf_add_remove(benchmark, iterations, force_reload):
+    # test loading and removing a URDF ArticultedObject multiple times consecutively
+    def instance_remove_urdf(iterations):
+        # first configure the simulator
+        cfg_settings = examples.settings.default_sim_settings.copy()
+        cfg_settings["scene"] = "NONE"
+        cfg_settings["enable_physics"] = True
+        hab_cfg = examples.settings.make_cfg(cfg_settings)
+        with habitat_sim.Simulator(hab_cfg) as sim:
+            art_obj_mgr = sim.get_articulated_object_manager()
+
+            robot_file = "data/test_assets/urdf/kuka_iiwa/model_free_base.urdf"
+
+            for _iteration in range(iterations):
+                robot = art_obj_mgr.add_articulated_object_from_urdf(
+                    robot_file, force_reload=force_reload
+                )
+                art_obj_mgr.remove_object_by_id(robot.object_id)
+
+    benchmark(instance_remove_urdf, iterations)

--- a/tests/test_physics_benchmarking.py
+++ b/tests/test_physics_benchmarking.py
@@ -29,6 +29,7 @@ def test_example_modules(args):
 
 
 # benchmark adding/removing articulated objects from URDF files
+@pytest.mark.sim_benchmarks
 @pytest.mark.skipif(
     not habitat_sim.built_with_bullet,
     reason="ArticulatedObject API requires Bullet physics.",


### PR DESCRIPTION
## Motivation and Context

Add a `pytest-benchmark` integration for benchmarking AO functionality. 
Initial PoC function benchmarks URDF parse->instance->remove loop with and without `force_reload` caching option.

Also added `habitat_sim.built_with_bullet` flag to easily check if Habitat-sim was compiled with Bullet physics from python.

Note: requires local installation with `pip install pytest-benchmark`.

## How Has This Been Tested

Local testing and CI integration. Example output of `pytest tests/benchmark_physics.py`:
![image](https://user-images.githubusercontent.com/1445143/121404008-6076f300-c910-11eb-91ac-eb6c227472e9.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
