### PR TITLE
Better default physics attribs (fix for disabled physics)

### DIFF
--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.cpp
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.cpp
@@ -10,9 +10,10 @@ namespace attributes {
 
 PhysicsManagerAttributes::PhysicsManagerAttributes(const std::string& handle)
     : AbstractAttributes("PhysicsManagerAttributes", handle) {
-  setSimulator("none");
-  setTimestep(0.01);
-  setMaxSubsteps(10);
+  setSimulator("bullet");
+  setTimestep(0.008);
+  setGravity({0, -9.8, 0});
+  setFrictionCoefficient(0.4);
 }  // PhysicsManagerAttributes ctor
 
 }  // namespace attributes


### PR DESCRIPTION
## Motivation and Context

We have a bug where someone installing Hab 2.0 from conda (and downloading our datasets) will generally find physics to be nonfunctional/disabled. The default attribs updated by this PR are used when `default.physics_config.json` is not found. Conda hab-sim users generally don't have this file (it isn't included in our current datasets). 

The source of confusion here was that we (Hab Sim Infra engineers) usually test with our data at `habitat-sim/data`, and our source tree includes `habitat-sim/data/default.physics_config.json`. Conda users don't have this because they don't get our source tree as part of a conda install.

## How Has This Been Tested

Local testing with the C++ viewer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
