### PR TITLE
[PBR][IBL] Shaders to pre-compute prefiltered environment map and irradiance map

### DIFF
--- a/src/esp/gfx/CMakeLists.txt
+++ b/src/esp/gfx/CMakeLists.txt
@@ -53,6 +53,8 @@ set(
   DoubleSphereCameraShader.h
   EquirectangularShader.cpp
   EquirectangularShader.h
+  PbrPrecomputedMapShader.cpp
+  PbrPrecomputedMapShader.h
   PbrTextureUnit.h
 )
 

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "PbrPrecomputedMapShader.h"
+#include "PbrTextureUnit.h"
+
+#include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Containers/Reference.h>
+#include <Corrade/Utility/Debug.h>
+#include <Corrade/Utility/DebugStl.h>
+#include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Resource.h>
+#include <Magnum/GL/Context.h>
+#include <Magnum/GL/Extensions.h>
+#include <Magnum/GL/Shader.h>
+#include <Magnum/GL/Version.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/Math/Matrix4.h>
+
+#include <initializer_list>
+#include <sstream>
+
+// This is to import the "resources" at runtime. When the resource is
+// compiled into static library, it must be explicitly initialized via this
+// macro, and should be called *outside* of any namespace.
+static void importShaderResources() {
+  CORRADE_RESOURCE_INITIALIZE(ShaderResources)
+}
+
+namespace Mn = Magnum;
+namespace Cr = Corrade;
+
+namespace esp {
+namespace gfx {
+
+PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
+  int countMutuallyExclusive = 0;
+  if (flags_ & Flag::IrradianceMap) {
+    ++countMutuallyExclusive;
+  }
+  if (flags & Flag::PrefilteredMap) {
+    ++countMutuallyExclusive;
+  }
+  CORRADE_ASSERT(countMutuallyExclusive <= 1,
+                 "PbrPrecomputedMapShader::PbrPrecomputedMapShader: "
+                 "Flag:S:IrradianceMap and "
+                 "Flag::PrefilteredMap are mutually exclusive.", );
+
+  if (!Corrade::Utility::Resource::hasGroup("default-shaders")) {
+    importShaderResources();
+  }
+
+#ifdef MAGNUM_TARGET_WEBGL
+  Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
+#else
+  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+#endif
+
+  // this is not the file name, but the group name in the config file
+  // see Shaders.conf in the shaders folder
+  const Cr::Utility::Resource rs{"default-shaders"};
+
+  Mn::GL::Shader vert{glVersion, Mn::GL::Shader::Type::Vertex};
+  Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
+
+  std::stringstream attributeLocationsStream;
+  attributeLocationsStream << Cr::Utility::formatString(
+      "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location);
+
+  // Add macros
+  vert.addSource(attributeLocationsStream.str())
+      .addSource(rs.get("pbrPrecomputedMap.vert"));
+
+  std::stringstream outputAttributeLocationsStream;
+  outputAttributeLocationsStream << Cr::Utility::formatString(
+      "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput);
+
+  frag.addSource(outputAttributeLocationsStream.str())
+      .addSource(rs.get("pbrCommon.glsl") + "\n");
+
+  if (flags & Flag::IrradianceMap) {
+    frag.addSource(rs.get("pbrIrradianceMap.frag"));
+  } else if (flags & Flag::PrefilteredMap) {
+    frag.addSource(rs.get("pbrPrefilteredMap.frag"));
+  }
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
+
+  attachShaders({vert, frag});
+
+  CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+  // bind attributes
+#ifndef MAGNUM_TARGET_GLES
+  if (!Mn::GL::Context::current()
+           .isExtensionSupported<
+               Mn::GL::Extensions::ARB::explicit_attrib_location>(glVersion))
+#endif
+  {
+    bindAttributeLocation(Position::Location, "vertexPosition");
+  }  // if
+
+  // set texture unit
+  setUniform(uniformLocation("EnvironmentMap"),
+             pbrTextureUnitSpace::TextureUnit::EnvironmentMap);
+
+  // setup uniforms
+  modelviewMatrixUniform_ = uniformLocation("ModelViewMatrix");
+  projMatrixUniform_ = uniformLocation("ProjectionMatrix");
+}
+
+PbrPrecomputedMapShader& PbrPrecomputedMapShader::bindEnvironmentMap(
+    Mn::GL::CubeMapTexture& texture) {
+  texture.bind(pbrTextureUnitSpace::TextureUnit::EnvironmentMap);
+  return *this;
+}
+
+PbrPrecomputedMapShader& PbrPrecomputedMapShader::setProjectionMatrix(
+    const Mn::Matrix4& matrix) {
+  setUniform(projMatrixUniform_, matrix);
+  return *this;
+}
+
+PbrPrecomputedMapShader& PbrPrecomputedMapShader::setTransformationMatrix(
+    const Mn::Matrix4& matrix) {
+  setUniform(modelviewMatrixUniform_, matrix);
+  return *this;
+}
+
+PbrPrecomputedMapShader& PbrPrecomputedMapShader::setRoughness(
+    float roughness) {
+  CORRADE_ASSERT(flags_ & Flag::PrefilteredMap,
+                 "PbrPrecomputedMapShader::setRoughness(): shader is NOT "
+                 "created to compute the prefiltered maps.",
+                 *this);
+  setUniform(roughnessUniform_, roughness);
+  return *this;
+}
+
+}  // namespace gfx
+}  // namespace esp

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -64,12 +64,9 @@ PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
   Mn::GL::Shader vert{glVersion, Mn::GL::Shader::Type::Vertex};
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
-  std::stringstream attributeLocationsStream;
-  attributeLocationsStream << Cr::Utility::formatString(
-      "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location);
-
   // Add macros
-  vert.addSource(attributeLocationsStream.str())
+  vert.addSource(Cr::Utility::formatString(
+      "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location))
       .addSource(rs.get("pbrPrecomputedMap.vert"));
 
   std::stringstream outputAttributeLocationsStream;

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -38,7 +38,7 @@ PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
   CORRADE_ASSERT(
       !((flags_ & Flag::IrradianceMap) && (flags_ & Flag::PrefilteredMap)),
       "PbrPrecomputedMapShader::PbrPrecomputedMapShader: "
-      "Flag:S:IrradianceMap and "
+      "Flag::IrradianceMap and "
       "Flag::PrefilteredMap are mutually exclusive.", );
 
   if (!Corrade::Utility::Resource::hasGroup("default-shaders")) {

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -69,11 +69,8 @@ PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
       "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location))
       .addSource(rs.get("pbrPrecomputedMap.vert"));
 
-  std::stringstream outputAttributeLocationsStream;
-  outputAttributeLocationsStream << Cr::Utility::formatString(
-      "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput);
-
-  frag.addSource(outputAttributeLocationsStream.str())
+  frag.addSource(Cr::Utility::formatString(
+      "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput))
       .addSource(rs.get("pbrCommon.glsl") + "\n");
 
   if (flags & Flag::IrradianceMap) {

--- a/src/esp/gfx/PbrPrecomputedMapShader.h
+++ b/src/esp/gfx/PbrPrecomputedMapShader.h
@@ -14,6 +14,12 @@ namespace esp {
 
 namespace gfx {
 
+/**
+ * @brief A shader to output the irradiance map, applied in the IBL diffuse
+ * part, or the prefiltered environment map, applied in the IBL specular part,
+ * based on the user setting.
+ */
+
 class PbrPrecomputedMapShader : public Magnum::GL::AbstractShaderProgram {
  public:
   // ==== Attribute definitions ====

--- a/src/esp/gfx/PbrPrecomputedMapShader.h
+++ b/src/esp/gfx/PbrPrecomputedMapShader.h
@@ -1,0 +1,120 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_GFX_PBR_PRECOMPUTEDMAP_SHADER_H_
+#define ESP_GFX_PBR_PRECOMPUTEDMAP_SHADER_H_
+
+#include <Corrade/Containers/EnumSet.h>
+#include <Magnum/GL/AbstractShaderProgram.h>
+#include <Magnum/GL/CubeMapTexture.h>
+#include <Magnum/Shaders/GenericGL.h>
+
+namespace esp {
+
+namespace gfx {
+
+class PbrPrecomputedMapShader : public Magnum::GL::AbstractShaderProgram {
+ public:
+  // ==== Attribute definitions ====
+  /**
+   * @brief vertex positions
+   */
+  typedef Magnum::Shaders::GenericGL3D::Position Position;
+
+  enum : Magnum::UnsignedInt {
+    /**
+     * Color shader output. @ref shaders-generic "Generic output",
+     * present always. Expects three- or four-component floating-point
+     * or normalized buffer attachment.
+     */
+    ColorOutput = Magnum::Shaders::GenericGL3D::ColorOutput,
+  };
+
+  /**
+   * @brief Flag
+   *
+   * @see @ref Flags, @ref flags()
+   */
+  enum class Flag : Magnum::UnsignedShort {
+    /**
+     * This shader is set to compute the irradiance map
+     */
+    IrradianceMap = 1 << 0,
+
+    /**
+     * This shader is set to compute the prefiltered environment map
+     */
+    PrefilteredMap = 1 << 1,
+  };
+
+  /**
+   * @brief Flags
+   */
+  typedef Corrade::Containers::EnumSet<Flag> Flags;
+
+  /**
+   * @brief Constructor
+   */
+  explicit PbrPrecomputedMapShader(Flags flags);
+
+  /** @brief Copying is not allowed */
+  PbrPrecomputedMapShader(const PbrPrecomputedMapShader&) = delete;
+
+  /** @brief Move constructor */
+  PbrPrecomputedMapShader(PbrPrecomputedMapShader&&) noexcept = default;
+
+  /** @brief Copying is not allowed */
+  PbrPrecomputedMapShader& operator=(const PbrPrecomputedMapShader&) = delete;
+
+  /** @brief Move assignment */
+  PbrPrecomputedMapShader& operator=(PbrPrecomputedMapShader&&) noexcept =
+      default;
+
+  // ======== set uniforms ===========
+  /**
+   *  @brief Set "projection" matrix to the uniform on GPU
+   *  @return Reference to self (for method chaining)
+   */
+  PbrPrecomputedMapShader& setProjectionMatrix(const Magnum::Matrix4& matrix);
+
+  /**
+   *  @brief Set modelview matrix to the uniform on GPU
+   *         modelview = view * model
+   *  @return Reference to self (for method chaining)
+   */
+  PbrPrecomputedMapShader& setTransformationMatrix(
+      const Magnum::Matrix4& matrix);
+
+  /**
+   * @breif Set roughness to the uniform on GPU
+   * NOTE: Flag::PrefilteredMap MUST be enabled
+   *  @return Reference to self (for method chaining)
+   */
+  PbrPrecomputedMapShader& setRoughness(float roughness);
+
+  // ======== texture binding ========
+  /**
+   * @brief Bind the environment map cubemap texture
+   * @return Reference to self (for method chaining)
+   */
+  PbrPrecomputedMapShader& bindEnvironmentMap(
+      Magnum::GL::CubeMapTexture& texture);
+
+ protected:
+  Flags flags_;
+  // ======= uniforms =======
+  // it hurts the performance to call glGetUniformLocation() every frame due
+  // to string operations. therefore, cache the locations in the constructor
+  // material uniforms
+  int modelviewMatrixUniform_ = -1;
+  int projMatrixUniform_ = -1;
+  int roughnessUniform_ = -1;
+};
+
+CORRADE_ENUMSET_OPERATORS(PbrPrecomputedMapShader::Flags)
+
+}  // namespace gfx
+}  // namespace esp
+
+#endif

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -118,7 +118,7 @@ bool URDFImporter::getJointInfo2(int linkIndex,
   }
 
   return false;
-};
+}
 
 bool URDFImporter::getJointInfo(int linkIndex,
                                 Mn::Matrix4& parent2joint,

--- a/src/shaders/Shaders.conf
+++ b/src/shaders/Shaders.conf
@@ -35,3 +35,12 @@ filename = equirectangular.frag
 
 [file]
 filename = pbrCommon.glsl
+
+[file]
+filename = pbrPrecomputedMap.vert
+
+[file]
+filename = pbrPrefilteredMap.frag
+
+[file]
+filename = pbrIrradianceMap.frag

--- a/src/shaders/pbrCommon.glsl
+++ b/src/shaders/pbrCommon.glsl
@@ -6,45 +6,52 @@ precision highp float;
 
 const float PI = 3.14159265358979;
 
-// Hacker's Delight, Henry S. Warren, 2001, ISBN:0201914654
- float radicalInverse_VdC(uint bits) {
-     bits = (bits << 16u) | (bits >> 16u);
-     bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
-     bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
-     bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
-     bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
-     return float(bits) * 2.3283064365386963e-10; // / 0x100000000
- }
-
-// This is based on
+// Use the Hammersley point set in 2D for fast and practical generation of
+// hemisphere directions in a shader program. See here:
 // Holger Dammertz, Hammersley Points on the Hemisphere (2012)
 // http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
- vec2 hammersley2d(uint i, uint N) {
-     return vec2(float(i)/float(N), radicalInverse_VdC(i));
- }
 
- vec3 hemisphereSample_uniform(float u, float v) {
-     float phi = v * 2.0 * PI;
-     float cosTheta = 1.0 - u;
-     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
-     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
- }
+// This is an efficient implementation of the Van der Corput radical inverse
+// see the above link
+float radicalInverse_VdC(uint bits) {
+  bits = (bits << 16u) | (bits >> 16u);
+  bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+  bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+  bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+  bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+  return float(bits) * 2.3283064365386963e-10;  // / 0x100000000
+}
 
- vec3 hemisphereSample_cos(float u, float v) {
-     float phi = v * 2.0 * PI;
-     float cosTheta = sqrt(1.0 - u);
-     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
-     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
- }
+// Hammersley Point Set in 2D
+vec2 hammersley2d(uint i, uint N) {
+  return vec2(float(i) / float(N), radicalInverse_VdC(i));
+}
+
+// uniform distributed direction (z-up) from the hammersley point
+vec3 hemisphereSample_uniform(float u, float v) {
+  float phi = v * 2.0 * PI;
+  float cosTheta = 1.0 - u;
+  float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+  return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+}
+
+// cosinus distributed direction (z-up) from the hammersley point
+vec3 hemisphereSample_cos(float u, float v) {
+  float phi = v * 2.0 * PI;
+  float cosTheta = sqrt(1.0 - u);
+  float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+  return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+}
 
 // Specular D, normal distribution function (NDF),
 // also known as ggxDistribution
 // normal: normal direction
 // light: light source direction
 // viwer: camera direction, aka light outgoing direction
-// n_dot_h: dot product of normal vector and the halfVector (half vector of light and view)
+// n_dot_h: dot product of normal vector and the halfVector (half vector of
+// light and view)
 //          usually n_dot_h = clamp(dot(normal, halfVector), 0.0, 1.0);
- float normalDistributionGGX(float n_dot_h, float roughness) {
+float normalDistributionGGX(float n_dot_h, float roughness) {
   float a = roughness * roughness;
   float a2 = a * a;
 

--- a/src/shaders/pbrCommon.glsl
+++ b/src/shaders/pbrCommon.glsl
@@ -6,6 +6,37 @@ precision highp float;
 
 const float PI = 3.14159265358979;
 
+// Hacker's Delight, Henry S. Warren, 2001, ISBN:0201914654
+ float radicalInverse_VdC(uint bits) {
+     bits = (bits << 16u) | (bits >> 16u);
+     bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+     bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+     bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+     bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+     return float(bits) * 2.3283064365386963e-10; // / 0x100000000
+ }
+
+// This is based on
+// Holger Dammertz, Hammersley Points on the Hemisphere (2012)
+// http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
+ vec2 hammersley2d(uint i, uint N) {
+     return vec2(float(i)/float(N), radicalInverse_VdC(i));
+ }
+
+ vec3 hemisphereSample_uniform(float u, float v) {
+     float phi = v * 2.0 * PI;
+     float cosTheta = 1.0 - u;
+     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+ }
+
+ vec3 hemisphereSample_cos(float u, float v) {
+     float phi = v * 2.0 * PI;
+     float cosTheta = sqrt(1.0 - u);
+     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+ }
+
 // Specular D, normal distribution function (NDF),
 // also known as ggxDistribution
 // normal: normal direction

--- a/src/shaders/pbrIrradianceMap.frag
+++ b/src/shaders/pbrIrradianceMap.frag
@@ -1,0 +1,52 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tre
+
+precision highp float;
+
+// ------------ input ------------------------
+in highp vec4 position; // world position
+
+// ------------ uniform ----------------------
+uniform samplerCube EnvironmentMap;
+
+// -------------- output ---------------------
+layout(location = OUTPUT_ATTRIBUTE_LOCATION_COLOR) out highp vec4 fragmentColor;
+
+// -------------- shader ---------------------
+ void main() {
+   vec3 normal = normalize(position.xyz); // N (z axis)
+   vec3 up = vec3(0.0, 1.0, 0.0); // U (y axis)
+   vec3 right = normalize(cross(up, normal)); // R (x axis)
+   up = normalize(cross(normal, right));
+
+   vec3 irradiance = vec3(0.0);
+   const uint sampleCounts = 4096u;
+   for (uint iPoint = 0u; iPoint < sampleCounts; ++iPoint) {
+     // sample point on 2D plane
+     // check pbrCommon.glsl for mor details
+     vec2 xi = hammersley2d(iPoint, sampleCounts);
+
+     // spherical to cartesian (in tangent space) z-up
+     // z-up (not y-up) is fine here
+     // check pbrCommon.glsl for mor details
+     vec3 tangentSample = hemisphereSample_cos(xi.x, xi.y);
+
+     // tangent space to world: [R U N][tangentSample] = xR + yU + zN
+     // we make the normal dirction in world space aligned with z-axis in tangent space
+     vec3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * normal;
+
+     // Careful:
+     // We used cosinus mapping not uniform mapping.
+     // We generated proportionally fewer rays at the center top of the hemisphere.
+     // So there is no need to compensate for the smaller areas
+     // by scaling the area by sinTheta
+     // irradiance += textureLod(EnvironmentMap, sampleVec, 0.0).rgb;
+     // Dev note:
+     // if the irradianceMap is full black,
+     // check if Environment enables mipmaps and you do populate them correctly.
+     irradiance += texture(EnvironmentMap, sampleVec).rgb;
+   }
+
+   fragmentColor = vec4(irradiance / float(sampleCounts), 1.0);
+ }

--- a/src/shaders/pbrPrecomputedMap.vert
+++ b/src/shaders/pbrPrecomputedMap.vert
@@ -1,0 +1,21 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+// ------------ input ------------------------
+// the input is a cube whose vertices are expressed in world space
+layout(location = ATTRIBUTE_LOCATION_POSITION) in highp vec4 vertexPosition;
+
+// ------------ uniform ----------------------
+uniform highp mat4 ModelViewMatrix;
+uniform highp mat4 ProjectionMatrix;
+
+// -------------- output ---------------------
+out highp vec4 position; // world position
+
+// -------------- shader ---------------------
+void main()
+{
+    position = vertexPosition;
+    gl_Position =  ProjectionMatrix * ModelViewMatrix * vertexPosition;
+}

--- a/src/shaders/pbrPrecomputedMap.vert
+++ b/src/shaders/pbrPrecomputedMap.vert
@@ -11,11 +11,10 @@ uniform highp mat4 ModelViewMatrix;
 uniform highp mat4 ProjectionMatrix;
 
 // -------------- output ---------------------
-out highp vec4 position; // world position
+out highp vec4 position;  // world position
 
 // -------------- shader ---------------------
-void main()
-{
-    position = vertexPosition;
-    gl_Position =  ProjectionMatrix * ModelViewMatrix * vertexPosition;
+void main() {
+  position = vertexPosition;
+  gl_Position = ProjectionMatrix * ModelViewMatrix * vertexPosition;
 }

--- a/src/shaders/pbrPrefilteredMap.frag
+++ b/src/shaders/pbrPrefilteredMap.frag
@@ -5,7 +5,7 @@
 precision highp float;
 
 // ------------ input ------------------------
-in highp vec4 position; // world position
+in highp vec4 position;  // world position
 
 // ------------ uniform ----------------------
 uniform samplerCube EnvironmentMap;
@@ -18,11 +18,10 @@ layout(location = OUTPUT_ATTRIBUTE_LOCATION_COLOR) out highp vec4 fragmentColor;
 // PI is defined in the pbrCommon.glsl
 const float TWO_PI = 2.0 * PI;
 
-// Compute a halfway vector that is biased towards the preferred alignment direction
-// (importance sampling).
-// The implementation is based on:
-// Křivánek J, Colbert M. Real‐time shading with filtered importance sampling
-// Computer Graphics Forum. Wiley/Blackwell (10.1111), 2008, 27(4): 1147-1154.
+// Compute a halfway vector that is biased towards the preferred alignment
+// direction (importance sampling). The implementation is based on: Křivánek J,
+// Colbert M. Real‐time shading with filtered importance sampling Computer
+// Graphics Forum. Wiley/Blackwell (10.1111), 2008, 27(4): 1147-1154.
 // http://dcgi.felk.cvut.cz/publications/2008/krivanek-cgf-rts
 //
 // https://github.com/SaschaWillems/Vulkan-glTF-PBR/
@@ -31,77 +30,78 @@ const float TWO_PI = 2.0 * PI;
 // https://www.tobias-franke.eu/log/2014/03/30/notes_on_importance_sampling.html
 
 vec3 importanceSamplingGGX(vec2 xi, float roughness, vec3 normal) {
-	// Maps a 2D point to a hemisphere with spread based on roughness
-	float alpha = roughness * roughness;
-  //In https://github.com/SaschaWillems/Vulkan-glTF-PBR/ it has one extra term
+  // Maps a 2D point to a hemisphere with spread based on roughness
+  float alpha = roughness * roughness;
+  // In https://github.com/SaschaWillems/Vulkan-glTF-PBR/ it has one extra term
   // "random(normal.xz) * 0.1;". Here we follow
   // https://github.com/KhronosGroup/glTF-Sample-Viewer/
   // and do not have it here.
-	float phi = TWO_PI * xi.x;
+  float phi = TWO_PI * xi.x;
 
-	float cosTheta = clamp(
-    sqrt((1.0 - xi.y) / (1.0 + (alpha * alpha - 1.0) * xi.y)), 0.0, 1.0);
-	float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+  float cosTheta = clamp(
+      sqrt((1.0 - xi.y) / (1.0 + (alpha * alpha - 1.0) * xi.y)), 0.0, 1.0);
+  float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
 
   // build halfway vector in cartesian coordinates (local tangent space)
-	vec3 h = vec3(sinTheta * cos(phi),
-                sinTheta * sin(phi),
-                cosTheta);
+  vec3 h = vec3(sinTheta * cos(phi), sinTheta * sin(phi), cosTheta);
 
-	// Tangent space
-	vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
-	vec3 right = normalize(cross(up, normal));
-	up = normalize(cross(normal, right));
+  // Tangent space
+  vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+  vec3 right = normalize(cross(up, normal));
+  up = normalize(cross(normal, right));
 
-	// Convert halfvector from tangent space to world Space: [R U N] * h
-	return normalize(right * h.x + up * h.y + normal * h.z);
+  // Convert halfvector from tangent space to world Space: [R U N] * h
+  return normalize(right * h.x + up * h.y + normal * h.z);
 }
 
 // https://placeholderart.wordpress.com/2015/07/28/implementation-notes-runtime-environment-map-filtering-for-image-based-lighting/
 void main() {
-	vec3 normal = normalize(position.xyz); // normal
+  vec3 normal = normalize(position.xyz);  // normal
   // in the name of speed, assuming that V equals R equals N
-	//
-	vec3 r = normal; // R: reflection
-	vec3 v = r; // V: view (from the shading location to the camera)
-	vec3 prefilteredColor = vec3(0.0);
-	float totalWeight = 0.0;
+  //
+  vec3 r = normal;  // R: reflection
+  vec3 v = r;       // V: view (from the shading location to the camera)
+  vec3 prefilteredColor = vec3(0.0);
+  float totalWeight = 0.0;
 
-	float imageSize = float(textureSize(EnvironmentMap, 0).s);
+  float imageSize = float(textureSize(EnvironmentMap, 0).s);
   // solid angle of 1 pixel across all cube faces
   float solidAnglePixel = 4.0 * PI / (6.0 * imageSize * imageSize);
 
-	const uint sampleCounts = 4096u;
+  const uint sampleCounts = 4096u;
   float invSampleCounts = 1.0f / float(sampleCounts);
 
-	for(uint iPoint = 0u; iPoint < sampleCounts; ++iPoint) {
-		// sample point on 2D plane
-		vec2 xi = hammersley2d(iPoint, sampleCounts);
-		vec3 h = importanceSamplingGGX(xi, Roughness, normal);
-		vec3 l = normalize(2.0 * dot(v, h) * h - v);
+  for (uint iPoint = 0u; iPoint < sampleCounts; ++iPoint) {
+    // sample point on 2D plane
+    vec2 xi = hammersley2d(iPoint, sampleCounts);
+    vec3 h = importanceSamplingGGX(xi, Roughness, normal);
+    vec3 l = normalize(2.0 * dot(v, h) * h - v);
 
-		float n_dot_l = clamp(dot(normal, l), 0.0, 1.0);
-		if(n_dot_l > 0.0) {
-			float n_dot_h = clamp(dot(normal, h), 0.0, 1.0);
-			float v_dot_h = clamp(dot(v, h), 0.0, 1.0);
+    float n_dot_l = clamp(dot(normal, l), 0.0, 1.0);
+    if (n_dot_l > 0.0) {
+      float n_dot_h = clamp(dot(normal, h), 0.0, 1.0);
+      float v_dot_h = clamp(dot(v, h), 0.0, 1.0);
 
-			// Probability Distribution Function
-			float pdf = normalDistributionGGX(n_dot_h, Roughness) *
-					n_dot_h / (4.0 * v_dot_h) + 0.0001;
+      // Probability Distribution Function
+      float pdf = normalDistributionGGX(n_dot_h, Roughness) * n_dot_h /
+                      (4.0 * v_dot_h) +
+                  0.0001;
 
-			// Solid angle for the current sample point
-			float solidAngle = invSampleCounts / pdf;
+      // Solid angle for the current sample point
+      float solidAngle = invSampleCounts / pdf;
 
-			// Biased (+1.0) mip level for better result
-			// see:
+      // Biased (+1.0) mip level for better result
+      // see:
       // https://github.com/SaschaWillems/Vulkan-glTF-PBR/
-			float mipLevel =
-			  Roughness == 0.0 ? 0.0 : max(0.5 * log2(solidAngle / solidAnglePixel) + 1.0, 0.0);
+      float mipLevel =
+          Roughness == 0.0
+              ? 0.0
+              : max(0.5 * log2(solidAngle / solidAnglePixel) + 1.0, 0.0);
 
-			prefilteredColor += textureLod(EnvironmentMap, l, mipLevel).rgb * n_dot_l;
-			totalWeight += n_dot_l;
-		} // if
-	}
+      prefilteredColor += textureLod(EnvironmentMap, l, mipLevel).rgb * n_dot_l;
+      totalWeight += n_dot_l;
+    }  // if
+  }
 
-	fragmentColor = vec4(prefilteredColor / totalWeight, 1.0);
+  fragmentColor = vec4(prefilteredColor / totalWeight, 1.0);
 }

--- a/src/shaders/pbrPrefilteredMap.frag
+++ b/src/shaders/pbrPrefilteredMap.frag
@@ -1,0 +1,107 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tre
+
+precision highp float;
+
+// ------------ input ------------------------
+in highp vec4 position; // world position
+
+// ------------ uniform ----------------------
+uniform samplerCube EnvironmentMap;
+uniform float Roughness;
+
+// -------------- output ---------------------
+layout(location = OUTPUT_ATTRIBUTE_LOCATION_COLOR) out highp vec4 fragmentColor;
+
+// ------------ shader -----------------------
+// PI is defined in the pbrCommon.glsl
+const float TWO_PI = 2.0 * PI;
+
+// Compute a halfway vector that is biased towards the preferred alignment direction
+// (importance sampling).
+// The implementation is based on:
+// Křivánek J, Colbert M. Real‐time shading with filtered importance sampling
+// Computer Graphics Forum. Wiley/Blackwell (10.1111), 2008, 27(4): 1147-1154.
+// http://dcgi.felk.cvut.cz/publications/2008/krivanek-cgf-rts
+//
+// https://github.com/SaschaWillems/Vulkan-glTF-PBR/
+// https://github.com/KhronosGroup/glTF-Sample-Viewer/
+// http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_slides.pdf
+// https://www.tobias-franke.eu/log/2014/03/30/notes_on_importance_sampling.html
+
+vec3 importanceSamplingGGX(vec2 xi, float roughness, vec3 normal) {
+	// Maps a 2D point to a hemisphere with spread based on roughness
+	float alpha = roughness * roughness;
+  //In https://github.com/SaschaWillems/Vulkan-glTF-PBR/ it has one extra term
+  // "random(normal.xz) * 0.1;". Here we follow
+  // https://github.com/KhronosGroup/glTF-Sample-Viewer/
+  // and do not have it here.
+	float phi = TWO_PI * xi.x;
+
+	float cosTheta = clamp(
+    sqrt((1.0 - xi.y) / (1.0 + (alpha * alpha - 1.0) * xi.y)), 0.0, 1.0);
+	float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+
+  // build halfway vector in cartesian coordinates (local tangent space)
+	vec3 h = vec3(sinTheta * cos(phi),
+                sinTheta * sin(phi),
+                cosTheta);
+
+	// Tangent space
+	vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+	vec3 right = normalize(cross(up, normal));
+	up = normalize(cross(normal, right));
+
+	// Convert halfvector from tangent space to world Space: [R U N] * h
+	return normalize(right * h.x + up * h.y + normal * h.z);
+}
+
+// https://placeholderart.wordpress.com/2015/07/28/implementation-notes-runtime-environment-map-filtering-for-image-based-lighting/
+void main() {
+	vec3 normal = normalize(position.xyz); // normal
+  // in the name of speed, assuming that V equals R equals N
+	//
+	vec3 r = normal; // R: reflection
+	vec3 v = r; // V: view (from the shading location to the camera)
+	vec3 prefilteredColor = vec3(0.0);
+	float totalWeight = 0.0;
+
+	float imageSize = float(textureSize(EnvironmentMap, 0).s);
+  // solid angle of 1 pixel across all cube faces
+  float solidAnglePixel = 4.0 * PI / (6.0 * imageSize * imageSize);
+
+	const uint sampleCounts = 4096u;
+  float invSampleCounts = 1.0f / float(sampleCounts);
+
+	for(uint iPoint = 0u; iPoint < sampleCounts; ++iPoint) {
+		// sample point on 2D plane
+		vec2 xi = hammersley2d(iPoint, sampleCounts);
+		vec3 h = importanceSamplingGGX(xi, Roughness, normal);
+		vec3 l = normalize(2.0 * dot(v, h) * h - v);
+
+		float n_dot_l = clamp(dot(normal, l), 0.0, 1.0);
+		if(n_dot_l > 0.0) {
+			float n_dot_h = clamp(dot(normal, h), 0.0, 1.0);
+			float v_dot_h = clamp(dot(v, h), 0.0, 1.0);
+
+			// Probability Distribution Function
+			float pdf = normalDistributionGGX(n_dot_h, Roughness) *
+					n_dot_h / (4.0 * v_dot_h) + 0.0001;
+
+			// Solid angle for the current sample point
+			float solidAngle = invSampleCounts / pdf;
+
+			// Biased (+1.0) mip level for better result
+			// see:
+      // https://github.com/SaschaWillems/Vulkan-glTF-PBR/
+			float mipLevel =
+			  Roughness == 0.0 ? 0.0 : max(0.5 * log2(solidAngle / solidAnglePixel) + 1.0, 0.0);
+
+			prefilteredColor += textureLod(EnvironmentMap, l, mipLevel).rgb * n_dot_l;
+			totalWeight += n_dot_l;
+		} // if
+	}
+
+	fragmentColor = vec4(prefilteredColor / totalWeight, 1.0);
+}


### PR DESCRIPTION
## Motivation and Context
This shader can render 2 cubemap textures that are must-have ones form IBL.
These 2 textures are:
Irradiance map, used in IBL diffuse part;
prefiltered map, used in IBL specular part;

Shader are tested in #1389.



<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
