### PR TITLE
--Hide Configuration Setters in Attributes for safety

### DIFF
--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -225,6 +225,15 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
 
  protected:
   /**
+   * @brief Changing access to setter so that Configuration bindings cannot be
+   * used to set a resserved value to an incorrect type. The inheritors of this
+   * class provide an interface to set the values that the consumers of these
+   * Attributes depend on and this should be the only mechanism capable of doing
+   * so.
+   */
+  using Configuration::set;
+
+  /**
    * @brief return a vector of shared pointers to const @ref AttributesBase
    * sub-configurations.
    * @param subAttrConfig The subconfiguration from which to aquire the

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -226,7 +226,7 @@ class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
  protected:
   /**
    * @brief Changing access to setter so that Configuration bindings cannot be
-   * used to set a resserved value to an incorrect type. The inheritors of this
+   * used to set a reserved value to an incorrect type. The inheritors of this
    * class provide an interface to set the values that the consumers of these
    * Attributes depend on and this should be the only mechanism capable of doing
    * so.

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -98,8 +98,6 @@ class AttributesManagersTest : public testing::Test {
    */
   template <typename T>
   void testCreateAndRemove(std::shared_ptr<T> mgr, const std::string& handle) {
-    // meaningless key to modify attributes for verifcation of behavior
-    std::string keyStr = "tempKey";
     // get starting number of templates
     int orignNumTemplates = mgr->getNumObjects();
     // verify template is not present - should not be
@@ -122,10 +120,10 @@ class AttributesManagersTest : public testing::Test {
 
     // test changing a user-defined field in each template, verify the templates
     // are not now the same
-    attrTemplate1->set(keyStr, "temp");
-    attrTemplate2->set(keyStr, "temp2");
-    ASSERT_NE(attrTemplate1->template get<std::string>(keyStr),
-              attrTemplate2->template get<std::string>(keyStr));
+    attrTemplate1->setFileDirectory("temp_dir_1");
+    attrTemplate2->setFileDirectory("temp_dir_2");
+    ASSERT_NE(attrTemplate1->getFileDirectory(),
+              attrTemplate2->getFileDirectory());
     // get original template ID
     int oldID = attrTemplate1->getID();
 
@@ -138,13 +136,13 @@ class AttributesManagersTest : public testing::Test {
     // get another copy
     auto attrTemplate3 = mgr->getObjectOrCopyByHandle(handle);
     // verify added field is present and the same
-    ASSERT_EQ(attrTemplate3->template get<std::string>(keyStr),
-              attrTemplate2->template get<std::string>(keyStr));
+    ASSERT_EQ(attrTemplate3->getFileDirectory(),
+              attrTemplate2->getFileDirectory());
     // change field in new copy
-    attrTemplate3->set(keyStr, "temp3");
+    attrTemplate3->setFileDirectory("temp_dir_3");
     // verify that now they are different
-    ASSERT_NE(attrTemplate3->template get<std::string>(keyStr),
-              attrTemplate2->template get<std::string>(keyStr));
+    ASSERT_NE(attrTemplate3->getFileDirectory(),
+              attrTemplate2->getFileDirectory());
 
     // test removal
     int removeID = attrTemplate2->getID();
@@ -295,6 +293,24 @@ class AttributesManagersTest : public testing::Test {
    * @param renderHandle a legal render handle to set for the new template so
    * that registration won't fail.
    */
+
+  // ignore for physics attributes
+
+  void processTemplateRenderAsset(
+      std::shared_ptr<AttrMgrs::PhysicsAttributesManager> mgr,
+      std::shared_ptr<Attrs::PhysicsManagerAttributes> newAttrTemplate0,
+      const std::string& handle) {}
+
+  template <typename T, typename U>
+  void processTemplateRenderAsset(std::shared_ptr<T> mgr,
+                                  std::shared_ptr<U> newAttrTemplate0,
+                                  const std::string& handle) {
+    auto attrTemplate1 = mgr->createObject(handle, false);
+    // set legitimate render handle in template
+    newAttrTemplate0->setRenderAssetHandle(
+        attrTemplate1->template get<std::string>("render_asset"));
+  }
+
   template <typename T>
   void testCreateAndRemoveDefault(std::shared_ptr<T> mgr,
                                   const std::string& handle,
@@ -312,14 +328,7 @@ class AttributesManagersTest : public testing::Test {
     // create template from source handle, register it and retrieve it
     // Note: registration of template means this is a copy of registered
     // template
-    if (setRenderHandle) {
-      auto attrTemplate1 = mgr->createObject(handle, false);
-      // set legitimate render handle in template
-      newAttrTemplate0->set(
-          "render_asset",
-          attrTemplate1->template get<std::string>("render_asset"));
-    }
-
+    processTemplateRenderAsset(mgr, newAttrTemplate0, handle);
     // register modified template and verify that this is the template now
     // stored
     int newID = mgr->registerObject(newAttrTemplate0, newHandle);
@@ -341,13 +350,14 @@ class AttributesManagersTest : public testing::Test {
    * @brief This method will test the user-defined configuration values to see
    * that they match with expected passed values.  The config is expected to
    * hold one of each type that it supports.
-   * @param userConfig The configuration object whose contents are to be tested
+   * @param userConfig The configuration object whose contents are to be
+   * tested
    * @param str_val Expected string value
    * @param bool_val Expected boolean value
    * @param double_val Exptected double value
    * @param vec_val Expected Magnum::Vector3 value
-   * @param quat_val Expected Quaternion value - note that the JSON is read with
-   * scalar at idx 0, whereas the quaternion constructor takes the vector
+   * @param quat_val Expected Quaternion value - note that the JSON is read
+   * with scalar at idx 0, whereas the quaternion constructor takes the vector
    * component in the first position and the scalar in the second.
    */
   void testUserDefinedConfigVals(
@@ -384,7 +394,6 @@ class AttributesManagersTest : public testing::Test {
    */
   template <typename T>
   void testAssetAttributesModRegRemove(std::shared_ptr<T> defaultAttribs,
-                                       const std::string& ctorModField,
                                        int legalVal,
                                        int const* illegalVal) {
     // get starting number of templates
@@ -401,13 +410,13 @@ class AttributesManagersTest : public testing::Test {
     if (nullptr != illegalVal) {
       // modify template value used by primitive constructor (will change
       // name) illegal modification
-      defaultAttribs->set(ctorModField, *illegalVal);
+      defaultAttribs->setNumSegments(*illegalVal);
       // verify template is not valid
       bool isTemplateValid = defaultAttribs->isValidTemplate();
       ASSERT_NE(isTemplateValid, true);
     }
     // legal modification, different than default
-    defaultAttribs->set(ctorModField, legalVal);
+    defaultAttribs->setNumSegments(legalVal);
     // verify template is valid
     isTemplateValid = defaultAttribs->isValidTemplate();
     ASSERT_EQ(isTemplateValid, true);
@@ -431,7 +440,7 @@ class AttributesManagersTest : public testing::Test {
     std::shared_ptr<T> newAttribs =
         assetAttributesManager_->getObjectOrCopyByHandle<T>(newHandle);
     // verify template has modified values
-    int newValue = newAttribs->template get<int>(ctorModField);
+    int newValue = newAttribs->getNumSegments();
     ASSERT_EQ(legalVal, newValue);
     // remove modified template via handle
     auto oldTemplate2 =
@@ -1162,7 +1171,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
-        dfltCapsAttribs, "segments", legalModValSolid, &illegalModValSolid);
+        dfltCapsAttribs, legalModValSolid, &illegalModValSolid);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(capsule3DSolidHandle);
@@ -1173,7 +1182,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     ASSERT_NE(nullptr, dfltCapsAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
-        dfltCapsAttribs, "segments", legalModValWF, &illegalModValWF);
+        dfltCapsAttribs, legalModValWF, &illegalModValWF);
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(capsule3DWireframeHandle);
   }
@@ -1189,7 +1198,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
-        dfltConeAttribs, "segments", legalModValSolid, &illegalModValSolid);
+        dfltConeAttribs, legalModValSolid, &illegalModValSolid);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(coneSolidHandle);
@@ -1200,7 +1209,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     ASSERT_NE(nullptr, dfltConeAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
-        dfltConeAttribs, "segments", legalModValWF, &illegalModValWF);
+        dfltConeAttribs, legalModValWF, &illegalModValWF);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(coneWireframeHandle);
@@ -1217,7 +1226,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
-        dfltCylAttribs, "segments", 5, &illegalModValSolid);
+        dfltCylAttribs, 5, &illegalModValSolid);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(cylinderSolidHandle);
@@ -1228,7 +1237,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     ASSERT_NE(nullptr, dfltCylAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
-        dfltCylAttribs, "segments", legalModValWF, &illegalModValWF);
+        dfltCylAttribs, legalModValWF, &illegalModValWF);
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(cylinderWireframeHandle);
   }
@@ -1244,7 +1253,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
-        dfltUVSphereAttribs, "segments", 5, &illegalModValSolid);
+        dfltUVSphereAttribs, 5, &illegalModValSolid);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(uvSphereSolidHandle);
@@ -1256,7 +1265,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     ASSERT_NE(nullptr, dfltUVSphereAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
-        dfltUVSphereAttribs, "segments", legalModValWF, &illegalModValWF);
+        dfltUVSphereAttribs, legalModValWF, &illegalModValWF);
 
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(uvSphereWireframeHandle);

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -668,21 +668,21 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     // quantity being modified
     std::string newHandle = primAttr->getHandle();
     CORRADE_VERIFY(newHandle != origCylinderHandle);
-    // set test label, to validate that copy is reggistered
-    primAttr->set("test", "test0");
+    // set bogus file directory, to validate that copy is reggistered
+    primAttr->setFileDirectory("test0");
     // register new attributes
     int idx = assetAttribsMgr->registerObject(primAttr);
     CORRADE_VERIFY(idx != esp::ID_UNDEFINED);
     // set new test label, to validate against retrieved copy
-    primAttr->set("test", "test1");
+    primAttr->setFileDirectory("test1");
     // retrieve registered attributes copy
     AbstractPrimitiveAttributes::ptr primAttr2 =
         assetAttribsMgr->getObjectCopyByHandle(newHandle);
     // verify pre-reg and post-reg are named the same
     CORRADE_VERIFY(primAttr->getHandle() == primAttr2->getHandle());
     // verify retrieved attributes is copy, not original
-    CORRADE_VERIFY(primAttr->get<std::string>("test") !=
-                   primAttr2->get<std::string>("test"));
+    CORRADE_VERIFY(primAttr->getFileDirectory() !=
+                   primAttr2->getFileDirectory());
     // remove modified attributes
     AbstractPrimitiveAttributes::ptr primAttr3 =
         assetAttribsMgr->removeObjectByHandle(newHandle);

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -168,7 +168,3 @@ def test_physics_object_attributes():
     assert object_template.join_collision_meshes == False
     object_template.requires_lighting = False
     assert object_template.requires_lighting == False
-
-    # test that inheritance is correctly configured
-    object_template.set("test_key", "test_string")
-    assert object_template.get("test_key") == "test_string"


### PR DESCRIPTION
## Motivation and Context
The Configuration class is a robust and flexible mechanism for storing and accessing hierarchical aggregations of data, providing templated setters and getters that will save and retrieve data of various types.  

The AbstractAttributes class, which inherits from the Configuration class, provides the base for the Attributes classes that define various components of the Habitat-sim simulation and dataset ecosystem.  The purpose of these various Attributes is to provide full and safe access to all the data fields pertinent to the constructs they define.

This PR makes the Configuration base class's templated setter in AbstractAttributes protected so that it can only be accessed from the derived implementations, removing external access from any AbstractAttributes-derived class object.  This is so that a user does not set a critical value to an incorrect type accidentally, by accessing that value via the Configuration bindings instead of the provided Attributes property bindings.  This would throw an error and terminate execution should the Attributes-based accessor be used to retrieve the value. 


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
