### PR TITLE
[TechDebt]--Minor Refactors; Attributes/ManagedContainer optimizations and documentation updates.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -910,7 +910,7 @@ void ResourceManager::computeInstanceMeshAbsoluteAABBs(
 std::vector<Mn::Matrix4> ResourceManager::computeAbsoluteTransformations(
     const std::vector<StaticDrawableInfo>& staticDrawableInfo) {
   // sanity check
-  if (staticDrawableInfo.size() == 0) {
+  if (staticDrawableInfo.empty()) {
     return {};
   }
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -217,7 +217,7 @@ bool ResourceManager::loadStage(
       ((_physicsManager != nullptr) &&
        (_physicsManager->getInitializationAttributes()->getSimulator() !=
         "none"));
-  const std::string renderLightSetupKey(stageAttributes->getLightSetup());
+  const std::string renderLightSetupKey(stageAttributes->getLightSetupKey());
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, buildCollisionMesh,
                                           createSemanticMesh);

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -85,8 +85,9 @@ void initAttributesBindings(py::module& m) {
       // string values, to guarantee essential value type integrity.)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key,
-             const std::string& val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const std::string& val) {
             CORRADE_ASSERT(false,
                            "Attributes should only use named properties or "
                            "subconfigurations to set string values, to "
@@ -95,8 +96,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key,
-             const char* val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const char* val) {
             CORRADE_ASSERT(false,
                            "Attributes should only use named properties or "
                            "subconfigurations to set string values, to "
@@ -105,7 +107,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key, const int val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const int val) {
             CORRADE_ASSERT(false,
                            "Attributes should only use named properties or "
                            "subconfigurations to set integer values, to "
@@ -114,8 +118,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key,
-             const double val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const double val) {
             CORRADE_ASSERT(false,
                            "Attributes should only use named properties or "
                            "subconfigurations to set floating-point values, to "
@@ -124,7 +129,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key, const bool val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const bool val) {
             CORRADE_ASSERT(false,
                            "Attributes should only use named properties or "
                            "subconfigurations to set boolean values, to "
@@ -133,8 +140,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key,
-             const Magnum::Quaternion& val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const Magnum::Quaternion& val) {
             CORRADE_ASSERT(
                 false,
                 "Attributes should only use named properties or "
@@ -144,8 +152,9 @@ void initAttributesBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
-          [](AbstractAttributes& self, const std::string& key,
-             const Magnum::Vector3& val) {
+          [](CORRADE_UNUSED AbstractAttributes& self,
+             CORRADE_UNUSED const std::string& key,
+             CORRADE_UNUSED const Magnum::Vector3& val) {
             CORRADE_ASSERT(
                 false,
                 "Attributes should only use named properties or "

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -79,7 +79,82 @@ void initAttributesBindings(py::module& m) {
                              R"(Class name of Attributes template.)")
       .def_property_readonly(
           "csv_info", &AbstractAttributes::getObjectInfo,
-          R"(Comma-separated informational string describing this Attributes template)");
+          R"(Comma-separated informational string describing this Attributes template)")
+
+      // Attributes should only use named properties or subconfigurations to set
+      // string values, to guarantee essential value type integrity.)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key,
+             const std::string& val) {
+            CORRADE_ASSERT(false,
+                           "Attributes should only use named properties or "
+                           "subconfigurations to set string values, to "
+                           "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key,
+             const char* val) {
+            CORRADE_ASSERT(false,
+                           "Attributes should only use named properties or "
+                           "subconfigurations to set string values, to "
+                           "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key, const int val) {
+            CORRADE_ASSERT(false,
+                           "Attributes should only use named properties or "
+                           "subconfigurations to set integer values, to "
+                           "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key,
+             const double val) {
+            CORRADE_ASSERT(false,
+                           "Attributes should only use named properties or "
+                           "subconfigurations to set floating-point values, to "
+                           "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key, const bool val) {
+            CORRADE_ASSERT(false,
+                           "Attributes should only use named properties or "
+                           "subconfigurations to set boolean values, to "
+                           "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key,
+             const Magnum::Quaternion& val) {
+            CORRADE_ASSERT(
+                false,
+                "Attributes should only use named properties or "
+                "subconfigurations to set Nagnum::Quaternion values, to "
+                "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](AbstractAttributes& self, const std::string& key,
+             const Magnum::Vector3& val) {
+            CORRADE_ASSERT(
+                false,
+                "Attributes should only use named properties or "
+                "subconfigurations to set Magnum::Vector3 values, to "
+                "guarantee essential value type integrity.", );
+          },
+          "key"_a, "value"_a)
+
+      ;
 
   // ==== AbstractObjectAttributes ====
   py::class_<AbstractObjectAttributes, AbstractAttributes,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -63,7 +63,7 @@ void initSimBindings(py::module& m) {
           &SimulatorConfiguration::overrideSceneLightDefaults,
           R"(Override scene lighting setup to use with value specified below.)")
       .def_readwrite("scene_light_setup",
-                     &SimulatorConfiguration::sceneLightSetup)
+                     &SimulatorConfiguration::sceneLightSetupKey)
       .def_readwrite("load_semantic_mesh",
                      &SimulatorConfiguration::loadSemanticMesh)
       .def_readwrite(

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -10,7 +10,6 @@
 #include <Corrade/Utility/FormatStl.h>
 #include <Magnum/Magnum.h>
 #include <string>
-#include <typeinfo>
 #include <unordered_map>
 
 #include "esp/core/Check.h"
@@ -159,17 +158,23 @@ class ConfigValue {
 
   template <class T>
   void set(const T& value) {
-    // this never fails, not a bool anymore
+    // this never fails
     deleteCurrentValue();
-    // this will blow up at compile time if such type is not supported
+    // this will blow up at compile time if given type is not supported
     _type = configStoredTypeFor<T>();
-    // see later
+    // these asserts are checking the integrity of the support for T's type, and
+    // will fire if...
+
+    // ...we added a new type into @ref ConfigStoredType enum improperly
+    // (trivial type added after entry ConfigStoredType::_nonTrivialTypes, or
+    // vice-versa)
     static_assert(isConfigStoredTypeNonTrivial(configStoredTypeFor<T>()) !=
                       std::is_trivially_copyable<T>::value,
-                  "something's off!");
-    // this will blow up if we added new larger types but forgot to update the
-    // storage
+                  "Something's incorrect about enum placement for added type!");
+    // ...we added a new type that is too large for internal storage
     static_assert(sizeof(T) <= sizeof(_data), "internal storage too small");
+    // ...we added a new type whose alignment does not match internal storage
+    // alignment
     static_assert(alignof(T) <= alignof(ConfigValue),
                   "internal storage too unaligned");
 

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -74,7 +74,7 @@ std::vector<std::string> getHandlesBySubStringPerTypeInternal(
     bool sorted) {
   std::vector<std::string> res;
   // if empty return empty vector
-  if (mapOfHandles.size() == 0) {
+  if (mapOfHandles.empty()) {
     return res;
   }
   res.reserve(mapOfHandles.size());
@@ -141,7 +141,7 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
   std::vector<std::string> handles =
       this->getObjectHandlesBySubstring(subStr, contains, true);
   std::vector<std::string> res(handles.size() + 1);
-  if (handles.size() == 0) {
+  if (handles.empty()) {
     res[0] = "No " + objectType_ + " constructs available.";
     return res;
   }
@@ -206,7 +206,7 @@ std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
   // object instance name will be the partition between the name and the count.
   char pivotChar = ':';
 
-  if (objHandles.size() != 0) {
+  if (!objHandles.empty()) {
     // handles exist with passed substring.  Find highest handle increment, add
     // 1 and use for new name 1, build new handle
     for (const std::string& objName : objHandles) {

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -101,7 +101,7 @@ std::vector<std::string> getHandlesBySubStringPerTypeInternal(
       if (found == contains) {
         // if found and searching for contains, or not found and searching for
         // not contains
-        res.emplace_back(rawKey);
+        res.emplace_back(std::move(rawKey));
       }
     }
   }

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -138,8 +138,8 @@ std::vector<std::string> ManagedContainerBase::getObjectInfoStrings(
     const std::string& subStr,
     bool contains) const {
   // get all handles that match query elements first
-  std::vector<std::string> handles =
-      this->getObjectHandlesBySubstring(subStr, contains, true);
+  std::vector<std::string> handles = getHandlesBySubStringPerTypeInternal<1>(
+      objectLibKeyByID_, subStr, contains, true);
   std::vector<std::string> res(handles.size() + 1);
   if (handles.empty()) {
     res[0] = "No " + objectType_ + " constructs available.";

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -59,36 +59,31 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
   if (mapOfHandles.size() == 0) {
     return res;
   }
+  res.reserve(mapOfHandles.size());
   // if search string is empty, return all values
   if (subStr.length() == 0) {
-    res.reserve(mapOfHandles.size());
     for (const auto& elem : mapOfHandles) {
       res.push_back(elem.second);
     }
-    if (sorted) {
-      std::sort(res.begin(), res.end());
-    }
-    return res;
-  }
-  // build search criteria
-  std::string strToLookFor = Cr::Utility::String::lowercase(subStr);
-
-  std::size_t strSize = strToLookFor.length();
-
-  for (std::unordered_map<int, std::string>::const_iterator iter =
-           mapOfHandles.begin();
-       iter != mapOfHandles.end(); ++iter) {
-    std::string key = Cr::Utility::String::lowercase(iter->second);
-    // be sure that key is big enough to search in (otherwise find has undefined
-    // behavior)
-    if (key.length() < strSize) {
-      continue;
-    }
-    bool found = (std::string::npos != key.find(strToLookFor));
-    if (found == contains) {
-      // if found and searching for contains, or not found and searching for not
-      // contains
-      res.push_back(iter->second);
+  } else {
+    // build search criteria for reverse map
+    std::string strToLookFor = Cr::Utility::String::lowercase(subStr);
+    std::size_t strSize = strToLookFor.length();
+    for (std::unordered_map<int, std::string>::const_iterator iter =
+             mapOfHandles.begin();
+         iter != mapOfHandles.end(); ++iter) {
+      std::string key = Cr::Utility::String::lowercase(iter->second);
+      // be sure that key is big enough to search in (otherwise find has
+      // undefined behavior)
+      if (key.length() < strSize) {
+        continue;
+      }
+      bool found = (std::string::npos != key.find(strToLookFor));
+      if (found == contains) {
+        // if found and searching for contains, or not found and searching for
+        // not contains
+        res.push_back(iter->second);
+      }
     }
   }
   if (sorted) {
@@ -108,36 +103,31 @@ ManagedContainerBase::getObjectHandlesBySubStringPerType(
   if (mapOfHandles.size() == 0) {
     return res;
   }
+  res.reserve(mapOfHandles.size());
   // if search string is empty, return all values
   if (subStr.length() == 0) {
-    res.reserve(mapOfHandles.size());
     for (const auto& elem : mapOfHandles) {
       res.push_back(elem.first);
     }
-    if (sorted) {
-      std::sort(res.begin(), res.end());
-    }
-    return res;
-  }
-  // build search criteria
-  std::string strToLookFor = Cr::Utility::String::lowercase(subStr);
-
-  std::size_t strSize = strToLookFor.length();
-
-  for (std::unordered_map<std::string, std::set<std::string>>::const_iterator
-           iter = mapOfHandles.begin();
-       iter != mapOfHandles.end(); ++iter) {
-    std::string key = Cr::Utility::String::lowercase(iter->first);
-    // be sure that key is big enough to search in (otherwise find has undefined
-    // behavior)
-    if (key.length() < strSize) {
-      continue;
-    }
-    bool found = (std::string::npos != key.find(strToLookFor));
-    if (found == contains) {
-      // if found and searching for contains, or not found and searching for not
-      // contains
-      res.push_back(iter->first);
+  } else {
+    // build search criteria
+    std::string strToLookFor = Cr::Utility::String::lowercase(subStr);
+    std::size_t strSize = strToLookFor.length();
+    for (std::unordered_map<std::string, std::set<std::string>>::const_iterator
+             iter = mapOfHandles.begin();
+         iter != mapOfHandles.end(); ++iter) {
+      std::string key = Cr::Utility::String::lowercase(iter->first);
+      // be sure that key is big enough to search in (otherwise find has
+      // undefined behavior)
+      if (key.length() < strSize) {
+        continue;
+      }
+      bool found = (std::string::npos != key.find(strToLookFor));
+      if (found == contains) {
+        // if found and searching for contains, or not found and searching for
+        // not contains
+        res.push_back(iter->first);
+      }
     }
   }
   if (sorted) {

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -12,11 +12,11 @@
  */
 
 #include "ManagedContainer.h"
+#include "esp/io/Json.h"
 
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/String.h>
-
-#include "esp/io/Json.h"
+#include <typeinfo>
 
 namespace esp {
 namespace core {
@@ -145,7 +145,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     // by here always fail
     ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
                 << Magnum::Debug::nospace << "> : File" << filename
-                << "failed due to unknown file type.";
+                << "failed due to unsupported file type :" << typeid(U).name();
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
   /**
@@ -202,8 +202,8 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
   std::string strHandle = Cr::Utility::String::lowercase(filename);
   std::string resHandle(filename);
   // If filename does not already have extension of interest
-  if (std::string::npos ==
-      strHandle.find(Cr::Utility::String::lowercase(fileTypeExt))) {
+  if (strHandle.find(Cr::Utility::String::lowercase(fileTypeExt)) ==
+      std::string::npos) {
     resHandle = Cr::Utility::Directory::splitExtension(filename).first + "." +
                 fileTypeExt;
     ESP_VERY_VERBOSE() << "<" << Magnum::Debug::nospace << this->objectType_

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -88,7 +88,7 @@ LightSetup getDefaultLights() {
 }
 
 Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
-  if (lightSetup.size() == 0) {
+  if (lightSetup.empty()) {
     // We assume an empty light setup means the user wants "flat" shading,
     // meaning object ambient color should be copied directly to pixels as-is.
     // We can achieve this in the Phong shader using an ambient light color of

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -57,7 +57,7 @@ bool MetadataMediator::setSimulatorConfiguration(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // pass relevant config values to the current dataset
   if (datasetAttr != nullptr) {
-    datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetup,
+    datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetupKey,
                                 simConfig_.frustumCulling);
   } else {
     ESP_ERROR() << "No active dataset exists or has been specified. Aborting";

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -14,7 +14,7 @@ namespace attributes {
 
 /**
  * @brief This class describes an instance of a light -
- * it's template name, location/direction, color, intensity, type and other
+ * its template name, location/direction, color, intensity, type and other
  * parameters if appropriate.
  */
 class LightInstanceAttributes : public AbstractAttributes {
@@ -38,72 +38,88 @@ class LightInstanceAttributes : public AbstractAttributes {
 
   explicit LightInstanceAttributes(const std::string& handle = "");
 
-  /**
-   * @brief Get/Set the position of the light.
-   */
+  /** @brief Set the position of the light. Used for positional lights.  */
   void setPosition(const Magnum::Vector3& position) {
     set("position", position);
   }
+
+  /** @brief Get the position of the light. Used for positional lights. */
   Magnum::Vector3 getPosition() const {
     return get<Magnum::Vector3>("position");
   }
 
-  /**
-   * @brief Get/Set the direction of the light.
-   */
+  /** @brief Set the direction of the light. Used for directional lights. */
   void setDirection(const Magnum::Vector3& direction) {
     set("direction", direction);
   }
+
+  /** @brief Get the direction of the light. Used for directional lights. */
   Magnum::Vector3 getDirection() const {
     return get<Magnum::Vector3>("direction");
   }
 
-  /**
-   * @brief Get/Set the color of the light.
-   */
+  /** @brief Set the color of the light.*/
   void setColor(const Magnum::Vector3& color) { set("color", color); }
+
+  /** @brief Get the color of the light.*/
   Magnum::Vector3 getColor() const { return get<Magnum::Vector3>("color"); }
 
-  /**
-   * @brief Get/Set the color scale of the light.
-   */
+  /** @brief Set the intensity of the light. */
   void setIntensity(double intensity) { set("intensity", intensity); }
+
+  /** @brief Get the intensity of the light. */
   double getIntensity() const { return get<double>("intensity"); }
 
-  /**
-   * @brief Get/Set the type of the light
-   */
+  /** @brief Set the type of the light */
   void setType(int type) { set("type", type); }
+
+  /** @brief Get the type of the light */
   int getType() const { return get<int>("type"); }
 
   /**
-   * @brief Get/Set the position model to use when placing the light - whether
+   * @brief Set the position model to use when placing the light - whether
    * the lights translation should be relative to the camera, the global scene
    * origin, or some object.
    */
   void setPositionModel(int position_model) {
     set("position_model", position_model);
   }
+
+  /**
+   * @brief Get the position model to use when placing the light - whether
+   * the lights translation should be relative to the camera, the global scene
+   * origin, or some object.
+   */
   int getPositionModel() const { return get<int>("position_model"); }
 
   /**
-   * @brief Get/Set inner cone angle for spotlights.  Should be ignored for
+   * @brief Set inner cone angle for spotlights.  Should be ignored for
    * other lights
    */
   void setInnerConeAngle(Magnum::Rad innerConeAngle) {
     set("innerConeAngle", innerConeAngle);
   }
+
+  /**
+   * @brief Get inner cone angle for spotlights.  Should be ignored for
+   * other lights
+   */
   Magnum::Rad getInnerConeAngle() const {
     return get<Magnum::Rad>("innerConeAngle");
   }
 
   /**
-   * @brief Get/Set inner cone angle for spotlights. Should be ignored for other
+   * @brief Set outer cone angle for spotlights. Should be ignored for other
    * lights
    */
   void setOuterConeAngle(Magnum::Rad outerConeAngle) {
     set("outerConeAngle", outerConeAngle);
   }
+
+  /**
+   * @brief Get outer cone angle for spotlights. Should be ignored for other
+   * lights
+   */
   Magnum::Rad getOuterConeAngle() const {
     return get<Magnum::Rad>("outerConeAngle");
   }
@@ -144,6 +160,7 @@ class LightInstanceAttributes : public AbstractAttributes {
     return "Position XYZ,Direction XYZ,Color RGB,Intensity,Light Type,"
            "Light Position Model,";
   }
+
   /**
    * @brief Retrieve a comma-separated informational string about the
    * contents of this managed object.
@@ -160,7 +177,7 @@ class LightInstanceAttributes : public AbstractAttributes {
  public:
   ESP_SMART_POINTERS(LightInstanceAttributes)
 
-};  // namespace attributes
+};  // class LightInstanceAttributes
 
 /**
  * @brief This class describes a lighting layout, consisting of a series of
@@ -249,8 +266,8 @@ class LightLayoutAttributes : public AbstractAttributes {
    * info returned for this managed object, type-specific. The individual light
    * instances return a header for this.
    */
-
   std::string getObjectInfoHeaderInternal() const override { return ","; };
+
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.
@@ -262,6 +279,7 @@ class LightLayoutAttributes : public AbstractAttributes {
    * configuration is created on LightLayoutAttributes construction.
    */
   std::shared_ptr<Configuration> lightInstConfig_{};
+
   /**
    * @brief Deque holding all released IDs to consume for light instances when
    * one is deleted, before using size of lightInstances_ container.
@@ -270,7 +288,7 @@ class LightLayoutAttributes : public AbstractAttributes {
 
  public:
   ESP_SMART_POINTERS(LightLayoutAttributes)
-};  // namespace attributes
+};  // class LightLayoutAttribute
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -36,6 +36,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setCollisionAssetIsPrimitive(false);
   setUseMeshCollision(true);
   setIsCollidable(true);
+  setIsVisible(true);
   setUnitsToMeters(1.0);
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
@@ -76,7 +77,6 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
   setShaderType(static_cast<int>(ObjectInstanceShaderType::Unknown));
   // TODO remove this once ShaderType support is complete
   setRequiresLighting(true);
-  setIsVisible(true);
   setSemanticId(0);
 }  // ObjectAttributes ctor
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -89,6 +89,12 @@ class AbstractObjectAttributes : public AbstractAttributes {
    */
   double getUnitsToMeters() const { return get<double>("units_to_meters"); }
 
+  /**
+   * @brief If not visible can add dynamic non-rendered object into a scene
+   * object.  If is not visible then should not add object to drawables.
+   */
+  void setIsVisible(bool isVisible) { set("is_visible", isVisible); }
+  bool getIsVisible() const { return get<bool>("is_visible"); }
   void setFrictionCoefficient(double frictionCoefficient) {
     set("friction_coefficient", frictionCoefficient);
   }
@@ -297,13 +303,6 @@ class ObjectAttributes : public AbstractObjectAttributes {
   bool getJoinCollisionMeshes() const {
     return get<bool>("join_collision_meshes");
   }
-
-  /**
-   * @brief If not visible can add dynamic non-rendered object into a scene
-   * object.  If is not visible then should not add object to drawables.
-   */
-  void setIsVisible(bool isVisible) { set("is_visible", isVisible); }
-  bool getIsVisible() const { return get<bool>("is_visible"); }
 
   void setSemanticId(int semanticId) { set("semantic_id", semanticId); }
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -202,7 +202,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
    */
   int getShaderType() const { return get<int>("shader_type"); }
 
-  // if true use phong illumination model instead of flat shading
+  /** @brief if true use phong illumination model instead of flat shading */
   void setRequiresLighting(bool requiresLighting) {
     set("requires_lighting", requiresLighting);
   }
@@ -251,8 +251,8 @@ class AbstractObjectAttributes : public AbstractAttributes {
 };  // class AbstractObjectAttributes
 
 /**
- * @brief Specific Attributes instance describing an object, constructed with
- * a default set of object-specific required attributes
+ * @brief Specific Attributes instance describing a rigid object, constructed
+ * with a default set of object-specific required attributes.
  */
 class ObjectAttributes : public AbstractObjectAttributes {
  public:
@@ -330,8 +330,8 @@ class ObjectAttributes : public AbstractObjectAttributes {
 // stage attributes
 
 /**
- * @brief Specific Attributes instance describing a stage, constructed with a
- * default set of stage-specific required attributes
+ * @brief Specific Attributes instance describing a rigid stage, constructed
+ * with a default set of stage-specific required attributes
  */
 class StageAttributes : public AbstractObjectAttributes {
  public:

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -379,11 +379,13 @@ class StageAttributes : public AbstractObjectAttributes {
    * @ref esp::sim::SimulatorConfiguration, is overridden by any value set in
    * json, if exists.
    */
-  void setLightSetup(const std::string& lightSetup) {
-    set("light_setup", lightSetup);
-    setRequiresLighting(lightSetup != NO_LIGHT_KEY);
+  void setLightSetupKey(const std::string& lightSetupKey) {
+    set("light_setup_key", lightSetupKey);
+    setRequiresLighting(lightSetupKey != NO_LIGHT_KEY);
   }
-  std::string getLightSetup() const { return get<std::string>("light_setup"); }
+  std::string getLightSetupKey() const {
+    return get<std::string>("light_setup_key");
+  }
 
   /**
    * @brief set frustum culling for stage.  Default value comes from
@@ -409,7 +411,7 @@ class StageAttributes : public AbstractObjectAttributes {
   std::string getAbstractObjectInfoInternal() const override {
     return Cr::Utility::formatString("{},{},{},{}", getNavmeshAssetHandle(),
                                      getAsString("gravity"),
-                                     getAsString("origin"), getLightSetup());
+                                     getAsString("origin"), getLightSetupKey());
   }
 
  public:

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -11,7 +11,10 @@ namespace esp {
 namespace metadata {
 namespace attributes {
 
-//! attributes for a single physics manager
+/**
+ * @brief attributes class describing essential and default quantities used to
+ * instantiate a physics manager.
+ */
 class PhysicsManagerAttributes : public AbstractAttributes {
  public:
   explicit PhysicsManagerAttributes(const std::string& handle = "");

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -29,7 +29,7 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   set("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
   set("translation", Mn::Vector3());
   // don't override attributes-specified visibility.
-  set("is_insitance_visible", ID_UNDEFINED);
+  set("is_instance_visible", ID_UNDEFINED);
   // defaults to unknown so that obj instances use scene instance setting
   setTranslationOrigin(
       static_cast<int>(SceneInstanceTranslationOrigin::Unknown));

--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -28,6 +28,8 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   // set to no rotation
   set("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
   set("translation", Mn::Vector3());
+  // don't override attributes-specified visibility.
+  set("is_insitance_visible", ID_UNDEFINED);
   // defaults to unknown so that obj instances use scene instance setting
   setTranslationOrigin(
       static_cast<int>(SceneInstanceTranslationOrigin::Unknown));

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -96,9 +96,9 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    */
   void setIsInstanceVisible(bool isVisible) {
     // needs to be int to cover "no specification"
-    set("is_insitance_visible", (isVisible ? 1 : 0));
+    set("is_instance_visible", (isVisible ? 1 : 0));
   }
-  int getIsInstanceVisible() const { return get<int>("is_insitance_visible"); }
+  int getIsInstanceVisible() const { return get<int>("is_instance_visible"); }
 
   /**
    * @brief Set the motion type for the object.  Ignored for stage instances.

--- a/src/esp/metadata/attributes/SceneAttributes.h
+++ b/src/esp/metadata/attributes/SceneAttributes.h
@@ -91,6 +91,16 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   }
 
   /**
+   * @brief If not visible can add dynamic non-rendered object into a scene
+   * object.  If is not visible then should not add object to drawables.
+   */
+  void setIsInstanceVisible(bool isVisible) {
+    // needs to be int to cover "no specification"
+    set("is_insitance_visible", (isVisible ? 1 : 0));
+  }
+  int getIsInstanceVisible() const { return get<int>("is_insitance_visible"); }
+
+  /**
    * @brief Set the motion type for the object.  Ignored for stage instances.
    */
   void setMotionType(int motionType) { set("motion_type", motionType); }

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -180,7 +180,7 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
 
   }  // if this is prim else
   if (nullptr != attrs) {
-    ESP_DEBUG() << msg << "" << this->objectType_ << "attributes created"
+    ESP_DEBUG() << msg << this->objectType_ << "attributes created"
                 << (registerTemplate ? "and registered." : ".");
   }
   return attrs;

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -403,7 +403,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // verify that a template with this field as the original file was loaded.
     std::vector<std::string> handles =
         attrMgr->getObjectHandlesBySubstring(originalFile, true);
-    if (handles.size() == 0) {
+    if (handles.empty()) {
       ESP_WARNING()
           << "\"" << tag
           << ".configs\" cell element in JSON config specified source file :"

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -177,7 +177,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
 
   // set defaults from SimulatorConfig values; these can also be overridden by
   // json, for example.
-  newAttributes->setLightSetup(cfgLightSetup_);
+  newAttributes->setLightSetupKey(cfgLightSetup_);
   newAttributes->setRequiresLighting(cfgLightSetup_ != NO_LIGHT_KEY);
   // set value from config so not necessary to be passed as argument
   newAttributes->setFrustumCulling(cfgFrustumCulling_);

--- a/src/esp/nav/GreedyFollower.cpp
+++ b/src/esp/nav/GreedyFollower.cpp
@@ -168,7 +168,7 @@ GreedyGeodesicFollowerImpl::CODES GreedyGeodesicFollowerImpl::nextActionAlong(
     thrashingActions_.pop_back();
   } else {
     const auto nextActions = nextBestPrimAlong(start, path);
-    if (nextActions.size() == 0) {
+    if (nextActions.empty()) {
       nextAction = CODES::ERROR;
     } else if (fixThrashing_ && isThrashing()) {
       thrashingActions_ = {nextActions.rbegin(), nextActions.rend()};
@@ -199,7 +199,7 @@ GreedyGeodesicFollowerImpl::findPath(const core::RigidState& start,
     path.requestedEnd = cast<vec3f>(end);
     pathfinder_->findPath(path);
     const auto nextPrim = nextBestPrimAlong(state, path);
-    if (nextPrim.size() == 0) {
+    if (nextPrim.empty()) {
       actions_.emplace_back(CODES::ERROR);
     } else {
       for (const auto nextAction : nextPrim) {

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1037,7 +1037,7 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
     return false;
   }
 
-  if (path.pimpl_->endRefs.size() != 0)
+  if (!path.pimpl_->endRefs.empty())
     return true;
 
   for (const auto& rqEnd : path.getRequestedEnds()) {

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -93,6 +93,14 @@ int PhysicsManager::addObjectInstance(
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
+  // check if an object is being set to be not visible for a particular
+  // instance.
+  int visSet = objInstAttributes->getIsInstanceVisible();
+  if (visSet != ID_UNDEFINED) {
+    // specfied in scene instance
+    objAttributes->setIsVisible(visSet == 1 ? true : false);
+  }
+
   if (!objAttributes) {
     ESP_ERROR() << "Missing/improperly configured objectAttributes"
                 << attributesHandle << ", whose handle contains"
@@ -282,6 +290,15 @@ int PhysicsManager::addArticulatedObjectInstance(
     const std::string& lightSetup) {
   // Get drawables from simulator. TODO: Support non-existent simulator?
   auto& drawables = simulator_->getDrawableGroup();
+
+  // check if an object is being set to be not visible for a particular
+  // instance.
+  int visSet = aObjInstAttributes->getIsInstanceVisible();
+  if (visSet != ID_UNDEFINED) {
+    // specfied in scene instance
+    // objAttributes->setIsVisible(visSet == 1 ? true : false);
+    // TODO: manage articulated object visibility.
+  }
 
   // call object creation (resides only in physics library-based derived physics
   // managers)

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -98,7 +98,7 @@ int PhysicsManager::addObjectInstance(
   int visSet = objInstAttributes->getIsInstanceVisible();
   if (visSet != ID_UNDEFINED) {
     // specfied in scene instance
-    objAttributes->setIsVisible(visSet == 1 ? true : false);
+    objAttributes->setIsVisible(visSet == 1);
   }
 
   if (!objAttributes) {
@@ -296,7 +296,7 @@ int PhysicsManager::addArticulatedObjectInstance(
   int visSet = aObjInstAttributes->getIsInstanceVisible();
   if (visSet != ID_UNDEFINED) {
     // specfied in scene instance
-    // objAttributes->setIsVisible(visSet == 1 ? true : false);
+    // objAttributes->setIsVisible(visSet == 1);
     // TODO: manage articulated object visibility.
   }
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -42,22 +42,25 @@ class Simulator;
 }
 namespace physics {
 
-//! Holds information about one ray hit instance.
+/** @brief Holds information about one ray hit instance. */
 struct RayHitInfo {
-  //! The id of the object hit by this ray. Stage hits are -1.
+  /** @brief The id of the object hit by this ray. Stage hits are -1. */
   int objectId{};
-  //! The first impact point of the ray in world space.
+
+  /** @brief  The first impact point of the ray in world space. */
   Magnum::Vector3 point;
-  //! The collision object normal at the point of impact.
+
+  /** @brief The collision object normal at the point of impact. */
   Magnum::Vector3 normal;
-  //! Distance along the ray direction from the ray origin (in units of ray
-  //! length).
+
+  /** @brief  Distance along the ray direction from the ray origin (in units of
+   * ray length). */
   double rayDistance{};
 
   ESP_SMART_POINTERS(RayHitInfo)
 };
 
-//! Holds information about all ray hit instances from a ray cast.
+/** @brief Holds information about all ray hit instances from a ray cast. */
 struct RaycastResults {
   std::vector<RayHitInfo> hits;
   esp::geo::Ray ray;
@@ -74,7 +77,7 @@ struct RaycastResults {
   ESP_SMART_POINTERS(RaycastResults)
 };
 
-// based on Bullet b3ContactPointData
+/** @brief based on Bullet b3ContactPointData */
 struct ContactPointData {
   int objectIdA = -2;  // stage is -1
   int objectIdB = -2;
@@ -105,77 +108,86 @@ struct ContactPointData {
   ESP_SMART_POINTERS(ContactPointData)
 };
 
-//! describes the type of a rigid constraint.
+/** @brief describes the type of a rigid constraint.*/
 enum class RigidConstraintType {
-  //! lock a point in one frame to a point in another with no orientation
-  //! constraint
+  /** @brief lock a point in one frame to a point in another with no orientation
+   * constraint
+   */
   PointToPoint,
-  //! fix one frame to another constraining relative position and orientation
+  /** @brief fix one frame to another constraining relative position and
+   * orientation
+   */
   Fixed
-};
+};  // enum class RigidConstraintType
 
-/**
- * @brief Stores rigid constraint parameters for creation and updates.
- */
+/** @brief Stores rigid constraint parameters for creation and updates.*/
 struct RigidConstraintSettings {
  public:
   RigidConstraintSettings() = default;
 
-  //! The type of constraint described by these settings. Determines which
-  //! parameters to use for creation and update.
+  /** @brief The type of constraint described by these settings. Determines
+   * which parameters to use for creation and update.
+   */
   RigidConstraintType constraintType = RigidConstraintType::PointToPoint;
 
-  //! The maximum impulse applied by this constraint. Should be tuned relative
-  //! to physics timestep.
+  /** @brief The maximum impulse applied by this constraint. Should be tuned
+   * relative to physics timestep.
+   */
   double maxImpulse = 1000.0;
 
-  //! objectIdA must always be >= 0. For mixed type constraints, objectA must be
-  //! the ArticulatedObject.
+  /** @brief objectIdA must always be >= 0. For mixed type constraints, objectA
+   * must be the ArticulatedObject.
+   */
   int objectIdA = ID_UNDEFINED;
-  //! objectIdB == ID_UNDEFINED indicates "world".
+
+  /** @brief objectIdB == ID_UNDEFINED indicates "world". */
   int objectIdB = ID_UNDEFINED;
 
-  //! link of objectA if articulated. ID_UNDEFINED(-1) refers to base.
+  /** @brief  link of objectA if articulated. ID_UNDEFINED(-1) refers to base.
+   */
   int linkIdA = ID_UNDEFINED;
-  //! link of objectB if articulated. ID_UNDEFINED(-1) refers to base.
+
+  /** @brief link of objectB if articulated. ID_UNDEFINED(-1) refers to base.*/
   int linkIdB = ID_UNDEFINED;
 
-  //! constraint point in local space of respective objects
+  /** @brief constraint point in local space of respective objects*/
   Mn::Vector3 pivotA{}, pivotB{};
 
-  //! constraint orientation frame in local space of respective objects for
-  //! RigidConstraintType::Fixed
+  /** @brief  constraint orientation frame in local space of respective objects
+   * for RigidConstraintType::Fixed
+   */
   Mn::Matrix3x3 frameA{}, frameB{};
 
   ESP_SMART_POINTERS(RigidConstraintSettings)
-};
+};  // struct RigidConstraintSettings
 
 class RigidObjectManager;
 class ArticulatedObjectManager;
 
 /**
-@brief Kinematic and dynamic scene and object manager.
-
-Responsible for tracking, updating, and synchronizing the state of the physical
-world and all non-static geometry in the scene as well as interfacing with
-specific physical simulation implementations.
-
-The physical world in this case consists of any objects which can be
-manipulated:addObject : (kinematically or dynamically) or simulated and anything
-such objects must be aware of (e.g. static scene collision geometry).
-
-Will later manager multiple physical scenes, but currently assumes only one
-unique physical world can exist.
-*/
+ * @brief Kinematic and dynamic scene and object manager. Responsible for
+ * tracking, updating, and synchronizing the state of the physical world and all
+ * non-static geometry in the scene as well as interfacing with specific
+ * physical simulation implementations.
+ *
+ * The physical world in this case consists of any objects which can be
+ * manipulated:addObject : (kinematically or dynamically) or simulated and
+ * anything such objects must be aware of (e.g. static scene collision
+ * geometry).
+ *
+ * May eventually manage multiple physical scenes, but currently
+ * assumes only one unique physical world can exist.
+ */
 class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
  public:
   //! ==== physics engines ====
 
   /**
-  @brief The specific physics implementation used by the current @ref
-  PhysicsManager. Each entry suggests a derived class of @ref PhysicsManager and
-  @ref RigidObject implementing the specific interface to a simulation library.
-  */
+   * @brief The specific physics implementation used by the current @ref
+   * PhysicsManager. Each entry suggests a derived class of @ref PhysicsManager
+   * and @ref RigidObject implementing the specific interface to a simulation
+   * library.
+   */
   enum class PhysicsSimulationLibrary {
 
     /**
@@ -1095,7 +1107,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   std::vector<int> recycledObjectIDs_;
 
-  //! maps constraint ids to their settings
+  /** @brief Tmaps constraint ids to their settings */
   std::unordered_map<int, RigidConstraintSettings> rigidConstraintSettings_;
 
   //! Utilities
@@ -1110,7 +1122,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   double fixedTimeStep_ = 1.0 / 240.0;
 
   /** @brief The current simulation time. Tracks the total amount of time
-   * simulated with @ref stepPhysics up to this point. */
+   * simulated with @ref stepPhysics up to this point.
+   */
   double worldTime_ = 0.0;
 
  public:

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -173,7 +173,7 @@ void BulletRigidStage::setRestitutionCoefficient(
 }
 
 double BulletRigidStage::getFrictionCoefficient() const {
-  if (bStaticCollisionObjects_.size() == 0) {
+  if (bStaticCollisionObjects_.empty()) {
     return 0.0;
   } else {
     // Assume uniform friction in scene parts
@@ -183,7 +183,7 @@ double BulletRigidStage::getFrictionCoefficient() const {
 
 double BulletRigidStage::getRestitutionCoefficient() const {
   // Assume uniform restitution in scene parts
-  if (bStaticCollisionObjects_.size() == 0) {
+  if (bStaticCollisionObjects_.empty()) {
     return 0.0;
   } else {
     return static_cast<double>(

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -336,7 +336,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // for this scene instance
   std::string lightSetupKey;
   if (config_.overrideSceneLightDefaults) {
-    lightSetupKey = config_.sceneLightSetup;
+    lightSetupKey = config_.sceneLightSetupKey;
     ESP_DEBUG() << "Using SimulatorConfiguration-specified Light key : -"
                 << lightSetupKey << "-";
   } else {
@@ -355,8 +355,9 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
                                       Mn::ResourceKey{lightSetupKey});
     }
   }
-  // set config's sceneLightSetup to track currently specified light setup key
-  config_.sceneLightSetup = lightSetupKey;
+  // set config's sceneLightSetupKey to track currently specified light setup
+  // key
+  config_.sceneLightSetupKey = lightSetupKey;
   metadataMediator_->setSimulatorConfiguration(config_);
 
   // 4. Load stage specified by Scene Instance Attributes
@@ -413,7 +414,7 @@ bool Simulator::instanceStageForActiveScene(
     stageAttributes->setShaderType(stageShaderType);
   }
   // set lighting key based on curent config value
-  stageAttributes->setLightSetup(config_.sceneLightSetup);
+  stageAttributes->setLightSetupKey(config_.sceneLightSetupKey);
   // set frustum culling from simulator config
   stageAttributes->setFrustumCulling(frustumCulling_);
   // set scaling values for this instance of stage attributes
@@ -519,7 +520,7 @@ bool Simulator::instanceObjectsForActiveScene(
     // objID =
     physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
                                        defaultCOMCorrection, attachmentNode,
-                                       config_.sceneLightSetup);
+                                       config_.sceneLightSetupKey);
   }  // for each object attributes
   return true;
 }  // Simulator::instanceObjectsForActiveScene()
@@ -545,7 +546,7 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
     // create articulated object
     // aoID =
     physicsManager_->addArticulatedObjectInstance(artObjFilePath, artObjInst,
-                                                  config_.sceneLightSetup);
+                                                  config_.sceneLightSetupKey);
   }  // for each articulated object instance
   return true;
 }  // Simulator::instanceArticulatedObjectsForActiveScene

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -423,7 +423,7 @@ bool Simulator::instanceStageForActiveScene(
   int visSet = stageInstanceAttributes->getIsInstanceVisible();
   if (visSet != ID_UNDEFINED) {
     // specfied in scene instance
-    stageAttributes->setIsVisible(visSet == 1 ? true : false);
+    stageAttributes->setIsVisible(visSet == 1);
   }
   // create a structure to manage active scene and active semantic scene ID
   // passing to and from loadStage

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -260,8 +260,8 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
       success = scene::SemanticScene::loadSemanticSceneDescriptor(
           filenameToUse, *semanticScene_);
       if (success) {
-        ESP_WARNING() << "SSD with SceneAttributes-provided name "
-                      << filenameToUse << "successfully found and loaded";
+        ESP_DEBUG() << "SSD with SceneAttributes-provided name "
+                    << filenameToUse << "successfully found and loaded";
       } else {
         // here if provided file exists but does not correspond to appropriate
         // SSD

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -419,7 +419,12 @@ bool Simulator::instanceStageForActiveScene(
   // set scaling values for this instance of stage attributes
   stageAttributes->setScale(stageAttributes->getScale() *
                             stageInstanceAttributes->getUniformScale());
-
+  // set visibility if explicitly specified in stage instance configs
+  int visSet = stageInstanceAttributes->getIsInstanceVisible();
+  if (visSet != ID_UNDEFINED) {
+    // specfied in scene instance
+    stageAttributes->setIsVisible(visSet == 1 ? true : false);
+  }
   // create a structure to manage active scene and active semantic scene ID
   // passing to and from loadStage
   std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1182,7 +1182,7 @@ class Simulator {
    * @param key The string key of the @ref gfx::LightSetup.
    */
   gfx::LightSetup getCurrentLightSetup() {
-    return *resourceManager_->getLightSetup(config_.sceneLightSetup);
+    return *resourceManager_->getLightSetup(config_.sceneLightSetupKey);
   }
 
   /**

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -27,7 +27,7 @@ bool operator==(const SimulatorConfiguration& a,
          a.sceneDatasetConfigFile == b.sceneDatasetConfigFile &&
          a.physicsConfigFile == b.physicsConfigFile &&
          a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
-         a.sceneLightSetup == b.sceneLightSetup;
+         a.sceneLightSetupKey == b.sceneLightSetupKey;
 }
 
 bool operator!=(const SimulatorConfiguration& a,

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -76,7 +76,7 @@ struct SimulatorConfiguration {
   bool overrideSceneLightDefaults = false;
 
   /** @brief Light setup key for scene */
-  std::string sceneLightSetup = esp::NO_LIGHT_KEY;
+  std::string sceneLightSetupKey = esp::NO_LIGHT_KEY;
 
   /**
    * @brief setup the image based lighting for pbr rendering

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -71,7 +71,7 @@ struct SimTest : Cr::TestSuite::Tester {
     simConfig.enablePhysics = true;
     simConfig.physicsConfigFile = physicsConfigFile;
     simConfig.overrideSceneLightDefaults = true;
-    simConfig.sceneLightSetup = sceneLightingKey;
+    simConfig.sceneLightSetupKey = sceneLightingKey;
 
     auto sim = Simulator::create_unique(simConfig);
     auto objAttrMgr = sim->getObjectAttributesManager();
@@ -93,7 +93,7 @@ struct SimTest : Cr::TestSuite::Tester {
     simConfig.enablePhysics = true;
     simConfig.physicsConfigFile = physicsConfigFile;
     simConfig.overrideSceneLightDefaults = true;
-    simConfig.sceneLightSetup = sceneLightingKey;
+    simConfig.sceneLightSetupKey = sceneLightingKey;
 
     MetadataMediator::ptr MM = MetadataMediator::create(simConfig);
     auto sim = Simulator::create_unique(simConfig, MM);
@@ -814,7 +814,7 @@ void SimTest::createMagnumRenderingOff() {
   simConfig.physicsConfigFile = physicsConfigFile;
   simConfig.overrideSceneLightDefaults = true;
   simConfig.createRenderer = false;
-  simConfig.sceneLightSetup = "custom_lighting_1";
+  simConfig.sceneLightSetupKey = "custom_lighting_1";
   auto simulator = Simulator::create_unique(simConfig);
 
   // configure objectAttributesManager

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -757,7 +757,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig_.enableGfxReplaySave = !gfxReplayRecordFilepath_.empty();
   if (args.isSet("stage-requires-lighting")) {
     ESP_DEBUG() << "Stage using DEFAULT_LIGHTING_KEY";
-    simConfig_.sceneLightSetup = esp::DEFAULT_LIGHTING_KEY;
+    simConfig_.sceneLightSetupKey = esp::DEFAULT_LIGHTING_KEY;
   }
 
   // setup the PhysicsManager config file


### PR DESCRIPTION
## Motivation and Context
This PR refactors a few things system-wide, and also adds some optimizations and small features to the Metadata/Attributes pipeline. 

- Improved stl checking/building in various locations in ManagedContainers, AbstractAttributes, and elsewhere.
- Renamed SimulatorConfiguration.sceneLightSetup ->SimulatorConfiguration.sceneLightSetupKey
- Cleaned up string search functionality used by ManagedContainers
- Add Scene Instance support for visibility flag (Note : ArticulatedObjects will require further coding to support config-based visibility setting, to be provided by a future PR.
- Hide Configuration setter access in AbstractAttributes bindings to prevent accidental type errors for essential fields.  Attributes' fields should always be accessed via specified property bindings
- Various message and docstring improvements.

Still WIP

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
