### PR TITLE
[Logging] Expand logging output information

### DIFF
--- a/src/esp/core/logging.cpp
+++ b/src/esp/core/logging.cpp
@@ -11,6 +11,7 @@
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/StaticArray.h>
 #include <Corrade/Containers/String.h>
+#include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/Format.h>
 
 namespace Cr = Corrade;
@@ -121,8 +122,14 @@ bool isLevelEnabled(Subsystem subsystem, LoggingLevel level) {
   return level >= LoggingContext::current().levelFor(subsystem);
 }
 
-Cr::Containers::String subsystemPrefix(Subsystem subsystem) {
-  return ""_s.join({"["_s, subsystemNames[uint8_t(subsystem)], "] "_s});
+Cr::Containers::String buildMessagePrefix(Subsystem subsystem,
+                                          const std::string& filename,
+                                          const std::string& function,
+                                          int line) {
+  auto baseFileName = Cr::Utility::Directory::filename(filename);
+  return ""_s.join({"["_s, subsystemNames[uint8_t(subsystem)], "] "_s,
+                    baseFileName.c_str(), "("_s, std::to_string(line).c_str(),
+                    ")::"_s, function.c_str(), " : "_s});
 }
 
 }  // namespace logging

--- a/src/esp/core/logging.h
+++ b/src/esp/core/logging.h
@@ -241,9 +241,13 @@ class LoggingContext {
 bool isLevelEnabled(Subsystem subsystem, LoggingLevel level);
 
 /**
- * @brief Return the prefix that gets printed for a given subsystem in that log.
+ * @brief Build appropriate prefix for logging messages, including
+ * subsystem/namespace, file, line number and function name
  */
-Corrade::Containers::String subsystemPrefix(Subsystem subsystem);
+Corrade::Containers::String buildMessagePrefix(Subsystem subsystem,
+                                               const std::string& filename,
+                                               const std::string& function,
+                                               int line);
 
 namespace impl {
 class LogMessageVoidify {
@@ -301,7 +305,8 @@ class LogMessageVoidify {
 // the case that the logger was created with a nospace flag.
 #define ESP_SUBSYS_LOG_IF(subsystem, level, output)                        \
   ESP_LOG_IF(esp::logging::isLevelEnabled((subsystem), (level)), (output)) \
-      << esp::logging::subsystemPrefix((subsystem))                        \
+      << esp::logging::buildMessagePrefix((subsystem), (__FILE__),         \
+                                          (__FUNCTION__), (__LINE__))      \
       << Corrade::Utility::Debug::nospace
 
 #define ESP_LOG_LEVEL_ENABLED(level) \

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -129,8 +129,8 @@ class ManagedContainer : public ManagedContainerBase {
     if (nullptr == managedObject) {
       ESP_ERROR() << "<" << Corrade::Utility::Debug::nospace
                   << this->objectType_ << Corrade::Utility::Debug::nospace
-                  << ">::registerObject : Invalid "
-                     "(null) managed object passed to registration. Aborting.";
+                  << "> : Invalid (null) managed object passed to "
+                     "registration. Aborting.";
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
@@ -141,9 +141,8 @@ class ManagedContainer : public ManagedContainerBase {
     if ("" == handleToSet) {
       ESP_ERROR() << "<" << Corrade::Utility::Debug::nospace
                   << this->objectType_ << Corrade::Utility::Debug::nospace
-                  << ">::registerObject : No "
-                     "valid handle specified for"
-                  << objectType_ << "managed object to register. Aborting.";
+                  << "> : No valid handle specified for" << objectType_
+                  << "managed object to register. Aborting.";
       return ID_UNDEFINED;
     }
     return registerObjectFinalize(managedObject, handleToSet,
@@ -617,9 +616,8 @@ auto ManagedContainer<T, Access>::removeObjectsBySubstring(
       getObjectHandlesBySubstring(subStr, contains);
   for (const std::string& objectHandle : handles) {
     int objID = this->getObjectIDByHandle(objectHandle);
-    ManagedPtr ptr = removeObjectInternal(
-        objID, objectHandle,
-        "<" + this->objectType_ + ">::removeObjectsBySubstring");
+    ManagedPtr ptr = removeObjectInternal(objID, objectHandle,
+                                          "<" + this->objectType_ + ">");
     if (nullptr != ptr) {
       res.push_back(ptr);
     }

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -32,8 +32,7 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
     const std::string& type) const {
   std::size_t numVals = mapOfHandles.size();
   if (numVals == 0) {
-    ESP_ERROR() << "::getRandomObjectHandlePerType : Attempting to get a random"
-                << type << objectType_
+    ESP_ERROR() << "Attempting to get a random" << type << objectType_
                 << "managed object handle but none are loaded; Aboring";
     return "";
   }
@@ -186,8 +185,7 @@ int ManagedContainerBase::getObjectIDByHandleOrNew(
   }
   if (!getNext) {
     ESP_ERROR() << "<" << Cr::Utility::Debug::nospace << this->objectType_
-                << Cr::Utility::Debug::nospace
-                << ">::getObjectIDByHandleOrNew : No" << objectType_
+                << Cr::Utility::Debug::nospace << "> : No" << objectType_
                 << "managed object with handle" << objectHandle
                 << "exists. Aborting";
     return ID_UNDEFINED;

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -201,7 +201,7 @@ class ManagedContainerBase {
    */
   std::string getObjectHandleByID(const int objectID) const {
     if (objectLibKeyByID_.count(objectID) == 0) {
-      ESP_ERROR() << "::getObjectHandleByID : Unknown" << objectType_
+      ESP_ERROR() << "Unknown" << objectType_
                   << "managed object ID:" << objectID << ". Aborting";
       // never will have registered object with registration handle == ""
       return "";

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -72,9 +72,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
-                  << Magnum::Debug::nospace << ">::createObjectFromFile ("
-                  << this->objectType_
-                  << ") : Failure reading document as JSON :" << filename
+                  << Magnum::Debug::nospace
+                  << "> : Failure reading document as JSON :" << filename
                   << ". Aborting.";
       return nullptr;
     }
@@ -98,9 +97,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
                                              CORRADE_UNUSED const U& config) {
     ESP_ERROR()
         << "<" << Magnum::Debug::nospace << this->objectType_
-        << Magnum::Debug::nospace << ">::buildManagedObjectFromDoc ("
-        << this->objectType_
-        << ") : Failure loading attributes from document of unknown type :"
+        << Magnum::Debug::nospace
+        << "> : Failure loading attributes from document of unknown type :"
         << filename << ". Aborting.";
   }
   /**
@@ -146,9 +144,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   bool verifyLoadDocument(const std::string& filename,
                           CORRADE_UNUSED U& resDoc) {
     // by here always fail
-    ESP_ERROR() << this->objectType_ << "<" << Magnum::Debug::nospace
-                << this->objectType_ << Magnum::Debug::nospace
-                << ">::verifyLoadDocument : File" << filename
+    ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
+                << Magnum::Debug::nospace << "> : File" << filename
                 << "failed due to unknown file type.";
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
@@ -211,16 +208,14 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
     resHandle = Cr::Utility::Directory::splitExtension(filename).first + "." +
                 fileTypeExt;
     ESP_VERY_VERBOSE() << "<" << Magnum::Debug::nospace << this->objectType_
-                       << Magnum::Debug::nospace
-                       << ">::convertFilenameToPassedExt : Filename :"
-                       << filename << "changed to proposed" << fileTypeExt
+                       << Magnum::Debug::nospace << "> : Filename :" << filename
+                       << "changed to proposed" << fileTypeExt
                        << "filename :" << resHandle;
   } else {
     ESP_VERY_VERBOSE() << "<" << Magnum::Debug::nospace << this->objectType_
-                       << Magnum::Debug::nospace
-                       << ">::convertFilenameToPassedExt : Filename :"
-                       << filename << "contains requested file extension"
-                       << fileTypeExt << "already.";
+                       << Magnum::Debug::nospace << "> : Filename :" << filename
+                       << "contains requested file extension" << fileTypeExt
+                       << "already.";
   }
   return resHandle;
 }  // ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt
@@ -234,8 +229,7 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
       jsonDoc = io::parseJsonFile(filename);
     } catch (...) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
-                  << Magnum::Debug::nospace
-                  << ">::verifyLoadDocument : Failed to parse" << filename
+                  << Magnum::Debug::nospace << "> : Failed to parse" << filename
                   << "as JSON.";
       return false;
     }
@@ -243,8 +237,8 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
   } else {
     // by here always fail
     ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
-                << Magnum::Debug::nospace << ">::verifyLoadDocument : File"
-                << filename << "does not exist";
+                << Magnum::Debug::nospace << "> : File" << filename
+                << "does not exist";
     return false;
   }
 }  // ManagedFileBasedContainer<T, Access>::verifyLoadDocument

--- a/src/esp/core/test/LoggingTest.cpp
+++ b/src/esp/core/test/LoggingTest.cpp
@@ -57,24 +57,31 @@ constexpr const struct {
   const char* expected;
 } EnvVarTestData[]{
     {nullptr,
-     "[Default] DebugDefault\n[Default] WarningDefault\n"
-     "[Sim] DebugSim\n[Sim] WarningSim\n"
-     "[Gfx] "
-     "DebugGfx\n[Gfx] WarningGfx\n"},
+     "[Default] LoggingTest.cpp(101)::envVarTest : DebugDefault\n[Default] "
+     "LoggingTest.cpp(102)::envVarTest : WarningDefault\n"
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
+     "LoggingTest.cpp(26)::warning : WarningSim\n"
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
+     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
     {"debug",
-     "[Default] DebugDefault\n[Default] WarningDefault\n"
-     "[Sim] DebugSim\n[Sim] WarningSim\n"
-     "[Gfx] "
-     "DebugGfx\n[Gfx] WarningGfx\n"},
+     "[Default] LoggingTest.cpp(101)::envVarTest : DebugDefault\n[Default] "
+     "LoggingTest.cpp(102)::envVarTest : WarningDefault\n"
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
+     "LoggingTest.cpp(26)::warning : WarningSim\n"
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
+     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
     {"quiet", ""},
     {"error", ""},
     {"quiet:Sim,Gfx=verbose",
-     "[Sim] DebugSim\n[Sim] WarningSim\n[Gfx] "
-     "DebugGfx\n[Gfx] WarningGfx\n"},
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
+     "LoggingTest.cpp(26)::warning : WarningSim\n[Gfx] "
+     "LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
+     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
     {"warning:Gfx=debug",
-     "[Default] WarningDefault\n"
-     "[Sim] WarningSim\n[Gfx] "
-     "DebugGfx\n[Gfx] WarningGfx\n"},
+     "[Default] LoggingTest.cpp(102)::envVarTest : WarningDefault\n"
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n[Gfx] "
+     "LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
+     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
 };  // namespace
 
 LoggingTest::LoggingTest() {

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -112,13 +112,10 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
   XMLDocument xml_doc;
   xml_doc.Parse(xmlString.c_str());
   if (xml_doc.Error()) {
-    ESP_ERROR()
-        << "Parser::parseURDF - XML parse error, aborting URDF parse/load for"
-        << filename;
+    ESP_ERROR() << "XML parse error, aborting URDF parse/load for" << filename;
     return false;
   }
-  ESP_VERY_VERBOSE()
-      << "Parser::parseURDF - XML parsed starting URDF parse/load.";
+  ESP_VERY_VERBOSE() << "XML parsed starting URDF parse/load.";
 
   const XMLElement* robot_xml = xml_doc.FirstChildElement("robot");
   if (!robot_xml) {
@@ -597,8 +594,7 @@ bool Parser::parseVisual(const std::shared_ptr<Model>& model,
           model->m_materials.at(visual.m_materialName);
       visual.m_geometry.m_hasLocalMaterial = true;
     } else {
-      ESP_VERY_VERBOSE() << "Warning: Parser::parseVisual : visual element \""
-                         << visual.m_name
+      ESP_VERY_VERBOSE() << "Warning: visual element \"" << visual.m_name
                          << "\" specified un-defined material name \""
                          << visual.m_materialName << "\".";
     }

--- a/src/esp/io/json.cpp
+++ b/src/esp/io/json.cpp
@@ -98,8 +98,7 @@ int loadJsonIntoConfiguration(const JsonGenericValue& jsonObj,
         // decrement count for key:obj due to not being handled vector
         --numConfigSettings;
         // TODO support numeric array in JSON
-        ESP_WARNING() << "::loadJsonIntoConfiguration : For subgroup name"
-                      << subGroupName
+        ESP_WARNING() << "For subgroup name" << subGroupName
                       << "config cell in JSON document contains key" << key
                       << "referencing an unsupported numeric array of length :"
                       << obj.Size() << "so skipping.";
@@ -117,8 +116,7 @@ int loadJsonIntoConfiguration(const JsonGenericValue& jsonObj,
       // TODO support other types?
       // decrement count for key:obj due to not being handled type
       --numConfigSettings;
-      ESP_WARNING() << "::loadJsonIntoConfiguration: For subgroup name"
-                    << subGroupName
+      ESP_WARNING() << "For subgroup name" << subGroupName
                     << "config cell in JSON document contains key" << key
                     << "referencing an unknown/unparsable value type, so "
                        "skipping this key.";

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -38,9 +38,9 @@ bool MetadataMediator::setSimulatorConfiguration(
   bool success = setActiveSceneDatasetName(simConfig_.sceneDatasetConfigFile);
   if (!success) {
     // something failed about setting up active scene dataset
-    ESP_ERROR() << "::setSimulatorConfiguration : Some error "
-                   "prevented current scene dataset name to be changed to"
-                << simConfig_.sceneDatasetConfigFile;
+    ESP_ERROR()
+        << "Some error prevented current scene dataset name to be changed to"
+        << simConfig_.sceneDatasetConfigFile;
     return false;
   }
 
@@ -48,8 +48,7 @@ bool MetadataMediator::setSimulatorConfiguration(
   success = setCurrPhysicsAttributesHandle(simConfig_.physicsConfigFile);
   if (!success) {
     // something failed about setting up physics attributes
-    ESP_ERROR() << "::setSimulatorConfiguration : Some error "
-                   "prevented current physics attributes to"
+    ESP_ERROR() << "Some error prevented current physics attributes to"
                 << simConfig_.physicsConfigFile;
     return false;
   }
@@ -61,12 +60,10 @@ bool MetadataMediator::setSimulatorConfiguration(
     datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetup,
                                 simConfig_.frustumCulling);
   } else {
-    ESP_ERROR() << "::setSimulatorConfiguration : No active "
-                   "dataset exists or has been specified. Aborting";
+    ESP_ERROR() << "No active dataset exists or has been specified. Aborting";
     return false;
   }
-  ESP_DEBUG() << "::setSimulatorConfiguration : Set new "
-                 "simulator config for scene/stage :"
+  ESP_DEBUG() << "Set new simulator config for scene/stage :"
               << simConfig_.activeSceneName
               << "and dataset :" << simConfig_.sceneDatasetConfigFile << "which"
               << (activeSceneDataset_ == simConfig_.sceneDatasetConfigFile
@@ -86,8 +83,7 @@ bool MetadataMediator::createPhysicsManagerAttributes(
     if (physAttrs == nullptr) {
       // something failed during creation process.
       ESP_WARNING()
-          << "::createPhysicsManagerAttributes : Unknown  "
-             "physics manager configuration file :"
+          << "Unknown physics manager configuration file :"
           << _physicsManagerAttributesPath
           << "does not exist and is not able to be created.  Aborting.";
       return false;
@@ -103,8 +99,7 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
-      ESP_WARNING() << "::createSceneDataset : Scene Dataset"
-                    << sceneDatasetName
+      ESP_WARNING() << "Scene Dataset" << sceneDatasetName
                     << "already exists.  To reload and overwrite existing "
                        "data, set overwrite to true. Aborting.";
       return false;
@@ -117,14 +112,12 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
       sceneDatasetAttributesManager_->createObject(sceneDatasetName, true);
   if (datasetAttribs == nullptr) {
     // not created, do not set name
-    ESP_WARNING() << "::createSceneDataset : Unknown dataset"
-                  << sceneDatasetName
+    ESP_WARNING() << "Unknown dataset" << sceneDatasetName
                   << "does not exist and is not able to be created.  Aborting.";
     return false;
   }
   // if not null then successfully created
-  ESP_DEBUG() << "::createSceneDataset : Dataset" << sceneDatasetName
-              << "successfully created.";
+  ESP_DEBUG() << "Dataset" << sceneDatasetName << "successfully created.";
   // lock dataset to prevent accidental deletion
   sceneDatasetAttributesManager_->setLock(sceneDatasetName, true);
   return true;
@@ -134,14 +127,14 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // First check if SceneDatasetAttributes exists
   if (!sceneDatasetExists(sceneDatasetName)) {
     // DNE, do nothing
-    ESP_WARNING() << "::removeSceneDataset : SceneDatasetAttributes"
-                  << sceneDatasetName << "does not exist. Aborting.";
+    ESP_WARNING() << "SceneDatasetAttributes" << sceneDatasetName
+                  << "does not exist. Aborting.";
     return false;
   }
 
   // Next check if is current activeSceneDataset_, and if so skip with warning
   if (sceneDatasetName == activeSceneDataset_) {
-    ESP_WARNING() << "::removeSceneDataset : Cannot remove "
+    ESP_WARNING() << "Cannot remove "
                      "active SceneDatasetAttributes"
                   << sceneDatasetName
                   << ".  Switch to another dataset before removing.";
@@ -156,8 +149,8 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // if failed here, probably means SceneDatasetAttributes was set to
   // undeletable, return message and false
   if (delDataset == nullptr) {
-    ESP_WARNING() << "::removeSceneDataset : SceneDatasetAttributes"
-                  << sceneDatasetName << "unable to be deleted. Aborting.";
+    ESP_WARNING() << "SceneDatasetAttributes" << sceneDatasetName
+                  << "unable to be deleted. Aborting.";
     return false;
   }
   // Should always have a default dataset. Use this process to remove extraneous
@@ -167,8 +160,8 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     // dataset.
     createSceneDataset("default");
   }
-  ESP_DEBUG() << "::removeSceneDataset : SceneDatasetAttributes"
-              << sceneDatasetName << "successfully removed.";
+  ESP_DEBUG() << "SceneDatasetAttributes" << sceneDatasetName
+              << "successfully removed.";
   return true;
 
 }  // MetadataMediator::removeSceneDataset
@@ -420,7 +413,7 @@ std::string MetadataMediator::createDatasetReport(
     ds = sceneDatasetAttributesManager_->getObjectByHandle(sceneDataset);
   } else {
     // unknown dataset
-    ESP_ERROR() << "::createDatasetReport : Dataset" << sceneDataset
+    ESP_ERROR() << "Dataset" << sceneDataset
                 << "is not found in the MetadataMediator.  Aborting.";
     return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
   }

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -419,7 +419,7 @@ class MetadataMediator {
       const std::map<std::string, std::string>& assetMapping,
       const std::string& msgString) {
     if (assetMapping.count(assetHandle) == 0) {
-      ESP_WARNING() << msgString << "(getAsset) : Unable to find file path for"
+      ESP_WARNING() << msgString << ": Unable to find file path for"
                     << assetHandle << ".  Aborting.";
       return "";
     }

--- a/src/esp/metadata/MetadataUtils.cpp
+++ b/src/esp/metadata/MetadataUtils.cpp
@@ -29,12 +29,11 @@ int getShaderTypeFromJsonDoc(const io::JsonGenericValue& jsonDoc) {
     if (found != attributes::ShaderTypeNamesMap.end()) {
       shader_type = static_cast<int>(found->second);
     } else {
-      ESP_WARNING()
-          << "getShaderTypeFromJsonDoc : `shader_type` value in json  : `"
-          << tmpShaderType << "` -> `" << strToLookFor
-          << "` does not map to a valid "
-             "ObjectInstanceShaderType value, so defaulting "
-             "shader type to ObjectInstanceShaderType::Unknown.";
+      ESP_WARNING() << "`shader_type` value in json  : `" << tmpShaderType
+                    << "` -> `" << strToLookFor
+                    << "` does not map to a valid "
+                       "ObjectInstanceShaderType value, so defaulting "
+                       "shader type to ObjectInstanceShaderType::Unknown.";
     }
   }
   return shader_type;

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -25,8 +25,7 @@ SceneDatasetAttributes::SceneDatasetAttributes(
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const attributes::SceneAttributes::ptr& sceneInstance) {
   // info display message prefix
-  const std::string infoPrefix("::addNewSceneInstanceToDataset : Dataset : '" +
-                               getSimplifiedHandle() + "' : ");
+  const std::string infoPrefix("Dataset : '" + getSimplifiedHandle() + "' : ");
 
   const std::string sceneInstanceName = sceneInstance->getHandle();
   // verify stage in sceneInstance (required) exists in SceneDatasetAttributes,

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -123,8 +123,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& key,
       const std::string& path,
       bool overwrite = false) {
-    return addNewValToMap(key, path, overwrite, navmeshMap_,
-                          "::addNavmeshPathEntry");
+    return addNewValToMap(key, path, overwrite, navmeshMap_, "<navmesh>");
   }  // addNavmeshPathEntry
 
   /**
@@ -141,7 +140,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& path,
       bool overwrite = false) {
     return addNewValToMap(key, path, overwrite, semanticSceneDescrMap_,
-                          "::addSemanticSceneDescrPathEntry");
+                          "<semanticSceneDescriptor");
   }  // addNavmeshPathEntry
 
   /**
@@ -264,9 +263,8 @@ class SceneDatasetAttributes : public AbstractAttributes {
   inline std::string getArticulatedObjModelFullHandle(
       const std::string& artObjModelName) {
     if (articulatedObjPaths.count(artObjModelName) == 0) {
-      ESP_ERROR() << "SceneDatasetAttributes::getArticulatedObjModelFullHandle "
-                     ": No Articulatd Model with name"
-                  << artObjModelName << "could be found.  Aborting.";
+      ESP_ERROR() << "No Articulatd Model with name" << artObjModelName
+                  << "could be found.  Aborting.";
       return "";
     }
     return articulatedObjPaths.at(artObjModelName);
@@ -283,11 +281,9 @@ class SceneDatasetAttributes : public AbstractAttributes {
   void setArticulatedObjectModelFilename(const std::string& key,
                                          const std::string& val) {
     if (articulatedObjPaths.count(key) != 0) {
-      ESP_WARNING()
-          << "SceneDatasetAttributes::setArticulatedObjectModelFilename "
-             ": Articulated model filepath named"
-          << key << "already exists (" << articulatedObjPaths.at(key)
-          << "), so this is being overwritten by" << val << ".";
+      ESP_WARNING() << "Articulated model filepath named" << key
+                    << "already exists (" << articulatedObjPaths.at(key)
+                    << "), so this is being overwritten by" << val << ".";
     }
     articulatedObjPaths[key] = val;
   }

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -181,7 +181,7 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
   }  // if this is prim else
   if (nullptr != attrs) {
     ESP_DEBUG() << msg << "" << this->objectType_ << "attributes created"
-                << (registerTemplate ? " and registered." : ".");
+                << (registerTemplate ? "and registered." : ".");
   }
   return attrs;
 
@@ -330,8 +330,8 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     } else {
       ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
                     << Magnum::Debug::nospace
-                    << ">::setJSONAssetHandleAndType : Value in json @ tag :"
-                    << jsonMeshTypeTag << ": `" << tmpVal
+                    << "> : Value in json @ tag :" << jsonMeshTypeTag << ": `"
+                    << tmpVal
                     << "` does not map to a valid "
                        "AbstractObjectAttributes::AssetTypeNamesMap value, so "
                        "defaulting mesh type to AssetType::UNKNOWN.";

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -105,7 +105,7 @@ AssetAttributesManager::AssetAttributesManager()
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
 
-  ESP_DEBUG() << "::constructor : Built default "
+  ESP_DEBUG() << "Built default "
                  "primitive asset templates :"
               << std::to_string(defaultPrimAttributeHandles_.size());
 }  // AssetAttributesManager::ctor
@@ -133,16 +133,14 @@ AssetAttributesManager::createTemplateFromHandle(
   std::size_t nameEndLoc = templateHandle.find('_');
   if (nameEndLoc == std::string::npos) {
     // handle is of incorrect format
-    ESP_ERROR() << "::createTemplateFromHandle : Given template handle :"
-                << templateHandle
+    ESP_ERROR() << "Given template handle :" << templateHandle
                 << "is not the correct format for a primitive.  Aborting.";
     return nullptr;
   }
   std::string primClassName = templateHandle.substr(0, nameEndLoc);
   if (primTypeConstructorMap_.count(primClassName) == 0) {
     // handle does not have proper primitive tyep encoded
-    ESP_ERROR() << "::createTemplateFromHandle : Requested primitive type :"
-                << primClassName
+    ESP_ERROR() << "Requested primitive type :" << primClassName
                 << "from given template handle :" << templateHandle
                 << "is not a valid Magnum::Primitives class.  Aborting.";
     return nullptr;
@@ -154,9 +152,9 @@ AssetAttributesManager::createTemplateFromHandle(
   if (templateHandle.length() > 0) {
     bool success = primAssetAttributes->parseStringIntoConfig(templateHandle);
     if (!success) {
-      ESP_WARNING() << "::createTemplateFromHandle : Prim Asset Attributes :"
-                    << primClassName << "failed parsing config string : `"
-                    << templateHandle << "`.  Providing" << primClassName
+      ESP_WARNING() << "Prim Asset Attributes :" << primClassName
+                    << "failed parsing config string : `" << templateHandle
+                    << "`.  Providing" << primClassName
                     << "template configured as closely as possible with "
                        "requested values, named"
                     << primAssetAttributes->getHandle() << ".";
@@ -172,8 +170,7 @@ int AssetAttributesManager::registerObjectFinalize(
   std::string primAttributesHandle = primAttributesTemplate->getHandle();
   // verify that attributes has been edited in a legal manner
   if (!primAttributesTemplate->isValidTemplate()) {
-    ESP_ERROR() << "::registerObjectFinalize "
-                   ": Primitive asset attributes template named"
+    ESP_ERROR() << "Primitive asset attributes template named"
                 << primAttributesHandle
                 << "is not configured properly for specified prmitive"
                 << primAttributesTemplate->getPrimObjClassName()
@@ -202,9 +199,7 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   // if not legal primitive asset attributes file name, have message and
   // return default sphere attributes.
   if (defaultPrimAttributeHandles_.count(primClassName) == 0) {
-    ESP_ERROR() << "::buildObjectFromJSONDoc :Unknown "
-                   "primitive class type :"
-                << primClassName
+    ESP_ERROR() << "Unknown primitive class type :" << primClassName
                 << "so returning default attributes for solid uvSphere.";
     return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         defaultPrimAttributeHandles_.at("uvSphereSolid"));
@@ -213,11 +208,10 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
   // create attributes for the primitive described in the JSON file
   auto primAssetAttributes = this->initNewObjectInternal(primClassName, true);
   if (nullptr == primAssetAttributes) {
-    ESP_ERROR()
-        << "::buildObjectFromJSONDoc : unable to "
-           "create default primitive asset attributes from primClassName"
-        << primClassName
-        << "so returning default attributes for solid uvSphere.";
+    ESP_ERROR() << "Unable to create default primitive asset attributes from "
+                   "primClassName"
+                << primClassName
+                << "so returning default attributes for solid uvSphere.";
     return this->getObjectCopyByHandle<attributes::UVSpherePrimitiveAttributes>(
         defaultPrimAttributeHandles_.at("uvSphereSolid"));
   }

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -166,9 +166,9 @@ class AssetAttributesManager
       PrimObjTypes primObjType,
       bool registerTemplate = true) {
     if (primObjType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      ESP_ERROR() << "::createObject : Illegal "
-                     "primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
-                     "Aborting.";
+      ESP_ERROR()
+          << "Illegal primtitive type name PrimObjTypes::END_PRIM_OBJ_TYPES. "
+             "Aborting.";
       return nullptr;
     }
     return this->createObject(PrimitiveNames3DMap.at(primObjType),
@@ -189,8 +189,7 @@ class AssetAttributesManager
       PrimObjTypes primType,
       bool contains = true) const {
     if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      ESP_ERROR() << "::getTemplateHandlesByPrimType : "
-                     "Illegal primtitive type "
+      ESP_ERROR() << "Illegal primtitive type "
                      "name PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return {};
     }
@@ -409,9 +408,9 @@ class AssetAttributesManager
   void setDefaultObject(
       CORRADE_UNUSED attributes::AbstractPrimitiveAttributes::ptr& _defaultObj)
       override {
-    ESP_WARNING() << "::setDefaultObject : Overriding "
-                     "default objects for PrimitiveAssetAttributes not "
-                     "currently supported.  Aborting.";
+    ESP_WARNING()
+        << "Overriding default objects for PrimitiveAssetAttributes not "
+           "currently supported.  Aborting.";
     this->defaultObj_ = nullptr;
   }  // AssetAttributesManager::setDefaultObject
 
@@ -452,7 +451,7 @@ class AssetAttributesManager
   bool verifyTemplateHandle(const std::string& templateHandle,
                             const std::string& attrType) {
     if (std::string::npos == templateHandle.find(attrType)) {
-      ESP_ERROR() << "::verifyTemplateHandle : Handle :" << templateHandle
+      ESP_ERROR() << "Handle :" << templateHandle
                   << "is not of appropriate type for desired" << attrType
                   << "primitives. Aborting.";
       return false;
@@ -490,8 +489,8 @@ class AssetAttributesManager
       const std::string& primClassName,
       CORRADE_UNUSED bool builtFromConfig) override {
     if (primTypeConstructorMap_.count(primClassName) == 0) {
-      ESP_ERROR() << "::initNewObjectInternal : No primitive class"
-                  << primClassName << "exists in Magnum::Primitives. Aborting.";
+      ESP_ERROR() << "No primitive class" << primClassName
+                  << "exists in Magnum::Primitives. Aborting.";
       return nullptr;
     }
     // these attributes ignore any default setttings.
@@ -507,7 +506,7 @@ class AssetAttributesManager
   template <typename T, bool isWireFrame, PrimObjTypes primitiveType>
   attributes::AbstractPrimitiveAttributes::ptr createPrimAttributes() {
     if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
-      ESP_ERROR() << "::createPrimAttributes : Cannot instantiate "
+      ESP_ERROR() << "Cannot instantiate "
                      "attributes::AbstractPrimitiveAttributes object for "
                      "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
       return nullptr;

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -239,14 +239,11 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
   if (paths.size() > 0) {
     std::string dir = Cr::Utility::Directory::path(paths[0]);
-    ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-                << Magnum::Debug::nospace
-                << ">::loadAllFileBasedTemplates : Loading" << paths.size()
-                << "" << this->objectType_ << "templates found in" << dir;
+    ESP_DEBUG() << "Loading" << paths.size() << "" << this->objectType_
+                << "templates found in" << dir;
     for (int i = 0; i < paths.size(); ++i) {
       auto attributesFilename = paths[i];
-      ESP_VERY_VERBOSE() << "::loadAllFileBasedTemplates : Load"
-                         << this->objectType_ << "template:"
+      ESP_VERY_VERBOSE() << "Load" << this->objectType_ << "template:"
                          << Cr::Utility::Directory::filename(
                                 attributesFilename);
       auto tmplt = this->createObject(attributesFilename, true);
@@ -263,8 +260,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
     }
   }
   ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-              << Magnum::Debug::nospace
-              << ">::loadAllFileBasedTemplates : Loaded file-based templates:"
+              << Magnum::Debug::nospace << "> : Loaded file-based templates:"
               << std::to_string(paths.size());
   return templateIndices;
 }  // AttributesManager<T, Access>::loadAllObjectTemplates
@@ -281,11 +277,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   // Check if directory
   const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
-    ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-                << Magnum::Debug::nospace
-                << ">::loadAllTemplatesFromPathAndExt <"
-                << Magnum::Debug::nospace << extType << Magnum::Debug::nospace
-                << "> : Parsing" << this->objectType_
+    ESP_DEBUG() << "Parsing" << this->objectType_
                 << "library directory: " + path + " for \'" + extType +
                        "\' files";
     for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
@@ -304,8 +296,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
       paths.push_back(attributesFilepath);
     } else {  // neither a directory or a file
       ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
-                    << Magnum::Debug::nospace
-                    << ">::loadAllTemplatesFromPathAndExt : Parsing"
+                    << Magnum::Debug::nospace << "> : Parsing"
                     << this->objectType_ << ": Cannot find" << path
                     << "as directory or" << attributesFilepath
                     << "as config file. Aborting parse.";
@@ -326,10 +317,8 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const io::JsonGenericValue& filePaths) {
   for (rapidjson::SizeType i = 0; i < filePaths.Size(); ++i) {
     if (!filePaths[i].IsString()) {
-      ESP_ERROR() << "::buildAttrSrcPathsFromJSONAndLoad : "
-                     "Invalid path "
-                     "value in file path array element @ idx"
-                  << i << ". Skipping.";
+      ESP_ERROR() << "Invalid path value in file path array element @ idx" << i
+                  << ". Skipping.";
       continue;
     }
     std::string absolutePath =
@@ -348,8 +337,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
   }
   ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
               << Magnum::Debug::nospace
-              << ">::buildAttrSrcPathsFromJSONAndLoad :"
-              << std::to_string(filePaths.Size())
+              << ">:" << std::to_string(filePaths.Size())
               << "paths specified in JSON doc for" << this->objectType_
               << "templates.";
 }  // AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
@@ -371,9 +359,8 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   bool jsonFileExists = (this->isValidFileName(jsonAttrFileName));
   ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
               << Magnum::Debug::nospace
-              << ">::createFromJsonOrDefaultInternal : Proposing JSON name :"
-              << jsonAttrFileName << "from original name :" << filename
-              << "| This file"
+              << ">: Proposing JSON name :" << jsonAttrFileName
+              << "from original name :" << filename << "| This file"
               << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
@@ -407,8 +394,8 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
   if (jsonConfig.HasMember("user_defined")) {
     if (!jsonConfig["user_defined"].IsObject()) {
       ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
-                    << Magnum::Debug::nospace << ">::parseUserDefinedJsonVals :"
-                    << attribs->getSimplifiedHandle()
+                    << Magnum::Debug::nospace
+                    << "> :" << attribs->getSimplifiedHandle()
                     << "attributes specifies user_defined attributes but they "
                        "are not of the correct format. Skipping.";
       return false;

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -32,7 +32,7 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::createObject(
 
   if (nullptr != attrs) {
     ESP_DEBUG() << msg << "light layout attributes created"
-                << (doRegister ? " and registered." : ".");
+                << (doRegister ? "and registered." : ".");
   }
   return attrs;
 }  // PhysicsAttributesManager::createObject
@@ -94,7 +94,7 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
       lightAttribs->addLightInstance(lightInstanceAttribs);
       ++count;
     }
-    ESP_DEBUG() << "::setValsFromJSONDoc :" << count << "of" << numLightConfigs
+    ESP_DEBUG() << "" << count << "of" << numLightConfigs
                 << "LightInstanceAttributes created successfully and added to "
                    "LightLayoutAttributes"
                 << layoutName << ".";
@@ -106,7 +106,7 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
     // register if anything worth registering was found
     this->postCreateRegister(lightAttribs, true);
   } else {
-    ESP_WARNING() << "::setValsFromJSONDoc :" << layoutName
+    ESP_WARNING() << layoutName
                   << "does not contain a \"lights\" object or a valid "
                      "\"user_defined\" object and so no parsing was "
                      "done and this attributes is not being saved.";
@@ -154,9 +154,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           LightInstanceAttributes::LightPositionNamesMap.at(strToLookFor));
     } else {
       ESP_WARNING()
-          << "::setLightInstanceValsFromJSONDoc : 'position_model' Value in "
-             "JSON : `"
-          << posMdleVal
+          << "'position_model' Value in JSON : `" << posMdleVal
           << "` does not map to a valid "
              "LightInstanceAttributes::LightPositionNamesMap value, so "
              "defaulting LightInfo position model to "
@@ -174,8 +172,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
     if (strToLookFor == "spot") {
       // TODO remove this if block to support spot lights
       ESP_WARNING()
-          << "::setLightInstanceValsFromJSONDoc : "
-             "Type spotlight specified in JSON not currently supported, so "
+          << "Type spotlight specified in JSON not currently supported, so "
              "defaulting LightInfo type to esp::gfx::LightType::Point.";
       specifiedTypeVal = static_cast<int>(esp::gfx::LightType::Point);
     } else if (LightInstanceAttributes::LightTypeNamesMap.count(strToLookFor) !=
@@ -184,9 +181,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           LightInstanceAttributes::LightTypeNamesMap.at(strToLookFor));
     } else {
       ESP_WARNING()
-          << "::setLightInstanceValsFromJSONDoc : "
-             "Type Value in JSON : `"
-          << tmpTypeVal
+          << "Type Value in JSON : `" << tmpTypeVal
           << "` does not map to a valid "
              "LightInstanceAttributes::LightTypeNamesMap value, so "
              "defaulting LightInfo type to esp::gfx::LightType::Point.";
@@ -222,7 +217,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
     if (!jsonConfig["spot"].IsObject()) {
       // TODO prune NOTE: component when spotlights are supported
       ESP_WARNING()
-          << "::setValsFromJSONDoc : \"spot\" cell in JSON config unable to be "
+          << "\"spot\" cell in JSON config unable to be "
              "parsed to set spotlight parameters so skipping.  NOTE : "
              "Spotlights not currently supported, so cone angle values are "
              "ignored and light will be created as a point light.";
@@ -316,9 +311,7 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
             break;
           }
           default: {
-            ESP_DEBUG() << "::createLightSetupFromAttributes : Enum "
-                           "gfx::LightType with val"
-                        << type
+            ESP_DEBUG() << "Enum gfx::LightType with val" << type
                         << "is not supported, so defaulting to "
                            "gfx::LightType::Point";
             lightVector = {lightAttr->getPosition(), 1.0f};

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -28,10 +28,9 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
-    ESP_ERROR()
-        << "::createPrimBasedAttributesTemplate : No primitive with handle '"
-        << Mn::Debug::nospace << primAttrTemplateHandle << Mn::Debug::nospace
-        << "' exists so cannot build physical object.  Aborting.";
+    ESP_ERROR() << "No primitive with handle '" << Mn::Debug::nospace
+                << primAttrTemplateHandle << Mn::Debug::nospace
+                << "' exists so cannot build physical object.  Aborting.";
     return nullptr;
   }
 
@@ -190,8 +189,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     bool forceRegistration) {
   if (objectTemplate->getRenderAssetHandle() == "") {
     ESP_ERROR()
-        << "::registerObjectFinalize : Attributes template named"
-        << objectTemplateHandle
+        << "Attributes template named" << objectTemplateHandle
         << "does not have a valid render asset handle specified. Aborting.";
     return ID_UNDEFINED;
   }
@@ -218,8 +216,7 @@ int ObjectAttributesManager::registerObjectFinalize(
   } else if (forceRegistration) {
     // Forcing registration in case of computationaly generated assets
     ESP_WARNING()
-        << "::registerObjectFinalize : Render asset template handle :"
-        << renderAssetHandle
+        << "Render asset template handle :" << renderAssetHandle
         << "specified in object template with handle :" << objectTemplateHandle
         << "does not correspond to any existing file or primitive render "
            "asset.  Objects created from this template may fail.";
@@ -229,8 +226,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     // attributes template hande, fail
     // by here always fail
     ESP_ERROR()
-        << "::registerObjectFinalize : Render asset template handle :"
-        << renderAssetHandle
+        << "Render asset template handle :" << renderAssetHandle
         << "specified in object template with handle :" << objectTemplateHandle
         << "does not correspond to any existing file or primitive render "
            "asset.  Aborting.";
@@ -248,8 +244,7 @@ int ObjectAttributesManager::registerObjectFinalize(
   } else {
     // Else, means no collision data specified, use specified render data
     ESP_DEBUG()
-        << "::registerObjectFinalize : Collision asset template handle :"
-        << collisionAssetHandle
+        << "Collision asset template handle :" << collisionAssetHandle
         << "specified in object template with handle :" << objectTemplateHandle
         << "does not correspond to any existing file or primitive render "
            "asset.  Overriding with given render asset handle :"

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -24,7 +24,7 @@ PhysicsManagerAttributes::ptr PhysicsAttributesManager::createObject(
 
   if (nullptr != attrs) {
     ESP_DEBUG() << msg << "physics manager attributes created"
-                << (registerTemplate ? " and registered." : ".");
+                << (registerTemplate ? "and registered." : ".");
   }
   return attrs;
 }  // PhysicsAttributesManager::createObject

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -29,7 +29,7 @@ SceneAttributes::ptr SceneAttributesManager::createObject(
 
   if (nullptr != attrs) {
     ESP_DEBUG() << msg << "scene instance attributes created"
-                << (registerTemplate ? " and registered." : ".");
+                << (registerTemplate ? "and registered." : ".");
   }
   return attrs;
 }  // SceneAttributesManager::createObject
@@ -62,8 +62,8 @@ void SceneAttributesManager::setValsFromJSONDoc(
     attribs->setStageInstance(
         createInstanceAttributesFromJSON(jsonConfig["stage_instance"]));
   } else {
-    ESP_WARNING() << "::setValsFromJSONDoc : No Stage specified for scene"
-                  << attribsDispName << ", or specification error.";
+    ESP_WARNING() << "No Stage specified for scene" << attribsDispName
+                  << ", or specification error.";
   }
 
   // Check for object instances existence
@@ -75,14 +75,13 @@ void SceneAttributesManager::setValsFromJSONDoc(
         if (objCell.IsObject()) {
           attribs->addObjectInstance(createInstanceAttributesFromJSON(objCell));
         } else {
-          ESP_WARNING()
-              << "::setValsFromJSONDoc : Object specification error in scene"
-              << attribsDispName << "at idx :" << i << ".";
+          ESP_WARNING() << "Object specification error in scene"
+                        << attribsDispName << "at idx :" << i << ".";
         }
       }
     } else {
-      ESP_WARNING() << "::setValsFromJSONDoc : No Objects specified for scene"
-                    << attribsDispName << ", or specification error.";
+      ESP_WARNING() << "No Objects specified for scene" << attribsDispName
+                    << ", or specification error.";
     }
   }
 
@@ -98,16 +97,12 @@ void SceneAttributesManager::setValsFromJSONDoc(
         attribs->addArticulatedObjectInstance(
             createAOInstanceAttributesFromJSON(artObjCell));
       } else {
-        ESP_WARNING() << "SceneAttributesManager::setValsFromJSONDoc : "
-                         "Articulated Object "
-                         "specification error in scene"
+        ESP_WARNING() << "Articulated Object specification error in scene"
                       << attribsDispName << "at idx :" << i << ".";
       }
     }
   } else {
-    ESP_WARNING() << "SceneAttributesManager::setValsFromJSONDoc : No "
-                     "Articulated Objects "
-                     "specified for scene"
+    ESP_WARNING() << "Articulated Objects specified for scene"
                   << attribsDispName << ", or specification error.";
   }
 
@@ -117,8 +112,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "default lighting" is specified in scene json set value.
     attribs->setLightingHandle(dfltLighting);
   } else {
-    ESP_WARNING() << "::setValsFromJSONDoc : No default_lighting "
-                     "specified for scene"
+    ESP_WARNING() << "No default_lighting specified for scene"
                   << attribsDispName << ".";
   }
 
@@ -128,8 +122,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "navmesh_instance" is specified in scene json set value.
     attribs->setNavmeshHandle(navmeshName);
   } else {
-    ESP_WARNING() << "::setValsFromJSONDoc : No navmesh_instance "
-                     "specified for scene"
+    ESP_WARNING() << "No navmesh_instance specified for scene"
                   << attribsDispName << ".";
   }
 
@@ -139,8 +132,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
     // if "semantic scene instance" is specified in scene json set value.
     attribs->setSemanticSceneHandle(semanticDesc);
   } else {
-    ESP_WARNING() << "::setValsFromJSONDoc : No semantic_scene_instance "
-                     "specified for scene"
+    ESP_WARNING() << "No semantic_scene_instance specified for scene"
                   << attribsDispName << ".";
   }
   // check for user defined attributes

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -80,16 +80,14 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
     namespace Dir = Cr::Utility::Directory;
     if (!jsonConfig[tag].IsObject()) {
       ESP_WARNING()
-          << "::setValsFromJSONDoc : \"" << tag
+          << "\"" << tag
           << "\" cell in JSON config not appropriately configured. Skipping.";
     } else {
       const auto& jCell = jsonConfig[tag];
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
           ESP_WARNING()
-              << "::setValsFromJSONDoc("
-                 "Articulated Object) : \""
-              << tag
+              << "(Articulated Object) : \"" << tag
               << ".paths\" cell in JSON config unable to be parsed as "
                  "a JSON object to determine search paths so skipping.";
         } else {
@@ -107,8 +105,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
               // for each entry in ao paths array object
               for (rapidjson::SizeType i = 0; i < aoPathsObj.Size(); ++i) {
                 if (!aoPathsObj[i].IsString()) {
-                  ESP_ERROR() << "::setValsFromJSONDoc("
-                                 "Articulated Object) : Invalid path "
+                  ESP_ERROR() << "(Articulated Object) : Invalid path "
                                  "value in file path array element @ idx"
                               << i << ". Skipping.";
                   continue;
@@ -128,8 +125,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                     // load all object templates available as configs in
                     // absolutePath
                     ESP_WARNING()
-                        << "::setValsFromJSONDoc("
-                           "Articulated Object) : Glob path result for"
+                        << "(Articulated Object) : Glob path result for"
                         << absolutePath << ":" << globPath;
                     // each globPath entry represents real unique entry on disk
 
@@ -139,7 +135,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                     const bool dirExists = Dir::isDirectory(globPath);
                     if (dirExists) {
                       ESP_DEBUG()
-                          << "::setValsFromJSONDoc(Articulated Object) : "
+                          << "(Articulated Object) : "
                              "Parsing articulated object library directory: " +
                                  globPath;
                       for (auto& file :
@@ -155,9 +151,8 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                                                              urdfPathExt)) {
                       aoFilePaths.push_back(globPath);
                     } else {  // neither a directory or a file
-                      ESP_WARNING() << "::setValsFromJSONDoc(Articulated "
-                                       "Object) : Parsing articulated objects "
-                                       " : Cannot find"
+                      ESP_WARNING() << "(Articulated Object) : Parsing "
+                                       "articulated objects  : Cannot find"
                                     << globPath
                                     << "as sub directory or as config file. "
                                        "Aborting parse.";
@@ -170,16 +165,14 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                   // traversing a subdirectory
                   if (aoFilePaths.size() > 0) {
                     std::string ao_dir = Dir::path(aoFilePaths[0]);
-                    ESP_DEBUG()
-                        << "::setValsFromJSONDoc(Articulated Object) : Loading"
-                        << aoFilePaths.size() << "" << this->objectType_
-                        << "templates found in" << ao_dir;
+                    ESP_DEBUG() << "(Articulated Object) : Loading"
+                                << aoFilePaths.size() << "" << this->objectType_
+                                << "templates found in" << ao_dir;
                     for (int i = 0; i < aoFilePaths.size(); ++i) {
                       auto aoModelFileName = aoFilePaths[i];
-                      ESP_DEBUG()
-                          << "::setValsFromJSONDoc(Articulated Object) : "
-                             "Found Articulated Object Model file :"
-                          << aoModelFileName;
+                      ESP_DEBUG() << "(Articulated Object) : "
+                                     "Found Articulated Object Model file :"
+                                  << aoModelFileName;
 
                       // set k-v pairs here.
                       auto key =
@@ -194,26 +187,24 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                           key, aoModelFileName);
                     }
                   }
-                  ESP_DEBUG() << "::loadAllFileBasedTemplates : Specified"
-                              << std::to_string(aoFilePaths.size())
-                              << "articulated object model filenames specified "
-                                 "in path GLOB object :"
-                              << absolutePath << ".";
+                  ESP_DEBUG()
+                      << "Specified" << std::to_string(aoFilePaths.size())
+                      << "articulated object model filenames specified "
+                         "in path GLOB object :"
+                      << absolutePath << ".";
 
                   //**//** end call to loadAllFileBasedTemplates
                   //**** end call to loadAllConfigsFromPath in AOManager
 
                 } else {
                   ESP_WARNING()
-                      << "::setValsFromJSONDoc("
-                         "Articulated Object) : No Glob path result for"
+                      << "(Articulated Object) : No Glob path result for"
                       << absolutePath;
                   continue;
                 }
               }  // for every path object in list in json
 
-              ESP_DEBUG() << "::setValsFromJSONDoc("
-                             "Articulated Object) :"
+              ESP_DEBUG() << "(Articulated Object) :"
                           << std::to_string(aoPathsObj.Size())
                           << "paths specified in JSON doc for articulated "
                              "object model files.";
@@ -223,8 +214,8 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
 
           if (pathsWarn) {
             ESP_WARNING()
-                << "::readDatasetJSONCell : \"" << tag << ".paths["
-                << Mn::Debug::nospace << pathsWarnType << Mn::Debug::nospace
+                << "\"" << tag << ".paths[" << Mn::Debug::nospace
+                << pathsWarnType << Mn::Debug::nospace
                 << "] cell in JSON config unable to be parsed as an array to "
                    "determine search paths for json configs so skipping.";
           }
@@ -269,7 +260,7 @@ void SceneDatasetAttributesManager::loadAndValidateMap(
     if (!Cr::Utility::Directory::exists(loc)) {
       std::string newLoc = Cr::Utility::Directory::join(dsDir, loc);
       if (!Cr::Utility::Directory::exists(newLoc)) {
-        ESP_WARNING() << "::loadAndValidateMap :" << jsonTag << "Value :" << loc
+        ESP_WARNING() << jsonTag << "Value :" << loc
                       << "not found on disk as absolute path or relative to"
                       << dsDir;
       } else {
@@ -290,7 +281,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
   if (jsonConfig.HasMember(tag)) {
     if (!jsonConfig[tag].IsObject()) {
       ESP_WARNING()
-          << "::readDatasetJSONCell : \"" << tag
+          << "\"" << tag
           << "\" cell in JSON config not appropriately configured. Skipping.";
 
     } else {
@@ -301,7 +292,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
           ESP_WARNING()
-              << "::readDatasetJSONCell : \"" << tag
+              << "\"" << tag
               << ".default_attributes\" cell in JSON config unable to "
                  "be parsed to set default attributes so skipping.";
         } else {
@@ -310,14 +301,14 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
               "default_attributes", jCell["default_attributes"]);
           if (nullptr == attr) {
             ESP_WARNING()
-                << "::readDatasetJSONCell : \"" << tag
+                << "\"" << tag
                 << ".default_attributes\" cell failed to successfully "
                    "create an attributes, so skipping.";
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
             ESP_DEBUG()
-                << "::readDatasetJSONCell : \"" << tag
+                << "\"" << tag
                 << ".default_attributes\" set in Attributes Manager from JSON.";
           }
         }  // if is an object
@@ -328,7 +319,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
           ESP_WARNING()
-              << "::readDatasetJSONCell : \"" << tag
+              << "\"" << tag
               << ".paths\" cell in JSON config unable to be parsed as "
                  "a JSON object to determine search paths so skipping.";
         } else {
@@ -356,8 +347,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           // TODO support other extension tags
           if (pathsWarn) {
             ESP_WARNING()
-                << "::readDatasetJSONCell : \"" << tag << ".paths["
-                << Mn::Debug::nospace << pathsWarnType << Mn::Debug::nospace
+                << "\"" << tag << ".paths\"[" << Mn::Debug::nospace
+                << pathsWarnType << Mn::Debug::nospace
                 << "] cell in JSON config unable to be parsed as an array to "
                    "determine search paths for json configs so skipping.";
           }
@@ -367,7 +358,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // existing attributes.
       if (jCell.HasMember("configs")) {
         if (!jCell["configs"].IsArray()) {
-          ESP_WARNING() << "::readDatasetJSONCell : \"" << tag
+          ESP_WARNING() << "\"" << tag
                         << ".configs\" cell in JSON config unable to be parsed "
                            "as an array to determine search paths so skipping.";
         } else {
@@ -391,7 +382,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   // every cell within configs array must have an attributes tag
   if ((!jCell.HasMember("attributes")) || (!jCell["attributes"].IsObject())) {
     ESP_WARNING()
-        << "::readDatasetConfigsJSONCell : \"" << tag
+        << "\"" << tag
         << ".configs\" cell element in JSON config lacks required data to "
            "construct configuration override (an attributes tag and data "
            "describing the overrides is not found), so skipping.";
@@ -415,7 +406,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
         attrMgr->getObjectHandlesBySubstring(originalFile, true);
     if (handles.size() == 0) {
       ESP_WARNING()
-          << "::readDatasetConfigsJSONCell : \"" << tag
+          << "\"" << tag
           << ".configs\" cell element in JSON config specified source file :"
           << originalFile << "which cannot be found, so skipping.";
       return;
@@ -437,7 +428,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
   // if neither handle is specified, cell will fail
   if (!validCell) {
     ESP_WARNING()
-        << "::readDatasetConfigsJSONCell : \"" << tag
+        << "\"" << tag
         << ".configs\" cell element in JSON config lacks required data to "
            "construct configuration override (either an original_file or a "
            "template_handle must be provided) so skipping.";
@@ -460,15 +451,14 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // origObjHandle is known to be legitimate file
     auto attr = attrMgr->getObjectCopyByHandle(origObjHandle);
     if (nullptr == attr) {
-      ESP_WARNING() << "::readDatasetConfigsJSONCell :"
-                    << attrMgr->getObjectType()
+      ESP_WARNING() << attrMgr->getObjectType()
                     << ": Attempting to make a copy of" << origObjHandle
                     << "failing so creating and registering a new object.";
       attr = attrMgr->createObject(origObjHandle, true);
       if (nullptr == attr) {
         ESP_WARNING()
-            << "::readDatasetConfigsJSONCell : \"" << tag
-            << ".configs\" cell element's original file (" << originalFile
+            << "\"" << tag << ".configs\" cell element's original file ("
+            << originalFile
             << ") failed to successfully create a base attributes to modify, "
                "so skipping.";
         return;
@@ -486,7 +476,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // if null then failed for some reason to create a new default object.
     if (nullptr == attr) {
       ESP_WARNING()
-          << "::readDatasetConfigsJSONCell : \"" << tag
+          << "\"" << tag
           << ".configs\" cell element failed to successfully create an "
              "attributes, so skipping.";
       return;

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -48,8 +48,7 @@ int StageAttributesManager::registerObjectFinalize(
     bool forceRegistration) {
   if (stageAttributes->getRenderAssetHandle() == "") {
     ESP_ERROR()
-        << "::registerObjectFinalize : Attributes template named"
-        << stageAttributesHandle
+        << "Attributes template named" << stageAttributesHandle
         << "does not have a valid render asset handle specified. Aborting.";
     return ID_UNDEFINED;
   }
@@ -76,16 +75,14 @@ int StageAttributesManager::registerObjectFinalize(
     stageAttributes->setRenderAssetIsPrimitive(false);
   } else if (forceRegistration) {
     ESP_WARNING()
-        << "::registerObjectFinalize : Render asset template handle :"
-        << renderAssetHandle
+        << "Render asset template handle :" << renderAssetHandle
         << "specified in stage template with handle :" << stageAttributesHandle
         << "does not correspond to any existing file or primitive render "
            "asset. This attributes is not in a valid state.";
   } else {
     // If renderAssetHandle is not valid file name needs to  fail
     ESP_ERROR()
-        << "::registerObjectFinalize : Render asset template handle :"
-        << renderAssetHandle
+        << "Render asset template handle :" << renderAssetHandle
         << "specified in stage template with handle :" << stageAttributesHandle
         << "does not correspond to any existing file or primitive render "
            "asset.  Aborting.";
@@ -109,8 +106,7 @@ int StageAttributesManager::registerObjectFinalize(
   } else {
     // Else, means no collision data specified, use specified render data
     ESP_DEBUG()
-        << "::registerObjectFinalize : Collision asset template handle :"
-        << collisionAssetHandle
+        << "Collision asset template handle :" << collisionAssetHandle
         << "specified in stage template with handle :" << stageAttributesHandle
         << "does not correspond to any existing file or primitive render "
            "asset.  Overriding with given render asset handle :"
@@ -136,10 +132,9 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!StageAttributesManager::isValidPrimitiveAttributes(primAssetHandle)) {
-    ESP_ERROR()
-        << "::createPrimBasedAttributesTemplate : No primitive with handle '"
-        << Mn::Debug::nospace << primAssetHandle << Mn::Debug::nospace
-        << "' exists so cannot build physical object.  Aborting.";
+    ESP_ERROR() << "No primitive with handle '" << Mn::Debug::nospace
+                << primAssetHandle << Mn::Debug::nospace
+                << "' exists so cannot build physical object.  Aborting.";
     return nullptr;
   }
 

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -186,63 +186,68 @@ class ArticulatedLink : public RigidBase {
 
   void setTransformation(
       CORRADE_UNUSED const Magnum::Matrix4& transformation) override {
-    ESP_DEBUG() << "(setTransformation) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void setTranslation(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "(setTranslation) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void setRotation(
       CORRADE_UNUSED const Magnum::Quaternion& quaternion) override {
-    ESP_DEBUG() << "(setRotation) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void setRigidState(
       CORRADE_UNUSED const core::RigidState& rigidState) override {
-    ESP_DEBUG() << "(setRigidState) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void resetTransformation() override {
-    ESP_DEBUG() << "(resetTransformation) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void translate(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "(translate) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void translateLocal(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "(translateLocal) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void rotate(CORRADE_UNUSED const Magnum::Rad angleInRad,
               CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
-    ESP_DEBUG() << "(rotate) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void rotateLocal(
       CORRADE_UNUSED const Magnum::Rad angleInRad,
       CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
-    ESP_DEBUG() << "(rotateLocal) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   void rotateX(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateX) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
+
   void rotateY(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateY) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
+
   void rotateZ(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateZ) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
+
   void rotateXLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateXLocal) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
+
   void rotateYLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateYLocal) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
+
   void rotateZLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "(rotateZLocal) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   /**
@@ -253,8 +258,7 @@ class ArticulatedLink : public RigidBase {
    */
   void resetStateFromSceneInstanceAttr(
       CORRADE_UNUSED bool defaultCOMCorrection = false) override {
-    ESP_DEBUG()
-        << "(resetStateFromSceneInstanceAttr) - ArticulatedLink can't do this.";
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
   }
 
   std::string linkName = "";
@@ -751,8 +755,7 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   virtual std::unordered_map<int, int> createMotorsForAllDofs(
       CORRADE_UNUSED const JointMotorSettings& settings =
           JointMotorSettings()) {
-    ESP_ERROR() << "ArticulatedObject::createMotorsForAllDofs(): - ERROR, "
-                   "SHOULD NOT BE CALLED WITHOUT BULLET";
+    ESP_ERROR() << "ERROR, SHOULD NOT BE CALLED WITHOUT BULLET";
     return std::unordered_map<int, int>();
   }
 
@@ -775,8 +778,7 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   virtual void updateAllMotorTargets(
       CORRADE_UNUSED const std::vector<float>& stateTargets,
       CORRADE_UNUSED bool velocities = false) {
-    ESP_ERROR() << "ArticulatedObject::updateAllMotorTargets(): - ERROR, "
-                   "SHOULD NOT BE CALLED WITHOUT BULLET";
+    ESP_ERROR() << "ERROR,SHOULD NOT BE CALLED WITHOUT BULLET";
   }
 
   //=========== END - Joint Motor API ===========

--- a/src/esp/physics/CollisionGroupHelper.cpp
+++ b/src/esp/physics/CollisionGroupHelper.cpp
@@ -112,8 +112,8 @@ bool CollisionGroupHelper::setGroupName(CollisionGroup group,
                                         const std::string& newName) {
   auto currentName = getGroupName(group);
   if (collisionGroupNames.count(newName) != 0) {
-    ESP_WARNING() << "CollisionGroupHelper::setGroupName - requested group "
-                     "name is already in use, aborting.";
+    ESP_WARNING() << "Requested group name: " << newName
+                  << "is already in use, aborting.";
     return false;
   }
   collisionGroupNames[newName] = collisionGroupNames.at(currentName);

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -79,14 +79,12 @@ int PhysicsManager::addObjectInstance(
     bool defaultCOMCorrection,
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
-  const std::string errMsgTmplt = "::addObjectInstance : ";
   // Get ObjectAttributes
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
   if (!objAttributes) {
-    ESP_ERROR() << errMsgTmplt
-                << "Missing/improperly configured objectAttributes"
+    ESP_ERROR() << "Missing/improperly configured objectAttributes"
                 << attributesHandle << ", whose handle contains"
                 << objInstAttributes->getHandle()
                 << "as specified in object instance attributes.";
@@ -110,7 +108,7 @@ int PhysicsManager::addObjectInstance(
 
   if (objID == ID_UNDEFINED) {
     // instancing failed for some reason.
-    ESP_ERROR() << errMsgTmplt << "Object create failed for objectAttributes"
+    ESP_ERROR() << "Object create failed for objectAttributes"
                 << attributesHandle << ", whose handle contains"
                 << objInstAttributes->getHandle()
                 << "as specified in object instance attributes.";
@@ -134,9 +132,8 @@ int PhysicsManager::addObject(const std::string& attributesHandle,
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
   if (!attributes) {
-    ESP_ERROR()
-        << "::addObject : Object creation failed due to unknown attributes"
-        << attributesHandle;
+    ESP_ERROR() << "Object creation failed due to unknown attributes"
+                << attributesHandle;
     return ID_UNDEFINED;
   } else {
     // attributes exist, get drawables if valid simulator accessible
@@ -157,8 +154,7 @@ int PhysicsManager::addObject(const int attributesID,
       resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
           attributesID);
   if (!attributes) {
-    ESP_ERROR() << "::addObject : "
-                   "Object creation failed due to unknown attributes ID"
+    ESP_ERROR() << "Object creation failed due to unknown attributes ID"
                 << attributesID;
     return ID_UNDEFINED;
   } else {
@@ -181,7 +177,7 @@ int PhysicsManager::addObject(
   //! Make rigid object and add it to existingObjects
   if (!objectAttributes) {
     // should never run, but just in case
-    ESP_ERROR() << "::addObject : Object creation failed due to nonexistant "
+    ESP_ERROR() << "Object creation failed due to nonexistant "
                    "objectAttributes";
     return ID_UNDEFINED;
   }
@@ -190,9 +186,8 @@ int PhysicsManager::addObject(
   bool objectSuccess =
       resourceManager_.instantiateAssetsOnDemand(objectAttributes);
   if (!objectSuccess) {
-    ESP_ERROR() << "::addObject : ResourceManager::instantiateAssetsOnDemand "
-                   "unsuccessful. "
-                   "Aborting.";
+    ESP_ERROR() << "ResourceManager::instantiateAssetsOnDemand "
+                   "unsuccessful. Aborting.";
     return ID_UNDEFINED;
   }
 
@@ -211,9 +206,8 @@ int PhysicsManager::addObject(
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
-    ESP_ERROR()
-        << "::addObject : PhysicsManager::makeRigidObject unsuccessful. "
-           " Aborting.";
+    ESP_ERROR() << "PhysicsManager::makeRigidObject unsuccessful. "
+                   " Aborting.";
     return ID_UNDEFINED;
   }
 
@@ -237,8 +231,7 @@ int PhysicsManager::addObject(
   if (!objectSuccess) {
     // if failed for some reason, remove and return
     removeObject(nextObjectID_, true, true);
-    ESP_ERROR() << "::addObject : PhysicsManager::finalizeObject "
-                   "unsuccessful.  Aborting.";
+    ESP_ERROR() << "PhysicsManager::finalizeObject unsuccessful.  Aborting.";
     return ID_UNDEFINED;
   }
   // Valid object exists by here.
@@ -246,10 +239,10 @@ int PhysicsManager::addObject(
   // and register wrapper with wrapper manager
   // 1.0 Get unique name for object using simplified attributes name.
   std::string simpleObjectHandle = objectAttributes->getSimplifiedHandle();
-  ESP_WARNING() << "::addObject : simpleObjectHandle :" << simpleObjectHandle;
   std::string newObjectHandle =
       rigidObjectManager_->getUniqueHandleFromCandidate(simpleObjectHandle);
-  ESP_WARNING() << "::addObject : newObjectHandle :" << newObjectHandle;
+  ESP_WARNING() << "Simplified template handle :" << simpleObjectHandle
+                << " | newObjectHandle :" << newObjectHandle;
 
   existingObjects_.at(nextObjectID_)->setObjectName(newObjectHandle);
 
@@ -270,8 +263,6 @@ int PhysicsManager::addArticulatedObjectInstance(
     const std::shared_ptr<esp::metadata::attributes::SceneAOInstanceAttributes>&
         aObjInstAttributes,
     const std::string& lightSetup) {
-  std::string errMsgTmplt = "PhysicsManager::addObjectInstance : ";
-
   // Get drawables from simulator. TODO: Support non-existent simulator?
   auto& drawables = simulator_->getDrawableGroup();
 
@@ -283,8 +274,7 @@ int PhysicsManager::addArticulatedObjectInstance(
       false, lightSetup);
   if (aObjID == ID_UNDEFINED) {
     // instancing failed for some reason.
-    ESP_ERROR() << errMsgTmplt
-                << "Articulated Object create failed for model filepath"
+    ESP_ERROR() << "Articulated Object create failed for model filepath"
                 << filepath << ", whose handle is"
                 << aObjInstAttributes->getHandle()
                 << "as specified in articulated object instance attributes.";

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -160,9 +160,9 @@ Responsible for tracking, updating, and synchronizing the state of the physical
 world and all non-static geometry in the scene as well as interfacing with
 specific physical simulation implementations.
 
-The physical world in this case consists of any objects which can be manipulated
-(kinematically or dynamically) or simulated and anything such objects must be
-aware of (e.g. static scene collision geometry).
+The physical world in this case consists of any objects which can be
+manipulated:addObject : (kinematically or dynamically) or simulated and anything
+such objects must be aware of (e.g. static scene collision geometry).
 
 Will later manager multiple physical scenes, but currently assumes only one
 unique physical world can exist.
@@ -335,9 +335,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
         resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
             attributesHandle);
     if (!attributes) {
-      ESP_ERROR()
-          << "::addObject : Object creation failed due to unknown attributes"
-          << attributesHandle;
+      ESP_ERROR() << "Object creation failed due to unknown attributes handle :"
+                  << attributesHandle;
       return ID_UNDEFINED;
     }
 
@@ -365,8 +364,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
         resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
             attributesID);
     if (!attributes) {
-      ESP_ERROR() << "::addObject : Object creation failed due to unknown "
-                     "attributes ID"
+      ESP_ERROR() << "Object creation failed due to unknown attributes ID :"
                   << attributesID;
       return ID_UNDEFINED;
     }
@@ -503,8 +501,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    ESP_DEBUG() << "addArticulatedObjectFromURDF not implemented in base "
-                   "PhysicsManager.";
+    ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;
   }
 
@@ -538,8 +535,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    ESP_DEBUG() << "addArticulatedObjectFromURDF not implemented in base "
-                   "PhysicsManager.";
+    ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;
   }
 
@@ -896,8 +892,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   virtual int createRigidConstraint(
       CORRADE_UNUSED const RigidConstraintSettings& settings) {
-    ESP_ERROR()
-        << "createRigidConstraint not implemented in base PhysicsManager";
+    ESP_ERROR() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;
   }
 
@@ -912,8 +907,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   virtual void updateRigidConstraint(
       CORRADE_UNUSED int constraintId,
       CORRADE_UNUSED const RigidConstraintSettings& settings) {
-    ESP_ERROR()
-        << "updateRigidConstraint not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager.";
   }
 
   /**
@@ -924,8 +918,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @param constraintId The id of the constraint to remove.
    */
   virtual void removeRigidConstraint(CORRADE_UNUSED int constraintId) {
-    ESP_ERROR()
-        << "removeRigidConstraint not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager.";
   }
 
   /**
@@ -937,9 +930,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   RigidConstraintSettings getRigidConstraintSettings(int constraintId) const {
     ESP_CHECK(rigidConstraintSettings_.count(constraintId) > 0,
-              "PhysicsManager::getRigidConstraintSettings - No RigidConstraint "
-              "exists with constraintId ="
-                  << constraintId);
+              "No RigidConstraint exists with constraintId =" << constraintId);
     return rigidConstraintSettings_.at(constraintId);
   }
 

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -88,7 +88,7 @@ class RigidStage : public RigidBase {
    * @param mt The desirved @ref MotionType.
    */
   void setMotionType(CORRADE_UNUSED MotionType mt) override {
-    ESP_WARNING() << "::setMotionType : Stages cannot have their "
+    ESP_WARNING() << "Stages cannot have their "
                      "motion type changed from MotionType::STATIC.  Aborting.";
   }
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -262,11 +262,9 @@ void BulletArticulatedObject::resetStateFromSceneInstanceAttr(
   size_t idx = 0;
   for (const auto& elem : initJointPos) {
     if (idx >= aoJointPose.size()) {
-      ESP_WARNING()
-          << "BulletArticulatedObject::resetStateFromSceneInstanceAttr :"
-          << "Attempting to specify more initial joint poses than "
-             "exist in articulated object"
-          << sceneObjInstanceAttr->getHandle() << ", so skipping";
+      ESP_WARNING() << "Attempting to specify more initial joint poses than "
+                       "exist in articulated object"
+                    << sceneObjInstanceAttr->getHandle() << ", so skipping";
       break;
     }
     aoJointPose[idx++] = elem.second;
@@ -283,7 +281,6 @@ void BulletArticulatedObject::resetStateFromSceneInstanceAttr(
   for (const auto& elem : initJointVel) {
     if (idx >= aoJointVels.size()) {
       ESP_WARNING()
-          << "BulletArticulatedObject::resetStateFromSceneInstanceAttr :"
           << "Attempting to specify more initial joint velocities than "
              "exist in articulated object"
           << sceneObjInstanceAttr->getHandle() << ", so skipping";
@@ -324,8 +321,8 @@ void BulletArticulatedObject::setRootAngularVelocity(
 
 void BulletArticulatedObject::setJointForces(const std::vector<float>& forces) {
   if (forces.size() != size_t(btMultiBody_->getNumDofs())) {
-    ESP_DEBUG() << "setJointForces - Force vector size mis-match (input:"
-                << forces.size() << ", expected:" << btMultiBody_->getNumDofs()
+    ESP_DEBUG() << "Force vector size mis-match (input:" << forces.size()
+                << ", expected:" << btMultiBody_->getNumDofs()
                 << "), aborting.";
   }
 
@@ -341,8 +338,8 @@ void BulletArticulatedObject::setJointForces(const std::vector<float>& forces) {
 
 void BulletArticulatedObject::addJointForces(const std::vector<float>& forces) {
   if (forces.size() != size_t(btMultiBody_->getNumDofs())) {
-    ESP_DEBUG() << "addJointForces - Force vector size mis-match (input:"
-                << forces.size() << ", expected:" << btMultiBody_->getNumDofs()
+    ESP_DEBUG() << "Force vector size mis-match (input:" << forces.size()
+                << ", expected:" << btMultiBody_->getNumDofs()
                 << "), aborting.";
   }
 
@@ -372,8 +369,8 @@ std::vector<float> BulletArticulatedObject::getJointForces() {
 void BulletArticulatedObject::setJointVelocities(
     const std::vector<float>& vels) {
   if (vels.size() != size_t(btMultiBody_->getNumDofs())) {
-    ESP_DEBUG() << "setJointVelocities - Velocity vector size mis-match (input:"
-                << vels.size() << ", expected:" << btMultiBody_->getNumDofs()
+    ESP_DEBUG() << "Velocity vector size mis-match (input:" << vels.size()
+                << ", expected:" << btMultiBody_->getNumDofs()
                 << "), aborting.";
   }
 
@@ -405,9 +402,8 @@ void BulletArticulatedObject::setJointPositions(
     const std::vector<float>& positions) {
   if (positions.size() != size_t(btMultiBody_->getNumPosVars())) {
     ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-        << "setJointPositions - Position vector size mis-match (input:"
-        << positions.size() << ", expected:" << btMultiBody_->getNumPosVars()
-        << "), aborting.";
+        << "Position vector size mis-match (input:" << positions.size()
+        << ", expected:" << btMultiBody_->getNumPosVars() << "), aborting.";
   }
 
   int posCount = 0;

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -41,15 +41,13 @@ class BulletArticulatedLink : public ArticulatedLink, public BulletBase {
 
   Magnum::Range3D getCollisionShapeAabb() const override {
     // TODO: collision object should be linked here
-    ESP_WARNING()
-        << "BulletArticulatedLink::getCollisionShapeAabb : Not implemented.";
+    ESP_WARNING() << "Not implemented.";
     return Magnum::Range3D();
   }
 
   //! link can't do this.
   void setMotionType(CORRADE_UNUSED MotionType mt) override {
-    ESP_WARNING() << "BulletArticulatedLink::setMotionType : Cannot set "
-                     "MotionType individually for links.";
+    ESP_WARNING() << "Cannot set MotionType individually for links.";
   }
 
  protected:

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -195,16 +195,11 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
               .first)
           .first;
 
-  ESP_DEBUG() << "BulletPhysicsManager::addArticulatedObjectFromURDF: "
-                 "simpleObjectHandle :"
-              << simpleArtObjHandle;
-
   std::string newArtObjectHandle =
       articulatedObjectManager_->getUniqueHandleFromCandidate(
           simpleArtObjHandle);
-  ESP_DEBUG() << "BulletPhysicsManager::addArticulatedObjectFromURDF: "
-                 "newArtObjectHandle :"
-              << newArtObjectHandle;
+  ESP_DEBUG() << "simpleArtObjHandle :" << simpleArtObjHandle
+              << " | newArtObjectHandle :" << newArtObjectHandle;
 
   existingArticulatedObjects_.at(articulatedObjectID)
       ->setObjectName(newArtObjectHandle);
@@ -356,8 +351,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
         visualSetupSuccess = false;
         break;
       default:
-        ESP_DEBUG() << "BulletPhysicsManager::attachGeometry "
-                       ": Unsupported visual type.";
+        ESP_DEBUG() << "Unsupported visual type.";
         visualSetupSuccess = false;
         break;
     }
@@ -502,7 +496,7 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
   results.ray = ray;
   double rayLength = static_cast<double>(ray.direction.length());
   if (rayLength == 0) {
-    ESP_ERROR() << "::castRay : Cannot cast ray with zero length, aborting.";
+    ESP_ERROR() << "Cannot cast ray with zero length, aborting.";
     return results;
   }
   btVector3 from(ray.origin);
@@ -881,8 +875,7 @@ void BulletPhysicsManager::removeRigidConstraint(int constraintId) {
     bWorld_->removeConstraint(rigidFixedConstraints_.at(constraintId).get());
     rigidFixedConstraints_.erase(constraintId);
   } else {
-    ESP_ERROR() << "removeRigidConstraint - No constraint with constraintId ="
-                << constraintId;
+    ESP_ERROR() << "No constraint with constraintId =" << constraintId;
     return;
   }
   rigidConstraintSettings_.erase(constraintId);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -259,7 +259,7 @@ void BulletRigidObject::setCollisionFromBB() {
 
 void BulletRigidObject::setMotionType(MotionType mt) {
   if (mt == MotionType::UNDEFINED) {
-    ESP_WARNING() << "::setMotionType : Cannot set motion type "
+    ESP_WARNING() << "Cannot set motion type "
                      "to MotionType::UNDEFINED.  Aborting.";
     return;
   }
@@ -479,7 +479,7 @@ bool BulletRigidObject::contactTest() {
 
 void BulletRigidObject::overrideCollisionGroup(CollisionGroup group) {
   if (!bObjectRigidBody_->isInWorld()) {
-    ESP_ERROR() << "::overrideCollisionGroup failed because "
+    ESP_ERROR() << "Failed because "
                    "the Bullet body hasn't yet been added to the Bullet world.";
   }
 

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -97,8 +97,7 @@ class PhysicsObjectBaseManager
     // construct a new wrapper based on the passed object
     if (managedObjTypeConstructorMap_.count(objectTypeName) == 0) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
-                  << Magnum::Debug::nospace << ">::initNewObjectInternal ("
-                  << this->objectType_ << ") Unknown constructor type"
+                  << Magnum::Debug::nospace << "> Unknown constructor type"
                   << objectTypeName << ".  Aborting.";
       return nullptr;
     }

--- a/src/esp/scene/GibsonSemanticScene.cpp
+++ b/src/esp/scene/GibsonSemanticScene.cpp
@@ -24,9 +24,9 @@ bool SemanticScene::
   }
 
   // top-level scene
-  ESP_VERY_VERBOSE() << "loadGibsonHouse::Parsing" << houseFilename;
+  ESP_VERY_VERBOSE() << "Parsing" << houseFilename;
   const io::JsonDocument& json = io::parseJsonFile(houseFilename);
-  ESP_VERY_VERBOSE() << "loadGibsonHouse::Parsed.";
+  ESP_VERY_VERBOSE() << "Parsed.";
 
   return buildGibsonHouse(json, scene, rotation);
 }  // SemanticScene::loadGibsonHouse

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -96,9 +96,8 @@ bool SemanticScene::loadMp3dHouse(
   std::string header;
   std::getline(ifs, header);
   if (header != "ASCII 1.1") {
-    ESP_ERROR() << "::loadMp3dHouse : Unsupported Mp3d House "
-                   "format header"
-                << header << "in file name" << houseFilename;
+    ESP_ERROR() << "Unsupported Mp3d House format header" << header
+                << "in file name" << houseFilename;
     return false;
   }
 

--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -29,9 +29,9 @@ bool SemanticScene::loadReplicaHouse(
   }
 
   // top-level scene
-  ESP_VERY_VERBOSE() << "loadReplicaHouse::Parsing" << houseFilename;
+  ESP_VERY_VERBOSE() << "Parsing" << houseFilename;
   const auto& json = io::parseJsonFile(houseFilename);
-  ESP_VERY_VERBOSE() << "loadReplicaHouse::Parsed.";
+  ESP_VERY_VERBOSE() << "Parsed.";
 
   // check if Replica or ReplicaCAD
   bool hasObjects = (json.HasMember("objects") && json["objects"].IsArray());

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -87,7 +87,7 @@ class CameraSensor : public VisualSensor {
     hfov_ = FOV;
     if (cameraSensorSpec_->sensorSubType != SensorSubType::Pinhole) {
       ESP_DEBUG()
-          << "CameraSensor::setFOV : Only Perspective-base CameraSensors use "
+          << "Only Perspective-base CameraSensors use "
              "FOV. Specified value saved but will not be consumed by this "
              "CameraSensor.";
     }

--- a/src/esp/sensor/SensorFactory.cpp
+++ b/src/esp/sensor/SensorFactory.cpp
@@ -59,8 +59,8 @@ void SensorFactory::deleteSubtreeSensor(scene::SceneNode& node,
   // If sensor does not exist, SensorFactory will log a message but proceed
   // without errors thrown
   if (node.getSubtreeSensors().count(uuid) == 0) {
-    ESP_DEBUG() << "SensorFactory::deleteSubtreeSensor(): Sensor with uuid"
-                << uuid << "does not exist at node" << node.getId();
+    ESP_DEBUG() << "Sensor with uuid" << uuid << "does not exist at node"
+                << node.getId();
     return;
   }
   deleteSensor(node.getSubtreeSensorSuite().get(uuid));

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -179,7 +179,7 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
   // (re) create scene instance
   success = createSceneInstance(config_.activeSceneName);
 
-  ESP_DEBUG() << "Simulator::reconfigure() : createSceneInstance success =="
+  ESP_DEBUG() << "CreateSceneInstance success =="
               << (success ? "true" : "false")
               << "for active scene name :" << config_.activeSceneName
               << (config_.createRenderer ? " with" : " without") << "renderer.";
@@ -203,21 +203,16 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   const std::string& navmeshFileLoc = metadataMediator_->getNavmeshPathByHandle(
       curSceneInstanceAttributes->getNavmeshHandle());
 
-  ESP_DEBUG() << "::setSceneInstanceAttributes : Navmesh file location in "
-                 "scene instance :"
-              << navmeshFileLoc;
+  ESP_DEBUG() << "Navmesh file location in scene instance :" << navmeshFileLoc;
   // Get name of navmesh and use to create pathfinder and load navmesh
   // create pathfinder and load navmesh if available
   pathfinder_ = nav::PathFinder::create();
   if (FileUtil::exists(navmeshFileLoc)) {
-    ESP_DEBUG() << "::setSceneInstanceAttributes : Loading navmesh from"
-                << navmeshFileLoc;
+    ESP_DEBUG() << "Loading navmesh from" << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);
-    ESP_DEBUG() << "::setSceneInstanceAttributes :"
-                << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
+    ESP_DEBUG() << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
   } else {
-    ESP_WARNING() << "::setSceneInstanceAttributes : Navmesh file not found, "
-                     "checked at filename : '"
+    ESP_WARNING() << "Navmesh file not found, checked at filename : '"
                   << Mn::Debug::nospace << navmeshFileLoc << Mn::Debug::nospace
                   << "'";
   }
@@ -244,13 +239,10 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   if (semanticSceneDescFilename != "") {
     bool fileExists = false;
     bool success = false;
-    const std::string msgPrefix =
-        "::setSceneInstanceAttributes : Attempt to load";
     // semantic scene descriptor might not exist, so
     semanticScene_ = nullptr;
     semanticScene_ = scene::SemanticScene::create();
-    ESP_DEBUG() << "::setSceneInstanceAttributes : SceneInstance :"
-                << activeSceneName
+    ESP_DEBUG() << "SceneInstance :" << activeSceneName
                 << "proposed Semantic Scene Descriptor filename :"
                 << semanticSceneDescFilename;
 
@@ -267,13 +259,13 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
       if (FileUtil::exists(tmpFName)) {
         success =
             scene::SemanticScene::loadReplicaHouse(tmpFName, *semanticScene_);
-        ESP_DEBUG() << msgPrefix
-                    << "Replica w/existing constructed file :" << tmpFName
-                    << "in directory with" << semanticSceneDescFilename << ":"
+        ESP_DEBUG() << "Attempt to load Replica w/existing constructed file :"
+                    << tmpFName << "in directory with"
+                    << semanticSceneDescFilename << ":"
                     << (success ? "" : "not ") << "successful";
       }
     }  // if given SSD file name specifiedd exists
-    ESP_WARNING() << "::setSceneInstanceAttributes : All attempts to load "
+    ESP_WARNING() << "All attempts to load "
                      "SSD with SceneAttributes-provided name"
                   << semanticSceneDescFilename << ": exist :" << fileExists
                   << ": loaded as expected type :" << success;
@@ -316,14 +308,12 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   if (config_.overrideSceneLightDefaults) {
     lightSetupKey = config_.sceneLightSetup;
-    ESP_DEBUG() << "::createSceneInstance : Using config-specified "
-                   "Light key : -"
-                << lightSetupKey << "-";
+    ESP_DEBUG() << "Using config-specified Light key : -" << lightSetupKey
+                << "-";
   } else {
     lightSetupKey = metadataMediator_->getLightSetupFullHandle(
         curSceneInstanceAttributes->getLightingHandle());
-    ESP_DEBUG() << "::createSceneInstance : Using scene instance-specified "
-                   "Light key : -"
+    ESP_DEBUG() << "Using scene instance-specified Light key : -"
                 << lightSetupKey << "-";
     if (lightSetupKey != NO_LIGHT_KEY) {
       // lighting attributes corresponding to this key should exist unless it
@@ -380,8 +370,8 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // create a structure to manage active scene and active semantic scene ID
   // passing to and from loadStage
   std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};
-  ESP_DEBUG() << "::createSceneInstance : Start to load stage named :"
-              << stageAttributes->getHandle() << "with render asset :"
+  ESP_DEBUG() << "Start to load stage named :" << stageAttributes->getHandle()
+              << "with render asset :"
               << stageAttributes->getRenderAssetHandle()
               << "and collision asset :"
               << stageAttributes->getCollisionAssetHandle();
@@ -392,14 +382,11 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       config_.loadSemanticMesh, config_.forceSeparateSemanticSceneGraph);
 
   if (!loadSuccess) {
-    ESP_ERROR() << "::createSceneInstance : Cannot load stage :"
-                << stageAttributesHandle;
+    ESP_ERROR() << "Cannot load stage :" << stageAttributesHandle;
     // Pass the error to the python through pybind11 allowing graceful exit
-    throw std::invalid_argument("::createSceneInstance : Cannot load: " +
-                                stageAttributesHandle);
+    throw std::invalid_argument("Cannot load: " + stageAttributesHandle);
   } else {
-    ESP_DEBUG() << "::createSceneInstance : Successfully loaded stage "
-                   "named :"
+    ESP_DEBUG() << "Successfully loaded stage named :"
                 << stageAttributes->getHandle();
   }
 
@@ -433,8 +420,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
             stageAttributesHandle == assets::EMPTY_SCENE)) {
         // TODO: programmatic generation of semantic meshes when no
         // annotations are provided.
-        ESP_WARNING() << "\n---\nSimulator::createSceneInstance : The active "
-                         "scene does not contain semantic "
+        ESP_WARNING() << "\n---\nThe active scene does not contain semantic "
                          "annotations. \n---";
       }
     }
@@ -488,16 +474,13 @@ bool Simulator::instanceObjectsForActiveScene() {
            curSceneInstanceAttributes->getTranslationOrigin()) ==
        metadata::attributes::SceneInstanceTranslationOrigin::AssetLocal);
 
-  std::string errMsgTmplt =
-      "::createSceneInstance : Error instancing scene : " + activeSceneName +
-      " : ";
   // Iterate through instances, create object and implement initial
   // transformation.
   for (const auto& objInst : objectInstances) {
     const std::string objAttrFullHandle =
         metadataMediator_->getObjAttrFullHandle(objInst->getHandle());
     if (objAttrFullHandle == "") {
-      ESP_ERROR() << errMsgTmplt
+      ESP_ERROR() << "Error instancing scene :" << activeSceneName << ":"
                   << "Unable to find objectAttributes whose handle contains"
                   << objInst->getHandle()
                   << "as specified in object instance attributes.";
@@ -525,11 +508,6 @@ bool Simulator::instanceArticulatedObjectsForActiveScene() {
 
   // get lightSetupKey from the value set when stage was created.
   const std::string lightSetupKey = config_.sceneLightSetup;
-
-  std::string errMsgTmplt =
-      "Simulator::instanceArticulatedObjectsForActiveScene : Error instancing "
-      "articulated objects : " +
-      activeSceneName + " : ";
 
   // 6. Load all articulated object instances
   // Get all instances of articulated objects described in scene
@@ -822,8 +800,7 @@ bool Simulator::setNavMeshVisualization(bool visualize) {
     navMeshVisPrimID_ = resourceManager_->loadNavMeshVisualization(
         *pathfinder_, navMeshVisNode_, &drawables);
     if (navMeshVisPrimID_ == ID_UNDEFINED) {
-      ESP_ERROR() << "::toggleNavMeshVisualization : Failed to load "
-                     "navmesh visualization.";
+      ESP_ERROR() << "Failed to load navmesh visualization.";
       delete navMeshVisNode_;
     }
   }
@@ -859,8 +836,7 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
   bool success = resourceManager_->buildTrajectoryVisualization(
       trajVisName, uniquePts, numSegments, radius, color, smooth, numInterp);
   if (!success) {
-    ESP_ERROR() << "::showTrajectoryVisualization : Failed to create "
-                   "Trajectory visualization mesh for"
+    ESP_ERROR() << "Failed to create Trajectory visualization mesh for"
                 << trajVisName;
     return ID_UNDEFINED;
   }
@@ -876,17 +852,14 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
   auto trajVisID = physicsManager_->addObject(trajVisName, &drawables);
   if (trajVisID == ID_UNDEFINED) {
     // failed to add object - need to delete asset from resourceManager.
-    ESP_ERROR() << "::showTrajectoryVisualization : Failed to create "
-                   "Trajectory visualization object for"
+    ESP_ERROR() << "Failed to create Trajectory visualization object for"
                 << trajVisName;
     // TODO : support removing asset by removing from resourceDict_ properly
     // using trajVisName
     return ID_UNDEFINED;
   }
   auto trajObj = getRigidObjectManager()->getObjectCopyByID(trajVisID);
-  ESP_DEBUG() << "::showTrajectoryVisualization : Trajectory "
-                 "visualization object created with ID"
-              << trajVisID;
+  ESP_DEBUG() << "Trajectory visualization object created with ID" << trajVisID;
   trajObj->setMotionType(esp::physics::MotionType::KINEMATIC);
   // add to internal references of object ID and resourceDict name
   // this is for eventual asset deletion/resource freeing.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1002,8 +1002,8 @@ class Simulator {
    */
   bool removeTrajVisByName(const std::string& trajVisName) {
     if (trajVisIDByName.count(trajVisName) == 0) {
-      ESP_DEBUG() << "::removeTrajVisByName : No trajectory named"
-                  << trajVisName << "exists.  Ignoring.";
+      ESP_DEBUG() << "No trajectory named" << trajVisName
+                  << "exists.  Ignoring.";
       return false;
     }
     return removeTrajVisObjectAndAssets(trajVisIDByName.at(trajVisName),
@@ -1018,8 +1018,8 @@ class Simulator {
    */
   bool removeTrajVisByID(int trajVisObjID) {
     if (trajVisNameByID.count(trajVisObjID) == 0) {
-      ESP_DEBUG() << "::removeTrajVisByName : No trajectory object with ID:"
-                  << trajVisObjID << "exists.  Ignoring.";
+      ESP_DEBUG() << "No trajectory object with ID:" << trajVisObjID
+                  << "exists.  Ignoring.";
       return false;
     }
     return removeTrajVisObjectAndAssets(trajVisObjID,


### PR DESCRIPTION
## Motivation and Context
The new logging functionality printed log messages that were somewhat arcane, lacking source information outside of what subsystem/namespace the log was being printed from : 

`[Metadata] <Dataset>::createFromJsonOrDefaultInternal : Proposing JSON name : default.scene_dataset_config.json from original name : default | This file  does not exist.`

This PR improves this by adding the source file (without path), the line number and the source function within which the logging macro call was executed  :

`[Metadata] AttributesManagerBase.h(360)::createFromJsonOrDefaultInternal : <Dataset>: Proposing JSON name : default.scene_dataset_config.json from original name : default | This file  does not exist.` 

The majority of the other file changes are just removing the now redundant references to calling function names that were ubiquitous in the logging calls, particularly in the metadata subsystem, having been added to provide this functionality that was lacking in glog also.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing C++ and python tests pass locally.  Logging test was modified to match new output format.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
