### PR TITLE
fix for rigid body setActive(false)

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -100,7 +100,9 @@ class BulletRigidObject : public BulletBase,
    */
   void setActive(bool active) override {
     if (!active) {
-      bObjectRigidBody_->setActivationState(WANTS_DEACTIVATION);
+      if (bObjectRigidBody_->isActive()) {
+        bObjectRigidBody_->setActivationState(WANTS_DEACTIVATION);
+      }
     } else {
       bObjectRigidBody_->activate(true);
     }


### PR DESCRIPTION
## Motivation and Context

The bug I observed with the old code was: already-asleep bodies got stuck in the WANTS_DEACTIVATION state.

## How Has This Been Tested

Ad hoc testing in [arrange recorder](https://github.com/eundersander/habitat-sim/tree/eundersander/arrange_recorder2)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
