### PR TITLE
--Add ability to retrieve a dictionary of handle-keyed templates/wrapped objects via substring query

### DIFF
--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -235,7 +235,17 @@ void declareBaseAttributesManager(py::module& m,
             " template specified by the passed handle if it exists, and NULL "
             "if it does not.")
                .c_str(),
-           "handle"_a);
+           "handle"_a)
+      .def("get_templates_by_handle_substring",
+           static_cast<std::unordered_map<std::string, AttribsPtr> (
+               MgrClass::*)(const std::string&, bool)>(
+               &MgrClass::getObjectsByHandleSubstring),
+           ("Returns a dictionary of " + attrType +
+            " templates, keyed by their handles, for all handles that either "
+            "contain or explicitly do not contain the passed search_str, based "
+            "on the value of boolean contains.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true);
 }  // declareBaseAttributesManager
 
 void initAttributesManagersBindings(py::module& m) {

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -176,7 +176,17 @@ void declareBaseWrapperManager(py::module& m,
             " specified by the passed handle if it exists, and NULL if it does "
             "not.")
                .c_str(),
-           "handle"_a);
+           "handle"_a)
+      .def("get_objects_by_handle_substring",
+           static_cast<std::unordered_map<std::string, WrapperPtr> (
+               MgrClass::*)(const std::string&, bool)>(
+               &MgrClass::template getObjectsByHandleSubstring<U>),
+           ("Returns a dictionary of " + objType +
+            " objects, keyed by their handles, for all handles that either "
+            "contain or explicitly do not contain the passed search_str, based "
+            "on the value of boolean contains.")
+               .c_str(),
+           "search_str"_a = "", "contains"_a = true);
 }  // declareBaseWrapperManager
 
 template <typename T>

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -215,6 +215,70 @@ class ManagedContainer : public ManagedContainerBase {
   }  // ManagedContainer::getObject
 
   /**
+   * @brief Retrieve a map of key= std::string handle; value = copy of
+   * ManagedPtr object where the handles match the passed @p .  See @ref
+   * ManagedContainerBase::getObjectHandlesBySubStringPerType.
+   * @param subStr substring key to search for within existing managed objects.
+   * @param contains whether to search for keys containing, or excluding,
+   * passed @p subStr
+   * @return a map of the objects whose keys match the specified substring
+   * search.
+   */
+  std::unordered_map<std::string, ManagedPtr> getObjectsByHandleSubstring(
+      const std::string& subStr = "",
+      bool contains = true) {
+    std::vector<std::string> keys = this->getObjectHandlesBySubStringPerType(
+        objectLibKeyByID_, subStr, contains, false);
+
+    std::unordered_map<std::string, ManagedPtr> res;
+    res.reserve(keys.size());
+    if (Access == ManagedObjectAccess::Copy) {
+      for (const auto& key : keys) {
+        res[key] = this->getObjectCopyByHandle(key);
+      }
+    } else {
+      for (const auto& key : keys) {
+        res[key] = this->getObjectByHandle(key);
+      }
+    }
+    return res;
+  }
+
+  /**
+   * @brief Templated version. Retrieve a map of key= std::string handle; value
+   * = copy of ManagedPtr object where the handles match the passed @p .  See
+   * @ref ManagedContainerBase::getObjectHandlesBySubStringPerType.
+   *
+   * @tparam Desired downcast class that inerheits from this ManagedContainer's
+   * ManagedObject type.
+   * @param subStr substring key to search for within existing managed objects.
+   * @param contains whether to search for keys containing, or excluding,
+   * passed @p subStr
+   * @return a map of the objects whose keys match the specified substring
+   * search.
+   */
+  template <class U>
+  std::unordered_map<std::string, std::shared_ptr<U>>
+  getObjectsByHandleSubstring(const std::string& subStr = "",
+                              bool contains = true) {
+    std::vector<std::string> keys = this->getObjectHandlesBySubStringPerType(
+        objectLibKeyByID_, subStr, contains, false);
+
+    std::unordered_map<std::string, std::shared_ptr<U>> res;
+    res.reserve(keys.size());
+    if (Access == ManagedObjectAccess::Copy) {
+      for (const auto& key : keys) {
+        res[key] = this->getObjectCopyByHandle<U>(key);
+      }
+    } else {
+      for (const auto& key : keys) {
+        res[key] = std::dynamic_pointer_cast<U>(this->getObjectByHandle(key));
+      }
+    }
+    return res;
+  }
+
+  /**
    * @brief Remove the managed object referenced by the passed string handle.
    * Will emplace managed object ID within deque of usable IDs and return the
    * managed object being removed.
@@ -392,6 +456,8 @@ class ManagedContainer : public ManagedContainerBase {
    * by the @p managedObjectID, casted to the appropriate derived managed object
    * class.
    *
+   * @tparam Desired downcast class that inerheits from this ManagedContainer's
+   * ManagedObject type.
    * @param managedObjectID The ID of the managed object. Is mapped to the key
    * referencing the asset in @ref ManagedContainerBase::objectLibrary_.
    * @return A mutable reference to a copy of the managed object casted to the
@@ -505,7 +571,8 @@ class ManagedContainer : public ManagedContainerBase {
 
   /**
    * @brief Build a shared pointer to a copy of a the passed managed object,
-   * of appropriate managed object type for passed object type.
+   * of appropriate managed object type for passed object type.  This is the
+   * function called by the copy constructor map.
    * @tparam U Type of managed object being created - must be a derived class
    * of ManagedPtr
    * @param orig original object of type ManagedPtr being copied

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -121,8 +121,8 @@ class ManagedContainerBase {
   }
 
   /**
-   * @brief Get a list of all managed objects whose keys contain @p subStr,
-   * ignoring subStr's case
+   * @brief Get a list of all managed objects handles that contain, or
+   * explicitly do not contain @p subStr, ignoring subStr's case
    * @param subStr substring key to search for within existing managed objects.
    * @param contains whether to search for keys containing, or excluding,
    * passed @p subStr

--- a/tests/test_attributes_managers.py
+++ b/tests/test_attributes_managers.py
@@ -98,6 +98,13 @@ def perform_general_tests(attr_mgr, search_string):
         tmplt_id = attr_mgr.register_template(template3, new_iter_handle)
         assert tmplt_id != -1
 
+    # retrieve a dictionary of all templates that were
+    # just created, using search on handle stub substring
+    new_template_dict = attr_mgr.get_templates_by_handle_substring(new_handle_stub)
+    assert len(new_template_dict) == num_to_add
+    for k, v in new_template_dict.items():
+        assert k == v.handle
+
     # lock all added templates
     locked_template_handles = attr_mgr.set_lock_by_substring(
         True, new_handle_stub, True

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -181,6 +181,12 @@ def test_dynamics():
             len(rigid_obj_mgr.get_object_handles()) == rigid_obj_mgr.get_num_objects()
         )
 
+        obj_dict = rigid_obj_mgr.get_objects_by_handle_substring("cheezit")
+        assert len(obj_dict) == rigid_obj_mgr.get_num_objects()
+        for k, v in obj_dict.items():
+            assert k == v.handle
+            assert v.is_alive
+
         # place the objects over the table in room
         cheezit_box1.translation = [-0.569043, 2.04804, 13.6156]
         cheezit_box2.translation = [-0.569043, 2.04804, 12.6156]


### PR DESCRIPTION
## Motivation and Context
In the existing system, you can search an attributes/object manager for a list of handles by providing a substring, and then retrieve the managed objects each handle references.  
This PR cuts a step from this, and adds the ability to retrieve a dictionary of managed objects (templates or object wrappers) via a substring search, where each entry is keyed by the handle and value is the managed object corresponding to that handle. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests.  test_attributes_managers.py and test_physics.py have been modified to test this functionality directly.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
