### PR TITLE
Retrieve list of scene instance handles of current dataset

### DIFF
--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -64,6 +64,9 @@ void initMetadataMediatorBindings(py::module& m) {
           pybind11::return_value_policy::reference,
           R"(The current dataset's StageAttributesManager instance
             for configuring simulation stage templates.)")
+      .def(
+          "get_scene_handles", &MetadataMediator::getAllSceneInstanceHandles,
+          R"(Returns a list the names of all the available scene instances in the currently active dataset.)")
       .def_property_readonly(
           "summary", &MetadataMediator::getDatasetsOverview,
           R"(This provides a summary of the datasets currently loaded.)")

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -177,6 +177,16 @@ class MetadataMediator {
   }  // getCurrentPhysicsManagerAttributes
 
   /**
+   * @brief Get a list of all scene instances available in the currently active
+   * dataset
+   */
+  const std::vector<std::string> getAllSceneInstanceHandles() {
+    return getActiveDSAttribs()
+        ->getSceneAttributesManager()
+        ->getObjectHandlesBySubstring();
+  }
+
+  /**
    * @brief Return copy of map of current active dataset's navmesh handles.
    */
   std::map<std::string, std::string> getActiveNavmeshMap() {

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -180,7 +180,7 @@ class MetadataMediator {
    * @brief Get a list of all scene instances available in the currently active
    * dataset
    */
-  const std::vector<std::string> getAllSceneInstanceHandles() {
+  std::vector<std::string> getAllSceneInstanceHandles() {
     return getActiveDSAttribs()
         ->getSceneAttributesManager()
         ->getObjectHandlesBySubstring();


### PR DESCRIPTION
## Motivation and Context
This small PR adds a function that will retrieve a list of all the scene instance handles in the currently active scene dataset.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
