### PR TITLE
[bugfix][viewer] Allow user to hide mouseinteraction text

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1394,10 +1394,10 @@ void Viewer::drawEvent() {
         break;
     }
     ImGui::Text("%s", profiler_.statistics().c_str());
+    std::string modeText =
+        "Mouse Interaction Mode: " + mouseModeNames.at(mouseInteractionMode);
+    ImGui::Text("%s", modeText.c_str());
   }
-  std::string modeText =
-      "Mouse Interaction Mode: " + mouseModeNames.at(mouseInteractionMode);
-  ImGui::Text("%s", modeText.c_str());
   ImGui::End();
 
   /* Set appropriate states. If you only draw ImGui, it is sufficient to


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Before this, the user could not hide the mouseInteraction text which made taking screnshots without the overlay impossible.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)