### PR TITLE
pytest-benchmark integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-sugar pytest-xdist
+                pip install pytest-sugar pytest-xdist pytest-benchmark
               fi
       - run:
           name: Install emscripten
@@ -525,6 +525,9 @@ jobs:
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pytest -n auto --durations=10 --cov-report=xml --cov=./
+
+              #run the marked pytest-benchmark tests and print the results
+              pytest -m sim_benchmarks
 
               #re-build without bullet and cuda and run physics tests again
               #TODO: instead of reinstall, do this with configuration

--- a/setup.py
+++ b/setup.py
@@ -446,7 +446,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         install_requires=requirements,
         setup_requires=setup_requires,
-        tests_require=["hypothesis", "pytest-cov", "pytest"],
+        tests_require=["hypothesis", "pytest-benchmark", "pytest"],
         python_requires=">=3.6",
         # add extension module
         ext_modules=[CMakeExtension("habitat_sim._ext.habitat_sim_bindings", "src")],

--- a/tests/test_physics_benchmarking.py
+++ b/tests/test_physics_benchmarking.py
@@ -1,10 +1,17 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import pytest
 
+import examples.settings
+import habitat_sim
 import utils
-from habitat_sim import vhacd_enabled
 
 
-@pytest.mark.skipif(not vhacd_enabled, reason="Test requires vhacd")
+@pytest.mark.skipif(not habitat_sim.vhacd_enabled, reason="Test requires vhacd")
 @pytest.mark.parametrize(
     "args",
     [
@@ -18,3 +25,34 @@ from habitat_sim import vhacd_enabled
 )
 def test_example_modules(args):
     utils.run_main_subproc(args)
+
+
+# benchmark adding/removing articulated objects from URDF files
+@pytest.mark.sim_benchmarks
+@pytest.mark.skipif(
+    not habitat_sim.built_with_bullet,
+    reason="ArticulatedObject API requires Bullet physics.",
+)
+@pytest.mark.benchmark(group="URDF load->remove iterations|force_reload")
+@pytest.mark.parametrize("iterations", [1, 10, 100, 200])
+@pytest.mark.parametrize("force_reload", [False, True])
+def test_benchmark_urdf_add_remove(benchmark, iterations, force_reload):
+    # test loading and removing a URDF ArticultedObject multiple times consecutively
+    def instance_remove_urdf(iterations):
+        # first configure the simulator
+        cfg_settings = examples.settings.default_sim_settings.copy()
+        cfg_settings["scene"] = "NONE"
+        cfg_settings["enable_physics"] = True
+        hab_cfg = examples.settings.make_cfg(cfg_settings)
+        with habitat_sim.Simulator(hab_cfg) as sim:
+            art_obj_mgr = sim.get_articulated_object_manager()
+
+            robot_file = "data/test_assets/urdf/kuka_iiwa/model_free_base.urdf"
+
+            for _iteration in range(iterations):
+                robot = art_obj_mgr.add_articulated_object_from_urdf(
+                    robot_file, force_reload=force_reload
+                )
+                art_obj_mgr.remove_object_by_id(robot.object_id)
+
+    benchmark(instance_remove_urdf, iterations)


### PR DESCRIPTION
## Motivation and Context

Note: migrated from #1304 

Adds `pytest-benchmark` integration for benchmarking simulator functionality locally and automatically on CI.
Initial PoC function benchmarks URDF parse->instance->remove loop with and without force_reload caching option.

Note: requires local installation with pip install pytest-benchmark.

## How Has This Been Tested

Local testing and CI integration. Example output of pytest tests/benchmark_physics.py:
![image](https://user-images.githubusercontent.com/1445143/121404008-6076f300-c910-11eb-91ac-eb6c227472e9.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
