### PR TITLE
Add rearrange task data_group to datasets_download.py

### DIFF
--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -106,7 +106,8 @@ def initialize_test_data_sources(data_path):
             "coda_scene",
             "replica_cad_dataset",
             "hab_fetch",
-        ]
+        ],
+        "rearrange_task_assets": ["replica_cad_dataset", "hab_fetch", "ycb"],
     }
 
 

--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -93,6 +93,12 @@ def initialize_test_data_sources(data_path):
             "link": data_path + "robots/hab_fetch",
             "version": "1.0",
         },
+        "rearrange_pick_dataset_v0": {
+            "source": "https://dl.fbaipublicfiles.com/habitat/data/datasets/rearrange_pick/replica_cad/v0/rearrange_pick_replica_cad_v0.zip",
+            "package_name": "rearrange_pick_replica_cad_v0.zip",
+            "link": data_path + "datasets/rearrange_pick/replica_cad/v0",
+            "version": "1.0",
+        },
     }
 
     # data sources can be grouped for batch commands with a new uid
@@ -107,7 +113,12 @@ def initialize_test_data_sources(data_path):
             "replica_cad_dataset",
             "hab_fetch",
         ],
-        "rearrange_task_assets": ["replica_cad_dataset", "hab_fetch", "ycb"],
+        "rearrange_task_assets": [
+            "replica_cad_dataset",
+            "hab_fetch",
+            "ycb",
+            "rearrange_pick_dataset_v0",
+        ],
     }
 
 


### PR DESCRIPTION
## Motivation and Context

A subset of assets is necessary to run the Habitat-lab rearrange pick task. Adding a data_group makes download/setup a 1 line call.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
