### PR TITLE
[Refactor] Cleanup redundant console message info

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -205,7 +205,7 @@ bool ResourceManager::loadStage(
     AssetInfo semanticInfo = assetInfoMap.at("semantic");
     auto semanticStageFilename = semanticInfo.filepath;
     if (Cr::Utility::Directory::exists(semanticStageFilename)) {
-      LOG(INFO) << "ResourceManager::loadStage : Loading Semantic Stage mesh : "
+      LOG(INFO) << "::loadStage : Loading Semantic Stage mesh : "
                 << semanticStageFilename;
       activeSemanticSceneID = sceneManagerPtr->initSceneGraph();
 
@@ -232,21 +232,20 @@ bool ResourceManager::loadStage(
       // regardless of load failure, original code still changed
       // activeSemanticSceneID_
       if (!semanticStageSuccess) {
-        LOG(ERROR) << " ResourceManager::loadStage : Semantic Stage mesh "
+        LOG(ERROR) << "::loadStage : Semantic Stage mesh "
                       "load failed.";
         return false;
       } else {
-        LOG(INFO) << "ResourceManager::loadStage : Semantic Stage mesh : "
+        LOG(INFO) << "::loadStage : Semantic Stage mesh : "
                   << semanticStageFilename << " loaded.";
       }
     } else {  // semantic file name does not exist but house does
-      LOG(WARNING)
-          << "ResourceManager::loadStage : Not loading semantic mesh - "
-             "File Name : "
-          << semanticStageFilename << " does not exist.";
+      LOG(WARNING) << "::loadStage : Not loading semantic mesh - "
+                      "File Name : "
+                   << semanticStageFilename << " does not exist.";
     }
   } else {  // not wanting to create semantic mesh
-    LOG(INFO) << "ResourceManager::loadStage : Not loading semantic mesh";
+    LOG(INFO) << "::loadStage : Not loading semantic mesh";
   }
 
   if (forceSeparateSemanticSceneGraph &&
@@ -274,8 +273,8 @@ bool ResourceManager::loadStage(
   }
   RenderAssetInstanceCreationInfo renderCreation(
       renderInfo.filepath, Cr::Containers::NullOpt, flags, renderLightSetupKey);
-  LOG(INFO) << "ResourceManager::loadStage : start load render asset "
-            << renderInfo.filepath << ".";
+  LOG(INFO) << "::loadStage : start load render asset " << renderInfo.filepath
+            << ".";
 
   bool renderMeshSuccess = loadStageInternal(renderInfo,  // AssetInfo
                                              &renderCreation,
@@ -293,7 +292,7 @@ bool ResourceManager::loadStage(
   if (assetInfoMap.count("collision") != 0u) {
     AssetInfo colInfo = assetInfoMap.at("collision");
     if (resourceDict_.count(colInfo.filepath) == 0) {
-      LOG(INFO) << "ResourceManager::loadStage : start load collision asset "
+      LOG(INFO) << "::loadStage : start load collision asset "
                 << colInfo.filepath << ".";
       // will not reload if already present
       bool collisionMeshSuccess =
@@ -328,7 +327,7 @@ bool ResourceManager::loadStage(
     // we are using None-type physicsManager.
     bool sceneSuccess = _physicsManager->addStage(stageAttributes, meshGroup);
     if (!sceneSuccess) {
-      LOG(ERROR) << "ResourceManager::loadStage : Adding Stage "
+      LOG(ERROR) << "::loadStage : Adding Stage "
                  << stageAttributes->getHandle()
                  << " to PhysicsManager failed. Aborting scene initialization.";
       return false;
@@ -363,7 +362,7 @@ bool ResourceManager::buildMeshGroups(
 
     // failure during build of collision mesh group
     if (!colMeshGroupSuccess) {
-      LOG(ERROR) << "ResourceManager::loadStage : Stage " << info.filepath
+      LOG(ERROR) << "::loadStage : Stage " << info.filepath
                  << " Collision mesh load failed. Aborting scene "
                     "initialization.";
       return false;
@@ -440,7 +439,7 @@ esp::geo::CoordinateFrame ResourceManager::buildFrameFromAttributes(
     esp::geo::CoordinateFrame frame{upEigen, frontEigen, originEigen};
     return frame;
   } else {
-    LOG(INFO) << "ResourceManager::buildFrameFromAttributes : Specified frame "
+    LOG(INFO) << "::buildFrameFromAttributes : Specified frame "
                  "in Attributes : "
               << attribs->getHandle()
               << " is not orthogonal, so returning default frame.";
@@ -676,14 +675,12 @@ bool ResourceManager::loadStageInternal(
     DrawableGroup* drawables) {
   // scene mesh loading
   const std::string& filename = info.filepath;
-  LOG(INFO) << "ResourceManager::loadStageInternal : Attempting to load stage "
-            << filename << " ";
+  LOG(INFO) << "::loadStageInternal : Attempting to load stage " << filename
+            << " ";
   bool meshSuccess = true;
   if (info.filepath != EMPTY_SCENE) {
     if (!Cr::Utility::Directory::exists(filename)) {
-      LOG(ERROR)
-          << "ResourceManager::loadStageInternal : Cannot find scene file "
-          << filename;
+      LOG(ERROR) << "::loadStageInternal : Cannot find scene file " << filename;
       meshSuccess = false;
     } else {
       if (info.type == AssetType::SUNCG_SCENE) {
@@ -715,8 +712,7 @@ bool ResourceManager::loadStageInternal(
       }
     }
   } else {
-    LOG(INFO) << "ResourceManager::loadStageInternal : Loading empty scene for "
-              << filename;
+    LOG(INFO) << "::loadStageInternal : Loading empty scene for " << filename;
     // EMPTY_SCENE (ie. "NONE") string indicates desire for an empty scene (no
     // scene mesh): welcome to the void
   }
@@ -741,7 +737,7 @@ bool ResourceManager::buildStageCollisionMeshGroup(
     if (rawMeshData == nullptr) {
       // means dynamic cast failed
       Cr::Utility::Debug()
-          << "ResourceManager::buildStageCollisionMeshGroup : "
+          << "::buildStageCollisionMeshGroup : "
              "AssetInfo::AssetType "
              "type error: unsupported mesh type, aborting. Try running "
              "without \"--enable-physics\" and consider logging an issue.";
@@ -1408,7 +1404,7 @@ bool ResourceManager::buildTrajectoryVisualization(
     radius = .001;
   }
 
-  LOG(INFO) << "ResourceManager::loadTrajectoryVisualization : Calling "
+  LOG(INFO) << "::loadTrajectoryVisualization : Calling "
                "trajectoryTubeSolid to build a tube named :"
             << trajVisName << " with " << pts.size()
             << " points, building a tube of radius :" << radius << " using "
@@ -1419,7 +1415,7 @@ bool ResourceManager::buildTrajectoryVisualization(
   Cr::Containers::Optional<Mn::Trade::MeshData> trajTubeMesh =
       geo::buildTrajectoryTubeSolid(pts, numSegments, radius, smooth,
                                     numInterp);
-  LOG(INFO) << "ResourceManager::loadTrajectoryVisualization : Successfully "
+  LOG(INFO) << "::loadTrajectoryVisualization : Successfully "
                "returned from trajectoryTubeSolid ";
 
   // make assetInfo

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -783,7 +783,7 @@ void ResourceManager::computePTexMeshAbsoluteAABBs(
 
   CORRADE_ASSERT(
       absTransforms.size() == staticDrawableInfo.size(),
-      "ResourceManager::computePTexMeshAbsoluteAABBs: number of "
+      "::computePTexMeshAbsoluteAABBs: number of "
       "transformations does not match number of drawables. Aborting.", );
 
   // obtain the sub-meshes within the ptex mesh
@@ -811,7 +811,7 @@ void ResourceManager::computeGeneralMeshAbsoluteAABBs(
       computeAbsoluteTransformations(staticDrawableInfo);
 
   CORRADE_ASSERT(absTransforms.size() == staticDrawableInfo.size(),
-                 "ResourceManager::computeGeneralMeshAbsoluteAABBs: number of "
+                 "::computeGeneralMeshAbsoluteAABBs: number of "
                  "transforms does not match number of drawables.", );
 
   for (uint32_t iEntry = 0; iEntry < absTransforms.size(); ++iEntry) {
@@ -820,7 +820,7 @@ void ResourceManager::computeGeneralMeshAbsoluteAABBs(
     Cr::Containers::Optional<Magnum::Trade::MeshData>& meshData =
         meshes_.at(meshID)->getMeshData();
     CORRADE_ASSERT(meshData,
-                   "ResourceManager::computeGeneralMeshAbsoluteAABBs: The mesh "
+                   "::computeGeneralMeshAbsoluteAABBs: The mesh "
                    "data specified at ID:"
                        << meshID << "is empty/undefined. Aborting", );
 
@@ -855,10 +855,9 @@ void ResourceManager::computeInstanceMeshAbsoluteAABBs(
   std::vector<Mn::Matrix4> absTransforms =
       computeAbsoluteTransformations(staticDrawableInfo);
 
-  CORRADE_ASSERT(
-      absTransforms.size() == staticDrawableInfo.size(),
-      "ResourceManager::computeInstancelMeshAbsoluteAABBs: Number of "
-      "transforms does not match number of drawables. Aborting.", );
+  CORRADE_ASSERT(absTransforms.size() == staticDrawableInfo.size(),
+                 "::computeInstancelMeshAbsoluteAABBs: Number of "
+                 "transforms does not match number of drawables. Aborting.", );
 
   for (size_t iEntry = 0; iEntry < absTransforms.size(); ++iEntry) {
     const int meshID = staticDrawableInfo[iEntry].meshID;
@@ -890,7 +889,7 @@ std::vector<Mn::Matrix4> ResourceManager::computeAbsoluteTransformations(
   auto* scene = dynamic_cast<MagnumScene*>(staticDrawableInfo[0].node.scene());
 
   CORRADE_ASSERT(scene != nullptr,
-                 "ResourceManager::computeAbsoluteTransformations: The node is "
+                 "::computeAbsoluteTransformations: The node is "
                  "not attached to any scene graph. Aborting.",
                  {});
 
@@ -1031,11 +1030,10 @@ bool ResourceManager::loadRenderAssetPTex(const AssetInfo& info) {
   meshMetaData.root.transformFromLocalToParent =
       R * meshMetaData.root.transformFromLocalToParent;
 
-  CORRADE_ASSERT(
-      meshMetaData.meshIndex.first == meshMetaData.meshIndex.second,
-      "ResourceManager::loadRenderAssetPTex: ptex mesh is not loaded "
-      "correctly. Aborting.",
-      false);
+  CORRADE_ASSERT(meshMetaData.meshIndex.first == meshMetaData.meshIndex.second,
+                 "::loadRenderAssetPTex: ptex mesh is not loaded "
+                 "correctly. Aborting.",
+                 false);
 
   return true;
 #else
@@ -1727,7 +1725,7 @@ gfx::PbrMaterialData::uptr ResourceManager::buildPbrShadedMaterialData(
     */
     CORRADE_ASSERT(
         material.hasNoneRoughnessMetallicTexture(),
-        "ResourceManager::buildPbrShadedMaterialData(): if both the metallic "
+        "::buildPbrShadedMaterialData(): if both the metallic "
         "and roughness texture exist, they must be packed in the same texture "
         "based on glTF 2.0 Spec.",
         finalMaterial);
@@ -1736,7 +1734,7 @@ gfx::PbrMaterialData::uptr ResourceManager::buildPbrShadedMaterialData(
   // TODO:
   // Support NormalRoughnessMetallicTexture packing
   CORRADE_ASSERT(!material.hasNormalRoughnessMetallicTexture(),
-                 "ResourceManager::buildPbrShadedMaterialData(): "
+                 "::buildPbrShadedMaterialData(): "
                  "Sorry. NormalRoughnessMetallicTexture is not supported in "
                  "the current version. We will work on it.",
                  finalMaterial);
@@ -1907,7 +1905,7 @@ bool ResourceManager::instantiateAssetsOnDemand(
     CORRADE_ASSERT(
         (ID_UNDEFINED != getObjectAttributesManager()->registerObject(
                              objectAttributes, objectTemplateHandle)),
-        "ResourceManager::instantiateAssetsOnDemand : Unknown failure "
+        "::instantiateAssetsOnDemand : Unknown failure "
         "attempting to register modified template :"
             << objectTemplateHandle
             << "before asset instantiation.  Aborting. ",

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -127,7 +127,8 @@ class ManagedContainer : public ManagedContainerBase {
                      const std::string& objectHandle = "",
                      bool forceRegistration = false) {
     if (nullptr == managedObject) {
-      LOG(ERROR) << "ManagedContainer::registerObject : Invalid "
+      LOG(ERROR) << "<" << this->objectType_
+                 << ">::registerObject : Invalid "
                     "(null) managed object passed to registration. Aborting.";
       return ID_UNDEFINED;
     }
@@ -137,7 +138,8 @@ class ManagedContainer : public ManagedContainerBase {
     }
     std::string handleToSet = managedObject->getHandle();
     if ("" == handleToSet) {
-      LOG(ERROR) << "ManagedContainer::registerObject : No "
+      LOG(ERROR) << "<" << this->objectType_
+                 << ">::registerObject : No "
                     "valid handle specified for "
                  << objectType_ << " managed object to register. Aborting.";
       return ID_UNDEFINED;
@@ -185,7 +187,7 @@ class ManagedContainer : public ManagedContainerBase {
   ManagedPtr getObjectByID(int managedObjectID) const {
     std::string objectHandle = getObjectHandleByID(managedObjectID);
     if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::getObjectByID")) {
+                                "<" + this->objectType_ + ">::getObjectByID")) {
       return nullptr;
     }
     return getObjectInternal<T>(objectHandle);
@@ -202,8 +204,8 @@ class ManagedContainer : public ManagedContainerBase {
    * exist
    */
   ManagedPtr getObjectByHandle(const std::string& objectHandle) const {
-    if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::getObjectByHandle")) {
+    if (!checkExistsWithMessage(
+            objectHandle, "<" + this->objectType_ + ">::getObjectByHandle")) {
       return nullptr;
     }
 
@@ -220,12 +222,13 @@ class ManagedContainer : public ManagedContainerBase {
    */
   ManagedPtr removeObjectByID(int objectID) {
     std::string objectHandle = getObjectHandleByID(objectID);
-    if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::removeObjectByID")) {
+    if (!checkExistsWithMessage(
+            objectHandle, "<" + this->objectType_ + ">::removeObjectByID")) {
       return nullptr;
     }
-    return removeObjectInternal(objectID, objectHandle,
-                                "ManagedContainer::removeObjectByID");
+    return removeObjectInternal(
+        objectID, objectHandle,
+        "<" + this->objectType_ + ">::removeObjectByID");
   }
 
   /**
@@ -237,16 +240,17 @@ class ManagedContainer : public ManagedContainerBase {
    * exist
    */
   ManagedPtr removeObjectByHandle(const std::string& objectHandle) {
-    if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::removeObjectByHandle")) {
+    if (!checkExistsWithMessage(objectHandle, "<" + this->objectType_ +
+                                                  ">::removeObjectByHandle")) {
       return nullptr;
     }
     int objectID = getObjectIDByHandle(objectHandle);
     if (objectID == ID_UNDEFINED) {
       return nullptr;
     }
-    return removeObjectInternal(objectID, objectHandle,
-                                "ManagedContainer::removeObjectByHandle");
+    return removeObjectInternal(
+        objectID, objectHandle,
+        "<" + this->objectType_ + ">::removeObjectByHandle");
   }
 
   /**
@@ -371,8 +375,8 @@ class ManagedContainer : public ManagedContainerBase {
    */
   ManagedPtr getObjectCopyByID(int managedObjectID) {
     std::string objectHandle = getObjectHandleByID(managedObjectID);
-    if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::getObjectCopyByID")) {
+    if (!checkExistsWithMessage(
+            objectHandle, "<" + this->objectType_ + ">::getObjectCopyByID")) {
       return nullptr;
     }
     auto orig = getObjectInternal<T>(objectHandle);
@@ -387,8 +391,8 @@ class ManagedContainer : public ManagedContainerBase {
    * does not exist
    */
   ManagedPtr getObjectCopyByHandle(const std::string& objectHandle) {
-    if (!checkExistsWithMessage(objectHandle,
-                                "ManagedContainer::getObjectCopyByHandle")) {
+    if (!checkExistsWithMessage(objectHandle, "<" + this->objectType_ +
+                                                  ">::getObjectCopyByHandle")) {
       return nullptr;
     }
     auto orig = getObjectInternal<T>(objectHandle);
@@ -514,9 +518,10 @@ class ManagedContainer : public ManagedContainerBase {
       return getObjectInternal<T>(objectHandle)->getID();
     } else {
       if (!getNext) {
-        LOG(ERROR) << "ManagedContainer::getObjectIDByHandleOrNew : No "
-                   << objectType_ << " managed object with handle "
-                   << objectHandle << "exists. Aborting";
+        LOG(ERROR) << "<" << this->objectType_
+                   << ">::getObjectIDByHandleOrNew : No " << objectType_
+                   << " managed object with handle " << objectHandle
+                   << "exists. Aborting";
         return ID_UNDEFINED;
       } else {
         return getUnusedObjectID();
@@ -651,7 +656,8 @@ auto ManagedContainer<T, Access>::removeObjectsBySubstring(
   for (const std::string& objectHandle : handles) {
     int objID = getObjectIDByHandle(objectHandle);
     ManagedPtr ptr = removeObjectInternal(
-        objID, objectHandle, "ManagedContainer::removeObjectsBySubstring");
+        objID, objectHandle,
+        "<" + this->objectType_ + ">::removeObjectsBySubstring");
     if (nullptr != ptr) {
       res.push_back(ptr);
     }

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -10,7 +10,8 @@ namespace core {
 bool ManagedContainerBase::setLock(const std::string& objectHandle, bool lock) {
   // if managed object does not currently exist then do not attempt to modify
   // its lock state
-  if (!checkExistsWithMessage(objectHandle, "ManagedContainerBase::setLock")) {
+  if (!checkExistsWithMessage(objectHandle,
+                              "<" + this->objectType_ + ">::setLock")) {
     return false;
   }
   // if setting lock else clearing lock
@@ -27,7 +28,8 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
     const std::string& type) const {
   std::size_t numVals = mapOfHandles.size();
   if (numVals == 0) {
-    LOG(ERROR) << "Attempting to get a random " << type << objectType_
+    LOG(ERROR) << "::getRandomObjectHandlePerType : Attempting to get a random "
+               << type << objectType_
                << " managed object handle but none are loaded; Aboring";
     return "";
   }

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -165,9 +165,8 @@ class ManagedContainerBase {
    */
   std::string getObjectHandleByID(const int objectID) const {
     if (objectLibKeyByID_.count(objectID) == 0) {
-      LOG(ERROR) << "ManagedContainerBase::getObjectHandleByID : Unknown "
-                 << objectType_ << " managed object ID:" << objectID
-                 << ". Aborting";
+      LOG(ERROR) << "::getObjectHandleByID : Unknown " << objectType_
+                 << " managed object ID:" << objectID << ". Aborting";
       // never will have registered object with registration handle == ""
       return "";
     }

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -209,12 +209,13 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
                 fileTypeExt;
     LOG(INFO) << "<" << this->objectType_
               << ">::convertFilenameToPassedExt : Filename : " << filename
-              << " changed to proposed JSON configuration filename : "
-              << resHandle;
+              << " changed to proposed " << fileTypeExt
+              << " filename : " << resHandle;
   } else {
     LOG(INFO) << "<" << this->objectType_
               << ">::convertFilenameToPassedExt : Filename : " << filename
-              << " is appropriate JSON configuration filename.";
+              << " contains requested file extension " << fileTypeExt
+              << " already.";
   }
   return resHandle;
 }  // ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -35,9 +35,10 @@ namespace core {
 template <class T, ManagedObjectAccess Access>
 class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
  public:
-  static_assert(std::is_base_of<AbstractFileBasedManagedObject, T>::value,
-                "ManagedContainer :: Managed object type must be derived from "
-                "AbstractFileBasedManagedObject");
+  static_assert(
+      std::is_base_of<AbstractFileBasedManagedObject, T>::value,
+      "ManagedFileBasedContainer :: Managed object type must be derived from "
+      "AbstractFileBasedManagedObject");
   typedef std::shared_ptr<T> ManagedFileIOPtr;
 
   explicit ManagedFileBasedContainer(const std::string& metadataType)
@@ -70,7 +71,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     io::JsonDocument docConfig = nullptr;
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
-      LOG(ERROR) << "ManagedFileBasedContainer::createObjectFromFile ("
+      LOG(ERROR) << "<" << this->objectType_ << ">::createObjectFromFile ("
                  << this->objectType_
                  << ") : Failure reading document as JSON : " << filename
                  << ". Aborting.";
@@ -95,7 +96,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   ManagedFileIOPtr buildManagedObjectFromDoc(const std::string& filename,
                                              CORRADE_UNUSED const U& config) {
     LOG(ERROR)
-        << "ManagedContainer::buildManagedObjectFromDoc (" << this->objectType_
+        << "<" << this->objectType_ << ">::buildManagedObjectFromDoc ("
+        << this->objectType_
         << ") : Failure loading attributes from document of unknown type : "
         << filename << ". Aborting.";
   }
@@ -142,8 +144,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   bool verifyLoadDocument(const std::string& filename,
                           CORRADE_UNUSED U& resDoc) {
     // by here always fail
-    LOG(ERROR) << this->objectType_
-               << "ManagedContainerBase::verifyLoadDocument : File " << filename
+    LOG(ERROR) << this->objectType_ << "<" << this->objectType_
+               << ">::verifyLoadDocument : File " << filename
                << " failed due to unknown file type.";
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
@@ -205,12 +207,12 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
       strHandle.find(Cr::Utility::String::lowercase(fileTypeExt))) {
     resHandle = Cr::Utility::Directory::splitExtension(filename).first + "." +
                 fileTypeExt;
-    LOG(INFO) << "ManagedFileBasedContainer<" << this->objectType_
+    LOG(INFO) << "<" << this->objectType_
               << ">::convertFilenameToPassedExt : Filename : " << filename
               << " changed to proposed JSON configuration filename : "
               << resHandle;
   } else {
-    LOG(INFO) << "ManagedFileBasedContainer<" << this->objectType_
+    LOG(INFO) << "<" << this->objectType_
               << ">::convertFilenameToPassedExt : Filename : " << filename
               << " is appropriate JSON configuration filename.";
   }
@@ -225,7 +227,7 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
     try {
       jsonDoc = io::parseJsonFile(filename);
     } catch (...) {
-      LOG(ERROR) << "ManagedFileBasedContainer<" << this->objectType_
+      LOG(ERROR) << "<" << this->objectType_
                  << ">::verifyLoadDocument : Failed to parse " << filename
                  << " as JSON.";
       return false;
@@ -233,9 +235,8 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
     return true;
   } else {
     // by here always fail
-    LOG(ERROR) << "ManagedFileBasedContainer<" << this->objectType_
-               << ">::verifyLoadDocument : File " << filename
-               << " does not exist";
+    LOG(ERROR) << "<" << this->objectType_ << ">::verifyLoadDocument : File "
+               << filename << " does not exist";
     return false;
   }
 }  // ManagedFileBasedContainer<T, Access>::verifyLoadDocument

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -38,7 +38,7 @@ bool MetadataMediator::setSimulatorConfiguration(
   bool success = setActiveSceneDatasetName(simConfig_.sceneDatasetConfigFile);
   if (!success) {
     // something failed about setting up active scene dataset
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : Some error "
+    LOG(ERROR) << "::setSimulatorConfiguration : Some error "
                   "prevented current scene dataset name to be changed to "
                << simConfig_.sceneDatasetConfigFile;
     return false;
@@ -48,7 +48,7 @@ bool MetadataMediator::setSimulatorConfiguration(
   success = setCurrPhysicsAttributesHandle(simConfig_.physicsConfigFile);
   if (!success) {
     // something failed about setting up physics attributes
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : Some error "
+    LOG(ERROR) << "::setSimulatorConfiguration : Some error "
                   "prevented current physics attributes to "
                << simConfig_.physicsConfigFile;
     return false;
@@ -61,11 +61,11 @@ bool MetadataMediator::setSimulatorConfiguration(
     datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetup,
                                 simConfig_.frustumCulling);
   } else {
-    LOG(ERROR) << "MetadataMediator::setSimulatorConfiguration : No active "
+    LOG(ERROR) << "::setSimulatorConfiguration : No active "
                   "dataset exists or has been specified. Aborting";
     return false;
   }
-  LOG(INFO) << "MetadataMediator::setSimulatorConfiguration : Set new "
+  LOG(INFO) << "::setSimulatorConfiguration : Set new "
                "simulator config for scene/stage : "
             << simConfig_.activeSceneName
             << " and dataset : " << simConfig_.sceneDatasetConfigFile
@@ -87,7 +87,7 @@ bool MetadataMediator::createPhysicsManagerAttributes(
     if (physAttrs == nullptr) {
       // something failed during creation process.
       LOG(WARNING)
-          << "MetadataMediator::createPhysicsManagerAttributes : Unknown  "
+          << "::createPhysicsManagerAttributes : Unknown  "
              "physics manager configuration file : "
           << _physicsManagerAttributesPath
           << " does not exist and is not able to be created.  Aborting.";
@@ -104,7 +104,7 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
-      LOG(WARNING) << "MetadataMediator::createSceneDataset : Scene Dataset "
+      LOG(WARNING) << "::createSceneDataset : Scene Dataset "
                    << sceneDatasetName
                    << " already exists.  To reload and overwrite existing "
                       "data, set overwrite to true. Aborting.";
@@ -118,14 +118,14 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
       sceneDatasetAttributesManager_->createObject(sceneDatasetName, true);
   if (datasetAttribs == nullptr) {
     // not created, do not set name
-    LOG(WARNING) << "MetadataMediator::createSceneDataset : Unknown dataset "
+    LOG(WARNING) << "::createSceneDataset : Unknown dataset "
                  << sceneDatasetName
                  << " does not exist and is not able to be created.  Aborting.";
     return false;
   }
   // if not null then successfully created
-  LOG(INFO) << "MetadataMediator::createSceneDataset : Dataset "
-            << sceneDatasetName << " successfully created.";
+  LOG(INFO) << "::createSceneDataset : Dataset " << sceneDatasetName
+            << " successfully created.";
   // lock dataset to prevent accidental deletion
   sceneDatasetAttributesManager_->setLock(sceneDatasetName, true);
   return true;
@@ -135,15 +135,14 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // First check if SceneDatasetAttributes exists
   if (!sceneDatasetExists(sceneDatasetName)) {
     // DNE, do nothing
-    LOG(WARNING)
-        << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
-        << sceneDatasetName << " does not exist. Aborting.";
+    LOG(WARNING) << "::removeSceneDataset : SceneDatasetAttributes "
+                 << sceneDatasetName << " does not exist. Aborting.";
     return false;
   }
 
   // Next check if is current activeSceneDataset_, and if so skip with warning
   if (sceneDatasetName == activeSceneDataset_) {
-    LOG(WARNING) << "MetadataMediator::removeSceneDataset : Cannot remove "
+    LOG(WARNING) << "::removeSceneDataset : Cannot remove "
                     "active SceneDatasetAttributes "
                  << sceneDatasetName
                  << ".  Switch to another dataset before removing.";
@@ -158,9 +157,8 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // if failed here, probably means SceneDatasetAttributes was set to
   // undeletable, return message and false
   if (delDataset == nullptr) {
-    LOG(WARNING)
-        << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
-        << sceneDatasetName << " unable to be deleted. Aborting.";
+    LOG(WARNING) << "::removeSceneDataset : SceneDatasetAttributes "
+                 << sceneDatasetName << " unable to be deleted. Aborting.";
     return false;
   }
   // Should always have a default dataset. Use this process to remove extraneous
@@ -170,7 +168,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     // dataset.
     createSceneDataset("default");
   }
-  LOG(INFO) << "MetadataMediator::removeSceneDataset : SceneDatasetAttributes "
+  LOG(INFO) << "::removeSceneDataset : SceneDatasetAttributes "
             << sceneDatasetName << " successfully removed.";
   return true;
 
@@ -182,7 +180,7 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
   if (physicsAttributesManager_->getObjectLibHasHandle(
           _physicsManagerAttributesPath)) {
     if (currPhysicsManagerAttributes_ != _physicsManagerAttributesPath) {
-      LOG(INFO) << "MetadataMediator::setCurrPhysicsAttributesHandle : Old "
+      LOG(INFO) << "::setCurrPhysicsAttributesHandle : Old "
                    "physics manager attributes "
                 << currPhysicsManagerAttributes_ << " changed to "
                 << _physicsManagerAttributesPath << " successfully.";
@@ -211,7 +209,7 @@ bool MetadataMediator::setActiveSceneDatasetName(
   // first check if dataset exists/is loaded, if so then set as default
   if (sceneDatasetExists(sceneDatasetName)) {
     if (activeSceneDataset_ != sceneDatasetName) {
-      LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Previous "
+      LOG(INFO) << "::setActiveSceneDatasetName : Previous "
                    "active dataset "
                 << activeSceneDataset_ << " changed to " << sceneDatasetName
                 << " successfully.";
@@ -220,7 +218,7 @@ bool MetadataMediator::setActiveSceneDatasetName(
     return true;
   }
   // if does not exist, attempt to create it
-  LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Attempting to "
+  LOG(INFO) << "::setActiveSceneDatasetName : Attempting to "
                "create new dataset "
             << sceneDatasetName;
   bool success = createSceneDataset(sceneDatasetName);
@@ -229,7 +227,7 @@ bool MetadataMediator::setActiveSceneDatasetName(
   if (success) {
     activeSceneDataset_ = sceneDatasetName;
   }
-  LOG(INFO) << "MetadataMediator::setActiveSceneDatasetName : Attempt to "
+  LOG(INFO) << "::setActiveSceneDatasetName : Attempt to "
                "create new dataset "
             << sceneDatasetName << " " << (success ? " succeeded." : " failed.")
             << " Currently active dataset : " << activeSceneDataset_;
@@ -242,7 +240,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // this should never happen
   if (datasetAttr == nullptr) {
-    LOG(ERROR) << "MetadataMediator::getSceneAttributesByName : No dataset "
+    LOG(ERROR) << "::getSceneAttributesByName : No dataset "
                   "specified/exists.";
     return nullptr;
   }
@@ -261,7 +259,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   if (sceneList.size() > 0) {
     // 1.  Existing, registered SceneAttributes in current active dataset.
     //    In this case the SceneAttributes is returned.
-    LOG(INFO) << "MetadataMediator::getSceneAttributesByName : Query dataset : "
+    LOG(INFO) << "::getSceneAttributesByName : Query dataset : "
               << activeSceneDataset_
               << " for SceneAttributes named : " << sceneName << " yields "
               << sceneList.size() << " candidates.  Using " << sceneList[0]
@@ -275,7 +273,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
       // 2.  Existing, valid SceneAttributes file on disk, but not in dataset.
       //    If this is the case, then the SceneAttributes should be loaded,
       //    registered, added to the dataset and returned.
-      LOG(INFO) << "MetadataMediator::getSceneAttributesByName : Dataset : "
+      LOG(INFO) << "::getSceneAttributesByName : Dataset : "
                 << activeSceneDataset_
                 << " does not reference a SceneAttributes named  " << sceneName
                 << " but a SceneAttributes config named "
@@ -293,7 +291,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         //    In this case, a SceneAttributes is created amd registered using
         //    sceneName, referencing the StageAttributes of the same name; This
         //    sceneAttributes is returned.
-        LOG(INFO) << "MetadataMediator::getSceneAttributesByName : No existing "
+        LOG(INFO) << "::getSceneAttributesByName : No existing "
                      "scene instance attributes containing name "
                   << sceneName << " found in Dataset : " << activeSceneDataset_
                   << " but " << stageList.size()
@@ -311,8 +309,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         //    In this case, a stage attributes is loaded and registered, then
         //    added to current dataset, and then 3. is performed.
         LOG(INFO)
-            << "MetadataMediator::getSceneAttributesByName : Dataset : "
-            << activeSceneDataset_
+            << "::getSceneAttributesByName : Dataset : " << activeSceneDataset_
             << " has no preloaded SceneAttributes or StageAttributes named : "
             << sceneName
             << " so loading/creating a new StageAttributes with this "

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -193,7 +193,7 @@ class MetadataMediator {
   std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
     return getFilePathForHandle(navMeshHandle,
                                 getActiveDSAttribs()->getNavmeshMap(),
-                                "MetadataMediator::getNavmeshPathByHandle");
+                                "::getNavmeshPathByHandle");
 
   }  // MetadataMediator::getNavmeshPathByHandle
 
@@ -217,7 +217,7 @@ class MetadataMediator {
       const std::string& ssDescrHandle) {
     return getFilePathForHandle(
         ssDescrHandle, getActiveDSAttribs()->getSemanticSceneDescrMap(),
-        "MetadataMediator::getSemanticSceneDescriptorPathByHandle");
+        "::getSemanticSceneDescriptorPathByHandle");
 
   }  // MetadataMediator::getNavMeshPathByHandle
 
@@ -407,7 +407,7 @@ class MetadataMediator {
     // this should never happen - there will always be a dataset with the name
     // activeSceneDataset_
     if (datasetAttr == nullptr) {
-      LOG(ERROR) << "MetadataMediator::getActiveDSAttribs : Unable to set "
+      LOG(ERROR) << "::getActiveDSAttribs : Unable to set "
                     "active dataset due to Unknown dataset named "
                  << activeSceneDataset_
                  << " so changing dataset to \"default\".";

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -27,7 +27,7 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
   // info display message prefix
   const std::string infoPrefix(
       "SceneDatasetAttributes::addNewSceneInstanceToDataset : Dataset : '" +
-      getSimplifiedHandle() + "' :");
+      getSimplifiedHandle() + "' : ");
 
   const std::string sceneInstanceName = sceneInstance->getHandle();
   // verify stage in sceneInstance (required) exists in SceneDatasetAttributes,
@@ -38,12 +38,12 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
       getFullAttrNameFromStr(stageHandle, stageAttributesManager_);
   if (fullStageName == "") {
     LOG(INFO)
-        << infoPrefix << " Stage Attributes '" << stageHandle
+        << infoPrefix << "Stage Attributes '" << stageHandle
         << "' specified in Scene Attributes but does not exist in dataset, so "
            "creating.";
     stageAttributesManager_->createObject(stageHandle, true);
   } else {
-    LOG(INFO) << infoPrefix << " Stage Attributes '" << stageHandle
+    LOG(INFO) << infoPrefix << "Stage Attributes '" << stageHandle
               << "' specified in Scene Attributes exists in dataset library.";
   }
 
@@ -54,12 +54,12 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const std::string fullObjHandle =
         getFullAttrNameFromStr(objHandle, objectAttributesManager_);
     if (fullObjHandle == "") {
-      LOG(INFO) << infoPrefix << " Object Attributes '" << objHandle
+      LOG(INFO) << infoPrefix << "Object Attributes '" << objHandle
                 << "' specified in Scene Attributes but does not exist in "
                    "dataset, so creating.";
       objectAttributesManager_->createObject(objHandle, true);
     } else {
-      LOG(INFO) << infoPrefix << " Object Attributes '" << objHandle
+      LOG(INFO) << infoPrefix << "Object Attributes '" << objHandle
                 << "' specified in Scene Attributes exists in dataset library.";
     }
   }
@@ -83,7 +83,7 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
            "creating.";
     lightLayoutAttributesManager_->createObject(lightHandle, true);
   } else {
-    LOG(INFO) << infoPrefix << " Lighting Layout Attributes " << lightHandle
+    LOG(INFO) << infoPrefix << "Lighting Layout Attributes " << lightHandle
               << " specified in Scene Attributes exists in dataset library.";
   }
 
@@ -92,7 +92,7 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
 
   // add scene attributes to scene attributes manager
   if (fullSceneInstanceName == "") {
-    LOG(INFO) << infoPrefix << " Scene Attributes " << sceneInstanceName
+    LOG(INFO) << infoPrefix << "Scene Attributes " << sceneInstanceName
               << " does not exist in dataset so adding.";
     sceneAttributesManager_->registerObject(sceneInstance);
   }

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -25,9 +25,8 @@ SceneDatasetAttributes::SceneDatasetAttributes(
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const attributes::SceneAttributes::ptr& sceneInstance) {
   // info display message prefix
-  const std::string infoPrefix(
-      "SceneDatasetAttributes::addNewSceneInstanceToDataset : Dataset : '" +
-      getSimplifiedHandle() + "' : ");
+  const std::string infoPrefix("::addNewSceneInstanceToDataset : Dataset : '" +
+                               getSimplifiedHandle() + "' : ");
 
   const std::string sceneInstanceName = sceneInstance->getHandle();
   // verify stage in sceneInstance (required) exists in SceneDatasetAttributes,

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -124,7 +124,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& path,
       bool overwrite = false) {
     return addNewValToMap(key, path, overwrite, navmeshMap_,
-                          "SceneDatasetAttributes::addNavmeshPathEntry");
+                          "::addNavmeshPathEntry");
   }  // addNavmeshPathEntry
 
   /**
@@ -140,9 +140,8 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& key,
       const std::string& path,
       bool overwrite = false) {
-    return addNewValToMap(
-        key, path, overwrite, semanticSceneDescrMap_,
-        "SceneDatasetAttributes::addSemanticSceneDescrPathEntry");
+    return addNewValToMap(key, path, overwrite, semanticSceneDescrMap_,
+                          "::addSemanticSceneDescrPathEntry");
   }  // addNavmeshPathEntry
 
   /**

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -328,13 +328,12 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     if (T::AssetTypeNamesMap.count(strToLookFor)) {
       typeVal = static_cast<int>(T::AssetTypeNamesMap.at(strToLookFor));
     } else {
-      LOG(WARNING)
-          << "AbstractObjectAttributesManager::setJSONAssetHandleAndType : "
-             "Value in json @ tag : "
-          << jsonMeshTypeTag << " : `" << tmpVal
-          << "` does not map to a valid "
-             "AbstractObjectAttributes::AssetTypeNamesMap value, so "
-             "defaulting mesh type to AssetType::UNKNOWN.";
+      LOG(WARNING) << "<" << this->objectType_
+                   << ">::setJSONAssetHandleAndType : Value in json @ tag : "
+                   << jsonMeshTypeTag << " : `" << tmpVal
+                   << "` does not map to a valid "
+                      "AbstractObjectAttributes::AssetTypeNamesMap value, so "
+                      "defaulting mesh type to AssetType::UNKNOWN.";
       typeVal = static_cast<int>(esp::assets::AssetType::UNKNOWN);
     }
     // value found so override current value, otherwise do not.

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -105,7 +105,7 @@ AssetAttributesManager::AssetAttributesManager()
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
 
-  LOG(INFO) << "AssetAttributesManager::constructor : Built default "
+  LOG(INFO) << "::constructor : Built default "
                "primitive asset templates : "
             << std::to_string(defaultPrimAttributeHandles_.size());
 }  // AssetAttributesManager::ctor
@@ -131,7 +131,7 @@ int AssetAttributesManager::registerObjectFinalize(
   std::string primAttributesHandle = primAttributesTemplate->getHandle();
   // verify that attributes has been edited in a legal manner
   if (!primAttributesTemplate->isValidTemplate()) {
-    LOG(ERROR) << "AssetAttributesManager::registerObjectFinalize "
+    LOG(ERROR) << "::registerObjectFinalize "
                   ": Primitive asset attributes template named"
                << primAttributesHandle
                << "is not configured properly for specified prmitive"
@@ -161,7 +161,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   // if not legal primitive asset attributes file name, have message and return
   // default sphere attributes.
   if (defaultPrimAttributeHandles_.count(primClassName) == 0) {
-    LOG(ERROR) << "AssetAttributesManager::buildObjectFromJSONDoc :Unknown "
+    LOG(ERROR) << "::buildObjectFromJSONDoc :Unknown "
                   "primitive class type : "
                << primClassName
                << " so returning default attributes for solid uvSphere.";
@@ -173,7 +173,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   auto primAssetAttributes = this->initNewObjectInternal(primClassName, true);
   if (nullptr == primAssetAttributes) {
     LOG(ERROR)
-        << "AssetAttributesManager::buildObjectFromJSONDoc : unable to "
+        << "::buildObjectFromJSONDoc : unable to "
            "create default primitive asset attributes from primClassName "
         << primClassName
         << " so returning default attributes for solid uvSphere.";

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -149,7 +149,7 @@ class AssetAttributesManager
       PrimObjTypes primObjType,
       bool registerTemplate = true) {
     if (primObjType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR) << "AssetAttributesManager::createObject : Illegal "
+      LOG(ERROR) << "::createObject : Illegal "
                     "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
                     "Aborting.";
       return nullptr;
@@ -172,7 +172,7 @@ class AssetAttributesManager
       PrimObjTypes primType,
       bool contains = true) const {
     if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR) << "AssetAttributesManager::getTemplateHandlesByPrimType : "
+      LOG(ERROR) << "::getTemplateHandlesByPrimType : "
                     "Illegal primtitive type "
                     "name PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return {};
@@ -392,7 +392,7 @@ class AssetAttributesManager
   void setDefaultObject(
       CORRADE_UNUSED attributes::AbstractPrimitiveAttributes::ptr& _defaultObj)
       override {
-    LOG(WARNING) << "AssetAttributesManager::setDefaultObject : Overriding "
+    LOG(WARNING) << "::setDefaultObject : Overriding "
                     "defualt objects for PrimitiveAssetAttributes not "
                     "currently supported.  Aborting.";
     this->defaultObj_ = nullptr;
@@ -435,9 +435,9 @@ class AssetAttributesManager
   bool verifyTemplateHandle(const std::string& templateHandle,
                             const std::string& attrType) {
     if (std::string::npos == templateHandle.find(attrType)) {
-      LOG(ERROR) << "AssetAttributesManager::verifyTemplateHandle : Handle : "
-                 << templateHandle << " is not of appropriate type for desired "
-                 << attrType << " primitives. Aborting.";
+      LOG(ERROR) << "::verifyTemplateHandle : Handle : " << templateHandle
+                 << " is not of appropriate type for desired " << attrType
+                 << " primitives. Aborting.";
       return false;
     }
     return true;
@@ -473,7 +473,7 @@ class AssetAttributesManager
       const std::string& primClassName,
       CORRADE_UNUSED bool builtFromConfig) override {
     if (primTypeConstructorMap_.count(primClassName) == 0) {
-      LOG(ERROR) << "AssetAttributesManager::buildPrimAttributes : No "
+      LOG(ERROR) << "::buildPrimAttributes : No "
                     "primitive class"
                  << primClassName << "exists in Magnum::Primitives. Aborting.";
       return nullptr;

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -239,13 +239,13 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
   if (paths.size() > 0) {
     std::string dir = Cr::Utility::Directory::path(paths[0]);
-    LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Loading "
-              << paths.size() << " " << this->objectType_
-              << " templates found in " << dir;
+    LOG(INFO) << "<" << this->objectType_
+              << ">::loadAllFileBasedTemplates : Loading " << paths.size()
+              << " " << this->objectType_ << " templates found in " << dir;
     for (int i = 0; i < paths.size(); ++i) {
       auto attributesFilename = paths[i];
-      LOG(INFO) << "AttributesManager::loadAllFileBasedTemplates : Load "
-                << this->objectType_ << " template: "
+      LOG(INFO) << "::loadAllFileBasedTemplates : Load " << this->objectType_
+                << " template: "
                 << Cr::Utility::Directory::filename(attributesFilename);
       auto tmplt = this->createObject(attributesFilename, true);
       // If failed to load, do not attempt to modify further
@@ -260,9 +260,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
       templateIndices[i] = tmplt->getID();
     }
   }
-  LOG(INFO)
-      << "AttributesManager::loadAllFileBasedTemplates : Loaded file-based "
-      << this->objectType_ << " templates: " << std::to_string(paths.size());
+  LOG(INFO) << "<" << this->objectType_
+            << ">::loadAllFileBasedTemplates : Loaded file-based templates: "
+            << std::to_string(paths.size());
   return templateIndices;
 }  // AttributesManager<T, Access>::loadAllObjectTemplates
 
@@ -278,8 +278,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   // Check if directory
   const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
-    LOG(INFO) << "AttributesManager::loadAllTemplatesFromPathAndExt <"
-              << extType << "> : Parsing " << this->objectType_
+    LOG(INFO) << "<" << this->objectType_
+              << ">::loadAllTemplatesFromPathAndExt <" << extType
+              << "> : Parsing " << this->objectType_
               << " library directory: " + path + " for \'" + extType +
                      "\' files";
     for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
@@ -297,11 +298,11 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     if (fileExists) {
       paths.push_back(attributesFilepath);
     } else {  // neither a directory or a file
-      LOG(WARNING)
-          << "AttributesManager::loadAllTemplatesFromPathAndExt : Parsing "
-          << this->objectType_ << " : Cannot find " << path
-          << " as directory or " << attributesFilepath
-          << " as config file. Aborting parse.";
+      LOG(WARNING) << "<" << this->objectType_
+                   << ">::loadAllTemplatesFromPathAndExt : Parsing "
+                   << this->objectType_ << " : Cannot find " << path
+                   << " as directory or " << attributesFilepath
+                   << " as config file. Aborting parse.";
       return templateIndices;
     }  // if fileExists else
   }    // if dirExists else
@@ -319,7 +320,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const io::JsonGenericValue& filePaths) {
   for (rapidjson::SizeType i = 0; i < filePaths.Size(); ++i) {
     if (!filePaths[i].IsString()) {
-      LOG(ERROR) << "AttributesManager::buildAttrSrcPathsFromJSONAndLoad : "
+      LOG(ERROR) << "::buildAttrSrcPathsFromJSONAndLoad : "
                     "Invalid path "
                     "value in file path array element @ idx "
                  << i << ". Skipping.";
@@ -339,7 +340,8 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
       LOG(WARNING) << "No Glob path result for " << absolutePath;
     }
   }
-  LOG(INFO) << "AttributesManager::buildAttrSrcPathsFromJSONAndLoad : "
+  LOG(INFO) << "<" << this->objectType_
+            << ">::buildAttrSrcPathsFromJSONAndLoad : "
             << std::to_string(filePaths.Size())
             << " paths specified in JSON doc for " << this->objectType_
             << " templates.";
@@ -360,10 +362,10 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   // Check if this configuration file exists and if so use it to build
   // attributes
   bool jsonFileExists = (this->isValidFileName(jsonAttrFileName));
-  LOG(INFO) << "AttributesManager::createFromJsonOrDefaultInternal  ("
-            << this->objectType_
-            << ") : Proposing JSON name : " << jsonAttrFileName
-            << " from original name : " << filename << " | This file "
+  LOG(INFO) << "<" << this->objectType_
+            << ">::createFromJsonOrDefaultInternal : Proposing JSON name : "
+            << jsonAttrFileName << " from original name : " << filename
+            << " | This file "
             << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
@@ -396,7 +398,8 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
   // check for user defined attributes
   if (jsonConfig.HasMember("user_defined")) {
     if (!jsonConfig["user_defined"].IsObject()) {
-      LOG(WARNING) << "AttributesManager::parseUserDefinedJsonVals : "
+      LOG(WARNING) << "<" << this->objectType_
+                   << ">::parseUserDefinedJsonVals : "
                    << attribs->getSimplifiedHandle()
                    << " attributes specifies user_defined attributes but they "
                       "are not of the correct format. Skipping.";
@@ -443,7 +446,8 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
             --numConfigSettings;
             // TODO support numeric array in JSON
             LOG(WARNING)
-                << "AttributesManager::parseUserDefinedJsonVals : For "
+                << "<" << this->objectType_
+                << ">::parseUserDefinedJsonVals : For "
                 << attribs->getSimplifiedHandle()
                 << " attributes, user_defined config cell in JSON document "
                    "contains key "
@@ -456,7 +460,8 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
           // decrement count for key:obj due to not being handled type
           --numConfigSettings;
           LOG(WARNING)
-              << "AttributesManager::parseUserDefinedJsonVals : For "
+              << "<" << this->objectType_
+              << ">::parseUserDefinedJsonVals : For "
               << attribs->getSimplifiedHandle()
               << " attributes, user_defined config cell in JSON document "
                  "contains key "

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -79,8 +79,7 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
       lightAttribs->addLightInstance(lightInstanceAttribs);
       ++count;
     }
-    LOG(INFO) << "LightLayoutAttributesManager::setValsFromJSONDoc : " << count
-              << " of " << numLightConfigs
+    LOG(INFO) << "::setValsFromJSONDoc : " << count << " of " << numLightConfigs
               << " LightInstanceAttributes created successfully and added to "
                  "LightLayoutAttributes "
               << layoutName << ".";
@@ -91,8 +90,7 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
     // register if anything worth registering was found
     this->postCreateRegister(lightAttribs, true);
   } else {
-    LOG(WARNING) << "LightLayoutAttributesManager::setValsFromJSONDoc : "
-                 << layoutName
+    LOG(WARNING) << "::setValsFromJSONDoc : " << layoutName
                  << " does not contain a \"lights\" object or a valid "
                     "\"user_defined\" object and so no parsing was "
                     "done and this attributes is not being saved.";
@@ -140,8 +138,8 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           LightInstanceAttributes::LightPositionNamesMap.at(strToLookFor));
     } else {
       LOG(WARNING)
-          << "LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc : "
-             "Position Model Value in JSON : `"
+          << "::setLightInstanceValsFromJSONDoc : 'position_model' Value in "
+             "JSON : `"
           << posMdleVal
           << "` does not map to a valid "
              "LightInstanceAttributes::LightPositionNamesMap value, so "
@@ -160,7 +158,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
     if (strToLookFor == "spot") {
       // TODO remove this if block to support spot lights
       LOG(WARNING)
-          << "LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc : "
+          << "::setLightInstanceValsFromJSONDoc : "
              "Type spotlight specified in JSON not currently supported, so "
              "defaulting LightInfo type to esp::gfx::LightType::Point.";
       specifiedTypeVal = static_cast<int>(esp::gfx::LightType::Point);
@@ -170,7 +168,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           LightInstanceAttributes::LightTypeNamesMap.at(strToLookFor));
     } else {
       LOG(WARNING)
-          << "LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc : "
+          << "::setLightInstanceValsFromJSONDoc : "
              "Type Value in JSON : `"
           << tmpTypeVal
           << "` does not map to a valid "
@@ -208,12 +206,10 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
     if (!jsonConfig["spot"].IsObject()) {
       // TODO prune NOTE: component when spotlights are supported
       LOG(WARNING)
-          << "LightLayoutAttributesManager::setValsFromJSONDoc : \"spot\" "
-             "cell in JSON config unable to be parsed to set "
-             "spotlight parameters so skipping.  NOTE : Spotlights not "
-             "currently supported, so cone anble values are ignored and "
-             "light "
-             "will be created as a point light.";
+          << "::setValsFromJSONDoc : \"spot\" cell in JSON config unable to be "
+             "parsed to set spotlight parameters so skipping.  NOTE : "
+             "Spotlights not currently supported, so cone angle values are "
+             "ignored and light will be created as a point light.";
     } else {
       const auto& spotArea = jsonConfig["spot"];
       // set inner cone angle
@@ -297,10 +293,8 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
             break;
           }
           default: {
-            LOG(INFO) << "LightLayoutAttributesManager::"
-                         "createLightSetupFromAttributes : Enum "
-                         "gfx::LightType with "
-                         "val "
+            LOG(INFO) << "::createLightSetupFromAttributes : Enum "
+                         "gfx::LightType with val "
                       << type
                       << " is not supported, so defaulting to "
                          "gfx::LightType::Point";

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -29,8 +29,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
     LOG(ERROR)
-        << "ObjectAttributesManager::createPrimBasedAttributesTemplate : No "
-           "primitive with handle '"
+        << "::createPrimBasedAttributesTemplate : No primitive with handle '"
         << primAttrTemplateHandle
         << "' exists so cannot build physical object.  Aborting.";
     return nullptr;
@@ -191,8 +190,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     bool forceRegistration) {
   if (objectTemplate->getRenderAssetHandle() == "") {
     LOG(ERROR)
-        << "ObjectAttributesManager::registerObjectFinalize : "
-           "Attributes template named "
+        << "::registerObjectFinalize : Attributes template named "
         << objectTemplateHandle
         << " does not have a valid render asset handle specified. Aborting.";
     return ID_UNDEFINED;
@@ -218,8 +216,7 @@ int ObjectAttributesManager::registerObjectFinalize(
   } else if (forceRegistration) {
     // Forcing registration in case of computationaly generated assets
     LOG(WARNING)
-        << "ObjectAttributesManager::registerObjectFinalize "
-           ": Render asset template handle : "
+        << "::registerObjectFinalize : Render asset template handle : "
         << renderAssetHandle << " specified in object template with handle : "
         << objectTemplateHandle
         << " does not correspond to any existing file or primitive render "
@@ -230,8 +227,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     // attributes template hande, fail
     // by here always fail
     LOG(ERROR)
-        << "ObjectAttributesManager::registerObjectFinalize "
-           ": Render asset template handle : "
+        << "::registerObjectFinalize : Render asset template handle : "
         << renderAssetHandle << " specified in object template with handle : "
         << objectTemplateHandle
         << " does not correspond to any existing file or primitive render "
@@ -250,8 +246,7 @@ int ObjectAttributesManager::registerObjectFinalize(
   } else {
     // Else, means no collision data specified, use specified render data
     LOG(INFO)
-        << "ObjectAttributesManager::registerObjectFinalize "
-           ": Collision asset template handle : "
+        << "::registerObjectFinalize : Collision asset template handle : "
         << collisionAssetHandle
         << " specified in object template with handle : "
         << objectTemplateHandle

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -63,22 +63,23 @@ void SceneAttributesManager::setValsFromJSONDoc(
                  << attribsDispName << ", or specification error.";
   }
   // Check for object instances existance
-  if ((jsonConfig.HasMember("object_instances")) &&
-      (jsonConfig["object_instances"].IsArray())) {
-    const auto& objectArray = jsonConfig["object_instances"];
-    for (rapidjson::SizeType i = 0; i < objectArray.Size(); i++) {
-      const auto& objCell = objectArray[i];
-      if (objCell.IsObject()) {
-        attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
-      } else {
-        LOG(WARNING)
-            << "::setValsFromJSONDoc : Object specification error in scene "
-            << attribsDispName << " at idx : " << i << ".";
+  if (jsonConfig.HasMember("object_instances")) {
+    if (jsonConfig["object_instances"].IsArray()) {
+      const auto& objectArray = jsonConfig["object_instances"];
+      for (rapidjson::SizeType i = 0; i < objectArray.Size(); i++) {
+        const auto& objCell = objectArray[i];
+        if (objCell.IsObject()) {
+          attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
+        } else {
+          LOG(WARNING)
+              << "::setValsFromJSONDoc : Object specification error in scene "
+              << attribsDispName << " at idx : " << i << ".";
+        }
       }
+    } else {
+      LOG(WARNING) << "::setValsFromJSONDoc : No Objects specified for scene "
+                   << attribsDispName << ", or specification error.";
     }
-  } else {
-    LOG(WARNING) << "::setValsFromJSONDoc : No Objects specified for scene "
-                 << attribsDispName << ", or specification error.";
   }
   std::string dfltLighting = "";
   if (io::readMember<std::string>(jsonConfig, "default_lighting",

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -59,8 +59,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     attribs->setStageInstance(
         createInstanceAttributesFromJSON(jsonConfig["stage_instance"]));
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Stage "
-                    "specified for scene "
+    LOG(WARNING) << "::setValsFromJSONDoc : No Stage specified for scene "
                  << attribsDispName << ", or specification error.";
   }
   // Check for object instances existance
@@ -72,14 +71,13 @@ void SceneAttributesManager::setValsFromJSONDoc(
       if (objCell.IsObject()) {
         attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
       } else {
-        LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : Object "
-                        "specification error in scene "
-                     << attribsDispName << " at idx : " << i << ".";
+        LOG(WARNING)
+            << "::setValsFromJSONDoc : Object specification error in scene "
+            << attribsDispName << " at idx : " << i << ".";
       }
     }
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No Objects "
-                    "specified for scene "
+    LOG(WARNING) << "::setValsFromJSONDoc : No Objects specified for scene "
                  << attribsDispName << ", or specification error.";
   }
   std::string dfltLighting = "";
@@ -88,10 +86,9 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "default lighting" is specified in scene json set value.
     attribs->setLightingHandle(dfltLighting);
   } else {
-    LOG(WARNING)
-        << "SceneAttributesManager::setValsFromJSONDoc : No default_lighting "
-           "specified for scene "
-        << attribsDispName << ".";
+    LOG(WARNING) << "::setValsFromJSONDoc : No default_lighting "
+                    "specified for scene "
+                 << attribsDispName << ".";
   }
 
   std::string navmeshName = "";
@@ -100,10 +97,9 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "navmesh_instance" is specified in scene json set value.
     attribs->setNavmeshHandle(navmeshName);
   } else {
-    LOG(WARNING)
-        << "SceneAttributesManager::setValsFromJSONDoc : No navmesh_instance "
-           "specified for scene "
-        << attribsDispName << ".";
+    LOG(WARNING) << "::setValsFromJSONDoc : No navmesh_instance "
+                    "specified for scene "
+                 << attribsDispName << ".";
   }
 
   std::string semanticDesc = "";
@@ -112,8 +108,8 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "semantic scene instance" is specified in scene json set value.
     attribs->setSemanticSceneHandle(semanticDesc);
   } else {
-    LOG(WARNING) << "SceneAttributesManager::setValsFromJSONDoc : No "
-                    "semantic_scene_instance specified for scene "
+    LOG(WARNING) << "::setValsFromJSONDoc : No semantic_scene_instance "
+                    "specified for scene "
                  << attribsDispName << ".";
   }
   // check for user defined attributes
@@ -154,12 +150,11 @@ SceneAttributesManager::createInstanceAttributesFromJSON(
     if (found != SceneObjectInstanceAttributes::MotionTypeNamesMap.end()) {
       motionTypeVal = static_cast<int>(found->second);
     } else {
-      LOG(WARNING)
-          << "SceneAttributesManager::createInstanceAttributesFromJSON : "
-             "motion_type value in json  : `"
-          << tmpVal << "|" << strToLookFor
-          << "` does not map to a valid physics::MotionType value, so "
-             "defaulting motion type to MotionType::UNDEFINED.";
+      LOG(WARNING) << "::createInstanceAttributesFromJSON : motion_type value "
+                      "in json  : `"
+                   << tmpVal << "|" << strToLookFor
+                   << "` does not map to a valid physics::MotionType value, so "
+                      "defaulting motion type to MotionType::UNDEFINED.";
     }
   }
   instanceAttrs->setMotionType(motionTypeVal);
@@ -200,12 +195,12 @@ int SceneAttributesManager::getTranslationOriginVal(
     if (found != SceneAttributes::InstanceTranslationOriginMap.end()) {
       transOrigin = static_cast<int>(found->second);
     } else {
-      LOG(WARNING) << "SceneAttributesManager::getTranslationOriginVal : "
-                      "motion_type value in json  : `"
-                   << tmpTransOriginVal << "|" << strToLookFor
-                   << "` does not map to a valid "
-                      "SceneInstanceTranslationOrigin value, so defaulting "
-                      "motion type to SceneInstanceTranslationOrigin::Unknown.";
+      LOG(WARNING)
+          << "::getTranslationOriginVal : motion_type value in json  : `"
+          << tmpTransOriginVal << "|" << strToLookFor
+          << "` does not map to a valid "
+             "SceneInstanceTranslationOrigin value, so defaulting "
+             "motion type to SceneInstanceTranslationOrigin::Unknown.";
     }
   }
   return transOrigin;

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -331,7 +331,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // assets will be named relative to this.
     attr->setFileDirectory(dsDir);
 
-    // object is available now. Modify it using json tag data
+    // default object is available now. Modify it using json tag data
     attrMgr->setValsFromJSONDoc(attr, jCell["attributes"]);
     // register object
     attrMgr->registerObject(attr, regHandle);

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -139,7 +139,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
           LOG(WARNING) << "::readDatasetJSONCell : \"" << tag
-                       << ".default attributes\" cell in JSON config unable to "
+                       << ".default_attributes\" cell in JSON config unable to "
                           "be parsed to set default attributes so skipping.";
         } else {
           // load attributes as default from file, do not register
@@ -147,17 +147,17 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
               "default_attributes", jCell["default_attributes"]);
           if (nullptr == attr) {
             LOG(WARNING) << "::readDatasetJSONCell : \"" << tag
-                         << ".default attributes\" cell failed to successfully "
+                         << ".default_attributes\" cell failed to successfully "
                             "create an attributes, so skipping.";
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
             LOG(INFO)
                 << "::readDatasetJSONCell : \"" << tag
-                << ".default attributes\" set in Attributes Manager from JSON.";
+                << ".default_attributes\" set in Attributes Manager from JSON.";
           }
         }  // if is an object
-      }    // if has default attributes cell
+      }    // if has default_attributes cell
 
       // 2. "paths" an array of paths to search for appropriately typed config
       // files.

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -106,8 +106,8 @@ void SceneDatasetAttributesManager::loadAndValidateMap(
     if (!Cr::Utility::Directory::exists(loc)) {
       std::string newLoc = Cr::Utility::Directory::join(dsDir, loc);
       if (!Cr::Utility::Directory::exists(newLoc)) {
-        LOG(WARNING) << "SceneDatasetAttributesManager::loadAndValidateMap : "
-                     << jsonTag << " Value : " << loc
+        LOG(WARNING) << "::loadAndValidateMap : " << jsonTag
+                     << " Value : " << loc
                      << " not found on disk as absolute path or relative to "
                      << dsDir;
       } else {
@@ -127,7 +127,10 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
     const U& attrMgr) {
   if (jsonConfig.HasMember(tag)) {
     if (!jsonConfig[tag].IsObject()) {
-      dispCellConfigError(tag);
+      LOG(WARNING)
+          << "::readDatasetJSONCell : \"" << tag
+          << "\" cell in JSON config not appropriately configured. Skipping.";
+
     } else {
       const auto& jCell = jsonConfig[tag];
       // process JSON jCell here - this cell potentially holds :
@@ -135,27 +138,22 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // type.
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
-          LOG(WARNING)
-              << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-              << tag
-              << ".default attributes\" cell in JSON config unable to "
-                 "be parsed to set default attributes so skipping.";
+          LOG(WARNING) << "::readDatasetJSONCell : \"" << tag
+                       << ".default attributes\" cell in JSON config unable to "
+                          "be parsed to set default attributes so skipping.";
         } else {
           // load attributes as default from file, do not register
           auto attr = attrMgr->buildObjectFromJSONDoc(
               "default_attributes", jCell["default_attributes"]);
           if (nullptr == attr) {
-            LOG(WARNING)
-                << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-                << tag
-                << ".default attributes\" cell failed to successfully "
-                   "create an attributes, so skipping.";
+            LOG(WARNING) << "::readDatasetJSONCell : \"" << tag
+                         << ".default attributes\" cell failed to successfully "
+                            "create an attributes, so skipping.";
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
             LOG(INFO)
-                << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-                << tag
+                << "::readDatasetJSONCell : \"" << tag
                 << ".default attributes\" set in Attributes Manager from JSON.";
           }
         }  // if is an object
@@ -166,8 +164,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
           LOG(WARNING)
-              << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-              << tag
+              << "::readDatasetJSONCell : \"" << tag
               << ".paths\" cell in JSON config unable to be parsed as "
                  "a JSON object to determine search paths so skipping.";
         } else {
@@ -195,8 +192,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           // TODO support other extention tags
           if (pathsWarn) {
             LOG(WARNING)
-                << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-                << tag << ".paths[" << pathsWarnType
+                << "::readDatasetJSONCell : \"" << tag << ".paths["
+                << pathsWarnType
                 << "] cell in JSON config unable to be parsed as an array to "
                    "determine search paths for json configs so skipping.";
           }
@@ -206,11 +203,9 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // existing attributes.
       if (jCell.HasMember("configs")) {
         if (!jCell["configs"].IsArray()) {
-          LOG(WARNING)
-              << "SceneDatasetAttributesManager::readDatasetJSONCell : \""
-              << tag
-              << ".configs\" cell in JSON config unable to be parsed "
-                 "as an array to determine search paths so skipping.";
+          LOG(WARNING) << "::readDatasetJSONCell : \"" << tag
+                       << ".configs\" cell in JSON config unable to be parsed "
+                          "as an array to determine search paths so skipping.";
         } else {
           const auto& configsAra = jCell["configs"];
           for (rapidjson::SizeType i = 0; i < configsAra.Size(); i++) {
@@ -232,8 +227,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   // every cell within configs array must have an attributes tag
   if ((!jCell.HasMember("attributes")) || (!jCell["attributes"].IsObject())) {
     LOG(WARNING)
-        << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
-        << tag
+        << "::readDatasetConfigsJSONCell : \"" << tag
         << ".configs\" cell element in JSON config lacks required data to "
            "construct configuration override (an attributes tag and data "
            "describing the overrides is not found), so skipping.";
@@ -257,8 +251,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
         attrMgr->getObjectHandlesBySubstring(originalFile, true);
     if (handles.size() == 0) {
       LOG(WARNING)
-          << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
-          << tag
+          << "::readDatasetConfigsJSONCell : \"" << tag
           << ".configs\" cell element in JSON config specified source file : "
           << originalFile << " which cannot be found, so skipping.";
       return;
@@ -280,8 +273,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   // if neither handle is specified, cell will fail
   if (!validCell) {
     LOG(WARNING)
-        << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
-        << tag
+        << "::readDatasetConfigsJSONCell : \"" << tag
         << ".configs\" cell element in JSON config lacks required data to "
            "construct configuration override (either an original_file or a "
            "template_handle must be provided) so skipping.";
@@ -304,17 +296,15 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // is known to be legitimate file
     auto attr = attrMgr->getObjectCopyByHandle(origObjHandle);
     if (nullptr == attr) {
-      LOG(WARNING)
-          << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : "
-          << attrMgr->getObjectType() << " : Attempting to make a copy of "
-          << origObjHandle
-          << " failing so creating and registering a new object.";
+      LOG(WARNING) << "::readDatasetConfigsJSONCell : "
+                   << attrMgr->getObjectType()
+                   << " : Attempting to make a copy of " << origObjHandle
+                   << " failing so creating and registering a new object.";
       attr = attrMgr->createObject(origObjHandle, true);
       if (nullptr == attr) {
         LOG(WARNING)
-            << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
-            << tag << ".configs\" cell element's original file ("
-            << originalFile
+            << "::readDatasetConfigsJSONCell : \"" << tag
+            << ".configs\" cell element's original file (" << originalFile
             << ") failed to successfully create a base attributes to modify, "
                "so skipping.";
         return;
@@ -332,8 +322,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // if null then failed for some reason to create a new default object.
     if (nullptr == attr) {
       LOG(WARNING)
-          << "SceneDatasetAttributesManager::readDatasetConfigsJSONCell : \""
-          << tag
+          << "::readDatasetConfigsJSONCell : \"" << tag
           << ".configs\" cell element failed to successfully create an "
              "attributes, so skipping.";
       return;

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -123,17 +123,6 @@ class SceneDatasetAttributesManager
                                   const U& attrMgr);
 
   /**
-   * @brief Internally used warning message if a cell in the dataset
-   * configuration is present but improperly configred.
-   * @param tag the name of the cell
-   */
-  void dispCellConfigError(const std::string& tag) {
-    LOG(WARNING)
-        << "SceneDatasetAttributesManager::readDatasetJSONCell : \"" << tag
-        << "\" cell in JSON config not appropriately configured. Skipping.";
-  }
-
-  /**
    * @brief Used Internally.  Create and configure newly-created dataset
    * attributes with any default values, before any specific values are set.
    *

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -48,8 +48,7 @@ int StageAttributesManager::registerObjectFinalize(
     bool forceRegistration) {
   if (stageAttributes->getRenderAssetHandle() == "") {
     LOG(ERROR)
-        << "StageAttributesManager::registerObjectFinalize : "
-           "Attributes template named "
+        << "::registerObjectFinalize : Attributes template named "
         << stageAttributesHandle
         << " does not have a valid render asset handle specified. Aborting.";
     return ID_UNDEFINED;
@@ -77,8 +76,7 @@ int StageAttributesManager::registerObjectFinalize(
     stageAttributes->setRenderAssetIsPrimitive(false);
   } else if (forceRegistration) {
     LOG(WARNING)
-        << "StageAttributesManager::registerObjectFinalize "
-           ": Render asset template handle : "
+        << "::registerObjectFinalize : Render asset template handle : "
         << renderAssetHandle << " specified in stage template with handle : "
         << stageAttributesHandle
         << " does not correspond to any existing file or primitive render "
@@ -86,8 +84,7 @@ int StageAttributesManager::registerObjectFinalize(
   } else {
     // If renderAssetHandle is not valid file name needs to  fail
     LOG(ERROR)
-        << "StageAttributesManager::registerObjectFinalize "
-           ": Render asset template handle : "
+        << "::registerObjectFinalize : Render asset template handle : "
         << renderAssetHandle << " specified in stage template with handle : "
         << stageAttributesHandle
         << " does not correspond to any existing file or primitive render "
@@ -112,8 +109,7 @@ int StageAttributesManager::registerObjectFinalize(
   } else {
     // Else, means no collision data specified, use specified render data
     LOG(INFO)
-        << "StageAttributesManager::registerObjectFinalize "
-           ": Collision asset template handle : "
+        << "::registerObjectFinalize : Collision asset template handle : "
         << collisionAssetHandle << " specified in stage template with handle : "
         << stageAttributesHandle
         << " does not correspond to any existing file or primitive render "
@@ -141,8 +137,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
   // verify that a primitive asset with the given handle exists
   if (!StageAttributesManager::isValidPrimitiveAttributes(primAssetHandle)) {
     LOG(ERROR)
-        << "StageAttributesManager::createPrimBasedAttributesTemplate : No "
-           "primitive with handle '"
+        << "::createPrimBasedAttributesTemplate : No primitive with handle '"
         << primAssetHandle
         << "' exists so cannot build physical object.  Aborting.";
     return nullptr;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -72,7 +72,7 @@ int PhysicsManager::addObjectInstance(
     bool defaultCOMCorrection,
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
-  const std::string errMsgTmplt = "PhysicsManager::addObjectInstance : ";
+  const std::string errMsgTmplt = "::addObjectInstance : ";
   // Get ObjectAttributes
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
@@ -127,9 +127,9 @@ int PhysicsManager::addObject(const std::string& attributesHandle,
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
   if (!attributes) {
-    LOG(ERROR) << "PhysicsManager::addObject : "
-                  "Object creation failed due to unknown attributes "
-               << attributesHandle;
+    LOG(ERROR)
+        << "::addObject : Object creation failed due to unknown attributes "
+        << attributesHandle;
     return ID_UNDEFINED;
   } else {
     // attributes exist, get drawables if valid simulator accessible
@@ -150,7 +150,7 @@ int PhysicsManager::addObject(const int attributesID,
       resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
           attributesID);
   if (!attributes) {
-    LOG(ERROR) << "PhysicsManager::addObject : "
+    LOG(ERROR) << "::addObject : "
                   "Object creation failed due to unknown attributes ID "
                << attributesID;
     return ID_UNDEFINED;
@@ -174,8 +174,7 @@ int PhysicsManager::addObject(
   //! Make rigid object and add it to existingObjects
   if (!objectAttributes) {
     // should never run, but just in case
-    LOG(ERROR) << "PhysicsManager::addObject : "
-                  "Object creation failed due to nonexistant "
+    LOG(ERROR) << "::addObject : Object creation failed due to nonexistant "
                   "objectAttributes";
     return ID_UNDEFINED;
   }
@@ -184,8 +183,8 @@ int PhysicsManager::addObject(
   bool objectSuccess =
       resourceManager_.instantiateAssetsOnDemand(objectAttributes);
   if (!objectSuccess) {
-    LOG(ERROR) << "PhysicsManager::addObject : "
-                  "ResourceManager::instantiateAssetsOnDemand unsuccessful. "
+    LOG(ERROR) << "::addObject : ResourceManager::instantiateAssetsOnDemand "
+                  "unsuccessful. "
                   "Aborting.";
     return ID_UNDEFINED;
   }
@@ -205,8 +204,8 @@ int PhysicsManager::addObject(
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
-    LOG(ERROR) << "PhysicsManager::addObject : PhysicsManager::makeRigidObject "
-                  "unsuccessful.  Aborting.";
+    LOG(ERROR) << "::addObject : PhysicsManager::makeRigidObject unsuccessful. "
+                  " Aborting.";
     return ID_UNDEFINED;
   }
 
@@ -230,7 +229,7 @@ int PhysicsManager::addObject(
   if (!objectSuccess) {
     // if failed for some reason, remove and return
     removeObject(nextObjectID_, true, true);
-    LOG(ERROR) << "PhysicsManager::addObject : PhysicsManager::finalizeObject "
+    LOG(ERROR) << "::addObject : PhysicsManager::finalizeObject "
                   "unsuccessful.  Aborting.";
     return ID_UNDEFINED;
   }
@@ -239,12 +238,10 @@ int PhysicsManager::addObject(
   // and register wrapper with wrapper manager
   // 1.0 Get unique name for object using simplified attributes name.
   std::string simpleObjectHandle = objectAttributes->getSimplifiedHandle();
-  LOG(WARNING) << "PhysicsManager::addObject : simpleObjectHandle : "
-               << simpleObjectHandle;
+  LOG(WARNING) << "::addObject : simpleObjectHandle : " << simpleObjectHandle;
   std::string newObjectHandle =
       rigidObjectManager_->getUniqueHandleFromCandidate(simpleObjectHandle);
-  LOG(WARNING) << "PhysicsManager::addObject : newObjectHandle : "
-               << newObjectHandle;
+  LOG(WARNING) << "::addObject : newObjectHandle : " << newObjectHandle;
 
   existingObjects_.at(nextObjectID_)->setObjectName(newObjectHandle);
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -285,9 +285,9 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
         resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
             attributesHandle);
     if (!attributes) {
-      LOG(ERROR) << "PhysicsManager::addObject : "
-                    "Object creation failed due to unknown attributes "
-                 << attributesHandle;
+      LOG(ERROR)
+          << "::addObject : Object creation failed due to unknown attributes "
+          << attributesHandle;
       return ID_UNDEFINED;
     }
 
@@ -315,8 +315,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
         resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
             attributesID);
     if (!attributes) {
-      LOG(ERROR) << "PhysicsManager::addObject : "
-                    "Object creation failed due to unknown attributes ID "
+      LOG(ERROR) << "::addObject : Object creation failed due to unknown "
+                    "attributes ID "
                  << attributesID;
       return ID_UNDEFINED;
     }

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -88,7 +88,7 @@ class RigidStage : public RigidBase {
    * @param mt The desirved @ref MotionType.
    */
   void setMotionType(CORRADE_UNUSED MotionType mt) override {
-    LOG(WARNING) << "RigidStage::setMotionType : Stages cannot have their "
+    LOG(WARNING) << "::setMotionType : Stages cannot have their "
                     "motion type changed from MotionType::STATIC.  Aborting.";
   }
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -216,8 +216,7 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
   results.ray = ray;
   double rayLength = static_cast<double>(ray.direction.length());
   if (rayLength == 0) {
-    LOG(ERROR) << "BulletPhysicsManager::castRay : Cannot case ray with zero "
-                  "length, aborting. ";
+    LOG(ERROR) << "::castRay : Cannot cast ray with zero length, aborting. ";
     return results;
   }
   btVector3 from(ray.origin);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -166,7 +166,7 @@ BulletRigidObject::buildPrimitiveCollisionObject(int primTypeVal,
       (primTypeVal >= 0) &&
           (primTypeVal <
            static_cast<int>(metadata::PrimObjTypes::END_PRIM_OBJ_TYPES)),
-      "BulletRigidObject::buildPrimitiveCollisionObject : Illegal primitive "
+      "::buildPrimitiveCollisionObject : Illegal primitive "
       "value requested : "
           << primTypeVal,
       nullptr);
@@ -259,7 +259,7 @@ void BulletRigidObject::setCollisionFromBB() {
 
 void BulletRigidObject::setMotionType(MotionType mt) {
   if (mt == MotionType::UNDEFINED) {
-    LOG(WARNING) << "BulletRigidObject::setMotionType : Cannot set motion type "
+    LOG(WARNING) << "::setMotionType : Cannot set motion type "
                     "to MotionType::UNDEFINED.  Aborting.";
     return;
   }
@@ -479,7 +479,7 @@ bool BulletRigidObject::contactTest() {
 
 void BulletRigidObject::overrideCollisionGroup(CollisionGroup group) {
   if (!bObjectRigidBody_->isInWorld()) {
-    LOG(ERROR) << "BulletRigidObject::overrideCollisionGroup failed because "
+    LOG(ERROR) << "::overrideCollisionGroup failed because "
                   "the Bullet body hasn't yet been added to the Bullet world.";
   }
 

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -96,7 +96,7 @@ class PhysicsObjectBaseManager
       CORRADE_UNUSED bool builtFromConfig) override {
     // construct a new wrapper based on the passed object
     if (managedObjTypeConstructorMap_.count(objectTypeName) == 0) {
-      LOG(ERROR) << "PhysicsObjectBaseManager::initNewObjectInternal ("
+      LOG(ERROR) << "<" << this->objectType_ << ">::initNewObjectInternal ("
                  << this->objectType_ << ") Unknown constructor type "
                  << objectTypeName << ".  Aborting.";
       return nullptr;

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -96,7 +96,7 @@ bool SemanticScene::loadMp3dHouse(
   std::string header;
   std::getline(ifs, header);
   if (header != "ASCII 1.1") {
-    LOG(ERROR) << "SemanticScene::loadMp3dHouse : Unsupported Mp3d House "
+    LOG(ERROR) << "::loadMp3dHouse : Unsupported Mp3d House "
                   "format header "
                << header << " in file name " << houseFilename;
     return false;

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -152,7 +152,7 @@ class SemanticScene {
   static bool checkFileExists(const std::string& filename,
                               const std::string& srcFunc) {
     if (!Cr::Utility::Directory::exists(filename)) {
-      LOG(ERROR) << "SemanticScene::" << srcFunc << " : File " << filename
+      LOG(ERROR) << "::" << srcFunc << " : File " << filename
                  << " does not exist.  Aborting load.";
       return false;
     }

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -150,7 +150,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     success = createSceneInstanceNoRenderer(config_.activeSceneName);
   }
 
-  LOG(INFO) << "Simulator::reconfigure : createSceneInstance success == "
+  LOG(INFO) << "::reconfigure : createSceneInstance success == "
             << (success ? "true" : "false")
             << " for active scene name : " << config_.activeSceneName
             << (config_.createRenderer ? " with" : " without") << " renderer.";
@@ -177,24 +177,22 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   const std::string& navmeshFileLoc = metadataMediator_->getNavmeshPathByHandle(
       curSceneInstanceAttributes->getNavmeshHandle());
 
-  LOG(INFO)
-      << "Simulator::setSceneInstanceAttributes : Navmesh file location in "
-         "scene instance : "
-      << navmeshFileLoc;
+  LOG(INFO) << "::setSceneInstanceAttributes : Navmesh file location in "
+               "scene instance : "
+            << navmeshFileLoc;
   // Get name of navmesh and use to create pathfinder and load navmesh
   // create pathfinder and load navmesh if available
   pathfinder_ = nav::PathFinder::create();
   if (FileUtil::exists(navmeshFileLoc)) {
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : Loading navmesh from "
+    LOG(INFO) << "::setSceneInstanceAttributes : Loading navmesh from "
               << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : "
+    LOG(INFO) << "::setSceneInstanceAttributes : "
               << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
   } else {
-    LOG(WARNING)
-        << "Simulator::setSceneInstanceAttributes : Navmesh file not found, "
-           "checked at filename : '"
-        << navmeshFileLoc << "'";
+    LOG(WARNING) << "::setSceneInstanceAttributes : Navmesh file not found, "
+                    "checked at filename : '"
+                 << navmeshFileLoc << "'";
   }
   // Calling to seeding needs to be done after the pathfinder creation but
   // before anything else.
@@ -220,11 +218,11 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
     bool fileExists = false;
     bool success = false;
     const std::string msgPrefix =
-        "Simulator::setSceneInstanceAttributes : Attempt to load ";
+        "::setSceneInstanceAttributes : Attempt to load ";
     // semantic scene descriptor might not exist, so
     semanticScene_ = nullptr;
     semanticScene_ = scene::SemanticScene::create();
-    LOG(INFO) << "Simulator::setSceneInstanceAttributes : SceneInstance : "
+    LOG(INFO) << "::setSceneInstanceAttributes : SceneInstance : "
               << activeSceneName
               << " proposed Semantic Scene Descriptor filename : "
               << semanticSceneDescFilename;
@@ -248,11 +246,10 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
                   << (success ? "" : "not ") << "successful";
       }
     }  // if given SSD file name specifiedd exists
-    LOG(WARNING)
-        << "Simulator::setSceneInstanceAttributes : All attempts to load "
-           "SSD with SceneAttributes-provided name "
-        << semanticSceneDescFilename << " : exist : " << fileExists
-        << " : loaded as expected type : " << success;
+    LOG(WARNING) << "::setSceneInstanceAttributes : All attempts to load "
+                    "SSD with SceneAttributes-provided name "
+                 << semanticSceneDescFilename << " : exist : " << fileExists
+                 << " : loaded as expected type : " << success;
 
   }  // if semantic scene descriptor specified in scene instance
 
@@ -291,16 +288,15 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   if (config_.overrideSceneLightDefaults) {
     lightSetupKey = config_.sceneLightSetup;
-    LOG(INFO) << "Simulator::createSceneInstance : Using config-specified "
+    LOG(INFO) << "::createSceneInstance : Using config-specified "
                  "Light key : -"
               << lightSetupKey << "-";
   } else {
     lightSetupKey = metadataMediator_->getLightSetupFullHandle(
         curSceneInstanceAttributes->getLightingHandle());
-    LOG(INFO)
-        << "Simulator::createSceneInstance : Using scene instance-specified "
-           "Light key : -"
-        << lightSetupKey << "-";
+    LOG(INFO) << "::createSceneInstance : Using scene instance-specified "
+                 "Light key : -"
+              << lightSetupKey << "-";
     if (lightSetupKey != NO_LIGHT_KEY) {
       // lighting attributes corresponding to this key should exist unless it
       // is empty; if empty, the following does nothing.
@@ -352,7 +348,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // create a structure to manage active scene and active semantic scene ID
   // passing to and from loadStage
   std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};
-  LOG(INFO) << "Simulator::createSceneInstance : Start to load stage named : "
+  LOG(INFO) << "::createSceneInstance : Start to load stage named : "
             << stageAttributes->getHandle() << " with render asset : "
             << stageAttributes->getRenderAssetHandle()
             << " and collision asset : "
@@ -364,14 +360,13 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       config_.loadSemanticMesh, config_.forceSeparateSemanticSceneGraph);
 
   if (!loadSuccess) {
-    LOG(ERROR) << "Simulator::createSceneInstance : Cannot load stage : "
+    LOG(ERROR) << "::createSceneInstance : Cannot load stage : "
                << stageAttributesHandle;
     // Pass the error to the python through pybind11 allowing graceful exit
-    throw std::invalid_argument(
-        "Simulator::createSceneInstance : Cannot load: " +
-        stageAttributesHandle);
+    throw std::invalid_argument("::createSceneInstance : Cannot load: " +
+                                stageAttributesHandle);
   } else {
-    LOG(INFO) << "Simulator::createSceneInstance : Successfully loaded stage "
+    LOG(INFO) << "::createSceneInstance : Successfully loaded stage "
                  "named : "
               << stageAttributes->getHandle();
   }
@@ -457,8 +452,8 @@ bool Simulator::instanceObjectsForActiveScene() {
        metadata::managers::SceneInstanceTranslationOrigin::AssetLocal);
 
   std::string errMsgTmplt =
-      "Simulator::createSceneInstance : Error instancing scene : " +
-      activeSceneName + " : ";
+      "::createSceneInstance : Error instancing scene : " + activeSceneName +
+      " : ";
   // Iterate through instances, create object and implement initial
   // transformation.
   for (const auto& objInst : objectInstances) {
@@ -688,7 +683,7 @@ bool Simulator::setNavMeshVisualization(bool visualize) {
     navMeshVisPrimID_ = resourceManager_->loadNavMeshVisualization(
         *pathfinder_, navMeshVisNode_, &drawables);
     if (navMeshVisPrimID_ == ID_UNDEFINED) {
-      LOG(ERROR) << "Simulator::toggleNavMeshVisualization : Failed to load "
+      LOG(ERROR) << "::toggleNavMeshVisualization : Failed to load "
                     "navmesh visualization.";
       delete navMeshVisNode_;
     }
@@ -713,7 +708,7 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
   bool success = resourceManager_->buildTrajectoryVisualization(
       trajVisName, pts, numSegments, radius, color, smooth, numInterp);
   if (!success) {
-    LOG(ERROR) << "Simulator::showTrajectoryVisualization : Failed to create "
+    LOG(ERROR) << "::showTrajectoryVisualization : Failed to create "
                   "Trajectory visualization mesh for "
                << trajVisName;
     return ID_UNDEFINED;
@@ -730,7 +725,7 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
   auto trajVisID = physicsManager_->addObject(trajVisName, &drawables);
   if (trajVisID == ID_UNDEFINED) {
     // failed to add object - need to delete asset from resourceManager.
-    LOG(ERROR) << "Simulator::showTrajectoryVisualization : Failed to create "
+    LOG(ERROR) << "::showTrajectoryVisualization : Failed to create "
                   "Trajectory visualization object for "
                << trajVisName;
     // TODO : support removing asset by removing from resourceDict_ properly
@@ -738,7 +733,7 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
     return ID_UNDEFINED;
   }
   auto trajObj = getRigidObjectManager()->getObjectCopyByID(trajVisID);
-  LOG(INFO) << "Simulator::showTrajectoryVisualization : Trajectory "
+  LOG(INFO) << "::showTrajectoryVisualization : Trajectory "
                "visualization object created with ID "
             << trajVisID;
   trajObj->setMotionType(esp::physics::MotionType::KINEMATIC);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -597,7 +597,7 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                                  const nav::NavMeshSettings& navMeshSettings,
                                  bool includeStaticObjects) {
   CORRADE_ASSERT(config_.createRenderer,
-                 "Simulator::recomputeNavMesh: "
+                 "::recomputeNavMesh: "
                  "SimulatorConfiguration::createRenderer is "
                  "false. Scene geometry is required to recompute navmesh. No "
                  "geometry is "

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -966,8 +966,8 @@ class Simulator {
    */
   bool removeTrajVisByName(const std::string& trajVisName) {
     if (trajVisIDByName.count(trajVisName) == 0) {
-      LOG(INFO) << "Simulator::removeTrajVisByName : No trajectory named "
-                << trajVisName << " exists.  Ignoring.";
+      LOG(INFO) << "::removeTrajVisByName : No trajectory named " << trajVisName
+                << " exists.  Ignoring.";
       return false;
     }
     return removeTrajVisObjectAndAssets(trajVisIDByName.at(trajVisName),
@@ -982,9 +982,8 @@ class Simulator {
    */
   bool removeTrajVisByID(int trajVisObjID) {
     if (trajVisNameByID.count(trajVisObjID) == 0) {
-      LOG(INFO)
-          << "Simulator::removeTrajVisByName : No trajectory object with ID: "
-          << trajVisObjID << " exists.  Ignoring.";
+      LOG(INFO) << "::removeTrajVisByName : No trajectory object with ID: "
+                << trajVisObjID << " exists.  Ignoring.";
       return false;
     }
     return removeTrajVisObjectAndAssets(trajVisObjID,

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -99,8 +99,7 @@ class Simulator {
    * --headless mode on linux
    */
   int gpuDevice() const {
-    CORRADE_ASSERT(context_ != nullptr,
-                   "Simulator::gpuDevice: no OpenGL context.", 0);
+    CORRADE_ASSERT(context_ != nullptr, "::gpuDevice: no OpenGL context.", 0);
     return context_->gpuDevice();
   }
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -450,8 +450,7 @@ class AttributesManagersTest : public testing::Test {
  * loading process is working as expected.
  */
 TEST_F(AttributesManagersTest, AttributesManagers_PhysicsJSONLoadTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest";
+  LOG(INFO) << "Starting AttributesManagers_PhysicsJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
   "physics_simulator": "bullet_test",
@@ -494,8 +493,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_PhysicsJSONLoadTest) {
  * loading process is working as expected.
  */
 TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::AttributesManagers_LightJSONLoadTest";
+  LOG(INFO) << "Starting AttributesManagers_LightJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
   "lights":{
@@ -573,9 +571,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
  * JSON loading process is working as expected.
  */
 TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::AttributesManagers_"
-               "SceneInstanceJSONLoadTest";
+  LOG(INFO) << "Starting AttributesManagers_SceneInstanceJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
   "translation_origin" : "Asset_Local",
@@ -710,8 +706,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
  * loading process is working as expected.
  */
 TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::AttributesManagers_StageJSONLoadTest";
+  LOG(INFO) << "Starting AttributesManagers_StageJSONLoadTest";
 
   // build JSON sample config
   const std::string& jsonString = R"({
@@ -779,8 +774,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
  * loading process is working as expected.
  */
 TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest";
+  LOG(INFO) << "Starting AttributesManagers_ObjectJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
   "scale":[2,3,4],
@@ -853,8 +847,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
  * own tests.
  */
 TEST_F(AttributesManagersTest, PhysicsAttributesManagersCreate) {
-  LOG(INFO)
-      << "Starting AttributesManagersTest::PhysicsAttributesManagersCreate";
+  LOG(INFO) << "Starting PhysicsAttributesManagersCreate";
 
   LOG(INFO) << "Start Test : Create, Edit, Remove Attributes for "
                "PhysicsAttributesManager @ "
@@ -942,8 +935,7 @@ TEST_F(AttributesManagersTest, ObjectAttributesManagersCreate) {
 }  // AttributesManagersTest::ObjectAttributesManagersCreate test
 
 TEST_F(AttributesManagersTest, LightLayoutAttributesManagerTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::LightLayoutAttributesManagerTest";
+  LOG(INFO) << "Starting LightLayoutAttributesManagerTest";
 
   std::string lightConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/lights/test_lights.lighting_config.json");
@@ -962,8 +954,7 @@ TEST_F(AttributesManagersTest, LightLayoutAttributesManagerTest) {
  * asset attributes are changed.
  */
 TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
-  LOG(INFO) << "Starting "
-               "AttributesManagersTest::PrimitiveAssetAttributesTest";
+  LOG(INFO) << "Starting PrimitiveAssetAttributesTest";
   /**
    * Primitive asset attributes require slightly different testing since a
    * default set of attributes (matching the default Magnum::Primitive
@@ -980,8 +971,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   //////////////////////////
   // get default template for solid capsule
   {
-    LOG(INFO) << "Starting "
-                 "AttributesManagersTest::CapsulePrimitiveAttributes";
+    LOG(INFO) << "Starting CapsulePrimitiveAttributes";
     CapsulePrimitiveAttributes::ptr dfltCapsAttribs =
         assetAttributesManager_->getDefaultCapsuleTemplate(false);
     // verify it exists
@@ -1002,8 +992,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   //////////////////////////
   // get default template for solid cone
   {
-    LOG(INFO) << "Starting "
-                 "AttributesManagersTest::ConePrimitiveAttributes";
+    LOG(INFO) << "Starting ConePrimitiveAttributes";
 
     ConePrimitiveAttributes::ptr dfltConeAttribs =
         assetAttributesManager_->getDefaultConeTemplate(false);
@@ -1025,8 +1014,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   //////////////////////////
   // get default template for solid cylinder
   {
-    LOG(INFO) << "Starting "
-                 "AttributesManagersTest::CylinderPrimitiveAttributes";
+    LOG(INFO) << "Starting CylinderPrimitiveAttributes";
 
     CylinderPrimitiveAttributes::ptr dfltCylAttribs =
         assetAttributesManager_->getDefaultCylinderTemplate(false);
@@ -1048,8 +1036,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   //////////////////////////
   // get default template for solid UV Sphere
   {
-    LOG(INFO) << "Starting "
-                 "AttributesManagersTest::UVSpherePrimitiveAttributes";
+    LOG(INFO) << "Starting UVSpherePrimitiveAttributes";
 
     UVSpherePrimitiveAttributes::ptr dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(false);

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -65,8 +65,7 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   // setup dataset 0 for test
   initDataset0();
 
-  LOG(INFO) << "Starting "
-               "MetadataMediatorTest::testDataset0 : test LoadStages";
+  LOG(INFO) << "Starting testDataset0 : test LoadStages";
   const auto& stageAttributesMgr = MM_->getStageAttributesManager();
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // should be 7 - one for default NONE stage, one original JSON, one based on
@@ -402,8 +401,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // primarily testing glob file wildcard loading
   initDataset1();
 
-  LOG(INFO) << "Starting "
-               "MetadataMediatorTest::testDataset1 : test LoadStages";
+  LOG(INFO) << "Starting testDataset1 : test LoadStages";
   const auto& stageAttributesMgr = MM_->getStageAttributesManager();
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // shoudld be 6 : one for default NONE stage, glob lookup yields 2 stages + 2

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -904,7 +904,7 @@ int Viewer::addPrimitiveObject() {
 
 void Viewer::buildTrajectoryVis() {
   if (agentLocs_.size() < 2) {
-    LOG(WARNING) << "Viewer::buildTrajectoryVis : No recorded trajectory "
+    LOG(WARNING) << "::buildTrajectoryVis : No recorded trajectory "
                     "points, so nothing to build. Aborting.";
     return;
   }
@@ -916,16 +916,16 @@ void Viewer::buildTrajectoryVis() {
           << agentLocs_.size() << "_pts";
   std::string trajObjName(tmpName.str());
 
-  LOG(INFO) << "Viewer::buildTrajectoryVis : Attempting to build trajectory "
+  LOG(INFO) << "::buildTrajectoryVis : Attempting to build trajectory "
                "tube for :"
             << agentLocs_.size() << " points.";
   int trajObjID = simulator_->addTrajectoryObject(
       trajObjName, agentLocs_, 6, agentTrajRad_, color, true, 10);
   if (trajObjID != esp::ID_UNDEFINED) {
-    LOG(INFO) << "Viewer::buildTrajectoryVis : Success!  Traj Obj Name : "
+    LOG(INFO) << "::buildTrajectoryVis : Success!  Traj Obj Name : "
               << trajObjName << " has object ID : " << trajObjID;
   } else {
-    LOG(WARNING) << "Viewer::buildTrajectoryVis : Attempt to build trajectory "
+    LOG(WARNING) << "::buildTrajectoryVis : Attempt to build trajectory "
                     "visualization "
                  << trajObjName << " failed; Returned ID_UNDEFINED.";
   }


### PR DESCRIPTION
## Motivation and Context
This small refactor PR removes redundant information (the class name) from informational/warning/error messages.  This information is already present in the prefix tag of the message, and removing this from these messages cuts back substantially on the runtime console clutter.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All current c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
