### PR TITLE
[BugFix] gltf/glb "extensionsUsed" not being set

### DIFF
--- a/tools/create_basis_compressed_glbs.py
+++ b/tools/create_basis_compressed_glbs.py
@@ -120,6 +120,11 @@ def _gltf2unlit(gltf_name: str):
     with open(gltf_name, "r") as f:
         json_data = json.load(f)
 
+    if "extensionsUsed" in json_data:
+        json_data["extensionsUsed"].append("KHR_materials_unlit")
+    else:
+        json_data["extensionsUsed"] = ["KHR_materials_unlit"]
+
     for material in json_data["materials"]:
         assert "pbrMetallicRoughness" in material
 

--- a/tools/create_basis_compressed_glbs.py
+++ b/tools/create_basis_compressed_glbs.py
@@ -124,8 +124,8 @@ def _gltf2unlit(gltf_name: str):
     ext_gltf_tags = ["extensionsUsed", "extensionsRequired"]
     for ext_tag in ext_gltf_tags:
         if ext_tag not in json_data:
-            json_data[ext_tag] = ["KHR_materials_unlit"]
-        elif "KHR_materials_unlit" not in json_data[ext_tag]:
+            json_data[ext_tag] = []
+        if "KHR_materials_unlit" not in json_data[ext_tag]:
             json_data[ext_tag].append("KHR_materials_unlit")
 
     for material in json_data["materials"]:

--- a/tools/create_basis_compressed_glbs.py
+++ b/tools/create_basis_compressed_glbs.py
@@ -119,11 +119,14 @@ def _gltf2unlit(gltf_name: str):
     assert osp.exists(gltf_name)
     with open(gltf_name, "r") as f:
         json_data = json.load(f)
-
-    if "extensionsUsed" in json_data:
-        json_data["extensionsUsed"].append("KHR_materials_unlit")
-    else:
-        json_data["extensionsUsed"] = ["KHR_materials_unlit"]
+    # add references to the KHR_materials_unlit extension in
+    # gltf root-level tags
+    ext_gltf_tags = ["extensionsUsed", "extensionsRequired"]
+    for ext_tag in ext_gltf_tags:
+        if ext_tag not in json_data:
+            json_data[ext_tag] = ["KHR_materials_unlit"]
+        elif "KHR_materials_unlit" not in json_data[ext_tag]:
+            json_data[ext_tag].append("KHR_materials_unlit")
 
     for material in json_data["materials"]:
         assert "pbrMetallicRoughness" in material


### PR DESCRIPTION
## Motivation and Context
This PR fixes the modification code for setting the materials in a glb to be unlit using the Khronos extension "KHR_materials_unlit" by adding a top-level entry for this extension in the "extensionsUsed" key. Without this setting, the created .gltf/.glb files will fail Khronos validation.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
