### PR TITLE
ArticulatedObjects: Enable support for secondary json config files.

### DIFF
--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -103,14 +103,13 @@ void Model::setMassScaling(float massScaling) {
 }
 
 bool Model::loadJsonAttributes(const std::string& filename) {
-  // rebuild name
   namespace CrUt = Corrade::Utility;
-  namespace CrUtDir = CrUt::Directory;
   const std::string jsonName = CrUt::formatString(
-      "{}.ao_config.json",
-      CrUtDir::splitExtension(CrUtDir::splitExtension(filename).first).first);
+      "{}.ao_config.json", CrUt::Directory::splitExtension(
+                               CrUt::Directory::splitExtension(filename).first)
+                               .first);
 
-  if (!CrUtDir::exists(jsonName)) {
+  if (!CrUt::Directory::exists(jsonName)) {
     // file does not exists, so no Json configuration defined for this Model.
     return false;
   }
@@ -121,14 +120,13 @@ bool Model::loadJsonAttributes(const std::string& filename) {
     ESP_ERROR() << "<Model> : Failed to parse" << jsonName << "as JSON.";
     return false;
   }
+  // JSON file exists and has been loaded; use to build this model's
+  // configuration attributes
   // convert doc to const Json Generic val
   const io::JsonGenericValue jsonConfig = docConfig->GetObject();
 
   const std::string subGroupName = "user_defined";
   const char* sg_cstr = subGroupName.c_str();
-  // JSON file exists and has been loaded; use to build this model's
-  // configuration attributes
-  jsonAttributes_ = std::make_shared<esp::core::config::Configuration>();
 
   // check for user defined attributes and verify it is an object
   if (jsonConfig.HasMember(sg_cstr)) {

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -245,7 +245,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
       return false;
     }
   }
-  if (urdfModel->m_links.size() == 0) {
+  if (urdfModel->m_links.empty()) {
     ESP_ERROR() << "No links found in URDF file. Aborting parse/load for"
                 << filename;
     return false;
@@ -956,7 +956,7 @@ bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
     }
   }
 
-  if (model->m_rootLinks.size() == 0) {
+  if (model->m_rootLinks.empty()) {
     ESP_VERY_VERBOSE() << "URDF without root link found.";
     return false;
   }

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -119,16 +119,15 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
 
   const XMLElement* robot_xml = xml_doc.FirstChildElement("robot");
   if (!robot_xml) {
-    ESP_ERROR()
-        << "E - expected a <robot> element. Aborting URDF parse/load for"
-        << filename;
+    ESP_ERROR() << "Expected a <robot> element. Aborting URDF parse/load for"
+                << filename;
     return false;
   }
 
   // Get robot name
   const char* name = robot_xml->Attribute("name");
   if (!name) {
-    ESP_ERROR() << "E - expected a name for robot. Aborting URDF parse/load for"
+    ESP_ERROR() << "Expected a name for robot. Aborting URDF parse/load for"
                 << filename;
     return false;
   }
@@ -159,7 +158,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
     if (parseLink(urdfModel, *link, link_xml)) {
       if (urdfModel->m_links.count(link->m_name) != 0u) {
         ESP_ERROR()
-            << "E - Link name  (" << link->m_name
+            << "Link name  (" << link->m_name
             << ") is not unique, link names "
                "in the same model have to be unique. Aborting parse/load for"
             << filename;
@@ -174,7 +173,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
             if (mat_itr != urdfModel->m_materials.end()) {
               vis.m_geometry.m_localMaterial = mat_itr->second;
             } else {
-              ESP_ERROR() << "E - Cannot find material with name:"
+              ESP_ERROR() << "Cannot find material with name:"
                           << vis.m_materialName << ". Aborting parse/load for"
                           << filename;
             }
@@ -185,13 +184,13 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
         urdfModel->m_links[link->m_name] = link;
       }
     } else {
-      ESP_ERROR() << "E - failed to parse link. Aborting parse/load for"
+      ESP_ERROR() << "Failed to parse link. Aborting parse/load for"
                   << filename;
       return false;
     }
   }
   if (urdfModel->m_links.size() == 0) {
-    ESP_ERROR() << "W - No links found in URDF file. Aborting parse/load for"
+    ESP_ERROR() << "No links found in URDF file. Aborting parse/load for"
                 << filename;
     return false;
   }
@@ -203,14 +202,14 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
 
     if (parseJoint(*joint, joint_xml)) {
       if (urdfModel->m_joints.count(joint->m_name) != 0u) {
-        ESP_ERROR() << "E - joint" << joint->m_name
+        ESP_ERROR() << "Joint" << joint->m_name
                     << "is not unique. Aborting parse/load for" << filename;
         return false;
       } else {
         urdfModel->m_joints[joint->m_name] = joint;
       }
     } else {
-      ESP_ERROR() << "E - joint xml is not initialized correctly. Aborting "
+      ESP_ERROR() << "Joint xml is not initialized correctly. Aborting "
                      "parse/load for"
                   << filename;
       return false;
@@ -223,7 +222,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
     return false;
   }
 
-  ESP_VERY_VERBOSE() << "Done parsing URDF";
+  ESP_VERY_VERBOSE() << "Done parsing URDF for" << filename;
 
   return true;
 }
@@ -272,7 +271,7 @@ static bool parseVector3(Mn::Vector3& vec3,
 
 bool Parser::parseMaterial(Material& material, const XMLElement* config) const {
   if (!config->Attribute("name")) {
-    ESP_VERY_VERBOSE() << "E - Material must contain a name attribute";
+    ESP_VERY_VERBOSE() << "Material must contain a name attribute";
     return false;
   }
   material.m_name = config->Attribute("name");
@@ -317,7 +316,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
                        const XMLElement* config) {
   const char* linkName = config->Attribute("name");
   if (!linkName) {
-    ESP_VERY_VERBOSE() << "E - Link with no name";
+    ESP_VERY_VERBOSE() << "Link with no name";
     return false;
   }
   ESP_VERY_VERBOSE() << "------------------------------------";
@@ -332,7 +331,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
       if (damping_xml) {
         if (!damping_xml->Attribute("value")) {
           ESP_VERY_VERBOSE()
-              << "E - Link/contact: damping element must have value attribute";
+              << "Link/contact: damping element must have value attribute";
           return false;
         }
 
@@ -345,7 +344,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
             ci->FirstChildElement("lateral_friction");
         if (friction_xml) {
           if (!friction_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: lateral_friction "
+            ESP_VERY_VERBOSE() << "Link/contact: lateral_friction "
                                   "element must have value attribute";
             return false;
           }
@@ -360,7 +359,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
             ci->FirstChildElement("rolling_friction");
         if (rolling_xml) {
           if (!rolling_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: rolling friction "
+            ESP_VERY_VERBOSE() << "Link/contact: rolling friction "
                                   "element must have value attribute";
             return false;
           }
@@ -376,7 +375,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
             ci->FirstChildElement("restitution");
         if (restitution_xml) {
           if (!restitution_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: restitution "
+            ESP_VERY_VERBOSE() << "Link/contact: restitution "
                                   "element must have value attribute";
             return false;
           }
@@ -392,7 +391,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
             ci->FirstChildElement("spinning_friction");
         if (spinning_xml) {
           if (!spinning_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: spinning friction "
+            ESP_VERY_VERBOSE() << "Link/contact: spinning friction "
                                   "element must have value attribute";
             return false;
           }
@@ -413,7 +412,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
         const XMLElement* stiffness_xml = ci->FirstChildElement("stiffness");
         if (stiffness_xml) {
           if (!stiffness_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: stiffness element "
+            ESP_VERY_VERBOSE() << "Link/contact: stiffness element "
                                   "must have value attribute";
             return false;
           }
@@ -427,7 +426,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
         const XMLElement* damping_xml = ci->FirstChildElement("damping");
         if (damping_xml) {
           if (!damping_xml->Attribute("value")) {
-            ESP_VERY_VERBOSE() << "E - Link/contact: damping element "
+            ESP_VERY_VERBOSE() << "Link/contact: damping element "
                                   "must have value attribute";
             return false;
           }
@@ -444,7 +443,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
   const XMLElement* i = config->FirstChildElement("inertial");
   if (i) {
     if (!parseInertia(link.m_inertia, i)) {
-      ESP_VERY_VERBOSE() << "E - Could not parse inertial element for Link:";
+      ESP_VERY_VERBOSE() << "Could not parse inertial element for Link:";
       ESP_VERY_VERBOSE() << link.m_name;
       return false;
     }
@@ -477,7 +476,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
     if (parseVisual(model, visual, vis_xml)) {
       link.m_visualArray.push_back(visual);
     } else {
-      ESP_VERY_VERBOSE() << "E - Could not parse visual element for Link:"
+      ESP_VERY_VERBOSE() << "Could not parse visual element for Link:"
                          << link.m_name;
       return false;
     }
@@ -491,7 +490,7 @@ bool Parser::parseLink(const std::shared_ptr<Model>& model,
     if (parseCollision(col, col_xml)) {
       link.m_collisionArray.push_back(col);
     } else {
-      ESP_VERY_VERBOSE() << "E - Could not parse collision element for Link:"
+      ESP_VERY_VERBOSE() << "Could not parse collision element for Link:"
                          << link.m_name.c_str();
       return false;
     }
@@ -567,7 +566,7 @@ bool Parser::parseVisual(const std::shared_ptr<Model>& model,
   if (mat) {
     // get material name
     if (!mat->Attribute("name")) {
-      ESP_VERY_VERBOSE() << "E - Visual material must contain a name attribute";
+      ESP_VERY_VERBOSE() << "Visual material must contain a name attribute";
       return false;
     }
     visual.m_materialName = mat->Attribute("name");
@@ -647,7 +646,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
 
   const XMLElement* shape = g->FirstChildElement();
   if (!shape) {
-    ESP_VERY_VERBOSE() << "E - Geometry tag contains no child element.";
+    ESP_VERY_VERBOSE() << "Geometry tag contains no child element.";
     return false;
   }
 
@@ -657,7 +656,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
     geom.m_type = GEOM_SPHERE;
 
     if (!shape->Attribute("radius")) {
-      ESP_VERY_VERBOSE() << "E - Sphere shape must have a radius attribute";
+      ESP_VERY_VERBOSE() << "Sphere shape must have a radius attribute";
       return false;
     } else {
       geom.m_sphereRadius = std::stod(shape->Attribute("radius"));
@@ -665,7 +664,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
   } else if (type_name == "box") {
     geom.m_type = GEOM_BOX;
     if (!shape->Attribute("size")) {
-      ESP_VERY_VERBOSE() << "E - box requires a size attribute";
+      ESP_VERY_VERBOSE() << "Box requires a size attribute";
       return false;
     } else {
       parseVector3(geom.m_boxSize, shape->Attribute("size"));
@@ -677,7 +676,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
 
     if (!shape->Attribute("length") || !shape->Attribute("radius")) {
       ESP_VERY_VERBOSE()
-          << "E - Cylinder shape must have both length and radius attributes";
+          << "Cylinder shape must have both length and radius attributes";
       return false;
     }
     geom.m_capsuleRadius = std::stod(shape->Attribute("radius"));
@@ -688,7 +687,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
 
     if (!shape->Attribute("length") || !shape->Attribute("radius")) {
       ESP_VERY_VERBOSE()
-          << "E - Capsule shape must have both length and radius attributes";
+          << "Capsule shape must have both length and radius attributes";
       return false;
     }
     geom.m_capsuleRadius = std::stod(shape->Attribute("radius"));
@@ -715,7 +714,7 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
     }
 
     if (fn.empty()) {
-      ESP_VERY_VERBOSE() << "E - Mesh filename is empty";
+      ESP_VERY_VERBOSE() << "Mesh filename is empty";
       return false;
     }
 
@@ -734,13 +733,13 @@ bool Parser::parseGeometry(Geometry& geom, const XMLElement* g) {
       geom.m_type = GEOM_PLANE;
 
       if (!shape->Attribute("normal")) {
-        ESP_VERY_VERBOSE() << "E - Plane requires a normal attribute";
+        ESP_VERY_VERBOSE() << "Plane requires a normal attribute";
         return false;
       } else {
         parseVector3(geom.m_planeNormal, shape->Attribute("normal"));
       }
     } else {
-      ESP_VERY_VERBOSE() << "E - Unknown geometry type:" << type_name;
+      ESP_VERY_VERBOSE() << "Unknown geometry type:" << type_name;
       return false;
     }
   }
@@ -763,13 +762,12 @@ bool Parser::parseInertia(Inertia& inertia, const XMLElement* config) {
 
   const XMLElement* mass_xml = config->FirstChildElement("mass");
   if (!mass_xml) {
-    ESP_VERY_VERBOSE() << "E - Inertial element must have a mass element";
+    ESP_VERY_VERBOSE() << "Inertial element must have a mass element";
     return false;
   }
 
   if (!mass_xml->Attribute("value")) {
-    ESP_VERY_VERBOSE()
-        << "E - Inertial: mass element must have value attribute";
+    ESP_VERY_VERBOSE() << "Inertial: mass element must have value attribute";
     return false;
   }
 
@@ -777,7 +775,7 @@ bool Parser::parseInertia(Inertia& inertia, const XMLElement* config) {
 
   const XMLElement* inertia_xml = config->FirstChildElement("inertia");
   if (!inertia_xml) {
-    ESP_VERY_VERBOSE() << "E - Inertial element must have inertia element";
+    ESP_VERY_VERBOSE() << "Inertial element must have inertia element";
     return false;
   }
 
@@ -793,7 +791,7 @@ bool Parser::parseInertia(Inertia& inertia, const XMLElement* config) {
       inertia.m_iyz = 0;
       inertia.m_izz = std::stod(inertia_xml->Attribute("izz"));
     } else {
-      ESP_VERY_VERBOSE() << "E - Inertial: inertia element must have "
+      ESP_VERY_VERBOSE() << "Inertial: inertia element must have "
                             "ixx,ixy,ixz,iyy,iyz,izz attributes";
       return false;
     }
@@ -845,21 +843,20 @@ bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
     std::string parent_link_name = joint->m_parentLinkName;
     std::string child_link_name = joint->m_childLinkName;
     if (parent_link_name.empty() || child_link_name.empty()) {
-      ESP_VERY_VERBOSE() << "E - parent link or child link is empty for joint:"
+      ESP_VERY_VERBOSE() << "Parent link or child link is empty for joint:"
                          << joint->m_name;
       return false;
     }
 
     if (model->m_links.count(joint->m_childLinkName) == 0u) {
-      ESP_VERY_VERBOSE() << "E - Cannot find child link for joint:"
-                         << joint->m_name
+      ESP_VERY_VERBOSE() << "Cannot find child link for joint:" << joint->m_name
                          << ", child:" << joint->m_childLinkName;
       return false;
     }
     auto childLink = model->m_links.at(joint->m_childLinkName);
 
     if (model->m_links.count(joint->m_parentLinkName) == 0u) {
-      ESP_VERY_VERBOSE() << "E - Cannot find parent link for joint:"
+      ESP_VERY_VERBOSE() << "Cannot find parent link for joint:"
                          << joint->m_name
                          << ", parent:" << joint->m_parentLinkName;
       return false;
@@ -897,7 +894,7 @@ bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
   }
 
   if (model->m_rootLinks.size() == 0) {
-    ESP_VERY_VERBOSE() << "E - URDF without root link found.";
+    ESP_VERY_VERBOSE() << "URDF without root link found.";
     return false;
   }
   return true;
@@ -955,7 +952,7 @@ bool Parser::parseJointDynamics(Joint& joint,
   }
 
   if (damping_str == nullptr && friction_str == nullptr) {
-    ESP_VERY_VERBOSE() << "E - joint dynamics element specified with no "
+    ESP_VERY_VERBOSE() << "Joint dynamics element specified with no "
                           "damping and no friction";
     return false;
   }
@@ -967,7 +964,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   // Get Joint Name
   const char* name = config->Attribute("name");
   if (!name) {
-    ESP_VERY_VERBOSE() << "E - unnamed joint found";
+    ESP_VERY_VERBOSE() << "Unnamed joint found";
     return false;
   }
   joint.m_name = name;
@@ -977,7 +974,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   const XMLElement* origin_xml = config->FirstChildElement("origin");
   if (origin_xml) {
     if (!parseTransform(joint.m_parentLinkToJointTransform, origin_xml)) {
-      ESP_VERY_VERBOSE() << "E - Malformed parent origin element for joint:"
+      ESP_VERY_VERBOSE() << "Malformed parent origin element for joint:"
                          << joint.m_name;
       return false;
     }
@@ -988,7 +985,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   if (parent_xml) {
     const char* pname = parent_xml->Attribute("link");
     if (!pname) {
-      ESP_VERY_VERBOSE() << "E - no parent link name specified for "
+      ESP_VERY_VERBOSE() << "No parent link name specified for "
                             "Joint link. this might be the root?"
                          << joint.m_name;
       return false;
@@ -1002,7 +999,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   if (child_xml) {
     const char* pname = child_xml->Attribute("link");
     if (!pname) {
-      ESP_VERY_VERBOSE() << "E - no child link name specified for Joint link"
+      ESP_VERY_VERBOSE() << "No child link name specified for Joint link"
                          << joint.m_name;
       return false;
     } else {
@@ -1013,7 +1010,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   // Get Joint type
   const char* type_char = config->Attribute("type");
   if (!type_char) {
-    ESP_VERY_VERBOSE() << "E - joint" << joint.m_name
+    ESP_VERY_VERBOSE() << "Joint" << joint.m_name
                        << "has no type, check to see if it's a reference.";
     return false;
   }
@@ -1034,7 +1031,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   else if (type_str == "fixed")
     joint.m_type = FixedJoint;
   else {
-    ESP_VERY_VERBOSE() << "E - Joint" << joint.m_name
+    ESP_VERY_VERBOSE() << "Joint" << joint.m_name
                        << "has unknown type:" << type_str;
     return false;
   }
@@ -1052,7 +1049,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
       if (axis_xml->Attribute("xyz")) {
         if (!parseVector3(joint.m_localJointAxis, axis_xml->Attribute("xyz"))) {
           ESP_VERY_VERBOSE()
-              << "E - Malformed axis element:" << axis_xml->Attribute("xyz")
+              << "Malformed axis element:" << axis_xml->Attribute("xyz")
               << "for joint:" << joint.m_name;
           return false;
         }
@@ -1064,17 +1061,17 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
   const XMLElement* limit_xml = config->FirstChildElement("limit");
   if (limit_xml) {
     if (!parseJointLimits(joint, limit_xml)) {
-      ESP_VERY_VERBOSE() << "E - Could not parse limit element for joint:"
+      ESP_VERY_VERBOSE() << "Could not parse limit element for joint:"
                          << joint.m_name;
       return false;
     }
   } else if (joint.m_type == RevoluteJoint) {
     ESP_VERY_VERBOSE()
-        << "E - Joint is of type REVOLUTE but it does not specify limits:"
+        << "Joint is of type REVOLUTE but it does not specify limits:"
         << joint.m_name;
     return false;
   } else if (joint.m_type == PrismaticJoint) {
-    ESP_VERY_VERBOSE() << "E - Joint is of type PRISMATIC without limits:"
+    ESP_VERY_VERBOSE() << "Joint is of type PRISMATIC without limits:"
                        << joint.m_name;
     return false;
   }
@@ -1098,7 +1095,7 @@ bool Parser::parseJoint(Joint& joint, const tinyxml2::XMLElement* config) {
     }
 
     if (damping_str == nullptr && friction_str == nullptr) {
-      ESP_VERY_VERBOSE() << "E - joint dynamics element specified with "
+      ESP_VERY_VERBOSE() << "Joint dynamics element specified with "
                             "no damping and no friction";
       return false;
     }

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "esp/core/Configuration.h"
 
 /** @file
  * @brief Storage classes for articulated object metadata and URDF file parsing
@@ -357,7 +358,42 @@ class Model {
    */
   float getMassScaling() const { return m_massScaling; }
 
+  /**
+   * @brief This function conditionally loads configuration data from a Json
+   * file for this Articulated Model, should an appropriate file exist. This
+   * configuration file must meet the following criteria to be loaded :
+   * --Exist in the same directory as thsi model's source URDF/XML file.
+   * - Have the same root name as this model's source URDF/XML file.
+   * - Have '.ao_config.json' as an extension.
+   *
+   * This method will construct a name candidate from the passed @p filename and
+   * attempt to load this file into this model's @ref jsonAttributes_ variable.
+   * @param filename The filename for the URDF?XML file describing this model.
+   * @return Whether successful or not.
+   */
+  bool loadJsonAttributes(const std::string& filename);
+
+  /**
+   * @brief Gets a smart pointer reference to a copy of the user-specified
+   * configuration data from a config file. Habitat does not parse or process
+   * this data, but it will be available to the user via python bindings for
+   * each object.
+   */
+  std::shared_ptr<core::config::Configuration> getUserConfiguration() const {
+    return jsonAttributes_->getSubconfigCopy("user_defined");
+  }
+
  protected:
+  /**
+   * @brief Json-based attributes defining characteristics of this model not
+   * specified in the source XML/URDF. Primarly to support defaultt user-defined
+   * attribnutes. This data is read in from a json file with the same name as
+   * the source XML/URDF for this model, and the extension ".ao_config.json".
+   */
+
+  std::shared_ptr<core::config::Configuration> jsonAttributes_ =
+      std::make_shared<core::config::Configuration>();
+
   // scaling values which can be applied to the model after parsing
   //! Global euclidean scaling applied to the model's transforms, asset scales,
   //! and prismatic joint limits. Does not affect mass.
@@ -368,7 +404,7 @@ class Model {
 
   //! Scale the transformation and parameters of a Shape
   void scaleShape(Shape& shape, float scale);
-};
+};  // class model
 
 /**
  * @brief Functional class for parsing URDF files into a URDF::Model

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -304,9 +304,9 @@ int PhysicsManager::addArticulatedObjectInstance(
   existingArticulatedObjects_.at(aObjID)->setSceneInstanceAttr(
       aObjInstAttributes);
 
-  // set articulated object's user-defined attributes, if any exist in scene
+  // merge articulated object's user-defined attributes, if any exist in scene
   // instance.
-  existingArticulatedObjects_.at(aObjID)->setUserAttributes(
+  existingArticulatedObjects_.at(aObjID)->mergeUserAttributes(
       aObjInstAttributes->getUserConfiguration());
 
   // set articulated object's location, rotation and other pertinent state

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -124,20 +124,19 @@ int PhysicsManager::addObjectInstance(
                 << "as specified in object instance attributes.";
     return ID_UNDEFINED;
   }
+  auto objPtr = this->existingObjects_.at(objID);
 
   // save the scene init attributes used to configure object's initial state
-  this->existingObjects_.at(objID)->setSceneInstanceAttr(objInstAttributes);
+  objPtr->setSceneInstanceAttr(objInstAttributes);
   // merge scene instance user-defined configurations with the new object's, if
   // scene instance specifies any set articulated object's user-defined
   // attributes, if any exist in scene
   // instance.
-  this->existingObjects_.at(objID)->mergeUserAttributes(
-      objInstAttributes->getUserConfiguration());
+  objPtr->mergeUserAttributes(objInstAttributes->getUserConfiguration());
 
   // set object's location, rotation and other pertinent state values based on
   // scene object instance attributes set in the object above.
-  this->existingObjects_.at(objID)->resetStateFromSceneInstanceAttr(
-      defaultCOMCorrection);
+  objPtr->resetStateFromSceneInstanceAttr(defaultCOMCorrection);
 
   return objID;
 }  // PhysicsManager::addObjectInstance
@@ -299,20 +298,18 @@ int PhysicsManager::addArticulatedObjectInstance(
   }
 
   // set articulated object up using scene instance
-
+  auto aObjPtr = existingArticulatedObjects_.at(aObjID);
   // set articulated object's scene instancing attributes
-  existingArticulatedObjects_.at(aObjID)->setSceneInstanceAttr(
-      aObjInstAttributes);
+  aObjPtr->setSceneInstanceAttr(aObjInstAttributes);
 
   // merge articulated object's user-defined attributes, if any exist in scene
   // instance.
-  existingArticulatedObjects_.at(aObjID)->mergeUserAttributes(
-      aObjInstAttributes->getUserConfiguration());
+  aObjPtr->mergeUserAttributes(aObjInstAttributes->getUserConfiguration());
 
   // set articulated object's location, rotation and other pertinent state
   // values based on
   // scene object instance attributes set in the object above.
-  existingArticulatedObjects_.at(aObjID)->resetStateFromSceneInstanceAttr();
+  aObjPtr->resetStateFromSceneInstanceAttr();
 
   return aObjID;
 }  // PhysicsManager::addArticulatedObjectInstance

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -62,7 +62,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
                     const assets::ResourceManager& resMgr)
       : Magnum::SceneGraph::AbstractFeature3D(*bodyNode),
         objectId_(objectId),
-        resMgr_(resMgr) {}
+        resMgr_(resMgr),
+        userAttributes_(std::make_shared<core::config::Configuration>()) {}
 
   ~PhysicsObjectBase() override = default;
 
@@ -503,7 +504,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * internally processed by habitat, but provide a "scratch pad" for the user
    * to access and save important information and metadata.
    */
-  core::config::Configuration::ptr userAttributes_{};
+  core::config::Configuration::ptr userAttributes_ = nullptr;
 
  private:
   /**

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -246,7 +246,7 @@ bool URDFImporter::getLinkContactInfo(
     io::URDF::LinkContactInfo& contactInfo) const {
   auto link = activeModel_->getLink(linkIndex);
   if (link == nullptr) {
-    ESP_DEBUG() << "E - No link with index =" << linkIndex;
+    ESP_DEBUG() << "No link with index =" << linkIndex;
     return false;
   }
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -159,6 +159,8 @@ void BulletArticulatedObject::initializeFromURDF(
         createJointMotor(linkIx, settings);
       }
     }
+    // set user config attributes from model.
+    setUserAttributes(urdfModel->getUserConfiguration());
 
     // in case the base transform is not zero by default
     syncPose();


### PR DESCRIPTION
## Motivation and Context
This PR introduces support of Json config files for URDF-based ArticulatedObject models in the URDFParser, which will hold default user-defined attributes (Such as bounding boxes for placements) that apply to all instances of articulated objects built from these models.   This PR also removed extraneous markers from error messages that did not match the format of our current message logging in the URDFParser.

To be compatible with this functionality, the json config file holding the user_defined attributes must meet these criteria : 
- Must be in the same directory as the AO's .urdf file
- Must have the same core filename (minus extensions) as the AO's .urdf file
- Must have the following extension :  <filename>**.ao_config.json**
- Internally, the file must have a root Json object, and within that object there must be a tag "user_defined" which references a Json object holding the user-defined values.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
