### PR TITLE
[ReplicaCAD] Support ReplicaCAD semantic lexicon json format.

### DIFF
--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -33,12 +33,16 @@ bool SemanticScene::loadReplicaHouse(
   const auto& json = io::parseJsonFile(houseFilename);
   VLOG(1) << "loadReplicaHouse::Parsed.";
 
-  return buildReplicaHouse(json, scene, worldRotation);
+  // check if Replica or ReplicaCAD
+  bool hasObjects = (json.HasMember("objects") && json["objects"].IsArray());
+
+  return buildReplicaHouse(json, scene, hasObjects, worldRotation);
 
 }  // SemanticScene::loadReplicaHouse
 
 bool SemanticScene::buildReplicaHouse(const io::JsonDocument& jsonDoc,
                                       SemanticScene& scene,
+                                      bool objectsExist,
                                       const quatf& worldRotation) {
   scene.categories_.clear();
   scene.objects_.clear();
@@ -62,6 +66,12 @@ bool SemanticScene::buildReplicaHouse(const io::JsonDocument& jsonDoc,
     }
     scene.categories_[id] = std::make_shared<ReplicaObjectCategory>(
         id, category["name"].GetString());
+  }
+
+  // if does not have objects, then this is ReplciaCAD semantic map which lacks
+  // object semantic mappings
+  if (!objectsExist) {
+    return true;
   }
 
   // objects

--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -68,7 +68,7 @@ bool SemanticScene::buildReplicaHouse(const io::JsonDocument& jsonDoc,
         id, category["name"].GetString());
   }
 
-  // if does not have objects, then this is ReplciaCAD semantic map which lacks
+  // if does not have objects, then this is ReplcaCAD semantic map which lacks
   // object semantic mappings
   if (!objectsExist) {
     return true;

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -47,16 +47,19 @@ bool SemanticScene::
         // if not successful then attempt to load known json files
         const io::JsonDocument& jsonDoc = io::parseJsonFile(houseFilename);
         // if no error thrown, then we loaded a json file of given name
-        if (jsonDoc.HasMember("objects") && jsonDoc["objects"].IsArray()) {
-          // check if also has "classes" tag, otherwise will assume it is a
-          // gibson file
-          if (jsonDoc.HasMember("classes") && jsonDoc["classes"].IsArray()) {
-            // load replica
-            success = buildReplicaHouse(jsonDoc, scene, rotation);
-          } else {
-            // load gibson
-            success = buildGibsonHouse(jsonDoc, scene, rotation);
-          }
+        // check if it has the objects d
+        bool hasCorrectObjects =
+            (jsonDoc.HasMember("objects") && jsonDoc["objects"].IsArray());
+        // check if also has "classes" tag, otherwise will assume it is a
+        // gibson file
+        if (jsonDoc.HasMember("classes") && jsonDoc["classes"].IsArray()) {
+          // attempt to load replica or replicaCAD if has classes (replicaCAD
+          // does not have objects in SSDescriptor)
+          success =
+              buildReplicaHouse(jsonDoc, scene, hasCorrectObjects, rotation);
+        } else if (hasCorrectObjects) {
+          // attempt to load gibson if has objects but not classes
+          success = buildGibsonHouse(jsonDoc, scene, rotation);
         }
       }
       if (success) {

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -46,8 +46,7 @@ bool SemanticScene::
       if (!success) {
         // if not successful then attempt to load known json files
         const io::JsonDocument& jsonDoc = io::parseJsonFile(houseFilename);
-        // if no error thrown, then we loaded a json file of given name
-        // check if it has the objects d
+        // if no error thrown, then we have loaded a json file of given name
         bool hasCorrectObjects =
             (jsonDoc.HasMember("objects") && jsonDoc["objects"].IsArray());
         // check if also has "classes" tag, otherwise will assume it is a

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -194,6 +194,8 @@ class SemanticScene {
    * expected to have been verified already.
    * @param jsonDoc the JSON document describing the semantic annotations.
    * @param scene reference to sceneNode to assign semantic scene to
+   * @param objectsExist whether objects cell exists in json. This cell will not
+   * exist in ReplicaCAD semantic lexicon.
    * @param rotation rotation to apply to semantic scene upon load.
    * @return successfully built. Currently only returns true, but retaining
    * return value for future support.
@@ -201,6 +203,7 @@ class SemanticScene {
   static bool buildReplicaHouse(
       const io::JsonDocument& jsonDoc,
       SemanticScene& scene,
+      bool objectsExist,
       const quatf& rotation = quatf::FromTwoVectors(-vec3f::UnitZ(),
                                                     geo::ESP_GRAVITY));
 

--- a/src/esp/scene/test/ReplicaSceneTest.cpp
+++ b/src/esp/scene/test/ReplicaSceneTest.cpp
@@ -24,6 +24,8 @@ namespace {
 const std::string replicaRoom0 =
     Cr::Utility::Directory::join(SCENE_DATASETS,
                                  "replica_dataset/room_0/habitat");
+const std::string replicaCAD =
+    Cr::Utility::Directory::join(SCENE_DATASETS, "replicaCAD");
 
 struct ReplicaSceneTest : Cr::TestSuite::Tester {
   explicit ReplicaSceneTest();
@@ -31,11 +33,14 @@ struct ReplicaSceneTest : Cr::TestSuite::Tester {
   void testSemanticSceneOBB();
 
   void testSemanticSceneLoading();
+
+  void testSemanticSceneDescriptorReplicaCAD();
 };
 
 ReplicaSceneTest::ReplicaSceneTest() {
   addTests({&ReplicaSceneTest::testSemanticSceneOBB,
-            &ReplicaSceneTest::testSemanticSceneLoading});
+            &ReplicaSceneTest::testSemanticSceneLoading,
+            &ReplicaSceneTest::testSemanticSceneDescriptorReplicaCAD});
 }
 
 void ReplicaSceneTest::testSemanticSceneOBB() {
@@ -117,6 +122,28 @@ void ReplicaSceneTest::testSemanticSceneLoading() {
   CORRADE_COMPARE(scene->objects()[12]->category()->name(), "book");
 }
 
+void ReplicaSceneTest::testSemanticSceneDescriptorReplicaCAD() {
+  if (!Cr::Utility::Directory::exists(replicaCAD)) {
+    CORRADE_SKIP("ReplicaCAD dataset not found at '" + replicaCAD +
+                 "'\nSkipping test");
+  }
+  esp::sim::SimulatorConfiguration cfg;
+  cfg.sceneDatasetConfigFile = Cr::Utility::Directory::join(
+      replicaCAD, "replicaCAD.scene_dataset_config.json");
+
+  cfg.activeSceneName = "apt_0.scene_instance";
+
+  esp::sim::Simulator sim{cfg};
+  // semantic scene descriptor is specified in scene dataset config
+  const auto& scene = sim.getSemanticScene();
+  CORRADE_VERIFY(scene != nullptr);
+  // ReplicaCAD only populates categories - 101 specified + cat 0
+  CORRADE_COMPARE(scene->categories().size(), 102);
+
+  // verify name id and name
+  CORRADE_COMPARE(scene->categories()[13]->index(), 13);
+  CORRADE_COMPARE(scene->categories()[13]->name(), "book");
+}
 }  // namespace
 
 CORRADE_TEST_MAIN(ReplicaSceneTest)


### PR DESCRIPTION
## Motivation and Context
This small PR modifies Replica support to also support the ReplicaCAD semantic lexicon.  The ReplicaCAD semantic lexicon just contains semantic category id's and names for all the mappings across the dataset, and does not have per-scene object mappings.  This is because every object config has the semantic_id specified for that object, which are used to provide the semantic mapping.

ReplicaSceneTest has been modified to make sure this behaves properly.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally.  ReplicaSceneTest modified to cover this functionality.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
