### PR TITLE
[Perf] AOWrapper pass settings by const ref instead of by value

### DIFF
--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -276,7 +276,7 @@ class ManagedArticulatedObject
   }
 
   std::unordered_map<int, int> createMotorsForAllDofs(
-      JointMotorSettings settings) {
+      const JointMotorSettings& settings) {
     if (auto sp = getObjectReference()) {
       return sp->createMotorsForAllDofs(settings);
     }


### PR DESCRIPTION
## Motivation and Context
* Static analysis suggested we were passing this by value when there was no reason to do so add the object was 80 bytes large. This should remove a copy of those 80 bytes with no bad effects. Surprised clang-tidy didn't pick up on this. Found by checking the lgtm.com static analysis.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
