### PR TITLE
ManagedContainers - Change underlying data structure to unordered map

### DIFF
--- a/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
@@ -839,7 +839,7 @@
     "    if not HAS_WIDGETS:\n",
     "        sel_file_obj_handle = file_obj_handles[0]\n",
     "        sel_prim_obj_handle = prim_obj_handles[0]\n",
-    "        sel_prim_obj_handle = prim_asset_handles[0]\n",
+    "        sel_asset_handle = prim_asset_handles[0]\n",
     "        return\n",
     "\n",
     "    # Build widgets\n",

--- a/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
@@ -512,7 +512,7 @@
     "    if not HAS_WIDGETS:\n",
     "        sel_file_obj_handle = file_obj_handles[0]\n",
     "        sel_prim_obj_handle = prim_obj_handles[0]\n",
-    "        sel_prim_obj_handle = prim_asset_handles[0]\n",
+    "        sel_asset_handle = prim_asset_handles[0]\n",
     "        return\n",
     "    file_obj_ddl, sel_file_obj_handle = set_handle_ddl_widget(\n",
     "        file_obj_handles,\n",
@@ -1067,6 +1067,7 @@
     "        output_path + example_type,\n",
     "        open_vid=show_video,\n",
     "    )\n",
+    "obj_attr_mgr.remove_template_by_handle(\"scaled_sel_obj\")\n",
     "rigid_obj_mgr.remove_all_objects()\n",
     "sim.navmesh_visualization = False"
    ]

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -815,7 +815,7 @@ def build_widget_ui(obj_attr_mgr, prim_attr_mgr):
     if not HAS_WIDGETS:
         sel_file_obj_handle = file_obj_handles[0]
         sel_prim_obj_handle = prim_obj_handles[0]
-        sel_prim_obj_handle = prim_asset_handles[0]
+        sel_asset_handle = prim_asset_handles[0]
         return
 
     # Build widgets

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -488,7 +488,7 @@ def build_widget_ui(obj_attr_mgr, prim_attr_mgr):
     if not HAS_WIDGETS:
         sel_file_obj_handle = file_obj_handles[0]
         sel_prim_obj_handle = prim_obj_handles[0]
-        sel_prim_obj_handle = prim_asset_handles[0]
+        sel_asset_handle = prim_asset_handles[0]
         return
     file_obj_ddl, sel_file_obj_handle = set_handle_ddl_widget(
         file_obj_handles,
@@ -956,6 +956,7 @@ if make_video:
         output_path + example_type,
         open_vid=show_video,
     )
+obj_attr_mgr.remove_template_by_handle("scaled_sel_obj")
 rigid_obj_mgr.remove_all_objects()
 sim.navmesh_visualization = False
 

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -74,14 +74,14 @@ void declareBaseAttributesManager(py::module& m,
           "handle"_a)
       .def("get_template_handles",
            static_cast<std::vector<std::string> (MgrClass::*)(
-               const std::string&, bool) const>(
+               const std::string&, bool, bool) const>(
                &MgrClass::getObjectHandlesBySubstring),
-           ("Returns a list of " + attrType +
+           ("Returns a potentially sorted list of " + attrType +
             " template handles that either contain or "
             "explicitly do not contain the passed search_str, based on the "
             "value of boolean contains.")
                .c_str(),
-           "search_str"_a = "", "contains"_a = true)
+           "search_str"_a = "", "contains"_a = true, "sorted"_a = true)
       .def("get_templates_info", &MgrClass::getObjectInfoStrings,
            ("Returns a list of CSV strings describing each " + attrType +
             " template whose handles either contain or explicitly do not "
@@ -376,12 +376,12 @@ void initAttributesManagersBindings(py::module& m) {
       .def(
           "get_file_template_handles",
           static_cast<std::vector<std::string> (ObjectAttributesManager::*)(
-              const std::string&, bool) const>(
+              const std::string&, bool, bool) const>(
               &ObjectAttributesManager::getFileTemplateHandlesBySubstring),
-          R"(Returns a list of file-based ObjectAttributes template handles that either contain or
-          explicitly do not contain the passed search_str, based on the value of
+          R"(Returns a potentially sorted list of file-based ObjectAttributes template handles
+          that either contain or explicitly do not contain the passed search_str, based on the value of
           contains.)",
-          "search_str"_a = "", "contains"_a = true)
+          "search_str"_a = "", "contains"_a = true, "sorted"_a = true)
       .def(
           "get_random_file_template_handle",
           &ObjectAttributesManager::getRandomFileTemplateHandle,
@@ -396,12 +396,12 @@ void initAttributesManagersBindings(py::module& m) {
       .def(
           "get_synth_template_handles",
           static_cast<std::vector<std::string> (ObjectAttributesManager::*)(
-              const std::string&, bool) const>(
+              const std::string&, bool, bool) const>(
               &ObjectAttributesManager::getSynthTemplateHandlesBySubstring),
-          R"(Returns a list of synthesized(primitive asset)-based ObjectAttributes template handles
-            that either contain or explicitly do not contain the passed search_str,
+          R"(Returns a potentially sorted list of synthesized(primitive asset)-based ObjectAttributes
+            template handles that either contain or explicitly do not contain the passed search_str,
             based on the value of contains.)",
-          "search_str"_a = "", "contains"_a = true)
+          "search_str"_a = "", "contains"_a = true, "sorted"_a = true)
       .def("get_random_synth_template_handle",
            &ObjectAttributesManager::getRandomSynthTemplateHandle,
            R"(Returns the handle for a random synthesized(primitive asset)-based

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -61,13 +61,13 @@ void declareBaseWrapperManager(py::module& m,
           "handle"_a)
       .def("get_object_handles",
            static_cast<std::vector<std::string> (MgrClass::*)(
-               const std::string&, bool) const>(
+               const std::string&, bool, bool) const>(
                &MgrClass::getObjectHandlesBySubstring),
-           ("Returns a list of " + objType +
+           ("Returns a potentially sorted list of " + objType +
             " handles that either contain or explicitly do not contain the "
             "passed search_str, based on the value of boolean contains.")
                .c_str(),
-           "search_str"_a = "", "contains"_a = true)
+           "search_str"_a = "", "contains"_a = true, "sorted"_a = true)
       .def("get_objects_info", &MgrClass::getObjectInfoStrings,
            ("Returns a list of CSV strings describing each " + objType +
             " whose handles either contain or explicitly do not contain the "

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -579,8 +579,9 @@ class ManagedContainer : public ManagedContainerBase {
    * @brief Define a map type referencing function pointers to @ref
    * createObjectCopy keyed by string names of classes being instanced,
    */
-  typedef std::map<std::string,
-                   ManagedPtr (ManagedContainer<T, Access>::*)(ManagedPtr&)>
+  typedef std::unordered_map<std::string,
+                             ManagedPtr (ManagedContainer<T, Access>::*)(
+                                 ManagedPtr&)>
       Map_Of_CopyCtors;
 
   /**

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -4,6 +4,7 @@
 
 #include "ManagedContainerBase.h"
 #include <Corrade/Utility/FormatStl.h>
+#include <algorithm>
 namespace esp {
 namespace core {
 
@@ -49,7 +50,8 @@ std::vector<std::string>
 ManagedContainerBase::getObjectHandlesBySubStringPerType(
     const std::unordered_map<int, std::string>& mapOfHandles,
     const std::string& subStr,
-    bool contains) const {
+    bool contains,
+    bool sorted) const {
   std::vector<std::string> res;
   // if empty return empty vector
   if (mapOfHandles.size() == 0) {
@@ -59,6 +61,9 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
   if (subStr.length() == 0) {
     for (const auto& elem : mapOfHandles) {
       res.push_back(elem.second);
+    }
+    if (sorted) {
+      std::sort(res.begin(), res.end());
     }
     return res;
   }
@@ -83,6 +88,9 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
       res.push_back(iter->second);
     }
   }
+  if (sorted) {
+    std::sort(res.begin(), res.end());
+  }
   return res;
 }  // ManagedContainerBase::getObjectHandlesBySubStringPerType
 
@@ -90,7 +98,8 @@ std::vector<std::string>
 ManagedContainerBase::getObjectHandlesBySubStringPerType(
     const std::unordered_map<std::string, std::set<std::string>>& mapOfHandles,
     const std::string& subStr,
-    bool contains) const {
+    bool contains,
+    bool sorted) const {
   std::vector<std::string> res;
   // if empty return empty vector
   if (mapOfHandles.size() == 0) {
@@ -100,6 +109,9 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
   if (subStr.length() == 0) {
     for (const auto& elem : mapOfHandles) {
       res.push_back(elem.first);
+    }
+    if (sorted) {
+      std::sort(res.begin(), res.end());
     }
     return res;
   }
@@ -124,6 +136,9 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
       res.push_back(iter->first);
     }
   }
+  if (sorted) {
+    std::sort(res.begin(), res.end());
+  }
   return res;
 }  // ManagedContainerBase::getObjectHandlesBySubStringPerType
 
@@ -132,7 +147,7 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
     bool contains) const {
   // get all handles that match query elements first
   std::vector<std::string> handles =
-      getObjectHandlesBySubstring(subStr, contains);
+      this->getObjectHandlesBySubstring(subStr, contains, true);
   std::vector<std::string> res(handles.size() + 1);
   if (handles.size() == 0) {
     res[0] = "No " + objectType_ + " constructs available.";
@@ -192,7 +207,7 @@ std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
   // of existing instances of this object name.  We are going to go through
   // all of these names and find the "last" instance, meaning the highest count.
   std::vector<std::string> objHandles =
-      this->getObjectHandlesBySubStringPerType(mapOfHandles, name, true);
+      this->getObjectHandlesBySubStringPerType(mapOfHandles, name, true, true);
 
   int incr = 0;
   // use this as pivot character - the last instance of this character in any

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -24,7 +24,7 @@ bool ManagedContainerBase::setLock(const std::string& objectHandle, bool lock) {
   return true;
 }  // ManagedContainerBase::setLock
 std::string ManagedContainerBase::getRandomObjectHandlePerType(
-    const std::map<int, std::string>& mapOfHandles,
+    const std::unordered_map<int, std::string>& mapOfHandles,
     const std::string& type) const {
   std::size_t numVals = mapOfHandles.size();
   if (numVals == 0) {
@@ -36,8 +36,8 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
   int randIDX = rand() % numVals;
 
   std::string res;
-  for (std::pair<std::map<int, std::string>::const_iterator, int> iter(
-           mapOfHandles.begin(), 0);
+  for (std::pair<std::unordered_map<int, std::string>::const_iterator, int>
+           iter(mapOfHandles.begin(), 0);
        (iter.first != mapOfHandles.end() && iter.second <= randIDX);
        ++iter.first, ++iter.second) {
     res = iter.first->second;
@@ -47,7 +47,7 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
 
 std::vector<std::string>
 ManagedContainerBase::getObjectHandlesBySubStringPerType(
-    const std::map<int, std::string>& mapOfHandles,
+    const std::unordered_map<int, std::string>& mapOfHandles,
     const std::string& subStr,
     bool contains) const {
   std::vector<std::string> res;
@@ -67,7 +67,8 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
 
   std::size_t strSize = strToLookFor.length();
 
-  for (std::map<int, std::string>::const_iterator iter = mapOfHandles.begin();
+  for (std::unordered_map<int, std::string>::const_iterator iter =
+           mapOfHandles.begin();
        iter != mapOfHandles.end(); ++iter) {
     std::string key = Cr::Utility::String::lowercase(iter->second);
     // be sure that key is big enough to search in (otherwise find has undefined
@@ -87,7 +88,7 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
 
 std::vector<std::string>
 ManagedContainerBase::getObjectHandlesBySubStringPerType(
-    const std::map<std::string, std::set<std::string>>& mapOfHandles,
+    const std::unordered_map<std::string, std::set<std::string>>& mapOfHandles,
     const std::string& subStr,
     bool contains) const {
   std::vector<std::string> res;
@@ -107,8 +108,8 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
 
   std::size_t strSize = strToLookFor.length();
 
-  for (std::map<std::string, std::set<std::string>>::const_iterator iter =
-           mapOfHandles.begin();
+  for (std::unordered_map<std::string, std::set<std::string>>::const_iterator
+           iter = mapOfHandles.begin();
        iter != mapOfHandles.end(); ++iter) {
     std::string key = Cr::Utility::String::lowercase(iter->first);
     // be sure that key is big enough to search in (otherwise find has undefined
@@ -185,7 +186,7 @@ std::string ManagedContainerBase::getObjectInfoCSVString(
 }  // ManagedContainerBase::getObjectInfoCSVString
 
 std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
-    const std::map<int, std::string>& mapOfHandles,
+    const std::unordered_map<int, std::string>& mapOfHandles,
     const std::string& name) const {
   // find all existing values with passed name - these should be a list
   // of existing instances of this object name.  We are going to go through

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -13,8 +13,8 @@
 
 #include <deque>
 #include <functional>
-#include <map>
 #include <set>
+#include <unordered_map>
 
 #include <Corrade/Utility/String.h>
 
@@ -362,7 +362,7 @@ class ManagedContainerBase {
    * string if none loaded
    */
   std::string getRandomObjectHandlePerType(
-      const std::map<int, std::string>& mapOfHandles,
+      const std::unordered_map<int, std::string>& mapOfHandles,
       const std::string& type) const;
 
   /**
@@ -377,14 +377,14 @@ class ManagedContainerBase {
    * @return A valid, unique name to use for a potential managed object.
    */
   std::string getUniqueHandleFromCandidatePerType(
-      const std::map<int, std::string>& mapOfHandles,
+      const std::unordered_map<int, std::string>& mapOfHandles,
       const std::string& name) const;
 
   /**
    * @brief Get a list of all managed objects of passed type whose origin
    * handles contain substr, ignoring subStr's case.
    *
-   * This version works on std::map<int,std::string> maps' values.
+   * This version works on std::unordered_map<int,std::string> maps' values.
    * @param mapOfHandles map containing the desired managed object handles
    * @param subStr substring to search for within existing managed objects
    * @param contains Whether to search for handles containing, or not
@@ -393,7 +393,7 @@ class ManagedContainerBase {
    * containing the passed substring
    */
   std::vector<std::string> getObjectHandlesBySubStringPerType(
-      const std::map<int, std::string>& mapOfHandles,
+      const std::unordered_map<int, std::string>& mapOfHandles,
       const std::string& subStr,
       bool contains) const;
 
@@ -401,8 +401,8 @@ class ManagedContainerBase {
    * @brief Get a list of all managed objects of passed type whose origin
    * handles contain substr, ignoring subStr's case.
    *
-   * This version works on std::map<std::string, std::set<std::string>> maps's
-   * keys.
+   * This version works on std::unordered_map<std::string,
+   * std::set<std::string>> maps's keys.
    * @param mapOfHandles map containing the desired keys to search.
    * @param subStr substring to search for within existing managed objects
    * @param contains Whether to search for handles containing, or not
@@ -411,7 +411,8 @@ class ManagedContainerBase {
    * containing the passed substring
    */
   std::vector<std::string> getObjectHandlesBySubStringPerType(
-      const std::map<std::string, std::set<std::string>>& mapOfHandles,
+      const std::unordered_map<std::string, std::set<std::string>>&
+          mapOfHandles,
       const std::string& subStr,
       bool contains) const;
 
@@ -439,7 +440,7 @@ class ManagedContainerBase {
   /**
    * @brief Maps string keys to managed object managed objects
    */
-  std::map<std::string, std::shared_ptr<void>> objectLibrary_;
+  std::unordered_map<std::string, std::shared_ptr<void>> objectLibrary_;
 
   /** @brief A descriptive name of the managed object being managed by this
    * manager.
@@ -450,7 +451,7 @@ class ManagedContainerBase {
    * @brief Maps all object attribute IDs to the appropriate handles used
    * by lib
    */
-  std::map<int, std::string> objectLibKeyByID_;
+  std::unordered_map<int, std::string> objectLibKeyByID_;
 
   /**
    * @brief Deque holding all IDs of deleted objects. These ID's should be

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -131,9 +131,10 @@ class ManagedContainerBase {
    */
   std::vector<std::string> getObjectHandlesBySubstring(
       const std::string& subStr = "",
-      bool contains = true) const {
+      bool contains = true,
+      bool sorted = true) const {
     return getObjectHandlesBySubStringPerType(objectLibKeyByID_, subStr,
-                                              contains);
+                                              contains, sorted);
   }  // ManagedContainerBase::getObjectHandlesBySubstring
 
   /**
@@ -389,13 +390,15 @@ class ManagedContainerBase {
    * @param subStr substring to search for within existing managed objects
    * @param contains Whether to search for handles containing, or not
    * containing, substr
+   * @param sorted whether the return vector values are sorted
    * @return vector of 0 or more managed object handles containing/not
    * containing the passed substring
    */
   std::vector<std::string> getObjectHandlesBySubStringPerType(
       const std::unordered_map<int, std::string>& mapOfHandles,
       const std::string& subStr,
-      bool contains) const;
+      bool contains,
+      bool sorted) const;
 
   /**
    * @brief Get a list of all managed objects of passed type whose origin
@@ -407,6 +410,7 @@ class ManagedContainerBase {
    * @param subStr substring to search for within existing managed objects
    * @param contains Whether to search for handles containing, or not
    * containing, substr
+   * @param sorted whether the return vector values are sorted
    * @return vector of 0 or more managed object handles containing/not
    * containing the passed substring
    */
@@ -414,7 +418,8 @@ class ManagedContainerBase {
       const std::unordered_map<std::string, std::set<std::string>>&
           mapOfHandles,
       const std::string& subStr,
-      bool contains) const;
+      bool contains,
+      bool sorted) const;
 
   /**
    * @brief Called internally only.  Remove all references from libraries for

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -91,6 +91,10 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
     return getString("primObjClassName");
   }
 
+  /**
+   * @brief The integer representation of the @ref esp::metadata::PrimObjTypes
+   * this primitive represents,
+   */
   int getPrimObjType() const { return getInt("primObjType"); }
   /**
    * @brief This will determine if the stated template has the required

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -196,7 +196,7 @@ class AssetAttributesManager
     }
     std::string subStr = PrimitiveNames3DMap.at(primType);
     return this->getObjectHandlesBySubStringPerType(this->objectLibKeyByID_,
-                                                    subStr, contains);
+                                                    subStr, contains, true);
   }  // AssetAttributeManager::getTemplateHandlesByPrimType
 
   /**

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -539,9 +539,9 @@ class AssetAttributesManager
    * createPrimAttributes() keyed by string names of classes being
    * instanced, as defined in @ref PrimitiveNames3DMap
    */
-  typedef std::map<std::string,
-                   attributes::AbstractPrimitiveAttributes::ptr (
-                       AssetAttributesManager::*)()>
+  typedef std::unordered_map<std::string,
+                             attributes::AbstractPrimitiveAttributes::ptr (
+                                 AssetAttributesManager::*)()>
       Map_Of_PrimTypeCtors;
 
   /**
@@ -556,7 +556,7 @@ class AssetAttributesManager
    * @brief Map relating primitive class name to default attributes template
    * handle. There should always be a template for each of these handles.
    */
-  std::map<std::string, std::string> defaultPrimAttributeHandles_;
+  std::unordered_map<std::string, std::string> defaultPrimAttributeHandles_;
 
  public:
   ESP_SMART_POINTERS(AssetAttributesManager)

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -196,7 +196,9 @@ int ObjectAttributesManager::registerObjectFinalize(
     return ID_UNDEFINED;
   }
 
-  std::map<int, std::string>* mapToUse = nullptr;
+  // create a ref to the partition map of either prims or file-based objects to
+  // place a ref to the object template being regsitered
+  std::unordered_map<int, std::string>* mapToUse = nullptr;
   // Handles for rendering and collision assets
   std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
   std::string collisionAssetHandle = objectTemplate->getCollisionAssetHandle();

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -257,13 +257,13 @@ class ObjectAttributesManager
    * @brief Maps loaded object template IDs to the appropriate template
    * handles
    */
-  std::map<int, std::string> physicsFileObjTmpltLibByID_;
+  std::unordered_map<int, std::string> physicsFileObjTmpltLibByID_;
 
   /**
    * @brief Maps synthesized, primitive-based object template IDs to the
    * appropriate template handles
    */
-  std::map<int, std::string> physicsSynthObjTmpltLibByID_;
+  std::unordered_map<int, std::string> physicsSynthObjTmpltLibByID_;
 
  public:
   ESP_SMART_POINTERS(ObjectAttributesManager)

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -107,14 +107,16 @@ class ObjectAttributesManager
    * templates
    * @param contains whether to search for keys containing, or not containing,
    * subStr
+   * @param sorted whether the return vector values are sorted
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
   std::vector<std::string> getFileTemplateHandlesBySubstring(
       const std::string& subStr = "",
-      bool contains = true) const {
+      bool contains = true,
+      bool sorted = true) const {
     return this->getObjectHandlesBySubStringPerType(physicsFileObjTmpltLibByID_,
-                                                    subStr, contains);
+                                                    subStr, contains, sorted);
   }
 
   /**
@@ -147,14 +149,16 @@ class ObjectAttributesManager
    * templates
    * @param contains whether to search for keys containing, or not containing,
    * subStr
+   * @param sorted whether the return vector values are sorted
    * @return vector of 0 or more template handles containing the passed
    * substring
    */
   std::vector<std::string> getSynthTemplateHandlesBySubstring(
       const std::string& subStr = "",
-      bool contains = true) const {
+      bool contains = true,
+      bool sorted = true) const {
     return this->getObjectHandlesBySubStringPerType(
-        physicsSynthObjTmpltLibByID_, subStr, contains);
+        physicsSynthObjTmpltLibByID_, subStr, contains, sorted);
   }
 
   // ======== End File-based and primitive-based partition functions ========
@@ -187,14 +191,14 @@ class ObjectAttributesManager
       std::function<void(int)> assetTypeSetter) override;
 
   /**
-   * @brief Used Internally.  Create and configure newly-created attributes with
-   * any default values, before any specific values are set.
+   * @brief Used Internally.  Create and configure newly-created attributes
+   * with any default values, before any specific values are set.
    *
    * @param handleName handle name to be assigned to attributes
-   * @param builtFromConfig Whether this object attributes is being constructed
-   * from a config file or from some other source.
-   * @return Newly created but unregistered ObjectAttributes pointer, with only
-   * default values set.
+   * @param builtFromConfig Whether this object attributes is being
+   * constructed from a config file or from some other source.
+   * @return Newly created but unregistered ObjectAttributes pointer, with
+   * only default values set.
    */
   attributes::ObjectAttributes::ptr initNewObjectInternal(
       const std::string& handleName,
@@ -224,7 +228,8 @@ class ObjectAttributesManager
    * be modified by the user.
    *
    * @param attributesTemplate The attributes template.
-   * @param attributesTemplateHandle The key for referencing the template in the
+   * @param attributesTemplateHandle The key for referencing the template in
+   * the
    * @ref objectLibrary_. Will be set as origin handle for template.
    * @param forceRegistration Will register object even if conditional
    * registration checks fail.

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -618,7 +618,8 @@ void SimTest::buildingPrimAssetObjectTemplates() {
       // the expected class name
       std::string className =
           esp::metadata::managers::AssetAttributesManager::PrimitiveNames3DMap
-              .at(static_cast<esp::metadata::PrimObjTypes>(i));
+              .at(static_cast<esp::metadata::PrimObjTypes>(
+                  primAttr->getPrimObjType()));
       CORRADE_VERIFY((primAttr->getHandle() == handle) &&
                      (handle.find(className) != std::string::npos));
     }
@@ -747,7 +748,7 @@ void SimTest::addSensorToObject() {
   auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
   // manager of object attributes
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
-  auto objs = objectAttribsMgr->getObjectHandlesBySubstring("sphere");
+  auto objs = objectAttribsMgr->getObjectHandlesBySubstring("icosphereSolid");
   int objectID = simulator->addObjectByHandle(objs[0]);
   CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   esp::scene::SceneNode& objectNode = *simulator->getObjectSceneNode(objectID);


### PR DESCRIPTION
## Motivation and Context
This PR changes the underlying data structure for the Managed Containers from std::map to std::unordered_map, for better performance with containers holding many elements.  

The only downside to this process is that formerly, any string-based query of the managed container would return results in sorted order. This PR will sort the results from such a query as default behavior, which can also be overridden on demand if sorting is not required. Since generally the results set is small (where the query is matching a substring of the handles of objects held in the map), the overhead for this sort will also generally be small.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
