### PR TITLE
ManagedObjects : CSV Informational Reports

### DIFF
--- a/habitat_sim/utils/__init__.py
+++ b/habitat_sim/utils/__init__.py
@@ -10,7 +10,7 @@
 # fixed
 
 
-from habitat_sim.utils import common, validators, viz_utils
+from habitat_sim.utils import common, manager_utils, validators, viz_utils
 from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
 
 __all__ = [

--- a/habitat_sim/utils/manager_utils.py
+++ b/habitat_sim/utils/manager_utils.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import csv
+
+
+def save_csv_report(file_name: str, report_string: str):
+    """This function takes a string, parses it on embedded newlines,
+    and writes the resultant array of CSV strings to a file.  This is the output format
+    of the various Attributes Managers and Physics Object manager's reports.
+
+    :param file_name: The name of the file to write to.
+    :param report_string: String with embedded newlines to par to write to file."""
+
+    report_list = report_string.splitlines()
+
+    with open(file_name, "w") as f:
+        writer = csv.writer(f, quoting=csv.QUOTE_ALL)
+        for x in report_list:
+            writer.writerow(x.split(","))

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -88,13 +88,15 @@ void initAttributesBindings(py::module& m) {
            &AbstractAttributes::setUserConfigValue<Magnum::Vector3>)
       .def("set_user_config_val",
            &AbstractAttributes::setUserConfigValue<Magnum::Quaternion>)
-
       .def_property_readonly(
           "num_user_configs",
           &AbstractAttributes::getNumUserDefinedConfigurations,
           R"(The number of currently specified user-defined configuration values.)")
       .def_property_readonly("template_class", &AbstractAttributes::getClassKey,
-                             R"(Class name of Attributes template.)");
+                             R"(Class name of Attributes template.)")
+      .def_property_readonly(
+          "csv_info", &AbstractAttributes::getObjectInfo,
+          R"(Comma-separated informational string describing this Attributes template)");
 
   // ==== AbstractObjectAttributes ====
   py::class_<AbstractObjectAttributes, AbstractAttributes,

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -83,6 +83,17 @@ void declareBaseAttributesManager(py::module& m,
                .c_str(),
            "search_str"_a = "", "contains"_a = true)
       .def(
+          "get_templates_info",
+          static_cast<std::vector<std::string> (MgrClass::*)(
+              const std::string&, bool) const>(&MgrClass::getObjectInfoStrings),
+          ("Returns a list of comma-separated strings describing each " +
+           attrType +
+           " template whose handles either contain or explicitly do not "
+           "contain the passed search_str, based on the value of boolean "
+           "contains.")
+              .c_str(),
+          "search_str"_a = "", "contains"_a = true)
+      .def(
           "load_configs",
           static_cast<std::vector<int> (MgrClass::*)(const std::string&, bool)>(
               &MgrClass::loadAllJSONConfigsFromPath),

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -82,17 +82,20 @@ void declareBaseAttributesManager(py::module& m,
             "value of boolean contains.")
                .c_str(),
            "search_str"_a = "", "contains"_a = true)
-      .def(
-          "get_templates_info",
-          static_cast<std::vector<std::string> (MgrClass::*)(
-              const std::string&, bool) const>(&MgrClass::getObjectInfoStrings),
-          ("Returns a list of comma-separated strings describing each " +
-           attrType +
-           " template whose handles either contain or explicitly do not "
-           "contain the passed search_str, based on the value of boolean "
-           "contains.")
-              .c_str(),
-          "search_str"_a = "", "contains"_a = true)
+      .def("get_templates_info", &MgrClass::getObjectInfoStrings,
+           ("Returns a list of CSV strings describing each " + attrType +
+            " template whose handles either contain or explicitly do not "
+            "contain the passed search_str, based on the value of boolean "
+            "contains.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true)
+      .def("get_templates_CSV_info", &MgrClass::getObjectInfoCSVString,
+           ("Returns a comma-separated string describing each " + attrType +
+            " template whose handles either contain or explicitly do not "
+            "contain the passed search_str, based on the value of boolean "
+            "contains.  Each template's info is separated by a newline.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true)
       .def(
           "load_configs",
           static_cast<std::vector<int> (MgrClass::*)(const std::string&, bool)>(

--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -63,7 +63,15 @@ void initMetadataMediatorBindings(py::module& m) {
           &MetadataMediator::getStageAttributesManager,
           pybind11::return_value_policy::reference,
           R"(The current dataset's StageAttributesManager instance
-            for configuring simulation stage templates.)");
+            for configuring simulation stage templates.)")
+      .def_property_readonly(
+          "summary", &MetadataMediator::getDatasetsOverview,
+          R"(This provides a summary of the datasets currently loaded.)")
+      .def(
+          "dataset_report", &MetadataMediator::createDatasetReport,
+          R"(This provides an indepth report of the loaded templates for the specified dataset.
+          If no dataset_name is specified, returns a report on the currently active dataset)",
+          "dataset_name"_a = "");
 
 }  // initMetadataMediatorBindings
 

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -188,6 +188,11 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           ("User-defined " + objType +
            " attributes.  These are not used internally by Habitat in any "
            "capacity, but are available for a user to consume how they wish.")
+              .c_str())
+      .def_property_readonly(
+          "csv_info", &PhysObjWrapper::getObjectInfo,
+          ("Comma-separated informational string describing this " + objType +
+           ".")
               .c_str());
 }  // declareBasePhysicsObjectWrapper
 

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -68,16 +68,22 @@ void declareBaseWrapperManager(py::module& m,
             "passed search_str, based on the value of boolean contains.")
                .c_str(),
            "search_str"_a = "", "contains"_a = true)
-      .def(
-          "get_objects_info",
-          static_cast<std::vector<std::string> (MgrClass::*)(
-              const std::string&, bool) const>(&MgrClass::getObjectInfoStrings),
-          ("Returns a list of comma-separated strings describing each " +
-           objType +
-           " whose handles either contain or explicitly do not contain the "
-           "passed search_str, based on the value of boolean contains.")
-              .c_str(),
-          "search_str"_a = "", "contains"_a = true)
+      .def("get_objects_info", &MgrClass::getObjectInfoStrings,
+           ("Returns a list of CSV strings describing each " + objType +
+            " whose handles either contain or explicitly do not contain the "
+            "passed search_str, based on the value of boolean contains.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true)
+
+      .def("get_objects_CSV_info", &MgrClass::getObjectInfoCSVString,
+           ("Returns a comma-separated string describing each " + objType +
+            " whose handles either contain or explicitly do not "
+            "contain the passed search_str, based on the value of boolean "
+            "contains.  Each " +
+            objType + "'s info is separated by a newline.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true)
+
       .def("get_num_objects", &MgrClass::getNumObjects,
            ("Returns the number of existing " + objType + "s being managed.")
                .c_str())

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -68,6 +68,16 @@ void declareBaseWrapperManager(py::module& m,
             "passed search_str, based on the value of boolean contains.")
                .c_str(),
            "search_str"_a = "", "contains"_a = true)
+      .def(
+          "get_objects_info",
+          static_cast<std::vector<std::string> (MgrClass::*)(
+              const std::string&, bool) const>(&MgrClass::getObjectInfoStrings),
+          ("Returns a list of comma-separated strings describing each " +
+           objType +
+           " whose handles either contain or explicitly do not contain the "
+           "passed search_str, based on the value of boolean contains.")
+              .c_str(),
+          "search_str"_a = "", "contains"_a = true)
       .def("get_num_objects", &MgrClass::getNumObjects,
            ("Returns the number of existing " + objType + "s being managed.")
                .c_str())

--- a/src/esp/core/managedContainers/AbstractManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractManagedObject.h
@@ -58,6 +58,12 @@ class AbstractManagedObject {
    */
   virtual std::string getObjectInfo() const = 0;
 
+  /**
+   * @brief Retrieve a comma-separated list of the values the getObjectInfo
+   * method returns.
+   */
+  virtual std::string getObjectInfoHeader() const = 0;
+
  protected:
   virtual void setClassKey(const std::string&) = 0;
 

--- a/src/esp/core/managedContainers/AbstractManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractManagedObject.h
@@ -52,6 +52,12 @@ class AbstractManagedObject {
    */
   virtual int getID() const = 0;
 
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   */
+  virtual std::string getObjectInfo() const = 0;
+
  protected:
   virtual void setClassKey(const std::string&) = 0;
 

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -454,21 +454,9 @@ class ManagedContainer : public ManagedContainerBase {
    */
   void clearDefaultObject() { defaultObj_ = nullptr; }
 
-  /**
-   * @brief Get a vector of strings holding the values of each of the objects
-   * this manager manages whose keys match @p subStr, ignoring subStr's case.
-   * Pass an empty string for all objects.
-   * @param subStr substring key to search for within existing managed objects.
-   * @param contains whether to search for keys containing, or excluding,
-   * @p substr
-   * @return A vector containing the managed object handles of managed objects
-   * whose lock state has been set to passed state.
-   */
-  std::vector<std::string> getObjectInfoStrings(const std::string& subStr = "",
-                                                bool contains = true) const;
-
  protected:
   //======== Internally accessed functions ========
+
   /**
    * @brief Perform post creation registration if specified.
    *
@@ -678,27 +666,6 @@ auto ManagedContainer<T, Access>::removeObjectsBySubstring(
   }
   return res;
 }  // ManagedContainer<T, Access>::removeObjectsBySubstring
-
-template <class T, ManagedObjectAccess Access>
-auto ManagedContainer<T, Access>::getObjectInfoStrings(
-    const std::string& subStr,
-    bool contains) const -> std::vector<std::string> {
-  // get all handles that match query elements first
-  std::vector<std::string> handles =
-      getObjectHandlesBySubstring(subStr, contains);
-  std::vector<std::string> res(handles.size());
-  int idx = 0;
-  for (const std::string& objectHandle : handles) {
-    // get the object
-    ManagedPtr objPtr = getObjectInternal<T>(objectHandle);
-    res[idx++] =
-        objectHandle + ", " +
-        ((this->getIsUndeletable(objectHandle)) ? "Undeletable, " : ", ") +
-        ((this->getIsUserLocked(objectHandle)) ? "Locked, " : ", ") +
-        objPtr->getObjectInfo();
-  }
-  return res;
-}  //// ManagedContainer<T, Access>::getObjectInfoStrings
 
 template <class T, ManagedObjectAccess Access>
 auto ManagedContainer<T, Access>::removeObjectInternal(

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -126,6 +126,34 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
   return res;
 }  // ManagedContainerBase::getObjectHandlesBySubStringPerType
 
+std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
+    const std::string& subStr,
+    bool contains) const {
+  // get all handles that match query elements first
+  std::vector<std::string> handles =
+      getObjectHandlesBySubstring(subStr, contains);
+  std::vector<std::string> res(handles.size() + 1);
+  if (handles.size() == 0) {
+    res[0] = "No " + objectType_ + " constructs available.";
+    return res;
+  }
+  int idx = 0;
+  for (const std::string& objectHandle : handles) {
+    // get the object
+    auto objPtr = getObjectInternal<AbstractManagedObject>(objectHandle);
+    if (idx == 0) {
+      res[idx++] = objectType_ + " Full name, Can delete?, Is locked?, " +
+                   objPtr->getObjectInfoHeader();
+    }
+    res[idx++] =
+        objectHandle + ", " +
+        ((this->getIsUndeletable(objectHandle)) ? "True, " : "False, ") +
+        ((this->getIsUserLocked(objectHandle)) ? "True, " : "False, ") +
+        objPtr->getObjectInfo();
+  }
+  return res;
+}  // ManagedContainer<T, Access>::getObjectInfoStrings
+
 std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
     const std::map<int, std::string>& mapOfHandles,
     const std::string& name) const {

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -142,14 +142,17 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
     // get the object
     auto objPtr = getObjectInternal<AbstractManagedObject>(objectHandle);
     if (idx == 0) {
-      res[idx++] = objectType_ + " Full name, Can delete?, Is locked?, " +
-                   objPtr->getObjectInfoHeader();
+      res[idx++]
+          .append(objectType_)
+          .append(" Full name, Can delete?, Is locked?, ")
+          .append(objPtr->getObjectInfoHeader());
     }
-    res[idx++] =
-        objectHandle + ", " +
-        ((this->getIsUndeletable(objectHandle)) ? "True, " : "False, ") +
-        ((this->getIsUserLocked(objectHandle)) ? "True, " : "False, ") +
-        objPtr->getObjectInfo();
+    res[idx++]
+        .append(objectHandle)
+        .append(", ")
+        .append(((this->getIsUndeletable(objectHandle)) ? "True, " : "False, "))
+        .append(((this->getIsUserLocked(objectHandle)) ? "True, " : "False, "))
+        .append(objPtr->getObjectInfo());
   }
   return res;
 }  // ManagedContainer<T, Access>::getObjectInfoStrings

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -155,7 +155,18 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
         .append(objPtr->getObjectInfo());
   }
   return res;
-}  // ManagedContainer<T, Access>::getObjectInfoStrings
+}  // ManagedContainerBase::getObjectInfoStrings
+
+std::string ManagedContainerBase::getObjectInfoCSVString(
+    const std::string& subStr,
+    bool contains) const {
+  std::vector<std::string> infoAra = getObjectInfoStrings(subStr, contains);
+  std::string res;
+  for (std::string& s : infoAra) {
+    res += s.append(1, '\n');
+  }
+  return res;
+}  // ManagedContainerBase::getObjectInfoCSVString
 
 std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
     const std::map<int, std::string>& mapOfHandles,

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -149,7 +149,7 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
     }
     res[idx++]
         .append(objectHandle)
-        .append(", ")
+        .append(1, ',')
         .append(((this->getIsUndeletable(objectHandle)) ? "False, " : "True, "))
         .append(((this->getIsUserLocked(objectHandle)) ? "True, " : "False, "))
         .append(objPtr->getObjectInfo());

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -150,7 +150,7 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
     res[idx++]
         .append(objectHandle)
         .append(", ")
-        .append(((this->getIsUndeletable(objectHandle)) ? "True, " : "False, "))
+        .append(((this->getIsUndeletable(objectHandle)) ? "False, " : "True, "))
         .append(((this->getIsUserLocked(objectHandle)) ? "True, " : "False, "))
         .append(objPtr->getObjectInfo());
   }

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -106,11 +106,11 @@ class ManagedContainerBase {
   }
 
   /**
-   * @brief Get a list of all managed objects whose origin handles contain
-   * subStr, ignoring subStr's case
-   * @param subStr substring to search for within existing managed objects.
+   * @brief Get a list of all managed objects whose keys contain @p subStr,
+   * ignoring subStr's case
+   * @param subStr substring key to search for within existing managed objects.
    * @param contains whether to search for keys containing, or excluding,
-   * passed subStr
+   * passed @p subStr
    * @return vector of 0 or more managed object handles containing the passed
    * substring
    */
@@ -133,6 +133,15 @@ class ManagedContainerBase {
   }  // ManagedContainerBase::getUndeletableObjectHandles
 
   /**
+   * @brief Returns whether the object with the passed @p key is undeletable.
+   * @param key Value to look for to check whether undeletable or not.
+   * @return True if handle exists and is undeletable.
+   */
+  bool getIsUndeletable(const std::string& key) {
+    return (this->undeletableObjectNames_.count(key) > 0);
+  }
+
+  /**
    * @brief returns a vector of managed object handles representing managed
    * objects that have been locked by the user.  These managed objects cannot be
    * deleted until they have been unlocked, although they can be edited while
@@ -145,12 +154,23 @@ class ManagedContainerBase {
   }  // ManagedContainerBase::getUserLockedObjectHandles
 
   /**
+   * @brief Returns whether the object with the passed @p key is user locked.
+   * @param key Value to look for to check whether locked or not.
+   * @return True if handle exists and is user-locked.
+   */
+  bool getIsUserLocked(const std::string& key) {
+    return (this->userLockedObjectNames_.count(key) > 0);
+  }
+
+  /**
    * @brief clears maps of handle-keyed managed object and ID-keyed handles.
    */
   void reset() {
     objectLibKeyByID_.clear();
     objectLibrary_.clear();
     availableObjectIDs_.clear();
+    undeletableObjectNames_.clear();
+    userLockedObjectNames_.clear();
     resetFinalize();
   }  // ManagedContainerBase::reset
 

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -215,6 +215,19 @@ class ManagedContainerBase {
    */
   const std::string& getObjectType() const { return objectType_; }
 
+  /**
+   * @brief Get a vector of strings holding the values of each of the objects
+   * this manager manages whose keys match @p subStr, ignoring subStr's case.
+   * Pass an empty string for all objects.
+   * @param subStr substring key to search for within existing managed objects.
+   * @param contains whether to search for keys containing, or excluding,
+   * @p substr
+   * @return A vector containing the managed object handles of managed objects
+   * whose lock state has been set to passed state.
+   */
+  std::vector<std::string> getObjectInfoStrings(const std::string& subStr = "",
+                                                bool contains = true) const;
+
  protected:
   //======== Internally accessed getter/setter/utilities ================
 

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -222,11 +222,25 @@ class ManagedContainerBase {
    * @param subStr substring key to search for within existing managed objects.
    * @param contains whether to search for keys containing, or excluding,
    * @p substr
-   * @return A vector containing the managed object handles of managed objects
-   * whose lock state has been set to passed state.
+   * @return A vector containing the string info of all the objects in this
+   * manager.
    */
   std::vector<std::string> getObjectInfoStrings(const std::string& subStr = "",
                                                 bool contains = true) const;
+
+  /***
+   * @brief Use @ref getObjectInfoStrings resultant array to build a single
+   * string, with nulls separating each line. This stirng holds the values of
+   * each of the objects this manager manages whose keys match @p subStr,
+   * ignoring subStr's case. Pass an empty string for all objects.
+   * @param subStr substring key to search for within existing managed objects.
+   * @param contains whether to search for keys containing, or excluding,
+   * @p substr
+   * @return A string containing the string info of all the objects in this
+   * manager, separated by newlines for each object.
+   */
+  std::string getObjectInfoCSVString(const std::string& subStr,
+                                     bool contains) const;
 
  protected:
   //======== Internally accessed getter/setter/utilities ================

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -137,7 +137,7 @@ class ManagedContainerBase {
    * @param key Value to look for to check whether undeletable or not.
    * @return True if handle exists and is undeletable.
    */
-  bool getIsUndeletable(const std::string& key) {
+  bool getIsUndeletable(const std::string& key) const {
     return (this->undeletableObjectNames_.count(key) > 0);
   }
 
@@ -158,7 +158,7 @@ class ManagedContainerBase {
    * @param key Value to look for to check whether locked or not.
    * @return True if handle exists and is user-locked.
    */
-  bool getIsUserLocked(const std::string& key) {
+  bool getIsUserLocked(const std::string& key) const {
     return (this->userLockedObjectNames_.count(key) > 0);
   }
 

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(
   metadata_SOURCES
   attributes/AttributesBase.h
+  attributes/AttributesBase.cpp
   attributes/LightLayoutAttributes.h
   attributes/LightLayoutAttributes.cpp
   attributes/ObjectAttributes.h

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -392,8 +392,8 @@ std::string MetadataMediator::getDatasetsOverview() const {
       attributes::SceneDatasetAttributes::getDatasetSummaryHeader() + "\n";
   for (const std::string& handle : sceneDatasetHandles) {
     res += sceneDatasetAttributesManager_->getObjectByHandle(handle)
-               ->getDatasetSummary() +
-           "\n";
+               ->getDatasetSummary();
+    res += '\n';
   }
 
   return res;
@@ -401,18 +401,26 @@ std::string MetadataMediator::getDatasetsOverview() const {
 
 std::string MetadataMediator::createDatasetReport(
     const std::string& sceneDataset) const {
+  attributes::SceneDatasetAttributes::ptr ds;
   if (sceneDataset == "") {
-    return sceneDatasetAttributesManager_
-        ->getObjectByHandle(activeSceneDataset_)
-        ->getObjectInfo();
-  }
+    ds = sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
 
-  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDataset)) {
-    return sceneDatasetAttributesManager_->getObjectByHandle(sceneDataset)
-        ->getObjectInfo();
+  } else if (sceneDatasetAttributesManager_->getObjectLibHasHandle(
+                 sceneDataset)) {
+    ds = sceneDatasetAttributesManager_->getObjectByHandle(sceneDataset);
+  } else {
+    // unknown dataset
+    LOG(ERROR) << "::createDatasetReport : Dataset " << sceneDataset
+               << " is not found in the MetadataMediator.  Aborting.";
+    return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
   }
-  // unknown dataset
-  return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
+  std::string res{"Scene Dataset"};
+
+  res.append(ds->getObjectInfoHeader())
+      .append(1, '\n')
+      .append(ds->getObjectInfo())
+      .append(1, '\n');
+  return res;
 
 }  // MetadataMediator::const std::string MetadataMediator::createDatasetReport(
 

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -383,5 +383,36 @@ attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
   return sceneAttributes;
 }  // MetadataMediator::makeSceneAndReferenceStage
 
+std::string MetadataMediator::getDatasetsOverview() const {
+  // reserve space for info strings for all scene datasets
+  std::vector<std::string> sceneDatasetHandles =
+      sceneDatasetAttributesManager_->getObjectHandlesBySubstring("");
+  std::string res = "Datasets : \n";
+  for (const std::string& handle : sceneDatasetHandles) {
+    res += sceneDatasetAttributesManager_->getObjectByHandle(handle)
+               ->getDatasetSummary() +
+           "\n";
+  }
+
+  return res;
+}  // MetadataMediator::getDatasetNames
+
+std::string MetadataMediator::createDatasetReport(
+    const std::string& sceneDataset) const {
+  if (sceneDataset == "") {
+    return sceneDatasetAttributesManager_
+        ->getObjectByHandle(activeSceneDataset_)
+        ->getObjectInfo();
+  }
+
+  if (sceneDatasetAttributesManager_->getObjectLibHasHandle(sceneDataset)) {
+    return sceneDatasetAttributesManager_->getObjectByHandle(sceneDataset)
+        ->getObjectInfo();
+  }
+  // unknown dataset
+  return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
+
+}  // MetadataMediator::const std::string MetadataMediator::createDatasetReport(
+
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -387,7 +387,9 @@ std::string MetadataMediator::getDatasetsOverview() const {
   // reserve space for info strings for all scene datasets
   std::vector<std::string> sceneDatasetHandles =
       sceneDatasetAttributesManager_->getObjectHandlesBySubstring("");
-  std::string res = "Datasets : \n";
+  std::string res =
+      "Datasets : \n" +
+      attributes::SceneDatasetAttributes::getDatasetSummaryHeader() + "\n";
   for (const std::string& handle : sceneDatasetHandles) {
     res += sceneDatasetAttributesManager_->getObjectByHandle(handle)
                ->getDatasetSummary() +

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -370,6 +370,23 @@ class MetadataMediator {
         sceneDatasetName);
   }
 
+  /**
+   * @brief This function returns a list of all the scene datasets currently
+   * loaded, along with some key statistics for each, formatted as a
+   * comma-separated string.
+   * @return a vector of strings holding scene dataset info.
+   */
+  std::string getDatasetsOverview() const;
+
+  /**
+   * @brief this function will create a report of the contents of the scene
+   * dataset with the passed name. If no name is provided, a report on the
+   * current active dataset will be returned.
+   * @param sceneDataset The name of the scene dataset to perform the report on.
+   * @return Comma-separated string of data describing the desired dataset.
+   */
+  std::string createDatasetReport(const std::string& sceneDataset = "") const;
+
  protected:
   /**
    * @brief Return the file path corresponding to the passed handle in the
@@ -475,7 +492,7 @@ class MetadataMediator {
 
  public:
   ESP_SMART_POINTERS(MetadataMediator)
-};  // class MetadataMediator
+};  // namespace metadata
 
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/MetadataUtils.cpp
+++ b/src/esp/metadata/MetadataUtils.cpp
@@ -25,10 +25,8 @@ int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc) {
     // shader_type tag was found, perform check - first convert to
     // lowercase
     std::string strToLookFor = Cr::Utility::String::lowercase(tmpShaderType);
-    auto found = attributes::AbstractObjectAttributes::ShaderTypeNamesMap.find(
-        strToLookFor);
-    if (found !=
-        attributes::AbstractObjectAttributes::ShaderTypeNamesMap.end()) {
+    auto found = attributes::ShaderTypeNamesMap.find(strToLookFor);
+    if (found != attributes::ShaderTypeNamesMap.end()) {
       shader_type = static_cast<int>(found->second);
     } else {
       LOG(WARNING)

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -45,10 +45,10 @@ std::string getTranslationOriginName(int translationOrigin) {
     return "default";
   }
   // Must always be valid value
-  ObjectInstanceShaderType shaderType =
-      static_cast<ObjectInstanceShaderType>(translationOrigin);
-  for (const auto& it : ShaderTypeNamesMap) {
-    if (it.second == shaderType) {
+  SceneInstanceTranslationOrigin transOrigin =
+      static_cast<SceneInstanceTranslationOrigin>(translationOrigin);
+  for (const auto& it : InstanceTranslationOriginMap) {
+    if (it.second == transOrigin) {
       return it.first;
     }
   }

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "AttributesBase.h"
+namespace esp {
+namespace metadata {
+namespace attributes {
+
+const std::map<std::string, ObjectInstanceShaderType> ShaderTypeNamesMap = {
+    {"material", ObjectInstanceShaderType::Material},
+    {"flat", ObjectInstanceShaderType::Flat},
+    {"phong", ObjectInstanceShaderType::Phong},
+    {"pbr", ObjectInstanceShaderType::PBR},
+};
+
+const std::map<std::string, SceneInstanceTranslationOrigin>
+    InstanceTranslationOriginMap = {
+        {"asset_local", SceneInstanceTranslationOrigin::AssetLocal},
+        {"com", SceneInstanceTranslationOrigin::COM},
+};
+
+std::string getShaderTypeName(int shaderTypeVal) {
+  if (shaderTypeVal <= static_cast<int>(ObjectInstanceShaderType::Unknown) ||
+      shaderTypeVal >=
+          static_cast<int>(ObjectInstanceShaderType::EndShaderType)) {
+    return "unknown shader type";
+  }
+  // Must always be valid value
+  ObjectInstanceShaderType shaderType =
+      static_cast<ObjectInstanceShaderType>(shaderTypeVal);
+  for (const auto& it : ShaderTypeNamesMap) {
+    if (it.second == shaderType) {
+      return it.first;
+    }
+  }
+  return "unknown shader type";
+}
+
+std::string getTranslationOriginName(int translationOrigin) {
+  if (translationOrigin <=
+          static_cast<int>(SceneInstanceTranslationOrigin::Unknown) ||
+      translationOrigin >=
+          static_cast<int>(SceneInstanceTranslationOrigin::EndTransOrigin)) {
+    return "default";
+  }
+  // Must always be valid value
+  ObjectInstanceShaderType shaderType =
+      static_cast<ObjectInstanceShaderType>(translationOrigin);
+  for (const auto& it : ShaderTypeNamesMap) {
+    if (it.second == shaderType) {
+      return it.first;
+    }
+  }
+  return "default";
+}
+
+}  // namespace attributes
+}  // namespace metadata
+}  // namespace esp

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -24,7 +24,7 @@ std::string getShaderTypeName(int shaderTypeVal) {
   if (shaderTypeVal <= static_cast<int>(ObjectInstanceShaderType::Unknown) ||
       shaderTypeVal >=
           static_cast<int>(ObjectInstanceShaderType::EndShaderType)) {
-    return "unknown shader type";
+    return "unspecified";
   }
   // Must always be valid value
   ObjectInstanceShaderType shaderType =
@@ -34,7 +34,7 @@ std::string getShaderTypeName(int shaderTypeVal) {
       return it.first;
     }
   }
-  return "unknown shader type";
+  return "unspecified";
 }
 
 std::string getTranslationOriginName(int translationOrigin) {

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -155,6 +155,14 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
   }
 
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object.
+   */
+  std::string getObjectInfoHeader() const override {
+    return "Simplified Name, ID, " + getObjectInfoHeaderInternal();
+  }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    */
@@ -165,8 +173,17 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  virtual std::string getObjectInfoHeaderInternal() const { return ","; }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
-   * of this managed object.
+   * of this managed object, type-specific.
    * TODO : once Magnum supports retrieving key-values of configurations, use
    * that to build this data.
    */

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -47,34 +47,19 @@ enum class ObjectInstanceShaderType {
   EndShaderType,
 };
 
-static const std::map<std::string, ObjectInstanceShaderType>
-    ShaderTypeNamesMap = {
-        {"material", ObjectInstanceShaderType::Material},
-        {"flat", ObjectInstanceShaderType::Flat},
-        {"phong", ObjectInstanceShaderType::Phong},
-        {"pbr", ObjectInstanceShaderType::PBR},
-};
+/**
+ * @brief Constant map to provide mappings from string tags to @ref
+ * ObjectInstanceShaderType values.  This will be used to map values set
+ * in json for translation origin to @ref ObjectInstanceShaderType.  Keys
+ * must be lowercase.
+ */
+const extern std::map<std::string, ObjectInstanceShaderType> ShaderTypeNamesMap;
 
 /**
  * @brief This method will convert an int value to the string key it maps to in
  * the ShaderTypeNamesMap
  */
-std::string inline getShaderTypeName(int shaderTypeVal) {
-  if (shaderTypeVal <= static_cast<int>(ObjectInstanceShaderType::Unknown) ||
-      shaderTypeVal >=
-          static_cast<int>(ObjectInstanceShaderType::EndShaderType)) {
-    return "unknown shader type";
-  }
-  // Must always be valid value
-  ObjectInstanceShaderType shaderType =
-      static_cast<ObjectInstanceShaderType>(shaderTypeVal);
-  for (const auto& it : ShaderTypeNamesMap) {
-    if (it.second == shaderType) {
-      return it.first;
-    }
-  }
-  return "unknown shader type";
-}
+std::string getShaderTypeName(int shaderTypeVal);
 
 /**
  * @brief This enum class describes whether an object instance position is
@@ -111,38 +96,18 @@ enum class SceneInstanceTranslationOrigin {
 };
 
 /**
- * @brief Constant static map to provide mappings from string tags to @ref
+ * @brief Constant map to provide mappings from string tags to @ref
  * SceneInstanceTranslationOrigin values.  This will be used to map values set
  * in json for translation origin to @ref SceneInstanceTranslationOrigin.  Keys
  * must be lowercase.
  */
-static const std::map<std::string, SceneInstanceTranslationOrigin>
-    InstanceTranslationOriginMap = {
-        {"asset_local", SceneInstanceTranslationOrigin::AssetLocal},
-        {"com", SceneInstanceTranslationOrigin::COM},
-};
-
+const extern std::map<std::string, SceneInstanceTranslationOrigin>
+    InstanceTranslationOriginMap;
 /**
  * @brief This method will convert an int value to the string key it maps to in
  * the InstanceTranslationOriginMap
  */
-std::string inline getTranslationOriginName(int translationOrigin) {
-  if (translationOrigin <=
-          static_cast<int>(SceneInstanceTranslationOrigin::Unknown) ||
-      translationOrigin >=
-          static_cast<int>(SceneInstanceTranslationOrigin::EndTransOrigin)) {
-    return "default";
-  }
-  // Must always be valid value
-  ObjectInstanceShaderType shaderType =
-      static_cast<ObjectInstanceShaderType>(translationOrigin);
-  for (const auto& it : ShaderTypeNamesMap) {
-    if (it.second == shaderType) {
-      return it.first;
-    }
-  }
-  return "default";
-}
+std::string getTranslationOriginName(int translationOrigin);
 
 /**
  * @brief Base class for all implemented attributes.  Inherits from @ref

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -47,6 +47,103 @@ enum class ObjectInstanceShaderType {
   _EndShaderType,
 };
 
+static const std::map<std::string, ObjectInstanceShaderType>
+    ShaderTypeNamesMap = {
+        {"material", ObjectInstanceShaderType::Material},
+        {"flat", ObjectInstanceShaderType::Flat},
+        {"phong", ObjectInstanceShaderType::Phong},
+        {"pbr", ObjectInstanceShaderType::PBR},
+};
+
+/**
+ * @brief This method will convert an int value to the string key it maps to in
+ * the ShaderTypeNamesMap
+ */
+static std::string getShaderTypeName(int shaderTypeVal) {
+  if (shaderTypeVal <= static_cast<int>(ObjectInstanceShaderType::Unknown) ||
+      shaderTypeVal >=
+          static_cast<int>(ObjectInstanceShaderType::_EndShaderType)) {
+    return "unknown shader type";
+  }
+  // Must always be valid value
+  ObjectInstanceShaderType shaderType =
+      static_cast<ObjectInstanceShaderType>(shaderTypeVal);
+  for (const auto& it : ShaderTypeNamesMap) {
+    if (it.second == shaderType) {
+      return it.first;
+    }
+  }
+  return "unknown shader type";
+}
+
+/**
+ * @brief This enum class describes whether an object instance position is
+ * relative to its COM or the asset's local origin.  Depending on this value, we
+ * may take certain actions when instantiating a scene described by a scene
+ * instance. For example, scene instances exported from Blender will have no
+ * conception of an object's configured COM, and so will require adjustment to
+ * translations to account for COM location when the object is placed*/
+enum class SceneInstanceTranslationOrigin {
+  /**
+   * @brief Default value - in the case of object instances, this means use the
+   * specified scene instance default; in the case of a scene instance, this
+   * means do not correct for COM.
+   */
+  Unknown = -1,
+  /**
+   * @brief Indicates scene instance objects were placed without knowledge of
+   * their COM location, and so need to be corrected when placed in scene in
+   * Habitat. For example, they were exported from an external editor like
+   * Blender.
+   */
+  AssetLocal,
+  /**
+   * @brief Indicates scene instance objects' location were recorded at their
+   * COM location, and so do not need correction.  For example they were
+   * exported from Habitat-sim.
+   */
+  COM,
+  /**
+   * End cap value - no instance translation origin type enums should be defined
+   * past this enum.
+   */
+  _EndTransOrigin,
+};
+
+/**
+ * @brief Constant static map to provide mappings from string tags to @ref
+ * SceneInstanceTranslationOrigin values.  This will be used to map values set
+ * in json for translation origin to @ref SceneInstanceTranslationOrigin.  Keys
+ * must be lowercase.
+ */
+static const std::map<std::string, SceneInstanceTranslationOrigin>
+    InstanceTranslationOriginMap = {
+        {"asset_local", SceneInstanceTranslationOrigin::AssetLocal},
+        {"com", SceneInstanceTranslationOrigin::COM},
+};
+
+/**
+ * @brief This method will convert an int value to the string key it maps to in
+ * the InstanceTranslationOriginMap
+ */
+static std::string getTranslationOriginName(int translationOrigin) {
+  if (translationOrigin <=
+          static_cast<int>(SceneInstanceTranslationOrigin::Unknown) ||
+      translationOrigin >=
+          static_cast<int>(SceneInstanceTranslationOrigin::_EndTransOrigin)) {
+    return "default";
+  }
+  // Must always be valid value
+  ObjectInstanceShaderType shaderType =
+      static_cast<ObjectInstanceShaderType>(translationOrigin);
+  for (const auto& it : ShaderTypeNamesMap) {
+    if (it.second == shaderType) {
+      return it.first;
+    }
+  }
+  return "default";
+}
+
 /**
  * @brief Base class for all implemented attributes.  Inherits from @ref
  * esp::core::AbstractFileBasedManagedObject so the attributes can be managed by

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -256,7 +256,8 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * info returned for this managed object.
    */
   std::string getObjectInfoHeader() const override {
-    return "Simplified Name, ID, " + getObjectInfoHeaderInternal();
+    std::string res{"Simplified Name, ID, "};
+    return res.append(getObjectInfoHeaderInternal());
   }
 
   /**
@@ -264,14 +265,17 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * of this managed object.
    */
   std::string getObjectInfo() const override {
-    return getSimplifiedHandle() + ", " + std::to_string(getID()) + ", " +
-           getObjectInfoInternal();
+    return getSimplifiedHandle()
+        .append(", ")
+        .append(std::to_string(getID()))
+        .append(", ")
+        .append(getObjectInfoInternal());
   }
 
  protected:
   /**
-   * @brief Retrieve a comma-separated string holding the header values for the
-   * info returned for this managed object, type-specific.
+   * @brief Retrieve a comma-separated string holding the header values for
+   * the info returned for this managed object, type-specific.
    * TODO : once Magnum supports retrieving key-values of configurations, use
    * that to build this data.
    */

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -90,7 +90,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * this attributes, so this should only be used for logging, and not for
    * attempts to search for attributes.
    */
-  std::string getSimplifiedHandle() const {
+  virtual std::string getSimplifiedHandle() const {
     // first parse for file name, and then get rid of extension(s).
     return Corrade::Utility::Directory::splitExtension(
                Corrade::Utility::Directory::splitExtension(

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -120,6 +120,16 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
     return getSubgroupValue<T>("user_defined", key);
   }
 
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   */
+  std::string getObjectInfo() const override {
+    // TODO : once Magnum supports retrieving key-values of configurations, use
+    // that to build this
+    return getHandle() + ",";
+  }
+
  protected:
   /**
    * @brief Set this attributes' class.  Should only be set from constructor.

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -44,7 +44,7 @@ enum class ObjectInstanceShaderType {
   /**
    * End cap value - no shader type enums should be defined past this enum.
    */
-  _EndShaderType,
+  EndShaderType,
 };
 
 static const std::map<std::string, ObjectInstanceShaderType>
@@ -59,10 +59,10 @@ static const std::map<std::string, ObjectInstanceShaderType>
  * @brief This method will convert an int value to the string key it maps to in
  * the ShaderTypeNamesMap
  */
-static std::string getShaderTypeName(int shaderTypeVal) {
+std::string inline getShaderTypeName(int shaderTypeVal) {
   if (shaderTypeVal <= static_cast<int>(ObjectInstanceShaderType::Unknown) ||
       shaderTypeVal >=
-          static_cast<int>(ObjectInstanceShaderType::_EndShaderType)) {
+          static_cast<int>(ObjectInstanceShaderType::EndShaderType)) {
     return "unknown shader type";
   }
   // Must always be valid value
@@ -107,7 +107,7 @@ enum class SceneInstanceTranslationOrigin {
    * End cap value - no instance translation origin type enums should be defined
    * past this enum.
    */
-  _EndTransOrigin,
+  EndTransOrigin,
 };
 
 /**
@@ -126,11 +126,11 @@ static const std::map<std::string, SceneInstanceTranslationOrigin>
  * @brief This method will convert an int value to the string key it maps to in
  * the InstanceTranslationOriginMap
  */
-static std::string getTranslationOriginName(int translationOrigin) {
+std::string inline getTranslationOriginName(int translationOrigin) {
   if (translationOrigin <=
           static_cast<int>(SceneInstanceTranslationOrigin::Unknown) ||
       translationOrigin >=
-          static_cast<int>(SceneInstanceTranslationOrigin::_EndTransOrigin)) {
+          static_cast<int>(SceneInstanceTranslationOrigin::EndTransOrigin)) {
     return "default";
   }
   // Must always be valid value

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -14,6 +14,40 @@ namespace metadata {
 namespace attributes {
 
 /**
+ * @brief This enum class defines the possible shader options for rendering
+ * instances of objects or stages in Habitat-sim.
+ */
+enum class ObjectInstanceShaderType {
+  /**
+   * Represents an unknown/unspecified value for the shader type to use. Resort
+   * to defaults for object type.
+   */
+  Unknown = ID_UNDEFINED,
+  /**
+   * Override any config-specified or default shader-type values to use the
+   * material-specified shader.
+   */
+  Material,
+  /**
+   * Refers to flat shading, pure color and no lighting.  This is often used for
+   * textured objects
+   */
+  Flat,
+  /**
+   * Refers to phong shading with pure diffuse color.
+   */
+  Phong,
+  /**
+   * Refers to using a shader built with physically-based rendering models.
+   */
+  PBR,
+  /**
+   * End cap value - no shader type enums should be defined past this enum.
+   */
+  _EndShaderType,
+};
+
+/**
  * @brief Base class for all implemented attributes.  Inherits from @ref
  * esp::core::AbstractFileBasedManagedObject so the attributes can be managed by
  * a @ref esp::core::ManagedContainer.
@@ -125,12 +159,20 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * of this managed object.
    */
   std::string getObjectInfo() const override {
-    // TODO : once Magnum supports retrieving key-values of configurations, use
-    // that to build this
-    return getHandle() + ",";
+    return getSimplifiedHandle() + ", " + std::to_string(getID()) + ", " +
+           getObjectInfoInternal();
   }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getObjectInfoInternal() const {
+    return "no internal attributes specified,";
+  };
   /**
    * @brief Set this attributes' class.  Should only be set from constructor.
    * Used as key in constructor function pointer maps in AttributesManagers.

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -37,6 +37,14 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
 LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)
     : AbstractAttributes("LightLayoutAttributes", handle) {}
 
+std::string LightLayoutAttributes::getObjectInfoInternal() const {
+  std::string res = "\n";
+  for (const auto& lightInst : lightInstances_) {
+    res += lightInst.second->getObjectInfo() + "\n";
+  }
+  return res;
+}
+
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -21,8 +21,10 @@ const std::map<std::string, esp::gfx::LightPositionModel>
         {"camera", esp::gfx::LightPositionModel::Camera},
         {"object", esp::gfx::LightPositionModel::Object}};
 
+int LightInstanceAttributes::_count{0};
 LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
     : AbstractAttributes("LightInstanceAttributes", handle) {
+  setID(_count++);
   setPosition({0.0, 0.0, 0.0});
   setDirection({0.0, -1.0, 0.0});
   setColor({1.0, 1.0, 1.0});

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -45,11 +45,13 @@ std::string LightLayoutAttributes::getObjectInfoInternal() const {
   for (const auto& lightInst : lightInstances_) {
     if (iter == 0) {
       iter++;
-      res.append(", ")
+      res.append(1, ',')
           .append(lightInst.second->getObjectInfoHeader())
-          .append("\n");
+          .append(1, '\n');
     }
-    res.append(", ").append(lightInst.second->getObjectInfo()).append("\n");
+    res.append(1, ',')
+        .append(lightInst.second->getObjectInfo())
+        .append(1, '\n');
   }
   return res;
 }

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -39,8 +39,13 @@ LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)
 
 std::string LightLayoutAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
+  int iter = 0;
   for (const auto& lightInst : lightInstances_) {
-    res += lightInst.second->getObjectInfo() + "\n";
+    if (iter == 0) {
+      iter++;
+      res += "," + lightInst.second->getObjectInfoHeader();
+    }
+    res += "," + lightInst.second->getObjectInfo() + "\n";
   }
   return res;
 }

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -43,9 +43,11 @@ std::string LightLayoutAttributes::getObjectInfoInternal() const {
   for (const auto& lightInst : lightInstances_) {
     if (iter == 0) {
       iter++;
-      res += "," + lightInst.second->getObjectInfoHeader();
+      res.append(", ")
+          .append(lightInst.second->getObjectInfoHeader())
+          .append("\n");
     }
-    res += "," + lightInst.second->getObjectInfo() + "\n";
+    res.append(", ").append(lightInst.second->getObjectInfo()).append("\n");
   }
   return res;
 }

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -127,7 +127,17 @@ class LightInstanceAttributes : public AbstractAttributes {
     }
     return "unknown position model";
   }
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
 
+  std::string getObjectInfoHeaderInternal() const override {
+    return "Position XYZ, Direction XYZ, Color RGB, Intensity, Light Type, "
+           "Light Position Model,";
+  }
   /**
    * @brief Retrieve a comma-separated informational string about the
    * contents of this managed object.
@@ -194,6 +204,15 @@ class LightLayoutAttributes : public AbstractAttributes {
   int getNumLightInstances() { return lightInstances_.size(); }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific. The individual light
+   * instances return a header for this.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getObjectInfoHeaderInternal() const override { return ","; };
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -35,6 +35,7 @@ class LightInstanceAttributes : public AbstractAttributes {
    */
   static const std::map<std::string, esp::gfx::LightPositionModel>
       LightPositionNamesMap;
+
   explicit LightInstanceAttributes(const std::string& handle = "");
 
   /**
@@ -99,10 +100,51 @@ class LightInstanceAttributes : public AbstractAttributes {
   }
   Magnum::Rad getOuterConeAngle() const { return getRad("outerConeAngle"); }
 
+ protected:
+  /**
+   * @brief Used for info purposes.  Return a string name corresponding to the
+   * currently specified light type value;
+   */
+  std::string getCurrLightTypeName() const {
+    // Must always be valid value
+    esp::gfx::LightType type = static_cast<esp::gfx::LightType>(getType());
+    for (const auto& it : LightTypeNamesMap) {
+      if (it.second == type) {
+        return it.first;
+      }
+    }
+    return "unknown light type";
+  }
+
+  std::string getCurrLightPositionModelName() const {
+    // Must always be valid value
+    esp::gfx::LightPositionModel type =
+        static_cast<esp::gfx::LightPositionModel>(getPositionModel());
+    for (const auto& it : LightPositionNamesMap) {
+      if (it.second == type) {
+        return it.first;
+      }
+    }
+    return "unknown position model";
+  }
+
+  /**
+   * @brief Retrieve a comma-separated informational string about the
+   * contents of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations,
+   * use that to build this data.
+   */
+  std::string getObjectInfoInternal() const override {
+    return cfg.value("position") + ", " + cfg.value("direction") + ", " +
+           cfg.value("color") + ", " + cfg.value("intensity") + ", " +
+           getCurrLightTypeName() + ", " + getCurrLightPositionModelName() +
+           ", ";
+  }
+
  public:
   ESP_SMART_POINTERS(LightInstanceAttributes)
 
-};  // class LightInstanceAttributes
+};  // namespace attributes
 
 /**
  * @brief This class describes a lighting layout, consisting of a series of
@@ -152,6 +194,14 @@ class LightLayoutAttributes : public AbstractAttributes {
   int getNumLightInstances() { return lightInstances_.size(); }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override;
+
   /**
    * @brief The light instances used by this lighting layout
    */

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -145,10 +145,18 @@ class LightInstanceAttributes : public AbstractAttributes {
    * use that to build this data.
    */
   std::string getObjectInfoInternal() const override {
-    return cfg.value("position") + ", " + cfg.value("direction") + ", " +
-           cfg.value("color") + ", " + cfg.value("intensity") + ", " +
-           getCurrLightTypeName() + ", " + getCurrLightPositionModelName() +
-           ", ";
+    return cfg.value("position")
+        .append(", ")
+        .append(cfg.value("direction"))
+        .append(", ")
+        .append(cfg.value("color"))
+        .append(", ")
+        .append(cfg.value("intensity"))
+        .append(", ")
+        .append(getCurrLightTypeName())
+        .append(", ")
+        .append(getCurrLightPositionModelName())
+        .append(", ");
   }
 
  public:

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -159,6 +159,9 @@ class LightInstanceAttributes : public AbstractAttributes {
         .append(", ");
   }
 
+ protected:
+  static int _count;
+
  public:
   ESP_SMART_POINTERS(LightInstanceAttributes)
 

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -146,17 +146,17 @@ class LightInstanceAttributes : public AbstractAttributes {
    */
   std::string getObjectInfoInternal() const override {
     return cfg.value("position")
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("direction"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("color"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("intensity"))
-        .append(", ")
+        .append(1, ',')
         .append(getCurrLightTypeName())
-        .append(", ")
+        .append(1, ',')
         .append(getCurrLightPositionModelName())
-        .append(", ");
+        .append(1, ',');
   }
 
  protected:

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -50,13 +50,27 @@ std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {
 }
 
 std::string AbstractObjectAttributes::getObjectInfoInternal() const {
-  return getRenderAssetHandle() + ", " + getCollisionAssetHandle() + ", " +
-         cfg.value("scale") + ", " + cfg.value("margin") + ", " +
-         cfg.value("orient_up") + ", " + cfg.value("orient_front") + ", " +
-         cfg.value("units_to_meters") + ", " +
-         cfg.value("friction_coefficient") + ", " +
-         cfg.value("restitution_coefficient") + ", " + getCurrShaderTypeName() +
-         ", " + getAbstractObjectInfoInternal();
+  return getRenderAssetHandle()
+      .append(", ")
+      .append(getCollisionAssetHandle())
+      .append(", ")
+      .append(cfg.value("scale"))
+      .append(", ")
+      .append(cfg.value("margin"))
+      .append(", ")
+      .append(cfg.value("orient_up"))
+      .append(", ")
+      .append(cfg.value("orient_front"))
+      .append(", ")
+      .append(cfg.value("units_to_meters"))
+      .append(", ")
+      .append(cfg.value("friction_coefficient"))
+      .append(", ")
+      .append(cfg.value("restitution_coefficient"))
+      .append(", ")
+      .append(getCurrShaderTypeName())
+      .append(", ")
+      .append(getAbstractObjectInfoInternal());
 }  // AbstractObjectAttributes::getObjectInfoInternal
 
 ObjectAttributes::ObjectAttributes(const std::string& handle)
@@ -80,6 +94,20 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
   setIsVisible(true);
   setSemanticId(0);
 }  // ObjectAttributes ctor
+
+std::string ObjectAttributes::getAbstractObjectInfoInternal() const {
+  return cfg.value("mass")
+      .append(", ")
+      .append(cfg.value("COM"))
+      .append(", ")
+      .append(cfg.value("inertia"))
+      .append(", ")
+      .append(cfg.value("angular_damping"))
+      .append(", ")
+      .append(cfg.value("linear_damping"))
+      .append(", ")
+      .append(cfg.value("semantic_id"));
+}
 
 StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -42,9 +42,9 @@ AbstractObjectAttributes::AbstractObjectAttributes(
 }  // AbstractObjectAttributes ctor
 
 std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {
-  return "Render Asset Handle, Collision Asset Handle, Scale, Margin, Up.x, "
-         "Up.y, Up.z, Front.x, Front.y, Front.z, Units to "
-         "M, Friction Coefficient, Restitution Coefficient, Current Shader "
+  return "Render Asset Handle, Collision Asset Handle, Scale, Margin, Up XYZ, "
+         "Front XYZ, Units to M, Friction Coefficient, Restitution "
+         "Coefficient, Current Shader "
          "Type, " +
          getAbstractObjectInfoHeaderInternal();
 }
@@ -86,7 +86,7 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
 
   setBoundingBoxCollisions(false);
   setJoinCollisionMeshes(true);
-  // default to unknown for objects - will use material-derived shader unless
+  // default to Unknown for objects - will use material-derived shader unless
   // otherwise specified in config
   setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
   // TODO remove this once ShaderType support is complete
@@ -113,7 +113,7 @@ StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
-  // default to unknown for stages - will use material-derived shader unless
+  // default to Unknown for stages - will use material-derived shader unless
   // otherwise specified in config
   setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
   // TODO remove this once ShaderType support is complete

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -17,15 +17,6 @@ const std::map<std::string, esp::assets::AssetType>
         {"suncg", esp::assets::AssetType::SUNCG_SCENE},
 };
 
-// All keys must be lowercase
-const std::map<std::string, ObjectInstanceShaderType>
-    AbstractObjectAttributes::ShaderTypeNamesMap = {
-        {"material", ObjectInstanceShaderType::Material},
-        {"flat", ObjectInstanceShaderType::Flat},
-        {"phong", ObjectInstanceShaderType::Phong},
-        {"pbr", ObjectInstanceShaderType::PBR},
-};
-
 AbstractObjectAttributes::AbstractObjectAttributes(
     const std::string& attributesClassKey,
     const std::string& handle)

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -50,13 +50,21 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setCollisionAssetHandle("");
 }  // AbstractObjectAttributes ctor
 
+std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {
+  return "Render Asset Handle, Collision Asset Handle, Scale, Margin, Up.x, "
+         "Up.y, Up.z, Front.x, Front.y, Front.z, Units to "
+         "M, Friction Coefficient, Restitution Coefficient, Current Shader "
+         "Type, " +
+         getAbstractObjectInfoHeaderInternal();
+}
+
 std::string AbstractObjectAttributes::getObjectInfoInternal() const {
-  return cfg.value("scale") + ", " + cfg.value("margin") + ", " +
+  return getRenderAssetHandle() + ", " + getCollisionAssetHandle() + ", " +
+         cfg.value("scale") + ", " + cfg.value("margin") + ", " +
          cfg.value("orient_up") + ", " + cfg.value("orient_front") + ", " +
          cfg.value("units_to_meters") + ", " +
          cfg.value("friction_coefficient") + ", " +
-         cfg.value("restitution_coefficient") + ", " + getRenderAssetHandle() +
-         ", " + getCollisionAssetHandle() + ", " + getCurrShaderTypeName() +
+         cfg.value("restitution_coefficient") + ", " + getCurrShaderTypeName() +
          ", " + getAbstractObjectInfoInternal();
 }  // AbstractObjectAttributes::getObjectInfoInternal
 

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -51,25 +51,25 @@ std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {
 
 std::string AbstractObjectAttributes::getObjectInfoInternal() const {
   return getRenderAssetHandle()
-      .append(", ")
+      .append(1, ',')
       .append(getCollisionAssetHandle())
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("scale"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("margin"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("orient_up"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("orient_front"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("units_to_meters"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("friction_coefficient"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("restitution_coefficient"))
-      .append(", ")
+      .append(1, ',')
       .append(getCurrShaderTypeName())
-      .append(", ")
+      .append(1, ',')
       .append(getAbstractObjectInfoInternal());
 }  // AbstractObjectAttributes::getObjectInfoInternal
 
@@ -97,15 +97,15 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
 
 std::string ObjectAttributes::getAbstractObjectInfoInternal() const {
   return cfg.value("mass")
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("COM"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("inertia"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("angular_damping"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("linear_damping"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("semantic_id"));
 }
 

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -50,6 +50,16 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setCollisionAssetHandle("");
 }  // AbstractObjectAttributes ctor
 
+std::string AbstractObjectAttributes::getObjectInfoInternal() const {
+  return cfg.value("scale") + ", " + cfg.value("margin") + ", " +
+         cfg.value("orient_up") + ", " + cfg.value("orient_front") + ", " +
+         cfg.value("units_to_meters") + ", " +
+         cfg.value("friction_coefficient") + ", " +
+         cfg.value("restitution_coefficient") + ", " + getRenderAssetHandle() +
+         ", " + getCollisionAssetHandle() + ", " + getCurrShaderTypeName() +
+         ", " + getAbstractObjectInfoInternal();
+}  // AbstractObjectAttributes::getObjectInfoInternal
+
 ObjectAttributes::ObjectAttributes(const std::string& handle)
     : AbstractObjectAttributes("ObjectAttributes", handle) {
   // fill necessary attribute defaults

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -29,9 +29,6 @@ class AbstractObjectAttributes : public AbstractAttributes {
    */
   static const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
 
-  static const std::map<std::string, ObjectInstanceShaderType>
-      ShaderTypeNamesMap;
-
   AbstractObjectAttributes(const std::string& classKey,
                            const std::string& handle);
 
@@ -208,22 +205,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
    */
   std::string getCurrShaderTypeName() const {
     int shaderTypeVal = getShaderType();
-    if (shaderTypeVal <=
-            static_cast<int>(attributes::ObjectInstanceShaderType::Unknown) ||
-        shaderTypeVal >=
-            static_cast<int>(
-                attributes::ObjectInstanceShaderType::_EndShaderType)) {
-      return "unknown shader type";
-    }
-    // Must always be valid value
-    attributes::ObjectInstanceShaderType shaderType =
-        static_cast<attributes::ObjectInstanceShaderType>(shaderTypeVal);
-    for (const auto& it : ShaderTypeNamesMap) {
-      if (it.second == shaderType) {
-        return it.first;
-      }
-    }
-    return "unknown shader type";
+    return getShaderTypeName(shaderTypeVal);
   }
 
  protected:

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -14,36 +14,6 @@ namespace metadata {
 namespace attributes {
 
 /**
- * @brief This enum class defines the possible shader options for rendering
- * instances of objects or stages in Habitat-sim.
- */
-enum class ObjectInstanceShaderType {
-  /**
-   * Represents an unknown/unspecified value for the shader type to use. Resort
-   * to defaults for object type.
-   */
-  Unknown = ID_UNDEFINED,
-  /**
-   * Override any config-specified or default shader-type values to use the
-   * material-specified shader.
-   */
-  Material,
-  /**
-   * Refers to flat shading, pure color and no lighting.  This is often used for
-   * textured objects
-   */
-  Flat,
-  /**
-   * Refers to phong shading with pure diffuse color.
-   */
-  Phong,
-  /**
-   * Refers to using a shader built with physically-based rendering models.
-   */
-  PBR,
-};
-
-/**
  * @brief base attributes object holding attributes shared by all
  * @ref esp::metadata::attributes::ObjectAttributes and @ref
  * esp::metadata::attributes::StageAttributes objects; Should be treated as
@@ -232,7 +202,44 @@ class AbstractObjectAttributes : public AbstractAttributes {
   bool getIsDirty() const { return getBool("__isDirty"); }
   void setIsClean() { setBool("__isDirty", false); }
 
+  /**
+   * @brief Used for info purposes.  Return a string name corresponding to the
+   * currently specified shader type value;
+   */
+  std::string getCurrShaderTypeName() const {
+    int shaderTypeVal = getShaderType();
+    if (shaderTypeVal <=
+            static_cast<int>(attributes::ObjectInstanceShaderType::Unknown) ||
+        shaderTypeVal >=
+            static_cast<int>(
+                attributes::ObjectInstanceShaderType::_EndShaderType)) {
+      return "unknown shader type";
+    }
+    // Must always be valid value
+    attributes::ObjectInstanceShaderType shaderType =
+        static_cast<attributes::ObjectInstanceShaderType>(shaderTypeVal);
+    for (const auto& it : ShaderTypeNamesMap) {
+      if (it.second == shaderType) {
+        return it.first;
+      }
+    }
+    return "unknown shader type";
+  }
+
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override;
+  /**
+   * @brief get AbstractObject specific info
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getAbstractObjectInfoInternal() const { return ""; };
   void setIsDirty() { setBool("__isDirty", true); }
 
  public:
@@ -241,8 +248,8 @@ class AbstractObjectAttributes : public AbstractAttributes {
 };  // class AbstractObjectAttributes
 
 /**
- * @brief Specific Attributes instance describing an object, constructed with a
- * default set of object-specific required attributes
+ * @brief Specific Attributes instance describing an object, constructed with
+ * a default set of object-specific required attributes
  */
 class ObjectAttributes : public AbstractObjectAttributes {
  public:
@@ -306,6 +313,13 @@ class ObjectAttributes : public AbstractObjectAttributes {
   void setSemanticId(uint32_t semanticId) { setInt("semantic_id", semanticId); }
 
   uint32_t getSemanticId() const { return getInt("semantic_id"); }
+
+ protected:
+  std::string getAbstractObjectInfoInternal() const override {
+    return cfg.value("mass") + ", " + cfg.value("COM") + ", " +
+           cfg.value("inertia") + ", " + cfg.value("linear_damping") + ", " +
+           cfg.value("angular_damping") + ", " + cfg.value("semantic_id");
+  }
 
  public:
   ESP_SMART_POINTERS(ObjectAttributes)
@@ -380,6 +394,12 @@ class StageAttributes : public AbstractObjectAttributes {
     setBool("frustum_culling", frustumCulling);
   }
   bool getFrustumCulling() const { return getBool("frustum_culling"); }
+
+ protected:
+  std::string getAbstractObjectInfoInternal() const override {
+    return getNavmeshAssetHandle() + ", " + cfg.value("gravity") + ", " +
+           cfg.value("origin") + ", " + cfg.value("light_setup");
+  }
 
  public:
   ESP_SMART_POINTERS(StageAttributes)

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -414,13 +414,14 @@ class StageAttributes : public AbstractObjectAttributes {
    * @brief get AbstractObject specific info for csv string
    */
   std::string getAbstractObjectInfoInternal() const override {
-    return getNavmeshAssetHandle()
-        .append(1, ',')
+    std::string res = getNavmeshAssetHandle();
+    res.append(1, ',')
         .append(cfg.value("gravity"))
         .append(1, ',')
         .append(cfg.value("origin"))
         .append(1, ',')
         .append(cfg.value("light_setup"));
+    return res;
   }
 
  public:

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -234,9 +234,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
    */
   std::string getObjectInfoInternal() const override;
   /**
-   * @brief get AbstractObject specific info
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
+   * @brief get AbstractObject specific info for csv string
    */
   virtual std::string getAbstractObjectInfoInternal() const { return ""; };
   void setIsDirty() { setBool("__isDirty", true); }
@@ -322,13 +320,11 @@ class ObjectAttributes : public AbstractObjectAttributes {
   std::string getAbstractObjectInfoHeaderInternal() const override {
     return "Mass, COM XYZ, I XX YY ZZ, Angular Damping, "
            "Linear Damping, Semantic ID";
-  };
-
-  std::string getAbstractObjectInfoInternal() const override {
-    return cfg.value("mass") + ", " + cfg.value("COM") + ", " +
-           cfg.value("inertia") + ", " + cfg.value("angular_damping") + ", " +
-           cfg.value("linear_damping") + ", " + cfg.value("semantic_id");
   }
+  /**
+   * @brief get AbstractObject specific info for csv string
+   */
+  std::string getAbstractObjectInfoInternal() const override;
 
  public:
   ESP_SMART_POINTERS(ObjectAttributes)
@@ -412,11 +408,19 @@ class StageAttributes : public AbstractObjectAttributes {
    */
   std::string getAbstractObjectInfoHeaderInternal() const override {
     return "Navmesh Handle, Gravity XYZ, Origin XYZ, Light Setup,";
-  };
+  }
 
+  /**
+   * @brief get AbstractObject specific info for csv string
+   */
   std::string getAbstractObjectInfoInternal() const override {
-    return getNavmeshAssetHandle() + ", " + cfg.value("gravity") + ", " +
-           cfg.value("origin") + ", " + cfg.value("light_setup");
+    return getNavmeshAssetHandle()
+        .append(", ")
+        .append(cfg.value("gravity"))
+        .append(", ")
+        .append(cfg.value("origin"))
+        .append(", ")
+        .append(cfg.value("light_setup"));
   }
 
  public:

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -415,11 +415,11 @@ class StageAttributes : public AbstractObjectAttributes {
    */
   std::string getAbstractObjectInfoInternal() const override {
     return getNavmeshAssetHandle()
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("gravity"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("origin"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("light_setup"));
   }
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -228,6 +228,23 @@ class AbstractObjectAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getObjectInfoHeaderInternal() const override;
+  /**
+   * @brief get AbstractObject specific info header
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getAbstractObjectInfoHeaderInternal() const {
+    return "";
+  };
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    * TODO : once Magnum supports retrieving key-values of configurations, use
@@ -315,10 +332,20 @@ class ObjectAttributes : public AbstractObjectAttributes {
   uint32_t getSemanticId() const { return getInt("semantic_id"); }
 
  protected:
+  /**
+   * @brief get AbstractObject specific info header
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getAbstractObjectInfoHeaderInternal() const override {
+    return "Mass, COM XYZ, I XX YY ZZ, Angular Damping, "
+           "Linear Damping, Semantic ID";
+  };
+
   std::string getAbstractObjectInfoInternal() const override {
     return cfg.value("mass") + ", " + cfg.value("COM") + ", " +
-           cfg.value("inertia") + ", " + cfg.value("linear_damping") + ", " +
-           cfg.value("angular_damping") + ", " + cfg.value("semantic_id");
+           cfg.value("inertia") + ", " + cfg.value("angular_damping") + ", " +
+           cfg.value("linear_damping") + ", " + cfg.value("semantic_id");
   }
 
  public:
@@ -396,6 +423,15 @@ class StageAttributes : public AbstractObjectAttributes {
   bool getFrustumCulling() const { return getBool("frustum_culling"); }
 
  protected:
+  /**
+   * @brief get AbstractObject specific info header
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getAbstractObjectInfoHeaderInternal() const override {
+    return "Navmesh Handle, Gravity XYZ, Origin XYZ, Light Setup,";
+  };
+
   std::string getAbstractObjectInfoInternal() const override {
     return getNavmeshAssetHandle() + ", " + cfg.value("gravity") + ", " +
            cfg.value("origin") + ", " + cfg.value("light_setup");

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -48,6 +48,18 @@ class PhysicsManagerAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getObjectInfoHeaderInternal() const override {
+    return "Simulator Type, Timestep, Max Substeps, Gravity XYZ, Friction "
+           "Coefficient, Restitution Coefficient,";
+  }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    * TODO : once Magnum supports retrieving key-values of configurations, use

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -46,6 +46,20 @@ class PhysicsManagerAttributes : public AbstractAttributes {
     return getDouble("restitution_coefficient");
   }
 
+ protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override {
+    return getSimulator() + ", " + cfg.value("timestep") + ", " +
+           cfg.value("max_substeps") + ", " + cfg.value("gravity") + ", " +
+           cfg.value("friction_coefficient") + ", " +
+           cfg.value("restitution_coefficient");
+  }
+
  public:
   ESP_SMART_POINTERS(PhysicsManagerAttributes)
 };  // class PhysicsManagerAttributes

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -66,10 +66,17 @@ class PhysicsManagerAttributes : public AbstractAttributes {
    * that to build this data.
    */
   std::string getObjectInfoInternal() const override {
-    return getSimulator() + ", " + cfg.value("timestep") + ", " +
-           cfg.value("max_substeps") + ", " + cfg.value("gravity") + ", " +
-           cfg.value("friction_coefficient") + ", " +
-           cfg.value("restitution_coefficient");
+    return getSimulator()
+        .append(", ")
+        .append(cfg.value("timestep"))
+        .append(", ")
+        .append(cfg.value("max_substeps"))
+        .append(", ")
+        .append(cfg.value("gravity"))
+        .append(", ")
+        .append(cfg.value("friction_coefficient"))
+        .append(", ")
+        .append(cfg.value("restitution_coefficient"));
   }
 
  public:

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -67,15 +67,15 @@ class PhysicsManagerAttributes : public AbstractAttributes {
    */
   std::string getObjectInfoInternal() const override {
     return getSimulator()
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("timestep"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("max_substeps"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("gravity"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("friction_coefficient"))
-        .append(", ")
+        .append(1, ',')
         .append(cfg.value("restitution_coefficient"));
   }
 

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -132,6 +132,17 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override {
+    // Handle already encodes all relevant info
+    return ", ";
+  }
+
+  /**
    * @brief Verifies that val is larger than, and a multiple of, divisor
    * div
    * @param val the value to check

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -130,6 +130,12 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
     return success;
   }
 
+  /**
+   * @brief PrimitiveAssetAttributes handles are already simplified, and embed
+   * no path info.
+   */
+  std::string getSimplifiedHandle() const override { return getHandle(); }
+
  protected:
   /**
    * @brief Retrieve a comma-separated informational string about the contents

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -138,6 +138,17 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoHeaderInternal() const override {
+    // Handle already encodes all relevant info
+    return ",";
+  }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    * TODO : once Magnum supports retrieving key-values of configurations, use

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -47,19 +47,19 @@ std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
 
 std::string SceneObjectInstanceAttributes::getObjectInfoInternal() const {
   return cfg.value("translation")
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("rotation"))
-      .append(", ")
+      .append(1, ',')
       .append(getCurrMotionTypeName())
-      .append(", ")
+      .append(1, ',')
       .append(getCurrShaderTypeName())
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("uniform_scale"))
-      .append(", ")
+      .append(1, ',')
       .append(cfg.value("mass_scale"))
-      .append(", ")
+      .append(1, ',')
       .append(getTranslationOriginName(getTranslationOrigin()))
-      .append(", ")
+      .append(1, ',')
       .append(getSceneObjInstanceInfoInternal());
 }  // SceneObjectInstanceAttributes::getObjectInfoInternal()
 
@@ -75,13 +75,13 @@ std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()
   std::string initPoseHdr;
   int iter = 0;
   for (const auto& it : initJointPose_) {
-    initPoseHdr.append(posePrfx).append(std::to_string(iter++)).append(", ");
+    initPoseHdr.append(posePrfx).append(std::to_string(iter++)).append(1, ',');
   }
   const std::string velPrfx{"Init Vel "};
   std::string initVelHdr;
   iter = 0;
   for (const auto& it : initJointPose_) {
-    initVelHdr.append(velPrfx).append(std::to_string(iter++)).append(", ");
+    initVelHdr.append(velPrfx).append(std::to_string(iter++)).append(1, ',');
   }
   std::string res{"Is Fixed Base?, "};
   res.append(initPoseHdr).append(initVelHdr);
@@ -91,16 +91,16 @@ std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
   std::string initJointPose{"["};
   for (const auto& it : initJointPose_) {
-    initJointPose.append(std::to_string(it.second)).append(", ");
+    initJointPose.append(std::to_string(it.second)).append(1, ',');
   }
   initJointPose.append("]");
   std::string initJointVels{"["};
   for (const auto& it : initJointPose_) {
-    initJointVels.append(std::to_string(it.second)).append(", ");
+    initJointVels.append(std::to_string(it.second)).append(1, ',');
   }
   initJointVels.append("]");
-  return cfg.value("fixed_base").append(", ") + initJointPose.append(", ") +
-         initJointVels.append(", ");
+  return cfg.value("fixed_base").append(1, ',') + initJointPose.append(1, ',') +
+         initJointVels.append(1, ',');
 }  // SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal()
 
 SceneAttributes::SceneAttributes(const std::string& handle)
@@ -118,29 +118,29 @@ std::string SceneAttributes::getObjectInfoInternal() const {
   // default translation origin
   res.append("Default Translation Origin : ")
       .append(getTranslationOriginName(getTranslationOrigin()))
-      .append(",\n");
+      .append(1, '\n');
   // specified lighting
-  res.append("Default Lighting, ").append(getLightingHandle()).append(",\n");
+  res.append("Default Lighting, ").append(getLightingHandle()).append(1, '\n');
 
   // specified navmesh(s)
-  res.append("Navmesh Handle, ").append(getNavmeshHandle() + ",\n");
+  res.append("Navmesh Handle, ").append(getNavmeshHandle()).append(1, '\n');
 
   // specified ssd
   res.append("Semantic Scene Descriptor Handle, ")
       .append(getSemanticSceneHandle())
-      .append(",\n");
+      .append(1, '\n');
 
   // stage instance info
-  res.append(stageInstance_->getObjectInfo()).append("\n");
+  res.append(stageInstance_->getObjectInfo()).append(1, '\n');
 
   // object instance info
   for (const auto& objInst : objectInstances_) {
-    res.append(objInst->getObjectInfo()).append("\n");
+    res.append(objInst->getObjectInfo()).append(1, '\n');
   }
 
   // articulated object instance info
   for (const auto& artObjInst : articulatedObjectInstances_) {
-    res.append(artObjInst->getObjectInfo()).append("\n");
+    res.append(artObjInst->getObjectInfo()).append(1, '\n');
   }
 
   return res;

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -26,6 +26,7 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   setMotionType(static_cast<int>(esp::physics::MotionType::UNDEFINED));
   // set to no rotation
   setQuat("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
+  setVec3("translation", Mn::Vector3());
   // defaults to unknown so that obj instances use scene instance setting
   setTranslationOrigin(
       static_cast<int>(SceneInstanceTranslationOrigin::Unknown));
@@ -40,7 +41,7 @@ std::string SceneObjectInstanceAttributes::getCurrShaderTypeName() const {
 }
 
 std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
-  return "Translation XYZ, Rotation WXYZ, Motion Type, Shader Type, Uniform "
+  return "Translation XYZ, Rotation XYZW, Motion Type, Shader Type, Uniform "
          "Scale, Mass Scale, Translation Origin, " +
          getSceneObjInstanceInfoHeaderInternal();
 }
@@ -116,32 +117,49 @@ std::string SceneAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
   // scene-specific info constants
   // default translation origin
-  res.append("Default Translation Origin : ")
-      .append(getTranslationOriginName(getTranslationOrigin()))
-      .append(1, '\n');
-  // specified lighting
-  res.append("Default Lighting, ").append(getLightingHandle()).append(1, '\n');
+  res.append(
+      "Default Translation Origin, Default Lighting,Navmesh Handle,Semantic "
+      "Scene Descriptor Handle,\n");
 
-  // specified navmesh(s)
-  res.append("Navmesh Handle, ").append(getNavmeshHandle()).append(1, '\n');
-
-  // specified ssd
-  res.append("Semantic Scene Descriptor Handle, ")
+  res.append(getTranslationOriginName(getTranslationOrigin()))
+      .append(1, ',')
+      .append(getLightingHandle())
+      .append(1, ',')
+      .append(getNavmeshHandle())
+      .append(1, ',')
       .append(getSemanticSceneHandle())
       .append(1, '\n');
 
   // stage instance info
+  res.append("Stage Instance Info :\n");
+  res.append(stageInstance_->getObjectInfoHeader()).append(1, '\n');
   res.append(stageInstance_->getObjectInfo()).append(1, '\n');
 
+  int iter = 0;
   // object instance info
   for (const auto& objInst : objectInstances_) {
+    if (iter == 0) {
+      iter++;
+      res.append("Object Instance Info :\n");
+      res.append(objInst->getObjectInfoHeader()).append(1, '\n');
+    }
     res.append(objInst->getObjectInfo()).append(1, '\n');
   }
 
   // articulated object instance info
+  iter = 0;
   for (const auto& artObjInst : articulatedObjectInstances_) {
+    if (iter == 0) {
+      iter++;
+      res.append("Articulated Object Instance Info :\n");
+      res.append(artObjInst->getObjectInfoHeader()).append(1, '\n');
+    }
     res.append(artObjInst->getObjectInfo()).append(1, '\n');
   }
+
+  res.append("End of data for Scene Instance ")
+      .append(getSimplifiedHandle())
+      .append(1, '\n');
 
   return res;
 }  // SceneAttributes::getObjectInfoInternal

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -14,7 +14,6 @@ const std::map<std::string, esp::physics::MotionType>
         {"kinematic", esp::physics::MotionType::KINEMATIC},
         {"dynamic", esp::physics::MotionType::DYNAMIC},
 };
-
 SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     const std::string& handle,
     const std::string& type)
@@ -29,35 +28,15 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   setQuat("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
   // defaults to unknown so that obj instances use scene instance setting
   setTranslationOrigin(
-      static_cast<int>(managers::SceneInstanceTranslationOrigin::Unknown));
+      static_cast<int>(SceneInstanceTranslationOrigin::Unknown));
   // set default multiplicative scaling values
   setUniformScale(1.0f);
   setMassScale(1.0f);
 }
 
-/**
- * @brief Used for info purposes.  Return a string name corresponding to the
- * currently specified shader type value;
- */
 std::string SceneObjectInstanceAttributes::getCurrShaderTypeName() const {
   int shaderTypeVal = getShaderType();
-  if (shaderTypeVal <=
-          static_cast<int>(attributes::ObjectInstanceShaderType::Unknown) ||
-      shaderTypeVal >=
-          static_cast<int>(
-              attributes::ObjectInstanceShaderType::_EndShaderType)) {
-    return "unknown shader type";
-  }
-  // Must always be valid value
-  ObjectInstanceShaderType shaderType =
-      static_cast<ObjectInstanceShaderType>(shaderTypeVal);
-  for (const auto& it :
-       attributes::AbstractObjectAttributes::ShaderTypeNamesMap) {
-    if (it.second == shaderType) {
-      return it.first;
-    }
-  }
-  return "unknown shader type";
+  return getShaderTypeName(shaderTypeVal);
 }
 
 std::string SceneObjectInstanceAttributes::getObjectInfoInternal() const {
@@ -88,23 +67,25 @@ std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
          ", ";
 }  // SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal()
 
-const std::map<std::string, managers::SceneInstanceTranslationOrigin>
-    SceneAttributes::InstanceTranslationOriginMap = {
-        {"asset_local", managers::SceneInstanceTranslationOrigin::AssetLocal},
-        {"com", managers::SceneInstanceTranslationOrigin::COM},
-};
-
 SceneAttributes::SceneAttributes(const std::string& handle)
     : AbstractAttributes("SceneAttributes", handle) {
   // defaults to no lights
   setLightingHandle(NO_LIGHT_KEY);
   // defaults to asset local
   setTranslationOrigin(
-      static_cast<int>(managers::SceneInstanceTranslationOrigin::AssetLocal));
+      static_cast<int>(SceneInstanceTranslationOrigin::AssetLocal));
 }
 
 std::string SceneAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
+  // scene-specific info constants
+
+  // specified lighting
+
+  // specified navmesh(s)
+
+  // specified ssd
+
   // stage instance info
   res += stageInstance_->getObjectInfo() + "\n";
 
@@ -117,6 +98,7 @@ std::string SceneAttributes::getObjectInfoInternal() const {
   for (const auto& artObjInst : articulatedObjectInstances_) {
     res += artObjInst->getObjectInfo() + "\n";
   }
+
   return res;
 }
 

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -46,11 +46,21 @@ std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
 }
 
 std::string SceneObjectInstanceAttributes::getObjectInfoInternal() const {
-  return cfg.value("translation") + ", " + cfg.value("rotation") + ", " +
-         getCurrMotionTypeName() + ", " + getCurrShaderTypeName() + ", " +
-         cfg.value("uniform_scale") + ", " + cfg.value("mass_scale") + ", " +
-         getTranslationOriginName(getTranslationOrigin()) + ", " +
-         getSceneObjInstanceInfoInternal();
+  return cfg.value("translation")
+      .append(", ")
+      .append(cfg.value("rotation"))
+      .append(", ")
+      .append(getCurrMotionTypeName())
+      .append(", ")
+      .append(getCurrShaderTypeName())
+      .append(", ")
+      .append(cfg.value("uniform_scale"))
+      .append(", ")
+      .append(cfg.value("mass_scale"))
+      .append(", ")
+      .append(getTranslationOriginName(getTranslationOrigin()))
+      .append(", ")
+      .append(getSceneObjInstanceInfoInternal());
 }  // SceneObjectInstanceAttributes::getObjectInfoInternal()
 
 SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
@@ -61,35 +71,36 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
 
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()
     const {
-  const std::string posePrfx = "Init Pose ";
-  std::string initPoseHdr = "";
+  const std::string posePrfx{"Init Pose "};
+  std::string initPoseHdr;
   int iter = 0;
   for (const auto& it : initJointPose_) {
-    initPoseHdr += posePrfx + std::to_string(iter++) + ", ";
+    initPoseHdr.append(posePrfx).append(std::to_string(iter++)).append(", ");
   }
-  const std::string velPrfx = "Init Vel ";
-  std::string initVelHdr = "";
+  const std::string velPrfx{"Init Vel "};
+  std::string initVelHdr;
   iter = 0;
   for (const auto& it : initJointPose_) {
-    initVelHdr += velPrfx + std::to_string(iter++) + ", ";
+    initVelHdr.append(velPrfx).append(std::to_string(iter++)).append(", ");
   }
-  std::string res = "Is Fixed Base?, " + initPoseHdr + initVelHdr;
+  std::string res{"Is Fixed Base?, "};
+  res.append(initPoseHdr).append(initVelHdr);
   return res;
 }  // SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal
 
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
-  std::string initJointPose = "[";
+  std::string initJointPose{"["};
   for (const auto& it : initJointPose_) {
-    initJointPose += std::to_string(it.second) + ", ";
+    initJointPose.append(std::to_string(it.second)).append(", ");
   }
-  initJointPose = "]";
-  std::string initJointVels = "[";
+  initJointPose.append("]");
+  std::string initJointVels{"["};
   for (const auto& it : initJointPose_) {
-    initJointVels += std::to_string(it.second) + ", ";
+    initJointVels.append(std::to_string(it.second)).append(", ");
   }
-  initJointVels = "]";
-  return cfg.value("fixed_base") + ", " + initJointPose + ", " + initJointVels +
-         ", ";
+  initJointVels.append("]");
+  return cfg.value("fixed_base").append(", ") + initJointPose.append(", ") +
+         initJointVels.append(", ");
 }  // SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal()
 
 SceneAttributes::SceneAttributes(const std::string& handle)
@@ -105,29 +116,31 @@ std::string SceneAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
   // scene-specific info constants
   // default translation origin
-  res += "Default Translation Origin : " +
-         getTranslationOriginName(getTranslationOrigin()) + ",\n";
+  res.append("Default Translation Origin : ")
+      .append(getTranslationOriginName(getTranslationOrigin()))
+      .append(",\n");
   // specified lighting
-  res += "Default Lighting, " + getLightingHandle() + ",\n";
+  res.append("Default Lighting, ").append(getLightingHandle()).append(",\n");
 
   // specified navmesh(s)
-  res += "Navmesh Handle, " + getNavmeshHandle() + ",\n";
+  res.append("Navmesh Handle, ").append(getNavmeshHandle() + ",\n");
 
   // specified ssd
-  res +=
-      "Semantic Scene Descriptor Handle, " + getSemanticSceneHandle() + ",\n";
+  res.append("Semantic Scene Descriptor Handle, ")
+      .append(getSemanticSceneHandle())
+      .append(",\n");
 
   // stage instance info
-  res += stageInstance_->getObjectInfo() + "\n";
+  res.append(stageInstance_->getObjectInfo()).append("\n");
 
   // object instance info
   for (const auto& objInst : objectInstances_) {
-    res += objInst->getObjectInfo() + "\n";
+    res.append(objInst->getObjectInfo()).append("\n");
   }
 
   // articulated object instance info
   for (const auto& artObjInst : articulatedObjectInstances_) {
-    res += artObjInst->getObjectInfo() + "\n";
+    res.append(artObjInst->getObjectInfo()).append("\n");
   }
 
   return res;

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -39,10 +39,17 @@ std::string SceneObjectInstanceAttributes::getCurrShaderTypeName() const {
   return getShaderTypeName(shaderTypeVal);
 }
 
+std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
+  return "Translation XYZ, Rotation WXYZ, Motion Type, Shader Type, Uniform "
+         "Scale, Mass Scale, Translation Origin, " +
+         getSceneObjInstanceInfoHeaderInternal();
+}
+
 std::string SceneObjectInstanceAttributes::getObjectInfoInternal() const {
   return cfg.value("translation") + ", " + cfg.value("rotation") + ", " +
          getCurrMotionTypeName() + ", " + getCurrShaderTypeName() + ", " +
          cfg.value("uniform_scale") + ", " + cfg.value("mass_scale") + ", " +
+         getTranslationOriginName(getTranslationOrigin()) + ", " +
          getSceneObjInstanceInfoInternal();
 }  // SceneObjectInstanceAttributes::getObjectInfoInternal()
 
@@ -51,6 +58,24 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
   // set default fixed base value (only used for articulated object)
   setFixedBase(false);
 }
+
+std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()
+    const {
+  const std::string posePrfx = "Init Pose ";
+  std::string initPoseHdr = "";
+  int iter = 0;
+  for (const auto& it : initJointPose_) {
+    initPoseHdr += posePrfx + std::to_string(iter++) + ", ";
+  }
+  const std::string velPrfx = "Init Vel ";
+  std::string initVelHdr = "";
+  iter = 0;
+  for (const auto& it : initJointPose_) {
+    initVelHdr += velPrfx + std::to_string(iter++) + ", ";
+  }
+  std::string res = "Is Fixed Base?, " + initPoseHdr + initVelHdr;
+  return res;
+}  // SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal
 
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
   std::string initJointPose = "[";
@@ -79,12 +104,18 @@ SceneAttributes::SceneAttributes(const std::string& handle)
 std::string SceneAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
   // scene-specific info constants
-
+  // default translation origin
+  res += "Default Translation Origin : " +
+         getTranslationOriginName(getTranslationOrigin()) + ",\n";
   // specified lighting
+  res += "Default Lighting, " + getLightingHandle() + ",\n";
 
   // specified navmesh(s)
+  res += "Navmesh Handle, " + getNavmeshHandle() + ",\n";
 
   // specified ssd
+  res +=
+      "Semantic Scene Descriptor Handle, " + getSemanticSceneHandle() + ",\n";
 
   // stage instance info
   res += stageInstance_->getObjectInfo() + "\n";
@@ -100,7 +131,7 @@ std::string SceneAttributes::getObjectInfoInternal() const {
   }
 
   return res;
-}
+}  // SceneAttributes::getObjectInfoInternal
 
 }  // namespace attributes
 }  // namespace metadata

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -238,17 +238,6 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
 
 class SceneAttributes : public AbstractAttributes {
  public:
-  /**
-   * @brief Constant static map to provide mappings from string tags to @ref
-   * metadata::managers::SceneInstanceTranslationOrigin values.  This will be
-   * used to map values set in json for translation origin to @ref
-   * metadata::managers::SceneInstanceTranslationOrigin.  Keys must be
-   * lowercase.
-   */
-  static const std::map<std::string,
-                        metadata::managers::SceneInstanceTranslationOrigin>
-      InstanceTranslationOriginMap;
-
   explicit SceneAttributes(const std::string& handle);
 
   /**

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -148,6 +148,13 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    * that to build this data.
    */
   std::string getObjectInfoInternal() const override;
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoHeaderInternal() const override;
 
   /**
    * @brief Retrieve a comma-separated informational string about the contents
@@ -156,6 +163,16 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    * that to build this data.
    */
   virtual std::string getSceneObjInstanceInfoInternal() const { return ""; }
+
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getSceneObjInstanceInfoHeaderInternal() const {
+    return "";
+  }
 
  public:
   ESP_SMART_POINTERS(SceneObjectInstanceAttributes)
@@ -220,6 +237,14 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
    * of this SceneAOInstanceAttributes object.
    */
   std::string getSceneObjInstanceInfoInternal() const override;
+
+  /**
+   * @brief Retrieve a comma-separated informational string
+   * about the contents of this managed object.
+   * TODO : once Magnum supports retrieving key-values of
+   * configurations, use that to build this data.
+   */
+  std::string getSceneObjInstanceInfoHeaderInternal() const override;
 
   /**
    * @brief Map of joint names/idxs to values for initial pose

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -16,7 +16,7 @@ enum class MotionType;
 namespace metadata {
 namespace managers {
 enum class SceneInstanceTranslationOrigin;
-}
+}  // namespace managers
 namespace attributes {
 
 /**
@@ -28,8 +28,9 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
  public:
   /**
    * @brief Constant static map to provide mappings from string tags to @ref
-   * esp::assets::AssetType values.  This will be used to map values set in json
-   * for mesh type to @ref esp::assets::AssetType.  Keys must be lowercase.
+   * esp::physics::MotionType values.  This will be used to map values set in
+   * json for mesh type to @ref esp::physics::MotionType.  Keys must be
+   * lowercase.
    */
   static const std::map<std::string, esp::physics::MotionType>
       MotionTypeNamesMap;
@@ -117,6 +118,45 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   float getMassScale() const { return getFloat("mass_scale"); }
   void setMassScale(float mass_scale) { setFloat("mass_scale", mass_scale); }
 
+  /**
+   * @brief Used for info purposes.  Return a string name corresponding to the
+   * currently specified motion type value;
+   */
+  std::string getCurrMotionTypeName() const {
+    // Must always be valid value
+    esp::physics::MotionType motionType =
+        static_cast<esp::physics::MotionType>(getMotionType());
+    for (const auto& it : MotionTypeNamesMap) {
+      if (it.second == motionType) {
+        return it.first;
+      }
+    }
+    return "unknown motion type";
+  }
+
+  /**
+   * @brief Used for info purposes.  Return a string name corresponding to the
+   * currently specified shader type value;
+   */
+  std::string getCurrShaderTypeName() const;
+
+ protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override;
+
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getSceneObjInstanceInfoInternal() const { return ""; }
+
  public:
   ESP_SMART_POINTERS(SceneObjectInstanceAttributes)
 };  // class SceneObjectInstanceAttributes
@@ -175,6 +215,12 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
   }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this SceneAOInstanceAttributes object.
+   */
+  std::string getSceneObjInstanceInfoInternal() const override;
+
   /**
    * @brief Map of joint names/idxs to values for initial pose
    */
@@ -303,6 +349,13 @@ class SceneAttributes : public AbstractAttributes {
   }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getObjectInfoInternal() const override;
   /**
    * @brief The stage instance used by the scene
    */

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -131,7 +131,7 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
         return it.first;
       }
     }
-    return "unknown motion type";
+    return "unspecified";
   }
 
   /**

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -350,6 +350,15 @@ class SceneAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getObjectInfoHeaderInternal() const override { return ""; }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    * TODO : once Magnum supports retrieving key-values of configurations, use

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -182,6 +182,78 @@ SceneDatasetAttributes::getNamedObjectAttributesCopy(
   return objectAttributesManager_->getObjectCopyByHandle(fullObjName);
 }  // SceneDatasetAttributes::getNamedObjectAttributesCopy
 
+std::string SceneDatasetAttributes::getObjectInfoInternal() const {
+  // provide a summary for all info for this scene dataset
+  std::string res = "\n";
+  // scene instances
+  res += "Scene Instances : \n";
+  std::vector<std::string> sceneInstAttrInfoAra =
+      sceneAttributesManager_->getObjectInfoStrings();
+  for (const std::string& s : sceneInstAttrInfoAra) {
+    res += s + "\n";
+  }
+  res += "Stage Templates : \n";
+  // stages
+  std::vector<std::string> stageAttrInfoAra =
+      stageAttributesManager_->getObjectInfoStrings();
+  for (const std::string& s : stageAttrInfoAra) {
+    res += s + "\n";
+  }
+  res += "Object Templates : \n";
+  // objects
+  std::vector<std::string> objAttrInfoAra =
+      objectAttributesManager_->getObjectInfoStrings();
+  for (const std::string& s : objAttrInfoAra) {
+    res += s + "\n";
+  }
+  res += "Articulated Object Models : \n";
+  // articulated objects
+  for (const auto& item : articulatedObjPaths) {
+    res += item.first + ", " + item.second + ",\n";
+  }
+  res += "Lighting Configurations : \n";
+  // lights
+  std::vector<std::string> lightAttrInfoAra =
+      lightLayoutAttributesManager_->getObjectInfoStrings();
+  for (const std::string& s : lightAttrInfoAra) {
+    res += s + "\n";
+  }
+  res += "Primitives Templates : \n";
+  // prims
+  std::vector<std::string> primAttrInfoAra =
+      assetAttributesManager_->getObjectInfoStrings();
+  for (const std::string& s : primAttrInfoAra) {
+    res += s + "\n";
+  }
+  res += "Navmeshes : \n";
+  // navmesh
+  for (const auto& item : navmeshMap_) {
+    res += item.first + ", " + item.second + ",\n";
+  }
+  res += "Semantic Scene Descriptors : \n";
+  // SSD entries
+  for (const auto& item : semanticSceneDescrMap_) {
+    res += item.first + ", " + item.second + ",\n";
+  }
+
+  return res;
+}
+
+std::string SceneDatasetAttributes::getDatasetSummary() {
+  std::string res =
+      getHandle() + ", " +
+      std::to_string(sceneAttributesManager_->getNumObjects()) + ", " +
+      std::to_string(stageAttributesManager_->getNumObjects()) + ", " +
+      std::to_string(objectAttributesManager_->getNumObjects()) + ", " +
+      std::to_string(lightLayoutAttributesManager_->getNumObjects()) + ", " +
+      std::to_string(articulatedObjPaths.size()) + ", " +
+      std::to_string(assetAttributesManager_->getNumObjects()) + ", " +
+      std::to_string(navmeshMap_.size()) + ", " +
+      std::to_string(semanticSceneDescrMap_.size()) + ", ";
+  return res;
+
+}  // SceneDatasetAttributes::getDatasetSummary
+
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -190,50 +190,50 @@ std::string SceneDatasetAttributes::getObjectInfoInternal() const {
   std::vector<std::string> sceneInstAttrInfoAra =
       sceneAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : sceneInstAttrInfoAra) {
-    res.append(s).append("\n");
+    res.append(s).append(1, '\n');
   }
   res += "Stage Templates : \n";
   // stages
   std::vector<std::string> stageAttrInfoAra =
       stageAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : stageAttrInfoAra) {
-    res.append(s).append("\n");
+    res.append(s).append(1, '\n');
   }
   res += "Object Templates : \n";
   // objects
   std::vector<std::string> objAttrInfoAra =
       objectAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : objAttrInfoAra) {
-    res.append(s).append("\n");
+    res.append(s).append(1, '\n');
   }
   res += "Articulated Object Models : \n";
   // articulated objects
   for (const auto& item : articulatedObjPaths) {
-    res.append(item.first).append(", ").append(item.second) + ",\n";
+    res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }
   res += "Lighting Configurations : \n";
   // lights
   std::vector<std::string> lightAttrInfoAra =
       lightLayoutAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : lightAttrInfoAra) {
-    res.append(s).append("\n");
+    res.append(s).append(1, '\n');
   }
   res += "Primitives Templates : \n";
   // prims
   std::vector<std::string> primAttrInfoAra =
       assetAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : primAttrInfoAra) {
-    res.append(s).append("\n");
+    res.append(s).append(1, '\n');
   }
   res += "Navmeshes : \n";
   // navmesh
   for (const auto& item : navmeshMap_) {
-    res.append(item.first).append(", ").append(item.second) + ",\n";
+    res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }
   res += "Semantic Scene Descriptors : \n";
   // SSD entries
   for (const auto& item : semanticSceneDescrMap_) {
-    res.append(item.first).append(", ").append(item.second) + ",\n";
+    res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }
 
   return res;
@@ -248,24 +248,24 @@ std::string SceneDatasetAttributes::getDatasetSummaryHeader() {
 std::string SceneDatasetAttributes::getDatasetSummary() const {
   std::string res{
       getSimplifiedHandle()
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(sceneAttributesManager_->getNumObjects()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(stageAttributesManager_->getNumObjects()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(objectAttributesManager_->getNumObjects()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(articulatedObjPaths.size()))
-          .append(", ")
+          .append(1, ',')
           .append(
               std::to_string(lightLayoutAttributesManager_->getNumObjects()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(assetAttributesManager_->getNumObjects()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(navmeshMap_.size()))
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(semanticSceneDescrMap_.size()))
-          .append(", ")};
+          .append(1, ',')};
   return res;
 
 }  // SceneDatasetAttributes::getDatasetSummary

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -190,50 +190,50 @@ std::string SceneDatasetAttributes::getObjectInfoInternal() const {
   std::vector<std::string> sceneInstAttrInfoAra =
       sceneAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : sceneInstAttrInfoAra) {
-    res += s + "\n";
+    res.append(s).append("\n");
   }
   res += "Stage Templates : \n";
   // stages
   std::vector<std::string> stageAttrInfoAra =
       stageAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : stageAttrInfoAra) {
-    res += s + "\n";
+    res.append(s).append("\n");
   }
   res += "Object Templates : \n";
   // objects
   std::vector<std::string> objAttrInfoAra =
       objectAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : objAttrInfoAra) {
-    res += s + "\n";
+    res.append(s).append("\n");
   }
   res += "Articulated Object Models : \n";
   // articulated objects
   for (const auto& item : articulatedObjPaths) {
-    res += item.first + ", " + item.second + ",\n";
+    res.append(item.first).append(", ").append(item.second) + ",\n";
   }
   res += "Lighting Configurations : \n";
   // lights
   std::vector<std::string> lightAttrInfoAra =
       lightLayoutAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : lightAttrInfoAra) {
-    res += s + "\n";
+    res.append(s).append("\n");
   }
   res += "Primitives Templates : \n";
   // prims
   std::vector<std::string> primAttrInfoAra =
       assetAttributesManager_->getObjectInfoStrings();
   for (const std::string& s : primAttrInfoAra) {
-    res += s + "\n";
+    res.append(s).append("\n");
   }
   res += "Navmeshes : \n";
   // navmesh
   for (const auto& item : navmeshMap_) {
-    res += item.first + ", " + item.second + ",\n";
+    res.append(item.first).append(", ").append(item.second) + ",\n";
   }
   res += "Semantic Scene Descriptors : \n";
   // SSD entries
   for (const auto& item : semanticSceneDescrMap_) {
-    res += item.first + ", " + item.second + ",\n";
+    res.append(item.first).append(", ").append(item.second) + ",\n";
   }
 
   return res;
@@ -246,16 +246,26 @@ std::string SceneDatasetAttributes::getDatasetSummaryHeader() {
 }
 
 std::string SceneDatasetAttributes::getDatasetSummary() const {
-  std::string res =
-      getSimplifiedHandle() + ", " +
-      std::to_string(sceneAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(stageAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(objectAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(articulatedObjPaths.size()) + ", " +
-      std::to_string(lightLayoutAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(assetAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(navmeshMap_.size()) + ", " +
-      std::to_string(semanticSceneDescrMap_.size()) + ", ";
+  std::string res{
+      getSimplifiedHandle()
+          .append(", ")
+          .append(std::to_string(sceneAttributesManager_->getNumObjects()))
+          .append(", ")
+          .append(std::to_string(stageAttributesManager_->getNumObjects()))
+          .append(", ")
+          .append(std::to_string(objectAttributesManager_->getNumObjects()))
+          .append(", ")
+          .append(std::to_string(articulatedObjPaths.size()))
+          .append(", ")
+          .append(
+              std::to_string(lightLayoutAttributesManager_->getNumObjects()))
+          .append(", ")
+          .append(std::to_string(assetAttributesManager_->getNumObjects()))
+          .append(", ")
+          .append(std::to_string(navmeshMap_.size()))
+          .append(", ")
+          .append(std::to_string(semanticSceneDescrMap_.size()))
+          .append(", ")};
   return res;
 
 }  // SceneDatasetAttributes::getDatasetSummary

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -186,52 +186,78 @@ std::string SceneDatasetAttributes::getObjectInfoInternal() const {
   // provide a summary for all info for this scene dataset
   std::string res = "\n";
   // scene instances
-  res += "Scene Instances : \n";
+
   std::vector<std::string> sceneInstAttrInfoAra =
       sceneAttributesManager_->getObjectInfoStrings();
+  res.append("\nScene Instances : ")
+      .append(std::to_string(sceneInstAttrInfoAra.size() - 1))
+      .append(" loaded.\n");
+
   for (const std::string& s : sceneInstAttrInfoAra) {
     res.append(s).append(1, '\n');
   }
-  res += "Stage Templates : \n";
+
   // stages
   std::vector<std::string> stageAttrInfoAra =
       stageAttributesManager_->getObjectInfoStrings();
+  res.append("\nStage Templates : ")
+      .append(std::to_string(stageAttrInfoAra.size() - 1))
+      .append(" loaded.\n");
   for (const std::string& s : stageAttrInfoAra) {
     res.append(s).append(1, '\n');
   }
-  res += "Object Templates : \n";
+
   // objects
   std::vector<std::string> objAttrInfoAra =
       objectAttributesManager_->getObjectInfoStrings();
+  res.append("\nObject Templates : ")
+      .append(std::to_string(objAttrInfoAra.size() - 1))
+      .append(" loaded.\n");
   for (const std::string& s : objAttrInfoAra) {
     res.append(s).append(1, '\n');
   }
-  res += "Articulated Object Models : \n";
+
   // articulated objects
+  res.append("\nArticulated Object Models : ")
+      .append(std::to_string(articulatedObjPaths.size()))
+      .append(" loaded.\n");
+
   for (const auto& item : articulatedObjPaths) {
     res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }
-  res += "Lighting Configurations : \n";
+
   // lights
   std::vector<std::string> lightAttrInfoAra =
       lightLayoutAttributesManager_->getObjectInfoStrings();
+  res.append("\nLighting Configurations : ")
+      .append(std::to_string(lightAttrInfoAra.size() - 1))
+      .append(" loaded.\n");
   for (const std::string& s : lightAttrInfoAra) {
     res.append(s).append(1, '\n');
   }
-  res += "Primitives Templates : \n";
+
   // prims
   std::vector<std::string> primAttrInfoAra =
       assetAttributesManager_->getObjectInfoStrings();
+  res.append("\nPrimitives Templates : ")
+      .append(std::to_string(primAttrInfoAra.size() - 1))
+      .append(" loaded.\n");
   for (const std::string& s : primAttrInfoAra) {
     res.append(s).append(1, '\n');
   }
-  res += "Navmeshes : \n";
+
   // navmesh
+  res.append("\nNavmeshes : ")
+      .append(std::to_string(navmeshMap_.size()))
+      .append(" loaded.\n");
   for (const auto& item : navmeshMap_) {
     res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }
-  res += "Semantic Scene Descriptors : \n";
+
   // SSD entries
+  res.append("\nSemantic Scene Descriptors : ")
+      .append(std::to_string(semanticSceneDescrMap_.size()))
+      .append(" loaded.\n");
   for (const auto& item : semanticSceneDescrMap_) {
     res.append(item.first).append(1, ',').append(item.second).append(1, '\n');
   }

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -239,14 +239,20 @@ std::string SceneDatasetAttributes::getObjectInfoInternal() const {
   return res;
 }
 
-std::string SceneDatasetAttributes::getDatasetSummary() {
+std::string SceneDatasetAttributes::getDatasetSummaryHeader() {
+  return "Dataset Name, Scene Instance Templates, Stage Templates, Object "
+         "Templates, Articulated Object Paths, Lighting Templates, Primitive "
+         "Templates, Navmesh Entries, Semantic Scene Descriptor Entries,";
+}
+
+std::string SceneDatasetAttributes::getDatasetSummary() const {
   std::string res =
-      getHandle() + ", " +
+      getSimplifiedHandle() + ", " +
       std::to_string(sceneAttributesManager_->getNumObjects()) + ", " +
       std::to_string(stageAttributesManager_->getNumObjects()) + ", " +
       std::to_string(objectAttributesManager_->getNumObjects()) + ", " +
-      std::to_string(lightLayoutAttributesManager_->getNumObjects()) + ", " +
       std::to_string(articulatedObjPaths.size()) + ", " +
+      std::to_string(lightLayoutAttributesManager_->getNumObjects()) + ", " +
       std::to_string(assetAttributesManager_->getNumObjects()) + ", " +
       std::to_string(navmeshMap_.size()) + ", " +
       std::to_string(semanticSceneDescrMap_.size()) + ", ";

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -334,6 +334,16 @@ class SceneDatasetAttributes : public AbstractAttributes {
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.  Individual
+   * components handle this.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getObjectInfoHeaderInternal() const override { return ","; }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    */

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -325,7 +325,12 @@ class SceneDatasetAttributes : public AbstractAttributes {
   /**
    * @brief return a summary of this dataset
    */
-  std::string getDatasetSummary();
+  std::string getDatasetSummary() const;
+
+  /**
+   * @brief returns the header row of the summary string.
+   */
+  static std::string getDatasetSummaryHeader();
 
  protected:
   /**

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -322,7 +322,18 @@ class SceneDatasetAttributes : public AbstractAttributes {
                                   lightLayoutAttributesManager_);
   }  // getLightSetupFullHandle
 
+  /**
+   * @brief return a summary of this dataset
+   */
+  std::string getDatasetSummary();
+
  protected:
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   */
+  std::string getObjectInfoInternal() const override;
+
   /**
    * @brief Returns actual attributes handle containing @p attrName as a
    * substring, or the empty string if none exists, from passed @p attrMgr .

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -298,7 +298,8 @@ void SceneAttributesManager::loadAbstractObjectAttributesFromJson(
 int SceneAttributesManager::getTranslationOriginVal(
     const io::JsonGenericValue& jsonDoc) const {
   // Check for translation origin.  Default to unknown.
-  int transOrigin = static_cast<int>(SceneInstanceTranslationOrigin::Unknown);
+  int transOrigin =
+      static_cast<int>(attributes::SceneInstanceTranslationOrigin::Unknown);
   std::string tmpTransOriginVal = "";
   if (io::readMember<std::string>(jsonDoc, "translation_origin",
                                   tmpTransOriginVal)) {
@@ -306,9 +307,8 @@ int SceneAttributesManager::getTranslationOriginVal(
     // lowercase
     std::string strToLookFor =
         Cr::Utility::String::lowercase(tmpTransOriginVal);
-    auto found =
-        SceneAttributes::InstanceTranslationOriginMap.find(strToLookFor);
-    if (found != SceneAttributes::InstanceTranslationOriginMap.end()) {
+    auto found = attributes::InstanceTranslationOriginMap.find(strToLookFor);
+    if (found != attributes::InstanceTranslationOriginMap.end()) {
       transOrigin = static_cast<int>(found->second);
     } else {
       LOG(WARNING)

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -13,35 +13,6 @@ namespace metadata {
 
 namespace managers {
 
-/**
- * @brief This enum class describes whether an object instance position is
- * relative to its COM or the asset's local origin.  Depending on this value, we
- * may take certain actions when instantiating a scene described by a scene
- * instance. For example, scene instances exported from Blender will have no
- * conception of an object's configured COM, and so will require adjustment to
- * translations to account for COM location when the object is placed*/
-enum class SceneInstanceTranslationOrigin {
-  /**
-   * @brief Default value - in the case of object instances, this means use the
-   * specified scene instance default; in the case of a scene instance, this
-   * means do not correct for COM.
-   */
-  Unknown = -1,
-  /**
-   * @brief Indicates scene instance objects were placed without knowledge of
-   * their COM location, and so need to be corrected when placed in scene in
-   * Habitat. For example, they were exported from an external editor like
-   * Blender.
-   */
-  AssetLocal,
-  /**
-   * @brief Indicates scene instance objects' location were recorded at their
-   * COM location, and so do not need correction.  For example they were
-   * exported from Habitat-sim.
-   */
-  COM
-};
-
 class SceneAttributesManager
     : public AttributesManager<attributes::SceneAttributes,
                                core::ManagedObjectAccess::Copy> {

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -77,13 +77,13 @@ void RigidObject::resetStateFromSceneInstanceAttr(bool defaultCOMCorrection) {
   auto translate = sceneInstanceAttr->getTranslation();
   // get instance override value, if exists
   auto instanceCOMOrigin =
-      static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
+      static_cast<metadata::attributes::SceneInstanceTranslationOrigin>(
           sceneInstanceAttr->getTranslationOrigin());
   if ((defaultCOMCorrection &&
        (instanceCOMOrigin !=
-        metadata::managers::SceneInstanceTranslationOrigin::COM)) ||
+        metadata::attributes::SceneInstanceTranslationOrigin::COM)) ||
       (instanceCOMOrigin ==
-       metadata::managers::SceneInstanceTranslationOrigin::AssetLocal)) {
+       metadata::attributes::SceneInstanceTranslationOrigin::AssetLocal)) {
     // if default COM correction is set and no object-based override, or if
     // Object set to correct for COM.
     translate -= sceneInstanceAttr->getRotation().transformVector(

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -285,6 +285,18 @@ class ManagedArticulatedObject
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getPhyObjInfoHeaderInternal() const override {
+    // TODO fill out appropriate reporting values
+    return "# links, ";
+  }
+
+  /**
    * @brief Specialization-specific extension of getObjectInfo, comma separated
    * info ideal for saving to csv
    */

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -303,7 +303,7 @@ class ManagedArticulatedObject
   std::string getPhysObjInfoInternal(
       std::shared_ptr<esp::physics::ArticulatedObject>& sp) const override {
     // TODO fill out appropriate reporting values
-    std::string res = std::to_string(sp->getNumLinks()).append(", ");
+    std::string res = std::to_string(sp->getNumLinks()).append(1, ',');
 
     return res;
   }

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -303,7 +303,7 @@ class ManagedArticulatedObject
   std::string getPhysObjInfoInternal(
       std::shared_ptr<esp::physics::ArticulatedObject>& sp) const override {
     // TODO fill out appropriate reporting values
-    std::string res = std::to_string(sp->getNumLinks()) + ", ";
+    std::string res = std::to_string(sp->getNumLinks()).append(", ");
 
     return res;
   }

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -283,6 +283,19 @@ class ManagedArticulatedObject
     }
   }
 
+ protected:
+  /**
+   * @brief Specialization-specific extension of getObjectInfo, comma separated
+   * info ideal for saving to csv
+   */
+  std::string getPhysObjInfoInternal(
+      std::shared_ptr<esp::physics::ArticulatedObject>& sp) const override {
+    // TODO fill out appropriate reporting values
+    std::string res = std::to_string(sp->getNumLinks()) + ", ";
+
+    return res;
+  }
+
  public:
   ESP_SMART_POINTERS(ManagedArticulatedObject)
 };  // namespace physics

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -267,15 +267,29 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
    * of this managed object.
    */
   std::string getObjectInfo() const override {
-    std::string res;
-    // TODO : support retrieving all informational quantities
+    std::string res = "unknown " + classKey_;
+    namespace CrUt = Corrade::Utility;
     if (auto sp = this->getObjectReference()) {
-      res = sp->getObjectName() + "," + std::to_string(sp->getObjectID());
+      res = classKey_ + ", " + sp->getObjectName() + ", " +
+            std::to_string(sp->getObjectID()) + ", " +
+            CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getTranslation(), {}) +
+            ", " +
+            CrUt::ConfigurationValue<Magnum::Quaternion>::toString(
+                sp->getRotation(), {}) +
+            ", " + getPhysObjInfoInternal(sp);
+      ;
     }
-    return ",";
+    return res + ", ";
   }
 
  protected:
+  /**
+   * @brief Specialization-specific extension of getObjectInfo, comma
+   * separated info ideal for saving to csv
+   */
+  virtual std::string getPhysObjInfoInternal(std::shared_ptr<T>& sp) const = 0;
+
   /**
    * @brief This function accesses the underlying shared pointer of this
    * object's @p weakObjRef_ if it exists; if not, it provides a message.
@@ -305,8 +319,8 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   }
 
   /**
-   * @brief Weak ref to object. If user has copy of this wrapper but object has
-   * been deleted, this will be nullptr.
+   * @brief Weak ref to object. If user has copy of this wrapper but object
+   * has been deleted, this will be nullptr.
    */
   WeakObjRef weakObjRef_{};
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -263,6 +263,15 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   }  // getVisualSceneNodes
 
   /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object.
+   */
+  std::string getObjectInfoHeader() const override {
+    return "Type, Name, ID, Translation XYZ, Rotation WXYZ, " +
+           getPhyObjInfoHeaderInternal();
+  }
+
+  /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
    */
@@ -284,6 +293,14 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
   }
 
  protected:
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  virtual std::string getPhyObjInfoHeaderInternal() const = 0;
   /**
    * @brief Specialization-specific extension of getObjectInfo, comma
    * separated info ideal for saving to csv

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -276,20 +276,24 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
    * of this managed object.
    */
   std::string getObjectInfo() const override {
-    std::string res = "unknown " + classKey_;
+    std::string res{"unknown " + classKey_};
     namespace CrUt = Corrade::Utility;
     if (auto sp = this->getObjectReference()) {
-      res = classKey_ + ", " + sp->getObjectName() + ", " +
-            std::to_string(sp->getObjectID()) + ", " +
-            CrUt::ConfigurationValue<Mn::Vector3>::toString(
-                sp->getTranslation(), {}) +
-            ", " +
-            CrUt::ConfigurationValue<Magnum::Quaternion>::toString(
-                sp->getRotation(), {}) +
-            ", " + getPhysObjInfoInternal(sp);
-      ;
+      res.append(classKey_)
+          .append(", ")
+          .append(sp->getObjectName())
+          .append(", ")
+          .append(std::to_string(sp->getObjectID()))
+          .append(", ")
+          .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+              sp->getTranslation(), {}))
+          .append(", ")
+          .append(CrUt::ConfigurationValue<Magnum::Quaternion>::toString(
+              sp->getRotation(), {}))
+          .append(", ")
+          .append(getPhysObjInfoInternal(sp));
     }
-    return res + ", ";
+    return res.append(", ");
   }
 
  protected:

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -280,20 +280,20 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
     namespace CrUt = Corrade::Utility;
     if (auto sp = this->getObjectReference()) {
       res.append(classKey_)
-          .append(", ")
+          .append(1, ',')
           .append(sp->getObjectName())
-          .append(", ")
+          .append(1, ',')
           .append(std::to_string(sp->getObjectID()))
-          .append(", ")
+          .append(1, ',')
           .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
               sp->getTranslation(), {}))
-          .append(", ")
+          .append(1, ',')
           .append(CrUt::ConfigurationValue<Magnum::Quaternion>::toString(
               sp->getRotation(), {}))
-          .append(", ")
+          .append(1, ',')
           .append(getPhysObjInfoInternal(sp));
     }
-    return res.append(", ");
+    return res.append(1, ',');
   }
 
  protected:

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -262,6 +262,19 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
     return std::vector<scene::SceneNode*>();
   }  // getVisualSceneNodes
 
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   */
+  std::string getObjectInfo() const override {
+    std::string res;
+    // TODO : support retrieving all informational quantities
+    if (auto sp = this->getObjectReference()) {
+      res = sp->getObjectName() + "," + std::to_string(sp->getObjectID());
+    }
+    return ",";
+  }
+
  protected:
   /**
    * @brief This function accesses the underlying shared pointer of this

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -267,7 +267,7 @@ class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
    * info returned for this managed object.
    */
   std::string getObjectInfoHeader() const override {
-    return "Type, Name, ID, Translation XYZ, Rotation WXYZ, " +
+    return "Type, Name, ID, Translation XYZ, Rotation XYZW, " +
            getPhyObjInfoHeaderInternal();
   }
 

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -210,6 +210,44 @@ class AbstractManagedRigidBase
     }
   }  // setSemanticId
 
+ protected:
+  /**
+   * @brief Specialization-specific extension of getObjectInfo, comma separated
+   * info ideal for saving to csv
+   */
+  std::string getPhysObjInfoInternal(std::shared_ptr<T>& sp) const override {
+    namespace CrUt = Corrade::Utility;
+    std::string res =
+        std::to_string(sp->getMass()) + ", " +
+        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getCOM(), {}) +
+        ", " +
+        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getInertiaVector(),
+                                                        {}) +
+        ", " +
+        CrUt::ConfigurationValue<Mn::Vector3>::toString(
+            sp->getAngularVelocity(), {}) +
+        ", " + std::to_string(sp->getAngularDamping()) + ", " +
+        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getLinearVelocity(),
+                                                        {}) +
+        ", " + std::to_string(sp->getLinearDamping()) + ", " +
+        (sp->getCollidable() ? "True" : "False") + ", " +
+
+        std::to_string(sp->getFrictionCoefficient()) + ", " +
+        std::to_string(sp->getRestitutionCoefficient()) + ", " +
+        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getScale(), {}) +
+        ", " + std::to_string(sp->getSemanticId()) +
+        getRigidBaseInfoInternal(sp);
+    return res;
+  }
+
+  /**
+   * @brief Specialization-specific extension of getPhysObjInfoInternal, comma
+   * separated info ideal for saving to csv information about RigidBase
+   * constructs.
+   */
+  virtual std::string getRigidBaseInfoInternal(
+      std::shared_ptr<T>& sp) const = 0;
+
  public:
   ESP_SMART_POINTERS(AbstractManagedRigidBase<T>)
 };

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -212,8 +212,29 @@ class AbstractManagedRigidBase
 
  protected:
   /**
-   * @brief Specialization-specific extension of getObjectInfo, comma separated
-   * info ideal for saving to csv
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object, type-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+
+  std::string getPhyObjInfoHeaderInternal() const override {
+    return "Mass, COM XYZ, I XX YY ZZ, AngVel XYZ, Angular Damping, Velocity "
+           "XYZ, Linear Damping, Is Collidable?, Friction Coeff, Restitution "
+           "Coeff, Scale XYZ, Semantic ID, " +
+           getRigidBaseInfoHeaderInternal();
+  }
+
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for
+   * the info returned for this managed object, rigid-base-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  virtual std::string getRigidBaseInfoHeaderInternal() const = 0;
+  /**
+   * @brief Specialization-specific extension of getObjectInfo, comma
+   * separated info ideal for saving to csv
    */
   std::string getPhysObjInfoInternal(std::shared_ptr<T>& sp) const override {
     namespace CrUt = Corrade::Utility;

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -239,25 +239,35 @@ class AbstractManagedRigidBase
   std::string getPhysObjInfoInternal(std::shared_ptr<T>& sp) const override {
     namespace CrUt = Corrade::Utility;
     std::string res =
-        std::to_string(sp->getMass()) + ", " +
-        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getCOM(), {}) +
-        ", " +
-        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getInertiaVector(),
-                                                        {}) +
-        ", " +
-        CrUt::ConfigurationValue<Mn::Vector3>::toString(
-            sp->getAngularVelocity(), {}) +
-        ", " + std::to_string(sp->getAngularDamping()) + ", " +
-        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getLinearVelocity(),
-                                                        {}) +
-        ", " + std::to_string(sp->getLinearDamping()) + ", " +
-        (sp->getCollidable() ? "True" : "False") + ", " +
-
-        std::to_string(sp->getFrictionCoefficient()) + ", " +
-        std::to_string(sp->getRestitutionCoefficient()) + ", " +
-        CrUt::ConfigurationValue<Mn::Vector3>::toString(sp->getScale(), {}) +
-        ", " + std::to_string(sp->getSemanticId()) +
-        getRigidBaseInfoInternal(sp);
+        std::to_string(sp->getMass())
+            .append(", ")
+            .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getCOM(), {}))
+            .append(", ")
+            .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getInertiaVector(), {}))
+            .append(", ")
+            .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getAngularVelocity(), {}))
+            .append(", ")
+            .append(std::to_string(sp->getAngularDamping()))
+            .append(", ")
+            .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getLinearVelocity(), {}))
+            .append(", ")
+            .append(std::to_string(sp->getLinearDamping()))
+            .append(", ")
+            .append(sp->getCollidable() ? "True" : "False")
+            .append(", ")
+            .append(std::to_string(sp->getFrictionCoefficient()))
+            .append(", ")
+            .append(std::to_string(sp->getRestitutionCoefficient()))
+            .append(", ")
+            .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
+                sp->getScale(), {}))
+            .append(", ")
+            .append(std::to_string(sp->getSemanticId()))
+            .append(getRigidBaseInfoInternal(sp));
     return res;
   }
 

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -240,32 +240,32 @@ class AbstractManagedRigidBase
     namespace CrUt = Corrade::Utility;
     std::string res =
         std::to_string(sp->getMass())
-            .append(", ")
+            .append(1, ',')
             .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
                 sp->getCOM(), {}))
-            .append(", ")
+            .append(1, ',')
             .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
                 sp->getInertiaVector(), {}))
-            .append(", ")
+            .append(1, ',')
             .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
                 sp->getAngularVelocity(), {}))
-            .append(", ")
+            .append(1, ',')
             .append(std::to_string(sp->getAngularDamping()))
-            .append(", ")
+            .append(1, ',')
             .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
                 sp->getLinearVelocity(), {}))
-            .append(", ")
+            .append(1, ',')
             .append(std::to_string(sp->getLinearDamping()))
-            .append(", ")
+            .append(1, ',')
             .append(sp->getCollidable() ? "True" : "False")
-            .append(", ")
+            .append(1, ',')
             .append(std::to_string(sp->getFrictionCoefficient()))
-            .append(", ")
+            .append(1, ',')
             .append(std::to_string(sp->getRestitutionCoefficient()))
-            .append(", ")
+            .append(1, ',')
             .append(CrUt::ConfigurationValue<Mn::Vector3>::toString(
                 sp->getScale(), {}))
-            .append(", ")
+            .append(1, ',')
             .append(std::to_string(sp->getSemanticId()))
             .append(getRigidBaseInfoInternal(sp));
     return res;

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -39,6 +39,18 @@ class ManagedRigidObject
     return nullptr;
   }  // getVelocityControl()
 
+ protected:
+  /**
+   * @brief Specialization-specific extension of getPhysObjInfoInternal, comma
+   * separated info ideal for saving to csv information about RigidBase
+   * constructs.
+   */
+  std::string getRigidBaseInfoInternal(
+      std::shared_ptr<esp::physics::RigidObject>& sp) const override {
+    std::string res = sp->getInitializationAttributes()->getHandle() + ", ";
+    return res;
+  }
+
  public:
   ESP_SMART_POINTERS(ManagedRigidObject)
 };

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -57,7 +57,8 @@ class ManagedRigidObject
    */
   std::string getRigidBaseInfoInternal(
       std::shared_ptr<esp::physics::RigidObject>& sp) const override {
-    std::string res = sp->getInitializationAttributes()->getHandle() + ", ";
+    std::string res =
+        sp->getInitializationAttributes()->getHandle().append(", ");
     return res;
   }
 

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -41,6 +41,16 @@ class ManagedRigidObject
 
  protected:
   /**
+   * @brief Retrieve a comma-separated string holding the header values for
+   * the info returned for this managed object, rigid-base-specific.
+   * TODO : once Magnum supports retrieving key-values of configurations, use
+   * that to build this data.
+   */
+  std::string getRigidBaseInfoHeaderInternal() const override {
+    return "Creation Attributes Name,";
+  }
+
+  /**
    * @brief Specialization-specific extension of getPhysObjInfoInternal, comma
    * separated info ideal for saving to csv information about RigidBase
    * constructs.

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -58,7 +58,7 @@ class ManagedRigidObject
   std::string getRigidBaseInfoInternal(
       std::shared_ptr<esp::physics::RigidObject>& sp) const override {
     std::string res =
-        sp->getInitializationAttributes()->getHandle().append(", ");
+        sp->getInitializationAttributes()->getHandle().append(1, ',');
     return res;
   }
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -456,9 +456,9 @@ bool Simulator::instanceObjectsForActiveScene() {
   // whether or not to correct for COM shift - only do for blender-sourced
   // scene attributes
   bool defaultCOMCorrection =
-      (static_cast<metadata::managers::SceneInstanceTranslationOrigin>(
+      (static_cast<metadata::attributes::SceneInstanceTranslationOrigin>(
            curSceneInstanceAttributes->getTranslationOrigin()) ==
-       metadata::managers::SceneInstanceTranslationOrigin::AssetLocal);
+       metadata::attributes::SceneInstanceTranslationOrigin::AssetLocal);
 
   std::string errMsgTmplt =
       "::createSceneInstance : Error instancing scene : " + activeSceneName +

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -692,7 +692,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   // match values set in test JSON
   ASSERT_EQ(
       sceneAttr->getTranslationOrigin(),
-      static_cast<int>(AttrMgrs::SceneInstanceTranslationOrigin::AssetLocal));
+      static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal));
   ASSERT_EQ(sceneAttr->getLightingHandle(), "test_lighting_configuration");
   ASSERT_EQ(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
   ASSERT_EQ(sceneAttr->getSemanticSceneHandle(),
@@ -724,7 +724,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   auto objInstance = objectInstanceList[0];
   ASSERT_EQ(objInstance->getHandle(), "test_object_template0");
   ASSERT_EQ(objInstance->getTranslationOrigin(),
-            static_cast<int>(AttrMgrs::SceneInstanceTranslationOrigin::COM));
+            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
   ASSERT_EQ(objInstance->getTranslation(), Magnum::Vector3(0, 1, 2));
   ASSERT_EQ(objInstance->getRotation(),
             Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
@@ -757,7 +757,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   auto artObjInstance = artObjInstances[0];
   ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template0");
   ASSERT_EQ(artObjInstance->getTranslationOrigin(),
-            static_cast<int>(AttrMgrs::SceneInstanceTranslationOrigin::COM));
+            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
   ASSERT_EQ(artObjInstance->getFixedBase(), false);
   ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
   ASSERT_EQ(artObjInstance->getMotionType(),

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -305,9 +305,9 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   ASSERT_NE(sceneAttrs, nullptr);
   // verify default value for translation origin
   ASSERT_EQ(sceneAttrs->getTranslationOrigin(),
-            static_cast<int>(AttrMgrs::SceneInstanceTranslationOrigin::COM));
+            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
   const int assetLocalInt =
-      static_cast<int>(AttrMgrs::SceneInstanceTranslationOrigin::AssetLocal);
+      static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal);
 
   //
   // miscellaneous scene instance attribute values
@@ -405,8 +405,8 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   LOG(INFO) << "Starting testDataset1 : test LoadStages";
   const auto& stageAttributesMgr = MM_->getStageAttributesManager();
   int numStageHandles = stageAttributesMgr->getNumObjects();
-  // shoudld be 6 : one for default NONE stage, glob lookup yields 2 stages + 2
-  // modified and 1 new stage in scene dataset config
+  // shoudld be 6 : one for default NONE stage, glob lookup yields 2 stages +
+  // 2 modified and 1 new stage in scene dataset config
   ASSERT_EQ(numStageHandles, 6);
   // end test LoadStages
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -58,6 +58,15 @@ class MetadataMediatorTest : public testing::Test {
     MM_->setSimulatorConfiguration(cfg_1);
   }
 
+  void displayDSReports() {
+    // display info report
+    std::string dsOverView = MM_->getDatasetsOverview();
+    LOG(WARNING) << "\nDataset Overview : \n" << dsOverView << "\n";
+    // display info report
+    std::string dsInfoReport = MM_->createDatasetReport();
+    LOG(WARNING) << "\nActive Dataset Details : \n" << dsInfoReport << "\n";
+  }
+
   MetadataMediator::ptr MM_ = nullptr;
 
 };  // class MetadataMediatorTest
@@ -395,7 +404,10 @@ TEST_F(MetadataMediatorTest, testDataset0) {
             "test_semantic_descriptor_path1");
   ASSERT_EQ(semanticMap.at("semantic_descriptor_path2"),
             "test_semantic_descriptor_path2");
+
   // end test LoadSemanticScene
+  displayDSReports();
+
 }  // testDataset0
 
 TEST_F(MetadataMediatorTest, testDataset1) {
@@ -482,6 +494,9 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // should have 3
   ASSERT_EQ(semanticMap.size(), 3);
   // testLoadSemanticScene
+  // display info report
+  displayDSReports();
+
 }  // testDataset1
 
 TEST_F(MetadataMediatorTest, testDatasetDelete) {
@@ -523,6 +538,9 @@ TEST_F(MetadataMediatorTest, testDatasetDelete) {
   ASSERT_EQ(MM_->removeSceneDataset(nameDS0), true);
   // verify the dataset does not exist anymore
   ASSERT_EQ(MM_->sceneDatasetExists(nameDS0), false);
+
+  // display info report
+  displayDSReports();
 
 }  // testDatasetDelete
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -514,6 +514,16 @@ TEST_F(MetadataMediatorTest, testDatasetDelete) {
   // verify deleted scene dataset's stage manager is nullptr
   ASSERT_EQ(stageAttrMgr_DS1, nullptr);
 
+  // attempt to delete dataset 0 and verify fails - cannot delete active dataset
+  ASSERT_EQ(MM_->removeSceneDataset(nameDS0), false);
+
+  // switch to default active dataset
+  MM_->setActiveSceneDatasetName("default");
+  // attempt to delete dataset 0 and verify delete
+  ASSERT_EQ(MM_->removeSceneDataset(nameDS0), true);
+  // verify the dataset does not exist anymore
+  ASSERT_EQ(MM_->sceneDatasetExists(nameDS0), false);
+
 }  // testDatasetDelete
 
 }  // namespace


### PR DESCRIPTION
## Motivation and Context
This PR introduces reporting functionality for loaded attributes and wrappers from their respective managers, and the Metadata Mediator.  Functions are provided that will construct csv-friendly strings of data from each attributes and managed object, and lists of these strings for each manager.  The MetadaMediator can be queried to provide an aggregate report of all loaded configurations. 

This functionality is of particular importance with upcoming MetadataMediator/SceneDataset/SceneInstance Documentation and Tutorials.  This also has a simple python writer function provided. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass. The MetadataMediator test has been expanded to test this functionality, although currently it just displays a report. 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
