### PR TITLE
[Bugfix]Clean up '0-as-null pointer' warnings

### DIFF
--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -68,7 +68,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    */
   ManagedFileIOPtr createObjectFromJSONFile(const std::string& filename,
                                             bool registerObject = true) {
-    io::JsonDocument docConfig = nullptr;
+    std::shared_ptr<io::JsonDocument> docConfig{};
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
@@ -78,7 +78,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
       return nullptr;
     }
     // convert doc to const value
-    const io::JsonGenericValue config = docConfig.GetObject();
+    const io::JsonGenericValue config = docConfig->GetObject();
     ManagedFileIOPtr attr = this->buildManagedObjectFromDoc(filename, config);
     return this->postCreateRegister(attr, registerObject);
   }  // ManagedFileBasedContainer::createObjectFromJSONFile
@@ -136,13 +136,13 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    * no appropriate specialization exists for passed type of document.
    *
    * @tparam type of document
-   * @param filename name of potentia document to load
+   * @param filename name of potential document to load
    * @param resDoc a reference to the document to be parsed.
    * @return whether document has been loaded successfully or not
    */
   template <class U>
   bool verifyLoadDocument(const std::string& filename,
-                          CORRADE_UNUSED U& resDoc) {
+                          CORRADE_UNUSED std::shared_ptr<U>& resDoc) {
     // by here always fail
     ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
                 << Magnum::Debug::nospace << "> : File" << filename
@@ -158,7 +158,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    * @return whether document has been loaded successfully or not
    */
   bool verifyLoadDocument(const std::string& filename,
-                          io::JsonDocument& jsonDoc);
+                          std::shared_ptr<io::JsonDocument>& jsonDoc);
 
   /**
    * @brief Will build a new file name for @p filename by replacing the existing
@@ -223,10 +223,10 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
 template <class T, ManagedObjectAccess Access>
 bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
     const std::string& filename,
-    io::JsonDocument& jsonDoc) {
+    std::shared_ptr<io::JsonDocument>& jsonDoc) {
   if (isValidFileName(filename)) {
     try {
-      jsonDoc = io::parseJsonFile(filename);
+      jsonDoc = std::make_shared<io::JsonDocument>(io::parseJsonFile(filename));
     } catch (...) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
                   << Magnum::Debug::nospace << "> : Failed to parse" << filename

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -68,7 +68,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    */
   ManagedFileIOPtr createObjectFromJSONFile(const std::string& filename,
                                             bool registerObject = true) {
-    std::shared_ptr<io::JsonDocument> docConfig{};
+    std::unique_ptr<io::JsonDocument> docConfig{};
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
@@ -142,7 +142,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    */
   template <class U>
   bool verifyLoadDocument(const std::string& filename,
-                          CORRADE_UNUSED std::shared_ptr<U>& resDoc) {
+                          CORRADE_UNUSED std::unique_ptr<U>& resDoc) {
     // by here always fail
     ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
                 << Magnum::Debug::nospace << "> : File" << filename
@@ -158,7 +158,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    * @return whether document has been loaded successfully or not
    */
   bool verifyLoadDocument(const std::string& filename,
-                          std::shared_ptr<io::JsonDocument>& jsonDoc);
+                          std::unique_ptr<io::JsonDocument>& jsonDoc);
 
   /**
    * @brief Will build a new file name for @p filename by replacing the existing
@@ -223,10 +223,10 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
 template <class T, ManagedObjectAccess Access>
 bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
     const std::string& filename,
-    std::shared_ptr<io::JsonDocument>& jsonDoc) {
+    std::unique_ptr<io::JsonDocument>& jsonDoc) {
   if (isValidFileName(filename)) {
     try {
-      jsonDoc = std::make_shared<io::JsonDocument>(io::parseJsonFile(filename));
+      jsonDoc = std::make_unique<io::JsonDocument>(io::parseJsonFile(filename));
     } catch (...) {
       ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
                   << Magnum::Debug::nospace << "> : Failed to parse" << filename

--- a/src/esp/io/JsonBuiltinTypes.h
+++ b/src/esp/io/JsonBuiltinTypes.h
@@ -75,7 +75,7 @@ JsonGenericValue toJsonValue(const T&, JsonAllocator&) {
 // can be directly constructed from the builtin types.
 
 inline JsonGenericValue toJsonValue(bool x, JsonAllocator&) {
-  return JsonGenericValue(x);
+  return JsonGenericValue(x, nullptr);
 }
 
 inline JsonGenericValue toJsonValue(int x, JsonAllocator&) {


### PR DESCRIPTION
## Motivation and Context
This small pr gets rid of 2 **Wzero-as-null-pointer-constant** warnings our rapidjson-consuming code was generating.  
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
