### PR TITLE
--Add support for nested User-defined attributes

### DIFF
--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -92,6 +92,13 @@ class Configuration {
     }
     return configPtr;
   }
+  void setConfigSubSubgroup(Configuration& config,
+                            const std::string& subGroupName,
+                            const std::string& subSubGroupName) {
+    cfg.group(subGroupName)->addGroup(subSubGroupName);
+    *cfg.group(subGroupName)->group(subSubGroupName) =
+        *config.cfg.group(subSubGroupName);
+  }
 
   int getNumConfigSubgroups(const std::string& name) const {
     if (cfg.hasGroup(name)) {
@@ -115,9 +122,21 @@ class Configuration {
     return strings;
   }
 
+  Corrade::Utility::ConfigurationGroup::Groups groups() const {
+    return cfg.groups();
+  }
+  Corrade::Utility::ConfigurationGroup::Values values() const {
+    return cfg.values();
+  }
+  bool hasValues() const { return cfg.hasValues(); }
+
   bool hasValue(const std::string& key) const { return cfg.hasValue(key); }
 
   bool removeValue(const std::string& key) { return cfg.removeValue(key); }
+
+  void setConfiguration(Corrade::Utility::ConfigurationGroup* _cfg) {
+    cfg = *_cfg;
+  }
 
  protected:
   /**

--- a/src/esp/io/json.cpp
+++ b/src/esp/io/json.cpp
@@ -3,7 +3,9 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "esp/io/json.h"
-
+#include <Corrade/Containers/Containers.h>
+#include <Corrade/Containers/Pair.h>
+#include <Corrade/Containers/StringView.h>
 #include <Corrade/Utility/String.h>
 #include <rapidjson/filereadstream.h>
 #include <rapidjson/filewritestream.h>
@@ -54,6 +56,76 @@ bool writeJsonToFile(const JsonDocument& document,
 
   return writeSuccess;
 }
+
+int loadJsonIntoConfiguration(const JsonGenericValue& jsonObj,
+                              const std::string& subGroupName,
+                              esp::core::Configuration& config) {
+  // count number of valid user config settings found
+
+  int numConfigSettings = 0;
+  for (rapidjson::Value::ConstMemberIterator it = jsonObj.MemberBegin();
+       it != jsonObj.MemberEnd(); ++it) {
+    // for each key, attempt to parse
+    const std::string key = it->name.GetString();
+    const auto& obj = it->value;
+    // increment, assuming is valid object
+    ++numConfigSettings;
+
+    if (obj.IsFloat()) {
+      config.setSubgroupValue<float>(subGroupName, key, obj.GetFloat());
+    } else if (obj.IsDouble()) {
+      config.setSubgroupValue<double>(subGroupName, key, obj.GetDouble());
+    } else if (obj.IsNumber()) {
+      config.setSubgroupValue<int>(subGroupName, key, obj.GetInt());
+    } else if (obj.IsString()) {
+      config.setSubgroupValue<std::string>(subGroupName, key, obj.GetString());
+    } else if (obj.IsBool()) {
+      config.setSubgroupValue<bool>(subGroupName, key, obj.GetBool());
+    } else if (obj.IsArray() && obj.Size() > 0 && obj[0].IsNumber()) {
+      // numeric vector or quaternion
+      if (obj.Size() == 3) {
+        Magnum::Vector3 val{};
+        if (io::fromJsonValue(obj, val)) {
+          config.setSubgroupValue<Magnum::Vector3>(subGroupName, key, val);
+        }
+      } else if (obj.Size() == 4) {
+        // assume is quaternion
+        Magnum::Quaternion val{};
+        if (io::fromJsonValue(obj, val)) {
+          config.setSubgroupValue<Magnum::Quaternion>(subGroupName, key, val);
+        }
+      } else {
+        // decrement count for key:obj due to not being handled vector
+        --numConfigSettings;
+        // TODO support numeric array in JSON
+        LOG(WARNING) << "::loadJsonIntoConfiguration : For subgroup name "
+                     << subGroupName
+                     << " config cell in JSON document contains key " << key
+                     << " referencing an unsupported numeric array of length : "
+                     << obj.Size() << " so skipping.";
+      }
+    } else if (obj.IsObject()) {
+      // support nested objects
+      auto subGroupPtr = config.getConfigSubgroupAsPtr(subGroupName);
+      // get subgroup configuration object
+      esp::core::Configuration newConfig = *subGroupPtr.get();
+      numConfigSettings += loadJsonIntoConfiguration(obj, key, newConfig);
+      // save subgroup's subgroup configuration in original config
+      config.setConfigSubSubgroup(newConfig, subGroupName, key);
+      //
+    } else {
+      // TODO support other types?
+      // decrement count for key:obj due to not being handled type
+      --numConfigSettings;
+      LOG(WARNING) << "::loadJsonIntoConfiguration: For subgroup name "
+                   << subGroupName
+                   << " config cell in JSON document contains key " << key
+                   << " referencing an unknown/unparsable value type, so "
+                      "skipping this key.";
+    }
+  }
+  return numConfigSettings;
+}  // namespace io
 
 JsonDocument parseJsonFile(const std::string& file) {
   FILE* pFile = fopen(file.c_str(), "rb");

--- a/src/esp/io/json.cpp
+++ b/src/esp/io/json.cpp
@@ -108,7 +108,7 @@ int loadJsonIntoConfiguration(const JsonGenericValue& jsonObj,
       // support nested objects
       auto subGroupPtr = config.getConfigSubgroupAsPtr(subGroupName);
       // get subgroup configuration object
-      esp::core::Configuration newConfig = *subGroupPtr.get();
+      esp::core::Configuration newConfig = *subGroupPtr;
       numConfigSettings += loadJsonIntoConfiguration(obj, key, newConfig);
       // save subgroup's subgroup configuration in original config
       config.setConfigSubSubgroup(newConfig, subGroupName, key);

--- a/src/esp/io/json.h
+++ b/src/esp/io/json.h
@@ -10,11 +10,11 @@
 #include <cstdint>
 #define RAPIDJSON_NO_INT64DEFINE
 #include <rapidjson/document.h>
-#include "esp/core/esp.h"
-
 #include <functional>
 #include <string>
 #include <vector>
+#include "esp/core/Configuration.h"
+#include "esp/core/esp.h"
 
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Quaternion.h>
@@ -53,6 +53,18 @@ std::string jsonToString(const JsonDocument& d);
 
 //! Return Vec3f coordinates representation of given JsonObject of array type
 esp::vec3f jsonToVec3f(const JsonGenericValue& jsonArray);
+
+/**
+ * @brief Recursively load a @ref esp::core::Configuration based on a json file.
+ * @param jsonObj The source json being read
+ * @param subGroupName The subgroup name to create amd populate within the
+ * configuration
+ * @param config The owning configuration that the subgroup is a part of
+ * @return The number of configuration settings successfully read.
+ */
+int loadJsonIntoConfiguration(const JsonGenericValue& jsonObj,
+                              const std::string& subGroupName,
+                              esp::core::Configuration& config);
 
 /**
  * @brief Check passed json doc for existence of passed jsonTag as value of

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -296,6 +296,11 @@ int PhysicsManager::addArticulatedObjectInstance(
   existingArticulatedObjects_.at(aObjID)->setSceneInstanceAttr(
       aObjInstAttributes);
 
+  // set articulated object's user-defined attributes, if any exist in scene
+  // instance.
+  existingArticulatedObjects_.at(aObjID)->setUserAttributes(
+      aObjInstAttributes->getUserConfiguration());
+
   // set articulated object's location, rotation and other pertinent state
   // values based on
   // scene object instance attributes set in the object above.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -425,6 +425,13 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   virtual std::vector<scene::SceneNode*> getVisualSceneNodes() const = 0;
 
   core::Configuration::ptr getUserAttributes() const { return userAttributes_; }
+
+  /**
+   * @brief This function will completely overwrite this object's
+   * user-defined attributes.
+   * @param attr A ptr to the user defined attributes specified for this object.
+   * merge into them.
+   */
   void setUserAttributes(core::Configuration::ptr attr) {
     userAttributes_ = std::move(attr);
   }

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -810,14 +810,6 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
     ASSERT_EQ(iter->second, jtVelVals[idx++]);
   }
   // test test_urdf_template0 ao instance attributes-level user config vals
-  // "user_defined" : {
-  //     "user_string" : "test_urdf_template0 instance defined string",
-  //     "user_bool" : false,
-  //     "user_int" : 2,
-  //     "user_float" : 1.22,
-  //     "user_vec3" : [120.3, 302.5, -25.07],
-  //     "user_quat" : [1.23, 1.22, 1.26, 1.21]
-  // }
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template0 instance defined string",
                             false, 2, 1.22f,
@@ -832,14 +824,6 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   ASSERT_EQ(artObjInstance->getMotionType(),
             static_cast<int>(esp::physics::MotionType::KINEMATIC));
   // test test_urdf_template0 ao instance attributes-level user config vals
-  // "user_defined" : {
-  //     "user_string" : "test_urdf_template1 instance defined string",
-  //     "user_bool" : false,
-  //     "user_int" : 21,
-  //     "user_float" : 11.22,
-  //     "user_vec3" : [190.3, 902.5, -95.07],
-  //     "user_quat" : [1.25, 9.22, 9.26, 0.21]
-  // }
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template1 instance defined string",
                             false, 21, 11.22f,

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -668,7 +668,15 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
               "rotation": [0.2, 0.3, 0.4, 0.5],
               "initial_joint_pose": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
               "initial_joint_velocities": [1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6],
-              "motion_type": "DYNAMIC"
+              "motion_type": "DYNAMIC",
+              "user_defined" : {
+                  "user_string" : "test_urdf_template0 instance defined string",
+                  "user_bool" : false,
+                  "user_int" : 2,
+                  "user_float" : 1.22,
+                  "user_vec3" : [120.3, 302.5, -25.07],
+                  "user_quat" : [1.23, 1.22, 1.26, 1.21]
+              }
           },
           {
               "template_name": "test_urdf_template1",
@@ -676,7 +684,15 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
               "auto_clamp_joint_limits" : true,
               "translation": [3, 2, 1],
               "rotation": [0.5, 0.6, 0.7, 0.8],
-              "motion_type": "KINEMATIC"
+              "motion_type": "KINEMATIC",
+              "user_defined" : {
+                  "user_string" : "test_urdf_template1 instance defined string",
+                  "user_bool" : false,
+                  "user_int" : 21,
+                  "user_float" : 11.22,
+                  "user_vec3" : [190.3, 902.5, -95.07],
+                  "user_quat" : [1.25, 9.22, 9.26, 0.21]
+              }
           }
       ],
       "default_lighting":  "test_lighting_configuration",
@@ -793,6 +809,20 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
        iter != initJoinVelMap.end(); ++iter) {
     ASSERT_EQ(iter->second, jtVelVals[idx++]);
   }
+  // test test_urdf_template0 ao instance attributes-level user config vals
+  // "user_defined" : {
+  //     "user_string" : "test_urdf_template0 instance defined string",
+  //     "user_bool" : false,
+  //     "user_int" : 2,
+  //     "user_float" : 1.22,
+  //     "user_vec3" : [120.3, 302.5, -25.07],
+  //     "user_quat" : [1.23, 1.22, 1.26, 1.21]
+  // }
+  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
+                            "test_urdf_template0 instance defined string",
+                            false, 2, 1.22f,
+                            Magnum::Vector3(120.3f, 302.5f, -25.07f),
+                            Magnum::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f));
 
   artObjInstance = artObjInstances[1];
   ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template1");
@@ -801,6 +831,20 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
   ASSERT_EQ(artObjInstance->getMotionType(),
             static_cast<int>(esp::physics::MotionType::KINEMATIC));
+  // test test_urdf_template0 ao instance attributes-level user config vals
+  // "user_defined" : {
+  //     "user_string" : "test_urdf_template1 instance defined string",
+  //     "user_bool" : false,
+  //     "user_int" : 21,
+  //     "user_float" : 11.22,
+  //     "user_vec3" : [190.3, 902.5, -95.07],
+  //     "user_quat" : [1.25, 9.22, 9.26, 0.21]
+  // }
+  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
+                            "test_urdf_template1 instance defined string",
+                            false, 21, 11.22f,
+                            Magnum::Vector3(190.3f, 902.5f, -95.07f),
+                            Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
 
 }  // AttributesManagers_SceneInstanceJSONLoadTest
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -675,7 +675,11 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
                   "user_int" : 2,
                   "user_float" : 1.22,
                   "user_vec3" : [120.3, 302.5, -25.07],
-                  "user_quat" : [1.23, 1.22, 1.26, 1.21]
+                  "user_quat" : [1.23, 1.22, 1.26, 1.21],
+                  "user_def_obj" : {
+                      "position" : [0.1, 0.2, 0.3],
+                      "rotation" : [0.5, 0.3, 0.1]
+                  }
               }
           },
           {
@@ -809,12 +813,25 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
        iter != initJoinVelMap.end(); ++iter) {
     ASSERT_EQ(iter->second, jtVelVals[idx++]);
   }
+
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template0 instance defined string",
                             false, 2, 1.22f,
                             Magnum::Vector3(120.3f, 302.5f, -25.07f),
                             Magnum::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f));
+
+  // test nested configuration
+  auto artObjNestedConfig =
+      artObjInstance->getUserConfiguration()->getConfigSubgroupAsPtr(
+          "user_def_obj");
+  ASSERT_NE(artObjNestedConfig, nullptr);
+  ASSERT_EQ(artObjNestedConfig->hasValues(), true);
+  ASSERT_EQ(artObjNestedConfig->getVec3("position"),
+            Magnum::Vector3(0.1f, 0.2f, 0.3f));
+  ASSERT_EQ(artObjNestedConfig->getVec3("rotation"),
+            Magnum::Vector3(0.5f, 0.3f, 0.1f));
+  LOG(WARNING) << "Articulated Object test 3";
 
   artObjInstance = artObjInstances[1];
   ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template1");


### PR DESCRIPTION
## Motivation and Context
Presently, the user-defined attributes fields within the various configuration files only support a single layer of data values of various types, but this PR adds support for nested json objects within user-defined attributes values, enabling a user to be able to specify sub-groupings within these fields.  

This functionality is required for ReplicaCAD to be properly used in Habitat 2.0 (to provide support for per-object placement box configurations)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Tests added in c++ to verify functionality.  Tested locally c++ and python
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
