### PR TITLE
[BugFix] Fix Typo in Articulated Object Manager

### DIFF
--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -190,7 +190,7 @@ class ManagedArticulatedObject
 
   int getLinkNumDoFs(int linkId) const {
     if (auto sp = getObjectReference()) {
-      return sp->getLinkDoFOffset(linkId);
+      return sp->getLinkNumDoFs(linkId);
     }
     return 0;
   }


### PR DESCRIPTION
Fixes #1405 where getLinkNumDoFs returned the wrong value in the ArticulatedObjectWrapper.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Fixes a typo in the ArticulatedObjectWrapper that returned the wrong value. 
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
