### PR TITLE
[bugfix] fix overlay_settings not being forwarded

### DIFF
--- a/habitat_sim/utils/viz_utils.py
+++ b/habitat_sim/utils/viz_utils.py
@@ -243,7 +243,7 @@ def make_video(
             primary_obs,
             primary_obs_type,
             video_dims,
-            overlay_settings=None,
+            overlay_settings=overlay_settings,
             observation_to_image=observation_to_image,
         )
 


### PR DESCRIPTION
## Motivation and Context

As identified by #1421, overlay_settings was not being forwarded during video creation.

## How Has This Been Tested

Locally with ECCV_2020_Interactivity.py

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
