### PR TITLE
[Bugfix]Shader type config value "material" option

### DIFF
--- a/src/esp/metadata/MetadataUtils.cpp
+++ b/src/esp/metadata/MetadataUtils.cpp
@@ -31,12 +31,12 @@ int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc) {
         attributes::AbstractObjectAttributes::ShaderTypeNamesMap.end()) {
       shader_type = static_cast<int>(found->second);
     } else {
-      LOG(WARNING) << "getShaderTypeFromJsonDoc : "
-                      "motion_type value in json  : `"
-                   << tmpShaderType << "|" << strToLookFor
-                   << "` does not map to a valid "
-                      "SceneInstanceTranslationOrigin value, so defaulting "
-                      "motion type to SceneInstanceTranslationOrigin::Unknown.";
+      LOG(WARNING)
+          << "getShaderTypeFromJsonDoc : `shader_type` value in json  : `"
+          << tmpShaderType << "` -> `" << strToLookFor
+          << "` does not map to a valid "
+             "ObjectInstanceShaderType value, so defaulting "
+             "shader type to ObjectInstanceShaderType::Unknown.";
     }
   }
   return shader_type;

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -63,7 +63,8 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);
-  // default to unknown for objects
+  // default to unknown for objects - will use material-derived shader unless
+  // otherwise specified in config
   setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
   // TODO remove this once ShaderType support is complete
   setRequiresLighting(true);
@@ -75,8 +76,9 @@ StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
-  // default to unknown for stages
-  setShaderType(static_cast<int>(ObjectInstanceShaderType::Flat));
+  // default to unknown for stages - will use material-derived shader unless
+  // otherwise specified in config
+  setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
   // TODO remove this once ShaderType support is complete
   setRequiresLighting(false);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -20,6 +20,7 @@ const std::map<std::string, esp::assets::AssetType>
 // All keys must be lowercase
 const std::map<std::string, ObjectInstanceShaderType>
     AbstractObjectAttributes::ShaderTypeNamesMap = {
+        {"material", ObjectInstanceShaderType::Material},
         {"flat", ObjectInstanceShaderType::Flat},
         {"phong", ObjectInstanceShaderType::Phong},
         {"pbr", ObjectInstanceShaderType::PBR},

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -22,20 +22,25 @@ enum class ObjectInstanceShaderType {
    * Represents an unknown/unspecified value for the shader type to use. Resort
    * to defaults for object type.
    */
-  Unknown = -1,
+  Unknown = ID_UNDEFINED,
+  /**
+   * Override any config-specified or default shader-type values to use the
+   * material-specified shader.
+   */
+  Material,
   /**
    * Refers to flat shading, pure color and no lighting.  This is often used for
    * textured objects
    */
-  Flat = 0,
+  Flat,
   /**
    * Refers to phong shading with pure diffuse color.
    */
-  Phong = 1,
+  Phong,
   /**
    * Refers to using a shader built with physically-based rendering models.
    */
-  PBR = 2,
+  PBR,
 };
 
 /**

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -18,8 +18,8 @@ const std::map<std::string, esp::physics::MotionType>
 SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     const std::string& handle)
     : AbstractAttributes("SceneObjectInstanceAttributes", handle) {
-  // default to unknown for object instances, to use attributes-specified
-  // defaults
+  // default to unknown for stage and object instances, to use
+  // attributes-specified defaults
   setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
 
   // defaults to unknown/undefined

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -329,15 +329,15 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       metadataMediator_->getStageAttributesManager()->getObjectCopyByHandle(
           stageAttributesHandle);
 
-  // constant representing unknown shader type
-  const int unknownShaderType =
-      static_cast<int>(metadata::attributes::ObjectInstanceShaderType::Unknown);
-
   // set defaults for stage creation
 
-  // set shader type to use for stage
+  // set shader type to use for stage - if no valid value is specified in
+  // instance attributes, this field will be whatever was specified in the stage
+  // attributes.
   int stageShaderType = stageInstanceAttributes->getShaderType();
-  if (stageShaderType != unknownShaderType) {
+  if (stageShaderType !=
+      static_cast<int>(
+          metadata::attributes::ObjectInstanceShaderType::Unknown)) {
     stageAttributes->setShaderType(stageShaderType);
   }
   // set lighting key

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -579,6 +579,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
       "template_name": "test_stage_template",
       "translation": [1,2,3],
       "rotation": [0.1, 0.2, 0.3, 0.4],
+      "shader_type" : "pbr",
       "user_defined" : {
           "user_string" : "stage instance defined string",
           "user_bool" : true,
@@ -665,6 +666,9 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
                             "stage instance defined string", true, 11, 2.2f,
                             Magnum::Vector3(1.2, 3.4, 5.6),
                             Magnum::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f));
+  // make sure that is not default value "flat"
+  ASSERT_EQ(stageInstance->getShaderType(),
+            static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
 
   // verify objects
   auto objectInstanceList = sceneAttr->getObjectInstances();
@@ -726,6 +730,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
   "semantic_asset":"testJSONSemanticAsset.glb",
   "nav_asset":"testJSONNavMeshAsset.glb",
   "house_filename":"testJSONHouseFileName.glb",
+  "shader_type" : "material",
   "user_defined" : {
       "user_string" : "stage defined string",
       "user_bool" : false,
@@ -757,6 +762,9 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
   ASSERT_EQ(stageAttr->getIsCollidable(), false);
   // stage-specific attributes
   ASSERT_EQ(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
+  // make sure that is not default value "flat"
+  ASSERT_EQ(stageAttr->getShaderType(),
+            static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
   ASSERT_EQ(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
   ASSERT_EQ(stageAttr->getSemanticAssetHandle(), "testJSONSemanticAsset.glb");
   ASSERT_EQ(stageAttr->getNavmeshAssetHandle(), "testJSONNavMeshAsset.glb");
@@ -794,6 +802,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
   "inertia": [1.1, 0.9, 0.3],
   "semantic_id" : 7,
   "COM": [0.1,0.2,0.3],
+  "shader_type" : "phong",
   "user_defined" : {
       "user_string" : "object defined string",
       "user_bool" : true,
@@ -825,6 +834,8 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
   ASSERT_EQ(objAttr->getSemanticId(), 7);
   // object-specific attributes
   ASSERT_EQ(objAttr->getMass(), 9);
+  ASSERT_EQ(objAttr->getShaderType(),
+            static_cast<int>(Attrs::ObjectInstanceShaderType::Phong));
   ASSERT_EQ(objAttr->getBoundingBoxCollisions(), true);
   ASSERT_EQ(objAttr->getJoinCollisionMeshes(), true);
   ASSERT_EQ(objAttr->getInertia(), Magnum::Vector3(1.1, 0.9, 0.3));


### PR DESCRIPTION
## Motivation and Context
This small PR introduces an accepted value of "material" for the "shader_type" field within the various configuration files describing objects and stages.  This value will override any previously set shader_type values for the particular asset to instead use whatever shader_type is specified by the materials within in asset's file.  This is necessary because there is a hierarchy of configuration specification in place, and without this option, the user would be unable to override any shader type specification set at a lower level configuration.  

For instance, a user may specify that the desired shader_type for all bananas (in their copy of banana.object_config.json) should be Flat.  However, within a certain scene, they may wish for a particular instance of banana to be rendered using the shader suggested by its own materials.  They can use the `"shader_type" : "material"` specification within the object instance describing the desired banana's instantiation in the scene instance config describing the scene in question, and this will override the default flat shader choice, but only for that one banana.

This is a bugfix because without this additional choice, undoing a config-specified shader type in the above manner (for a single instance, for example) would be impossible.

EDIT : This PR also reverts the change from [this PR](https://github.com/facebookresearch/habitat-sim/pull/1307) that specified that shader_type default for stages be flat. This PR changes this so that the default is Unknown, which means the stage material dictates its shader type.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.  Simple tests were added to verify specification works correctly for both template config level and scene object instance config level
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
