### PR TITLE
--add binding to access read-only dictionary of URDF paths

### DIFF
--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -64,6 +64,10 @@ void initMetadataMediatorBindings(py::module& m) {
           pybind11::return_value_policy::reference,
           R"(The current dataset's StageAttributesManager instance
             for configuring simulation stage templates.)")
+      .def_property_readonly(
+          "urdf_paths", &MetadataMediator::getArticulatedObjectModelFilenames,
+          pybind11::return_value_policy::reference,
+          R"(Access to the dictionary of URDF paths, keyed by shortened name, value being full path.)")
       .def(
           "get_scene_handles", &MetadataMediator::getAllSceneInstanceHandles,
           R"(Returns a list the names of all the available scene instances in the currently active dataset.)")


### PR DESCRIPTION
## Motivation and Context
Provide read-only bindings to dictionary of urdf paths in current scene dataset.  Keyed by simplified name, value is fully qualified filepath.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Locally c++ and python tests
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
