### PR TITLE
change URDF assert to ESP_CHECK

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -124,9 +124,9 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     float massScale,
     bool forceReload,
     const std::string& lightSetup) {
-  CORRADE_ASSERT(
+  ESP_CHECK(
       urdfImporter_->loadURDF(filepath, globalScale, massScale, forceReload),
-      "E - failed to parse/load URDF file " << filepath, ID_UNDEFINED);
+      "failed to parse/load URDF file " << filepath);
 
   int articulatedObjectID = allocateObjectID();
 


### PR DESCRIPTION
## Motivation and Context

I'd like us to avoid using asserts in this way. In principle, asserts are a debugging tool and we should be able to disable them in a release build. Here, the (essential) loading is happening inside the assert.

## How Has This Been Tested

Tested locally in viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
