### PR TITLE
[BUGFIX]Remove redundant method refs in log messages

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -214,8 +214,7 @@ bool ResourceManager::loadStage(
     AssetInfo semanticInfo = assetInfoMap.at("semantic");
     auto semanticStageFilename = semanticInfo.filepath;
     if (Cr::Utility::Directory::exists(semanticStageFilename)) {
-      ESP_DEBUG() << "::loadStage : Loading Semantic Stage mesh :"
-                  << semanticStageFilename;
+      ESP_DEBUG() << "Loading Semantic Stage mesh :" << semanticStageFilename;
       activeSemanticSceneID = sceneManagerPtr->initSceneGraph();
 
       auto& semanticSceneGraph =
@@ -241,21 +240,19 @@ bool ResourceManager::loadStage(
       // regardless of load failure, original code still changed
       // activeSemanticSceneID_
       if (!semanticStageSuccess) {
-        ESP_ERROR() << "::loadStage : Semantic Stage mesh "
-                       "load failed.";
+        ESP_ERROR() << "Semantic Stage mesh load failed.";
         return false;
       } else {
-        ESP_DEBUG() << "::loadStage : Semantic Stage mesh :"
-                    << semanticStageFilename << "loaded.";
+        ESP_DEBUG() << "Semantic Stage mesh :" << semanticStageFilename
+                    << "loaded.";
       }
     } else if (semanticStageFilename !=
                "") {  // semantic file name does not exist but house does
-      ESP_ERROR() << "::loadStage : Not loading semantic mesh - "
-                     "File Name :"
+      ESP_ERROR() << "Not loading semantic mesh with File Name :"
                   << semanticStageFilename << "does not exist.";
     }
   } else {  // not wanting to create semantic mesh
-    ESP_DEBUG() << "::loadStage : Not loading semantic mesh";
+    ESP_DEBUG() << "Not loading semantic mesh";
   }
 
   if (forceSeparateSemanticSceneGraph &&
@@ -283,8 +280,7 @@ bool ResourceManager::loadStage(
   }
   RenderAssetInstanceCreationInfo renderCreation(
       renderInfo.filepath, Cr::Containers::NullOpt, flags, renderLightSetupKey);
-  ESP_DEBUG() << "::loadStage : start load render asset" << renderInfo.filepath
-              << ".";
+  ESP_DEBUG() << "Start load render asset" << renderInfo.filepath << ".";
 
   bool renderMeshSuccess = loadStageInternal(renderInfo,  // AssetInfo
                                              &renderCreation,
@@ -292,8 +288,7 @@ bool ResourceManager::loadStage(
                                              &drawables);  //  drawable group
   if (!renderMeshSuccess) {
     ESP_ERROR()
-        << "ResourceManager::loadStage : Stage render mesh load failed, "
-           "Aborting scene initialization.";
+        << "Stage render mesh load failed, Aborting scene initialization.";
     return false;
   }
   // declare mesh group variable
@@ -302,8 +297,7 @@ bool ResourceManager::loadStage(
   if (assetInfoMap.count("collision") != 0u) {
     AssetInfo colInfo = assetInfoMap.at("collision");
     if (resourceDict_.count(colInfo.filepath) == 0) {
-      ESP_DEBUG() << "::loadStage : start load collision asset"
-                  << colInfo.filepath << ".";
+      ESP_DEBUG() << "Start load collision asset" << colInfo.filepath << ".";
       // will not reload if already present
       bool collisionMeshSuccess =
           loadStageInternal(colInfo,   // AssetInfo
@@ -312,8 +306,8 @@ bool ResourceManager::loadStage(
                             nullptr);  // drawable group
 
       if (!collisionMeshSuccess) {
-        ESP_ERROR() << "ResourceManager::loadStage : Stage collision mesh "
-                       "load failed.  Aborting scene initialization.";
+        ESP_ERROR() << "Stage collision mesh load failed.  Aborting scene "
+                       "initialization.";
         return false;
       }
     }
@@ -337,8 +331,7 @@ bool ResourceManager::loadStage(
     // we are using None-type physicsManager.
     bool sceneSuccess = _physicsManager->addStage(stageAttributes, meshGroup);
     if (!sceneSuccess) {
-      ESP_ERROR() << "::loadStage : Adding Stage"
-                  << stageAttributes->getHandle()
+      ESP_ERROR() << "Adding Stage" << stageAttributes->getHandle()
                   << "to PhysicsManager failed. Aborting scene initialization.";
       return false;
     }
@@ -372,7 +365,7 @@ bool ResourceManager::buildMeshGroups(
 
     // failure during build of collision mesh group
     if (!colMeshGroupSuccess) {
-      ESP_ERROR() << "::loadStage : Stage" << info.filepath
+      ESP_ERROR() << "Stage" << info.filepath
                   << "Collision mesh load failed. Aborting scene "
                      "initialization.";
       return false;
@@ -449,9 +442,7 @@ esp::geo::CoordinateFrame ResourceManager::buildFrameFromAttributes(
     esp::geo::CoordinateFrame frame{upEigen, frontEigen, originEigen};
     return frame;
   } else {
-    ESP_DEBUG() << "::buildFrameFromAttributes : Specified frame "
-                   "in Attributes :"
-                << attribs->getHandle()
+    ESP_DEBUG() << "Specified frame in Attributes :" << attribs->getHandle()
                 << "is not orthogonal, so returning default frame.";
     esp::geo::CoordinateFrame frame;
     return frame;
@@ -698,12 +689,11 @@ bool ResourceManager::loadStageInternal(
     DrawableGroup* drawables) {
   // scene mesh loading
   const std::string& filename = info.filepath;
-  ESP_DEBUG() << "::loadStageInternal : Attempting to load stage" << filename
-              << "";
+  ESP_DEBUG() << "Attempting to load stage" << filename << "";
   bool meshSuccess = true;
   if (info.filepath != EMPTY_SCENE) {
     if (!Cr::Utility::Directory::exists(filename)) {
-      ESP_ERROR() << "::loadStageInternal : Cannot find scene file" << filename;
+      ESP_ERROR() << "Cannot find scene file" << filename;
       meshSuccess = false;
     } else {
       if (info.type == AssetType::SUNCG_SCENE) {
@@ -735,7 +725,7 @@ bool ResourceManager::loadStageInternal(
       }
     }
   } else {
-    ESP_DEBUG() << "::loadStageInternal : Loading empty scene for" << filename;
+    ESP_DEBUG() << "Loading empty scene for" << filename;
     // EMPTY_SCENE (ie. "NONE") string indicates desire for an empty scene (no
     // scene mesh): welcome to the void
   }
@@ -760,8 +750,7 @@ bool ResourceManager::buildStageCollisionMeshGroup(
     if (rawMeshData == nullptr) {
       // means dynamic cast failed
       ESP_DEBUG()
-          << "::buildStageCollisionMeshGroup : "
-             "AssetInfo::AssetType "
+          << "AssetInfo::AssetType "
              "type error: unsupported mesh type, aborting. Try running "
              "without \"--enable-physics\" and consider logging an issue.";
       return false;
@@ -961,10 +950,9 @@ void ResourceManager::buildPrimitiveAssetData(
         primTemplateHandle);
     // if still null, fail.
     if (newTemplate == nullptr) {
-      ESP_ERROR()
-          << "::buildPrimitiveAssetData : Attempting to reference or build a "
-             "primitive template from an unknown/malformed handle :"
-          << primTemplateHandle << ".  Aborting";
+      ESP_ERROR() << "Attempting to reference or build a "
+                     "primitive template from an unknown/malformed handle :"
+                  << primTemplateHandle << ".  Aborting";
       return;
     }
     // we do not want a copy of the newly created template, but the actual
@@ -1458,8 +1446,7 @@ bool ResourceManager::buildTrajectoryVisualization(
     radius = .001;
   }
 
-  ESP_DEBUG() << "::loadTrajectoryVisualization : Calling "
-                 "trajectoryTubeSolid to build a tube named :"
+  ESP_DEBUG() << "Calling trajectoryTubeSolid to build a tube named :"
               << trajVisName << "with" << pts.size()
               << "points, building a tube of radius :" << radius << "using"
               << numSegments << "circular segments and" << numInterp
@@ -1469,8 +1456,7 @@ bool ResourceManager::buildTrajectoryVisualization(
   Cr::Containers::Optional<Mn::Trade::MeshData> trajTubeMesh =
       geo::buildTrajectoryTubeSolid(pts, numSegments, radius, smooth,
                                     numInterp);
-  ESP_DEBUG() << "::loadTrajectoryVisualization : Successfully "
-                 "returned from trajectoryTubeSolid";
+  ESP_DEBUG() << "Successfully returned from trajectoryTubeSolid";
 
   // make assetInfo
   AssetInfo info{AssetType::PRIMITIVE};

--- a/src/esp/gfx/BackgroundRenderer.cpp
+++ b/src/esp/gfx/BackgroundRenderer.cpp
@@ -111,8 +111,7 @@ void BackgroundRenderer::releaseContext() {
 
 int BackgroundRenderer::threadRender() {
   if (!threadOwnsContext_) {
-    ESP_VERY_VERBOSE()
-        << "BackgroundRenderer:: Background thread acquired GL Context";
+    ESP_VERY_VERBOSE() << "Background thread acquired GL Context";
     context_->makeCurrentPlatform();
     Mn::GL::Context::makeCurrent(threadContext_.get());
     threadOwnsContext_ = true;

--- a/src/esp/gfx/DebugLineRender.cpp
+++ b/src/esp/gfx/DebugLineRender.cpp
@@ -81,11 +81,8 @@ void DebugLineRender::setLineWidth(float lineWidth) {
   // This is derived from experiments with glLineWidth on Nvidia hardware.
   const float maxLineWidth = 20.f;
   if (lineWidth > maxLineWidth) {
-    ESP_WARNING() << "DebugLineRender::setLineWidth: requested lineWidth of"
-                  << lineWidth
-                  << "is greater than "
-                     "max supported width of"
-                  << maxLineWidth;
+    ESP_WARNING() << "Requested lineWidth of" << lineWidth
+                  << "is greater than max supported width of" << maxLineWidth;
     lineWidth = maxLineWidth;
   }
   _internalLineWidth = lineWidth / 2;  // see also DebugLineRender::flushLines

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -26,17 +26,14 @@ void Player::readKeyframesFromFile(const std::string& filepath) {
   close();
 
   if (!Corrade::Utility::Directory::exists(filepath)) {
-    ESP_ERROR() << "Player::readKeyframesFromFile: file" << filepath
-                << "not found.";
+    ESP_ERROR() << "File" << filepath << "not found.";
     return;
   }
   try {
     auto newDoc = esp::io::parseJsonFile(filepath);
     readKeyframesFromJsonDocument(newDoc);
   } catch (...) {
-    ESP_ERROR()
-        << "Player::readKeyframesFromFile: failed to parse keyframes from"
-        << filepath << ".";
+    ESP_ERROR() << "Failed to parse keyframes from" << filepath << ".";
   }
 }
 
@@ -112,9 +109,8 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     const auto& creation = pair.second;
     if (assetInfos_.count(creation.filepath) == 0u) {
       if (failedFilepaths_.count(creation.filepath) == 0u) {
-        ESP_WARNING() << "Player: missing asset info for ["
-                      << Mn::Debug::nospace << creation.filepath
-                      << Mn::Debug::nospace << "]";
+        ESP_WARNING() << "Missing asset info for [" << Mn::Debug::nospace
+                      << creation.filepath << Mn::Debug::nospace << "]";
         failedFilepaths_.insert(creation.filepath);
       }
       continue;
@@ -124,7 +120,7 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
         assetInfos_[creation.filepath], creation);
     if (!node) {
       if (failedFilepaths_.count(creation.filepath) == 0u) {
-        ESP_WARNING() << "Player: load failed for asset [" << Mn::Debug::nospace
+        ESP_WARNING() << "Load failed for asset [" << Mn::Debug::nospace
                       << creation.filepath << Mn::Debug::nospace << "]";
         failedFilepaths_.insert(creation.filepath);
       }

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -195,8 +195,7 @@ void Recorder::consolidateSavedKeyframes() {
 
 rapidjson::Document Recorder::writeKeyframesToJsonDocument() {
   if (savedKeyframes_.empty()) {
-    ESP_WARNING() << "Recorder::writeKeyframesToJsonDocument: no saved "
-                     "keyframes to write";
+    ESP_WARNING() << "No saved keyframes to write";
     return rapidjson::Document();
   }
 

--- a/src/esp/gfx/replay/ReplayManager.cpp
+++ b/src/esp/gfx/replay/ReplayManager.cpp
@@ -13,9 +13,8 @@ std::shared_ptr<Player> ReplayManager::readKeyframesFromFile(
   auto player = std::make_shared<Player>(playerCallback_);
   player->readKeyframesFromFile(filepath);
   if (player->getNumKeyframes() == 0) {
-    ESP_ERROR() << "ReplayManager::readKeyframesFromFile: failed to load any "
-                   "keyframes from ["
-                << Mn::Debug::nospace << filepath << Mn::Debug::nospace << "]";
+    ESP_ERROR() << "Failed to load any keyframes from [" << Mn::Debug::nospace
+                << filepath << Mn::Debug::nospace << "]";
     return nullptr;
   }
   return player;

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -201,27 +201,21 @@ bool MetadataMediator::setActiveSceneDatasetName(
   // first check if dataset exists/is loaded, if so then set as default
   if (sceneDatasetExists(sceneDatasetName)) {
     if (activeSceneDataset_ != sceneDatasetName) {
-      ESP_DEBUG() << "::setActiveSceneDatasetName : Previous "
-                     "active dataset"
-                  << activeSceneDataset_ << "changed to" << sceneDatasetName
-                  << "successfully.";
+      ESP_DEBUG() << "Previous active dataset" << activeSceneDataset_
+                  << "changed to" << sceneDatasetName << "successfully.";
       activeSceneDataset_ = sceneDatasetName;
     }
     return true;
   }
   // if does not exist, attempt to create it
-  ESP_DEBUG() << "::setActiveSceneDatasetName : Attempting to "
-                 "create new dataset"
-              << sceneDatasetName;
+  ESP_DEBUG() << "Attempting to create new dataset" << sceneDatasetName;
   bool success = createSceneDataset(sceneDatasetName);
   // if successfully created, set default name to access dataset attributes in
   // SceneDatasetAttributesManager
   if (success) {
     activeSceneDataset_ = sceneDatasetName;
   }
-  ESP_DEBUG() << "::setActiveSceneDatasetName : Attempt to "
-                 "create new dataset"
-              << sceneDatasetName << ""
+  ESP_DEBUG() << "Attempt to create new dataset" << sceneDatasetName << ""
               << (success ? " succeeded." : " failed.")
               << "Currently active dataset :" << activeSceneDataset_;
   return success;
@@ -233,8 +227,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // this should never happen
   if (datasetAttr == nullptr) {
-    ESP_ERROR() << "::getSceneAttributesByName : No dataset "
-                   "specified/exists.";
+    ESP_ERROR() << "No dataset specified/exists.";
     return nullptr;
   }
   // directory to look for attributes for this dataset
@@ -252,8 +245,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   if (sceneList.size() > 0) {
     // 1.  Existing, registered SceneAttributes in current active dataset.
     //    In this case the SceneAttributes is returned.
-    ESP_DEBUG() << "::getSceneAttributesByName : Query dataset :"
-                << activeSceneDataset_
+    ESP_DEBUG() << "Query dataset :" << activeSceneDataset_
                 << "for SceneAttributes named :" << sceneName << "yields"
                 << sceneList.size() << "candidates.  Using" << sceneList[0]
                 << ".";
@@ -266,8 +258,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
       // 2.  Existing, valid SceneAttributes file on disk, but not in dataset.
       //    If this is the case, then the SceneAttributes should be loaded,
       //    registered, added to the dataset and returned.
-      ESP_DEBUG() << "::getSceneAttributesByName : Dataset :"
-                  << activeSceneDataset_
+      ESP_DEBUG() << "Dataset :" << activeSceneDataset_
                   << "does not reference a SceneAttributes named" << sceneName
                   << "but a SceneAttributes config named"
                   << sceneFilenameCandidate
@@ -284,8 +275,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         //    In this case, a SceneAttributes is created amd registered using
         //    sceneName, referencing the StageAttributes of the same name; This
         //    sceneAttributes is returned.
-        ESP_DEBUG() << "::getSceneAttributesByName : No existing "
-                       "scene instance attributes containing name"
+        ESP_DEBUG() << "No existing scene instance attributes containing name"
                     << sceneName << "found in Dataset :" << activeSceneDataset_
                     << "but" << stageList.size()
                     << "StageAttributes found.  Using" << stageList[0]
@@ -302,7 +292,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         //    In this case, a stage attributes is loaded and registered, then
         //    added to current dataset, and then 3. is performed.
         ESP_DEBUG()
-            << "::getSceneAttributesByName : Dataset :" << activeSceneDataset_
+            << "Dataset :" << activeSceneDataset_
             << "has no preloaded SceneAttributes or StageAttributes named :"
             << sceneName
             << "so loading/creating a new StageAttributes with this "

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -203,7 +203,7 @@ class MetadataMediator {
   std::string getNavmeshPathByHandle(const std::string& navMeshHandle) {
     return getFilePathForHandle(navMeshHandle,
                                 getActiveDSAttribs()->getNavmeshMap(),
-                                "::getNavmeshPathByHandle");
+                                "<getNavmeshPathByHandle>");
 
   }  // MetadataMediator::getNavmeshPathByHandle
 
@@ -227,7 +227,7 @@ class MetadataMediator {
       const std::string& ssDescrHandle) {
     return getFilePathForHandle(
         ssDescrHandle, getActiveDSAttribs()->getSemanticSceneDescrMap(),
-        "::getSemanticSceneDescriptorPathByHandle");
+        "<getSemanticSceneDescriptorPathByHandle>");
 
   }  // MetadataMediator::getNavMeshPathByHandle
 
@@ -468,8 +468,7 @@ class MetadataMediator {
     // this should never happen - there will always be a dataset with the name
     // activeSceneDataset_
     if (datasetAttr == nullptr) {
-      ESP_ERROR() << "::getActiveDSAttribs : Unable to set "
-                     "active dataset due to Unknown dataset named"
+      ESP_ERROR() << "Unable to set active dataset due to Unknown dataset named"
                   << activeSceneDataset_
                   << "so changing dataset to \"default\".";
       activeSceneDataset_ = "default";

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -353,8 +353,7 @@ TEST(GfxReplayTest, playerReadInvalidFile) {
   // remove bogus file created for this test
   bool success = Corrade::Utility::Directory::rm(testFilepath);
   if (!success) {
-    ESP_WARNING() << "GfxReplayTest::playerReadInvalidFile : unable to remove "
-                     "temporary test JSON file"
+    ESP_WARNING() << "Unable to remove temporary test JSON file"
                   << testFilepath;
   }
 }
@@ -422,8 +421,7 @@ TEST(GfxReplayTest, simulatorIntegration) {
   // remove file created for this test
   bool success = Corrade::Utility::Directory::rm(testFilepath);
   if (!success) {
-    ESP_WARNING() << "GfxReplayTest::simulatorIntegration : unable to remove "
-                     "temporary test JSON file"
+    ESP_WARNING() << "Unable to remove temporary test JSON file"
                   << testFilepath;
   }
 }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1044,7 +1044,7 @@ int Viewer::addPrimitiveObject() {
 
 void Viewer::buildTrajectoryVis() {
   if (agentLocs_.size() < 2) {
-    ESP_WARNING() << "::buildTrajectoryVis : No recorded trajectory "
+    ESP_WARNING() << "No recorded trajectory "
                      "points, so nothing to build. Aborting.";
     return;
   }
@@ -1056,18 +1056,17 @@ void Viewer::buildTrajectoryVis() {
           << agentLocs_.size() << "_pts";
   std::string trajObjName(tmpName.str());
 
-  ESP_DEBUG() << "::buildTrajectoryVis : Attempting to build trajectory "
+  ESP_DEBUG() << "Attempting to build trajectory "
                  "tube for :"
               << agentLocs_.size() << "points.";
   int trajObjID = simulator_->addTrajectoryObject(
       trajObjName, agentLocs_, 6, agentTrajRad_, color, true, 10);
   if (trajObjID != esp::ID_UNDEFINED) {
-    ESP_DEBUG() << "::buildTrajectoryVis : Success!  Traj Obj Name :"
-                << trajObjName << "has object ID :" << trajObjID;
+    ESP_DEBUG() << "Success!  Traj Obj Name :" << trajObjName
+                << "has object ID :" << trajObjID;
   } else {
-    ESP_WARNING() << "::buildTrajectoryVis : Attempt to build trajectory "
-                     "visualization"
-                  << trajObjName << "failed; Returned ID_UNDEFINED.";
+    ESP_WARNING() << "Attempt to build trajectory visualization" << trajObjName
+                  << "failed; Returned ID_UNDEFINED.";
   }
 }  // buildTrajectoryVis
 


### PR DESCRIPTION
## Motivation and Context
With the most recent logging functionality, filename, source function, and line number for logging message is provided automatically.  This PR removes some remaining log messages that were also including this information, which is now redundant.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally, c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
