### PR TITLE
Subsystem Logging

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ INPUT_PAGES = [
     "pages/image-extractor.rst",
     "pages/asset-viewer-tutorial.rst",
     "pages/managed-rigid-object-tutorial.rst",
+    "pages/logging.rst",
 ]
 
 PLUGINS = [

--- a/docs/namespaces.dox
+++ b/docs/namespaces.dox
@@ -12,4 +12,8 @@ namespace esp {
  * @brief GFX library
  */
 
+/** @namespace esp::logging
+ * @brief logging library
+ */
+
 }

--- a/docs/pages/index.rst
+++ b/docs/pages/index.rst
@@ -49,6 +49,11 @@ Python Classes
 
 See the `Classes <./classes.html>`_ tab.
 
+Logging Configuration
+=====================
+
+See :ref:`Logging Configuration <std:doc:logging>` for how to configure *Habitat-Sim* logging.
+
 Python Unit Tests
 =================
 

--- a/docs/pages/logging.rst
+++ b/docs/pages/logging.rst
@@ -1,0 +1,55 @@
+Logging Configuration
+=====================
+
+This page explains how to configure what is logged in Habitat-Sim.
+
+Turn off non-critical logging
+-----------------------------
+
+To turn off non-critical logging, use one of the following based on your current version:
+
+* Habitat-Sim version >= 0.2.0.1
+  .. code-block::
+
+    export MAGNUM_LOG=quiet HABITAT_SIM_LOG=quiet
+
+* Habitat-Sim version < 0.2.0.1
+  .. code-block::
+
+    export MAGNUM_LOG=quiet GLOG_minloglevel=2
+
+Turning on specific logging
+---------------------------
+
+Habitat-Sim has numerous different subsystems (gfx, physics, sim, scene, etc.) and these
+can all have their logging levels set independently.  The ``HABITAT_SIM_LOG`` environment
+variable takes a string that configures these which is governed by the following
+grammar
+
+.. code-block:: sh
+
+    FilterString: SetLevelCommand (COLON SetLevelCommand)*
+    SetLevelCommand: (SUBSYSTEM (COMMA SUBSYSTEM)* EQUALS)? LOGGING_LEVEL
+
+
+where ``SUBSYSTEM`` is the name (or names) of a given subsystem and ``LOGGING_LEVEL`` is the logging level name. If no subsystem name is given, the level will be applied to all subsystems.
+
+For example, ``HABITAT_SIM_LOG=quiet:physics,sim=verbose`` will set all subsystems to quiet and then set both the physics and sim subsystems to verbose.
+Logging level names and subsystem names are not case sensitive in this filter configuration string.
+
+
+Logging Level: :dox:`esp::logging::LoggingLevel`
+
+Logging subsystems: :dox:`esp::logging::Subsystem`
+
+
+
+
+GPU Context Debugging
+---------------------
+
+When trying to debug things related to GPU contexts, set the following
+
+.. code-block:: sh
+
+    export MAGNUM_LOG=verbose MAGNUM_GPU_VALIDATION=ON

--- a/src/esp/core/CMakeLists.txt
+++ b/src/esp/core/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   Configuration.h
   esp.cpp
   esp.h
+  logging.cpp
   logging.h
   managedContainers/AbstractManagedObject.h
   managedContainers/ManagedContainer.h
@@ -62,3 +63,7 @@ target_link_libraries(
 )
 
 target_include_directories(core PUBLIC ${PROJECT_BINARY_DIR})
+
+if(BUILD_TEST)
+  add_subdirectory(test)
+endif()

--- a/src/esp/core/logging.cpp
+++ b/src/esp/core/logging.cpp
@@ -44,7 +44,7 @@ LoggingLevel levelFromName(const Corrade::Containers::StringView name) {
   if (lowerCaseName == #name##_s) \
   return LoggingLevel::level
 
-  CASE(Verbose1, verbose1);
+  CASE(VeryVerbose, veryverbose);
   CASE(Verbose, verbose);
   CASE(Debug, debug);
   CASE(Warning, warning);

--- a/src/esp/core/logging.cpp
+++ b/src/esp/core/logging.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "logging.h"
+#include "Check.h"
+
+#include <algorithm>
+#include <cstdlib>
+
+#include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/StaticArray.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Format.h>
+
+namespace Cr = Corrade;
+using Cr::Containers::Literals::operator""_s;
+
+namespace esp {
+namespace logging {
+
+static_assert(uint8_t(Subsystem::NumSubsystems) ==
+                  (sizeof(subsystemNames) / sizeof(subsystemNames[0])),
+              "Missing a subsystem name.");
+
+Subsystem subsystemFromName(const Corrade::Containers::StringView name) {
+  const Cr::Containers::String lowerCaseName =
+      Cr::Utility::String::lowercase(name);
+  for (uint8_t i = 0; i < uint8_t(Subsystem::NumSubsystems); ++i)
+    if (lowerCaseName == Cr::Utility::String::lowercase(
+                             Cr::Containers::StringView{subsystemNames[i]}))
+      return Subsystem(i);
+
+  CORRADE_ASSERT_UNREACHABLE("Unknown subsystem '"
+                                 << Cr::Utility::Debug::nospace << name
+                                 << Cr::Utility::Debug::nospace << "'",
+                             {});
+}
+
+LoggingLevel levelFromName(const Corrade::Containers::StringView name) {
+  const Cr::Containers::String lowerCaseName =
+      Cr::Utility::String::lowercase(name);
+#define CASE(level, name)         \
+  if (lowerCaseName == #name##_s) \
+  return LoggingLevel::level
+
+  CASE(Verbose1, verbose1);
+  CASE(Verbose, verbose);
+  CASE(Debug, debug);
+  CASE(Warning, warning);
+  CASE(Quiet, quiet);
+  CASE(Error, error);
+
+#undef CASE
+  CORRADE_ASSERT_UNREACHABLE("Unknown logging level name '"
+                                 << Cr::Utility::Debug::nospace << name
+                                 << Cr::Utility::Debug::nospace << "'",
+                             {});
+}
+
+namespace {
+#ifdef CORRADE_BUILD_MULTITHREADED
+CORRADE_THREAD_LOCAL
+#endif
+#if defined(MAGNUM_BUILD_STATIC_UNIQUE_GLOBALS) && \
+    !defined(CORRADE_TARGET_WINDOWS)
+/* On static builds that get linked to multiple shared libraries and then used
+   in a single app we want to ensure there's just one global symbol. On Linux
+   it's apparently enough to just export, macOS needs the weak attribute.
+   Windows handled differently below. */
+CORRADE_VISIBILITY_EXPORT
+#ifdef __GNUC__
+__attribute__((weak))
+#else
+/* uh oh? the test will fail, probably */
+#endif
+#endif
+LoggingContext* currentLoggingContext = nullptr;
+}  // namespace
+
+bool LoggingContext::hasCurrent() {
+  return currentLoggingContext != nullptr;
+}
+
+LoggingContext& LoggingContext::current() {
+  ESP_CHECK(hasCurrent(),
+            "esp::logging::LoggingContext: No current logging context.");
+
+  return *currentLoggingContext;
+}
+
+LoggingContext::LoggingContext(Corrade::Containers::StringView envString)
+    : loggingLevels_{Cr::DirectInit, uint8_t(Subsystem::NumSubsystems),
+                     DEFAULT_LEVEL},
+      prevContext_{currentLoggingContext} {
+  currentLoggingContext = this;
+  processEnvString(envString);
+}
+
+LoggingContext::LoggingContext()
+    : LoggingContext{std::getenv(LOGGING_ENV_VAR_NAME)} {}
+
+LoggingContext::~LoggingContext() {
+  currentLoggingContext = prevContext_;
+}
+
+void LoggingContext::processEnvString(
+    const Cr::Containers::StringView envString) {
+  for (const Cr::Containers::StringView setLevelCommand :
+       envString.split(':')) {
+    if (setLevelCommand.contains("=")) {
+      const auto parts = setLevelCommand.partition('=');
+      LoggingLevel lvl = levelFromName(parts[2]);
+
+      for (const Cr::Containers::StringView subsystemName : parts[0].split(','))
+        loggingLevels_[uint8_t(subsystemFromName(subsystemName))] = lvl;
+    } else {
+      std::fill(loggingLevels_.begin(), loggingLevels_.end(),
+                levelFromName(setLevelCommand));
+    }
+  }
+}
+
+void LoggingContext::reinitializeFromEnv() {
+  std::fill(loggingLevels_.begin(), loggingLevels_.end(), DEFAULT_LEVEL);
+  processEnvString(std::getenv(LOGGING_ENV_VAR_NAME));
+}
+
+LoggingLevel LoggingContext::levelFor(Subsystem subsystem) const {
+  return loggingLevels_[uint8_t(subsystem)];
+}
+
+bool isLevelEnabled(Subsystem subsystem, LoggingLevel level) {
+  return level >= LoggingContext::current().levelFor(subsystem);
+}
+
+Cr::Containers::String subsystemPrefix(Subsystem subsystem) {
+  return ""_s.join({"["_s, subsystemNames[uint8_t(subsystem)], "] "_s});
+}
+
+}  // namespace logging
+}  // namespace esp

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -208,19 +208,21 @@ class LogMessageVoidify {
  * would work for this overload.  That way the logging statements get evaluated
  * first, then the voidify, then the ternary.
  */
-#define ESP_LOG_IF(condition, output) \
-  !(condition) ? static_cast<void>(0) \
-               : esp::logging::impl::LogMessageVoidify{} & (output)
+
+#define ESP_LOG_IF(condition, output)                      \
+  !(condition) ? static_cast<void>(0)                      \
+               : esp::logging::impl::LogMessageVoidify{} & \
+                     (output) /* NOLINT(bugprone-macro-parentheses) */
 
 // This ends with a nospace since the space is baked in to subsystemPrefix for
 // the case that the logger was created with a nospace flag.
-#define ESP_SUBSYS_LOG_IF(subsystem, level, output)                  \
-  ESP_LOG_IF(esp::logging::isLevelEnabled(subsystem, level), output) \
-      << esp::logging::subsystemPrefix(subsystem)                    \
+#define ESP_SUBSYS_LOG_IF(subsystem, level, output)                        \
+  ESP_LOG_IF(esp::logging::isLevelEnabled((subsystem), (level)), (output)) \
+      << esp::logging::subsystemPrefix((subsystem))                        \
       << Corrade::Utility::Debug::nospace
 
 #define ESP_LOG_LEVEL_ENABLED(level) \
-  esp::logging::isLevelEnabled(espLoggingSubsystem(), level)
+  esp::logging::isLevelEnabled(espLoggingSubsystem(), (level))
 
 #define ESP_VERBOSE_1(...)                                              \
   ESP_SUBSYS_LOG_IF(                                                    \
@@ -283,7 +285,7 @@ class LogMessageVoidify {
 #define ASSERT(x, ...)                                                   \
   do {                                                                   \
     if (!(x)) {                                                          \
-      ESP_ERROR(Corrade::Utility::Debug::Flag::NoSpace)                  \
+      Corrade::Utility::Error{Corrade::Utility::Debug::Flag::NoSpace}    \
           << "Assert failed: " #x << "," << __FILE__ << ":" << __LINE__; \
       exit(-1);                                                          \
     }                                                                    \

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -209,10 +209,11 @@ class LogMessageVoidify {
  * first, then the voidify, then the ternary.
  */
 
-#define ESP_LOG_IF(condition, output) \
-  !(condition)                        \
-      ? static_cast<void>(0)          \
-      : esp::logging::impl::LogMessageVoidify{} & (output) /* NOLINT */
+// No formatting on this macro as the NOLINT for clang
+#define ESP_LOG_IF(condition, output)                                         \
+  !(condition)                                                                \
+      ? static_cast<void>(0) /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
+      : esp::logging::impl::LogMessageVoidify{} & (output)
 
 // This ends with a nospace since the space is baked in to subsystemPrefix for
 // the case that the logger was created with a nospace flag.

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -209,10 +209,10 @@ class LogMessageVoidify {
  * first, then the voidify, then the ternary.
  */
 
-#define ESP_LOG_IF(condition, output)                      \
-  !(condition) ? static_cast<void>(0)                      \
-               : esp::logging::impl::LogMessageVoidify{} & \
-                     (output) /* NOLINT(bugprone-macro-parentheses) */
+#define ESP_LOG_IF(condition, output) \
+  !(condition)                        \
+      ? static_cast<void>(0)          \
+      : esp::logging::impl::LogMessageVoidify{} & (output) /* NOLINT */
 
 // This ends with a nospace since the space is baked in to subsystemPrefix for
 // the case that the logger was created with a nospace flag.

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -170,7 +170,6 @@ Corrade::Containers::String subsystemPrefix(Subsystem subsystem);
 namespace impl {
 class LogMessageVoidify {
  public:
-  LogMessageVoidify() {}
   // This has to be an operator with a precedence lower than << but
   // higher than ?:
   void operator&(Corrade::Utility::Debug&) {}
@@ -209,35 +208,35 @@ class LogMessageVoidify {
  * would work for this overload.  That way the logging statements get evaluated
  * first, then the voidify, then the ternary.
  */
-#define _ESP_LOG_IF(condition, output) \
-  !(condition) ? static_cast<void>(0)  \
-               : esp::logging::impl::LogMessageVoidify{} & output
+#define ESP_LOG_IF(condition, output) \
+  !(condition) ? static_cast<void>(0) \
+               : esp::logging::impl::LogMessageVoidify{} & (output)
 
 // This ends with a nospace since the space is baked in to subsystemPrefix for
 // the case that the logger was created with a nospace flag.
-#define _ESP_SUBSYS_LOG_IF(subsystem, level, output)                  \
-  _ESP_LOG_IF(esp::logging::isLevelEnabled(subsystem, level), output) \
-      << esp::logging::subsystemPrefix(subsystem)                     \
+#define ESP_SUBSYS_LOG_IF(subsystem, level, output)                  \
+  ESP_LOG_IF(esp::logging::isLevelEnabled(subsystem, level), output) \
+      << esp::logging::subsystemPrefix(subsystem)                    \
       << Corrade::Utility::Debug::nospace
 
 #define ESP_LOG_LEVEL_ENABLED(level) \
   esp::logging::isLevelEnabled(espLoggingSubsystem(), level)
 
 #define ESP_VERBOSE_1(...)                                              \
-  _ESP_SUBSYS_LOG_IF(                                                   \
+  ESP_SUBSYS_LOG_IF(                                                    \
       espLoggingSubsystem(), esp::logging::LoggingLevel::Verbose1,      \
       Corrade::Utility::Debug{Corrade::Utility::Debug::defaultOutput(), \
                               __VA_ARGS__})
-#define ESP_DEBUG(...)                                                         \
-  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Debug, \
-                     Corrade::Utility::Debug{__VA_ARGS__})
-#define ESP_WARNING(...)                                  \
-  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(),               \
-                     esp::logging::LoggingLevel::Warning, \
-                     Corrade::Utility::Warning{__VA_ARGS__})
-#define ESP_ERROR(...)                                                         \
-  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Error, \
-                     Corrade::Utility::Error{__VA_ARGS__})
+#define ESP_DEBUG(...)                                                        \
+  ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Debug, \
+                    Corrade::Utility::Debug{__VA_ARGS__})
+#define ESP_WARNING(...)                                 \
+  ESP_SUBSYS_LOG_IF(espLoggingSubsystem(),               \
+                    esp::logging::LoggingLevel::Warning, \
+                    Corrade::Utility::Warning{__VA_ARGS__})
+#define ESP_ERROR(...)                                                        \
+  ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Error, \
+                    Corrade::Utility::Error{__VA_ARGS__})
 
 #if defined(ESP_BUILD_GLOG_SHIM)
 

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -281,13 +281,13 @@ class LogMessageVoidify {
 #include <glog/stl_logging.h>
 #endif
 
-#define ASSERT(x, ...)                                              \
-  do {                                                              \
-    if (!(x)) {                                                     \
-      ESP_ERROR() << "Assert failed: " #x << "," << __FILE__ << ":" \
-                  << __LINE__;                                      \
-      exit(-1);                                                     \
-    }                                                               \
+#define ASSERT(x, ...)                                                   \
+  do {                                                                   \
+    if (!(x)) {                                                          \
+      ESP_ERROR(Corrade::Utility::Debug::Flag::NoSpace)                  \
+          << "Assert failed: " #x << "," << __FILE__ << ":" << __LINE__; \
+      exit(-1);                                                          \
+    }                                                                    \
   } while (false)
 
 #endif  // ESP_CORE_LOGGING_H_

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -7,14 +7,167 @@
 
 #include "esp/core/configure.h"
 
-#if defined(ESP_BUILD_GLOG_SHIM)
-
+#include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Containers/StringView.h>
 #include <Corrade/Utility/Debug.h>
 #include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/String.h>
 
-// Our own shims "emulating" GLOG
-// TODO shims are hack to get things compiling, implement expected behaviors
+namespace esp {
+namespace logging {
+// These are all subsystems that have different logging levels
+// They correspond to namespaces.  When adding a new subsystem, make sure
+// to add an appropriate loggingSubsystem function (see the ADD_SUBSYSTEM_FN
+// helper bellow) and add it to @ref subsystemFromName()
+enum class Subsystem : uint8_t {
+  // This is the catch all subsystem
+  Default,
+  gfx,
+  scene,
+  sim,
+  physics,
+  nav,
+  metadata,
+  geo,
+  io,
+  URDF,
 
+  // Must always be last
+  NumSubsystems,
+};
+
+constexpr const char* subsystemNames[] = {"Default", "Gfx", "Scene",    "Sim",
+                                          "Physics", "Nav", "Metadata", "Geo",
+                                          "IO",      "URDF"};
+
+Subsystem subsystemFromName(Corrade::Containers::StringView name);
+
+}  // namespace logging
+}  // namespace esp
+
+// This is the catch all for subsystems without a specialization
+// Using c style namespacing that way logging can work outside our namespace
+inline esp::logging::Subsystem espLoggingSubsystem() {
+  return esp::logging::Subsystem::Default;
+}
+
+#define ADD_SUBSYSTEM_FN(subsystemName)             \
+  namespace esp {                                   \
+  namespace subsystemName {                         \
+  inline logging::Subsystem espLoggingSubsystem() { \
+    return logging::Subsystem::subsystemName;       \
+  }                                                 \
+  }                                                 \
+  }
+
+ADD_SUBSYSTEM_FN(gfx);
+ADD_SUBSYSTEM_FN(scene);
+ADD_SUBSYSTEM_FN(sim);
+ADD_SUBSYSTEM_FN(physics);
+ADD_SUBSYSTEM_FN(nav);
+ADD_SUBSYSTEM_FN(metadata);
+ADD_SUBSYSTEM_FN(geo);
+ADD_SUBSYSTEM_FN(io);
+
+namespace esp {
+namespace io {
+namespace URDF {
+inline logging::Subsystem espLoggingSubsystem() {
+  return logging::Subsystem::URDF;
+}
+}  // namespace URDF
+}  // namespace io
+}  // namespace esp
+
+namespace esp {
+namespace logging {
+
+enum class LoggingLevel : uint8_t {
+  Verbose1,
+  Debug,
+  Warning,
+  Error,
+
+  // Verbose enables debug and higher
+  // Note:  If you add something lower prio than Debug,
+  // Verbose should be set equal to that
+  Verbose = Debug,
+  // Quiet is errors and higher
+  Quiet = Error,
+};
+
+LoggingLevel levelFromName(Corrade::Containers::StringView name);
+
+class LoggingContext {
+ public:
+  constexpr static const char* LOGGING_ENV_VAR_NAME = "HABITAT_SIM_LOG";
+  constexpr static LoggingLevel DEFAULT_LEVEL = LoggingLevel::Verbose;
+
+  /**
+   * @brief Convenience constructor that grabs the configuration string from the
+   * environment variable and calls @ref
+   * LoggingContext(Corrade::Containers::StringView)
+   */
+  LoggingContext();
+
+  /**
+   * @brief Constructor
+   *
+   * @param[in] envString Configuration string. See @ref processEnvString for
+   * details
+   */
+  explicit LoggingContext(Corrade::Containers::StringView envString);
+
+  ~LoggingContext();
+
+  LoggingContext(LoggingContext&&) = delete;
+  LoggingContext(LoggingContext&) = delete;
+  LoggingContext& operator=(LoggingContext&) = delete;
+  LoggingContext& operator=(LoggingContext&&) = delete;
+
+  /**
+   * @brief Processes the environment variable string that configures the
+   * habitat-sim logging levels for various subsystems
+   *
+   * This environment string has a fairly simple grammar that is as follows
+   *
+   *    FilterString: SetLevelCommand (COLON SetLevelCommand)*
+   *    SetLevelCommand: (SUBSYSTEM (COMMA SUBSYSTEM)* EQUALS)? LOGGING_LEVEL
+   *
+   * where SUBSYSTEM is a known logging subsystem and LOGGING_LEVEL is one of
+   * the logging levels.  If a SetLevelCommand does not contain a list of
+   * subsystems, that level is applied to all subsystems.
+   *
+   *
+   * A logging statement is printed if it's logging level has a higher or equal
+   * priority to the current logging level for it's subsystem.  verbose is the
+   * lowest level. quiet disables debug and warnings.
+   */
+  void processEnvString(Corrade::Containers::StringView envString);
+
+  /**
+   * @brief Retrieves the configuration string from the environment variable
+   * and reconfigures levels.  Useful for allowing the environment variable
+   * to be changed after module level initialization.
+   */
+  void reinitializeFromEnv();
+
+  LoggingLevel levelFor(Subsystem subsystem) const;
+
+  static bool hasCurrent();
+  static LoggingContext& current();
+
+ private:
+  Corrade::Containers::Array<LoggingLevel> loggingLevels_;
+  LoggingContext* prevContext_;
+};
+
+bool isLevelEnabled(Subsystem subsystem, LoggingLevel level);
+
+Corrade::Containers::String subsystemPrefix(Subsystem subsystem);
+
+namespace impl {
 class LogMessageVoidify {
  public:
   LogMessageVoidify() {}
@@ -22,6 +175,75 @@ class LogMessageVoidify {
   // higher than ?:
   void operator&(Corrade::Utility::Debug&) {}
 };
+}  // namespace impl
+}  // namespace logging
+}  // namespace esp
+
+/**
+ * @brief Magic macro that creates a conditional logging statement
+ *
+ * The intent of this macro is actually rather simple (although the
+ * implementation is quite opaque).  This macro is just
+ *
+ *   if (condition) output
+ *
+ * This is a "so simple it's obvious" way to implement a conditional logging
+ * macro.  However, the if statement implementation would potentially interact
+ * with other parts of the code.  While certianly an edge case, the following
+ * should not be valid code:
+ *
+ *   ESP_DEBUG() << ... ;
+ *   else {
+ *      ...
+ *   }
+ *
+ * So instead, a ternary is used to encapsulate everything as a single
+ * expression.  Since a ternary requires both a true and false clause and the
+ * false clause comes second, the condition is negated.
+ *
+ * The final piece of the puzzle is how to have both the true and false clause
+ * return the same thing (a return of void is used to avoid unused value
+ * compiler warnings). The `LogMessageVoidify{} & output` does this as
+ * `LogMessageVoidify` has an `operator&` overload that returns void.  Any
+ * operator that is lower precedence than `operator<<` and higher than `?:`
+ * would work for this overload.  That way the logging statements get evaluated
+ * first, then the voidify, then the ternary.
+ */
+#define _ESP_LOG_IF(condition, output) \
+  !(condition) ? static_cast<void>(0)  \
+               : esp::logging::impl::LogMessageVoidify{} & output
+
+// This ends with a nospace since the space is baked in to subsystemPrefix for
+// the case that the logger was created with a nospace flag.
+#define _ESP_SUBSYS_LOG_IF(subsystem, level, output)                  \
+  _ESP_LOG_IF(esp::logging::isLevelEnabled(subsystem, level), output) \
+      << esp::logging::subsystemPrefix(subsystem)                     \
+      << Corrade::Utility::Debug::nospace
+
+#define ESP_LOG_LEVEL_ENABLED(level) \
+  esp::logging::isLevelEnabled(espLoggingSubsystem(), level)
+
+#define ESP_VERBOSE_1(...)                                              \
+  _ESP_SUBSYS_LOG_IF(                                                   \
+      espLoggingSubsystem(), esp::logging::LoggingLevel::Verbose1,      \
+      Corrade::Utility::Debug{Corrade::Utility::Debug::defaultOutput(), \
+                              __VA_ARGS__})
+#define ESP_DEBUG(...)                                                         \
+  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Debug, \
+                     Corrade::Utility::Debug{__VA_ARGS__})
+#define ESP_WARNING(...)                                  \
+  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(),               \
+                     esp::logging::LoggingLevel::Warning, \
+                     Corrade::Utility::Warning{__VA_ARGS__})
+#define ESP_ERROR(...)                                                         \
+  _ESP_SUBSYS_LOG_IF(espLoggingSubsystem(), esp::logging::LoggingLevel::Error, \
+                     Corrade::Utility::Error{__VA_ARGS__})
+
+#if defined(ESP_BUILD_GLOG_SHIM)
+
+// Our own shims "emulating" GLOG
+// TODO shims are hack to get things compiling, implement expected
+// behaviors
 
 #define GLOG_INFO \
   Corrade::Utility::Debug {}
@@ -62,8 +284,8 @@ class LogMessageVoidify {
 #define ASSERT(x, ...)                                              \
   do {                                                              \
     if (!(x)) {                                                     \
-      LOG(ERROR) << "Assert failed: " #x << ", " << __FILE__ << ":" \
-                 << __LINE__;                                       \
+      ESP_ERROR() << "Assert failed: " #x << "," << __FILE__ << ":" \
+                  << __LINE__;                                      \
       exit(-1);                                                     \
     }                                                               \
   } while (false)

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -256,7 +256,8 @@ class LogMessageVoidify {
   Corrade::Utility::Fatal {}
 #define LOG(severity) GLOG_##severity
 #define LOG_IF(severity, condition) \
-  !(condition) ? (void)0 : LogMessageVoidify() & LOG(severity)
+  !(condition) ? (void)0            \
+               : esp::logging::impl::LogMessageVoidify{} & LOG(severity)
 
 #define VLOG_LEVEL 0
 

--- a/src/esp/core/test/CMakeLists.txt
+++ b/src/esp/core/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(Corrade REQUIRED Utility)
+
+corrade_add_test(coreLoggingTest LoggingTest.cpp LIBRARIES core Corrade::Utility)
+set_tests_properties(coreLoggingTest PROPERTIES ENVIRONMENT HABITAT_SIM_LOG="")

--- a/src/esp/core/test/LoggingTest.cpp
+++ b/src/esp/core/test/LoggingTest.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "esp/core/logging.h"
+
+#include <sstream>
+
+#include <Corrade/Containers/StaticArray.h>
+#include <Corrade/Containers/String.h>
+#include <Corrade/Containers/StringStl.h>
+#include <Corrade/Containers/StringView.h>
+#include <Corrade/TestSuite/Tester.h>
+
+namespace Cr = Corrade;
+
+namespace esp {
+
+namespace sim {
+namespace test {
+namespace {
+void debug(const Cr::Containers::StringView statement) {
+  ESP_DEBUG() << statement;
+}
+void warning(const Cr::Containers::StringView statement) {
+  ESP_WARNING() << statement;
+}
+}  // namespace
+}  // namespace test
+}  // namespace sim
+
+namespace gfx {
+namespace test {
+namespace {
+void debug(const Cr::Containers::StringView statement) {
+  ESP_DEBUG() << statement;
+}
+void warning(const Cr::Containers::StringView statement) {
+  ESP_WARNING() << statement;
+}
+}  // namespace
+}  // namespace test
+}  // namespace gfx
+
+namespace logging {
+namespace test {
+namespace {
+
+struct LoggingTest : Cr::TestSuite::Tester {
+  explicit LoggingTest();
+
+  void envVarTest();
+};
+
+constexpr const struct {
+  const char* envString;
+  const char* expected;
+} EnvVarTestData[]{
+    {nullptr,
+     "[Default] DebugDefault\n[Default] WarningDefault\n"
+     "[Sim] DebugSim\n[Sim] WarningSim\n"
+     "[Gfx] "
+     "DebugGfx\n[Gfx] WarningGfx\n"},
+    {"debug",
+     "[Default] DebugDefault\n[Default] WarningDefault\n"
+     "[Sim] DebugSim\n[Sim] WarningSim\n"
+     "[Gfx] "
+     "DebugGfx\n[Gfx] WarningGfx\n"},
+    {"quiet", ""},
+    {"error", ""},
+    {"quiet:Sim,Gfx=verbose",
+     "[Sim] DebugSim\n[Sim] WarningSim\n[Gfx] "
+     "DebugGfx\n[Gfx] WarningGfx\n"},
+    {"warning:Gfx=debug",
+     "[Default] WarningDefault\n"
+     "[Sim] WarningSim\n[Gfx] "
+     "DebugGfx\n[Gfx] WarningGfx\n"},
+};  // namespace
+
+LoggingTest::LoggingTest() {
+  addInstancedTests({&LoggingTest::envVarTest},
+                    Cr::Containers::arraySize(EnvVarTestData));
+}
+
+void LoggingTest::envVarTest() {
+  auto&& data = EnvVarTestData[testCaseInstanceId()];
+
+  LoggingContext ctx{data.envString};
+
+  std::ostringstream out;
+  Cr::Utility::Debug debugCapture{&out};
+  Cr::Utility::Warning warnCapture{&out};
+
+  ESP_DEBUG() << "DebugDefault";
+  ESP_WARNING() << "WarningDefault";
+
+  sim::test::debug("DebugSim");
+  sim::test::warning("WarningSim");
+
+  gfx::test::debug("DebugGfx");
+  gfx::test::warning("WarningGfx");
+
+  CORRADE_COMPARE(Cr::Containers::StringView{out.str()},
+                  Cr::Containers::StringView{data.expected});
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace logging
+}  // namespace esp
+
+CORRADE_TEST_MAIN(esp::logging::test::LoggingTest)


### PR DESCRIPTION
## Motivation and Context

In #1184 we discussed having different logging subsystems for habitat-sim so that we can filter logs based on different subsystems.  This PR takes an attempt at implementing this.  The most important user facing part of this is how different logging filters are constructed with the environment variable (named `HABITAT_SIM_LOG`).  This simply applies a series of changes to the logging level for each system or a subset of systems, letting you construct an arbitrary filter.

The filter has a simple grammar
```
Filter: SetLevelCommand (COLON SetLevelCommand)*
SetLevelCommand: (SUBSYSTEM (COMMA SUBSYSTEM)* EQUALS)? LOGGING_LEVEL
```

So to have verbose logging on just the physics subset, you can do
```
quiet:physics=verbose
```
The "quiet" sets all subsets to subsystem and "physics=verbose" sets the just the physics subsystem to verbose.  If you want physics and gfx logging,
```
quiet:physics,gfx=verbose
```

Currently I have a couple subsystems added and a catch all "Other" subsystem.  The logging levels are "verbose,debug,warning,quiet,error" where `verbose` includes everything and `quiet` includes errors or worse.  The other names correspond to a given logger type.  A log level is printed if its logger type has a higher level than the current logging level for a subsystem.  So and `ESP_DEBUG()` get's printed if the logging level is "debug" or lower in the given subsystem.

This isn't 100% done yet, i.e. if folks like this we can just ditch glog, but I thought I would open this up for feedback.

Open questions:
[x] ~Should we ditch glog?~  Yes, in the next PR tho.
[x] ~What should the default level be?  Just warnings?~  Everything but very verbose things.
[x] ~Should we inject the subsystem name into the logging statement?  I think yes as that'll make it easier to turn noisy things off.~ Yes
[x] ~Would something like an `ESP_DEBUG_ALWAYS()` be useful?  That way you can just disable all logging and have rise above while debugging?~ `Mn::Debug{}` or `!Mn::Debug{}` does this.
[x] ~Should we change the default log level based on `GLOG_minloglevel` to enable backwards compatibility?~ No

## How Has This Been Tested

With the unit test.

## Types of changes

New feature (non-breaking change which adds functionality)
