### PR TITLE
change frame color buffer from srgb to linear (RGBA8)

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -66,7 +66,7 @@ struct RenderTarget::Impl {
     }
 
     if (flags_ & Flag::RgbaAttachment) {
-      colorBuffer_.setStorage(Mn::GL::RenderbufferFormat::SRGB8Alpha8, size);
+      colorBuffer_.setStorage(Mn::GL::RenderbufferFormat::RGBA8, size);
     }
     if (flags_ & Flag::ObjectIdAttachment) {
       objectIdTexture_.setMinificationFilter(Mn::GL::SamplerFilter::Nearest)


### PR DESCRIPTION
## Motivation and Context

We were requesting an srgb frame color buffer, which didn't affect most scenarios but does cause a visual problem for WebXR (where we end up copying the color buffer to another canvas). 

From Mosra:
>Huh. The rendering pipeline is certainly not sRGB-correct at the moment, so it definitely shouldn't render to a sRGB framebuffer... Use RGBA8 there, yes, for all platforms. It worked on desktop GL only because the Renderer::Feature::FramebufferSrgb is off by default there (as you discovered already) and so the sRGB attachment worked the same as plain RGB.

[Slack thread with more context](https://cvmlp.slack.com/archives/C01NZ9Z0VKL/p1629750596041700)

## How Has This Been Tested

Ad hoc testing in WebXR build and C++ viewer. Our graphical unit tests should also help here. (We don't have any WebXR graphical tests, so no graphical tests need to be updated with this change.)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
