### PR TITLE
datasets_download.py - change default data_path 

### DIFF
--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -505,21 +505,21 @@ def main(args):
     args = parser.parse_args(args)
     replace = args.replace
 
-    # get a default data_path from git
+    # get a default data_path "./data/"
     data_path = args.data_path
     if not data_path:
         try:
-            import git
-
-            repo = git.Repo(".", search_parent_directories=True)
-            dir_path = repo.working_tree_dir
-            # Root data directory. Optionaly overridden by input argument "--data-path".
-            data_path = os.path.join(dir_path, "data")
+            data_path = os.path.abspath("./data/")
+            print(
+                f"No data-path provided, default to: {data_path}. Use '--data-path' to specify another location."
+            )
+            if not os.path.exists(data_path):
+                os.makedirs(data_path)
         except Exception:
             traceback.print_exc(file=sys.stdout)
             print("----------------------------------------------------------------")
             print(
-                "Aborting download, failed to get default data_path from git repo and none provided."
+                "Aborting download, failed to create default data_path and none provided."
             )
             print("Try providing --data-path (e.g. '/path/to/habitat-sim/data/')")
             print("----------------------------------------------------------------")

--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -527,8 +527,7 @@ def main(args):
             exit(2)
 
     # initialize data_sources and data_groups with test and example assets
-    if not os.path.exists(data_path):
-        os.mkdir(data_path)
+    os.makedirs(data_path, exist_ok=True)
     data_path = os.path.abspath(data_path) + "/"
     initialize_test_data_sources(data_path=data_path)
 


### PR DESCRIPTION
## Motivation and Context

Change default data_path from git to ./data/ so the script has a reasonable default outside of git repo but is also compatible with previous default behavior in habitat-sim directory and doesn't flood an existing user directory. 

## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
