### PR TITLE
Scale Phong materials to better match PBR intensities

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -461,8 +461,10 @@ std::string ResourceManager::createColorMaterial(
     gfx::PhongMaterialData::uptr phongMaterial =
         gfx::PhongMaterialData::create_unique();
     phongMaterial->ambientColor = materialColor.ambientColor;
-    phongMaterial->diffuseColor = materialColor.diffuseColor;
-    phongMaterial->specularColor = materialColor.specularColor;
+    // NOTE: This multiplication is a hack to roughly balance the Phong and PBR
+    // light intensity reactions.
+    phongMaterial->diffuseColor = materialColor.diffuseColor * 0.175;
+    phongMaterial->specularColor = materialColor.specularColor * 0.175;
 
     std::unique_ptr<gfx::MaterialData> finalMaterial(phongMaterial.release());
     shaderManager_.set(newMaterialID, finalMaterial.release());

--- a/src/esp/gfx/MaterialData.h
+++ b/src/esp/gfx/MaterialData.h
@@ -44,8 +44,10 @@ struct PhongMaterialData : public MaterialData {
 
   Magnum::Float shininess = 80.f;
   Magnum::Color4 ambientColor{0.1};
-  Magnum::Color4 diffuseColor{0.7};
-  Magnum::Color4 specularColor{0.2};
+  // NOTE: This multiplication is a hack to roughly balance the Phong and PBR
+  // light intensity reactions.
+  Magnum::Color4 diffuseColor{0.7 * 0.175};
+  Magnum::Color4 specularColor{0.2 * 0.175};
   Magnum::GL::Texture2D *ambientTexture = nullptr, *diffuseTexture = nullptr,
                         *specularTexture = nullptr, *normalTexture = nullptr;
 

--- a/src/esp/gfx/MaterialUtil.cpp
+++ b/src/esp/gfx/MaterialUtil.cpp
@@ -69,6 +69,11 @@ gfx::PhongMaterialData::uptr buildPhongFromPbrMetallicRoughness(
   finalMaterial->ambientColor = material.baseColor();
   finalMaterial->ambientTexture = finalMaterial->diffuseTexture;
 
+  // NOTE: This multiplication is a hack to roughly balance the Phong and PBR
+  // light intensity reactions.
+  finalMaterial->diffuseColor *= 0.15;
+  finalMaterial->specularColor *= 0.15;
+
   // normal mapping
   if (material.hasAttribute(Mn::Trade::MaterialAttribute::NormalTexture)) {
     finalMaterial->normalTexture =


### PR DESCRIPTION
## Motivation and Context

Phong and PBR materials respond very differently to that same lighting. We recently updated the light setups to support our transition to PBR primary materials which caused Phong materials (primarily primitives and URDF with color overrides) to be very bright. This PR adds a multiplier hack to balance the color intensities of Phong and PBR.

## How Has This Been Tested
Used Viewer to balance w/ default lights:

Before: 
![image](https://user-images.githubusercontent.com/1445143/123892839-2c3f9280-d910-11eb-963e-332c8f1d181b.png)

After: 
![image](https://user-images.githubusercontent.com/1445143/123892592-bf2bfd00-d90f-11eb-99c1-4b74834a4375.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
