### PR TITLE
Don't run flushLines code when there are no lines

### DIFF
--- a/src/esp/gfx/DebugLineRender.cpp
+++ b/src/esp/gfx/DebugLineRender.cpp
@@ -98,6 +98,10 @@ void DebugLineRender::flushLines(const Magnum::Matrix4& camMatrix,
                  "DebugLineRender::flushLines: no GL resources; see "
                  "also releaseGLResources", );
 
+  if (_verts.empty()) {
+    return;
+  }
+
   bool doToggleBlend = !glIsEnabled(GL_BLEND);
 
   if (doToggleBlend) {


### PR DESCRIPTION
## Motivation and Context

This early-outs DebugLineRender::flushLines when there are no lines to be flushed. It significantly improves performance on frames where there are no debug lines to render.

## How Has This Been Tested

I tested this optimization on my WebXR mobile demo webapp.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
