### PR TITLE
[Compilation] Allow ThinLTO and Fix CI flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,7 +563,7 @@ jobs:
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
-              pytest -n auto --durations=10 --cov-report=xml --cov=./
+              pytest -n 8 --durations=10 --cov-report=xml --cov=./
 
               #run the marked pytest-benchmark tests and print the results
               pytest -m sim_benchmarks

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,12 @@ def str2bool(input_str: str) -> bool:
     return bool(strtobool(input_str.lower()))
 
 
-def is_pip():
-    # This will end with python if driven with python setup.py ...
-    return osp.basename(os.environ.get("_", "/pip/no")).startswith("pip")
+def is_pip() -> bool:
+    # This will end with python if driven with python setup.py or PEP517_BUILD_BACKEND will be set
+    return (
+        osp.basename(os.environ.get("_", "/pip/no")).startswith("pip")
+        or os.environ.get("PEP517_BUILD_BACKEND") is not None
+    )
 
 
 # TODO refactor to the proper way to pass options to setup.py so pip can do so.
@@ -447,11 +450,6 @@ if __name__ == "__main__":
     with open("./requirements.txt", "r") as f:
         requirements = [l.strip() for l in f.readlines() if len(l.strip()) > 0]
 
-    # Only install pytest if we are running tests
-    if {"pytest", "test", "ptr"}.intersection(sys.argv):
-        setup_requires = ["pytest-runner"]
-    else:
-        setup_requires = []
     builtins.__HSIM_SETUP__ = True
     import habitat_sim
 
@@ -463,7 +461,6 @@ if __name__ == "__main__":
         long_description="",
         packages=find_packages(),
         install_requires=requirements,
-        setup_requires=setup_requires,
         tests_require=["hypothesis", "pytest-benchmark", "pytest"],
         python_requires=">=3.6",
         # add extension module
@@ -473,7 +470,6 @@ if __name__ == "__main__":
         zip_safe=False,
         include_package_data=True,
     )
-
     pymagnum_build_dir = osp.join(
         _cmake_build_dir, "deps", "magnum-bindings", "src", "python"
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,13 +92,18 @@ if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     # Policy that enables INTERPROCEDURAL_OPTIMIZATION
     set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
     cmake_policy(SET CMP0069 NEW)
-    #if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # Clang has some issues with thinLTO (segfaults on final linking)
-    # This enables full LTO through CMake
-    # FullLTO is slow, but may yield performance improvements.
-    #set(CMAKE_{lang}_COMPILE_OPTIONS_IPO ${CMAKE_CXX_COMPILE_OPTIONS_IPO} -flto)
-    #add_compile_options("-flto=full") # alternate way of forcing FAT LTO.
-    #endif()
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
+       OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION
+                                                     VERSION_LESS 13.0)
+    )
+      message("-- Forcing full LTO for compatibility: ThinLTO requires Clang>13.0")
+      # Clang has some issues with thinLTO (segfaults on final linking)
+      # This enables full LTO through CMake
+      # FullLTO is slow, but may yield performance improvements.
+      #set(CMAKE_{lang}_COMPILE_OPTIONS_IPO ${CMAKE_CXX_COMPILE_OPTIONS_IPO} -flto)
+      add_compile_options("-flto=full") # alternate way of forcing FAT LTO.
+    endif()
   endif()
 endif()
 # avoid ld visibility warnings, should be done by CMAKE_CXX_VISIBILITY_PRESET

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,13 +92,13 @@ if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     # Policy that enables INTERPROCEDURAL_OPTIMIZATION
     set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
     cmake_policy(SET CMP0069 NEW)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      # Clang has some issues with thinLTO (segfaults on final linking)
-      # This enables full LTO through CMake
-      # FullLTO is slow, but may yield performance improvements.
-      #set(CMAKE_{lang}_COMPILE_OPTIONS_IPO ${CMAKE_CXX_COMPILE_OPTIONS_IPO} -flto)
-      add_compile_options("-flto=full") # alternate way of forcing FAT LTO.
-    endif()
+    #if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Clang has some issues with thinLTO (segfaults on final linking)
+    # This enables full LTO through CMake
+    # FullLTO is slow, but may yield performance improvements.
+    #set(CMAKE_{lang}_COMPILE_OPTIONS_IPO ${CMAKE_CXX_COMPILE_OPTIONS_IPO} -flto)
+    #add_compile_options("-flto=full") # alternate way of forcing FAT LTO.
+    #endif()
   endif()
 endif()
 # avoid ld visibility warnings, should be done by CMAKE_CXX_VISIBILITY_PRESET

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,9 @@ if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
        OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION
                                                      VERSION_LESS 13.0)
     )
-      message("-- Forcing full LTO for compatibility: ThinLTO requires Clang>13.0")
+      message(
+        "-- Forcing full LTO for compatibility: ThinLTO requires LLVM Clang>=13.0"
+      )
       # Clang has some issues with thinLTO (segfaults on final linking)
       # This enables full LTO through CMake
       # FullLTO is slow, but may yield performance improvements.


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* I just tested the latest LLVM (13.0) and it fixes the segfault that prevented us from using using ThinLTO compilation. 
* Also tries to fix a flaky portion of the CI
* I can remove the cludge for EMSCRIPTEM (which is already at a supported LLVM version number), once my toolchains PR is merged in (https://github.com/mosra/toolchains/pull/14) Ping @mosra
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Tested with LLVM Clang 13.0
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
