### PR TITLE
--Fix clang-tidy cast complaint in configuration.

### DIFF
--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -363,7 +363,7 @@ class Configuration {
   }
 
   void set(const std::string& key, float value) {
-    valueMap_[key].set<double>(value);
+    valueMap_[key].set<double>(static_cast<double>(value));
   }
 
   // ****************** Value removal ******************


### PR DESCRIPTION
## Motivation and Context
This fixes the clang-tidy cast complaint on current master. Sorry Folks! CI showed completely passed before I merged. (I needed to refresh).
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python (and clang-tidy)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
