### PR TITLE
--Use subconfigs instead of local vectors for scene instance and light attributes

### DIFF
--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -114,14 +114,15 @@ void initConfigBindings(py::module& m) {
           "get_subconfig_keys", &Configuration::getSubconfigKeys,
           R"(Retrieves a list of the keys of this configuration's subconfigurations)")
 
-      .def("get_subconfig", &Configuration::editSubconfig,
+      .def("get_subconfig", &Configuration::editSubconfig<Configuration>,
            py::return_value_policy::reference_internal,
            R"(Get the subconfiguration with the given name.)", "name"_a)
-      .def("get_subconfig_copy", &Configuration::getSubconfigCopy,
+      .def("get_subconfig_copy",
+           &Configuration::getSubconfigCopy<Configuration>,
            py::return_value_policy::reference,
            R"(Get a copy of the subconfiguration with the given name.)",
            "name"_a)
-      .def("save_subconfig", &Configuration::setSubconfigPtr,
+      .def("save_subconfig", &Configuration::setSubconfigPtr<Configuration>,
            R"(Save a subconfiguration with the given name.)", "name"_a,
            "subconfig"_a)
       .def(

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -297,10 +297,9 @@ int findValueInternal(const Configuration& config,
     // if found, will be greater than curLevel
     if (resLevel > curLevel) {
       return resLevel;
-    } else {
-      // remove subconfig key from breadcrumb
-      breadcrumb.pop_back();
     }
+    // remove subconfig key from breadcrumb
+    breadcrumb.pop_back();
   }
   // if not found, return lowest level having been checked
   return parentLevel;
@@ -323,11 +322,6 @@ Configuration& Configuration::operator=(const Configuration& otr) {
       configMap_[entry.first] = std::make_shared<Configuration>(*entry.second);
     }
   }
-  return *this;
-}
-Configuration& Configuration::operator=(Configuration&& otr) noexcept {
-  configMap_ = std::move(otr.configMap_);
-  valueMap_ = std::move(otr.valueMap_);
   return *this;
 }
 

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -225,6 +225,43 @@ bool ConfigValue::putValueInConfigGroup(
   }  // switch
 }  // ConfigValue::putValueInConfigGroup
 
+/**
+ * @brief Retrieves a shared pointer to a copy of the subConfig @ref
+ * esp::core::Configuration that has the passed @p name . This will create a
+ * pointer to a new sub-configuration if none exists already with that name,
+ * but will not add this configuration to this Configuration's internal
+ * storage.
+ *
+ * @param name The name of the configuration to retrieve.
+ * @return A pointer to a copy of the configuration having the requested
+ * name, or a pointer to an empty configuration.
+ */
+
+template <>
+std::shared_ptr<Configuration> Configuration::getSubconfigCopy<Configuration>(
+    const std::string& name) const {
+  auto configIter = configMap_.find(name);
+  if (configIter != configMap_.end()) {
+    // if exists return copy, so that consumers can modify it freely
+    return std::make_shared<Configuration>(*configIter->second);
+  }
+  return std::make_shared<Configuration>();
+}
+
+template <>
+std::shared_ptr<Configuration> Configuration::editSubconfig<Configuration>(
+    const std::string& name) {
+  // retrieve existing (or create new) subgroup, with passed name
+  return addSubgroup(name);
+}
+
+template <>
+void Configuration::setSubconfigPtr<Configuration>(
+    const std::string& name,
+    std::shared_ptr<Configuration>& configPtr) {
+  configMap_[name] = std::move(configPtr);
+}  // setSubconfigPtr
+
 Mn::Debug& operator<<(Mn::Debug& debug, const ConfigStoredType& value) {
   return debug << "Type:" << getNameForStoredType(value);
 }

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -271,10 +271,10 @@ void Configuration::setSubconfigPtr<Configuration>(
   configMap_[name] = std::move(configPtr);
 }  // setSubconfigPtr
 
-int findValueInternal(const Configuration& config,
-                      const std::string& key,
-                      int parentLevel,
-                      std::vector<std::string>& breadcrumb) {
+int Configuration::findValueInternal(const Configuration& config,
+                                     const std::string& key,
+                                     int parentLevel,
+                                     std::vector<std::string>& breadcrumb) {
   int curLevel = parentLevel + 1;
   if (config.valueMap_.count(key) > 0) {
     // Found at this level, access directly via key to get value

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -316,7 +316,7 @@ Configuration& Configuration::operator=(const Configuration& otr) {
   }
   return *this;
 }
-Configuration& Configuration::operator=(Configuration&& otr) {
+Configuration& Configuration::operator=(Configuration&& otr) noexcept {
   configMap_ = std::move(otr.configMap_);
   valueMap_ = std::move(otr.valueMap_);
   return *this;

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -306,6 +306,22 @@ int Configuration::findValueInternal(
   return parentLevel;
 }
 
+Configuration& Configuration::operator=(const Configuration& otr) {
+  if (this != &otr) {
+    configMap_.clear();
+    valueMap_ = otr.valueMap_;
+    for (const auto& entry : otr.configMap_) {
+      configMap_[entry.first] = std::make_shared<Configuration>(*entry.second);
+    }
+  }
+  return *this;
+}
+Configuration& Configuration::operator=(Configuration&& otr) {
+  configMap_ = std::move(otr.configMap_);
+  valueMap_ = std::move(otr.valueMap_);
+  return *this;
+}
+
 }  // namespace config
 }  // namespace core
 }  // namespace esp

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -646,7 +646,7 @@ class Configuration {
    * @return The level @p key was found. 0 if not found (so can be treated
    * as bool)
    */
-  friend int findValueInternal(const Configuration& config,
+  static int findValueInternal(const Configuration& config,
                                const std::string& key,
                                int parentLevel,
                                std::vector<std::string>& breadcrumb);

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -218,14 +218,13 @@ class Configuration {
  public:
   // convenience typedefs
   typedef std::unordered_map<std::string, ConfigValue> ValueMapType;
-  typedef std::unordered_map<std::string, std::shared_ptr<Configuration>>
-      ConfigMapType;
+  typedef std::map<std::string, std::shared_ptr<Configuration>> ConfigMapType;
 
   Configuration() = default;
 
   Configuration(const Configuration& otr)
       : configMap_(), valueMap_(otr.valueMap_) {
-    configMap_.reserve(otr.configMap_.size());
+    // configMap_.reserve(otr.configMap_.size());
     for (const auto& entry : otr.configMap_) {
       configMap_[entry.first] = std::make_shared<Configuration>(*entry.second);
     }

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -229,7 +229,7 @@ class Configuration {
     }
   }  // copy ctor
 
-  Configuration(Configuration&& otr)
+  Configuration(Configuration&& otr) noexcept
       : configMap_(std::move(otr.configMap_)),
         valueMap_(std::move(otr.valueMap_)) {}  // move ctor
 
@@ -245,7 +245,7 @@ class Configuration {
   /**
    * @brief Move Assignment.
    */
-  Configuration& operator=(Configuration&& otr);
+  Configuration& operator=(Configuration&& otr) noexcept;
 
   // ****************** Getters ******************
   /**

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -245,7 +245,7 @@ class Configuration {
   /**
    * @brief Move Assignment.
    */
-  Configuration& operator=(Configuration&& otr) noexcept;
+  Configuration& operator=(Configuration&& otr) noexcept = default;
 
   // ****************** Getters ******************
   /**

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -533,15 +533,18 @@ class Configuration {
   }
 
   /**
-   * @brief Retrieves the stored shared pointer to the subConfig @ref
-   * esp::core::Configuration that has the passed @p name . This will create a
-   * new sub-configuration if none exists.
+   * @brief Templated Version. Retrieves the stored shared pointer to the
+   * subConfig @ref esp::core::Configuration that has the passed @p name , cast
+   * to the specified type. This will create a shared pointer to a new
+   * sub-configuration if none exists and return it, cast to specified type.
    *
    * Use this function when you wish to modify this configuration's
    * subgroup, possibly creating it in the process.
+   * @tparam The type to cast the @ref esp::core::Configuration to.  Type is
+   * checked to verify that it inherits from Configuration.
    * @param name The name of the configuration to edit.
    * @return The actual pointer to the configuration having the requested
-   * name.
+   * name, cast to the specified type.
    */
   template <class T>
   std::shared_ptr<T> editSubconfig(const std::string& name) {
@@ -637,37 +640,7 @@ class Configuration {
    */
   int findValueInternal(const std::string& key,
                         int parentLevel,
-                        std::vector<std::string>& breadcrumb) const {
-    int curLevel = parentLevel + 1;
-    if (valueMap_.count(key) > 0) {
-      // Found at this level, access directly via key to get value
-      breadcrumb.push_back(key);
-      return curLevel;
-    }
-
-    // not found by here in data maps, check subconfigs, to see what level
-    for (const auto& subConfig : configMap_) {
-      if (subConfig.first == key) {
-        // key matches name of subconfiguration
-        breadcrumb.push_back(key);
-        return curLevel;
-      }
-      // add subconfig key to breadcrumb
-      breadcrumb.push_back(subConfig.first);
-      // search this subconfiguration
-      int resLevel =
-          subConfig.second->findValueInternal(key, curLevel, breadcrumb);
-      // if found, will be greater than curLevel
-      if (resLevel > curLevel) {
-        return resLevel;
-      } else {
-        // remove subconfig key from breadcrumb
-        breadcrumb.pop_back();
-      }
-    }
-    // if not found, return lowest level having been checked
-    return parentLevel;
-  }
+                        std::vector<std::string>& breadcrumb) const;
 
   /**
    * @brief Populate the passed cfg with all the values this map holds, along

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -462,13 +462,7 @@ class Configuration {
    * @return A breadcrumb list to where the value referenced by @p key
    * resides. An empty list means the value was not found.
    */
-  std::vector<std::string> findValue(const std::string& key) const {
-    std::vector<std::string> breadcrumbs{};
-    // this will make room for some layers without realloc.
-    breadcrumbs.reserve(10);
-    findValueInternal(key, 0, breadcrumbs);
-    return breadcrumbs;
-  }
+  std::vector<std::string> findValue(const std::string& key) const;
 
   /**
    * @brief Builds and returns @ref Cr::Utility::ConfigurationGroup
@@ -533,11 +527,11 @@ class Configuration {
   }
 
   /**
-   * @brief return pointer to sub-configuration of given @p name.  Will fail if
-   * configuration with given name dne.
+   * @brief return pointer to read-only sub-configuration of given @p name. Will
+   * fail if configuration with given name dne.
    * @param name The name of the desired configuration.
    */
-  std::shared_ptr<Configuration> getSubconfigRef(
+  std::shared_ptr<const Configuration> getSubconfigView(
       const std::string& name) const {
     auto configIter = configMap_.find(name);
     CORRADE_ASSERT(configIter != configMap_.end(), "", nullptr);
@@ -641,8 +635,9 @@ class Configuration {
 
  protected:
   /**
-   * @brief Checks if passed @p key is contained in this configuration.
+   * @brief Friend function.  Checks if passed @p key is contained in @p config.
    * Returns the highest level where @p key was found
+   * @param config The configuration to search for passed key
    * @param key The key to look for
    * @param parentLevel The parent level to the current iteration.  If
    * iteration finds @p key, it will return parentLevel+1
@@ -651,9 +646,10 @@ class Configuration {
    * @return The level @p key was found. 0 if not found (so can be treated
    * as bool)
    */
-  int findValueInternal(const std::string& key,
-                        int parentLevel,
-                        std::vector<std::string>& breadcrumb) const;
+  friend int findValueInternal(const Configuration& config,
+                               const std::string& key,
+                               int parentLevel,
+                               std::vector<std::string>& breadcrumb);
 
   /**
    * @brief Populate the passed cfg with all the values this map holds, along

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -224,15 +224,28 @@ class Configuration {
 
   Configuration(const Configuration& otr)
       : configMap_(), valueMap_(otr.valueMap_) {
-    // configMap_.reserve(otr.configMap_.size());
     for (const auto& entry : otr.configMap_) {
       configMap_[entry.first] = std::make_shared<Configuration>(*entry.second);
     }
-  }
+  }  // copy ctor
+
+  Configuration(Configuration&& otr)
+      : configMap_(std::move(otr.configMap_)),
+        valueMap_(std::move(otr.valueMap_)) {}  // move ctor
 
   // virtual destructor set to that pybind11 recognizes attributes inheritance
   // from configuration to be polymorphic
   virtual ~Configuration() = default;
+
+  /**
+   * @brief Copy Assignment.
+   */
+  Configuration& operator=(const Configuration& otr);
+
+  /**
+   * @brief Move Assignment.
+   */
+  Configuration& operator=(Configuration&& otr);
 
   // ****************** Getters ******************
   /**

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -140,7 +140,8 @@ bool Model::loadJsonAttributes(const std::string& filename) {
 
     // get pointer to user_defined subgroup configuration
     std::shared_ptr<core::config::Configuration> subGroupPtr =
-        jsonAttributes_->getSubconfigCopy(subGroupName);
+        jsonAttributes_->getSubconfigCopy<core::config::Configuration>(
+            subGroupName);
     // get json object referenced by tag subGroupName
     const io::JsonGenericValue& jsonObj = jsonConfig[subGroupName.c_str()];
     // count number of valid user config settings found

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -388,10 +388,9 @@ class Model {
   /**
    * @brief Json-based attributes defining characteristics of this model not
    * specified in the source XML/URDF. Primarly to support defaultt user-defined
-   * attribnutes. This data is read in from a json file with the same name as
-   * the source XML/URDF for this model, and the extension ".ao_config.json".
+   * attributes. This data is read in from a json file with the same base name
+   * as the source XML/URDF for this model but the extension ".ao_config.json".
    */
-
   std::shared_ptr<core::config::Configuration> jsonAttributes_ =
       std::make_shared<core::config::Configuration>();
 

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -380,7 +380,8 @@ class Model {
    * each object.
    */
   std::shared_ptr<core::config::Configuration> getUserConfiguration() const {
-    return jsonAttributes_->getSubconfigCopy("user_defined");
+    return jsonAttributes_->getSubconfigCopy<core::config::Configuration>(
+        "user_defined");
   }
 
  protected:

--- a/src/esp/io/json.cpp
+++ b/src/esp/io/json.cpp
@@ -104,11 +104,10 @@ int loadJsonIntoConfiguration(
       // support nested objects
       // create a new subgroup
       std::shared_ptr<core::config::Configuration> subGroupPtr =
-          config->getSubconfigCopy(key);
-      ;
+          config->getSubconfigCopy<core::config::Configuration>(key);
       numConfigSettings += loadJsonIntoConfiguration(obj, subGroupPtr);
       // save subgroup's subgroup configuration in original config
-      config->setSubconfigPtr(key, subGroupPtr);
+      config->setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
       //
     } else {
       // TODO support other types?

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -247,7 +247,7 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
     ESP_DEBUG() << "Query dataset :" << activeSceneDataset_
                 << "for SceneAttributes named :" << sceneName << "yields"
                 << sceneList.size() << "candidates.  Using" << sceneList[0]
-                << ".";
+                << Mn::Debug::nospace << ".";
     sceneAttributes = dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
   } else {
     const std::string sceneFilenameCandidate =

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -55,6 +55,36 @@ std::string getTranslationOriginName(int translationOrigin) {
   return "default";
 }
 
+AbstractAttributes::AbstractAttributes(const std::string& attributesClassKey,
+                                       const std::string& handle)
+    : Configuration() {
+  // set up an existing subgroup for user_defined attributes
+  addSubgroup("user_defined");
+  AbstractAttributes::setClassKey(attributesClassKey);
+  AbstractAttributes::setHandle(handle);
+  // set initial vals, will be overwritten when registered
+  set("ID", 0);
+  set("fileDirectory", "");
+}
+
+AbstractAttributes::AbstractAttributes(const AbstractAttributes& otr)
+    : Configuration(otr) {}
+AbstractAttributes::AbstractAttributes(AbstractAttributes&& otr) noexcept
+    : Configuration(std::move(otr)) {}
+
+AbstractAttributes& AbstractAttributes::operator=(
+    const AbstractAttributes& otr) {
+  if (this != &otr) {
+    this->Configuration::operator=(otr);
+  }
+  return *this;
+}
+AbstractAttributes& AbstractAttributes::operator=(
+    AbstractAttributes&& otr) noexcept {
+  this->Configuration::operator=(std::move(otr));
+  return *this;
+}
+
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -67,24 +67,6 @@ AbstractAttributes::AbstractAttributes(const std::string& attributesClassKey,
   set("fileDirectory", "");
 }
 
-AbstractAttributes::AbstractAttributes(const AbstractAttributes& otr)
-    : Configuration(otr) {}
-AbstractAttributes::AbstractAttributes(AbstractAttributes&& otr) noexcept
-    : Configuration(std::move(otr)) {}
-
-AbstractAttributes& AbstractAttributes::operator=(
-    const AbstractAttributes& otr) {
-  if (this != &otr) {
-    this->Configuration::operator=(otr);
-  }
-  return *this;
-}
-AbstractAttributes& AbstractAttributes::operator=(
-    AbstractAttributes&& otr) noexcept {
-  this->Configuration::operator=(std::move(otr));
-  return *this;
-}
-
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -121,11 +121,11 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
   AbstractAttributes(const std::string& attributesClassKey,
                      const std::string& handle);
 
-  AbstractAttributes(const AbstractAttributes& otr);
-  AbstractAttributes(AbstractAttributes&& otr) noexcept;
+  AbstractAttributes(const AbstractAttributes& otr) = default;
+  AbstractAttributes(AbstractAttributes&& otr) noexcept = default;
 
-  AbstractAttributes& operator=(const AbstractAttributes& otr);
-  AbstractAttributes& operator=(AbstractAttributes&& otr) noexcept;
+  AbstractAttributes& operator=(const AbstractAttributes& otr) = default;
+  AbstractAttributes& operator=(AbstractAttributes&& otr) noexcept = default;
 
   ~AbstractAttributes() override = default;
   /**

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -185,7 +185,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * object.
    */
   std::shared_ptr<Configuration> getUserConfiguration() const {
-    return getSubconfigCopy("user_defined");
+    return getSubconfigCopy<Configuration>("user_defined");
   }
 
   /**
@@ -195,7 +195,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * object.  This method is for editing the configuration.
    */
   std::shared_ptr<Configuration> editUserConfiguration() {
-    return editSubconfig("user_defined");
+    return editSubconfig<Configuration>("user_defined");
   }
 
   /**
@@ -203,7 +203,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
    * sub-ConfigurationGroup) this attributes has.
    */
   int getNumUserDefinedConfigurations() const {
-    return getNumSubconfigs("user_defined");
+    return getSubconfigNumEntries("user_defined");
   }
 
   /**

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -39,19 +39,57 @@ LightLayoutAttributes::LightLayoutAttributes(const std::string& handle)
   // set default scaling for positive and negative intensities to 1.0
   setPositiveIntensityScale(1.0);
   setNegativeIntensityScale(1.0);
+  // get ref to internal subconfig for light instances
+  lightInstConfig_ = editSubconfig<Configuration>("light_instances");
+}
+LightLayoutAttributes::LightLayoutAttributes(const LightLayoutAttributes& otr)
+    : AbstractAttributes(otr), availableLightIDs_(otr.availableLightIDs_) {
+  lightInstConfig_ = editSubconfig<Configuration>("light_instances");
+
+  copySubconfigIntoMe<LightInstanceAttributes>(otr.lightInstConfig_,
+                                               lightInstConfig_);
+}
+LightLayoutAttributes::LightLayoutAttributes(
+    LightLayoutAttributes&& otr) noexcept
+    : AbstractAttributes(std::move(static_cast<AbstractAttributes>(otr))),
+      availableLightIDs_(std::move(otr.availableLightIDs_)) {
+  lightInstConfig_ = editSubconfig<Configuration>("light_instances");
+}
+
+LightLayoutAttributes& LightLayoutAttributes::operator=(
+    const LightLayoutAttributes& otr) {
+  if (this != &otr) {
+    this->AbstractAttributes::operator=(otr);
+    // point to our own light instance config and available ids
+    availableLightIDs_ = otr.availableLightIDs_;
+    lightInstConfig_ = editSubconfig<Configuration>("light_instances");
+    copySubconfigIntoMe<LightInstanceAttributes>(otr.lightInstConfig_,
+                                                 lightInstConfig_);
+  }
+  return *this;
+}
+LightLayoutAttributes& LightLayoutAttributes::operator=(
+    LightLayoutAttributes&& otr) noexcept {
+  // point to our own light instance config and available ids
+  availableLightIDs_ = std::move(otr.availableLightIDs_);
+  this->AbstractAttributes::operator=(
+      std::move(static_cast<AbstractAttributes>(otr)));
+  lightInstConfig_ = editSubconfig<Configuration>("light_instances");
+  return *this;
 }
 
 std::string LightLayoutAttributes::getObjectInfoInternal() const {
   std::string res = "\n";
   int iter = 0;
-  for (const auto& lightInst : lightInstances_) {
+  auto lightInstances = getLightInstances();
+  for (const auto& lightInst : lightInstances) {
     if (iter == 0) {
       ++iter;
       Cr::Utility::formatInto(res, res.size(), ",{}\n",
-                              lightInst.second->getObjectInfoHeader());
+                              lightInst->getObjectInfoHeader());
     }
     Cr::Utility::formatInto(res, res.size(), ",{}\n",
-                            lightInst.second->getObjectInfo());
+                            lightInst->getObjectInfo());
   }
   return res;
 }

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -113,14 +113,19 @@ std::string SceneAttributes::getObjectInfoInternal() const {
 
   std::string res = Cr::Utility::formatString(
       "\nDefault Translation Origin,Default Lighting,Navmesh Handle,Semantic "
-      "Scene Descriptor Handle,\n{},{},{},{}\nStage Instance Info :\n{}\n{}\n",
+      "Scene Descriptor Handle,\n{},{},{},{}\n",
       getTranslationOriginName(getTranslationOrigin()), getLightingHandle(),
-      getNavmeshHandle(), getSemanticSceneHandle(),
-      stageInstance_->getObjectInfoHeader(), stageInstance_->getObjectInfo());
+      getNavmeshHandle(), getSemanticSceneHandle());
+
+  const SceneObjectInstanceAttributes::cptr stageInstance = getStageInstance();
+  Cr::Utility::formatInto(res, res.size(), "Stage Instance Info :\n{}\n{}\n",
+                          stageInstance->getObjectInfoHeader(),
+                          stageInstance->getObjectInfo());
   // stage instance info
   int iter = 0;
   // object instance info
-  for (const auto& objInst : objectInstances_) {
+  const auto& objInstances = getObjectInstances();
+  for (const auto& objInst : objInstances) {
     if (iter == 0) {
       ++iter;
       Cr::Utility::formatInto(res, res.size(), "Object Instance Info :\n{}\n",
@@ -131,7 +136,8 @@ std::string SceneAttributes::getObjectInfoInternal() const {
 
   // articulated object instance info
   iter = 0;
-  for (const auto& artObjInst : articulatedObjectInstances_) {
+  const auto& articulatedObjectInstances = getArticulatedObjectInstances();
+  for (const auto& artObjInst : articulatedObjectInstances) {
     if (iter == 0) {
       ++iter;
       Cr::Utility::formatInto(res, res.size(),

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -105,6 +105,9 @@ SceneAttributes::SceneAttributes(const std::string& handle)
   // defaults to asset local
   setTranslationOrigin(
       static_cast<int>(SceneInstanceTranslationOrigin::AssetLocal));
+  // get refs to internal subconfigs for object and ao instances
+  objInstConfig_ = editSubconfig<Configuration>("object_instances");
+  artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
 }
 
 std::string SceneAttributes::getObjectInfoInternal() const {

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -110,6 +110,53 @@ SceneAttributes::SceneAttributes(const std::string& handle)
   artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
 }
 
+SceneAttributes::SceneAttributes(const SceneAttributes& otr)
+    : AbstractAttributes(otr),
+      availableObjInstIDs_(otr.availableObjInstIDs_),
+      availableArtObjInstIDs_(otr.availableArtObjInstIDs_) {
+  // get refs to internal subconfigs for object and ao instances
+  objInstConfig_ = editSubconfig<Configuration>("object_instances");
+  copySubconfigIntoMe<SceneObjectInstanceAttributes>(otr.objInstConfig_,
+                                                     objInstConfig_);
+  artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
+  copySubconfigIntoMe<SceneAOInstanceAttributes>(otr.artObjInstConfig_,
+                                                 artObjInstConfig_);
+}
+SceneAttributes::SceneAttributes(SceneAttributes&& otr) noexcept
+    : AbstractAttributes(std::move(static_cast<AbstractAttributes>(otr))),
+      availableObjInstIDs_(std::move(otr.availableObjInstIDs_)),
+      availableArtObjInstIDs_(std::move(otr.availableArtObjInstIDs_)) {
+  // get refs to internal subconfigs for object and ao instances
+  // originals were moved over so should retain full derived class
+  objInstConfig_ = editSubconfig<Configuration>("object_instances");
+  artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
+}
+
+SceneAttributes& SceneAttributes::operator=(const SceneAttributes& otr) {
+  if (this != &otr) {
+    this->AbstractAttributes::operator=(otr);
+    availableObjInstIDs_ = otr.availableObjInstIDs_;
+    availableArtObjInstIDs_ = otr.availableArtObjInstIDs_;
+    // get refs to internal subconfigs for object and ao instances
+    objInstConfig_ = editSubconfig<Configuration>("object_instances");
+    copySubconfigIntoMe<SceneObjectInstanceAttributes>(otr.objInstConfig_,
+                                                       objInstConfig_);
+    artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
+    copySubconfigIntoMe<SceneAOInstanceAttributes>(otr.artObjInstConfig_,
+                                                   artObjInstConfig_);
+  }
+  return *this;
+}
+SceneAttributes& SceneAttributes::operator=(SceneAttributes&& otr) noexcept {
+  availableObjInstIDs_ = std::move(otr.availableObjInstIDs_);
+  availableArtObjInstIDs_ = std::move(otr.availableArtObjInstIDs_);
+  this->AbstractAttributes::operator=(
+      std::move(static_cast<AbstractAttributes>(otr)));
+
+  objInstConfig_ = editSubconfig<Configuration>("object_instances");
+  artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
+  return *this;
+}
 std::string SceneAttributes::getObjectInfoInternal() const {
   // scene-specific info constants
   // default translation origin

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -371,8 +371,7 @@ class SceneAttributes : public AbstractAttributes {
   /**
    * @brief Get the object instance descriptions for this scene
    */
-  const std::vector<SceneObjectInstanceAttributes::cptr> getObjectInstances()
-      const {
+  std::vector<SceneObjectInstanceAttributes::cptr> getObjectInstances() const {
     return getObjectInstanceAttrInternal<SceneObjectInstanceAttributes>(
         objInstConfig_);
   }
@@ -390,8 +389,8 @@ class SceneAttributes : public AbstractAttributes {
   /**
    * @brief Get the object instance descriptions for this scene
    */
-  const std::vector<SceneAOInstanceAttributes::cptr>
-  getArticulatedObjectInstances() const {
+  std::vector<SceneAOInstanceAttributes::cptr> getArticulatedObjectInstances()
+      const {
     return getObjectInstanceAttrInternal<SceneAOInstanceAttributes>(
         artObjInstConfig_);
   }

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -287,6 +287,12 @@ class SceneAttributes : public AbstractAttributes {
  public:
   explicit SceneAttributes(const std::string& handle);
 
+  SceneAttributes(const SceneAttributes& otr);
+  SceneAttributes(SceneAttributes&& otr) noexcept;
+
+  SceneAttributes& operator=(const SceneAttributes& otr);
+  SceneAttributes& operator=(SceneAttributes&& otr) noexcept;
+
   /**
    * @brief Set a value representing the mechanism used to create this scene
    * instance - should map to an enum value in @InstanceTranslationOriginMap.
@@ -373,8 +379,15 @@ class SceneAttributes : public AbstractAttributes {
    * @brief Get the object instance descriptions for this scene
    */
   std::vector<SceneObjectInstanceAttributes::cptr> getObjectInstances() const {
-    return getSubAttributesInternal<SceneObjectInstanceAttributes>(
+    return getSubAttributesListInternal<SceneObjectInstanceAttributes>(
         objInstConfig_);
+  }
+  /**
+   * @brief Return the number of defined @ref SceneObjectInstanceAttributes
+   * subconfigs in this scene instance.
+   */
+  int getNumObjInstances() const {
+    return getNumSubAttributesInternal("obj_inst_", objInstConfig_);
   }
 
   /**
@@ -392,8 +405,16 @@ class SceneAttributes : public AbstractAttributes {
    */
   std::vector<SceneAOInstanceAttributes::cptr> getArticulatedObjectInstances()
       const {
-    return getSubAttributesInternal<SceneAOInstanceAttributes>(
+    return getSubAttributesListInternal<SceneAOInstanceAttributes>(
         artObjInstConfig_);
+  }
+
+  /**
+   * @brief Return the number of defined @ref SceneAOInstanceAttributes
+   * subconfigs in this scene instance.
+   */
+  int getNumAOInstances() const {
+    return getNumSubAttributesInternal("art_obj_inst_", artObjInstConfig_);
   }
 
  protected:

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -286,11 +286,8 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
                               .color = {0.4, 0.4, 0.4},
                               .model = gfx::LightPositionModel::Global}};
     } else {
-      const std::map<std::string, LightInstanceAttributes::ptr>&
-          lightInstances = lightLayoutAttributes->getLightInstances();
-      for (const std::pair<const std::string, LightInstanceAttributes::ptr>&
-               elem : lightInstances) {
-        const LightInstanceAttributes::ptr& lightAttr = elem.second;
+      auto lightInstances = lightLayoutAttributes->getLightInstances();
+      for (const LightInstanceAttributes::cptr& lightAttr : lightInstances) {
         const int type = lightAttr->getType();
         const gfx::LightType typeEnum = static_cast<gfx::LightType>(type);
         const gfx::LightPositionModel posModelEnum =

--- a/src/esp/metadata/managers/SceneAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneAttributesManager.cpp
@@ -102,7 +102,7 @@ void SceneAttributesManager::setValsFromJSONDoc(
       }
     }
   } else {
-    ESP_WARNING() << "Articulated Objects specified for scene"
+    ESP_WARNING() << "No Articulated Objects specified for scene"
                   << attribsDispName << ", or specification error.";
   }
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -827,9 +827,10 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
 
   // test nested configuration
   auto artObjNestedConfig =
-      artObjInstance->getUserConfiguration()->getSubconfigCopy("user_def_obj");
+      artObjInstance->getUserConfiguration()
+          ->getSubconfigCopy<esp::core::config::Configuration>("user_def_obj");
   ASSERT_NE(artObjNestedConfig, nullptr);
-  ASSERT_EQ(artObjNestedConfig->hasValues(), true);
+  ASSERT_EQ(artObjNestedConfig->getNumEntries() > 0, true);
   ASSERT_EQ(artObjNestedConfig->template get<Magnum::Vector3>("position"),
             Magnum::Vector3(0.1f, 0.2f, 0.3f));
   ASSERT_EQ(artObjNestedConfig->template get<Magnum::Vector3>("rotation"),


### PR DESCRIPTION
## Motivation and Context
Use subconfig system instead of redundant member variable vectors to store stage, object and articulated object scene instances, and lighting configs.  Lights and scene instances are now supported.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
