### PR TITLE
[BugFix] Enable URDF AO Loader to support unlit / baked lighting assets.

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -274,6 +274,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
     const std::shared_ptr<io::URDF::Link>& link,
     gfx::DrawableGroup* drawables,
     const std::string& lightSetup) {
+  bool reqLighting = (lightSetup != esp::NO_LIGHT_KEY);
   bool geomSuccess = false;
 
   for (auto& visual : link->m_visualArray) {
@@ -289,7 +290,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
 
     // prep the AssetInfo, overwrite the filepath later
     assets::AssetInfo visualMeshInfo{assets::AssetType::UNKNOWN};
-    visualMeshInfo.requiresLighting = true;
+    visualMeshInfo.requiresLighting = reqLighting;
 
     // create a modified asset if necessary for material override
     std::shared_ptr<io::URDF::Material> material =

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -274,7 +274,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
     const std::shared_ptr<io::URDF::Link>& link,
     gfx::DrawableGroup* drawables,
     const std::string& lightSetup) {
-  bool reqLighting = (lightSetup != esp::NO_LIGHT_KEY);
+  const bool reqLighting = (lightSetup != esp::NO_LIGHT_KEY);
   bool geomSuccess = false;
 
   for (auto& visual : link->m_visualArray) {


### PR DESCRIPTION
## Motivation and Context
The loading of assets for articulated objects did not support unlit/flat-shaded assets, even if "no_lights" was specified.  This PR addresses this by only setting "requiresLighting" for the assetInfo used to instantiate the asset if the lighting specification is not no_lights. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and Python tests, locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
