### PR TITLE
Eundersander/decoupled sim render prototype

### DIFF
--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -60,6 +60,8 @@ class Player {
    */
   void readKeyframesFromFile(const std::string& filepath);
 
+  void checkNamedPipe(const std::string& pipeName);
+
   /**
    * @brief Get the currently-set keyframe, or -1 if no keyframe is set.
    */
@@ -110,6 +112,8 @@ class Player {
   std::map<std::string, esp::assets::AssetInfo> assetInfos_;
   std::map<RenderAssetInstanceKey, scene::SceneNode*> createdInstances_;
   std::set<std::string> failedFilepaths_;
+  int m_pipeFd = -1;
+  std::vector<char> m_pipeBuffer;
 
   ESP_SMART_POINTERS(Player)
 };

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -108,6 +108,8 @@ class Recorder {
   }
 
  private:
+  void sendLatestKeyframeToPipe();
+
   // NodeDeletionHelper calls onDeleteRenderAssetInstance
   friend class NodeDeletionHelper;
 
@@ -140,6 +142,7 @@ class Recorder {
   Keyframe currKeyframe_;
   std::vector<Keyframe> savedKeyframes_;
   RenderAssetInstanceKey nextInstanceKey_ = 0;
+  int m_pipeFd = -1;
 };
 
 }  // namespace replay

--- a/src/esp/gfx/replay/ReplayManager.cpp
+++ b/src/esp/gfx/replay/ReplayManager.cpp
@@ -21,6 +21,11 @@ std::shared_ptr<Player> ReplayManager::readKeyframesFromFile(
   return player;
 }
 
+std::shared_ptr<Player> ReplayManager::createEmptyPlayer() {
+  auto player = std::make_shared<Player>(playerCallback_);
+  return player;
+}
+
 }  // namespace replay
 }  // namespace gfx
 }  // namespace esp

--- a/src/esp/gfx/replay/ReplayManager.h
+++ b/src/esp/gfx/replay/ReplayManager.h
@@ -47,6 +47,8 @@ class ReplayManager {
    */
   std::shared_ptr<Player> readKeyframesFromFile(const std::string& filepath);
 
+  std::shared_ptr<Player> createEmptyPlayer();
+
  private:
   std::shared_ptr<Recorder> recorder_;
   Player::LoadAndCreateRenderAssetInstanceCallback playerCallback_;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -359,6 +359,7 @@ Key Commands:
   esp::scene::SceneGraph* activeSceneGraph_ = nullptr;
   bool drawObjectBBs = false;
   std::string gfxReplayRecordFilepath_;
+  std::shared_ptr<esp::gfx::replay::Player> player_;
 
   std::string agentTransformLoadPath_;
   Cr::Containers::Optional<Mn::Matrix4> savedAgentTransform_ =
@@ -726,6 +727,10 @@ Viewer::Viewer(const Arguments& arguments)
 
   // Per frame profiler will average measurements taken over previous 50 frames
   profiler_.setup(profilerValues, 50);
+
+  if (gfxReplayRecordFilepath_.empty()) {
+    player_ = simulator_->getGfxReplayManager()->createEmptyPlayer();
+  }
 
   printHelpText();
 }  // end Viewer::Viewer
@@ -1140,6 +1145,13 @@ void Viewer::drawEvent() {
       const auto recorder = simulator_->getGfxReplayManager()->getRecorder();
       if (recorder) {
         recorder->saveKeyframe();
+      }
+    }
+
+    if (player_) {
+      player_->checkNamedPipe("my_habitat_pipe");
+      if (player_->getNumKeyframes()) {
+        player_->setKeyframeIndex(player_->getNumKeyframes() - 1);
       }
     }
     // reset timeSinceLastSimulation, accounting for potential overflow


### PR DESCRIPTION
Do not merge. Just documenting a branch.

This is a prototype of decoupled simulation/rendering. See [slack discussion thread](https://cvmlp.slack.com/archives/CFN5TAUSD/p1621454945005400) for more info.

This demo has two pieces: a writer (the simulation) and a reader (the decoupled renderer). Each is an instance of the C++ viewer, just launched with different command-line options. We use a [named pipe](https://www.google.com/search?q=named+pipe) to communicate between the two processes.

Note that the writer also renders normally (hence the video showing two separate windows), but we can imagine disabling this to make it a "pure" simulation.

The writer is a normal C++ viewer except configured to to record a gfx-replay. In `Recorder::saveKeyframe`, we call `sendLatestKeyframeToPipe()`. Run the writer like so:
```
./build/utils/viewer/viewer /path/to/my_scene.glb --gfx-replay-record-filepath "./my_replay.replay.json" --enable-physics
```
To be clear, the replay json filepath here doesn't matter; the writer is hard-coded to also write to a named pipe called `my_habitat_pipe`. When you launch it, it will appear to be frozen; look for terminal output like so:
```
Recorder::sendLatestKeyframeToPipe: waiting for a process to open named pipe my_habitat_pipe for reading...
```

The reader is a normal C++ viewer except hard-coded to create a `gfx::replay::Player` and read from the named pipe (`player_->checkNamedPipe("my_habitat_pipe")`). After launching the writer, launch the reader like so:
```
./build/utils/viewer/viewer NONE
```

https://user-images.githubusercontent.com/6557808/125372368-cd2e4480-e337-11eb-8423-4905be1c43c0.mp4
