### PR TITLE
Lighting Attributes : Add intensity scaling vals

### DIFF
--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -37,7 +37,11 @@ LightInstanceAttributes::LightInstanceAttributes(const std::string& handle)
 }  // ctor
 
 LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)
-    : AbstractAttributes("LightLayoutAttributes", handle) {}
+    : AbstractAttributes("LightLayoutAttributes", handle) {
+  // set default scaling for positive and negative intensities to 1.0
+  setPositiveIntensityScale(1.0);
+  setNegativeIntensityScale(1.0);
+}
 
 std::string LightLayoutAttributes::getObjectInfoInternal() const {
   std::string res = "\n";

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -176,6 +176,36 @@ class LightLayoutAttributes : public AbstractAttributes {
   explicit LightLayoutAttributes(const std::string& handle = "");
 
   /**
+   * @brief Set a scale of all positive intensities by specified amount.
+   * This is to make simple, sweeping adjustments to scene lighting in habitat.
+   */
+  void setPositiveIntensityScale(double positive_intensity_scale) {
+    setDouble("positive_intensity_scale", positive_intensity_scale);
+  }
+  /**
+   * @brief Get a scale of all positive intensities by specified amount.
+   * This is to make simple, sweeping adjustments to scene lighting in habitat.
+   */
+  double getPositiveIntensityScale() const {
+    return getDouble("positive_intensity_scale");
+  }
+
+  /**
+   * @brief Set a scale of all negative intensities by specified amount.
+   * This is to make simple, sweeping adjustments to scene lighting in habitat.
+   */
+  void setNegativeIntensityScale(double negative_intensity_scale) {
+    setDouble("negative_intensity_scale", negative_intensity_scale);
+  }
+  /**
+   * @brief Get a scale of all negative intensities by specified amount.
+   * This is to make simple, sweeping adjustments to scene lighting in habitat.
+   */
+  double getNegativeIntensityScale() const {
+    return getDouble("negative_intensity_scale");
+  }
+
+  /**
    * @brief Add a light instance to this lighting layout
    */
   void addLightInstance(const LightInstanceAttributes::ptr& _lightInstance) {

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -554,7 +554,9 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
         "user_float" : 2.3,
         "user_vec3" : [1.1, 3.3, 5.5],
         "user_quat" : [0.5, 0.6, 0.7, 0.8]
-    }
+    },
+    "positive_intensity_scale" : 2.0,
+    "negative_intensity_scale" : 1.5
   })";
 
   auto lightLayoutAttr =
@@ -569,7 +571,8 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
                             "light attribs defined string", true, 23, 2.3f,
                             Magnum::Vector3(1.1, 3.3, 5.5),
                             Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
-
+  ASSERT_EQ(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
+  ASSERT_EQ(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
   auto lightAttr = lightLayoutAttr->getLightInstance("test");
   // verify that lightAttr exists
   ASSERT_NE(nullptr, lightAttr);
@@ -579,6 +582,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
   ASSERT_EQ(lightAttr->getPosition(), Magnum::Vector3(2.5, 0.1, 3.8));
   ASSERT_EQ(lightAttr->getDirection(), Magnum::Vector3(1.0, -1.0, 1.0));
   ASSERT_EQ(lightAttr->getColor(), Magnum::Vector3(2, 1, -1));
+
   ASSERT_EQ(lightAttr->getIntensity(), -0.1);
   ASSERT_EQ(lightAttr->getType(),
             static_cast<int>(esp::gfx::LightType::Directional));


### PR DESCRIPTION
## Motivation and Context
This PR adds to values to the lighting config jsons - "positive_intensity_scale" and "negative_intensity_scale".  These multiplicative values are used to scale the intensities of all light configs in a single command, to easily tweak existing lighting configs for habitat sim engine, at least in a broad stroke.  This is intended to provide a simple config-based mechanism for (somewhat heavy-handed) lighting adjustments, instead of necessitating hand tweaking of config values, if, for example, scenes are too dark.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass locally.  Added test cases to verify being properly configured in AttributesManagersTest.cpp
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
