### PR TITLE
[ObjectInstances] Remove platform dependence on pivot char; add checks for validity

### DIFF
--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -199,7 +199,7 @@ std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
       const std::string digitStr = vals.back();
       if (digitStr.empty() ||
           (std::find_if(digitStr.begin(), digitStr.end(), [](unsigned char c) {
-             return !std::isdigit(c);
+             return std::isdigit(c) == 0;
            }) != digitStr.end())) {
         // if string is not a valid representation of an integer, skip this name
         // candidate

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -98,7 +98,8 @@ class ManagedContainerBase {
    * then the passed value will be returned; Otherwise, an incremented handle
    * will be returned, based on the names present.
    * @param name Candidate name for object.  If DNE then this string is
-   * returned; if does exist, then an incrementing scheme will be followed.
+   * returned with a count component of 0000; if does exist, then an
+   * incrementing scheme will be followed.
    * @return A valid, unique name to use for a potential managed object.
    */
   std::string getUniqueHandleFromCandidate(const std::string& name) const {


### PR DESCRIPTION
## Motivation and Context
This small PR removes the platform-dependent pivot character used to partition the count component of the object instance name, so that users can write platform-independent code referencing object instances by name.  Checks were also added to verify that candidate names were formatted appropriately.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
