### PR TITLE
[Bugfix] Specify default stage shader type as flat;

### DIFF
--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -75,7 +75,7 @@ StageAttributes::StageAttributes(const std::string& handle)
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
   // default to unknown for stages
-  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Flat));
   // TODO remove this once ShaderType support is complete
   setRequiresLighting(false);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -362,8 +362,6 @@ class StageAttributes : public AbstractObjectAttributes {
    */
   void setLightSetup(const std::string& lightSetup) {
     setString("light_setup", lightSetup);
-    // force requires lighting to reflect light setup
-    setRequiresLighting(lightSetup != NO_LIGHT_KEY);
   }
   std::string getLightSetup() { return getString("light_setup"); }
 


### PR DESCRIPTION
## Motivation and Context
Small bugfix that specifies a stage's default shader type to be flat instead of unknown.  Since stages often come with lighting baked into the textures, we do not want to apply phong or pbr shading on top of this.   This, of course, can be easily overridden, either at the stage config level, or for individual instancing scenes.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
