### PR TITLE
Create Appropriate PrimitiveAssetAttributes from valid handle

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -925,9 +925,29 @@ void ResourceManager::translateMesh(BaseMesh* meshDataGL,
 void ResourceManager::buildPrimitiveAssetData(
     const std::string& primTemplateHandle) {
   // retrieves -actual- template, not a copy
-  const esp::metadata::attributes::AbstractPrimitiveAttributes::ptr
-      primTemplate =
-          getAssetAttributesManager()->getObjectByHandle(primTemplateHandle);
+  esp::metadata::attributes::AbstractPrimitiveAttributes::ptr primTemplate =
+      getAssetAttributesManager()->getObjectByHandle(primTemplateHandle);
+
+  if (primTemplate == nullptr) {
+    // Template does not yet exist, create it using its name - primitive
+    // template names encode all the pertinent template settings and cannot be
+    // changed by the user, so the template name can be used to recreate the
+    // template itself.
+    auto newTemplate = getAssetAttributesManager()->createTemplateFromHandle(
+        primTemplateHandle);
+    // if still null, fail.
+    if (newTemplate == nullptr) {
+      LOG(ERROR)
+          << "::buildPrimitiveAssetData : Attempting to reference or build a "
+             "primitive template from an unknown/malformed handle : "
+          << primTemplateHandle << ".  Aborting";
+      return;
+    }
+    // we do not want a copy of the newly created template, but the actual
+    // template
+    primTemplate = getAssetAttributesManager()->getObjectByHandle(
+        newTemplate->getHandle());
+  }
   // check if unique name of attributes describing primitive asset is present
   // already - don't remake if so
   auto primAssetHandle = primTemplate->getHandle();

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.cpp
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.cpp
@@ -27,7 +27,26 @@ CapsulePrimitiveAttributes::CapsulePrimitiveAttributes(
     setHalfLength(1.0);
   }
   buildHandle();  // build handle based on config
-}  // PhysicsCapsulePrimAttributes
+}  // CapsulePrimitiveAttributes
+
+bool CapsulePrimitiveAttributes::parseStringIntoConfigDetail(
+    const std::string& configString) {
+  bool hemiRingSet =
+      setIntFromConfigKey("_hemiRings_", configString,
+                          [this](int val) { setHemisphereRings(val); });
+  bool cylRingSet = setIntFromConfigKey(
+      "_cylRings_", configString, [this](int val) { setCylinderRings(val); });
+  bool segmentSet = setIntFromConfigKey(
+      "_segments_", configString, [this](int val) { setNumSegments(val); });
+  auto halflenSet = setDoubleFromConfigKey(
+      "_halfLen_", configString, [this](double val) { setHalfLength(val); });
+
+  if (!getIsWireframe()) {
+    setUseTextureCoords(getBoolForConfigKey("_useTexCoords_", configString));
+    setUseTangents(getBoolForConfigKey("_useTangents_", configString));
+  }
+  return hemiRingSet && cylRingSet && segmentSet && halflenSet;
+}  // CapsulePrimitiveAttributes::parseStringIntoConfigDetail(
 
 ConePrimitiveAttributes::ConePrimitiveAttributes(
     bool isWireframe,
@@ -47,7 +66,24 @@ ConePrimitiveAttributes::ConePrimitiveAttributes(
     setNumSegments(32);
   }
   buildHandle();  // build handle based on config
-}  // PhysicsConePrimAttributes
+}  // ConePrimitiveAttributes
+
+bool ConePrimitiveAttributes::parseStringIntoConfigDetail(
+    const std::string& configString) {
+  bool segmentSet = setIntFromConfigKey(
+      "_segments_", configString, [this](int val) { setNumSegments(val); });
+  auto halflenSet = setDoubleFromConfigKey(
+      "_halfLen_", configString, [this](double val) { setHalfLength(val); });
+  if (!getIsWireframe()) {
+    bool ringSet = setIntFromConfigKey("_rings_", configString,
+                                       [this](int val) { setNumRings(val); });
+    setUseTextureCoords(getBoolForConfigKey("_useTexCoords_", configString));
+    setUseTangents(getBoolForConfigKey("_useTangents_", configString));
+    setCapEnd(getBoolForConfigKey("_capEnd_", configString));
+  }
+  return segmentSet && halflenSet;
+
+}  // ConePrimitiveAttributes::parseStringIntoConfigDetail(
 
 CylinderPrimitiveAttributes::CylinderPrimitiveAttributes(
     bool isWireframe,
@@ -67,7 +103,24 @@ CylinderPrimitiveAttributes::CylinderPrimitiveAttributes(
     setNumSegments(32);
   }
   buildHandle();  // build handle based on config
-}  // PhysicsCylinderPrimAttributes
+}  // CylinderPrimitiveAttributes
+
+bool CylinderPrimitiveAttributes::parseStringIntoConfigDetail(
+    const std::string& configString) {
+  bool ringSet = setIntFromConfigKey("_rings_", configString,
+                                     [this](int val) { setNumRings(val); });
+  bool segmentSet = setIntFromConfigKey(
+      "_segments_", configString, [this](int val) { setNumSegments(val); });
+  auto halflenSet = setDoubleFromConfigKey(
+      "_halfLen_", configString, [this](double val) { setHalfLength(val); });
+
+  if (!getIsWireframe()) {
+    setUseTextureCoords(getBoolForConfigKey("_useTexCoords_", configString));
+    setUseTangents(getBoolForConfigKey("_useTangents_", configString));
+    setCapEnds(getBoolForConfigKey("_capEnds_", configString));
+  }
+  return ringSet && halflenSet && segmentSet;
+}  // CylinderPrimitiveAttributes::parseStringIntoConfigDetail(
 
 UVSpherePrimitiveAttributes::UVSpherePrimitiveAttributes(
     bool isWireframe,
@@ -85,7 +138,22 @@ UVSpherePrimitiveAttributes::UVSpherePrimitiveAttributes(
     setNumSegments(32);
   }
   buildHandle();  // build handle based on config
-}  // PhysicsUVSpherePrimAttributes
+}  // UVSpherePrimitiveAttributes
+
+bool UVSpherePrimitiveAttributes::parseStringIntoConfigDetail(
+    const std::string& configString) {
+  std::ostringstream oHndlStrm;
+
+  bool ringSet = setIntFromConfigKey("_rings_", configString,
+                                     [this](int val) { setNumRings(val); });
+  bool segmentSet = setIntFromConfigKey(
+      "_segments_", configString, [this](int val) { setNumSegments(val); });
+  if (!getIsWireframe()) {
+    setUseTextureCoords(getBoolForConfigKey("_useTexCoords_", configString));
+    setUseTangents(getBoolForConfigKey("_useTangents_", configString));
+  }
+  return ringSet && segmentSet;
+}  // UVSpherePrimitiveAttributes::parseStringIntoConfigDetail(
 
 }  // namespace attributes
 }  // namespace metadata

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.cpp
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.cpp
@@ -74,14 +74,15 @@ bool ConePrimitiveAttributes::parseStringIntoConfigDetail(
       "_segments_", configString, [this](int val) { setNumSegments(val); });
   auto halflenSet = setDoubleFromConfigKey(
       "_halfLen_", configString, [this](double val) { setHalfLength(val); });
+  bool ringSet = true;
   if (!getIsWireframe()) {
-    bool ringSet = setIntFromConfigKey("_rings_", configString,
-                                       [this](int val) { setNumRings(val); });
+    ringSet = setIntFromConfigKey("_rings_", configString,
+                                  [this](int val) { setNumRings(val); });
     setUseTextureCoords(getBoolForConfigKey("_useTexCoords_", configString));
     setUseTangents(getBoolForConfigKey("_useTangents_", configString));
     setCapEnd(getBoolForConfigKey("_capEnd_", configString));
   }
-  return segmentSet && halflenSet;
+  return segmentSet && halflenSet && ringSet;
 
 }  // ConePrimitiveAttributes::parseStringIntoConfigDetail(
 

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -152,23 +152,23 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   std::string getValueForConfigKey(const std::string& key,
                                    const std::string& configStr) {
     std::size_t keyLoc = configStr.find(key);
-    if (keyLoc == configStr.npos) {
+    if (keyLoc == std::string::npos) {
       LOG(WARNING) << "Key " << key << " not found in configStr " << configStr
                    << ". Aborting.";
       return "";
     }
     std::size_t keyLen = key.length(), keyEnd = keyLoc + keyLen;
-    return configStr.substr(keyEnd, configStr.find("_", keyEnd) - keyEnd);
+    return configStr.substr(keyEnd, configStr.find('_', keyEnd) - keyEnd);
   }
   bool getBoolForConfigKey(const std::string& key,
                            const std::string& configStr) {
     std::string res = getValueForConfigKey(key, configStr);
-    return (res.find("true") != res.npos);
+    return (res.find("true") != std::string::npos);
   }
 
   bool setIntFromConfigKey(const std::string& key,
                            const std::string& configStr,
-                           std::function<void(int)> setter) {
+                           const std::function<void(int)>& setter) {
     const std::string conv = getValueForConfigKey(key, configStr);
     try {
       setter(stoi(conv));
@@ -183,7 +183,7 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
 
   bool setDoubleFromConfigKey(const std::string& key,
                               const std::string& configStr,
-                              std::function<void(double)> setter) {
+                              const std::function<void(double)>& setter) {
     const std::string conv = getValueForConfigKey(key, configStr);
     try {
       setter(stod(conv));

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -113,6 +113,23 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
     setString("handle", oHndlStrm.str());
   }
 
+  /**
+   * @brief This will parse the passed candidate object template handle, treated
+   * as a configuration string, and populate the appropriate values.
+   * @param configString The configuration string to parse.
+   * @return Whether the parsing has succeeded or not (might fail with
+   * inappropriate formatting for object type.)
+   */
+  bool parseStringIntoConfig(const std::string& configString) {
+    bool success = parseStringIntoConfigDetail(configString);
+    if (success) {
+      // if parsed successfully, make sure the object's handle contains the
+      // original config string
+      return (this->getHandle().find(configString) != std::string::npos);
+    }
+    return success;
+  }
+
  protected:
   /**
    * @brief Verifies that val is larger than, and a multiple of, divisor
@@ -130,7 +147,58 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   std::string getBoolDispStr(bool val) const {
     return (val ? "true" : "false");
   }
+
+  // helper for parseStringIntoConfig process
+  std::string getValueForConfigKey(const std::string& key,
+                                   const std::string& configStr) {
+    std::size_t keyLoc = configStr.find(key);
+    if (keyLoc == configStr.npos) {
+      LOG(WARNING) << "Key " << key << " not found in configStr " << configStr
+                   << ". Aborting.";
+      return "";
+    }
+    std::size_t keyLen = key.length(), keyEnd = keyLoc + keyLen;
+    return configStr.substr(keyEnd, configStr.find("_", keyEnd) - keyEnd);
+  }
+  bool getBoolForConfigKey(const std::string& key,
+                           const std::string& configStr) {
+    std::string res = getValueForConfigKey(key, configStr);
+    return (res.find("true") != res.npos);
+  }
+
+  bool setIntFromConfigKey(const std::string& key,
+                           const std::string& configStr,
+                           std::function<void(int)> setter) {
+    const std::string conv = getValueForConfigKey(key, configStr);
+    try {
+      setter(stoi(conv));
+      return true;
+    } catch (...) {
+      LOG(WARNING) << "Failed due to -" << conv << "- value for key -" << key
+                   << "- in format string -" << configStr
+                   << "- not being recognized as an int.";
+      return false;
+    }
+  }
+
+  bool setDoubleFromConfigKey(const std::string& key,
+                              const std::string& configStr,
+                              std::function<void(double)> setter) {
+    const std::string conv = getValueForConfigKey(key, configStr);
+    try {
+      setter(stod(conv));
+      return true;
+    } catch (...) {
+      LOG(WARNING) << "Failed due to -" << conv << "- value for key -" << key
+                   << "- in format string -" << configStr
+                   << "- not being recognized as a double.";
+      return false;
+    }
+  }
+
   virtual std::string buildHandleDetail() = 0;
+
+  virtual bool parseStringIntoConfigDetail(const std::string& configString) = 0;
 
  private:
   // Should never change, only set by ctor
@@ -171,8 +239,8 @@ class CapsulePrimitiveAttributes : public AbstractPrimitiveAttributes {
   /**
    * @brief This will determine if the stated template has the required
    * quantities needed to instantiate a primitive properly of desired type
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override {
     bool wfCheck =
@@ -196,6 +264,8 @@ class CapsulePrimitiveAttributes : public AbstractPrimitiveAttributes {
     return oHndlStrm.str();
   }  // buildHandleDetail
 
+  bool parseStringIntoConfigDetail(const std::string& configString) override;
+
  public:
   ESP_SMART_POINTERS(CapsulePrimitiveAttributes)
 };  // class CapsulePrimitiveAttributes
@@ -216,8 +286,8 @@ class ConePrimitiveAttributes : public AbstractPrimitiveAttributes {
   /**
    * @brief This will determine if the stated template has the required
    * quantities needed to instantiate a primitive properly of desired type
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override {
     bool wfCheck =
@@ -241,6 +311,8 @@ class ConePrimitiveAttributes : public AbstractPrimitiveAttributes {
     return oHndlStrm.str();
   }  // buildHandleDetail
 
+  bool parseStringIntoConfigDetail(const std::string& configString) override;
+
  public:
   ESP_SMART_POINTERS(ConePrimitiveAttributes)
 };  // class ConePrimitiveAttributes
@@ -259,15 +331,20 @@ class CubePrimitiveAttributes : public AbstractPrimitiveAttributes {
 
   /**
    * @brief This will determine if the stated template has the required
-   * quantities needed to instantiate a primitive properly of desired type. Cube
-   * primitives require no values and so this attributes is always valid.
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * quantities needed to instantiate a primitive properly of desired type.
+   * Cube primitives require no values and so this attributes is always valid.
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override { return true; }
 
  protected:
   std::string buildHandleDetail() override { return ""; }
+
+  bool parseStringIntoConfigDetail(
+      CORRADE_UNUSED const std::string& configString) override {
+    return true;
+  }
 
  public:
   ESP_SMART_POINTERS(CubePrimitiveAttributes)
@@ -289,8 +366,8 @@ class CylinderPrimitiveAttributes : public AbstractPrimitiveAttributes {
   /**
    * @brief This will determine if the stated template has the required
    * quantities needed to instantiate a primitive properly of desired type
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override {
     bool wfCheck =
@@ -311,6 +388,8 @@ class CylinderPrimitiveAttributes : public AbstractPrimitiveAttributes {
     }
     return oHndlStrm.str();
   }  // buildHandleDetail
+
+  bool parseStringIntoConfigDetail(const std::string& configString) override;
 
  public:
   ESP_SMART_POINTERS(CylinderPrimitiveAttributes)
@@ -343,8 +422,8 @@ class IcospherePrimitiveAttributes : public AbstractPrimitiveAttributes {
   /**
    * @brief This will determine if the stated template has the required
    * quantities needed to instantiate a primitive properly of desired type
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override {
     return (getIsWireframe() || (!getIsWireframe() && getSubdivisions() >= 0));
@@ -359,6 +438,13 @@ class IcospherePrimitiveAttributes : public AbstractPrimitiveAttributes {
     return oHndlStrm.str();
   }  // buildHandleDetail
 
+  bool parseStringIntoConfigDetail(const std::string& configString) override {
+    bool subDivsSet = setIntFromConfigKey(
+        "_subdivs_", configString, [this](int val) { setSubdivisions(val); });
+
+    return subDivsSet;
+  }
+
  public:
   ESP_SMART_POINTERS(IcospherePrimitiveAttributes)
 };  // class IcospherePrimitiveAttributes
@@ -372,8 +458,8 @@ class UVSpherePrimitiveAttributes : public AbstractPrimitiveAttributes {
   /**
    * @brief This will determine if the stated template has the required
    * quantities needed to instantiate a primitive properly of desired type
-   * @return whether or not the template holds valid data for desired primitive
-   * type
+   * @return whether or not the template holds valid data for desired
+   * primitive type
    */
   bool isValidTemplate() override {
     return ((getIsWireframe() &&
@@ -392,6 +478,8 @@ class UVSpherePrimitiveAttributes : public AbstractPrimitiveAttributes {
     }
     return oHndlStrm.str();
   }  // buildHandleDetail
+
+  bool parseStringIntoConfigDetail(const std::string& configString) override;
 
  public:
   ESP_SMART_POINTERS(UVSpherePrimitiveAttributes)

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -129,8 +129,8 @@ AssetAttributesManager::createTemplateFromHandle(
     const std::string& templateHandle,
     bool registerTemplate) {
   // first determine what base type the attributes is - find first underscore.
-  std::size_t nameEndLoc = templateHandle.find("_");
-  if (nameEndLoc == templateHandle.npos) {
+  std::size_t nameEndLoc = templateHandle.find('_');
+  if (nameEndLoc == std::string::npos) {
     // handle is of incorrect format
     LOG(ERROR) << "::createTemplateFromHandle : Given template handle : "
                << templateHandle
@@ -161,7 +161,7 @@ AssetAttributesManager::createTemplateFromHandle(
                    << primAssetAttributes->getHandle() << ".";
     }
   }
-  return this->postCreateRegister(primAssetAttributes, true);
+  return this->postCreateRegister(primAssetAttributes, registerTemplate);
 }  // AssetAttributesManager::createTemplateFromHandle
 
 int AssetAttributesManager::registerObjectFinalize(

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -124,6 +124,46 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
   return this->postCreateRegister(primAssetAttributes, registerTemplate);
 }  // AssetAttributesManager::createObject
 
+attributes::AbstractPrimitiveAttributes::ptr
+AssetAttributesManager::createTemplateFromHandle(
+    const std::string& templateHandle,
+    bool registerTemplate) {
+  // first determine what base type the attributes is - find first underscore.
+  std::size_t nameEndLoc = templateHandle.find("_");
+  if (nameEndLoc == templateHandle.npos) {
+    // handle is of incorrect format
+    LOG(ERROR) << "::createTemplateFromHandle : Given template handle : "
+               << templateHandle
+               << " is not the correct format for a primitive.  Aborting.";
+    return nullptr;
+  }
+  std::string primClassName = templateHandle.substr(0, nameEndLoc);
+  if (primTypeConstructorMap_.count(primClassName) == 0) {
+    // handle does not have proper primitive tyep encoded
+    LOG(ERROR) << "::createTemplateFromHandle : Requested primitive type : "
+               << primClassName
+               << " from given template handle : " << templateHandle
+               << " is not a valid Magnum::Primitives class.  Aborting.";
+    return nullptr;
+  }
+  // create but do not register template for this prim class, since it will be
+  // modified based on config string
+  auto primAssetAttributes = this->createObject(primClassName, false);
+  // certain prims such as cubes do not have config settings
+  if (templateHandle.length() > 0) {
+    bool success = primAssetAttributes->parseStringIntoConfig(templateHandle);
+    if (!success) {
+      LOG(WARNING) << "::createTemplateFromHandle : Prim Asset Attributes : "
+                   << primClassName << " failed parsing config string : `"
+                   << templateHandle << "`.  Providing " << primClassName
+                   << " template configured as closely as possible with "
+                      "requested values, named "
+                   << primAssetAttributes->getHandle() << ".";
+    }
+  }
+  return this->postCreateRegister(primAssetAttributes, true);
+}  // AssetAttributesManager::createTemplateFromHandle
+
 int AssetAttributesManager::registerObjectFinalize(
     AbstractPrimitiveAttributes::ptr primAttributesTemplate,
     const std::string&,
@@ -158,8 +198,8 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
 
   std::string primClassName =
       Cr::Utility::String::partition(primAttrHandle, '_')[0];
-  // if not legal primitive asset attributes file name, have message and return
-  // default sphere attributes.
+  // if not legal primitive asset attributes file name, have message and
+  // return default sphere attributes.
   if (defaultPrimAttributeHandles_.count(primClassName) == 0) {
     LOG(ERROR) << "::buildObjectFromJSONDoc :Unknown "
                   "primitive class type : "

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -135,6 +135,23 @@ class AssetAttributesManager
                           const io::JsonGenericValue& jsonConfig) override;
 
   /**
+   * @brief Creates a template based on the provided template handle. Since the
+   * primitive asset attributes templates encode their structure in their
+   * handles, and these handles are not user editable, a properly configured
+   * handle can be used to build a template.
+   * @param templateHandle The template handle to use to create the attributes.
+   * @param registerTemplate whether to add this template to the library.
+   * If the user is going to edit this template, this should be false - any
+   * subsequent editing will require re-registration. Defaults to true. If
+   * specified as true, then this function returns a copy of the registered
+   * template.
+   * @return The attributes that most closely matches the given handle.
+   */
+  attributes::AbstractPrimitiveAttributes::ptr createTemplateFromHandle(
+      const std::string& templateHandle,
+      bool registerTemplate = true);
+
+  /**
    * @brief Should only be called internally. Creates an instance of a
    * primtive asset attributes template described by passed enum value. For
    * primitive assets this mapes to the Magnum primitive class name
@@ -473,8 +490,7 @@ class AssetAttributesManager
       const std::string& primClassName,
       CORRADE_UNUSED bool builtFromConfig) override {
     if (primTypeConstructorMap_.count(primClassName) == 0) {
-      LOG(ERROR) << "::buildPrimAttributes : No "
-                    "primitive class"
+      LOG(ERROR) << "::initNewObjectInternal : No primitive class"
                  << primClassName << "exists in Magnum::Primitives. Aborting.";
       return nullptr;
     }
@@ -491,10 +507,9 @@ class AssetAttributesManager
   template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
   attributes::AbstractPrimitiveAttributes::ptr createPrimAttributes() {
     if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      LOG(ERROR)
-          << "AssetAttributeManager::createPrimAttributes : Cannot instantiate "
-             "attributes::AbstractPrimitiveAttributes object for "
-             "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
+      LOG(ERROR) << "::createPrimAttributes : Cannot instantiate "
+                    "attributes::AbstractPrimitiveAttributes object for "
+                    "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return nullptr;
     }
     int idx = static_cast<int>(primitiveType);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -436,6 +436,35 @@ class AttributesManagersTest : public testing::Test {
 
   }  // AttributesManagersTest::testAssetAttributesModRegRemove
 
+  void testAssetAttributesTemplateCreateFromHandle(
+      const std::string& newTemplateName) {
+    // get starting number of templates
+    int orignNumTemplates = assetAttributesManager_->getNumObjects();
+    // first verify that no template with given name exists
+    bool templateExists =
+        assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
+    ASSERT_EQ(templateExists, false);
+    // create new template based on handle and verify that it is created
+    auto newTemplate = assetAttributesManager_->createTemplateFromHandle(
+        newTemplateName, true);
+    ASSERT_NE(newTemplate, nullptr);
+
+    // now verify that template is in library
+    templateExists =
+        assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
+    ASSERT_EQ(templateExists, true);
+
+    // remove new template via handle
+    auto oldTemplate =
+        assetAttributesManager_->removeObjectByHandle(newTemplateName);
+    // verify deleted template  exists
+    ASSERT_NE(nullptr, oldTemplate);
+
+    // verify there are same number of templates as when we started
+    ASSERT_EQ(orignNumTemplates, assetAttributesManager_->getNumObjects());
+
+  }  // AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle
+
   AttrMgrs::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
   AttrMgrs::LightLayoutAttributesManager::ptr lightLayoutAttributesManager_ =
       nullptr;
@@ -979,6 +1008,29 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   int legalModValSolid = 5;
   int illegalModValSolid = 0;
 
+  const std::string capsule3DSolidHandle =
+      "capsule3DSolid_hemiRings_5_cylRings_2_segments_16_halfLen_1.75_"
+      "useTexCoords_true_useTangents_true";
+  const std::string capsule3DWireframeHandle =
+      "capsule3DWireframe_hemiRings_8_cylRings_2_segments_20_halfLen_1.5";
+
+  const std::string coneSolidHandle =
+      "coneSolid_segments_12_halfLen_1.35_rings_1_useTexCoords_true_"
+      "useTangents_true_capEnd_true";
+  const std::string coneWireframeHandle =
+      "coneWireframe_segments_32_halfLen_1.44";
+
+  const std::string cylinderSolidHandle =
+      "cylinderSolid_rings_1_segments_28_halfLen_1.11_useTexCoords_true_"
+      "useTangents_true_capEnds_true";
+  const std::string cylinderWireframeHandle =
+      "cylinderWireframe_rings_1_segments_32_halfLen_1.23";
+
+  const std::string uvSphereSolidHandle =
+      "uvSphereSolid_rings_16_segments_8_useTexCoords_true_useTangents_true";
+  const std::string uvSphereWireframeHandle =
+      "uvSphereWireframe_rings_20_segments_24";
+
   //////////////////////////
   // get default template for solid capsule
   {
@@ -992,6 +1044,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
         dfltCapsAttribs, "segments", legalModValSolid, &illegalModValSolid);
 
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(capsule3DSolidHandle);
+
     // test wireframe version
     dfltCapsAttribs = assetAttributesManager_->getDefaultCapsuleTemplate(true);
     // verify it exists
@@ -999,6 +1054,8 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
         dfltCapsAttribs, "segments", legalModValWF, &illegalModValWF);
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(capsule3DWireframeHandle);
   }
   //////////////////////////
   // get default template for solid cone
@@ -1014,6 +1071,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
         dfltConeAttribs, "segments", legalModValSolid, &illegalModValSolid);
 
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(coneSolidHandle);
+
     // test wireframe version
     dfltConeAttribs = assetAttributesManager_->getDefaultConeTemplate(true);
     // verify it exists
@@ -1021,6 +1081,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
         dfltConeAttribs, "segments", legalModValWF, &illegalModValWF);
+
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(coneWireframeHandle);
   }
   //////////////////////////
   // get default template for solid cylinder
@@ -1036,6 +1099,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
         dfltCylAttribs, "segments", 5, &illegalModValSolid);
 
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(cylinderSolidHandle);
+
     // test wireframe version
     dfltCylAttribs = assetAttributesManager_->getDefaultCylinderTemplate(true);
     // verify it exists
@@ -1043,6 +1109,8 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
         dfltCylAttribs, "segments", legalModValWF, &illegalModValWF);
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(cylinderWireframeHandle);
   }
   //////////////////////////
   // get default template for solid UV Sphere
@@ -1058,6 +1126,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
         dfltUVSphereAttribs, "segments", 5, &illegalModValSolid);
 
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(uvSphereSolidHandle);
+
     // test wireframe version
     dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(true);
@@ -1066,6 +1137,9 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
         dfltUVSphereAttribs, "segments", legalModValWF, &illegalModValWF);
+
+    // test that a new template can be created from the specified handles
+    testAssetAttributesTemplateCreateFromHandle(uvSphereWireframeHandle);
   }
 }  // AttributesManagersTest::AsssetAttributesManagerGetAndModify test
 


### PR DESCRIPTION
## Motivation and Context
This small PR will take a valid PrimitiveAssetAttributes handle and use it to create and configure an appropriate PrimitiveAssetAttributes template.  The handles of these templates encode all the relevant information required to properly instantiate a Magnum Primitive, and the handles cannot be changed by the user, so these handles can be expected to be valid descriptions/encodings of the described primitive template.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass.  C++ tests have been added to verify that template handles can be parsed into templates with appropriate field values.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
