### PR TITLE
[Web] Add flag to enable SIMD instructions in WASM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^(build|data/datasets|data/scene_datasets|node_modules/|src/deps|src/obsolete)'
+exclude: '^(build(js)$|data/datasets|data/scene_datasets|node_modules/|src/deps|src/obsolete)'
 
 default_language_version:
     python: python3

--- a/build_js.sh
+++ b/build_js.sh
@@ -11,8 +11,8 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --bullet) BULLET=true ;;
         --no-web-apps) WEB_APPS=false ;;
-	--simd) USE_SIMD=true ;;
-	*) echo "Unknown parameter passed: $1"; exit 1 ;;
+        --simd) USE_SIMD=true ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done

--- a/build_js.sh
+++ b/build_js.sh
@@ -36,7 +36,7 @@ cd build_js
 EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
 HAB_C_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=0"
 if ${USE_SIMD} ;
-    then HAB_C_FLAGS="${HAB_CXX_FLAGS} -msimd128"
+    then HAB_C_FLAGS="${HAB_C_FLAGS} -msimd128"
 fi
 cmake ../src \
     -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/RelWithDebInfo/bin/corrade-rc \
@@ -71,4 +71,3 @@ if [ -o ${WEB_APPS} ]
     echo "Or open in a VR-capable browser:"
     echo "http://0.0.0.0:8000/build_js/esp/bindings_js/webvr.html?scene=skokloster-castle.glb"
 fi
-

--- a/build_js.sh
+++ b/build_js.sh
@@ -5,12 +5,14 @@ set -e
 
 BULLET=false
 WEB_APPS=true
+USE_SIMD=false
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --bullet) BULLET=true ;;
         --no-web-apps) WEB_APPS=false ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+	--simd) USE_SIMD=true ;;
+	*) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
@@ -32,6 +34,10 @@ cd build_js
 
 
 EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
+HAB_C_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=0"
+if ${USE_SIMD} ;
+    then HAB_C_FLAGS="${HAB_CXX_FLAGS} -msimd128"
+fi
 cmake ../src \
     -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/RelWithDebInfo/bin/corrade-rc \
     -DBUILD_GUI_VIEWERS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )" \
@@ -44,7 +50,8 @@ cmake ../src \
     -DCMAKE_TOOLCHAIN_FILE="../src/deps/corrade/toolchains/generic/Emscripten-wasm.cmake" \
     -DCMAKE_INSTALL_PREFIX="." \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
-    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=0" \
+    -DCMAKE_C_FLAGS="${HAB_C_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${HAB_C_FLAGS}" \
     -DCMAKE_EXE_LINKER_FLAGS="${EXE_LINKER_FLAGS}" \
     -DBUILD_WITH_BULLET="$( if ${BULLET} ; then echo ON ; else echo OFF; fi )" \
     -DBUILD_WEB_APPS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )"


### PR DESCRIPTION
## Motivation and Context
* Adds a flag that can enable building the Web build of Habitat to use SIMD. This should speed up physics and other linalg heavy vectorization quite significantly. The browser must support SIMD in WASM like modern versions of Chrome though.
* To enable pass the --simd flag to build_js.sh
* Also fixes a small bug with pre-commit that prevented shell check from running on build.sh and build_js.sh .
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and with CI.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
