### PR TITLE
[Bugfix] Various fixes for articulated object loading and instancing

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -157,6 +157,11 @@ void declareBaseAttributesManager(py::module& m,
             attrType + " template in the library.")
                .c_str(),
            "handle"_a)
+      .def("get_library_has_id", &MgrClass::getObjectLibHasID,
+           ("Returns whether the passed template ID describes an existing " +
+            attrType + " template in the library.")
+               .c_str(),
+           "template_id"_a)
       .def("set_template_lock", &MgrClass::setLock,
            ("This sets the lock state for the " + attrType +
             " template that has the passed name. Lock == True makes the " +

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -107,6 +107,11 @@ void declareBaseWrapperManager(py::module& m,
             objType + " in the library.")
                .c_str(),
            "handle"_a)
+      .def("get_library_has_id", &MgrClass::getObjectLibHasID,
+           ("Returns whether the passed object ID describes an existing " +
+            objType + " in the library.")
+               .c_str(),
+           "object_id"_a)
       .def("set_object_lock", &MgrClass::setLock,
            ("This sets the lock state for the  " + objType +
             " that has the passed name. Lock == True makes the  " + objType +

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -245,7 +245,7 @@ class ManagedContainer : public ManagedContainerBase {
                                                   ">::removeObjectByHandle")) {
       return nullptr;
     }
-    int objectID = getObjectIDByHandle(objectHandle);
+    int objectID = this->getObjectIDByHandle(objectHandle);
     if (objectID == ID_UNDEFINED) {
       return nullptr;
     }
@@ -278,20 +278,6 @@ class ManagedContainer : public ManagedContainerBase {
   std::vector<ManagedPtr> removeObjectsBySubstring(
       const std::string& subStr = "",
       bool contains = true);
-
-  /**
-   * @brief Get the ID of the managed object in @ref
-   * ManagedContainerBase::objectLibrary_ for the given managed object Handle,
-   * if exists.
-   *
-   * @param objectHandle The string key referencing the managed object in
-   * @ref ManagedContainerBase::objectLibrary_. Usually the origin handle.
-   * @return The object ID for the managed object with the passed handle, or
-   * ID_UNDEFINED if none exists.
-   */
-  int getObjectIDByHandle(const std::string& objectHandle) {
-    return getObjectIDByHandleOrNew(objectHandle, false);
-  }  // ManagedContainer::getObjectIDByHandle
 
   /**
    * @brief Get a reference to, or a copy of, the managed object identified by
@@ -503,35 +489,6 @@ class ManagedContainer : public ManagedContainerBase {
                                   const std::string& src);
 
   /**
-   * @brief Used Internally. Get the ID of the managed object in @ref
-   * objectLibrary_ for the given managed object Handle, if exists. If
-   * the managed object is not in the library and getNext is true then returns
-   * next available id, otherwise throws assertion and returns ID_UNDEFINED
-   *
-   * @param objectHandle The string key referencing the managed object in
-   * @ref ManagedContainerBase::objectLibrary_. Usually the origin handle.
-   * @param getNext Whether to get the next available ID if not found, or to
-   * throw an assertion. Defaults to false
-   * @return The managed object's ID if found. The next available ID if not
-   * found and getNext is true. Otherwise ID_UNDEFINED.
-   */
-  int getObjectIDByHandleOrNew(const std::string& objectHandle, bool getNext) {
-    if (getObjectLibHasHandle(objectHandle)) {
-      return getObjectInternal<T>(objectHandle)->getID();
-    } else {
-      if (!getNext) {
-        LOG(ERROR) << "<" << this->objectType_
-                   << ">::getObjectIDByHandleOrNew : No " << objectType_
-                   << " managed object with handle " << objectHandle
-                   << "exists. Aborting";
-        return ID_UNDEFINED;
-      } else {
-        return getUnusedObjectID();
-      }
-    }
-  }  // ManagedContainer::getObjectIDByHandle
-
-  /**
    * @brief implementation of managed object type-specific registration
    * @param object the managed object to be registered
    * @param objectHandle the name to register the managed object with.
@@ -656,7 +613,7 @@ auto ManagedContainer<T, Access>::removeObjectsBySubstring(
   std::vector<std::string> handles =
       getObjectHandlesBySubstring(subStr, contains);
   for (const std::string& objectHandle : handles) {
-    int objID = getObjectIDByHandle(objectHandle);
+    int objID = this->getObjectIDByHandle(objectHandle);
     ManagedPtr ptr = removeObjectInternal(
         objID, objectHandle,
         "<" + this->objectType_ + ">::removeObjectsBySubstring");

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -162,17 +162,15 @@ int ManagedContainerBase::getObjectIDByHandleOrNew(
     bool getNext) {
   if (getObjectLibHasHandle(objectHandle)) {
     return getObjectInternal<AbstractManagedObject>(objectHandle)->getID();
-  } else {
-    if (!getNext) {
-      LOG(ERROR) << "<" << this->objectType_
-                 << ">::getObjectIDByHandleOrNew : No " << objectType_
-                 << " managed object with handle " << objectHandle
-                 << "exists. Aborting";
-      return ID_UNDEFINED;
-    } else {
-      return getUnusedObjectID();
-    }
   }
+  if (!getNext) {
+    LOG(ERROR) << "<" << this->objectType_
+               << ">::getObjectIDByHandleOrNew : No " << objectType_
+               << " managed object with handle " << objectHandle
+               << "exists. Aborting";
+    return ID_UNDEFINED;
+  }
+  return getUnusedObjectID();
 }  // ManagedContainerBase::getObjectIDByHandle
 
 std::string ManagedContainerBase::getObjectInfoCSVString(

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -22,7 +22,7 @@ bool ManagedContainerBase::setLock(const std::string& objectHandle, bool lock) {
     userLockedObjectNames_.erase(objectHandle);
   }
   return true;
-}  // ManagedContainer::setLock
+}  // ManagedContainerBase::setLock
 std::string ManagedContainerBase::getRandomObjectHandlePerType(
     const std::map<int, std::string>& mapOfHandles,
     const std::string& type) const {
@@ -43,7 +43,7 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
     res = iter.first->second;
   }
   return res;
-}  // ManagedContainer::getRandomObjectHandlePerType
+}  // ManagedContainerBase::getRandomObjectHandlePerType
 
 std::vector<std::string>
 ManagedContainerBase::getObjectHandlesBySubStringPerType(
@@ -156,6 +156,24 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
   }
   return res;
 }  // ManagedContainerBase::getObjectInfoStrings
+
+int ManagedContainerBase::getObjectIDByHandleOrNew(
+    const std::string& objectHandle,
+    bool getNext) {
+  if (getObjectLibHasHandle(objectHandle)) {
+    return getObjectInternal<AbstractManagedObject>(objectHandle)->getID();
+  } else {
+    if (!getNext) {
+      LOG(ERROR) << "<" << this->objectType_
+                 << ">::getObjectIDByHandleOrNew : No " << objectType_
+                 << " managed object with handle " << objectHandle
+                 << "exists. Aborting";
+      return ID_UNDEFINED;
+    } else {
+      return getUnusedObjectID();
+    }
+  }
+}  // ManagedContainerBase::getObjectIDByHandle
 
 std::string ManagedContainerBase::getObjectInfoCSVString(
     const std::string& subStr,

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -64,6 +64,20 @@ class ManagedContainerBase {
   }  // ManagedContainerBase::setLockByHandles
 
   /**
+   * @brief Get the ID of the managed object in @ref
+   * ManagedContainerBase::objectLibrary_ for the given managed object Handle,
+   * if exists.
+   *
+   * @param objectHandle The string key referencing the managed object in
+   * @ref ManagedContainerBase::objectLibrary_. Usually the origin handle.
+   * @return The object ID for the managed object with the passed handle, or
+   * ID_UNDEFINED if none exists.
+   */
+  int getObjectIDByHandle(const std::string& objectHandle) {
+    return getObjectIDByHandleOrNew(objectHandle, false);
+  }  // ManagedContainerBase::getObjectIDByHandle
+
+  /**
    * @brief set lock state on all managed objects that contain passed substring.
    * @param lock boolean to set or clear lock on managed objects
    * @param subStr substring to search for within existing primitive object
@@ -192,7 +206,7 @@ class ManagedContainerBase {
       return "";
     }
     return objectLibKeyByID_.at(objectID);
-  }  // ManagedContainer::getObjectHandleByID
+  }  // ManagedContainerBase::getObjectHandleByID
 
   /**
    * @brief Gets the number of object managed objects stored in the @ref
@@ -208,6 +222,19 @@ class ManagedContainerBase {
    * @param handle the key to look for
    */
   bool getObjectLibHasHandle(const std::string& handle) const {
+    return objectLibrary_.count(handle) > 0;
+  }  // ManagedContainerBase::getObjectLibHasHandle
+
+  /**
+   * @brief Checks whether managed object library has an object with passed
+   * integer as ID.
+   * @param ID the ID to look for
+   */
+  bool getObjectLibHasID(int ID) const {
+    const std::string handle = getObjectHandleByID(ID);
+    if (handle == "") {
+      return false;
+    }
     return objectLibrary_.count(handle) > 0;
   }  // ManagedContainerBase::getObjectLibHasHandle
 
@@ -245,6 +272,20 @@ class ManagedContainerBase {
 
  protected:
   //======== Internally accessed getter/setter/utilities ================
+  /**
+   * @brief Used Internally. Get the ID of the managed object in @ref
+   * objectLibrary_ for the given managed object Handle, if exists. If
+   * the managed object is not in the library and getNext is true then returns
+   * next available id, otherwise throws assertion and returns ID_UNDEFINED
+   *
+   * @param objectHandle The string key referencing the managed object in
+   * @ref ManagedContainerBase::objectLibrary_. Usually the origin handle.
+   * @param getNext Whether to get the next available ID if not found, or to
+   * throw an assertion. Defaults to false
+   * @return The managed object's ID if found. The next available ID if not
+   * found and getNext is true. Otherwise ID_UNDEFINED.
+   */
+  int getObjectIDByHandleOrNew(const std::string& objectHandle, bool getNext);
 
   /**
    * @brief Retrieve shared pointer to object held in library, NOT a copy.
@@ -310,7 +351,7 @@ class ManagedContainerBase {
     }
     return objectLibrary_.size();
 
-  }  // ManagedContainerBase::getObjectIDByHandle
+  }  // ManagedContainerBase::getUnusedObjectID
 
   /**
    * @brief Return a random handle selected from the passed map

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -241,8 +241,6 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
   /**
    * @brief Retrieve a comma-separated string holding the header values for
    * the info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   virtual std::string getObjectInfoHeaderInternal() const { return ","; }
@@ -250,8 +248,6 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   virtual std::string getObjectInfoInternal() const {
     return "no internal attributes specified,";

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -130,8 +130,6 @@ class LightInstanceAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override {
@@ -249,16 +247,12 @@ class LightLayoutAttributes : public AbstractAttributes {
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific. The individual light
    * instances return a header for this.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override { return ","; };
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override;
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -212,15 +212,11 @@ class AbstractObjectAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override;
   /**
    * @brief get AbstractObject specific info header
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   virtual std::string getAbstractObjectInfoHeaderInternal() const {
     return "";
@@ -229,8 +225,6 @@ class AbstractObjectAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override;
   /**
@@ -314,8 +308,6 @@ class ObjectAttributes : public AbstractObjectAttributes {
  protected:
   /**
    * @brief get AbstractObject specific info header
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getAbstractObjectInfoHeaderInternal() const override {
     return "Mass, COM XYZ, I XX YY ZZ, Angular Damping, "
@@ -403,8 +395,6 @@ class StageAttributes : public AbstractObjectAttributes {
  protected:
   /**
    * @brief get AbstractObject specific info header
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getAbstractObjectInfoHeaderInternal() const override {
     return "Navmesh Handle, Gravity XYZ, Origin XYZ, Light Setup,";

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -50,8 +50,6 @@ class PhysicsManagerAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override {
@@ -62,8 +60,6 @@ class PhysicsManagerAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override {
     return getSimulator()

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -140,8 +140,6 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoHeaderInternal() const override {
     // Handle already encodes all relevant info
@@ -151,8 +149,6 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override {
     // Handle already encodes all relevant info

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -66,8 +66,10 @@ std::string SceneObjectInstanceAttributes::getObjectInfoInternal() const {
 
 SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
     : SceneObjectInstanceAttributes(handle, "SceneAOInstanceAttributes") {
-  // set default fixed base value (only used for articulated object)
+  // set default fixed base and auto clamp values (only used for articulated
+  // object)
   setFixedBase(false);
+  setAutoClampJointLimits(false);
 }
 
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -192,6 +192,18 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
   void setFixedBase(bool fixed_base) { setBool("fixed_base", fixed_base); }
 
   /**
+   * @brief Articulated Object Instance only. Get or set whether or not dofs
+   * should be automatically clamped to specified joint limits before physics
+   * simulation step.
+   */
+  bool getAutoClampJointLimits() const {
+    return getBool("auto_clamp_joint_limits");
+  }
+  void setAutoClampJointLimits(bool auto_clamp_joint_limits) {
+    setBool("auto_clamp_joint_limits", auto_clamp_joint_limits);
+  }
+
+  /**
    * @brief retrieve a mutable reference to this scene attributes joint initial
    * pose map
    */

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -144,31 +144,23 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override;
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoHeaderInternal() const override;
 
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   virtual std::string getSceneObjInstanceInfoInternal() const { return ""; }
 
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   virtual std::string getSceneObjInstanceInfoHeaderInternal() const {
     return "";
@@ -241,8 +233,6 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
   /**
    * @brief Retrieve a comma-separated informational string
    * about the contents of this managed object.
-   * TODO : once Magnum supports retrieving key-values of
-   * configurations, use that to build this data.
    */
   std::string getSceneObjInstanceInfoHeaderInternal() const override;
 
@@ -366,8 +356,6 @@ class SceneAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override { return ""; }
@@ -375,8 +363,6 @@ class SceneAttributes : public AbstractAttributes {
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getObjectInfoInternal() const override;
   /**

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -337,8 +337,6 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.  Individual
    * components handle this.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getObjectInfoHeaderInternal() const override { return ","; }

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -174,6 +174,14 @@ SceneAttributesManager::createAOInstanceAttributesFromJSON(
                            });
 
   // only used for articulated objects
+  // auto clamp joint limits
+  io::jsonIntoSetter<bool>(
+      jCell, "auto_clamp_joint_limits",
+      [instanceAttrs](bool auto_clamp_joint_limits) {
+        instanceAttrs->setAutoClampJointLimits(auto_clamp_joint_limits);
+      });
+
+  // only used for articulated objects
   // initial joint pose
   if (jCell.HasMember("initial_joint_pose")) {
     if (jCell["initial_joint_pose"].IsArray()) {

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -138,10 +138,10 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                     // Check if directory
                     const bool dirExists = Dir::isDirectory(globPath);
                     if (dirExists) {
-                      LOG(INFO) << "::setValsFromJSONDoc(Articulated Object) : "
-                                   "Parsing "
-                                   "articulated object library directory: " +
-                                       globPath;
+                      LOG(INFO)
+                          << "::setValsFromJSONDoc(Articulated Object) : "
+                             "Parsing articulated object library directory: " +
+                                 globPath;
                       for (auto& file :
                            Dir::list(globPath, Dir::Flag::SortAscending)) {
                         std::string absoluteSubfilePath =
@@ -175,23 +175,22 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                         << aoFilePaths.size() << " " << this->objectType_
                         << " templates found in " << ao_dir;
                     for (int i = 0; i < aoFilePaths.size(); ++i) {
-                      auto aoModelName = aoFilePaths[i];
-                      auto aoFullFileName = Dir::filename(aoModelName);
+                      auto aoModelFileName = aoFilePaths[i];
                       LOG(INFO) << "::setValsFromJSONDoc(Articulated Object) : "
                                    "Found Articulated Object Model file : "
-                                << aoFullFileName;
+                                << aoModelFileName;
 
                       // set k-v pairs here.
                       auto key =
                           Corrade::Utility::Directory::splitExtension(
                               Corrade::Utility::Directory::splitExtension(
                                   Corrade::Utility::Directory::filename(
-                                      aoFullFileName))
+                                      aoModelFileName))
                                   .first)
                               .first;
 
                       dsAttribs->setArticulatedObjectModelFilename(
-                          key, aoFullFileName);
+                          key, aoModelFileName);
                     }
                   }
                   LOG(INFO) << "::loadAllFileBasedTemplates : Specified "

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -112,6 +112,9 @@ class AttributesManagersTest : public testing::Test {
     auto attrTemplate1 = mgr->createObject(handle, true);
     // verify it exists
     ASSERT_NE(nullptr, attrTemplate1);
+    // verify ID exists
+    bool idIsPresent = mgr->getObjectLibHasID(attrTemplate1->getID());
+    ASSERT_EQ(idIsPresent, true);
     // retrieve a copy of the named attributes template
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(handle);
     // verify copy has same quantities and values as original
@@ -169,6 +172,9 @@ class AttributesManagersTest : public testing::Test {
     auto oldTemplate3 = mgr->removeObjectByHandle(handle);
     // verify deleted template  exists
     ASSERT_NE(nullptr, oldTemplate3);
+    // verify ID does not exist in library now
+    idIsPresent = mgr->getObjectLibHasID(oldTemplate3->getID());
+    ASSERT_EQ(idIsPresent, false);
     // verify there are same number of templates as when we started
     ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
 
@@ -414,7 +420,6 @@ class AttributesManagersTest : public testing::Test {
     assetAttributesManager_->registerObject(defaultAttribs);
 
     // verify new handle is in template library
-    // get template by handle
     ASSERT(assetAttributesManager_->getObjectLibHasHandle(newHandle));
     // verify old template is still present as well
     ASSERT(assetAttributesManager_->getObjectLibHasHandle(oldHandle));

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -658,6 +658,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
               "template_name": "test_urdf_template0",
               "translation_origin": "COM",
               "fixed_base": false,
+              "auto_clamp_joint_limits" : true,
               "translation": [5,4,5],
               "rotation": [0.2, 0.3, 0.4, 0.5],
               "initial_joint_pose": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
@@ -667,6 +668,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
           {
               "template_name": "test_urdf_template1",
               "fixed_base" : true,
+              "auto_clamp_joint_limits" : true,
               "translation": [3, 2, 1],
               "rotation": [0.5, 0.6, 0.7, 0.8],
               "motion_type": "KINEMATIC"
@@ -763,6 +765,8 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   ASSERT_EQ(artObjInstance->getTranslationOrigin(),
             static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
   ASSERT_EQ(artObjInstance->getFixedBase(), false);
+  ASSERT_EQ(artObjInstance->getAutoClampJointLimits(), true);
+
   ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
   ASSERT_EQ(artObjInstance->getMotionType(),
             static_cast<int>(esp::physics::MotionType::DYNAMIC));
@@ -788,6 +792,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   artObjInstance = artObjInstances[1];
   ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template1");
   ASSERT_EQ(artObjInstance->getFixedBase(), true);
+  ASSERT_EQ(artObjInstance->getAutoClampJointLimits(), true);
   ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
   ASSERT_EQ(artObjInstance->getMotionType(),
             static_cast<int>(esp::physics::MotionType::KINEMATIC));

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -476,6 +476,9 @@ TEST_F(MetadataMediatorTest, testDataset1) {
     ASSERT_EQ(Dir::splitExtension(Dir::filename(iter->second))
                   .second.compare(".urdf"),
               0);
+    // test that file actually exists
+    const std::string filename = iter->second;
+    ASSERT_EQ(Dir::exists(filename), true);
   }
   // end test LoadArticulatedObjects
 

--- a/tests/test_attributes_managers.py
+++ b/tests/test_attributes_managers.py
@@ -22,6 +22,10 @@ def perform_general_tests(attr_mgr, search_string):
     template_id = attr_mgr.get_template_id_by_handle(template_handle)
     assert search_string in template_handle
 
+    # verify both handle and id exist in the manager
+    assert attr_mgr.get_library_has_handle(template_handle)
+    assert attr_mgr.get_library_has_id(template_id)
+
     # verify that access is the same for ID and handle lookup
     template0 = attr_mgr.get_template_by_handle(template_handle)
     template1 = attr_mgr.get_template_by_id(template_id)


### PR DESCRIPTION
## Motivation and Context
This PR contains bugfixes and cleanup for the following issues : 

- Remove out-of-date attributes todo messages
- Fix bug where Articulated Object model filename was getting erroneously parsed before saving upon load of SceneDataset, causing file to be unloadable.
- Add SceneInstance-level Articulated Object instance support for initial "autoClampJointLimits_" boolean setting, which controls whether or not dof limits should be enforced automatically before physics step is taken.
- Add mechanism to query whether ManagedContainer has an entry with a passed integer ID value.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass.  
Tests added to 
 - Verify autoClampJointLimits is read properly from SceneInstance
 - AO model filename actually exists as specified in SceneDataset config.
 - Test to verify that query for ID works in both python and c++
 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
