### PR TITLE
Add --no-replace to datasets_download.py 

### DIFF
--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -307,6 +307,7 @@ def download_and_place(
     username: Optional[str] = None,
     password: Optional[str] = None,
     replace=False,
+    prompt_user_replace=True,
 ):
     r"""Data-source download function. Validates uid, handles existing data version, downloads data, unpacks, writes version, cleans up."""
     if not data_sources.get(uid):
@@ -327,7 +328,11 @@ def download_and_place(
             f"Existing data source ({uid}) version ({version_tag}) is current. Data located: '{version_dir}'. Symblink: '{link_path}'."
         )
         replace_existing = (
-            replace if replace else prompt_yes_no("Replace versioned data?")
+            replace
+            if replace
+            else prompt_yes_no("Replace versioned data?")
+            if prompt_user_replace
+            else False
         )
 
         if replace_existing:
@@ -480,6 +485,11 @@ def main(args):
         action="store_true",
         help="If set, existing equivalent versions of any dataset found during download will be deleted automatically. Otherwise user will be prompted before overriding existing data.",
     )
+    arg_group2.add_argument(
+        "--no-replace",
+        action="store_true",
+        help="If set, existing equivalent versions of any dataset found during download will be skipped automatically. Otherwise user will be prompted before overriding existing data.",
+    )
 
     parser.add_argument(
         "--username",
@@ -496,6 +506,7 @@ def main(args):
 
     args = parser.parse_args(args)
     replace = args.replace
+    prompt_user_replace = not args.no_replace and not replace
 
     # get a default data_path from git
     data_path = args.data_path
@@ -557,7 +568,12 @@ def main(args):
                 clean_data(uid, data_path)
             else:
                 download_and_place(
-                    uid, data_path, args.username, args.password, replace
+                    uid,
+                    data_path,
+                    args.username,
+                    args.password,
+                    replace,
+                    prompt_user_replace,
                 )
 
 

--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -306,8 +306,7 @@ def download_and_place(
     data_path,
     username: Optional[str] = None,
     password: Optional[str] = None,
-    replace=False,
-    prompt_user_replace=True,
+    replace=None,
 ):
     r"""Data-source download function. Validates uid, handles existing data version, downloads data, unpacks, writes version, cleans up."""
     if not data_sources.get(uid):
@@ -328,11 +327,7 @@ def download_and_place(
             f"Existing data source ({uid}) version ({version_tag}) is current. Data located: '{version_dir}'. Symblink: '{link_path}'."
         )
         replace_existing = (
-            replace
-            if replace
-            else prompt_yes_no("Replace versioned data?")
-            if prompt_user_replace
-            else False
+            replace if replace != None else prompt_yes_no("Replace versioned data?")
         )
 
         if replace_existing:
@@ -482,12 +477,15 @@ def main(args):
     )
     arg_group2.add_argument(
         "--replace",
+        dest="replace",
+        default=None,
         action="store_true",
         help="If set, existing equivalent versions of any dataset found during download will be deleted automatically. Otherwise user will be prompted before overriding existing data.",
     )
     arg_group2.add_argument(
         "--no-replace",
-        action="store_true",
+        dest="replace",
+        action="store_false",
         help="If set, existing equivalent versions of any dataset found during download will be skipped automatically. Otherwise user will be prompted before overriding existing data.",
     )
 
@@ -506,7 +504,6 @@ def main(args):
 
     args = parser.parse_args(args)
     replace = args.replace
-    prompt_user_replace = not args.no_replace and not replace
 
     # get a default data_path from git
     data_path = args.data_path
@@ -568,12 +565,7 @@ def main(args):
                 clean_data(uid, data_path)
             else:
                 download_and_place(
-                    uid,
-                    data_path,
-                    args.username,
-                    args.password,
-                    replace,
-                    prompt_user_replace,
+                    uid, data_path, args.username, args.password, replace
                 )
 
 

--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -306,7 +306,7 @@ def download_and_place(
     data_path,
     username: Optional[str] = None,
     password: Optional[str] = None,
-    replace=None,
+    replace: Optional[bool] = None,
 ):
     r"""Data-source download function. Validates uid, handles existing data version, downloads data, unpacks, writes version, cleans up."""
     if not data_sources.get(uid):

--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -327,7 +327,7 @@ def download_and_place(
             f"Existing data source ({uid}) version ({version_tag}) is current. Data located: '{version_dir}'. Symblink: '{link_path}'."
         )
         replace_existing = (
-            replace if replace != None else prompt_yes_no("Replace versioned data?")
+            replace if replace is not None else prompt_yes_no("Replace versioned data?")
         )
 
         if replace_existing:


### PR DESCRIPTION
## Motivation and Context

Add `--no-replace` to datasets_download.py to skip existing data automatically. Should fix use-cases with automated download that are run multiple times, currently requiring re-download with `--replace` or crashing due to user prompt.

## How Has This Been Tested

Locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
