### PR TITLE
CollisionGroup::Noncollidable fix

### DIFF
--- a/src/esp/physics/CollisionGroupHelper.cpp
+++ b/src/esp/physics/CollisionGroupHelper.cpp
@@ -46,7 +46,7 @@ std::map<CollisionGroup, CollisionGroups>
         // everything except Noncollidable
         {CollisionGroup::Robot, ~CollisionGroup::Noncollidable},
         // nothing
-        {CollisionGroup::Noncollidable, ~CollisionGroups()},
+        {CollisionGroup::Noncollidable, CollisionGroups()},
 
         // everything except Noncollidable
         {CollisionGroup::UserGroup0, ~CollisionGroup::Noncollidable},

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -542,6 +542,11 @@ def test_collision_groups():
             assert not cube_obj1.contact_test()
             assert not cube_obj2.contact_test()
 
+            # test Noncollidable vs Noncollidable
+            cube_obj1.override_collision_group(cg.Noncollidable)
+            assert not cube_obj1.contact_test()
+            assert not cube_obj2.contact_test()
+
 
 def check_articulated_object_root_state(
     articulated_object, target_rigid_state, epsilon=1.0e-4


### PR DESCRIPTION
## Motivation and Context

Fix to ensure CollisionGroup::Noncollidable has a mask of 0 and thus collides with nothing.

The previous code used a mask of -1, with the result that a Noncollidable would collide with another Noncollidable.

## How Has This Been Tested

Ad hoc local testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
