### PR TITLE
[Sensor] reset the orientation of a cubemap

### DIFF
--- a/src/esp/agent/Agent.h
+++ b/src/esp/agent/Agent.h
@@ -44,7 +44,7 @@ struct ActionSpec {
   std::string name;
   // linear, angular forces, joint torques, sensor actuation
   ActuationMap actuation;
-  ESP_SMART_POINTERS(ActionSpec);
+  ESP_SMART_POINTERS(ActionSpec)
 };
 bool operator==(const ActionSpec& a, const ActionSpec& b);
 bool operator!=(const ActionSpec& a, const ActionSpec& b);

--- a/src/esp/core/random.h
+++ b/src/esp/core/random.h
@@ -56,7 +56,7 @@ class Random {
   std::uniform_int_distribution<uint32_t> uniform_uint32_;
   std::normal_distribution<float> normal_float_01_;
 
-  ESP_SMART_POINTERS(Random);
+  ESP_SMART_POINTERS(Random)
 };
 
 }  // namespace core

--- a/src/esp/gfx/CubeMapCamera.cpp
+++ b/src/esp/gfx/CubeMapCamera.cpp
@@ -54,6 +54,12 @@ Mn::Matrix4 CubeMapCamera::getCameraLocalTransform(
   Mn::Vector3 eye{0.0, 0.0, 0.0};
   Mn::Vector3 yUp{0.0, 1.0, 0.0};
   Mn::Vector3 zUp{0.0, 0.0, 1.0};
+
+  // Careful: the coordinate system for cubemaps is left-handed.
+  // The following implementation is based on:
+  // https://www.khronos.org/opengl/wiki/Cubemap_Texture
+  // check the diagram which shows how each face in the cubemap is oriented
+  // relative to the cube being defined.
   switch (cubeSideIndex) {
     case Mn::GL::CubeMapCoordinate::PositiveX:
       return Mn::Matrix4::lookAt(eye, Mn::Vector3{1.0, 0.0, 0.0}, -yUp);

--- a/src/esp/gfx/CubeMapCamera.cpp
+++ b/src/esp/gfx/CubeMapCamera.cpp
@@ -49,38 +49,41 @@ CubeMapCamera& CubeMapCamera::switchToFace(unsigned int cubeSideIndex) {
   return *this;
 }
 
-CubeMapCamera& CubeMapCamera::switchToFace(Mn::GL::CubeMapCoordinate cubeSide) {
+Mn::Matrix4 CubeMapCamera::getCameraLocalTransform(
+    Mn::GL::CubeMapCoordinate cubeSideIndex) {
   Mn::Vector3 eye{0.0, 0.0, 0.0};
   Mn::Vector3 yUp{0.0, 1.0, 0.0};
   Mn::Vector3 zUp{0.0, 0.0, 1.0};
+  switch (cubeSideIndex) {
+    case Mn::GL::CubeMapCoordinate::PositiveX:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{1.0, 0.0, 0.0}, -yUp);
+      break;
+    case Mn::GL::CubeMapCoordinate::NegativeX:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{-1.0, 0.0, 0.0}, -yUp);
+      break;
+    case Mn::GL::CubeMapCoordinate::PositiveY:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 1.0, 0.0}, zUp);
+      break;
+    case Mn::GL::CubeMapCoordinate::NegativeY:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, -1.0, 0.0}, -zUp);
+      break;
+    case Mn::GL::CubeMapCoordinate::PositiveZ:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, 1.0}, -yUp);
+      break;
+    case Mn::GL::CubeMapCoordinate::NegativeZ:
+      return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, -1.0}, -yUp);
+      break;
+    default:
+      CORRADE_INTERNAL_ASSERT_UNREACHABLE();
+      break;
+  }
+}
 
-  auto cameraLocalTransform = [&]() {
-    switch (cubeSide) {
-      case Mn::GL::CubeMapCoordinate::PositiveX:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{-1.0, 0.0, 0.0}, -yUp);
-        break;
-      case Mn::GL::CubeMapCoordinate::NegativeX:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{1.0, 0.0, 0.0}, -yUp);
-        break;
-      case Mn::GL::CubeMapCoordinate::PositiveY:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 1.0, 0.0}, -zUp);
-        break;
-      case Mn::GL::CubeMapCoordinate::NegativeY:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, -1.0, 0.0}, zUp);
-        break;
-      case Mn::GL::CubeMapCoordinate::PositiveZ:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, -1.0}, -yUp);
-        break;
-      case Mn::GL::CubeMapCoordinate::NegativeZ:
-        return Mn::Matrix4::lookAt(eye, Mn::Vector3{0.0, 0.0, 1.0}, -yUp);
-        break;
-      default:
-        CORRADE_INTERNAL_ASSERT_UNREACHABLE();
-        break;
-    }
-  };
-  this->node().setTransformation(originalViewingMatrix_ *
-                                 cameraLocalTransform());
+CubeMapCamera& CubeMapCamera::switchToFace(Mn::GL::CubeMapCoordinate cubeSide) {
+  this->node().setTransformation(
+      originalViewingMatrix_ *
+      CubeMapCamera::getCameraLocalTransform(cubeSide));
+
   return *this;
 }
 

--- a/src/esp/gfx/CubeMapCamera.h
+++ b/src/esp/gfx/CubeMapCamera.h
@@ -116,6 +116,13 @@ class CubeMapCamera : public RenderCamera {
    */
   CubeMapCamera& restoreTransformation();
 
+  /**
+   * @brief return the camera local transformation matrix when it is about to
+   * render a specific cube face.
+   */
+  static Magnum::Matrix4 getCameraLocalTransform(
+      Mn::GL::CubeMapCoordinate cubeSideIndex);
+
  protected:
   // viewing matrix (in parent node space) computed by Mn::Matrix4::lookAt(eye,
   // target, up)

--- a/src/shaders/doubleSphereCamera.frag
+++ b/src/shaders/doubleSphereCamera.frag
@@ -35,8 +35,6 @@ out highp uint fragmentObjectId;
 void main(void) {
   vec3 m;
   m.xy = (gl_FragCoord.xy - PrincipalPointOffset) / FocalLength;
-  // MUST flip the x axis
-  m.x = -m.x;
   float r2 = dot(m.xy, m.xy);
   float sq1 = 1.0 - (2.0 * Alpha - 1.0) * r2;
   if (sq1 < 0.0)
@@ -51,7 +49,9 @@ void main(void) {
   // unproject to get the ray direction
   vec3 ray = (m.z * Xi + sqrt(sq2)) / (mz2 + r2) * m - vec3(0.0, 0.0, Xi);
 
-  ray.x = -ray.x;
+  // so far, coordinates are computed in the right-handed Cartesian system
+  // now, flip the z since OpenGL cubemap is using a left-handed system
+  // https://www.khronos.org/opengl/wiki/Cubemap_Texture
   ray.z = -ray.z;
 
 #if defined(COLOR_TEXTURE)

--- a/src/shaders/doubleSphereCamera.frag
+++ b/src/shaders/doubleSphereCamera.frag
@@ -51,6 +51,9 @@ void main(void) {
   // unproject to get the ray direction
   vec3 ray = (m.z * Xi + sqrt(sq2)) / (mz2 + r2) * m - vec3(0.0, 0.0, Xi);
 
+  ray.x = -ray.x;
+  ray.z = -ray.z;
+
 #if defined(COLOR_TEXTURE)
   fragmentColor = texture(ColorTexture, normalize(ray));
 #endif

--- a/src/shaders/doubleSphereCamera.frag
+++ b/src/shaders/doubleSphereCamera.frag
@@ -46,12 +46,18 @@ void main(void) {
   if (sq2 < 0.0)
     discard;
 
+  // Careful!
+  // one cannot flip the z at this point,
+  // otherwise a wrong offset would be introducted in the "ray"
+  // based on the following equation.
+
   // unproject to get the ray direction
   vec3 ray = (m.z * Xi + sqrt(sq2)) / (mz2 + r2) * m - vec3(0.0, 0.0, Xi);
 
-  // so far, coordinates are computed in the right-handed Cartesian system
-  // now, flip the z since OpenGL cubemap is using a left-handed system
-  // https://www.khronos.org/opengl/wiki/Cubemap_Texture
+  // So far, coordinates are computed in the right-handed Cartesian system.
+  // However, OpenGL cubemap uses a left-handed system with z points inwards,
+  // (https://www.khronos.org/opengl/wiki/Cubemap_Texture)
+  // so flip the z here:
   ray.z = -ray.z;
 
 #if defined(COLOR_TEXTURE)

--- a/src/shaders/equirectangular.frag
+++ b/src/shaders/equirectangular.frag
@@ -37,9 +37,9 @@ void main(void) {
   const float PI = 3.1415926535897932384626433832795;
   float phi = gl_FragCoord.x * 2.0 * PI / float(ViewportWidth);
   float theta = gl_FragCoord.y * PI / float(ViewportHeight);
-  m.x = sin(phi) * sin(theta);
-  m.y = cos(theta) * -1.0;
-  m.z = cos(phi) * sin(theta) * -1.0;
+  m.x = -sin(phi) * sin(theta);
+  m.y = -cos(theta);
+  m.z = cos(phi) * sin(theta);
 
 #if defined(COLOR_TEXTURE)
   fragmentColor = texture(ColorTexture, normalize(m));


### PR DESCRIPTION
## Motivation and Context
This diff is to:
- reset the orientation of a cubemap so it aligns to the official definition found here:
https://www.khronos.org/opengl/wiki/Cubemap_Texture
(It is a must-have change as I will use the cubemap heavily in the PBR IBL)
- make changes in the fisheye shader and equirectangular shader accordingly;
- fix 2 places that caused the compiler warnings;

<!--- Why is this change required? What problem does it solve? -->
Cubemap before and after:
They are the same if the orientation is ignored.
But when you do consider the orientation, one is just transformed by rotating the other cube 180 degrees around the Y-axis.
The one after this fix is the "standard, correct" cubemap that we should use in the system.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
