### PR TITLE
[PBR][IBL] Add a drawable type for runtime identification

### DIFF
--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -12,8 +12,10 @@ namespace gfx {
 uint64_t Drawable::drawableIdCounter = 0;
 Drawable::Drawable(scene::SceneNode& node,
                    Magnum::GL::Mesh& mesh,
+                   DrawableType type,
                    DrawableGroup* group /* = nullptr */)
     : Magnum::SceneGraph::Drawable3D{node, group},
+      type_(type),
       node_(node),
       mesh_(mesh),
       drawableId_(drawableIdCounter++) {

--- a/src/esp/gfx/Drawable.h
+++ b/src/esp/gfx/Drawable.h
@@ -18,6 +18,15 @@ namespace gfx {
 
 class DrawableGroup;
 
+enum class DrawableType : uint8_t {
+  None = 0,
+  Generic = 1,
+  Pbr = 2,
+  PTexMesh = 3,
+  MeshVisualizer = 4,
+  VarianceShadowMap = 6,
+};
+
 /**
  * @brief Drawable for use with @ref DrawableGroup.
  *
@@ -55,10 +64,12 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    *
    * @param node Node which will be made drawable.
    * @param mesh Mesh to draw when on render.
+   * @param type the type of this drawable
    * @param group Drawable group this drawable will be added to.
    */
   Drawable(scene::SceneNode& node,
            Magnum::GL::Mesh& mesh,
+           DrawableType type,
            DrawableGroup* group = nullptr);
   ~Drawable() override;
 
@@ -77,10 +88,23 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    */
   uint64_t getDrawableId() const { return drawableId_; }
 
+  /**
+   * @brief setup the lights.
+   * NOTE: sub-class should override this function
+   */
   virtual void setLightSetup(
       CORRADE_UNUSED const Magnum::ResourceKey& lightSetup){};
 
-  Magnum::GL::Mesh& getMesh() { return mesh_; }
+  /**
+   * @brief the the scene node
+   */
+  virtual scene::SceneNode& getSceneNode() const { return node_; }
+
+  /** @brief get the GL mesh */
+  Magnum::GL::Mesh& getMesh() const { return mesh_; }
+
+  /** @brief get the drawable type */
+  DrawableType getDrawableType() const { return type_; }
 
   /**
    * @brief Get the Magnum GL mesh for visualization, highlighting (e.g., used
@@ -103,14 +127,16 @@ class Drawable : public Magnum::SceneGraph::Drawable3D {
    * Each derived drawable class needs to implement this draw() function.
    * It's nothing more than drawing itself with its group's shader.
    */
-  void draw(const Magnum::Matrix4& transformationMatrix,
-            Magnum::SceneGraph::Camera3D& camera) override = 0;
+  void draw(CORRADE_UNUSED const Magnum::Matrix4& transformationMatrix,
+            CORRADE_UNUSED Magnum::SceneGraph::Camera3D& camera) override = 0;
 
-  static uint64_t drawableIdCounter;
-  uint64_t drawableId_;
+  DrawableType type_ = DrawableType::None;
 
   scene::SceneNode& node_;
   Magnum::GL::Mesh& mesh_;
+
+  static uint64_t drawableIdCounter;
+  uint64_t drawableId_;
 };
 
 CORRADE_ENUMSET_OPERATORS(Drawable::Flags)

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -23,7 +23,7 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
                                  const Mn::ResourceKey& lightSetupKey,
                                  const Mn::ResourceKey& materialDataKey,
                                  DrawableGroup* group /* = nullptr */)
-    : Drawable{node, mesh, group},
+    : Drawable{node, mesh, DrawableType::Generic, group},
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetupKey)},
       materialData_{

--- a/src/esp/gfx/MeshVisualizerDrawable.cpp
+++ b/src/esp/gfx/MeshVisualizerDrawable.cpp
@@ -16,7 +16,8 @@ MeshVisualizerDrawable::MeshVisualizerDrawable(
     Magnum::Shaders::MeshVisualizerGL3D& shader,
     Magnum::GL::Mesh& mesh,
     DrawableGroup* group)
-    : Drawable{node, mesh, group}, shader_(shader) {}
+    : Drawable{node, mesh, DrawableType::MeshVisualizer, group},
+      shader_(shader) {}
 
 void MeshVisualizerDrawable::draw(const Magnum::Matrix4& transformationMatrix,
                                   Magnum::SceneGraph::Camera3D& camera) {

--- a/src/esp/gfx/PTexMeshDrawable.cpp
+++ b/src/esp/gfx/PTexMeshDrawable.cpp
@@ -18,7 +18,8 @@ PTexMeshDrawable::PTexMeshDrawable(scene::SceneNode& node,
                                    int submeshID,
                                    ShaderManager& shaderManager,
                                    DrawableGroup* group /* = nullptr */)
-    : Drawable{node, ptexMeshData.getRenderingBuffer(submeshID)->mesh, group},
+    : Drawable{node, ptexMeshData.getRenderingBuffer(submeshID)->mesh,
+               DrawableType::PTexMesh, group},
       atlasTexture_(ptexMeshData.getRenderingBuffer(submeshID)->atlasTexture),
 #ifndef CORRADE_TARGET_APPLE
       adjFacesBufferTexture_(

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -20,7 +20,7 @@ PbrDrawable::PbrDrawable(scene::SceneNode& node,
                          const Mn::ResourceKey& lightSetupKey,
                          const Mn::ResourceKey& materialDataKey,
                          DrawableGroup* group)
-    : Drawable{node, mesh, group},
+    : Drawable{node, mesh, DrawableType::Pbr, group},
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetupKey)},
       materialData_{


### PR DESCRIPTION
## Motivation and Context
As titled.
So the actual drawable type (pbr, generic, ptex etc.) can be identified even from the base class "Drawable" during the fly.
It will be useful later when creating new drawables only used in the shadow map pre-computation.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
