### PR TITLE
usePrettyWriter and precision options for JSON writing

### DIFF
--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -96,6 +96,11 @@ class Player {
     keyframes_ = std::move(keyframes);
   }
 
+  /**
+   * @brief Reserved for unit-testing.
+   */
+  const std::vector<Keyframe>& debugGetKeyframes() const { return keyframes_; }
+
  private:
   void readKeyframesFromJsonDocument(const rapidjson::Document& d);
   void clearFrame();

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -162,9 +162,13 @@ void Recorder::advanceKeyframe() {
   currKeyframe_ = Keyframe{};
 }
 
-void Recorder::writeSavedKeyframesToFile(const std::string& filepath) {
+void Recorder::writeSavedKeyframesToFile(const std::string& filepath,
+                                         bool usePrettyWriter) {
   auto document = writeKeyframesToJsonDocument();
-  esp::io::writeJsonToFile(document, filepath);
+  // replay::Keyframes use floats (not doubles) so this is plenty of precision
+  const float maxDecimalPlaces = 7;
+  esp::io::writeJsonToFile(document, filepath, usePrettyWriter,
+                           maxDecimalPlaces);
 
   consolidateSavedKeyframes();
 }

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -27,17 +27,13 @@ class NodeDeletionHelper;
 /**
  * @brief Recording for "render replay".
  *
- * This class is work in progress (writeSavedKeyframesToFile isn't implemented
- * yet).
- *
  * This class saves and serializes render keyframes. A render keyframe is a
  * visual snapshot of a scene. It includes the visual parts of a scene, such
  * that observations can be reproduced (from the same camera perspective or a
  * different one). The render keyframe includes support for named "user
  * transforms" which can be used to store cameras, agents, or other
- * application-specific objects. See also @ref Player (coming soon). See
- * examples/replay_tutorial.py for usage of this class through bindings (coming
- * soon).
+ * application-specific objects. See also @ref Player. See
+ * examples/replay_tutorial.py for usage of this class through bindings.
  */
 class Recorder {
  public:
@@ -92,8 +88,12 @@ class Recorder {
   /**
    * @brief write saved keyframes to file.
    * @param filepath
+   *
+   * If you prefer more readable json, set usePrettyWriter to true, but beware
+   * larger filesize.
    */
-  void writeSavedKeyframesToFile(const std::string& filepath);
+  void writeSavedKeyframesToFile(const std::string& filepath,
+                                 bool usePrettyWriter = false);
 
   /**
    * @brief write saved keyframes to string.

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   JsonMagnumTypes.cpp
   JsonMagnumTypes.h
   JsonStlTypes.h
+  JsonUtils.h
   URDFParser.cpp
   URDFParser.h
 )

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   JsonBuiltinTypes.h
   JsonEspTypes.cpp
   JsonEspTypes.h
+  JsonMagnumTypes.cpp
   JsonMagnumTypes.h
   JsonStlTypes.h
   URDFParser.cpp

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -12,9 +12,9 @@ JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
                              JsonAllocator& allocator) {
   JsonGenericValue arr(rapidjson::kArrayType);
   // note squashing
-  arr.PushBack(squashTinyFloats(quat.scalar()), allocator);
+  arr.PushBack(squashTinyDecimals(quat.scalar()), allocator);
   for (int i = 0; i < 3; i++) {
-    arr.PushBack(squashTinyFloats(quat.vector()[i]), allocator);
+    arr.PushBack(squashTinyDecimals(quat.vector()[i]), allocator);
   }
   return arr;
 }

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "JsonAllTypes.h"
+#include "JsonUtils.h"
+
+namespace esp {
+namespace io {
+
+JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
+                             JsonAllocator& allocator) {
+  JsonGenericValue arr(rapidjson::kArrayType);
+  // note squashing
+  arr.PushBack(squashTinyFloats(quat.scalar()), allocator);
+  for (int i = 0; i < 3; i++) {
+    arr.PushBack(squashTinyFloats(quat.vector()[i]), allocator);
+  }
+  return arr;
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Quaternion& val) {
+  if (obj.IsArray() && obj.Size() == 4) {
+    for (rapidjson::SizeType i = 0; i < 4; ++i) {
+      if (obj[i].IsNumber()) {
+        if (i == 0) {
+          val.scalar() = obj[0].GetFloat();
+        } else {
+          val.vector()[i - 1] = obj[i].GetFloat();
+        }
+      } else {
+        LOG(ERROR)
+            << " Invalid numeric value specified in JSON Quaternion, index :"
+            << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+}  // namespace io
+}  // namespace esp

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -84,15 +84,8 @@ inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
   return false;
 }
 
-inline JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
-                                    JsonAllocator& allocator) {
-  JsonGenericValue arr(rapidjson::kArrayType);
-  arr.PushBack(quat.scalar(), allocator);
-  for (int i = 0; i < 3; i++) {
-    arr.PushBack(quat.vector()[i], allocator);
-  }
-  return arr;
-}
+JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
+                             JsonAllocator& allocator);
 
 /**
  * @brief Specialization to handle Magnum::Quaternion values. Populate passed @p
@@ -103,27 +96,7 @@ inline JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
  * @param val destination value to be populated
  * @return whether successful or not
  */
-inline bool fromJsonValue(const JsonGenericValue& obj,
-                          Magnum::Quaternion& val) {
-  if (obj.IsArray() && obj.Size() == 4) {
-    for (rapidjson::SizeType i = 0; i < 4; ++i) {
-      if (obj[i].IsNumber()) {
-        if (i == 0) {
-          val.scalar() = obj[0].GetFloat();
-        } else {
-          val.vector()[i - 1] = obj[i].GetFloat();
-        }
-      } else {
-        LOG(ERROR)
-            << " Invalid numeric value specified in JSON Quaternion, index :"
-            << i;
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Quaternion& val);
 
 // Containers::Optional is handled differently than ordinary structs. Instead of
 // offering toJsonValue/fromJsonValue, we offer addMember/readMember, which

--- a/src/esp/io/JsonUtils.h
+++ b/src/esp/io/JsonUtils.h
@@ -1,0 +1,22 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_IO_JSONUTILS_H_
+#define ESP_IO_JSONUTILS_H_
+
+namespace esp {
+namespace io {
+
+// when writing to json, we often want to clamp tiny floats to 0.0 so they can
+// be serialized concisely as "0.0"
+template <typename T>
+T squashTinyFloats(T x) {
+  const T eps = 1e-6f;
+  return (x < eps && x > -eps) ? T(0.0) : x;
+}
+
+}  // namespace io
+}  // namespace esp
+
+#endif

--- a/src/esp/io/JsonUtils.h
+++ b/src/esp/io/JsonUtils.h
@@ -11,7 +11,7 @@ namespace io {
 // when writing to json, we often want to clamp tiny floats to 0.0 so they can
 // be serialized concisely as "0.0"
 template <typename T>
-T squashTinyFloats(T x) {
+T squashTinyDecimals(T x) {
   const T eps = 1e-6f;
   return (x < eps && x > -eps) ? T(0.0) : x;
 }

--- a/src/esp/io/json.cpp
+++ b/src/esp/io/json.cpp
@@ -19,7 +19,9 @@ namespace esp {
 namespace io {
 
 bool writeJsonToFile(const JsonDocument& document,
-                     const std::string& filepath) {
+                     const std::string& filepath,
+                     bool usePrettyWriter,
+                     int maxDecimalPlaces) {
   assert(!filepath.empty());
   std::string outFilePath = filepath;
   if (!Cr::Utility::String::endsWith(outFilePath, ".json")) {
@@ -34,8 +36,20 @@ bool writeJsonToFile(const JsonDocument& document,
   char writeBuffer[65536];
   rapidjson::FileWriteStream os(f, writeBuffer, sizeof(writeBuffer));
 
-  rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
-  bool writeSuccess = document.Accept(writer);
+  bool writeSuccess = false;
+  if (usePrettyWriter) {
+    rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
+    if (maxDecimalPlaces != -1) {
+      writer.SetMaxDecimalPlaces(maxDecimalPlaces);
+    }
+    writeSuccess = document.Accept(writer);
+  } else {
+    rapidjson::Writer<rapidjson::FileWriteStream> writer(os);
+    if (maxDecimalPlaces != -1) {
+      writer.SetMaxDecimalPlaces(maxDecimalPlaces);
+    }
+    writeSuccess = document.Accept(writer);
+  }
   fclose(f);
 
   return writeSuccess;

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -26,7 +26,10 @@ namespace io {
 typedef rapidjson::Document JsonDocument;
 
 //! Write a JsonDocument to file
-bool writeJsonToFile(const JsonDocument& document, const std::string& file);
+bool writeJsonToFile(const JsonDocument& document,
+                     const std::string& file,
+                     bool usePrettyWriter = true,
+                     int maxDecimalPlaces = -1);
 
 //! Parse JSON file and return as JsonDocument object
 JsonDocument parseJsonFile(const std::string& file);

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -25,7 +25,18 @@ namespace io {
 
 typedef rapidjson::Document JsonDocument;
 
-//! Write a JsonDocument to file
+/**
+ * @brief Write a Json doc to file
+ *
+ * @param document an already-populated document object
+ * @param file
+ * @param usePrettyWriter The pretty writer does nice indenting and spacing but
+ * leads to larger filesize.
+ * @param maxDecimalPlaces Set this to a positive integer to shorten how
+ * floats/doubles are written. Beware loss of precision in your saved data.
+ *
+ * @return whether successful or not
+ */
 bool writeJsonToFile(const JsonDocument& document,
                      const std::string& file,
                      bool usePrettyWriter = true,

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -357,6 +357,20 @@ TEST(GfxReplayTest, simulatorIntegration) {
   simConfig.enableGfxReplaySave = true;
 
   auto sim = Simulator::create_unique(simConfig);
+  auto objAttrMgr = sim->getObjectAttributesManager();
+  objAttrMgr->loadAllJSONConfigsFromPath(
+      Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+
+  auto handles = objAttrMgr->getObjectHandlesBySubstring("nested_box");
+  EXPECT_FALSE(handles.empty());
+  auto rigidObj =
+      sim->getRigidObjectManager()->addBulletObjectByHandle(handles[0]);
+  auto rigidObjTranslation = Mn::Vector3(1.f, 2.f, 3.f);
+  auto rigidObjRotation = Mn::Quaternion::rotation(
+      Mn::Deg(45.f), Mn::Vector3(1.f, 1.f, 0.f).normalized());
+  rigidObj->setTranslation(rigidObjTranslation);
+  rigidObj->setRotation(rigidObjRotation);
+
   auto& sceneGraph = sim->getActiveSceneGraph();
   auto& rootNode = sceneGraph.getRootNode();
   auto prevNumberOfChildrenOfRoot = getNumberOfChildrenOfRoot(rootNode);
@@ -370,12 +384,23 @@ TEST(GfxReplayTest, simulatorIntegration) {
   EXPECT_TRUE(player);
   EXPECT_EQ(player->getNumKeyframes(), 1);
   player->setKeyframeIndex(0);
-  // second copy of box was loaded
+  // second copies of transform_box and nested_box were loaded
   EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode),
-            prevNumberOfChildrenOfRoot + 1);
+            prevNumberOfChildrenOfRoot + 2);
+
+  const auto& keyframes = player->debugGetKeyframes();
+  // we expect state updates for the state and the object instance
+  EXPECT_EQ(keyframes[0].stateUpdates.size(), 2);
+  // check the pose for nested_box
+  const auto& stateUpdate = keyframes[0].stateUpdates[1];
+  const auto transform = stateUpdate.second.absTransform;
+  EXPECT_LE((transform.translation - rigidObjTranslation).length(), 1.0e-5);
+  EXPECT_LE((transform.rotation.vector() - rigidObjRotation.vector()).length(),
+            1.0e-5);
 
   player = nullptr;
-  // second copy of box removed when Player is deleted
+  // second copies of transform_box and nested_box are removed when Player is
+  // deleted
   EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode), prevNumberOfChildrenOfRoot);
 
   // remove file created for this test


### PR DESCRIPTION
## Motivation and Context

Turning off the PrettyWriter and reducing precision helps reduce filesize for gfx-replay and `arrange_recorder`.

I also made a small change to how Quaternions are serialized, again to reduce filesize.

## How Has This Been Tested

GfxReplayTest was modified to ensure we test precision of serialized/deserialized Quaternions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
