### PR TITLE
Modify ResourceManager::loadStage to receive SceneObjectInstance for stage, and consume MM instead of arguments.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -192,9 +192,18 @@ bool ResourceManager::loadStage(
     StageAttributes::ptr& stageAttributes,
     const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
     esp::scene::SceneManager* sceneManagerPtr,
-    std::vector<int>& activeSceneIDs,
-    bool createSemanticMesh,
-    bool forceSeparateSemanticSceneGraph) {
+    std::vector<int>& activeSceneIDs) {
+  // If the semantic mesh should be created, based on SimulatorConfiguration
+  bool createSemanticMesh =
+      metadataMediator_->getSimulatorConfiguration().loadSemanticMesh;
+
+  // Force creation of a separate semantic scene graph, even when no semantic
+  // mesh is loaded for the stage.  This is required to support playback of any
+  // replay that includes a semantic-only render asset instance.
+  bool forceSeparateSemanticSceneGraph =
+      metadataMediator_->getSimulatorConfiguration()
+          .forceSeparateSemanticSceneGraph;
+
   // create AssetInfos here for each potential mesh file for the scene, if they
   // are unique.
   bool buildCollisionMesh =

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -75,6 +75,7 @@ using metadata::attributes::AbstractObjectAttributes;
 using metadata::attributes::CubePrimitiveAttributes;
 using metadata::attributes::ObjectAttributes;
 using metadata::attributes::PhysicsManagerAttributes;
+using metadata::attributes::SceneObjectInstanceAttributes;
 using metadata::attributes::StageAttributes;
 using metadata::managers::AssetAttributesManager;
 using metadata::managers::ObjectAttributesManager;
@@ -190,7 +191,8 @@ void ResourceManager::initPhysicsManager(
 }  // ResourceManager::initPhysicsManager
 
 bool ResourceManager::loadStage(
-    StageAttributes::ptr& stageAttributes,
+    const StageAttributes::ptr& stageAttributes,
+    const SceneObjectInstanceAttributes::ptr& stageInstanceAttributes,
     const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
     esp::scene::SceneManager* sceneManagerPtr,
     std::vector<int>& activeSceneIDs) {
@@ -339,7 +341,8 @@ bool ResourceManager::loadStage(
     // Either add with pre-built meshGroup if collision assets are loaded
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
-    bool sceneSuccess = _physicsManager->addStage(stageAttributes, meshGroup);
+    bool sceneSuccess = _physicsManager->addStage(
+        stageAttributes, stageInstanceAttributes, meshGroup);
     if (!sceneSuccess) {
       ESP_ERROR() << "Adding Stage" << stageAttributes->getHandle()
                   << "to PhysicsManager failed. Aborting scene initialization.";

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -150,10 +150,11 @@ void ResourceManager::initDefaultPrimAttributes() {
 
 void ResourceManager::initPhysicsManager(
     std::shared_ptr<physics::PhysicsManager>& physicsManager,
-    bool isEnabled,
     scene::SceneNode* parent,
     const metadata::attributes::PhysicsManagerAttributes::ptr&
         physicsManagerAttributes) {
+  const bool isEnabled =
+      metadataMediator_->getSimulatorConfiguration().enablePhysics;
   //! PHYSICS INIT: Use the passed attributes to initialize physics engine
   bool defaultToNoneSimulator = true;
   if (isEnabled) {
@@ -194,13 +195,13 @@ bool ResourceManager::loadStage(
     esp::scene::SceneManager* sceneManagerPtr,
     std::vector<int>& activeSceneIDs) {
   // If the semantic mesh should be created, based on SimulatorConfiguration
-  bool createSemanticMesh =
+  const bool createSemanticMesh =
       metadataMediator_->getSimulatorConfiguration().loadSemanticMesh;
 
   // Force creation of a separate semantic scene graph, even when no semantic
   // mesh is loaded for the stage.  This is required to support playback of any
   // replay that includes a semantic-only render asset instance.
-  bool forceSeparateSemanticSceneGraph =
+  const bool forceSeparateSemanticSceneGraph =
       metadataMediator_->getSimulatorConfiguration()
           .forceSeparateSemanticSceneGraph;
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -181,21 +181,13 @@ class ResourceManager {
    * parent node.
    * @param [out] activeSceneIDs active scene ID is in idx 0, if semantic scene
    * is made, its activeID should be pushed onto vector
-   * @param createSemanticMesh If the semantic mesh should be created, based on
-   * @ref SimulatorConfiguration
-   * @param forceSeparateSemanticSceneGraph Force creation of a separate
-   * semantic scene graph, even when no semantic mesh is loaded for the stage.
-   * This is required to support playback of any replay that includes a
-   * semantic-only render asset instance.
    * @return Whether or not the scene load succeeded.
    */
   bool loadStage(
       metadata::attributes::StageAttributes::ptr& sceneAttributes,
       const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
       esp::scene::SceneManager* sceneManagerPtr,
-      std::vector<int>& activeSceneIDs,
-      bool createSemanticMesh,
-      bool forceSeparateSemanticSceneGraph = false);
+      std::vector<int>& activeSceneIDs);
 
   /**
    * @brief Construct scene collision mesh group based on name and type of

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -171,8 +171,11 @@ class ResourceManager {
    * If parent and drawables are not specified, the assets are loaded, but no
    * new @ref gfx::Drawable is added for the scene (i.e. it will not be
    * rendered).
-   * @param sceneAttributes The @ref StageAttributes that describes the
-   * scene
+   * @param stageAttributes The @ref StageAttributes that describes the
+   * stage
+   * @param stageInstanceAttributes The @ref SceneObjectInstanceAttributes that
+   * describes this particular instance of the stage.  If nullptr then not
+   * created by SceneInstanceAttributes.
    * @param _physicsManager The currently defined @ref physics::PhysicsManager.
    * @param sceneManagerPtr Pointer to scene manager, to fetch drawables and
    * parent node.
@@ -181,7 +184,9 @@ class ResourceManager {
    * @return Whether or not the scene load succeeded.
    */
   bool loadStage(
-      metadata::attributes::StageAttributes::ptr& sceneAttributes,
+      const metadata::attributes::StageAttributes::ptr& stageAttributes,
+      const metadata::attributes::SceneObjectInstanceAttributes::ptr&
+          stageInstanceAttributes,
       const std::shared_ptr<physics::PhysicsManager>& _physicsManager,
       esp::scene::SceneManager* sceneManagerPtr,
       std::vector<int>& activeSceneIDs);
@@ -537,7 +542,7 @@ class ResourceManager {
    * and return it
    *
    * @param attribs the attributes to query for the information.
-   * @param origin Either the origin of the sceneAttributes or the COM value of
+   * @param origin Either the origin of the stageAttributes or the COM value of
    * the objectAttributes.
    * @return the coordinate frame of the assets the passed attributes describes.
    */

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -152,8 +152,6 @@ class ResourceManager {
    * attributes
    * @param physicsManager The currently defined @ref physics::PhysicsManager.
    * Will be reseated to the specified physics implementation.
-   * @param isEnabled Whether this PhysicsManager is enabled or not.  Takes the
-   * place of old checks for nullptr.
    * @param parent The @ref scene::SceneNode of which the scene mesh will be
    * added as a child. Typically near the root of the scene. Expected to be
    * static.
@@ -162,7 +160,6 @@ class ResourceManager {
    */
   void initPhysicsManager(
       std::shared_ptr<physics::PhysicsManager>& physicsManager,
-      bool isEnabled,
       scene::SceneNode* parent,
       const metadata::attributes::PhysicsManagerAttributes::ptr&
           physicsManagerAttributes);

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -172,8 +172,7 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
   if (physicsAttributesManager_->getObjectLibHasHandle(
           _physicsManagerAttributesPath)) {
     if (currPhysicsManagerAttributes_ != _physicsManagerAttributesPath) {
-      ESP_DEBUG() << "::setCurrPhysicsAttributesHandle : Old "
-                     "physics manager attributes"
+      ESP_DEBUG() << "Old physics manager attributes"
                   << currPhysicsManagerAttributes_ << "changed to"
                   << _physicsManagerAttributesPath << "successfully.";
       currPhysicsManagerAttributes_ = _physicsManagerAttributesPath;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -52,6 +52,8 @@ PhysicsManager::~PhysicsManager() {
 
 bool PhysicsManager::addStage(
     const metadata::attributes::StageAttributes::ptr& initAttributes,
+    const metadata::attributes::SceneObjectInstanceAttributes::ptr&
+        stageInstanceAttributes,
     const std::vector<assets::CollisionMeshData>& meshGroup) {
   // Test Mesh primitive is valid
   for (const assets::CollisionMeshData& meshData : meshGroup) {
@@ -60,16 +62,24 @@ bool PhysicsManager::addStage(
     }
   }
 
-  //! Initialize scene
+  //! Initialize stage
   bool sceneSuccess = addStageFinalize(initAttributes);
+  // add/merge stageInstanceAttributes' copy of user_attributes.
+  if (!stageInstanceAttributes) {
+    ESP_DEBUG() << "Stage built from StageInstanceAttributes";
+    // TODO merge instance attributes into staticStageObject_'s existing
+    // attributes
+  }
+  // TODO process any stage transformations here from stageInstanceAttributes
+
   return sceneSuccess;
 }  // PhysicsManager::addStage
 
 bool PhysicsManager::addStageFinalize(
     const metadata::attributes::StageAttributes::ptr& initAttributes) {
-  //! Initialize scene
-  bool sceneSuccess = staticStageObject_->initialize(initAttributes);
-  return sceneSuccess;
+  //! Initialize stage
+  bool stageSuccess = staticStageObject_->initialize(initAttributes);
+  return stageSuccess;
 }  // PhysicsManager::addStageFinalize
 
 int PhysicsManager::addObjectInstance(

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -252,11 +252,15 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @param initAttributes The attributes structure defining physical
    * properties of the scene.  Must be a copy of the attributes stored in the
    * Attributes Manager.
+   * @param stageInstanceAttributes The stage instance attributes that was used
+   * to create this stage. Might be empty.
    * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
   bool addStage(
       const metadata::attributes::StageAttributes::ptr& initAttributes,
+      const metadata::attributes::SceneObjectInstanceAttributes::ptr&
+          stageInstanceAttributes,
       const std::vector<assets::CollisionMeshData>& meshGroup);
 
   /**

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -83,7 +83,7 @@ bool BulletPhysicsManager::initPhysicsFinalize() {
 // https://github.com/mosra/magnum-integration/issues/20
 bool BulletPhysicsManager::addStageFinalize(
     const metadata::attributes::StageAttributes::ptr& initAttributes) {
-  //! Initialize scene
+  //! Initialize BulletRigidStage
   bool sceneSuccess = staticStageObject_->initialize(initAttributes);
 
   return sceneSuccess;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -384,8 +384,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   // Load stage
   bool loadSuccess = resourceManager_->loadStage(
-      stageAttributes, physicsManager_, sceneManager_.get(), tempIDs,
-      config_.loadSemanticMesh, config_.forceSeparateSemanticSceneGraph);
+      stageAttributes, physicsManager_, sceneManager_.get(), tempIDs);
 
   if (!loadSuccess) {
     ESP_ERROR() << "Cannot load stage :" << stageAttributesHandle;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -421,7 +421,8 @@ bool Simulator::instanceStageForActiveScene(
 
   // Load stage
   bool loadSuccess = resourceManager_->loadStage(
-      stageAttributes, physicsManager_, sceneManager_.get(), tempIDs);
+      stageAttributes, stageInstanceAttributes, physicsManager_,
+      sceneManager_.get(), tempIDs);
 
   if (!loadSuccess) {
     ESP_ERROR() << "Cannot load stage :" << stageAttributesHandle;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -235,7 +235,7 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
           curSceneInstanceAttributes->getSemanticSceneHandle());
 
   if (semanticSceneDescFilename != "") {
-    std::string filenameToUse = semanticSceneDescFilename;
+    const std::string& filenameToUse = semanticSceneDescFilename;
     bool success = false;
     // semantic scene descriptor might not exist, so
     semanticScene_ = nullptr;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -478,7 +478,7 @@ bool Simulator::instanceObjectsForActiveScene(
 
   // node to attach object to
   scene::SceneNode* attachmentNode = nullptr;
-  int objID = 0;
+  // int objID = 0;
 
   // whether or not to correct for COM shift - only do for blender-sourced
   // scene attributes
@@ -501,9 +501,10 @@ bool Simulator::instanceObjectsForActiveScene(
       return false;
     }
 
-    objID = physicsManager_->addObjectInstance(
-        objInst, objAttrFullHandle, defaultCOMCorrection, attachmentNode,
-        config_.sceneLightSetup);
+    // objID =
+    physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
+                                       defaultCOMCorrection, attachmentNode,
+                                       config_.sceneLightSetup);
   }  // for each object attributes
   return true;
 }  // Simulator::instanceObjectsForActiveScene()
@@ -516,7 +517,7 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
   const std::vector<SceneAOInstanceAttributes::ptr> artObjInstances =
       curSceneInstanceAttributes->getArticulatedObjectInstances();
 
-  int aoID = 0;
+  // int aoID = 0;
   auto& drawables = getDrawableGroup();
   // Iterate through instances, create object and implement initial
   // transformation.
@@ -527,8 +528,9 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
             artObjInst->getHandle());
 
     // create articulated object
-    aoID = physicsManager_->addArticulatedObjectInstance(
-        artObjFilePath, artObjInst, config_.sceneLightSetup);
+    // aoID =
+    physicsManager_->addArticulatedObjectInstance(artObjFilePath, artObjInst,
+                                                  config_.sceneLightSetup);
   }  // for each articulated object instance
   return true;
 }  // Simulator::instanceArticulatedObjectsForActiveScene

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1028,6 +1028,17 @@ class Simulator {
 
  protected:
   /**
+   * @brief if Navemesh visualization is active, reset the visualization.
+   */
+  void resetNavMeshVisIfActive() {
+    if (isNavMeshVisualizationActive()) {
+      // if updating pathfinder_ instance, refresh the visualization.
+      setNavMeshVisualization(false);  // first clear the old instance
+      setNavMeshVisualization(true);
+    }
+  }
+
+  /**
    * @brief Internal use only. Remove a trajectory object, its mesh, and all
    * references to it.
    * @param trajVisObjID The object ID of the trajectory visualization to
@@ -1324,16 +1335,6 @@ class Simulator {
    * @return Whether successful or not.
    */
   bool createSceneInstance(const std::string& activeSceneName);
-
-  /**
-   * @brief Builds a scene instance based on @ref
-   * esp::metadata::attributes::SceneAttributes referenced by @p activeSceneName
-   * . This function is specifically for cases where no renderer is desired.
-   * @param activeSceneName The name of the desired SceneAttributes to use to
-   * instantiate a scene.
-   * @return Whether successful or not.
-   */
-  bool createSceneInstanceNoRenderer(const std::string& activeSceneName);
 
   /**
    * @brief Shared initial functionality for creating/setting the current scene

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1348,19 +1348,38 @@ class Simulator {
       const std::string& activeSceneName);
 
   /**
+   * @brief Instance the stage for the current scene based on the current active
+   * schene's scene instance configuration.
+   * @param curSceneInstanceAttributes The attributes describing the current
+   * scene instance.
+   * @return whether stage creation is completed successfully
+   */
+  bool instanceStageForActiveScene(
+      const metadata::attributes::SceneAttributes::cptr&
+          curSceneInstanceAttributes);
+
+  /**
    * @brief Instance all the objects in the scene based on the current active
    * schene's scene instance configuration.
+   * @param curSceneInstanceAttributes The attributes describing the current
+   * scene instance.
    * @return whether object creation and placement is completed successfully
    */
-  bool instanceObjectsForActiveScene();
+  bool instanceObjectsForActiveScene(
+      const metadata::attributes::SceneAttributes::cptr&
+          curSceneInstanceAttributes);
 
   /**
    * @brief Instance all the articulated objects in the scene based on the
    * current active schene's scene instance configuration.
+   * @param curSceneInstanceAttributes The attributes describing the current
+   * scene instance.
    * @return whether articulated object creation and placement is completed
    * successfully
    */
-  bool instanceArticulatedObjectsForActiveScene();
+  bool instanceArticulatedObjectsForActiveScene(
+      const metadata::attributes::SceneAttributes::cptr&
+          curSceneInstanceAttributes);
 
   /**
    * @brief sample a random valid AgentState in passed agentState

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -83,7 +83,7 @@ int CullingTest::setupTests() {
   int sceneID = sceneManager_->initSceneGraph();
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager_->loadStage(stageAttributes, nullptr,
+  bool result = resourceManager_->loadStage(stageAttributes, nullptr, nullptr,
                                             sceneManager_.get(), tempIDs);
   CORRADE_VERIFY(result);
   return sceneID;

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -61,6 +61,9 @@ CullingTest::CullingTest() {
 int CullingTest::setupTests() {
   // set up a default simulation config to initialize MM
   auto cfg = esp::sim::SimulatorConfiguration{};
+  // setting values for stage load
+  cfg.loadSemanticMesh = false;
+  cfg.forceSeparateSemanticSceneGraph = false;
   auto MM = MetadataMediator::create(cfg);
   // must declare these in this order due to avoid deallocation errors
   if (!resourceManager_) {
@@ -80,8 +83,8 @@ int CullingTest::setupTests() {
   int sceneID = sceneManager_->initSceneGraph();
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager_->loadStage(
-      stageAttributes, nullptr, sceneManager_.get(), tempIDs, false);
+  bool result = resourceManager_->loadStage(stageAttributes, nullptr,
+                                            sceneManager_.get(), tempIDs);
   CORRADE_VERIFY(result);
   return sceneID;
 }

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -74,7 +74,7 @@ DrawableTest::DrawableTest() {
   drawableGroup_ = &sceneGraph.getDrawables();
 
   std::vector<int> tempIDs{sceneID_, esp::ID_UNDEFINED};
-  bool result = resourceManager_->loadStage(stageAttributes, nullptr,
+  bool result = resourceManager_->loadStage(stageAttributes, nullptr, nullptr,
                                             &sceneManager_, tempIDs);
 }
 

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -56,6 +56,9 @@ struct DrawableTest : Cr::TestSuite::Tester {
 
 DrawableTest::DrawableTest() {
   auto cfg = esp::sim::SimulatorConfiguration{};
+  // setting values for stage load
+  cfg.loadSemanticMesh = false;
+  cfg.forceSeparateSemanticSceneGraph = false;
   auto MM = MetadataMediator::create(cfg);
   resourceManager_ = std::make_unique<ResourceManagerExtended>(MM);
   //clang-format off
@@ -72,7 +75,7 @@ DrawableTest::DrawableTest() {
 
   std::vector<int> tempIDs{sceneID_, esp::ID_UNDEFINED};
   bool result = resourceManager_->loadStage(stageAttributes, nullptr,
-                                            &sceneManager_, tempIDs, false);
+                                            &sceneManager_, tempIDs);
 }
 
 void DrawableTest::addRemoveDrawables() {

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -46,6 +46,7 @@ class PhysicsManagerTest : public testing::TestWithParam<bool> {
     // setting values for stage load
     cfg.loadSemanticMesh = false;
     cfg.forceSeparateSemanticSceneGraph = false;
+    cfg.enablePhysics = true;
     metadataMediator_ = MetadataMediator::create(cfg);
     resourceManager_ = std::make_unique<ResourceManager>(metadataMediator_);
     if (createRenderer) {
@@ -74,7 +75,7 @@ class PhysicsManagerTest : public testing::TestWithParam<bool> {
     auto stageAttributes = stageAttributesMgr->createObject(stageFile, true);
 
     // construct physics manager based on specifications in attributes
-    resourceManager_->initPhysicsManager(physicsManager_, true, &rootNode,
+    resourceManager_->initPhysicsManager(physicsManager_, &rootNode,
                                          physicsManagerAttributes);
 
     // load scene

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -80,7 +80,7 @@ class PhysicsManagerTest : public testing::TestWithParam<bool> {
 
     // load scene
     std::vector<int> tempIDs{sceneID_, esp::ID_UNDEFINED};
-    resourceManager_->loadStage(stageAttributes, physicsManager_,
+    resourceManager_->loadStage(stageAttributes, nullptr, physicsManager_,
                                 &sceneManager_, tempIDs);
 
     rigidObjectManager_ = physicsManager_->getRigidObjectManager();

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -43,6 +43,9 @@ class PhysicsManagerTest : public testing::TestWithParam<bool> {
   void resetCreateRendererFlag(bool createRenderer) {
     auto cfg = esp::sim::SimulatorConfiguration{};
     cfg.createRenderer = createRenderer;
+    // setting values for stage load
+    cfg.loadSemanticMesh = false;
+    cfg.forceSeparateSemanticSceneGraph = false;
     metadataMediator_ = MetadataMediator::create(cfg);
     resourceManager_ = std::make_unique<ResourceManager>(metadataMediator_);
     if (createRenderer) {
@@ -77,7 +80,7 @@ class PhysicsManagerTest : public testing::TestWithParam<bool> {
     // load scene
     std::vector<int> tempIDs{sceneID_, esp::ID_UNDEFINED};
     resourceManager_->loadStage(stageAttributes, physicsManager_,
-                                &sceneManager_, tempIDs, false);
+                                &sceneManager_, tempIDs);
 
     rigidObjectManager_ = physicsManager_->getRigidObjectManager();
   }

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -51,7 +51,7 @@ TEST(ResourceManagerTest, createJoinedCollisionMesh) {
   const esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager.loadStage(stageAttributes, nullptr,
+  bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
                                           &sceneManager_, tempIDs);
 
   esp::assets::MeshData::uptr joinedBox =
@@ -123,7 +123,7 @@ TEST(ResourceManagerTest, VHACDUsageTest) {
       esp::assets::AssetInfo::fromPath(donutFile);
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager.loadStage(stageAttributes, nullptr,
+  bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
                                           &sceneManager_, tempIDs);
 
   esp::assets::MeshData::uptr joinedBox =

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -32,7 +32,11 @@ TEST(ResourceManagerTest, createJoinedCollisionMesh) {
   std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
 
   // must declare these in this order due to avoid deallocation errors
-  auto MM = MetadataMediator::create();
+  auto cfg = esp::sim::SimulatorConfiguration{};
+  // setting values for stage load
+  cfg.loadSemanticMesh = false;
+  cfg.forceSeparateSemanticSceneGraph = false;
+  auto MM = MetadataMediator::create(cfg);
   ResourceManager resourceManager(MM);
   SceneManager sceneManager_;
   auto stageAttributesMgr = MM->getStageAttributesManager();
@@ -48,7 +52,7 @@ TEST(ResourceManagerTest, createJoinedCollisionMesh) {
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
   bool result = resourceManager.loadStage(stageAttributes, nullptr,
-                                          &sceneManager_, tempIDs, false);
+                                          &sceneManager_, tempIDs);
 
   esp::assets::MeshData::uptr joinedBox =
       resourceManager.createJoinedCollisionMesh(boxFile);

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -100,7 +100,12 @@ TEST(ResourceManagerTest, VHACDUsageTest) {
   std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
 
   // must declare these in this order due to avoid deallocation errors
-  auto MM = MetadataMediator::create();
+  // must declare these in this order due to avoid deallocation errors
+  auto cfg = esp::sim::SimulatorConfiguration{};
+  // setting values for stage load
+  cfg.loadSemanticMesh = false;
+  cfg.forceSeparateSemanticSceneGraph = false;
+  auto MM = MetadataMediator::create(cfg);
   ResourceManager resourceManager(MM);
   SceneManager sceneManager_;
   auto stageAttributesMgr = MM->getStageAttributesManager();
@@ -119,7 +124,7 @@ TEST(ResourceManagerTest, VHACDUsageTest) {
 
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
   bool result = resourceManager.loadStage(stageAttributes, nullptr,
-                                          &sceneManager_, tempIDs, false);
+                                          &sceneManager_, tempIDs);
 
   esp::assets::MeshData::uptr joinedBox =
       resourceManager.createJoinedCollisionMesh(donutFile);


### PR DESCRIPTION
## Motivation and Context
This small PR changes the argument list for loadStage to remove createSemanticMesh and forceSeparateSemanticSceneGraph, and instead query the MetadataMediator's copy of simConfig for these values, which is always synced with Simulator and always the most relevant/pertinent simConfig whenever a scene's assets are loaded. 

This PR also passes the SceneObjectInstance attributes to loadStage so that (in a future PR) the stage can have transformations performed during creation (if required) and per-instance user defined attributes metadata merged with existing user attributes data.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local C++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
