### PR TITLE
Add cache and query for ArticulatedObject global scaling.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,6 @@ jobs:
                 numpy \
                 pytest \
                 sphinx \
-                pillow \
                 tqdm
               pip install -r requirements.txt torch --progress-bar off
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
                 pytest \
                 sphinx \
                 tqdm
-              pip install -r requirements.txt torch --progress-bar off
+              pip install --prefer-binary -r requirements.txt torch --progress-bar off
       - run:
           name: run black
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,8 @@ jobs:
               sudo rm  llvm-config
               sudo ln -s llvm-config-10 llvm-config
               cd ~/project/
-              pip install -U \
+              pip install -U pip
+              pip install -U --prefer-binary \
                 black \
                 flake8 \
                 flake8-bugbear \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ matplotlib
 numba
 numpy
 numpy-quaternion
-pillow
+pillow<=8.3.1
 scipy>=1.3.0
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ matplotlib
 numba
 numpy
 numpy-quaternion
-pillow<=8.3.1
+pillow
 scipy>=1.3.0
 tqdm

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -337,6 +337,9 @@ void declareArticulatedObjectWrapper(py::module& m,
              AbstractManagedPhysicsObject<ArticulatedObject>,
              std::shared_ptr<ManagedArticulatedObject>>(m,
                                                         classStrPrefix.c_str())
+      .def_property_readonly(
+          "global_scale", &ManagedArticulatedObject::getGlobalScale,
+          R"(The uniform global scaling applied to this object during import.)")
       .def("get_link_scene_node", &ManagedArticulatedObject::getLinkSceneNode,
            ("Get the scene node for this " + objType +
             "'s articulated link specified by the passed "

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -315,6 +315,12 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   };
 
   /**
+   * @brief Get the uniform global scaling applied to this object during import.
+   * @return The global scaling applied to the object.
+   */
+  float getGlobalScale() const { return globalScale_; }
+
+  /**
    * @brief Get a const reference to an ArticulatedLink SceneNode for
    * info query purposes.
    * @param linkId The ArticulatedLink ID or -1 for the baseLink.
@@ -827,6 +833,9 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   //! if true, automatically clamp dofs to joint limits before physics
   //! simulation steps
   bool autoClampJointLimits_ = false;
+
+  //! Cache the global scaling from the source model. Set during import.
+  float globalScale_ = 1.0;
 
  public:
   ESP_SMART_POINTERS(ArticulatedObject)

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -79,6 +79,9 @@ void BulletArticulatedObject::initializeFromURDF(
 
   auto urdfModel = u2b.getModel();
 
+  // cache the global scaling from the source model
+  globalScale_ = urdfModel->getGlobalScaling();
+
   int urdfLinkIndex = u2b.getRootLinkIndex();
   // int rootIndex = u2b.getRootLinkIndex();
 

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -24,6 +24,13 @@ class ManagedArticulatedObject
       : AbstractManagedPhysicsObject<esp::physics::ArticulatedObject>(
             classKey) {}
 
+  float getGlobalScale() const {
+    if (auto sp = getObjectReference()) {
+      return sp->getGlobalScale();
+    }
+    return 1.0;
+  }
+
   scene::SceneNode* getLinkSceneNode(int linkId = -1) const {
     if (auto sp = getObjectReference()) {
       return &const_cast<scene::SceneNode&>(sp->getLinkSceneNode(linkId));

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -654,9 +654,12 @@ def test_articulated_object_add_remove():
         assert robot.object_id == 0  # first robot added
 
         # add a second robot
-        robot2 = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        robot2 = art_obj_mgr.add_articulated_object_from_urdf(
+            filepath=robot_file, global_scale=2.0
+        )
         assert robot2
         assert art_obj_mgr.get_num_objects() == 2
+        assert robot2.global_scale == 2.0
 
         # remove a robot and check that it was removed
         art_obj_mgr.remove_object_by_handle(robot.handle)


### PR DESCRIPTION
## Motivation and Context

Articulated objects can be programmatically scaled upon instantiation in the scene. Any geometric metadata defined in the original frame should be scaled also, requiring that this global scale is cached when the object is created and queryable later.

## How Has This Been Tested

Added a simple test in python.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
