### PR TITLE
Allow non-headless bullet conda-builds

### DIFF
--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -60,7 +60,7 @@ def main():
     # For CI test only one package build for test speed interest
     if args.ci_test:
         bullet_modes = [True]
-        headless_modes = [False]
+        headless_modes = [True]
         py_vers = ["3.6"]
 
     for py_ver, use_bullet, headless, cuda_ver in itertools.product(

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -63,13 +63,8 @@ def main():
         headless_modes = [True]
         py_vers = ["3.6"]
 
-    # TODO: Remove filter bullet_modes = True, headless_modes = False as failing
-    filter_bullet_with_display = lambda product: itertools.filterfalse(
-        lambda op: op[1:3] == (True, False), product
-    )
-
-    for py_ver, use_bullet, headless, cuda_ver in filter_bullet_with_display(
-        itertools.product(py_vers, bullet_modes, headless_modes, cuda_vers)
+    for py_ver, use_bullet, headless, cuda_ver in itertools.product(
+        py_vers, bullet_modes, headless_modes, cuda_vers
     ):
         env = os.environ.copy()
 

--- a/conda-build/linux_matrix_builder.py
+++ b/conda-build/linux_matrix_builder.py
@@ -60,7 +60,7 @@ def main():
     # For CI test only one package build for test speed interest
     if args.ci_test:
         bullet_modes = [True]
-        headless_modes = [True]
+        headless_modes = [False]
         py_vers = ["3.6"]
 
     for py_ver, use_bullet, headless, cuda_ver in itertools.product(


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Now that we build bullet from source, this should solve the issues were having with building both withbullet and non-headless. This disables the filter that prevents it.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
