### PR TITLE
--[BugFix]Fix erroneous ConfigStoredType checks

### DIFF
--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -193,7 +193,8 @@ std::string ConfigValue::getAsString() const {
       return std::to_string(r.operator float());
     }
     default:
-      ESP_CHECK(true, "Unknown/unsupported Type in ConfigValue::getAsString.");
+      CORRADE_ASSERT_UNREACHABLE(
+          "Unknown/unsupported Type in ConfigValue::getAsString", "");
   }  // switch
 }  // ConfigValue::getAsString
 
@@ -218,11 +219,10 @@ bool ConfigValue::putValueInConfigGroup(
     case ConfigStoredType::MagnumRad:
       return cfg.setValue(key, get<Mn::Rad>());
     default:
-      ESP_CHECK(
-          true,
-          "Unknown/unsupported Type in ConfigValue::putValueInConfigGroup.");
+      CORRADE_ASSERT_UNREACHABLE(
+          "Unknown/unsupported Type in ConfigValue::putValueInConfigGroup",
+          false);
   }  // switch
-  return false;
 }  // ConfigValue::putValueInConfigGroup
 
 Mn::Debug& operator<<(Mn::Debug& debug, const ConfigStoredType& value) {


### PR DESCRIPTION
## Motivation and Context
This small PR addresses a logic error in a check attempting to verify that all possible values of an enum are properly supported in switch statements of two functions. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally tested c++ and python
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
