### PR TITLE
Add YCB objects to download script

### DIFF
--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -69,6 +69,12 @@ def initialize_test_data_sources(data_path):
             "link": data_path + "scene_datasets/coda",
             "version": "1.0",
         },
+        "ycb": {
+            "source": "https://dl.fbaipublicfiles.com/habitat/ycb/hab_ycb_v1.0.zip",
+            "package_name": "hab_ycb_v1.0.zip",
+            "link": data_path + "objects/ycb",
+            "version": "1.0",
+        },
     }
 
     # data sources can be grouped for batch commands with a new uid


### PR DESCRIPTION
## Motivation and Context

Add [YCB objects](https://www.ycbbenchmarks.com/object-models/) to `datasets_download.py` with habitat compatible configs.

NOTE: objects are a bit dark in-engine currently.

## How Has This Been Tested

Local testing with script and viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
