### PR TITLE
--[Bugfix] Scene Instance Viewer list start.

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -403,7 +403,8 @@ Key Commands:
     if (curSceneInstances_.size() == 0) {
       return 0;
     }
-    return (curSceneInstanceIDX_ + incr) % curSceneInstances_.size();
+    return (curSceneInstanceIDX_ + curSceneInstances_.size() + incr) %
+           curSceneInstances_.size();
   }
 
   /**
@@ -763,7 +764,8 @@ Viewer::Viewer(const Arguments& arguments)
   // found.
   curSceneInstanceIDX_ = 0;
   for (int i = 0; i < curSceneInstances_.size(); ++i) {
-    if (curSceneInstances_[i].find(simConfig_.activeSceneName)) {
+    if (curSceneInstances_[i].find(simConfig_.activeSceneName) !=
+        std::string::npos) {
       curSceneInstanceIDX_ = i;
       break;
     }


### PR DESCRIPTION
## Motivation and Context
Minor bug fix to make sure we accurately find starting scene in list of scenes in viewer, and tab/shift tab appropriately cycles through other scenes.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally  c++.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
