### PR TITLE
fix for KINEMATIC objects being moved by Bullet unexpectedly

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -332,7 +332,7 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
 
   double mass = 0;
   btVector3 bInertia = {0, 0, 0};
-  if (mt != MotionType::STATIC) {
+  if (mt == MotionType::DYNAMIC) {
     mass = tmpAttr->getMass();
     bInertia = btVector3(tmpAttr->getInertia());
     if (bInertia == btVector3{0, 0, 0}) {
@@ -394,7 +394,7 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
         bObjectRigidBody_->getCollisionFlags() |
         btCollisionObject::CF_KINEMATIC_OBJECT);
     CORRADE_INTERNAL_ASSERT(bObjectRigidBody_->isKinematicObject());
-    CORRADE_INTERNAL_ASSERT(!bObjectRigidBody_->isStaticObject());
+    CORRADE_INTERNAL_ASSERT(bObjectRigidBody_->isStaticObject());
     bWorld_->addRigidBody(
         bObjectRigidBody_.get(), int(CollisionGroup::Kinematic),
         uint32_t(

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -781,7 +781,7 @@ TEST_F(PhysicsManagerTest, TestMotionTypes) {
                         .length(),
                     1.0e-3);
           ASSERT_LE((objWrapper1->getTranslation() -
-                     Magnum::Vector3{0.5, boxHalfExtent * 4, 0.0})
+                     Magnum::Vector3{0.559155, boxHalfExtent * 4, 0.0})
                         .length(),
                     2.0e-3);
         } break;


### PR DESCRIPTION
## Motivation and Context

Alex and I have both seen behavior where a Bullet body with kinematic motion will get moved by Bullet stepWorld. This is avoided by setting zero mass. Alex speculated that collision-resolution code isn't checking the kinematic flag and is thus moving the kinematic body when the mass is non-zero.

## How Has This Been Tested

I tested locally in a scene with kinematic and dynamic objects. This change fixed the behavior bug for me.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
