### PR TITLE
[BUGFIX] Do not set orientation based on file ext if default attributes provided, overrides default config for orientation.

### DIFF
--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -292,7 +292,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
           ESP_WARNING()
-              << "\"" << tag
+              << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
               << ".default_attributes\" cell in JSON config unable to "
                  "be parsed to set default attributes so skipping.";
         } else {
@@ -307,8 +307,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
-            ESP_DEBUG()
-                << "\"" << tag
+            ESP_WARNING()
+                << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
                 << ".default_attributes\" set in Attributes Manager from JSON.";
           }
         }  // if is an object
@@ -319,7 +319,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
           ESP_WARNING()
-              << "\"" << tag
+              << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
               << ".paths\" cell in JSON config unable to be parsed as "
                  "a JSON object to determine search paths so skipping.";
         } else {

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -164,7 +164,8 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
   // copy
   StageAttributes::ptr newAttributes =
       this->constructFromDefault(attributesHandle);
-  if (nullptr == newAttributes) {
+  bool createNewAttributes = (nullptr == newAttributes);
+  if (createNewAttributes) {
     newAttributes = StageAttributes::create(attributesHandle);
   }
   // attempt to set source directory if exists
@@ -213,8 +214,8 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
     // from AssetInfo::fromPath
     // set defaults for passed render asset handles
     StageAttributesManager::setDefaultAssetNameBasedAttributes(
-        newAttributes, true, newAttributes->getRenderAssetHandle(),
-        [newAttributes](auto&& PH1) {
+        newAttributes, createNewAttributes,
+        newAttributes->getRenderAssetHandle(), [newAttributes](auto&& PH1) {
           newAttributes->setRenderAssetType(std::forward<decltype(PH1)>(PH1));
         });
     // set defaults for passed collision asset handles


### PR DESCRIPTION
## Motivation and Context
This PR fixes an issue when someone loads an asset with a particular extension that we have hardcoded internally to have a certain orientation (for backwards compatibility).  If the desired asset does not have that orientation, it is impossible to set the orientation via default attributes settings in scene dataset configuration file.  

This fix is a stopgap measure for now, and should work mostly, but the only foolproof solution to this is going to be getting rid of the hardcoded asset setting based on extension.  As we get more dataset assets, we cannot assume anything orientation-wise about assets solely on their extension.  To do this, we need to rework the tests to use config-backed assets.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
