### PR TITLE
[TechDebt]--Refactor tests to use Corrade test suite (Part 1 of 2)

### DIFF
--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -282,7 +282,7 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   // template
   auto attrTemplate1 = mgr->createObject(handle, true);
   // verify it exists
-  CORRADE_VERIFY(attrTemplate1 != nullptr);
+  CORRADE_VERIFY(attrTemplate1);
   // verify ID exists
   bool idIsPresent = mgr->getObjectLibHasID(attrTemplate1->getID());
   CORRADE_VERIFY(idIsPresent);
@@ -322,7 +322,7 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   // remove template by ID, acquire copy of removed template
   auto oldTemplate = mgr->removeObjectByID(removeID);
   // verify it exists
-  CORRADE_VERIFY(oldTemplate != nullptr);
+  CORRADE_VERIFY(oldTemplate);
   // verify there are same number of templates as when we started
   CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
   // re-add template copy via registration
@@ -335,14 +335,14 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   // attempt to remove attributes via handle
   auto oldTemplate2 = mgr->removeObjectByHandle(handle);
   // verify no template was deleted
-  CORRADE_VERIFY(oldTemplate2 == nullptr);
+  CORRADE_VERIFY(!oldTemplate2);
   // unlock template
   success = mgr->setLock(handle, false);
 
   // remove  attributes via handle
   auto oldTemplate3 = mgr->removeObjectByHandle(handle);
   // verify deleted template exists
-  CORRADE_VERIFY(oldTemplate3 != nullptr);
+  CORRADE_VERIFY(oldTemplate3);
   // verify ID does not exist in library now
   idIsPresent = mgr->getObjectLibHasID(oldTemplate3->getID());
   CORRADE_VERIFY(!idIsPresent);
@@ -421,7 +421,7 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     CORRADE_VERIFY(tmpltID != -1);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
     // verify added template  exists
-    CORRADE_VERIFY(attrTemplate2 != nullptr);
+    CORRADE_VERIFY(attrTemplate2);
   }
 
   // now delete all templates that
@@ -438,7 +438,7 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     CORRADE_VERIFY(tmpltID != -1);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
     // verify added template  exists
-    CORRADE_VERIFY(attrTemplate2 != nullptr);
+    CORRADE_VERIFY(attrTemplate2);
   }
 
   // now delete all templates that have just been added
@@ -471,7 +471,7 @@ void AttributesManagersTest::testCreateAndRemoveDefault(
   // create new template but do not register it
   auto newAttrTemplate0 = mgr->createDefaultObject(newHandle, false);
   // verify real template was returned
-  CORRADE_VERIFY(newAttrTemplate0 != nullptr);
+  CORRADE_VERIFY(newAttrTemplate0);
 
   // create template from source handle, register it and retrieve it
   // Note: registration of template means this is a copy of registered
@@ -488,7 +488,7 @@ void AttributesManagersTest::testCreateAndRemoveDefault(
   auto newAttrTemplate1 = mgr->removeObjectByHandle(newHandle);
 
   // verify it exists
-  CORRADE_VERIFY(newAttrTemplate1 != nullptr);
+  CORRADE_VERIFY(newAttrTemplate1);
   // verify there are same number of templates as when we started
   CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
 
@@ -517,16 +517,13 @@ void AttributesManagersTest::testUserDefinedConfigVals(
     Magnum::Vector3 vec_val,
     Magnum::Quaternion quat_val) {
   // user defined attributes from light instance
-  CORRADE_VERIFY(userConfig != nullptr);
-  CORRADE_COMPARE(userConfig->template get<std::string>("user_string"),
-                  str_val);
-  CORRADE_COMPARE(userConfig->template get<bool>("user_bool"), bool_val);
-  CORRADE_COMPARE(userConfig->template get<int>("user_int"), int_val);
-  CORRADE_COMPARE(userConfig->template get<double>("user_double"), double_val);
-  CORRADE_COMPARE(userConfig->template get<Magnum::Vector3>("user_vec3"),
-                  vec_val);
-  CORRADE_COMPARE(userConfig->template get<Magnum::Quaternion>("user_quat"),
-                  quat_val);
+  CORRADE_VERIFY(userConfig);
+  CORRADE_COMPARE(userConfig->get<std::string>("user_string"), str_val);
+  CORRADE_COMPARE(userConfig->get<bool>("user_bool"), bool_val);
+  CORRADE_COMPARE(userConfig->get<int>("user_int"), int_val);
+  CORRADE_COMPARE(userConfig->get<double>("user_double"), double_val);
+  CORRADE_COMPARE(userConfig->get<Magnum::Vector3>("user_vec3"), vec_val);
+  CORRADE_COMPARE(userConfig->get<Magnum::Quaternion>("user_quat"), quat_val);
 
 }  // AttributesManagersTest::testUserDefinedConfigVals
 
@@ -595,7 +592,7 @@ void AttributesManagersTest::testAssetAttributesModRegRemove(
   // remove modified template via handle
   auto oldTemplate2 = assetAttributesManager_->removeObjectByHandle(newHandle);
   // verify deleted template  exists
-  CORRADE_VERIFY(oldTemplate2 != nullptr);
+  CORRADE_VERIFY(oldTemplate2);
 
   // verify there are same number of templates as when we started
   CORRADE_COMPARE(orignNumTemplates, assetAttributesManager_->getNumObjects());
@@ -613,7 +610,7 @@ void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
   // create new template based on handle and verify that it is created
   auto newTemplate =
       assetAttributesManager_->createTemplateFromHandle(newTemplateName, true);
-  CORRADE_VERIFY(newTemplate != nullptr);
+  CORRADE_VERIFY(newTemplate);
 
   // now verify that template is in library
   templateExists =
@@ -624,7 +621,7 @@ void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
   auto oldTemplate =
       assetAttributesManager_->removeObjectByHandle(newTemplateName);
   // verify deleted template  exists
-  CORRADE_VERIFY(oldTemplate != nullptr);
+  CORRADE_VERIFY(oldTemplate);
 
   // verify there are same number of templates as when we started
   CORRADE_COMPARE(orignNumTemplates, assetAttributesManager_->getNumObjects());
@@ -659,7 +656,7 @@ void AttributesManagersTest::testPhysicsJSONLoad() {
                                         Attrs::PhysicsManagerAttributes>(
           physicsAttributesManager_, jsonString);
   // verify exists
-  CORRADE_VERIFY(physMgrAttr != nullptr);
+  CORRADE_VERIFY(physMgrAttr);
   // match values set in test JSON
   // TODO : get these values programmatically?
   CORRADE_COMPARE(physMgrAttr->getGravity(), Magnum::Vector3(1, 2, 3));
@@ -725,7 +722,7 @@ void AttributesManagersTest::testLightJSONLoad() {
           lightLayoutAttributesManager_, jsonString);
 
   // verify exists
-  CORRADE_VERIFY(lightLayoutAttr != nullptr);
+  CORRADE_VERIFY(lightLayoutAttr);
   // test light layout attributes-level user config vals
   testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
                             "light attribs defined string", true, 23, 2.3,
@@ -735,7 +732,7 @@ void AttributesManagersTest::testLightJSONLoad() {
   CORRADE_COMPARE(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
   auto lightAttr = lightLayoutAttr->getLightInstance("test");
   // verify that lightAttr exists
-  CORRADE_VERIFY(lightAttr != nullptr);
+  CORRADE_VERIFY(lightAttr);
 
   // match values set in test JSON
   // TODO : get these values programmatically?
@@ -875,7 +872,7 @@ void AttributesManagersTest::testSceneInstanceJSONLoad() {
           sceneAttributesManager_, jsonString);
 
   // verify exists
-  CORRADE_VERIFY(sceneAttr != nullptr);
+  CORRADE_VERIFY(sceneAttr);
 
   // match values set in test JSON
   CORRADE_COMPARE(
@@ -983,7 +980,7 @@ void AttributesManagersTest::testSceneInstanceJSONLoad() {
   auto artObjNestedConfig =
       artObjInstance->getUserConfiguration()
           ->getSubconfigCopy<esp::core::config::Configuration>("user_def_obj");
-  CORRADE_VERIFY(artObjNestedConfig != nullptr);
+  CORRADE_VERIFY(artObjNestedConfig);
   CORRADE_VERIFY(artObjNestedConfig->getNumEntries() > 0);
   CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("position"),
                   Magnum::Vector3(0.1f, 0.2f, 0.3f));
@@ -1050,7 +1047,7 @@ void AttributesManagersTest::testStageJSONLoad() {
                                         Attrs::StageAttributes>(
           stageAttributesManager_, jsonString);
   // verify exists
-  CORRADE_VERIFY(stageAttr != nullptr);
+  CORRADE_VERIFY(stageAttr);
   // match values set in test JSON
   // TODO : get these values programmatically?
   CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 3, 4));
@@ -1126,7 +1123,7 @@ void AttributesManagersTest::testObjectJSONLoad() {
                                         Attrs::ObjectAttributes>(
           objectAttributesManager_, jsonString);
   // verify exists
-  CORRADE_VERIFY(objAttr != nullptr);
+  CORRADE_VERIFY(objAttr);
   // match values set in test JSON
   // TODO : get these values programmatically?
   CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(2, 3, 4));
@@ -1321,7 +1318,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     CapsulePrimitiveAttributes::ptr dfltCapsAttribs =
         assetAttributesManager_->getDefaultCapsuleTemplate(false);
     // verify it exists
-    CORRADE_VERIFY(dfltCapsAttribs != nullptr);
+    CORRADE_VERIFY(dfltCapsAttribs);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
@@ -1333,7 +1330,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     // test wireframe version
     dfltCapsAttribs = assetAttributesManager_->getDefaultCapsuleTemplate(true);
     // verify it exists
-    CORRADE_VERIFY(dfltCapsAttribs != nullptr);
+    CORRADE_VERIFY(dfltCapsAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
         dfltCapsAttribs, legalModValWF, &illegalModValWF);
@@ -1348,7 +1345,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     ConePrimitiveAttributes::ptr dfltConeAttribs =
         assetAttributesManager_->getDefaultConeTemplate(false);
     // verify it exists
-    CORRADE_VERIFY(dfltConeAttribs != nullptr);
+    CORRADE_VERIFY(dfltConeAttribs);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
@@ -1360,7 +1357,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     // test wireframe version
     dfltConeAttribs = assetAttributesManager_->getDefaultConeTemplate(true);
     // verify it exists
-    CORRADE_VERIFY(dfltConeAttribs != nullptr);
+    CORRADE_VERIFY(dfltConeAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
         dfltConeAttribs, legalModValWF, &illegalModValWF);
@@ -1376,7 +1373,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     CylinderPrimitiveAttributes::ptr dfltCylAttribs =
         assetAttributesManager_->getDefaultCylinderTemplate(false);
     // verify it exists
-    CORRADE_VERIFY(dfltCylAttribs != nullptr);
+    CORRADE_VERIFY(dfltCylAttribs);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
@@ -1388,7 +1385,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     // test wireframe version
     dfltCylAttribs = assetAttributesManager_->getDefaultCylinderTemplate(true);
     // verify it exists
-    CORRADE_VERIFY(dfltCylAttribs != nullptr);
+    CORRADE_VERIFY(dfltCylAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
         dfltCylAttribs, legalModValWF, &illegalModValWF);
@@ -1403,7 +1400,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     UVSpherePrimitiveAttributes::ptr dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(false);
     // verify it exists
-    CORRADE_VERIFY(dfltUVSphereAttribs != nullptr);
+    CORRADE_VERIFY(dfltUVSphereAttribs);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
@@ -1416,7 +1413,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(true);
     // verify it exists
-    CORRADE_VERIFY(dfltUVSphereAttribs != nullptr);
+    CORRADE_VERIFY(dfltUVSphereAttribs);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
         dfltUVSphereAttribs, legalModValWF, &illegalModValWF);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -422,8 +422,7 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     // register template with new handle
     int tmpltID = mgr->registerObject(attrTemplate1, newHandleIter);
     // verify template added
-    CORRADE_COMPARE_AS(tmpltID, esp::ID_UNDEFINED,
-                       Cr::TestSuite::Compare::NotEqual);
+    CORRADE_VERIFY(tmpltID != esp::ID_UNDEFINED);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
     // verify added template  exists
     CORRADE_VERIFY(attrTemplate2);
@@ -440,8 +439,7 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     // register template with new handle
     int tmpltID = mgr->registerObject(tmplt);
     // verify template added
-    CORRADE_COMPARE_AS(tmpltID, esp::ID_UNDEFINED,
-                       Cr::TestSuite::Compare::NotEqual);
+    CORRADE_VERIFY(tmpltID != esp::ID_UNDEFINED);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
     // verify added template  exists
     CORRADE_VERIFY(attrTemplate2);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -176,16 +176,16 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
       const std::string& newTemplateName);
 
   // actual test functions
-  void AttributesManagers_PhysicsJSONLoadTest();
-  void AttributesManagers_LightJSONLoadTest();
-  void AttributesManagers_SceneInstanceJSONLoadTest();
-  void AttributesManagers_StageJSONLoadTest();
-  void AttributesManagers_ObjectJSONLoadTest();
-  void PhysicsAttributesManagersCreateTest();
-  void StageAttributesManagersCreateTest();
-  void ObjectAttributesManagersCreateTest();
-  void LightLayoutAttributesManagerTest();
-  void PrimitiveAssetAttributesTest();
+  void testPhysicsJSONLoad();
+  void testLightJSONLoad();
+  void testSceneInstanceJSONLoad();
+  void testStageJSONLoad();
+  void testObjectJSONLoad();
+  void testPhysicsAttributesManagersCreate();
+  void testStageAttributesManagersCreate();
+  void testObjectAttributesManagersCreate();
+  void testLightLayoutAttributesManager();
+  void testPrimitiveAssetAttributes();
 
   // test member vars
 
@@ -213,16 +213,16 @@ AttributesManagersTest::AttributesManagersTest() {
   stageAttributesManager_ = MM->getStageAttributesManager();
 
   addTests({
-      &AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest,
-      &AttributesManagersTest::AttributesManagers_LightJSONLoadTest,
-      &AttributesManagersTest::AttributesManagers_SceneInstanceJSONLoadTest,
-      &AttributesManagersTest::AttributesManagers_StageJSONLoadTest,
-      &AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest,
-      &AttributesManagersTest::PhysicsAttributesManagersCreateTest,
-      &AttributesManagersTest::StageAttributesManagersCreateTest,
-      &AttributesManagersTest::ObjectAttributesManagersCreateTest,
-      &AttributesManagersTest::LightLayoutAttributesManagerTest,
-      &AttributesManagersTest::PrimitiveAssetAttributesTest,
+      &AttributesManagersTest::testPhysicsJSONLoad,
+      &AttributesManagersTest::testLightJSONLoad,
+      &AttributesManagersTest::testSceneInstanceJSONLoad,
+      &AttributesManagersTest::testStageJSONLoad,
+      &AttributesManagersTest::testObjectJSONLoad,
+      &AttributesManagersTest::testPhysicsAttributesManagersCreate,
+      &AttributesManagersTest::testStageAttributesManagersCreate,
+      &AttributesManagersTest::testObjectAttributesManagersCreate,
+      &AttributesManagersTest::testLightLayoutAttributesManager,
+      &AttributesManagersTest::testPrimitiveAssetAttributes,
   });
 }
 
@@ -248,8 +248,8 @@ std::shared_ptr<U> AttributesManagersTest::testBuildAttributesFromJSONString(
 
     return attrTemplate1;
   } catch (...) {
-    ESP_ERROR() << "testBuildAttributesFromJSONString : Failed to parse"
-                << jsonString << "as JSON.";
+    CORRADE_FAIL_IF(true, "testBuildAttributesFromJSONString : Failed to parse"
+                              << jsonString << "as JSON.");
     return nullptr;
   }
 
@@ -412,6 +412,7 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
   for (int i = 0; i < numToAdd; ++i) {
     // assign template a handle
     std::string newHandleIter("newTemplateHandle_" + std::to_string(i));
+    CORRADE_ITERATION(newHandleIter);
     // create a template with a legal handle
     auto attrTemplate1 = mgr->createObject(handle, false);
     // register template with new handle
@@ -575,7 +576,6 @@ void AttributesManagersTest::testAssetAttributesModRegRemove(
 
   // get synthesized handle
   std::string newHandle = defaultAttribs->getHandle();
-  ESP_DEBUG() << "Modified Template Handle :" << newHandle;
   // register modified template
   assetAttributesManager_->registerObject(defaultAttribs);
 
@@ -637,8 +637,7 @@ void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
  * @brief This test will verify that the physics attributes' managers' JSON
  * loading process is working as expected.
  */
-void AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest() {
-  ESP_DEBUG() << "Starting AttributesManagers_PhysicsJSONLoadTest";
+void AttributesManagersTest::testPhysicsJSONLoad() {
   // build JSON sample config
   const std::string& jsonString = R"({
   "physics_simulator": "bullet_test",
@@ -683,8 +682,7 @@ void AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest() {
  * @brief This test will verify that the Light Attributes' managers' JSON
  * loading process is working as expected.
  */
-void AttributesManagersTest::AttributesManagers_LightJSONLoadTest() {
-  ESP_DEBUG() << "Starting AttributesManagers_LightJSONLoadTest";
+void AttributesManagersTest::testLightJSONLoad() {
   // build JSON sample config
   const std::string& jsonString = R"({
   "lights":{
@@ -768,8 +766,7 @@ void AttributesManagersTest::AttributesManagers_LightJSONLoadTest() {
  * @brief This test will verify that the Scene Instance attributes' managers'
  * JSON loading process is working as expected.
  */
-void AttributesManagersTest::AttributesManagers_SceneInstanceJSONLoadTest() {
-  ESP_DEBUG() << "Starting AttributesManagers_SceneInstanceJSONLoadTest";
+void AttributesManagersTest::testSceneInstanceJSONLoad() {
   // build JSON sample config
   const std::string& jsonString = R"({
   "translation_origin" : "Asset_Local",
@@ -1017,9 +1014,7 @@ void AttributesManagersTest::AttributesManagers_SceneInstanceJSONLoadTest() {
  * @brief This test will verify that the Stage attributes' managers' JSON
  * loading process is working as expected.
  */
-void AttributesManagersTest::AttributesManagers_StageJSONLoadTest() {
-  ESP_DEBUG() << "Starting AttributesManagers_StageJSONLoadTest";
-
+void AttributesManagersTest::testStageJSONLoad() {
   // build JSON sample config
   const std::string& jsonString =
       R"({
@@ -1096,8 +1091,7 @@ void AttributesManagersTest::AttributesManagers_StageJSONLoadTest() {
  * @brief This test will verify that the Object attributes' managers' JSON
  * loading process is working as expected.
  */
-void AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest() {
-  ESP_DEBUG() << "Starting AttributesManagers_ObjectJSONLoadTest";
+void AttributesManagersTest::testObjectJSONLoad() {
   // build JSON sample config
   const std::string& jsonString = R"({
   "scale":[2,3,4],
@@ -1165,7 +1159,7 @@ void AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest() {
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltJSONString(objectAttributesManager_);
 
-}  // AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest
+}  // AttributesManagersTest::testObjectJSONLoadTest
 
 /**
  * @brief This test will test creating, modifying, registering and deleting
@@ -1176,12 +1170,11 @@ void AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest() {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-void AttributesManagersTest::PhysicsAttributesManagersCreateTest() {
-  ESP_DEBUG() << "Starting PhysicsAttributesManagersCreate";
-
-  ESP_DEBUG() << "Start Test : Create, Edit, Remove Attributes for "
-                 "PhysicsAttributesManager @"
-              << physicsConfigFile;
+void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
+  CORRADE_INFO(
+      "Start Test : Create, Edit, Remove Attributes for "
+      "PhysicsAttributesManager @"
+      << physicsConfigFile);
 
   // physics attributes manager attributes verifcation
   testCreateAndRemove<AttrMgrs::PhysicsAttributesManager>(
@@ -1199,13 +1192,14 @@ void AttributesManagersTest::PhysicsAttributesManagersCreateTest() {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-void AttributesManagersTest::StageAttributesManagersCreateTest() {
+void AttributesManagersTest::testStageAttributesManagersCreate() {
   std::string stageConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/scenes/simple_room.glb");
 
-  ESP_DEBUG() << "Start Test : Create, Edit, Remove Attributes for "
-                 "StageAttributesManager @"
-              << stageConfigFile;
+  CORRADE_INFO(
+      "Start Test : Create, Edit, Remove Attributes for "
+      "StageAttributesManager @"
+      << stageConfigFile);
 
   // scene attributes manager attributes verifcation
   testCreateAndRemove<AttrMgrs::StageAttributesManager>(stageAttributesManager_,
@@ -1224,13 +1218,14 @@ void AttributesManagersTest::StageAttributesManagersCreateTest() {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-void AttributesManagersTest::ObjectAttributesManagersCreateTest() {
+void AttributesManagersTest::testObjectAttributesManagersCreate() {
   std::string objectConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/objects/chair.object_config.json");
 
-  ESP_DEBUG() << "Start Test : Create, Edit, Remove Attributes for "
-                 "ObjectAttributesManager @"
-              << objectConfigFile;
+  CORRADE_INFO(
+      "Start Test : Create, Edit, Remove Attributes for "
+      "ObjectAttributesManager @"
+      << objectConfigFile);
 
   int origNumFileBased = objectAttributesManager_->getNumFileTemplateObjects();
   int origNumPrimBased = objectAttributesManager_->getNumSynthTemplateObjects();
@@ -1264,15 +1259,14 @@ void AttributesManagersTest::ObjectAttributesManagersCreateTest() {
   CORRADE_COMPARE(origNumPrimBased, newNumPrimBased3);
 }  // AttributesManagersTest::ObjectAttributesManagersCreate test
 
-void AttributesManagersTest::LightLayoutAttributesManagerTest() {
-  ESP_DEBUG() << "Starting LightLayoutAttributesManagerTest";
-
+void AttributesManagersTest::testLightLayoutAttributesManager() {
   std::string lightConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/lights/test_lights.lighting_config.json");
 
-  ESP_DEBUG() << "Start Test : Create, Edit, Remove Attributes for "
-                 "LightLayoutAttributesManager @"
-              << lightConfigFile;
+  CORRADE_INFO(
+      "Start Test : Create, Edit, Remove Attributes for "
+      "LightLayoutAttributesManager @"
+      << lightConfigFile);
   // light attributes manager attributes verifcation
   testCreateAndRemoveLights(lightLayoutAttributesManager_, lightConfigFile);
 
@@ -1283,8 +1277,7 @@ void AttributesManagersTest::LightLayoutAttributesManagerTest() {
  * managers. This includes testing handle auto-gen when relevant fields in
  * asset attributes are changed.
  */
-void AttributesManagersTest::PrimitiveAssetAttributesTest() {
-  ESP_DEBUG() << "Starting PrimitiveAssetAttributesTest";
+void AttributesManagersTest::testPrimitiveAssetAttributes() {
   /**
    * Primitive asset attributes require slightly different testing since a
    * default set of attributes (matching the default Magnum::Primitive
@@ -1324,7 +1317,7 @@ void AttributesManagersTest::PrimitiveAssetAttributesTest() {
   //////////////////////////
   // get default template for solid capsule
   {
-    ESP_DEBUG() << "Starting CapsulePrimitiveAttributes";
+    CORRADE_INFO("Starting CapsulePrimitiveAttributes");
     CapsulePrimitiveAttributes::ptr dfltCapsAttribs =
         assetAttributesManager_->getDefaultCapsuleTemplate(false);
     // verify it exists
@@ -1350,7 +1343,7 @@ void AttributesManagersTest::PrimitiveAssetAttributesTest() {
   //////////////////////////
   // get default template for solid cone
   {
-    ESP_DEBUG() << "Starting ConePrimitiveAttributes";
+    CORRADE_INFO("Starting ConePrimitiveAttributes");
 
     ConePrimitiveAttributes::ptr dfltConeAttribs =
         assetAttributesManager_->getDefaultConeTemplate(false);
@@ -1378,7 +1371,7 @@ void AttributesManagersTest::PrimitiveAssetAttributesTest() {
   //////////////////////////
   // get default template for solid cylinder
   {
-    ESP_DEBUG() << "Starting CylinderPrimitiveAttributes";
+    CORRADE_INFO("Starting CylinderPrimitiveAttributes");
 
     CylinderPrimitiveAttributes::ptr dfltCylAttribs =
         assetAttributesManager_->getDefaultCylinderTemplate(false);
@@ -1405,7 +1398,7 @@ void AttributesManagersTest::PrimitiveAssetAttributesTest() {
   //////////////////////////
   // get default template for solid UV Sphere
   {
-    ESP_DEBUG() << "Starting UVSpherePrimitiveAttributes";
+    CORRADE_INFO("Starting UVSpherePrimitiveAttributes");
 
     UVSpherePrimitiveAttributes::ptr dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(false);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <string>
 
@@ -295,8 +296,9 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   // are not now the same
   attrTemplate1->setFileDirectory("temp_dir_1");
   attrTemplate2->setFileDirectory("temp_dir_2");
-  CORRADE_VERIFY(attrTemplate1->getFileDirectory() !=
-                 attrTemplate2->getFileDirectory());
+  CORRADE_COMPARE_AS(attrTemplate1->getFileDirectory(),
+                     attrTemplate2->getFileDirectory(),
+                     Cr::TestSuite::Compare::NotEqual);
   // get original template ID
   int oldID = attrTemplate1->getID();
 
@@ -314,8 +316,9 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   // change field in new copy
   attrTemplate3->setFileDirectory("temp_dir_3");
   // verify that now they are different
-  CORRADE_VERIFY(attrTemplate3->getFileDirectory() !=
-                 attrTemplate2->getFileDirectory());
+  CORRADE_COMPARE_AS(attrTemplate3->getFileDirectory(),
+                     attrTemplate2->getFileDirectory(),
+                     Cr::TestSuite::Compare::NotEqual);
 
   // test removal
   int removeID = attrTemplate2->getID();
@@ -372,7 +375,8 @@ void AttributesManagersTest::testCreateAndRemoveLights(
   int numLoadedLights = mgr->getNumObjects();
 
   // verify lights were added
-  CORRADE_VERIFY(numLoadedLights != origNumTemplates);
+  CORRADE_COMPARE_AS(numLoadedLights, origNumTemplates,
+                     Cr::TestSuite::Compare::NotEqual);
 
   // get handles of all lights added
   auto lightHandles = mgr->getObjectHandlesBySubstring();
@@ -418,7 +422,8 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     // register template with new handle
     int tmpltID = mgr->registerObject(attrTemplate1, newHandleIter);
     // verify template added
-    CORRADE_VERIFY(tmpltID != -1);
+    CORRADE_COMPARE_AS(tmpltID, esp::ID_UNDEFINED,
+                       Cr::TestSuite::Compare::NotEqual);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
     // verify added template  exists
     CORRADE_VERIFY(attrTemplate2);
@@ -435,7 +440,8 @@ void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
     // register template with new handle
     int tmpltID = mgr->registerObject(tmplt);
     // verify template added
-    CORRADE_VERIFY(tmpltID != -1);
+    CORRADE_COMPARE_AS(tmpltID, esp::ID_UNDEFINED,
+                       Cr::TestSuite::Compare::NotEqual);
     auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
     // verify added template  exists
     CORRADE_VERIFY(attrTemplate2);

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <gtest/gtest.h>
+#include <Corrade/TestSuite/Tester.h>
 #include <string>
 
 #include "esp/metadata/MetadataMediator.h"
@@ -16,7 +16,6 @@
 
 #include "configure.h"
 
-namespace {
 namespace Cr = Corrade;
 
 using Magnum::Math::Literals::operator""_radf;
@@ -41,24 +40,15 @@ using Attrs::SceneAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
 
+namespace Test {
 const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
                                  "test_assets/testing.physics_config.json");
 
-class AttributesManagersTest : public testing::Test {
- protected:
-  void SetUp() override {
-    // set up a default simulation config to initialize MM
-    auto cfg = esp::sim::SimulatorConfiguration{};
-    auto MM = MetadataMediator::create(cfg);
-    // get attributes managers for default dataset
-    assetAttributesManager_ = MM->getAssetAttributesManager();
-    lightLayoutAttributesManager_ = MM->getLightLayoutAttributesManager();
-    objectAttributesManager_ = MM->getObjectAttributesManager();
-    physicsAttributesManager_ = MM->getPhysicsAttributesManager();
-    sceneAttributesManager_ = MM->getSceneAttributesManager();
-    stageAttributesManager_ = MM->getStageAttributesManager();
-  };
+struct AttributesManagersTest : Cr::TestSuite::Tester {
+  explicit AttributesManagersTest();
+
+  // Test helper functions
 
   /**
    * @brief Test loading from JSON
@@ -70,24 +60,14 @@ class AttributesManagersTest : public testing::Test {
   template <typename T, typename U>
   std::shared_ptr<U> testBuildAttributesFromJSONString(
       std::shared_ptr<T> mgr,
-      const std::string& jsonString) {
-    // create JSON document
-    try {
-      esp::io::JsonDocument tmp = esp::io::parseJsonString(jsonString);
-      // io::JsonGenericValue :
-      const esp::io::JsonGenericValue jsonDoc = tmp.GetObject();
-      // create an empty template
-      std::shared_ptr<U> attrTemplate1 =
-          mgr->buildManagedObjectFromDoc("new_template_from_json", jsonDoc);
+      const std::string& jsonString);
 
-      return attrTemplate1;
-    } catch (...) {
-      ESP_ERROR() << "testBuildAttributesFromJSONString : Failed to parse"
-                  << jsonString << "as JSON.";
-      return nullptr;
-    }
-
-  }  // testBuildAttributesFromJSONString
+  /**
+   * @brief remove added template built from JSON string.
+   * @param mgr the Attributes Manager being tested
+   */
+  template <typename T>
+  void testRemoveAttributesBuiltJSONString(std::shared_ptr<T> mgr);
 
   /**
    * @brief Test creation, copying and removal of templates for Object, Physics
@@ -97,86 +77,7 @@ class AttributesManagersTest : public testing::Test {
    * @param handle the handle of the desired attributes template to work with
    */
   template <typename T>
-  void testCreateAndRemove(std::shared_ptr<T> mgr, const std::string& handle) {
-    // get starting number of templates
-    int orignNumTemplates = mgr->getNumObjects();
-    // verify template is not present - should not be
-    bool isPresentAlready = mgr->getObjectLibHasHandle(handle);
-    ASSERT_NE(isPresentAlready, true);
-
-    // create template from source handle, register it and retrieve it
-    // Note: registration of template means this is a copy of registered
-    // template
-    auto attrTemplate1 = mgr->createObject(handle, true);
-    // verify it exists
-    ASSERT_NE(nullptr, attrTemplate1);
-    // verify ID exists
-    bool idIsPresent = mgr->getObjectLibHasID(attrTemplate1->getID());
-    ASSERT_EQ(idIsPresent, true);
-    // retrieve a copy of the named attributes template
-    auto attrTemplate2 = mgr->getObjectOrCopyByHandle(handle);
-    // verify copy has same quantities and values as original
-    ASSERT_EQ(attrTemplate1->getHandle(), attrTemplate2->getHandle());
-
-    // test changing a user-defined field in each template, verify the templates
-    // are not now the same
-    attrTemplate1->setFileDirectory("temp_dir_1");
-    attrTemplate2->setFileDirectory("temp_dir_2");
-    ASSERT_NE(attrTemplate1->getFileDirectory(),
-              attrTemplate2->getFileDirectory());
-    // get original template ID
-    int oldID = attrTemplate1->getID();
-
-    // register modified template and verify that this is the template now
-    // stored
-    int newID = mgr->registerObject(attrTemplate2, handle);
-    // verify IDs are the same
-    ASSERT_EQ(oldID, newID);
-
-    // get another copy
-    auto attrTemplate3 = mgr->getObjectOrCopyByHandle(handle);
-    // verify added field is present and the same
-    ASSERT_EQ(attrTemplate3->getFileDirectory(),
-              attrTemplate2->getFileDirectory());
-    // change field in new copy
-    attrTemplate3->setFileDirectory("temp_dir_3");
-    // verify that now they are different
-    ASSERT_NE(attrTemplate3->getFileDirectory(),
-              attrTemplate2->getFileDirectory());
-
-    // test removal
-    int removeID = attrTemplate2->getID();
-    // remove template by ID, acquire copy of removed template
-    auto oldTemplate = mgr->removeObjectByID(removeID);
-    // verify it exists
-    ASSERT_NE(nullptr, oldTemplate);
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
-    // re-add template copy via registration
-    int newAddID = mgr->registerObject(attrTemplate2, handle);
-    // verify IDs are the same
-    ASSERT_EQ(removeID, newAddID);
-
-    // lock template referenced by handle
-    bool success = mgr->setLock(handle, true);
-    // attempt to remove attributes via handle
-    auto oldTemplate2 = mgr->removeObjectByHandle(handle);
-    // verify no template was deleted
-    ASSERT_EQ(nullptr, oldTemplate2);
-    // unlock template
-    success = mgr->setLock(handle, false);
-
-    // remove  attributes via handle
-    auto oldTemplate3 = mgr->removeObjectByHandle(handle);
-    // verify deleted template  exists
-    ASSERT_NE(nullptr, oldTemplate3);
-    // verify ID does not exist in library now
-    idIsPresent = mgr->getObjectLibHasID(oldTemplate3->getID());
-    ASSERT_EQ(idIsPresent, false);
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
-
-  }  // AttributesManagersTest::testCreateAndRemove
+  void testCreateAndRemove(std::shared_ptr<T> mgr, const std::string& handle);
 
   /**
    * @brief Test creation, copying and removal of templates for lights
@@ -187,33 +88,7 @@ class AttributesManagersTest : public testing::Test {
 
   void testCreateAndRemoveLights(
       AttrMgrs::LightLayoutAttributesManager::ptr mgr,
-      const std::string& handle) {
-    // meaningless key to modify attributes for verifcation of behavior
-    std::string keyStr = "tempKey";
-    // get starting number of templates
-    int orignNumTemplates = mgr->getNumObjects();
-
-    // Source config for lights holds multiple light configurations.
-    // Create a single template for each defined light in configuration and
-    // register it.
-    mgr->createObject(handle, true);
-    // get number of templates loaded
-    int numLoadedLights = mgr->getNumObjects();
-    // verify lights were added
-    ASSERT_NE(numLoadedLights, orignNumTemplates);
-
-    // get handles of all lights added
-    auto lightHandles = mgr->getObjectHandlesBySubstring();
-    ASSERT_EQ(lightHandles.size(), numLoadedLights);
-
-    // remove all added handles
-    for (auto handle : lightHandles) {
-      mgr->removeObjectByHandle(handle);
-    }
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
-
-  }  // AttributesManagersTest::testCreateAndRemove
+      const std::string& handle);
 
   /**
    * @brief Test creation many templates and removing all but defaults.
@@ -225,65 +100,7 @@ class AttributesManagersTest : public testing::Test {
   template <typename T>
   void testRemoveAllButDefault(std::shared_ptr<T> mgr,
                                const std::string& handle,
-                               bool setRenderHandle) {
-    // get starting number of templates
-    int orignNumTemplates = mgr->getNumObjects();
-    // lock all current handles
-    std::vector<std::string> origHandles =
-        mgr->setLockBySubstring(true, "", true);
-    // make sure we have locked all original handles
-    ASSERT_EQ(orignNumTemplates, origHandles.size());
-
-    // create multiple new templates, and then test deleting all those created
-    // using single command.
-    int numToAdd = 10;
-    for (int i = 0; i < numToAdd; ++i) {
-      // assign template a handle
-      std::string newHandleIter("newTemplateHandle_" + std::to_string(i));
-      // create a template with a legal handle
-      auto attrTemplate1 = mgr->createObject(handle, false);
-      // register template with new handle
-      int tmpltID = mgr->registerObject(attrTemplate1, newHandleIter);
-      // verify template added
-      ASSERT_NE(tmpltID, -1);
-      auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
-      // verify added template  exists
-      ASSERT_NE(nullptr, attrTemplate2);
-    }
-
-    // now delete all templates that
-    auto removedNamedTemplates =
-        mgr->removeObjectsBySubstring("newTemplateHandle_", true);
-    // verify that the number removed == the number added
-    ASSERT_EQ(removedNamedTemplates.size(), numToAdd);
-
-    // re-add templates
-    for (auto& tmplt : removedNamedTemplates) {
-      // register template with new handle
-      int tmpltID = mgr->registerObject(tmplt);
-      // verify template added
-      ASSERT_NE(tmpltID, -1);
-      auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
-      // verify added template  exists
-      ASSERT_NE(nullptr, attrTemplate2);
-    }
-
-    // now delete all templates that have just been added
-    auto removedTemplates = mgr->removeAllObjects();
-    // verify that the number removed == the number added
-    ASSERT_EQ(removedTemplates.size(), numToAdd);
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
-
-    // unlock all original handles
-    std::vector<std::string> newOrigHandles =
-        mgr->setLockByHandles(origHandles, false);
-    // verify orig handles are those that have been unlocked
-    ASSERT_EQ(newOrigHandles, origHandles);
-    // make sure we have unlocked all original handles
-    ASSERT_EQ(orignNumTemplates, newOrigHandles.size());
-
-  }  // AttributesManagersTest::testRemoveAllButDefault
+                               bool setRenderHandle);
 
   /**
    * @brief Test creation, copying and removal of new default/empty templates
@@ -314,38 +131,7 @@ class AttributesManagersTest : public testing::Test {
   template <typename T>
   void testCreateAndRemoveDefault(std::shared_ptr<T> mgr,
                                   const std::string& handle,
-                                  bool setRenderHandle) {
-    // get starting number of templates
-    int orignNumTemplates = mgr->getNumObjects();
-    // assign template a handle
-    std::string newHandle = "newTemplateHandle";
-
-    // create new template but do not register it
-    auto newAttrTemplate0 = mgr->createDefaultObject(newHandle, false);
-    // verify real template was returned
-    ASSERT_NE(nullptr, newAttrTemplate0);
-
-    // create template from source handle, register it and retrieve it
-    // Note: registration of template means this is a copy of registered
-    // template
-    processTemplateRenderAsset(mgr, newAttrTemplate0, handle);
-    // register modified template and verify that this is the template now
-    // stored
-    int newID = mgr->registerObject(newAttrTemplate0, newHandle);
-
-    // get a copy of added template
-    auto attrTemplate3 = mgr->getObjectOrCopyByHandle(newHandle);
-
-    // remove new template by name
-    auto newAttrTemplate1 = mgr->removeObjectByHandle(newHandle);
-
-    // verify it exists
-    ASSERT_NE(nullptr, newAttrTemplate1);
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, mgr->getNumObjects());
-
-  }  // AttributesManagersTest::testCreateAndRemoveDefault
-
+                                  bool setRenderHandle);
   /**
    * @brief This method will test the user-defined configuration values to see
    * that they match with expected passed values.  The config is expected to
@@ -367,18 +153,7 @@ class AttributesManagersTest : public testing::Test {
       int int_val,
       double double_val,
       Magnum::Vector3 vec_val,
-      Magnum::Quaternion quat_val) {
-    // user defined attributes from light instance
-    ASSERT_NE(nullptr, userConfig);
-    ASSERT_EQ(userConfig->template get<std::string>("user_string"), str_val);
-    ASSERT_EQ(userConfig->template get<bool>("user_bool"), bool_val);
-    ASSERT_EQ(userConfig->template get<int>("user_int"), int_val);
-    ASSERT_EQ(userConfig->template get<double>("user_double"), double_val);
-    ASSERT_EQ(userConfig->template get<Magnum::Vector3>("user_vec3"), vec_val);
-    ASSERT_EQ(userConfig->template get<Magnum::Quaternion>("user_quat"),
-              quat_val);
-
-  }  // AttributesManagersTest::testUserDefinedConfigVals
+      Magnum::Quaternion quat_val);
 
   /**
    * @brief Test creation, copying and removal of templates for primitive
@@ -395,92 +170,24 @@ class AttributesManagersTest : public testing::Test {
   template <typename T>
   void testAssetAttributesModRegRemove(std::shared_ptr<T> defaultAttribs,
                                        int legalVal,
-                                       int const* illegalVal) {
-    // get starting number of templates
-    int orignNumTemplates = assetAttributesManager_->getNumObjects();
-
-    // get name of default template
-    std::string oldHandle = defaultAttribs->getHandle();
-
-    // verify default template is valid
-    bool isTemplateValid = defaultAttribs->isValidTemplate();
-    ASSERT_EQ(isTemplateValid, true);
-
-    // if illegal values are possible
-    if (nullptr != illegalVal) {
-      // modify template value used by primitive constructor (will change
-      // name) illegal modification
-      defaultAttribs->setNumSegments(*illegalVal);
-      // verify template is not valid
-      bool isTemplateValid = defaultAttribs->isValidTemplate();
-      ASSERT_NE(isTemplateValid, true);
-    }
-    // legal modification, different than default
-    defaultAttribs->setNumSegments(legalVal);
-    // verify template is valid
-    isTemplateValid = defaultAttribs->isValidTemplate();
-    ASSERT_EQ(isTemplateValid, true);
-    // rebuild handle to reflect new parameters
-    defaultAttribs->buildHandle();
-
-    // get synthesized handle
-    std::string newHandle = defaultAttribs->getHandle();
-    ESP_DEBUG() << "Modified Template Handle :" << newHandle;
-    // register modified template
-    assetAttributesManager_->registerObject(defaultAttribs);
-
-    // verify new handle is in template library
-    CORRADE_INTERNAL_ASSERT(
-        assetAttributesManager_->getObjectLibHasHandle(newHandle));
-    // verify old template is still present as well
-    CORRADE_INTERNAL_ASSERT(
-        assetAttributesManager_->getObjectLibHasHandle(oldHandle));
-
-    // get new template
-    std::shared_ptr<T> newAttribs =
-        assetAttributesManager_->getObjectOrCopyByHandle<T>(newHandle);
-    // verify template has modified values
-    int newValue = newAttribs->getNumSegments();
-    ASSERT_EQ(legalVal, newValue);
-    // remove modified template via handle
-    auto oldTemplate2 =
-        assetAttributesManager_->removeObjectByHandle(newHandle);
-    // verify deleted template  exists
-    ASSERT_NE(nullptr, oldTemplate2);
-
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, assetAttributesManager_->getNumObjects());
-
-  }  // AttributesManagersTest::testAssetAttributesModRegRemove
+                                       int const* illegalVal);
 
   void testAssetAttributesTemplateCreateFromHandle(
-      const std::string& newTemplateName) {
-    // get starting number of templates
-    int orignNumTemplates = assetAttributesManager_->getNumObjects();
-    // first verify that no template with given name exists
-    bool templateExists =
-        assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
-    ASSERT_EQ(templateExists, false);
-    // create new template based on handle and verify that it is created
-    auto newTemplate = assetAttributesManager_->createTemplateFromHandle(
-        newTemplateName, true);
-    ASSERT_NE(newTemplate, nullptr);
+      const std::string& newTemplateName);
 
-    // now verify that template is in library
-    templateExists =
-        assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
-    ASSERT_EQ(templateExists, true);
+  // actual test functions
+  void AttributesManagers_PhysicsJSONLoadTest();
+  void AttributesManagers_LightJSONLoadTest();
+  void AttributesManagers_SceneInstanceJSONLoadTest();
+  void AttributesManagers_StageJSONLoadTest();
+  void AttributesManagers_ObjectJSONLoadTest();
+  void PhysicsAttributesManagersCreateTest();
+  void StageAttributesManagersCreateTest();
+  void ObjectAttributesManagersCreateTest();
+  void LightLayoutAttributesManagerTest();
+  void PrimitiveAssetAttributesTest();
 
-    // remove new template via handle
-    auto oldTemplate =
-        assetAttributesManager_->removeObjectByHandle(newTemplateName);
-    // verify deleted template  exists
-    ASSERT_NE(nullptr, oldTemplate);
-
-    // verify there are same number of templates as when we started
-    ASSERT_EQ(orignNumTemplates, assetAttributesManager_->getNumObjects());
-
-  }  // AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle
+  // test member vars
 
   esp::logging::LoggingContext loggingContext_;
   AttrMgrs::AssetAttributesManager::ptr assetAttributesManager_ = nullptr;
@@ -490,13 +197,447 @@ class AttributesManagersTest : public testing::Test {
   AttrMgrs::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
   AttrMgrs::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
   AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
-};  // class AttributesManagersTest
+
+};  // struct AttributesManagersTest
+
+AttributesManagersTest::AttributesManagersTest() {
+  // set up a default simulation config to initialize MM
+  auto cfg = esp::sim::SimulatorConfiguration{};
+  auto MM = MetadataMediator::create(cfg);
+  // get attributes managers for default dataset
+  assetAttributesManager_ = MM->getAssetAttributesManager();
+  lightLayoutAttributesManager_ = MM->getLightLayoutAttributesManager();
+  objectAttributesManager_ = MM->getObjectAttributesManager();
+  physicsAttributesManager_ = MM->getPhysicsAttributesManager();
+  sceneAttributesManager_ = MM->getSceneAttributesManager();
+  stageAttributesManager_ = MM->getStageAttributesManager();
+
+  addTests({
+      &AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest,
+      &AttributesManagersTest::AttributesManagers_LightJSONLoadTest,
+      &AttributesManagersTest::AttributesManagers_SceneInstanceJSONLoadTest,
+      &AttributesManagersTest::AttributesManagers_StageJSONLoadTest,
+      &AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest,
+      &AttributesManagersTest::PhysicsAttributesManagersCreateTest,
+      &AttributesManagersTest::StageAttributesManagersCreateTest,
+      &AttributesManagersTest::ObjectAttributesManagersCreateTest,
+      &AttributesManagersTest::LightLayoutAttributesManagerTest,
+      &AttributesManagersTest::PrimitiveAssetAttributesTest,
+  });
+}
+
+/**
+ * @brief Test loading from JSON
+ * @tparam T Class of attributes manager
+ * @tparam U Class of attributes
+ * @param mgr the Attributes Manager being tested
+ * @return attributes template built from JSON parsed from string
+ */
+template <typename T, typename U>
+std::shared_ptr<U> AttributesManagersTest::testBuildAttributesFromJSONString(
+    std::shared_ptr<T> mgr,
+    const std::string& jsonString) {
+  // create JSON document
+  try {
+    esp::io::JsonDocument tmp = esp::io::parseJsonString(jsonString);
+    // io::JsonGenericValue :
+    const esp::io::JsonGenericValue jsonDoc = tmp.GetObject();
+    // create an empty template
+    std::shared_ptr<U> attrTemplate1 =
+        mgr->buildManagedObjectFromDoc("new_template_from_json", jsonDoc);
+
+    return attrTemplate1;
+  } catch (...) {
+    ESP_ERROR() << "testBuildAttributesFromJSONString : Failed to parse"
+                << jsonString << "as JSON.";
+    return nullptr;
+  }
+
+}  // testBuildAttributesFromJSONString
+
+template <typename T>
+void AttributesManagersTest::testRemoveAttributesBuiltJSONString(
+    std::shared_ptr<T> mgr) {
+  mgr->removeObjectByHandle("new_template_from_json");
+}
+
+/**
+ * @brief Test creation, copying and removal of templates for Object, Physics
+ * and Stage Attributes Managers
+ * @tparam Class of attributes manager
+ * @param mgr the Attributes Manager being tested,
+ * @param handle the handle of the desired attributes template to work with
+ */
+template <typename T>
+void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
+                                                 const std::string& handle) {
+  // get starting number of templates
+  int orignNumTemplates = mgr->getNumObjects();
+  // verify template is not present - should not be
+  bool isPresentAlready = mgr->getObjectLibHasHandle(handle);
+  CORRADE_VERIFY(!isPresentAlready);
+
+  // create template from source handle, register it and retrieve it
+  // Note: registration of template means this is a copy of registered
+  // template
+  auto attrTemplate1 = mgr->createObject(handle, true);
+  // verify it exists
+  CORRADE_VERIFY(attrTemplate1 != nullptr);
+  // verify ID exists
+  bool idIsPresent = mgr->getObjectLibHasID(attrTemplate1->getID());
+  CORRADE_VERIFY(idIsPresent);
+  // retrieve a copy of the named attributes template
+  auto attrTemplate2 = mgr->getObjectOrCopyByHandle(handle);
+  // verify copy has same quantities and values as original
+  CORRADE_COMPARE(attrTemplate1->getHandle(), attrTemplate2->getHandle());
+
+  // test changing a user-defined field in each template, verify the templates
+  // are not now the same
+  attrTemplate1->setFileDirectory("temp_dir_1");
+  attrTemplate2->setFileDirectory("temp_dir_2");
+  CORRADE_VERIFY(attrTemplate1->getFileDirectory() !=
+                 attrTemplate2->getFileDirectory());
+  // get original template ID
+  int oldID = attrTemplate1->getID();
+
+  // register modified template and verify that this is the template now
+  // stored
+  int newID = mgr->registerObject(attrTemplate2, handle);
+  // verify IDs are the same
+  CORRADE_COMPARE(oldID, newID);
+
+  // get another copy
+  auto attrTemplate3 = mgr->getObjectOrCopyByHandle(handle);
+  // verify added field is present and the same
+  CORRADE_COMPARE(attrTemplate3->getFileDirectory(),
+                  attrTemplate2->getFileDirectory());
+  // change field in new copy
+  attrTemplate3->setFileDirectory("temp_dir_3");
+  // verify that now they are different
+  CORRADE_VERIFY(attrTemplate3->getFileDirectory() !=
+                 attrTemplate2->getFileDirectory());
+
+  // test removal
+  int removeID = attrTemplate2->getID();
+  // remove template by ID, acquire copy of removed template
+  auto oldTemplate = mgr->removeObjectByID(removeID);
+  // verify it exists
+  CORRADE_VERIFY(oldTemplate != nullptr);
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
+  // re-add template copy via registration
+  int newAddID = mgr->registerObject(attrTemplate2, handle);
+  // verify IDs are the same
+  CORRADE_COMPARE(removeID, newAddID);
+
+  // lock template referenced by handle
+  bool success = mgr->setLock(handle, true);
+  // attempt to remove attributes via handle
+  auto oldTemplate2 = mgr->removeObjectByHandle(handle);
+  // verify no template was deleted
+  CORRADE_VERIFY(oldTemplate2 == nullptr);
+  // unlock template
+  success = mgr->setLock(handle, false);
+
+  // remove  attributes via handle
+  auto oldTemplate3 = mgr->removeObjectByHandle(handle);
+  // verify deleted template exists
+  CORRADE_VERIFY(oldTemplate3 != nullptr);
+  // verify ID does not exist in library now
+  idIsPresent = mgr->getObjectLibHasID(oldTemplate3->getID());
+  CORRADE_VERIFY(!idIsPresent);
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
+
+}  // AttributesManagersTest::testCreateAndRemove
+
+/**
+ * @brief Test creation, copying and removal of templates for lights
+ * attributes managers.
+ * @param mgr the Attributes Manager being tested,
+ * @param handle the handle of the desired attributes template to work with
+ */
+
+void AttributesManagersTest::testCreateAndRemoveLights(
+    AttrMgrs::LightLayoutAttributesManager::ptr mgr,
+    const std::string& handle) {
+  // get starting number of templates
+  int origNumTemplates = mgr->getNumObjects();
+
+  // Source config for lights holds multiple light configurations.
+  // Create a single template for each defined light in configuration and
+  // register it.
+  mgr->createObject(handle, true);
+  // get number of templates loaded
+  int numLoadedLights = mgr->getNumObjects();
+
+  // verify lights were added
+  CORRADE_VERIFY(numLoadedLights != origNumTemplates);
+
+  // get handles of all lights added
+  auto lightHandles = mgr->getObjectHandlesBySubstring();
+  CORRADE_COMPARE(lightHandles.size(), numLoadedLights);
+
+  // remove all added handles
+  for (auto handle : lightHandles) {
+    mgr->removeObjectByHandle(handle);
+  }
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(mgr->getNumObjects(), origNumTemplates);
+
+}  // AttributesManagersTest::testCreateAndRemove
+
+/**
+ * @brief Test creation many templates and removing all but defaults.
+ * @tparam Class of attributes manager
+ * @param mgr the Attributes Manager being tested,
+ * @param renderHandle a legal render handle to set for the new template so
+ * that registration won't fail.
+ */
+template <typename T>
+void AttributesManagersTest::testRemoveAllButDefault(std::shared_ptr<T> mgr,
+                                                     const std::string& handle,
+                                                     bool setRenderHandle) {
+  // get starting number of templates
+  int orignNumTemplates = mgr->getNumObjects();
+  // lock all current handles
+  std::vector<std::string> origHandles =
+      mgr->setLockBySubstring(true, "", true);
+  // make sure we have locked all original handles
+  CORRADE_COMPARE(orignNumTemplates, origHandles.size());
+
+  // create multiple new templates, and then test deleting all those created
+  // using single command.
+  int numToAdd = 10;
+  for (int i = 0; i < numToAdd; ++i) {
+    // assign template a handle
+    std::string newHandleIter("newTemplateHandle_" + std::to_string(i));
+    // create a template with a legal handle
+    auto attrTemplate1 = mgr->createObject(handle, false);
+    // register template with new handle
+    int tmpltID = mgr->registerObject(attrTemplate1, newHandleIter);
+    // verify template added
+    CORRADE_VERIFY(tmpltID != -1);
+    auto attrTemplate2 = mgr->getObjectOrCopyByHandle(newHandleIter);
+    // verify added template  exists
+    CORRADE_VERIFY(attrTemplate2 != nullptr);
+  }
+
+  // now delete all templates that
+  auto removedNamedTemplates =
+      mgr->removeObjectsBySubstring("newTemplateHandle_", true);
+  // verify that the number removed == the number added
+  CORRADE_COMPARE(removedNamedTemplates.size(), numToAdd);
+
+  // re-add templates
+  for (auto& tmplt : removedNamedTemplates) {
+    // register template with new handle
+    int tmpltID = mgr->registerObject(tmplt);
+    // verify template added
+    CORRADE_VERIFY(tmpltID != -1);
+    auto attrTemplate2 = mgr->getObjectOrCopyByHandle(tmplt->getHandle());
+    // verify added template  exists
+    CORRADE_VERIFY(attrTemplate2 != nullptr);
+  }
+
+  // now delete all templates that have just been added
+  auto removedTemplates = mgr->removeAllObjects();
+  // verify that the number removed == the number added
+  CORRADE_COMPARE(removedTemplates.size(), numToAdd);
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
+
+  // unlock all original handles
+  std::vector<std::string> newOrigHandles =
+      mgr->setLockByHandles(origHandles, false);
+  // verify orig handles are those that have been unlocked
+  CORRADE_COMPARE(newOrigHandles, origHandles);
+  // make sure we have unlocked all original handles
+  CORRADE_COMPARE(orignNumTemplates, newOrigHandles.size());
+
+}  // AttributesManagersTest::testRemoveAllButDefault
+
+template <typename T>
+void AttributesManagersTest::testCreateAndRemoveDefault(
+    std::shared_ptr<T> mgr,
+    const std::string& handle,
+    bool setRenderHandle) {
+  // get starting number of templates
+  int orignNumTemplates = mgr->getNumObjects();
+  // assign template a handle
+  std::string newHandle = "newTemplateHandle";
+
+  // create new template but do not register it
+  auto newAttrTemplate0 = mgr->createDefaultObject(newHandle, false);
+  // verify real template was returned
+  CORRADE_VERIFY(newAttrTemplate0 != nullptr);
+
+  // create template from source handle, register it and retrieve it
+  // Note: registration of template means this is a copy of registered
+  // template
+  processTemplateRenderAsset(mgr, newAttrTemplate0, handle);
+  // register modified template and verify that this is the template now
+  // stored
+  int newID = mgr->registerObject(newAttrTemplate0, newHandle);
+
+  // get a copy of added template
+  auto attrTemplate3 = mgr->getObjectOrCopyByHandle(newHandle);
+
+  // remove new template by name
+  auto newAttrTemplate1 = mgr->removeObjectByHandle(newHandle);
+
+  // verify it exists
+  CORRADE_VERIFY(newAttrTemplate1 != nullptr);
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
+
+}  // AttributesManagersTest::testCreateAndRemoveDefault
+
+/**
+ * @brief This method will test the user-defined configuration values to see
+ * that they match with expected passed values.  The config is expected to
+ * hold one of each type that it supports.
+ * @param userConfig The configuration object whose contents are to be
+ * tested
+ * @param str_val Expected string value
+ * @param bool_val Expected boolean value
+ * @param double_val Exptected double value
+ * @param vec_val Expected Magnum::Vector3 value
+ * @param quat_val Expected Quaternion value - note that the JSON is read
+ * with scalar at idx 0, whereas the quaternion constructor takes the vector
+ * component in the first position and the scalar in the second.
+ */
+void AttributesManagersTest::testUserDefinedConfigVals(
+    std::shared_ptr<esp::core::config::Configuration> userConfig,
+    const std::string& str_val,
+    bool bool_val,
+    int int_val,
+    double double_val,
+    Magnum::Vector3 vec_val,
+    Magnum::Quaternion quat_val) {
+  // user defined attributes from light instance
+  CORRADE_VERIFY(userConfig != nullptr);
+  CORRADE_COMPARE(userConfig->template get<std::string>("user_string"),
+                  str_val);
+  CORRADE_COMPARE(userConfig->template get<bool>("user_bool"), bool_val);
+  CORRADE_COMPARE(userConfig->template get<int>("user_int"), int_val);
+  CORRADE_COMPARE(userConfig->template get<double>("user_double"), double_val);
+  CORRADE_COMPARE(userConfig->template get<Magnum::Vector3>("user_vec3"),
+                  vec_val);
+  CORRADE_COMPARE(userConfig->template get<Magnum::Quaternion>("user_quat"),
+                  quat_val);
+
+}  // AttributesManagersTest::testUserDefinedConfigVals
+
+/**
+ * @brief Test creation, copying and removal of templates for primitive
+ * assets.
+ * @tparam Class of attributes being managed
+ * @param defaultAttribs the default template of the passed type T
+ * @param ctorModField the name of the modified field of type @ref U that
+ * impacts the constructor.
+ * @param legalVal a legal value of ctorModField; This should be different
+ * than template default for @ref ctorModField.
+ * @param illegalVal a legal value of ctorModField.  If null ptr then no
+ * illegal values possible.
+ */
+template <typename T>
+void AttributesManagersTest::testAssetAttributesModRegRemove(
+    std::shared_ptr<T> defaultAttribs,
+    int legalVal,
+    int const* illegalVal) {
+  // get starting number of templates
+  int orignNumTemplates = assetAttributesManager_->getNumObjects();
+
+  // get name of default template
+  std::string oldHandle = defaultAttribs->getHandle();
+
+  // verify default template is valid
+  bool isTemplateValid = defaultAttribs->isValidTemplate();
+  CORRADE_VERIFY(isTemplateValid);
+
+  // if illegal values are possible
+  if (illegalVal != nullptr) {
+    // modify template value used by primitive constructor (will change
+    // name) illegal modification
+    defaultAttribs->setNumSegments(*illegalVal);
+    // verify template is not valid
+    bool isTemplateValid = defaultAttribs->isValidTemplate();
+    CORRADE_VERIFY(!isTemplateValid);
+  }
+  // legal modification, different than default
+  defaultAttribs->setNumSegments(legalVal);
+  // verify template is valid
+  isTemplateValid = defaultAttribs->isValidTemplate();
+  CORRADE_VERIFY(isTemplateValid);
+  // rebuild handle to reflect new parameters
+  defaultAttribs->buildHandle();
+
+  // get synthesized handle
+  std::string newHandle = defaultAttribs->getHandle();
+  ESP_DEBUG() << "Modified Template Handle :" << newHandle;
+  // register modified template
+  assetAttributesManager_->registerObject(defaultAttribs);
+
+  // verify new handle is in template library
+  CORRADE_INTERNAL_ASSERT(
+      assetAttributesManager_->getObjectLibHasHandle(newHandle));
+  // verify old template is still present as well
+  CORRADE_INTERNAL_ASSERT(
+      assetAttributesManager_->getObjectLibHasHandle(oldHandle));
+
+  // get new template
+  std::shared_ptr<T> newAttribs =
+      assetAttributesManager_->getObjectOrCopyByHandle<T>(newHandle);
+  // verify template has modified values
+  int newValue = newAttribs->getNumSegments();
+  CORRADE_COMPARE(legalVal, newValue);
+  // remove modified template via handle
+  auto oldTemplate2 = assetAttributesManager_->removeObjectByHandle(newHandle);
+  // verify deleted template  exists
+  CORRADE_VERIFY(oldTemplate2 != nullptr);
+
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, assetAttributesManager_->getNumObjects());
+
+}  // AttributesManagersTest::testAssetAttributesModRegRemove
+
+void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
+    const std::string& newTemplateName) {
+  // get starting number of templates
+  int orignNumTemplates = assetAttributesManager_->getNumObjects();
+  // first verify that no template with given name exists
+  bool templateExists =
+      assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
+  CORRADE_VERIFY(!templateExists);
+  // create new template based on handle and verify that it is created
+  auto newTemplate =
+      assetAttributesManager_->createTemplateFromHandle(newTemplateName, true);
+  CORRADE_VERIFY(newTemplate != nullptr);
+
+  // now verify that template is in library
+  templateExists =
+      assetAttributesManager_->getObjectLibHasHandle(newTemplateName);
+  CORRADE_VERIFY(templateExists);
+
+  // remove new template via handle
+  auto oldTemplate =
+      assetAttributesManager_->removeObjectByHandle(newTemplateName);
+  // verify deleted template  exists
+  CORRADE_VERIFY(oldTemplate != nullptr);
+
+  // verify there are same number of templates as when we started
+  CORRADE_COMPARE(orignNumTemplates, assetAttributesManager_->getNumObjects());
+
+}  // AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle
+
+/////////////  Begin JSON String-based tests
 
 /**
  * @brief This test will verify that the physics attributes' managers' JSON
  * loading process is working as expected.
  */
-TEST_F(AttributesManagersTest, AttributesManagers_PhysicsJSONLoadTest) {
+void AttributesManagersTest::AttributesManagers_PhysicsJSONLoadTest() {
   ESP_DEBUG() << "Starting AttributesManagers_PhysicsJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
@@ -519,19 +660,22 @@ TEST_F(AttributesManagersTest, AttributesManagers_PhysicsJSONLoadTest) {
                                         Attrs::PhysicsManagerAttributes>(
           physicsAttributesManager_, jsonString);
   // verify exists
-  ASSERT_NE(nullptr, physMgrAttr);
+  CORRADE_VERIFY(physMgrAttr != nullptr);
   // match values set in test JSON
   // TODO : get these values programmatically?
-  ASSERT_EQ(physMgrAttr->getGravity(), Magnum::Vector3(1, 2, 3));
-  ASSERT_EQ(physMgrAttr->getTimestep(), 1.0);
-  ASSERT_EQ(physMgrAttr->getSimulator(), "bullet_test");
-  ASSERT_EQ(physMgrAttr->getFrictionCoefficient(), 1.4);
-  ASSERT_EQ(physMgrAttr->getRestitutionCoefficient(), 1.1);
+  CORRADE_COMPARE(physMgrAttr->getGravity(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(physMgrAttr->getTimestep(), 1.0);
+  CORRADE_COMPARE(physMgrAttr->getSimulator(), "bullet_test");
+  CORRADE_COMPARE(physMgrAttr->getFrictionCoefficient(), 1.4);
+  CORRADE_COMPARE(physMgrAttr->getRestitutionCoefficient(), 1.1);
   // test physics manager attributes-level user config vals
   testUserDefinedConfigVals(physMgrAttr->getUserConfiguration(),
                             "pm defined string", true, 15, 12.6,
                             Magnum::Vector3(215.4, 217.6, 2110.1),
                             Magnum::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f));
+  // remove added template
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltJSONString(physicsAttributesManager_);
 
 }  // AttributesManagers_PhysicsJSONLoadTest
 
@@ -539,7 +683,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_PhysicsJSONLoadTest) {
  * @brief This test will verify that the Light Attributes' managers' JSON
  * loading process is working as expected.
  */
-TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
+void AttributesManagersTest::AttributesManagers_LightJSONLoadTest() {
   ESP_DEBUG() << "Starting AttributesManagers_LightJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
@@ -583,31 +727,31 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
           lightLayoutAttributesManager_, jsonString);
 
   // verify exists
-  ASSERT_NE(nullptr, lightLayoutAttr);
+  CORRADE_VERIFY(lightLayoutAttr != nullptr);
   // test light layout attributes-level user config vals
   testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
                             "light attribs defined string", true, 23, 2.3,
                             Magnum::Vector3(1.1, 3.3, 5.5),
                             Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
-  ASSERT_EQ(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
-  ASSERT_EQ(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
+  CORRADE_COMPARE(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
+  CORRADE_COMPARE(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
   auto lightAttr = lightLayoutAttr->getLightInstance("test");
   // verify that lightAttr exists
-  ASSERT_NE(nullptr, lightAttr);
+  CORRADE_VERIFY(lightAttr != nullptr);
 
   // match values set in test JSON
   // TODO : get these values programmatically?
-  ASSERT_EQ(lightAttr->getPosition(), Magnum::Vector3(2.5, 0.1, 3.8));
-  ASSERT_EQ(lightAttr->getDirection(), Magnum::Vector3(1.0, -1.0, 1.0));
-  ASSERT_EQ(lightAttr->getColor(), Magnum::Vector3(2, 1, -1));
+  CORRADE_COMPARE(lightAttr->getPosition(), Magnum::Vector3(2.5, 0.1, 3.8));
+  CORRADE_COMPARE(lightAttr->getDirection(), Magnum::Vector3(1.0, -1.0, 1.0));
+  CORRADE_COMPARE(lightAttr->getColor(), Magnum::Vector3(2, 1, -1));
 
-  ASSERT_EQ(lightAttr->getIntensity(), -0.1);
-  ASSERT_EQ(lightAttr->getType(),
-            static_cast<int>(esp::gfx::LightType::Directional));
-  ASSERT_EQ(lightAttr->getPositionModel(),
-            static_cast<int>(esp::gfx::LightPositionModel::Camera));
-  ASSERT_EQ(lightAttr->getInnerConeAngle(), -0.75_radf);
-  ASSERT_EQ(lightAttr->getOuterConeAngle(), -1.57_radf);
+  CORRADE_COMPARE(lightAttr->getIntensity(), -0.1);
+  CORRADE_COMPARE(lightAttr->getType(),
+                  static_cast<int>(esp::gfx::LightType::Directional));
+  CORRADE_COMPARE(lightAttr->getPositionModel(),
+                  static_cast<int>(esp::gfx::LightPositionModel::Camera));
+  CORRADE_COMPARE(lightAttr->getInnerConeAngle(), -0.75_radf);
+  CORRADE_COMPARE(lightAttr->getOuterConeAngle(), -1.57_radf);
 
   // test user defined attributes from light instance
   testUserDefinedConfigVals(lightAttr->getUserConfiguration(),
@@ -615,13 +759,16 @@ TEST_F(AttributesManagersTest, AttributesManagers_LightJSONLoadTest) {
                             Magnum::Vector3(0.1, 2.3, 4.5),
                             Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
 
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltJSONString(lightLayoutAttributesManager_);
+
 }  // AttributesManagers_LightJSONLoadTest
 
 /**
  * @brief This test will verify that the Scene Instance attributes' managers'
  * JSON loading process is working as expected.
  */
-TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
+void AttributesManagersTest::AttributesManagers_SceneInstanceJSONLoadTest() {
   ESP_DEBUG() << "Starting AttributesManagers_SceneInstanceJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
@@ -731,16 +878,17 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
           sceneAttributesManager_, jsonString);
 
   // verify exists
-  ASSERT_NE(nullptr, sceneAttr);
+  CORRADE_VERIFY(sceneAttr != nullptr);
 
   // match values set in test JSON
-  ASSERT_EQ(
+  CORRADE_COMPARE(
       sceneAttr->getTranslationOrigin(),
       static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal));
-  ASSERT_EQ(sceneAttr->getLightingHandle(), "test_lighting_configuration");
-  ASSERT_EQ(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
-  ASSERT_EQ(sceneAttr->getSemanticSceneHandle(),
-            "test_semantic_descriptor_path1");
+  CORRADE_COMPARE(sceneAttr->getLightingHandle(),
+                  "test_lighting_configuration");
+  CORRADE_COMPARE(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
+  CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
+                  "test_semantic_descriptor_path1");
   // test scene instance attributes-level user config vals
   testUserDefinedConfigVals(sceneAttr->getUserConfiguration(),
                             "scene instance defined string", true, 99, 9.1,
@@ -749,31 +897,31 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
 
   // verify stage populated properly
   auto stageInstance = sceneAttr->getStageInstance();
-  ASSERT_EQ(stageInstance->getHandle(), "test_stage_template");
-  ASSERT_EQ(stageInstance->getTranslation(), Magnum::Vector3(1, 2, 3));
-  ASSERT_EQ(stageInstance->getRotation(),
-            Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
+  CORRADE_COMPARE(stageInstance->getHandle(), "test_stage_template");
+  CORRADE_COMPARE(stageInstance->getTranslation(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(stageInstance->getRotation(),
+                  Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
   // test stage instance attributes-level user config vals
   testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
                             "stage instance defined string", true, 11, 2.2,
                             Magnum::Vector3(1.2, 3.4, 5.6),
                             Magnum::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f));
   // make sure that is not default value "flat"
-  ASSERT_EQ(stageInstance->getShaderType(),
-            static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
+  CORRADE_COMPARE(stageInstance->getShaderType(),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
 
   // verify objects
   auto objectInstanceList = sceneAttr->getObjectInstances();
-  ASSERT_EQ(objectInstanceList.size(), 2);
+  CORRADE_COMPARE(objectInstanceList.size(), 2);
   auto objInstance = objectInstanceList[0];
-  ASSERT_EQ(objInstance->getHandle(), "test_object_template0");
-  ASSERT_EQ(objInstance->getTranslationOrigin(),
-            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
-  ASSERT_EQ(objInstance->getTranslation(), Magnum::Vector3(0, 1, 2));
-  ASSERT_EQ(objInstance->getRotation(),
-            Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
-  ASSERT_EQ(objInstance->getMotionType(),
-            static_cast<int>(esp::physics::MotionType::KINEMATIC));
+  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template0");
+  CORRADE_COMPARE(objInstance->getTranslationOrigin(),
+                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
+  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, 1, 2));
+  CORRADE_COMPARE(objInstance->getRotation(),
+                  Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
+  CORRADE_COMPARE(objInstance->getMotionType(),
+                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
 
   // test object 0 instance attributes-level user config vals
   testUserDefinedConfigVals(objInstance->getUserConfiguration(),
@@ -782,12 +930,12 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
                             Magnum::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f));
 
   objInstance = objectInstanceList[1];
-  ASSERT_EQ(objInstance->getHandle(), "test_object_template1");
-  ASSERT_EQ(objInstance->getTranslation(), Magnum::Vector3(0, -1, -2));
-  ASSERT_EQ(objInstance->getRotation(),
-            Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
-  ASSERT_EQ(objInstance->getMotionType(),
-            static_cast<int>(esp::physics::MotionType::DYNAMIC));
+  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template1");
+  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, -1, -2));
+  CORRADE_COMPARE(objInstance->getRotation(),
+                  Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
+  CORRADE_COMPARE(objInstance->getMotionType(),
+                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
 
   // test object 0 instance attributes-level user config vals
   testUserDefinedConfigVals(objInstance->getUserConfiguration(),
@@ -797,17 +945,17 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
 
   // verify articulated object instances
   auto artObjInstances = sceneAttr->getArticulatedObjectInstances();
-  ASSERT_EQ(artObjInstances.size(), 2);
+  CORRADE_COMPARE(artObjInstances.size(), 2);
   auto artObjInstance = artObjInstances[0];
-  ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template0");
-  ASSERT_EQ(artObjInstance->getTranslationOrigin(),
-            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
-  ASSERT_EQ(artObjInstance->getFixedBase(), false);
-  ASSERT_EQ(artObjInstance->getAutoClampJointLimits(), true);
+  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template0");
+  CORRADE_COMPARE(artObjInstance->getTranslationOrigin(),
+                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
+  CORRADE_COMPARE(artObjInstance->getFixedBase(), false);
+  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
 
-  ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
-  ASSERT_EQ(artObjInstance->getMotionType(),
-            static_cast<int>(esp::physics::MotionType::DYNAMIC));
+  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
+  CORRADE_COMPARE(artObjInstance->getMotionType(),
+                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
   // verify init join pose
   const auto& initJointPoseMap = artObjInstance->getInitJointPose();
   const std::vector<float> jtPoseVals{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
@@ -815,7 +963,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   for (std::map<std::string, float>::const_iterator iter =
            initJointPoseMap.begin();
        iter != initJointPoseMap.end(); ++iter) {
-    ASSERT_EQ(iter->second, jtPoseVals[idx++]);
+    CORRADE_COMPARE(iter->second, jtPoseVals[idx++]);
   }
   // verify init joint vels
   const auto& initJoinVelMap = artObjInstance->getInitJointVelocities();
@@ -824,7 +972,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   for (std::map<std::string, float>::const_iterator iter =
            initJoinVelMap.begin();
        iter != initJoinVelMap.end(); ++iter) {
-    ASSERT_EQ(iter->second, jtVelVals[idx++]);
+    CORRADE_COMPARE(iter->second, jtVelVals[idx++]);
   }
 
   // test test_urdf_template0 ao instance attributes-level user config vals
@@ -838,21 +986,21 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
   auto artObjNestedConfig =
       artObjInstance->getUserConfiguration()
           ->getSubconfigCopy<esp::core::config::Configuration>("user_def_obj");
-  ASSERT_NE(artObjNestedConfig, nullptr);
-  ASSERT_EQ(artObjNestedConfig->getNumEntries() > 0, true);
-  ASSERT_EQ(artObjNestedConfig->template get<Magnum::Vector3>("position"),
-            Magnum::Vector3(0.1f, 0.2f, 0.3f));
-  ASSERT_EQ(artObjNestedConfig->template get<Magnum::Vector3>("rotation"),
-            Magnum::Vector3(0.5f, 0.3f, 0.1f));
+  CORRADE_VERIFY(artObjNestedConfig != nullptr);
+  CORRADE_VERIFY(artObjNestedConfig->getNumEntries() > 0);
+  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("position"),
+                  Magnum::Vector3(0.1f, 0.2f, 0.3f));
+  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("rotation"),
+                  Magnum::Vector3(0.5f, 0.3f, 0.1f));
   ESP_WARNING() << "Articulated Object test 3";
 
   artObjInstance = artObjInstances[1];
-  ASSERT_EQ(artObjInstance->getHandle(), "test_urdf_template1");
-  ASSERT_EQ(artObjInstance->getFixedBase(), true);
-  ASSERT_EQ(artObjInstance->getAutoClampJointLimits(), true);
-  ASSERT_EQ(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
-  ASSERT_EQ(artObjInstance->getMotionType(),
-            static_cast<int>(esp::physics::MotionType::KINEMATIC));
+  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template1");
+  CORRADE_VERIFY(artObjInstance->getFixedBase());
+  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
+  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
+  CORRADE_COMPARE(artObjInstance->getMotionType(),
+                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template1 instance defined string",
@@ -860,13 +1008,16 @@ TEST_F(AttributesManagersTest, AttributesManagers_SceneInstanceJSONLoadTest) {
                             Magnum::Vector3(190.3f, 902.5f, -95.07f),
                             Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
 
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltJSONString(sceneAttributesManager_);
+
 }  // AttributesManagers_SceneInstanceJSONLoadTest
 
 /**
  * @brief This test will verify that the Stage attributes' managers' JSON
  * loading process is working as expected.
  */
-TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
+void AttributesManagersTest::AttributesManagers_StageJSONLoadTest() {
   ESP_DEBUG() << "Starting AttributesManagers_StageJSONLoadTest";
 
   // build JSON sample config
@@ -904,34 +1055,40 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
                                         Attrs::StageAttributes>(
           stageAttributesManager_, jsonString);
   // verify exists
-  ASSERT_NE(nullptr, stageAttr);
+  CORRADE_VERIFY(stageAttr != nullptr);
   // match values set in test JSON
   // TODO : get these values programmatically?
-  ASSERT_EQ(stageAttr->getScale(), Magnum::Vector3(2, 3, 4));
-  ASSERT_EQ(stageAttr->getMargin(), 0.9);
-  ASSERT_EQ(stageAttr->getFrictionCoefficient(), 0.321);
-  ASSERT_EQ(stageAttr->getRestitutionCoefficient(), 0.456);
-  ASSERT_EQ(stageAttr->getRequiresLighting(), true);
-  ASSERT_EQ(stageAttr->getUnitsToMeters(), 1.1);
-  ASSERT_EQ(stageAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
-  ASSERT_EQ(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
-  ASSERT_EQ(stageAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
-  ASSERT_EQ(stageAttr->getCollisionAssetHandle(), "testJSONCollisionAsset.glb");
-  ASSERT_EQ(stageAttr->getIsCollidable(), false);
+  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 3, 4));
+  CORRADE_COMPARE(stageAttr->getMargin(), 0.9);
+  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.321);
+  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.456);
+  CORRADE_VERIFY(stageAttr->getRequiresLighting());
+  CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 1.1);
+  CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
+  CORRADE_COMPARE(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
+  CORRADE_COMPARE(stageAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
+  CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(),
+                  "testJSONCollisionAsset.glb");
+  CORRADE_VERIFY(!stageAttr->getIsCollidable());
   // stage-specific attributes
-  ASSERT_EQ(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
+  CORRADE_COMPARE(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
   // make sure that is not default value "flat"
-  ASSERT_EQ(stageAttr->getShaderType(),
-            static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
-  ASSERT_EQ(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
-  ASSERT_EQ(stageAttr->getSemanticAssetHandle(), "testJSONSemanticAsset.glb");
-  ASSERT_EQ(stageAttr->getNavmeshAssetHandle(), "testJSONNavMeshAsset.glb");
-  ASSERT_EQ(stageAttr->getHouseFilename(), "testJSONHouseFileName.glb");
+  CORRADE_COMPARE(stageAttr->getShaderType(),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
+  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(stageAttr->getSemanticAssetHandle(),
+                  "testJSONSemanticAsset.glb");
+  CORRADE_COMPARE(stageAttr->getNavmeshAssetHandle(),
+                  "testJSONNavMeshAsset.glb");
+  CORRADE_COMPARE(stageAttr->getHouseFilename(), "testJSONHouseFileName.glb");
   // test stage attributes-level user config vals
   testUserDefinedConfigVals(stageAttr->getUserConfiguration(),
                             "stage defined string", false, 3, 0.8,
                             Magnum::Vector3(5.4, 7.6, 10.1),
                             Magnum::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltJSONString(stageAttributesManager_);
 
 }  // AttributesManagers_StageJSONLoadTest
 
@@ -939,7 +1096,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_StageJSONLoadTest) {
  * @brief This test will verify that the Object attributes' managers' JSON
  * loading process is working as expected.
  */
-TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
+void AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest() {
   ESP_DEBUG() << "Starting AttributesManagers_ObjectJSONLoadTest";
   // build JSON sample config
   const std::string& jsonString = R"({
@@ -975,34 +1132,38 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
                                         Attrs::ObjectAttributes>(
           objectAttributesManager_, jsonString);
   // verify exists
-  ASSERT_NE(nullptr, objAttr);
+  CORRADE_VERIFY(objAttr != nullptr);
   // match values set in test JSON
   // TODO : get these values programmatically?
-  ASSERT_EQ(objAttr->getScale(), Magnum::Vector3(2, 3, 4));
-  ASSERT_EQ(objAttr->getMargin(), 0.9);
-  ASSERT_EQ(objAttr->getFrictionCoefficient(), 0.321);
-  ASSERT_EQ(objAttr->getRestitutionCoefficient(), 0.456);
-  ASSERT_EQ(objAttr->getRequiresLighting(), false);
-  ASSERT_EQ(objAttr->getUnitsToMeters(), 1.1);
-  ASSERT_EQ(objAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
-  ASSERT_EQ(objAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
-  ASSERT_EQ(objAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
-  ASSERT_EQ(objAttr->getCollisionAssetHandle(), "testJSONCollisionAsset.glb");
-  ASSERT_EQ(objAttr->getIsCollidable(), false);
-  ASSERT_EQ(objAttr->getSemanticId(), 7);
+  CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(2, 3, 4));
+  CORRADE_COMPARE(objAttr->getMargin(), 0.9);
+  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.321);
+  CORRADE_COMPARE(objAttr->getRestitutionCoefficient(), 0.456);
+  CORRADE_VERIFY(!objAttr->getRequiresLighting());
+  CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.1);
+  CORRADE_COMPARE(objAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
+  CORRADE_COMPARE(objAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
+  CORRADE_COMPARE(objAttr->getRenderAssetHandle(), "testJSONRenderAsset.glb");
+  CORRADE_COMPARE(objAttr->getCollisionAssetHandle(),
+                  "testJSONCollisionAsset.glb");
+  CORRADE_VERIFY(!objAttr->getIsCollidable());
+  CORRADE_COMPARE(objAttr->getSemanticId(), 7);
   // object-specific attributes
-  ASSERT_EQ(objAttr->getMass(), 9);
-  ASSERT_EQ(objAttr->getShaderType(),
-            static_cast<int>(Attrs::ObjectInstanceShaderType::Phong));
-  ASSERT_EQ(objAttr->getBoundingBoxCollisions(), true);
-  ASSERT_EQ(objAttr->getJoinCollisionMeshes(), true);
-  ASSERT_EQ(objAttr->getInertia(), Magnum::Vector3(1.1, 0.9, 0.3));
-  ASSERT_EQ(objAttr->getCOM(), Magnum::Vector3(0.1, 0.2, 0.3));
+  CORRADE_COMPARE(objAttr->getMass(), 9);
+  CORRADE_COMPARE(objAttr->getShaderType(),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::Phong));
+  CORRADE_VERIFY(objAttr->getBoundingBoxCollisions());
+  CORRADE_VERIFY(objAttr->getJoinCollisionMeshes());
+  CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(1.1, 0.9, 0.3));
+  CORRADE_COMPARE(objAttr->getCOM(), Magnum::Vector3(0.1, 0.2, 0.3));
   // test object attributes-level user config vals
   testUserDefinedConfigVals(objAttr->getUserConfiguration(),
                             "object defined string", true, 5, 2.6,
                             Magnum::Vector3(15.4, 17.6, 110.1),
                             Magnum::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltJSONString(objectAttributesManager_);
 
 }  // AttributesManagersTest::AttributesManagers_ObjectJSONLoadTest
 
@@ -1015,7 +1176,7 @@ TEST_F(AttributesManagersTest, AttributesManagers_ObjectJSONLoadTest) {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-TEST_F(AttributesManagersTest, PhysicsAttributesManagersCreate) {
+void AttributesManagersTest::PhysicsAttributesManagersCreateTest() {
   ESP_DEBUG() << "Starting PhysicsAttributesManagersCreate";
 
   ESP_DEBUG() << "Start Test : Create, Edit, Remove Attributes for "
@@ -1038,7 +1199,7 @@ TEST_F(AttributesManagersTest, PhysicsAttributesManagersCreate) {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-TEST_F(AttributesManagersTest, StageAttributesManagersCreate) {
+void AttributesManagersTest::StageAttributesManagersCreateTest() {
   std::string stageConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/scenes/simple_room.glb");
 
@@ -1063,7 +1224,7 @@ TEST_F(AttributesManagersTest, StageAttributesManagersCreate) {
  * PrimitiveAssetAttributes exhibit slightly different behavior and need their
  * own tests.
  */
-TEST_F(AttributesManagersTest, ObjectAttributesManagersCreate) {
+void AttributesManagersTest::ObjectAttributesManagersCreateTest() {
   std::string objectConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/objects/chair.object_config.json");
 
@@ -1081,16 +1242,16 @@ TEST_F(AttributesManagersTest, ObjectAttributesManagersCreate) {
   // remain
   int newNumFileBased1 = objectAttributesManager_->getNumFileTemplateObjects();
   int newNumPrimBased1 = objectAttributesManager_->getNumSynthTemplateObjects();
-  ASSERT_EQ(origNumFileBased, newNumFileBased1);
-  ASSERT_EQ(origNumPrimBased, newNumPrimBased1);
+  CORRADE_COMPARE(origNumFileBased, newNumFileBased1);
+  CORRADE_COMPARE(origNumPrimBased, newNumPrimBased1);
   testCreateAndRemoveDefault<AttrMgrs::ObjectAttributesManager>(
       objectAttributesManager_, objectConfigFile, true);
   // verify that no new file-based and no new synth based template objects
   // remain
   int newNumFileBased2 = objectAttributesManager_->getNumFileTemplateObjects();
   int newNumPrimBased2 = objectAttributesManager_->getNumSynthTemplateObjects();
-  ASSERT_EQ(origNumFileBased, newNumFileBased2);
-  ASSERT_EQ(origNumPrimBased, newNumPrimBased2);
+  CORRADE_COMPARE(origNumFileBased, newNumFileBased2);
+  CORRADE_COMPARE(origNumPrimBased, newNumPrimBased2);
 
   // test adding many and removing all but defaults
   testRemoveAllButDefault<AttrMgrs::ObjectAttributesManager>(
@@ -1099,11 +1260,11 @@ TEST_F(AttributesManagersTest, ObjectAttributesManagersCreate) {
   // remain
   int newNumFileBased3 = objectAttributesManager_->getNumFileTemplateObjects();
   int newNumPrimBased3 = objectAttributesManager_->getNumSynthTemplateObjects();
-  ASSERT_EQ(origNumFileBased, newNumFileBased3);
-  ASSERT_EQ(origNumPrimBased, newNumPrimBased3);
+  CORRADE_COMPARE(origNumFileBased, newNumFileBased3);
+  CORRADE_COMPARE(origNumPrimBased, newNumPrimBased3);
 }  // AttributesManagersTest::ObjectAttributesManagersCreate test
 
-TEST_F(AttributesManagersTest, LightLayoutAttributesManagerTest) {
+void AttributesManagersTest::LightLayoutAttributesManagerTest() {
   ESP_DEBUG() << "Starting LightLayoutAttributesManagerTest";
 
   std::string lightConfigFile = Cr::Utility::Directory::join(
@@ -1122,7 +1283,7 @@ TEST_F(AttributesManagersTest, LightLayoutAttributesManagerTest) {
  * managers. This includes testing handle auto-gen when relevant fields in
  * asset attributes are changed.
  */
-TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
+void AttributesManagersTest::PrimitiveAssetAttributesTest() {
   ESP_DEBUG() << "Starting PrimitiveAssetAttributesTest";
   /**
    * Primitive asset attributes require slightly different testing since a
@@ -1167,7 +1328,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     CapsulePrimitiveAttributes::ptr dfltCapsAttribs =
         assetAttributesManager_->getDefaultCapsuleTemplate(false);
     // verify it exists
-    ASSERT_NE(nullptr, dfltCapsAttribs);
+    CORRADE_VERIFY(dfltCapsAttribs != nullptr);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
@@ -1179,7 +1340,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // test wireframe version
     dfltCapsAttribs = assetAttributesManager_->getDefaultCapsuleTemplate(true);
     // verify it exists
-    ASSERT_NE(nullptr, dfltCapsAttribs);
+    CORRADE_VERIFY(dfltCapsAttribs != nullptr);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CapsulePrimitiveAttributes>(
         dfltCapsAttribs, legalModValWF, &illegalModValWF);
@@ -1194,7 +1355,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     ConePrimitiveAttributes::ptr dfltConeAttribs =
         assetAttributesManager_->getDefaultConeTemplate(false);
     // verify it exists
-    ASSERT_NE(nullptr, dfltConeAttribs);
+    CORRADE_VERIFY(dfltConeAttribs != nullptr);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
@@ -1206,7 +1367,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // test wireframe version
     dfltConeAttribs = assetAttributesManager_->getDefaultConeTemplate(true);
     // verify it exists
-    ASSERT_NE(nullptr, dfltConeAttribs);
+    CORRADE_VERIFY(dfltConeAttribs != nullptr);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<ConePrimitiveAttributes>(
         dfltConeAttribs, legalModValWF, &illegalModValWF);
@@ -1222,7 +1383,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     CylinderPrimitiveAttributes::ptr dfltCylAttribs =
         assetAttributesManager_->getDefaultCylinderTemplate(false);
     // verify it exists
-    ASSERT_NE(nullptr, dfltCylAttribs);
+    CORRADE_VERIFY(dfltCylAttribs != nullptr);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
@@ -1234,7 +1395,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     // test wireframe version
     dfltCylAttribs = assetAttributesManager_->getDefaultCylinderTemplate(true);
     // verify it exists
-    ASSERT_NE(nullptr, dfltCylAttribs);
+    CORRADE_VERIFY(dfltCylAttribs != nullptr);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<CylinderPrimitiveAttributes>(
         dfltCylAttribs, legalModValWF, &illegalModValWF);
@@ -1249,7 +1410,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     UVSpherePrimitiveAttributes::ptr dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(false);
     // verify it exists
-    ASSERT_NE(nullptr, dfltUVSphereAttribs);
+    CORRADE_VERIFY(dfltUVSphereAttribs != nullptr);
 
     // for solid primitives, and value > 2 for segments is legal
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
@@ -1262,7 +1423,7 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
     dfltUVSphereAttribs =
         assetAttributesManager_->getDefaultUVSphereTemplate(true);
     // verify it exists
-    ASSERT_NE(nullptr, dfltUVSphereAttribs);
+    CORRADE_VERIFY(dfltUVSphereAttribs != nullptr);
     // segments must be mult of 4 for wireframe primtives
     testAssetAttributesModRegRemove<UVSpherePrimitiveAttributes>(
         dfltUVSphereAttribs, legalModValWF, &illegalModValWF);
@@ -1272,4 +1433,6 @@ TEST_F(AttributesManagersTest, PrimitiveAssetAttributesTest) {
   }
 }  // AttributesManagersTest::AsssetAttributesManagerGetAndModify test
 
-}  // namespace
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::AttributesManagersTest)

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -40,7 +40,7 @@ using Attrs::SceneAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
 
-namespace Test {
+namespace {
 const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
                                  "test_assets/testing.physics_config.json");
@@ -1423,6 +1423,6 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
   }
 }  // AttributesManagersTest::AsssetAttributesManagerGetAndModify test
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::AttributesManagersTest)
+CORRADE_TEST_MAIN(AttributesManagersTest)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,16 +1,6 @@
 find_package(Magnum REQUIRED DebugTools AnyImageConverter)
 find_package(MagnumPlugins REQUIRED StbImageImporter)
 
-macro(TEST TEST_NAME)
-  add_executable(${TEST_NAME} "${TEST_NAME}.cpp")
-  target_link_libraries(${TEST_NAME} core gtest_main)
-  set(DEPENDENCIES "${ARGN}")
-  foreach(DEPENDENCY IN LISTS DEPENDENCIES)
-    target_link_libraries(${TEST_NAME} ${DEPENDENCY})
-  endforeach()
-  add_test(${TEST_NAME} ${TEST_NAME})
-endmacro(TEST)
-
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/configure.h
 )
@@ -66,6 +56,18 @@ corrade_add_test(
 )
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+corrade_add_test(PhysicsTest PhysicsTest.cpp LIBRARIES physics)
+target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(ResourceManagerTest ResourceManagerTest.cpp LIBRARIES assets)
+target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(SceneGraphTest SceneGraphTest.cpp LIBRARIES scene)
+target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(SensorTest SensorTest.cpp LIBRARIES sensor sim)
+target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 corrade_add_test(
   SimTest
   SimTest.cpp
@@ -77,11 +79,8 @@ corrade_add_test(
 )
 target_include_directories(SimTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-corrade_add_test(PhysicsTest PhysicsTest.cpp LIBRARIES physics)
-target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-corrade_add_test(ResourceManagerTest ResourceManagerTest.cpp LIBRARIES assets)
-target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+corrade_add_test(SuncgTest SuncgTest.cpp LIBRARIES scene)
+target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if(BUILD_WITH_VHACD)
   corrade_add_test(
@@ -97,15 +96,6 @@ if(BUILD_WITH_VHACD)
   )
   target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()
-
-corrade_add_test(SceneGraphTest SceneGraphTest.cpp LIBRARIES scene)
-target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-test(SuncgTest scene)
-target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-corrade_add_test(SensorTest SensorTest.cpp LIBRARIES sensor sim)
-target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Some tests are LOUD, we don't want to include their full log (but OTOH we
 # want to have full log from others, so this is a compromise)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ configure_file(
 test(AttributesManagersTest assets metadata)
 target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(CoreTest io)
+corrade_add_test(CoreTest CoreTest.cpp LIBRARIES core io)
 
 test(MetadataMediatorTest assets metadata)
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -63,10 +63,8 @@ corrade_add_test(ResourceManagerTest ResourceManagerTest.cpp LIBRARIES assets)
 target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(SceneGraphTest SceneGraphTest.cpp LIBRARIES scene)
-target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(SensorTest SensorTest.cpp LIBRARIES sensor sim)
-target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(
   SimTest

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -53,7 +53,14 @@ corrade_add_test(
 )
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(NavTest nav assets)
+corrade_add_test(
+  NavTest
+  NavTest.cpp
+  LIBRARIES
+  core
+  nav
+  assets
+)
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(Mp3dTest scene)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -53,6 +53,9 @@ corrade_add_test(
 )
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+corrade_add_test(Mp3dTest Mp3dTest.cpp LIBRARIES scene)
+target_include_directories(Mp3dTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 corrade_add_test(
   NavTest
   NavTest.cpp
@@ -62,9 +65,6 @@ corrade_add_test(
   assets
 )
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-test(Mp3dTest scene)
-target_include_directories(Mp3dTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(
   SimTest
@@ -110,8 +110,6 @@ target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 # Some tests are LOUD, we don't want to include their full log (but OTOH we
 # want to have full log from others, so this is a compromise)
 set_tests_properties(
-  NavTest Mp3dTest SuncgTest PROPERTIES ENVIRONMENT "HABITAT_SIM_LOG=nav,scene=quiet"
-)
-set_tests_properties(
-  SimTest PROPERTIES ENVIRONMENT "HABITAT_SIM_LOG=quiet;MAGNUM_LOG=QUIET"
+  NavTest Mp3dTest SimTest SuncgTest
+  PROPERTIES ENVIRONMENT "HABITAT_SIM_LOG=quiet;MAGNUM_LOG=QUIET"
 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -45,14 +45,14 @@ corrade_add_test(
 )
 target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+corrade_add_test(IOTest IOTest.cpp LIBRARIES io metadata)
+target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 test(MetadataMediatorTest assets metadata)
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(NavTest nav assets)
 target_include_directories(NavTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-test(IOTest io metadata)
-target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(Mp3dTest scene)
 target_include_directories(Mp3dTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -48,7 +48,9 @@ target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 corrade_add_test(IOTest IOTest.cpp LIBRARIES io metadata)
 target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(MetadataMediatorTest assets metadata)
+corrade_add_test(
+  MetadataMediatorTest MetadataMediatorTest.cpp LIBRARIES assets metadata
+)
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(NavTest nav assets)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -98,7 +98,7 @@ if(BUILD_WITH_VHACD)
   target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-test(SceneGraphTest scene)
+corrade_add_test(SceneGraphTest SceneGraphTest.cpp LIBRARIES scene)
 target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(SuncgTest scene)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,7 +15,14 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/configure.h
 )
 
-test(AttributesManagersTest assets metadata)
+corrade_add_test(
+  AttributesManagersTest
+  AttributesManagersTest.cpp
+  LIBRARIES
+  core
+  assets
+  metadata
+)
 target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(CoreTest CoreTest.cpp LIBRARIES core io)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ target_include_directories(SimTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 corrade_add_test(PhysicsTest PhysicsTest.cpp LIBRARIES physics)
 target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(ResourceManagerTest assets)
+corrade_add_test(ResourceManagerTest ResourceManagerTest.cpp LIBRARIES assets)
 target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if(BUILD_WITH_VHACD)
@@ -98,11 +98,11 @@ if(BUILD_WITH_VHACD)
   target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-test(SuncgTest scene)
-target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
 test(SceneGraphTest scene)
 target_include_directories(SceneGraphTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+test(SuncgTest scene)
+target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 corrade_add_test(SensorTest SensorTest.cpp LIBRARIES sensor sim)
 target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ corrade_add_test(
 )
 target_include_directories(SimTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-test(PhysicsTest physics)
+corrade_add_test(PhysicsTest PhysicsTest.cpp LIBRARIES physics)
 target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(ResourceManagerTest assets)
@@ -110,6 +110,6 @@ target_include_directories(SensorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 # Some tests are LOUD, we don't want to include their full log (but OTOH we
 # want to have full log from others, so this is a compromise)
 set_tests_properties(
-  NavTest Mp3dTest SimTest SuncgTest
+  MetadataMediatorTest Mp3dTest NavTest SimTest SuncgTest
   PROPERTIES ENVIRONMENT "HABITAT_SIM_LOG=quiet;MAGNUM_LOG=QUIET"
 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -27,6 +27,24 @@ target_include_directories(AttributesManagersTest PRIVATE ${CMAKE_CURRENT_BINARY
 
 corrade_add_test(CoreTest CoreTest.cpp LIBRARIES core io)
 
+corrade_add_test(CullingTest CullingTest.cpp LIBRARIES gfx)
+target_include_directories(CullingTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(DrawableTest DrawableTest.cpp LIBRARIES gfx)
+target_include_directories(DrawableTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(GeoTest GeoTest.cpp LIBRARIES geo)
+
+corrade_add_test(
+  GfxReplayTest
+  GfxReplayTest.cpp
+  LIBRARIES
+  assets
+  gfx
+  sim
+)
+target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 test(MetadataMediatorTest assets metadata)
 target_include_directories(MetadataMediatorTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -50,16 +68,8 @@ corrade_add_test(
 )
 target_include_directories(SimTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-corrade_add_test(GeoTest GeoTest.cpp LIBRARIES geo)
-
-corrade_add_test(DrawableTest DrawableTest.cpp LIBRARIES gfx)
-target_include_directories(DrawableTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
 test(PhysicsTest physics)
 target_include_directories(PhysicsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-test(GfxReplayTest assets gfx sim)
-target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(ResourceManagerTest assets)
 target_include_directories(ResourceManagerTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
@@ -78,9 +88,6 @@ if(BUILD_WITH_VHACD)
   )
   target_include_directories(VoxelGridTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()
-
-corrade_add_test(CullingTest CullingTest.cpp LIBRARIES gfx)
-target_include_directories(CullingTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 test(SuncgTest scene)
 target_include_directories(SuncgTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -2,19 +2,36 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <gtest/gtest.h>
-
+#include <Corrade/TestSuite/Tester.h>
 #include "esp/core/Configuration.h"
 #include "esp/core/esp.h"
 
 using namespace esp::core::config;
 
-TEST(CoreTest, ConfigurationTest) {
+namespace Test {
+
+struct CoreTest : Cr::TestSuite::Tester {
+  explicit CoreTest();
+
+  void TestConfiguration();
+
+  esp::logging::LoggingContext loggingContext_;
+};  // struct CoreTest
+
+CoreTest::CoreTest() {
+  addTests({&CoreTest::TestConfiguration});
+}
+
+void CoreTest::TestConfiguration() {
   Configuration cfg;
   cfg.set("myInt", 10);
   cfg.set("myString", "test");
-  EXPECT_TRUE(cfg.hasValue("myInt"));
-  EXPECT_TRUE(cfg.hasValue("myString"));
-  EXPECT_EQ(cfg.get<int>("myInt"), 10);
-  EXPECT_EQ(cfg.get<std::string>("myString"), "test");
+  CORRADE_VERIFY(cfg.hasValue("myInt"));
+  CORRADE_VERIFY(cfg.hasValue("myString"));
+  CORRADE_VERIFY(cfg.get<int>("myInt") == 10);
+  CORRADE_COMPARE(cfg.get<std::string>("myString"), "test");
 }
+
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::CoreTest)

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -8,7 +8,7 @@
 
 using namespace esp::core::config;
 
-namespace Test {
+namespace {
 
 struct CoreTest : Cr::TestSuite::Tester {
   explicit CoreTest();
@@ -32,6 +32,6 @@ void CoreTest::TestConfiguration() {
   CORRADE_COMPARE(cfg.get<std::string>("myString"), "test");
 }
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::CoreTest)
+CORRADE_TEST_MAIN(CoreTest)

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -28,7 +28,7 @@ void CoreTest::TestConfiguration() {
   cfg.set("myString", "test");
   CORRADE_VERIFY(cfg.hasValue("myInt"));
   CORRADE_VERIFY(cfg.hasValue("myString"));
-  CORRADE_VERIFY(cfg.get<int>("myInt") == 10);
+  CORRADE_COMPARE(cfg.get<int>("myInt"), 10);
   CORRADE_COMPARE(cfg.get<std::string>("myString"), "test");
 }
 

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -30,7 +30,6 @@ using esp::metadata::MetadataMediator;
 using esp::scene::SceneManager;
 using Magnum::Math::Literals::operator""_degf;
 
-namespace Test {
 // on GCC and Clang, the following namespace causes useful warnings to be
 // printed when you have accidentally unused variables or functions in the test
 namespace {
@@ -276,6 +275,5 @@ void CullingTest::frustumCulling() {
   CORRADE_COMPARE(numVisibleObjects, numVisibleObjectsGroundTruth);
 }
 }  // namespace
-}  // namespace Test
 
-CORRADE_TEST_MAIN(Test::CullingTest)
+CORRADE_TEST_MAIN(CullingTest)

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -112,9 +112,9 @@ void DrawableTest::addRemoveDrawables() {
 
   // we already had 5 boxes in the scene, 1 toy box added before the current
   // one, so the id should be 6
-  CORRADE_VERIFY(dr->getDrawableId() == 6);
+  CORRADE_COMPARE(dr->getDrawableId(), 6);
   // verify this drawable has been added to drawable group
-  CORRADE_VERIFY(dr->drawables() == drawableGroup_);
+  CORRADE_COMPARE(dr->drawables(), drawableGroup_);
 
   // step 2: add a single drawable to a group
   dr = new esp::gfx::GenericDrawable{node,

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -24,7 +24,6 @@ using esp::assets::ResourceManager;
 using esp::metadata::MetadataMediator;
 using esp::scene::SceneManager;
 
-namespace Test {
 // on GCC and Clang, the following namespace causes useful warnings to be
 // printed when you have accidentally unused variables or functions in the test
 namespace {
@@ -155,6 +154,5 @@ void DrawableTest::addRemoveDrawables() {
 }
 
 }  // namespace
-}  // namespace Test
 
-CORRADE_TEST_MAIN(Test::DrawableTest)
+CORRADE_TEST_MAIN(DrawableTest)

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -62,7 +62,7 @@ DrawableTest::DrawableTest() {
   resourceManager_ = std::make_unique<ResourceManagerExtended>(MM);
   //clang-format off
   addTests({&DrawableTest::addRemoveDrawables});
-  // flang-format on
+  //clang-format on
   auto stageAttributesMgr = MM->getStageAttributesManager();
   std::string stageFile =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/5boxes.glb");

--- a/src/tests/GeoTest.cpp
+++ b/src/tests/GeoTest.cpp
@@ -20,26 +20,7 @@ using namespace esp;
 using namespace esp::geo;
 
 // reference: https://github.com/facebookresearch/habitat-sim/pull/496/files
-namespace Test {
-// standard method
-// transform the 8 corners, and extract the min and max
-Mn::Range3D getTransformedBB_standard(const Mn::Range3D& range,
-                                      const Mn::Matrix4& xform) {
-  std::vector<Mn::Vector3> corners;
-  corners.push_back(xform.transformPoint(range.frontBottomLeft()));
-  corners.push_back(xform.transformPoint(range.frontBottomRight()));
-  corners.push_back(xform.transformPoint(range.frontTopLeft()));
-  corners.push_back(xform.transformPoint(range.frontTopRight()));
-
-  corners.push_back(xform.transformPoint(range.backTopLeft()));
-  corners.push_back(xform.transformPoint(range.backTopRight()));
-  corners.push_back(xform.transformPoint(range.backBottomLeft()));
-  corners.push_back(xform.transformPoint(range.backBottomRight()));
-
-  Mn::Range3D transformedBB{Mn::Math::minmax(corners)};
-
-  return transformedBB;
-}
+namespace {
 
 struct GeoTest : Cr::TestSuite::Tester {
   explicit GeoTest();
@@ -51,6 +32,10 @@ struct GeoTest : Cr::TestSuite::Tester {
   // benchmarks
   void getTransformedBB_standard();
   void getTransformedBB();
+  // standard method
+  // transform the 8 corners, and extract the min and max
+  Mn::Range3D getTransformedBB_standard(const Mn::Range3D& range,
+                                        const Mn::Matrix4& xform);
 
   std::vector<Mn::Matrix4> xforms_;
   // number of transformations
@@ -87,10 +72,30 @@ GeoTest::GeoTest() {
   }
 }
 
+// standard method
+// transform the 8 corners, and extract the min and max
+Mn::Range3D GeoTest::getTransformedBB_standard(const Mn::Range3D& range,
+                                               const Mn::Matrix4& xform) {
+  std::vector<Mn::Vector3> corners;
+  corners.push_back(xform.transformPoint(range.frontBottomLeft()));
+  corners.push_back(xform.transformPoint(range.frontBottomRight()));
+  corners.push_back(xform.transformPoint(range.frontTopLeft()));
+  corners.push_back(xform.transformPoint(range.frontTopRight()));
+
+  corners.push_back(xform.transformPoint(range.backTopLeft()));
+  corners.push_back(xform.transformPoint(range.backTopRight()));
+  corners.push_back(xform.transformPoint(range.backBottomLeft()));
+  corners.push_back(xform.transformPoint(range.backBottomRight()));
+
+  Mn::Range3D transformedBB{Mn::Math::minmax(corners)};
+
+  return transformedBB;
+}
+
 void GeoTest::getTransformedBB_standard() {
   Mn::Range3D aabb;
   CORRADE_BENCHMARK(iterations_) for (auto& xform : xforms_) {
-    aabb = Test::getTransformedBB_standard(box_, xform);
+    aabb = getTransformedBB_standard(box_, xform);
   }
 }
 
@@ -106,7 +111,7 @@ void GeoTest::aabb() {
   // respectively.
   // compare the results, which should be identical
   for (auto& xform : xforms_) {
-    Mn::Range3D aabbControl = Test::getTransformedBB_standard(box_, xform);
+    Mn::Range3D aabbControl = getTransformedBB_standard(box_, xform);
     Mn::Range3D aabbTest = esp::geo::getTransformedBB(box_, xform);
 
     float eps = 1e-8f;
@@ -196,6 +201,6 @@ void GeoTest::coordinateFrame() {
   CORRADE_COMPARE(c1.toString(), j);
 }
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::GeoTest)
+CORRADE_TEST_MAIN(GeoTest)

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -142,9 +142,8 @@ void GfxReplayTest::testRecorder() {
   CORRADE_COMPARE(keyframes[0].loads.size(), 1);
   CORRADE_VERIFY(keyframes[0].loads[0] == info);
   CORRADE_COMPARE(keyframes[0].creations.size(), 1);
-  CORRADE_COMPARE_AS(keyframes[0].creations[0].second.filepath.find(
-                         "objects/transform_box.glb"),
-                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(keyframes[0].creations[0].second.filepath.find(
+                     "objects/transform_box.glb") != std::string::npos);
   CORRADE_COMPARE(keyframes[0].stateUpdates.size(), 1);
   esp::gfx::replay::RenderAssetInstanceKey instanceKey =
       keyframes[0].creations[0].first;

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -33,7 +33,7 @@ using esp::scene::SceneManager;
 using esp::sim::Simulator;
 using esp::sim::SimulatorConfiguration;
 
-namespace Test {
+namespace {
 
 struct GfxReplayTest : Cr::TestSuite::Tester {
   explicit GfxReplayTest();
@@ -142,8 +142,9 @@ void GfxReplayTest::testRecorder() {
   CORRADE_COMPARE(keyframes[0].loads.size(), 1);
   CORRADE_VERIFY(keyframes[0].loads[0] == info);
   CORRADE_COMPARE(keyframes[0].creations.size(), 1);
-  CORRADE_VERIFY(keyframes[0].creations[0].second.filepath.find(
-                     "objects/transform_box.glb") != std::string::npos);
+  CORRADE_COMPARE_AS(keyframes[0].creations[0].second.filepath.find(
+                         "objects/transform_box.glb"),
+                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
   CORRADE_COMPARE(keyframes[0].stateUpdates.size(), 1);
   esp::gfx::replay::RenderAssetInstanceKey instanceKey =
       keyframes[0].creations[0].first;
@@ -445,6 +446,6 @@ void GfxReplayTest::testSimulatorIntegration() {
   }
 }
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::GfxReplayTest)
+CORRADE_TEST_MAIN(GfxReplayTest)

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -4,6 +4,12 @@
 
 #include "configure.h"
 
+#include <Corrade/Containers/Optional.h>
+#include <Corrade/TestSuite/Tester.h>
+#include <Corrade/Utility/Directory.h>
+#include <Magnum/EigenIntegration/Integration.h>
+#include <Magnum/Math/Range.h>
+
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/Renderer.h"
@@ -14,12 +20,6 @@
 #include "esp/scene/SceneManager.h"
 #include "esp/sim/Simulator.h"
 
-#include <Corrade/Containers/Optional.h>
-#include <Corrade/Utility/Directory.h>
-#include <Magnum/EigenIntegration/Integration.h>
-#include <Magnum/Math/Range.h>
-
-#include <gtest/gtest.h>
 #include <fstream>
 #include <string>
 
@@ -32,6 +32,23 @@ using esp::scene::SceneManager;
 using esp::sim::Simulator;
 using esp::sim::SimulatorConfiguration;
 
+namespace Test {
+
+struct GfxReplayTest : Cr::TestSuite::Tester {
+  explicit GfxReplayTest();
+
+  void testRecorder();
+
+  void testPlayer();
+
+  void testPlayerReadMissingFile();
+  void testPlayerReadInvalidFile();
+  void testSimulatorIntegration();
+
+  esp::logging::LoggingContext loggingContext;
+
+};  // struct GfxReplayTest
+
 // Helper function to get numberOfChildrenOfRoot
 int getNumberOfChildrenOfRoot(esp::scene::SceneNode& rootNode) {
   int numberOfChildrenOfRoot = 1;
@@ -39,7 +56,7 @@ int getNumberOfChildrenOfRoot(esp::scene::SceneNode& rootNode) {
   if (!lastRootChild) {
     return 0;
   } else {
-    CORRADE_INTERNAL_ASSERT(lastRootChild);
+    CORRADE_VERIFY(lastRootChild);
     while (lastRootChild->nextSibling()) {
       lastRootChild = lastRootChild->nextSibling();
       numberOfChildrenOfRoot++;
@@ -48,9 +65,15 @@ int getNumberOfChildrenOfRoot(esp::scene::SceneNode& rootNode) {
   return numberOfChildrenOfRoot;
 }
 
+GfxReplayTest::GfxReplayTest() {
+  addTests({&GfxReplayTest::testRecorder, &GfxReplayTest::testPlayer,
+            &GfxReplayTest::testPlayerReadMissingFile,
+            &GfxReplayTest::testPlayerReadInvalidFile,
+            &GfxReplayTest::testSimulatorIntegration});
+}  // ctor
+
 // Manipulate the scene and save some keyframes using replay::Recorder
-TEST(GfxReplayTest, recorder) {
-  esp::logging::LoggingContext loggingContext;
+void GfxReplayTest::testRecorder() {
   esp::gfx::WindowlessContext::uptr context_ =
       esp::gfx::WindowlessContext::create_unique(0);
 
@@ -78,11 +101,10 @@ TEST(GfxReplayTest, recorder) {
   std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
   auto* node = resourceManager.loadAndCreateRenderAssetInstance(
       info, creation, &sceneManager_, tempIDs);
-  CORRADE_INTERNAL_ASSERT(node);
+  CORRADE_VERIFY(node);
 
   // cosntruct an AssetInfo with override color material
-  CORRADE_INTERNAL_ASSERT(info.overridePhongMaterial ==
-                          Cr::Containers::NullOpt);
+  CORRADE_VERIFY(info.overridePhongMaterial == Cr::Containers::NullOpt);
   esp::assets::AssetInfo info2(info);
   info2.overridePhongMaterial = esp::assets::PhongMaterialColor();
   info2.overridePhongMaterial->ambientColor = Mn::Color4(0.1, 0.2, 0.3, 0.4);
@@ -99,7 +121,7 @@ TEST(GfxReplayTest, recorder) {
   // add the new override AssetInfo after 1st keyframe
   auto* node2 = resourceManager.loadAndCreateRenderAssetInstance(
       info2, creation, &sceneManager_, tempIDs);
-  CORRADE_INTERNAL_ASSERT(node2);
+  CORRADE_VERIFY(node2);
   recorder.onLoadRenderAsset(info2);
   recorder.onCreateRenderAssetInstance(node2, creation);
 
@@ -112,57 +134,51 @@ TEST(GfxReplayTest, recorder) {
 
   // verify 3 saved keyframes
   const auto& keyframes = recorder.debugGetSavedKeyframes();
-  CORRADE_INTERNAL_ASSERT(keyframes.size() == 3);
+  CORRADE_VERIFY(keyframes.size() == 3);
 
   // verify frame #0 loads a render asset, creates an instance, and stores a
   // state update for the instance
-  CORRADE_INTERNAL_ASSERT(keyframes[0].loads.size() == 1);
-  CORRADE_INTERNAL_ASSERT(keyframes[0].loads[0] == info);
-  CORRADE_INTERNAL_ASSERT(keyframes[0].creations.size() == 1);
-  CORRADE_INTERNAL_ASSERT(keyframes[0].creations[0].second.filepath.find(
-                              "objects/transform_box.glb") !=
-                          std::string::npos);
-  CORRADE_INTERNAL_ASSERT(keyframes[0].stateUpdates.size() == 1);
+  CORRADE_VERIFY(keyframes[0].loads.size() == 1);
+  CORRADE_VERIFY(keyframes[0].loads[0] == info);
+  CORRADE_VERIFY(keyframes[0].creations.size() == 1);
+  CORRADE_VERIFY(keyframes[0].creations[0].second.filepath.find(
+                     "objects/transform_box.glb") != std::string::npos);
+  CORRADE_VERIFY(keyframes[0].stateUpdates.size() == 1);
   esp::gfx::replay::RenderAssetInstanceKey instanceKey =
       keyframes[0].creations[0].first;
-  CORRADE_INTERNAL_ASSERT(keyframes[0].stateUpdates[0].first == instanceKey);
+  CORRADE_VERIFY(keyframes[0].stateUpdates[0].first == instanceKey);
 
   // verify frame #1 has an updated state for node and state for new node2
-  CORRADE_INTERNAL_ASSERT(keyframes[1].stateUpdates.size() == 2);
+  CORRADE_VERIFY(keyframes[1].stateUpdates.size() == 2);
   // verify frame #1 has our translation and semantic Id
-  CORRADE_INTERNAL_ASSERT(
-      keyframes[1].stateUpdates[0].second.absTransform.translation ==
-      Mn::Vector3(1.f, 2.f, 3.f));
-  CORRADE_INTERNAL_ASSERT(keyframes[1].stateUpdates[0].second.semanticId == 7);
+  CORRADE_VERIFY(keyframes[1].stateUpdates[0].second.absTransform.translation ==
+                 Mn::Vector3(1.f, 2.f, 3.f));
+  CORRADE_VERIFY(keyframes[1].stateUpdates[0].second.semanticId == 7);
 
   // verify override material AssetInfo is loaded correctly
-  CORRADE_INTERNAL_ASSERT(keyframes[1].loads.size() == 1);
-  CORRADE_INTERNAL_ASSERT(keyframes[1].loads[0] == info2);
-  CORRADE_INTERNAL_ASSERT(keyframes[1].loads[0].overridePhongMaterial !=
-                          Cr::Containers::NullOpt);
-  CORRADE_INTERNAL_ASSERT(
-      keyframes[1].loads[0].overridePhongMaterial->ambientColor ==
-      info2.overridePhongMaterial->ambientColor);
-  CORRADE_INTERNAL_ASSERT(
-      keyframes[1].loads[0].overridePhongMaterial->diffuseColor ==
-      info2.overridePhongMaterial->diffuseColor);
-  CORRADE_INTERNAL_ASSERT(
-      keyframes[1].loads[0].overridePhongMaterial->specularColor ==
-      info2.overridePhongMaterial->specularColor);
+  CORRADE_VERIFY(keyframes[1].loads.size() == 1);
+  CORRADE_VERIFY(keyframes[1].loads[0] == info2);
+  CORRADE_VERIFY(keyframes[1].loads[0].overridePhongMaterial !=
+                 Cr::Containers::NullOpt);
+  CORRADE_VERIFY(keyframes[1].loads[0].overridePhongMaterial->ambientColor ==
+                 info2.overridePhongMaterial->ambientColor);
+  CORRADE_VERIFY(keyframes[1].loads[0].overridePhongMaterial->diffuseColor ==
+                 info2.overridePhongMaterial->diffuseColor);
+  CORRADE_VERIFY(keyframes[1].loads[0].overridePhongMaterial->specularColor ==
+                 info2.overridePhongMaterial->specularColor);
 
   // verify frame #2 has our deletion and our user transform
-  CORRADE_INTERNAL_ASSERT(keyframes[2].deletions.size() == 1);
-  CORRADE_INTERNAL_ASSERT(keyframes[2].deletions[0] == instanceKey);
-  CORRADE_INTERNAL_ASSERT(keyframes[2].userTransforms.size() == 1);
-  CORRADE_INTERNAL_ASSERT(
-      keyframes[2].userTransforms.count("my_user_transform"));
-  CORRADE_INTERNAL_ASSERT(
+  CORRADE_VERIFY(keyframes[2].deletions.size() == 1);
+  CORRADE_VERIFY(keyframes[2].deletions[0] == instanceKey);
+  CORRADE_VERIFY(keyframes[2].userTransforms.size() == 1);
+  CORRADE_VERIFY(keyframes[2].userTransforms.count("my_user_transform"));
+  CORRADE_VERIFY(
       keyframes[2].userTransforms.at("my_user_transform").translation ==
       Mn::Vector3(4.f, 5.f, 6.f));
 }
 
 // construct some render keyframes and play them using replay::Player
-TEST(GfxReplayTest, player) {
+void GfxReplayTest::testPlayer() {
   esp::logging::LoggingContext loggingContext;
   esp::gfx::WindowlessContext::uptr context_ =
       esp::gfx::WindowlessContext::create_unique(0);
@@ -250,8 +266,8 @@ TEST(GfxReplayTest, player) {
 
   player.debugSetKeyframes(std::move(keyframes));
 
-  CORRADE_INTERNAL_ASSERT(player.getNumKeyframes() == 4);
-  CORRADE_INTERNAL_ASSERT(player.getKeyframeIndex() == -1);
+  CORRADE_VERIFY(player.getNumKeyframes() == 4);
+  CORRADE_VERIFY(player.getKeyframeIndex() == -1);
 
   // test setting keyframes in various order
   const auto keyframeIndicesToTest = {-1, 0, 1,  2, 3,  -1, 3, 2,
@@ -263,63 +279,62 @@ TEST(GfxReplayTest, player) {
 
     if (keyframeIndex == -1) {
       // assert that no new nodes were created
-      CORRADE_INTERNAL_ASSERT(updatedNumberOfChildren == numberOfChildren);
+      CORRADE_VERIFY(updatedNumberOfChildren == numberOfChildren);
     } else if (keyframeIndex == 0) {
       // assert that a new node was created under root
-      CORRADE_INTERNAL_ASSERT(updatedNumberOfChildren > numberOfChildren);
+      CORRADE_VERIFY(updatedNumberOfChildren > numberOfChildren);
     } else if (keyframeIndex == 1) {
       // assert that our stateUpdate was applied and a new node was created
       // under root
-      CORRADE_INTERNAL_ASSERT(updatedNumberOfChildren > numberOfChildren);
+      CORRADE_VERIFY(updatedNumberOfChildren > numberOfChildren);
       if (numberOfChildren ==
           0) {  // if rootNode had no children to begin with, then stateUpdate
                 // was applied to a new child node
         const auto* rootChild = rootNode.children().first();
-        CORRADE_INTERNAL_ASSERT(rootChild);
+        CORRADE_VERIFY(rootChild);
         const esp::scene::SceneNode* instanceNode =
             static_cast<const esp::scene::SceneNode*>(rootChild);
-        CORRADE_INTERNAL_ASSERT(instanceNode->translation() ==
-                                Mn::Vector3(1.f, 2.f, 3.f));
-        CORRADE_INTERNAL_ASSERT(instanceNode->getSemanticId() == semanticId);
+        CORRADE_VERIFY(instanceNode->translation() ==
+                       Mn::Vector3(1.f, 2.f, 3.f));
+        CORRADE_VERIFY(instanceNode->getSemanticId() == semanticId);
       } else {  // if rootNode had children originally, then stateUpdate was
                 // applied to a sibling of the lastRootChild
         // get the lastRootChild before the stateUpdate
         const auto* rootChild = rootNode.children().first();
         for (int i = 1; i < numberOfChildren; i++) {
-          CORRADE_INTERNAL_ASSERT(rootChild);
+          CORRADE_VERIFY(rootChild);
           rootChild = rootChild->nextSibling();
         }
         // Check that stateUpdate was applied to the sibling of lastRootChild
-        CORRADE_INTERNAL_ASSERT(rootChild->nextSibling());
+        CORRADE_VERIFY(rootChild->nextSibling());
         const esp::scene::SceneNode* instanceNode =
             static_cast<const esp::scene::SceneNode*>(rootChild->nextSibling());
-        CORRADE_INTERNAL_ASSERT(instanceNode->translation() ==
-                                Mn::Vector3(1.f, 2.f, 3.f));
-        CORRADE_INTERNAL_ASSERT(instanceNode->getSemanticId() == semanticId);
+        CORRADE_VERIFY(instanceNode->translation() ==
+                       Mn::Vector3(1.f, 2.f, 3.f));
+        CORRADE_VERIFY(instanceNode->getSemanticId() == semanticId);
       }
     } else if (keyframeIndex == 2) {
       // assert that no new nodes were created
-      CORRADE_INTERNAL_ASSERT(updatedNumberOfChildren == numberOfChildren);
+      CORRADE_VERIFY(updatedNumberOfChildren == numberOfChildren);
       // assert that there's no user transform
       Mn::Vector3 userTranslation;
       Mn::Quaternion userRotation;
-      CORRADE_INTERNAL_ASSERT(!player.getUserTransform(
-          "my_user_transform", &userTranslation, &userRotation));
+      CORRADE_VERIFY(!player.getUserTransform("my_user_transform",
+                                              &userTranslation, &userRotation));
     } else if (keyframeIndex == 3) {
       // assert that no new nodes were created
-      CORRADE_INTERNAL_ASSERT(updatedNumberOfChildren == numberOfChildren);
+      CORRADE_VERIFY(updatedNumberOfChildren == numberOfChildren);
       // assert on expected user transform
       Mn::Vector3 userTranslation;
       Mn::Quaternion userRotation;
-      CORRADE_INTERNAL_ASSERT(player.getUserTransform(
-          "my_user_transform", &userTranslation, &userRotation));
-      CORRADE_INTERNAL_ASSERT(userTranslation == Mn::Vector3(4.f, 5.f, 6.f));
+      CORRADE_VERIFY(player.getUserTransform("my_user_transform",
+                                             &userTranslation, &userRotation));
+      CORRADE_VERIFY(userTranslation == Mn::Vector3(4.f, 5.f, 6.f));
     }
   }
 }
 
-TEST(GfxReplayTest, playerReadMissingFile) {
-  esp::logging::LoggingContext loggingContext;
+void GfxReplayTest::testPlayerReadMissingFile() {
   auto dummyCallback =
       [&](const esp::assets::AssetInfo& assetInfo,
           const esp::assets::RenderAssetInstanceCreationInfo& creation) {
@@ -328,10 +343,10 @@ TEST(GfxReplayTest, playerReadMissingFile) {
   esp::gfx::replay::Player player(dummyCallback);
 
   player.readKeyframesFromFile("file_that_does_not_exist.json");
-  EXPECT_EQ(player.getNumKeyframes(), 0);
+  CORRADE_COMPARE(player.getNumKeyframes(), 0);
 }
 
-TEST(GfxReplayTest, playerReadInvalidFile) {
+void GfxReplayTest::testPlayerReadInvalidFile() {
   esp::logging::LoggingContext loggingContext;
   auto testFilepath =
       Corrade::Utility::Directory::join(DATA_DIR, "./gfx_replay_test.json");
@@ -348,7 +363,7 @@ TEST(GfxReplayTest, playerReadInvalidFile) {
   esp::gfx::replay::Player player(dummyCallback);
 
   player.readKeyframesFromFile(testFilepath);
-  EXPECT_EQ(player.getNumKeyframes(), 0);
+  CORRADE_COMPARE(player.getNumKeyframes(), 0);
 
   // remove bogus file created for this test
   bool success = Corrade::Utility::Directory::rm(testFilepath);
@@ -359,8 +374,7 @@ TEST(GfxReplayTest, playerReadInvalidFile) {
 }
 
 // test recording and playback through the simulator interface
-TEST(GfxReplayTest, simulatorIntegration) {
-  esp::logging::LoggingContext loggingContext;
+void GfxReplayTest::testSimulatorIntegration() {
   std::string boxFile =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
   auto testFilepath =
@@ -377,7 +391,7 @@ TEST(GfxReplayTest, simulatorIntegration) {
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
 
   auto handles = objAttrMgr->getObjectHandlesBySubstring("nested_box");
-  EXPECT_FALSE(handles.empty());
+  CORRADE_VERIFY(!handles.empty());
   auto rigidObj =
       sim->getRigidObjectManager()->addBulletObjectByHandle(handles[0]);
   auto rigidObjTranslation = Mn::Vector3(1.f, 2.f, 3.f);
@@ -391,32 +405,35 @@ TEST(GfxReplayTest, simulatorIntegration) {
   auto prevNumberOfChildrenOfRoot = getNumberOfChildrenOfRoot(rootNode);
 
   const auto recorder = sim->getGfxReplayManager()->getRecorder();
-  EXPECT_TRUE(recorder);
+  CORRADE_VERIFY(recorder);
   recorder->saveKeyframe();
   recorder->writeSavedKeyframesToFile(testFilepath);
 
   auto player = sim->getGfxReplayManager()->readKeyframesFromFile(testFilepath);
-  EXPECT_TRUE(player);
-  EXPECT_EQ(player->getNumKeyframes(), 1);
+  CORRADE_VERIFY(player);
+  CORRADE_COMPARE(player->getNumKeyframes(), 1);
   player->setKeyframeIndex(0);
   // second copies of transform_box and nested_box were loaded
-  EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode),
-            prevNumberOfChildrenOfRoot + 2);
+  CORRADE_COMPARE(getNumberOfChildrenOfRoot(rootNode),
+                  prevNumberOfChildrenOfRoot + 2);
 
   const auto& keyframes = player->debugGetKeyframes();
   // we expect state updates for the state and the object instance
-  EXPECT_EQ(keyframes[0].stateUpdates.size(), 2);
+  CORRADE_COMPARE(keyframes[0].stateUpdates.size(), 2);
   // check the pose for nested_box
   const auto& stateUpdate = keyframes[0].stateUpdates[1];
   const auto transform = stateUpdate.second.absTransform;
-  EXPECT_LE((transform.translation - rigidObjTranslation).length(), 1.0e-5);
-  EXPECT_LE((transform.rotation.vector() - rigidObjRotation.vector()).length(),
-            1.0e-5);
+  CORRADE_VERIFY((transform.translation - rigidObjTranslation).length() <=
+                 1.0e-5);
+  CORRADE_VERIFY(
+      (transform.rotation.vector() - rigidObjRotation.vector()).length() <=
+      1.0e-5);
 
   player = nullptr;
-  // second copies of transform_box and nested_box are removed when Player is
-  // deleted
-  EXPECT_EQ(getNumberOfChildrenOfRoot(rootNode), prevNumberOfChildrenOfRoot);
+  // second copies of transform_box and nested_box are removed when Player
+  // is deleted
+  CORRADE_COMPARE(getNumberOfChildrenOfRoot(rootNode),
+                  prevNumberOfChildrenOfRoot);
 
   // remove file created for this test
   bool success = Corrade::Utility::Directory::rm(testFilepath);
@@ -425,3 +442,7 @@ TEST(GfxReplayTest, simulatorIntegration) {
                   << testFilepath;
   }
 }
+
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::GfxReplayTest)

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -33,15 +33,15 @@ struct IOTest : Cr::TestSuite::Tester {
   void fileRmExtTest();
   void fileReplaceExtTest();
   void tokenizeTest();
+
   void parseURDF();
-  void JsonTest();
-  void JsonBuiltinTypesTest();
+  void testJson();
+  void testJsonBuiltinTypes();
+  void testJsonStlTypes();
+  void testJsonMagnumTypes();
+  void testJsonEspTypes();
 
-  void JsonStlTypesTest();
-  void JsonMagnumTypesTest();
-  void JsonEspTypesTest();
-
-  void JsonUserTypeTest();
+  void testJsonUserType();
 
   esp::logging::LoggingContext loggingContext;
 };
@@ -49,10 +49,10 @@ struct IOTest : Cr::TestSuite::Tester {
 IOTest::IOTest() {
   addTests({&IOTest::fileExistTest, &IOTest::fileSizeTest,
             &IOTest::fileRmExtTest, &IOTest::fileReplaceExtTest,
-            &IOTest::tokenizeTest, &IOTest::parseURDF, &IOTest::JsonTest,
-            &IOTest::JsonBuiltinTypesTest, &IOTest::JsonStlTypesTest,
-            &IOTest::JsonMagnumTypesTest, &IOTest::JsonEspTypesTest,
-            &IOTest::JsonUserTypeTest});
+            &IOTest::tokenizeTest, &IOTest::parseURDF, &IOTest::testJson,
+            &IOTest::testJsonBuiltinTypes, &IOTest::testJsonStlTypes,
+            &IOTest::testJsonMagnumTypes, &IOTest::testJsonEspTypes,
+            &IOTest::testJsonUserType});
 }
 
 void IOTest::fileExistTest() {
@@ -197,7 +197,7 @@ void IOTest::parseURDF() {
 /**
  * @brief Test basic JSON file processing
  */
-void IOTest::JsonTest() {
+void IOTest::testJson() {
   std::string s = "{\"test\":[1,2,3,4]}";
   const auto& json = esp::io::parseJsonString(s);
   std::vector<int> t;
@@ -262,7 +262,7 @@ void IOTest::JsonTest() {
 
 // Serialize/deserialize the 7 rapidjson builtin types using
 // io::esp::io::addMember/esp::io::readMember and assert equality.
-void IOTest::JsonBuiltinTypesTest() {
+void IOTest::testJsonBuiltinTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
@@ -337,7 +337,7 @@ void IOTest::JsonBuiltinTypesTest() {
 
 // Serialize/deserialize a few stl types using
 // io::esp::io::addMember/esp::io::readMember and assert equality.
-void IOTest::JsonStlTypesTest() {
+void IOTest::testJsonStlTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
@@ -369,7 +369,7 @@ void IOTest::JsonStlTypesTest() {
 // Serialize/deserialize a few Magnum types using
 // io::esp::io::addMember/esp::io::readMember and
 // assert equality.
-void IOTest::JsonMagnumTypesTest() {
+void IOTest::testJsonMagnumTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
@@ -401,7 +401,7 @@ void IOTest::JsonMagnumTypesTest() {
 
 // Serialize/deserialize a few esp types using
 // io::esp::io::addMember/esp::io::readMember and assert equality.
-void IOTest::JsonEspTypesTest() {
+void IOTest::testJsonEspTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
@@ -546,7 +546,7 @@ bool fromJsonValue(const esp::io::JsonGenericValue& obj, MyOuterStruct& x) {
 // Serialize/deserialize MyOuterStruct using
 // io::esp::io::addMember/esp::io::readMember and assert
 // equality.
-void IOTest::JsonUserTypeTest() {
+void IOTest::testJsonUserType() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -2,9 +2,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/Directory.h>
-#include <gtest/gtest.h>
+
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/core/esp.h"
 #include "esp/io/JsonAllTypes.h"
@@ -16,179 +17,200 @@
 #include "configure.h"
 
 namespace Cr = Corrade;
-#include <limits>
 
 using esp::metadata::attributes::AbstractObjectAttributes;
 using esp::metadata::attributes::ObjectAttributes;
-namespace esp {
-namespace io {
 
+namespace Test {
 const std::string dataDir =
     Corrade::Utility::Directory::join(SCENE_DATASETS, "../");
 
-TEST(IOTest, fileExistTest) {
-  logging::LoggingContext loggingContext;
+struct IOTest : Cr::TestSuite::Tester {
+  explicit IOTest();
+
+  void fileExistTest();
+  void fileSizeTest();
+  void fileRmExtTest();
+  void fileReplaceExtTest();
+  void tokenizeTest();
+  void parseURDF();
+  void JsonTest();
+  void JsonBuiltinTypesTest();
+
+  void JsonStlTypesTest();
+  void JsonMagnumTypesTest();
+  void JsonEspTypesTest();
+
+  void JsonUserTypeTest();
+
+  esp::logging::LoggingContext loggingContext;
+};
+
+IOTest::IOTest() {
+  addTests({&IOTest::fileExistTest, &IOTest::fileSizeTest,
+            &IOTest::fileRmExtTest, &IOTest::fileReplaceExtTest,
+            &IOTest::tokenizeTest, &IOTest::parseURDF, &IOTest::JsonTest,
+            &IOTest::JsonBuiltinTypesTest, &IOTest::JsonStlTypesTest,
+            &IOTest::JsonMagnumTypesTest, &IOTest::JsonEspTypesTest,
+            &IOTest::JsonUserTypeTest});
+}
+
+void IOTest::fileExistTest() {
   std::string file = FILE_THAT_EXISTS;
-  bool result = exists(file);
-  EXPECT_TRUE(result);
+  bool result = esp::io::exists(file);
+  CORRADE_VERIFY(result);
 
   file = "Foo.bar";
-  result = exists(file);
-  EXPECT_FALSE(result);
+  result = esp::io::exists(file);
+  CORRADE_VERIFY(!result);
 }
 
-TEST(IOTest, fileSizeTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::fileSizeTest() {
   std::string existingFile = FILE_THAT_EXISTS;
-  auto result = fileSize(existingFile);
-  ESP_DEBUG() << "File size of" << existingFile << "is" << result;
+  auto result = esp::io::fileSize(existingFile);
+  CORRADE_VERIFY(result > 0);
 
   std::string nonexistingFile = "Foo.bar";
-  result = fileSize(nonexistingFile);
-  ESP_DEBUG() << "File size of" << nonexistingFile << "is" << result;
+  result = esp::io::fileSize(nonexistingFile);
+  CORRADE_COMPARE(result, 0);
 }
 
-TEST(IOTest, fileRmExtTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::fileRmExtTest() {
   std::string filename = "/foo/bar.jpeg";
 
   // rm extension
-  std::string result = removeExtension(filename);
-  EXPECT_EQ(result, "/foo/bar");
-  EXPECT_EQ(filename, "/foo/bar.jpeg");
+  std::string result = esp::io::removeExtension(filename);
+  CORRADE_COMPARE(result, "/foo/bar");
+  CORRADE_COMPARE(filename, "/foo/bar.jpeg");
 
   std::string filenameNoExt = "/path/to/foobar";
-  result = removeExtension(filenameNoExt);
-  EXPECT_EQ(result, filenameNoExt);
+  result = esp::io::removeExtension(filenameNoExt);
+  CORRADE_COMPARE(result, filenameNoExt);
 }
 
-TEST(IOTest, fileReplaceExtTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::fileReplaceExtTest() {
   std::string filename = "/foo/bar.jpeg";
 
   // change extension
   std::string ext = ".png";
-  std::string result = changeExtension(filename, ext);
+  std::string result = esp::io::changeExtension(filename, ext);
 
-  EXPECT_EQ(result, "/foo/bar.png");
+  CORRADE_COMPARE(result, "/foo/bar.png");
 
   std::string filenameNoExt = "/path/to/foobar";
-  result = changeExtension(filenameNoExt, ext);
-  EXPECT_EQ(result, "/path/to/foobar.png");
+  result = esp::io::changeExtension(filenameNoExt, ext);
+  CORRADE_COMPARE(result, "/path/to/foobar.png");
 
   std::string cornerCase = "";
-  result = changeExtension(cornerCase, ext);
-  EXPECT_EQ(result, ".png");
+  result = esp::io::changeExtension(cornerCase, ext);
+  CORRADE_COMPARE(result, ".png");
 
   cornerCase = ".";
-  result = changeExtension(cornerCase, ext);
-  EXPECT_EQ(result, "..png");
+  result = esp::io::changeExtension(cornerCase, ext);
+  CORRADE_COMPARE(result, "..png");
 
   cornerCase = "..";
-  result = changeExtension(cornerCase, ext);
-  EXPECT_EQ(result, "...png");
+  result = esp::io::changeExtension(cornerCase, ext);
+  CORRADE_COMPARE(result, "...png");
 
   std::string cornerCaseExt = "png";  // no dot
-  result = changeExtension(filename, cornerCaseExt);
-  EXPECT_EQ(result, "/foo/bar.png");
+  result = esp::io::changeExtension(filename, cornerCaseExt);
+  CORRADE_COMPARE(result, "/foo/bar.png");
 
   cornerCase = ".";
-  result = changeExtension(cornerCase, cornerCaseExt);
-  EXPECT_EQ(result, "..png");
+  result = esp::io::changeExtension(cornerCase, cornerCaseExt);
+  CORRADE_COMPARE(result, "..png");
 
   cornerCase = "..";
-  result = changeExtension(cornerCase, cornerCaseExt);
-  EXPECT_EQ(result, "...png");
+  result = esp::io::changeExtension(cornerCase, cornerCaseExt);
+  CORRADE_COMPARE(result, "...png");
 
   cornerCase = ".jpg";
-  result = changeExtension(cornerCase, cornerCaseExt);
-  EXPECT_EQ(result, ".jpg.png");
+  result = esp::io::changeExtension(cornerCase, cornerCaseExt);
+  CORRADE_COMPARE(result, ".jpg.png");
 }
 
-TEST(IOTest, tokenizeTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::tokenizeTest() {
   std::string file = ",a,|,bb|c";
-  const auto& t1 = tokenize(file, ",");
-  EXPECT_EQ((std::vector<std::string>{"", "a", "|", "bb|c"}), t1);
-  const auto& t2 = tokenize(file, "|");
-  EXPECT_EQ((std::vector<std::string>{",a,", ",bb", "c"}), t2);
-  const auto& t3 = tokenize(file, ",|", 0, true);
-  EXPECT_EQ((std::vector<std::string>{"", "a", "bb", "c"}), t3);
+  const auto& t1 = esp::io::tokenize(file, ",");
+  CORRADE_COMPARE((std::vector<std::string>{"", "a", "|", "bb|c"}), t1);
+  const auto& t2 = esp::io::tokenize(file, "|");
+  CORRADE_COMPARE((std::vector<std::string>{",a,", ",bb", "c"}), t2);
+  const auto& t3 = esp::io::tokenize(file, ",|", 0, true);
+  CORRADE_COMPARE((std::vector<std::string>{"", "a", "bb", "c"}), t3);
 }
 
-TEST(IOTest, parseURDF) {
-  logging::LoggingContext loggingContext;
+void IOTest::parseURDF() {
   const std::string iiwaURDF = Cr::Utility::Directory::join(
       TEST_ASSETS, "urdf/kuka_iiwa/model_free_base.urdf");
 
-  URDF::Parser parser;
+  esp::io::URDF::Parser parser;
 
   // load the iiwa test asset
   std::shared_ptr<esp::io::URDF::Model> urdfModel;
   parser.parseURDF(urdfModel, iiwaURDF);
   ESP_DEBUG() << "name:" << urdfModel->m_name;
-  EXPECT_EQ(urdfModel->m_name, "lbr_iiwa");
+  CORRADE_COMPARE(urdfModel->m_name, "lbr_iiwa");
   ESP_DEBUG() << "file:" << urdfModel->m_sourceFile;
-  EXPECT_EQ(urdfModel->m_sourceFile, iiwaURDF);
+  CORRADE_COMPARE(urdfModel->m_sourceFile, iiwaURDF);
   ESP_DEBUG() << "links:" << urdfModel->m_links;
-  EXPECT_EQ(urdfModel->m_links.size(), 8);
+  CORRADE_COMPARE(urdfModel->m_links.size(), 8);
   ESP_DEBUG() << "root links:" << urdfModel->m_rootLinks;
-  EXPECT_EQ(urdfModel->m_rootLinks.size(), 1);
+  CORRADE_COMPARE(urdfModel->m_rootLinks.size(), 1);
   ESP_DEBUG() << "joints:" << urdfModel->m_joints;
-  EXPECT_EQ(urdfModel->m_joints.size(), 7);
+  CORRADE_COMPARE(urdfModel->m_joints.size(), 7);
   ESP_DEBUG() << "materials:" << urdfModel->m_materials;
-  EXPECT_EQ(urdfModel->m_materials.size(), 3);
+  CORRADE_COMPARE(urdfModel->m_materials.size(), 3);
 
   // check global scaling
-  EXPECT_EQ(urdfModel->getGlobalScaling(), 1.0);
+  CORRADE_COMPARE(urdfModel->getGlobalScaling(), 1.0);
   // this link is a mesh shape, so check the mesh scale
-  EXPECT_EQ(urdfModel->getLink(1)->m_collisionArray.back().m_geometry.m_type,
-            5);
-  EXPECT_EQ(
+  CORRADE_COMPARE(
+      urdfModel->getLink(1)->m_collisionArray.back().m_geometry.m_type, 5);
+  CORRADE_COMPARE(
       urdfModel->getLink(1)->m_collisionArray.back().m_geometry.m_meshScale,
       Mn::Vector3{1.0});
   urdfModel->setGlobalScaling(2.0);
-  EXPECT_EQ(urdfModel->getGlobalScaling(), 2.0);
-  EXPECT_EQ(
+  CORRADE_COMPARE(urdfModel->getGlobalScaling(), 2.0);
+  CORRADE_COMPARE(
       urdfModel->getLink(1)->m_collisionArray.back().m_geometry.m_meshScale,
       Mn::Vector3{2.0});
 
   // check mass scaling
-  EXPECT_EQ(urdfModel->getMassScaling(), 1.0);
-  EXPECT_EQ(urdfModel->getLink(1)->m_inertia.m_mass, 4.0);
+  CORRADE_COMPARE(urdfModel->getMassScaling(), 1.0);
+  CORRADE_COMPARE(urdfModel->getLink(1)->m_inertia.m_mass, 4.0);
   urdfModel->setMassScaling(3.0);
-  EXPECT_EQ(urdfModel->getMassScaling(), 3.0);
-  EXPECT_EQ(urdfModel->getLink(1)->m_inertia.m_mass, 12.0);
+  CORRADE_COMPARE(urdfModel->getMassScaling(), 3.0);
+  CORRADE_COMPARE(urdfModel->getLink(1)->m_inertia.m_mass, 12.0);
 
   // test overwrite re-load
   parser.parseURDF(urdfModel, iiwaURDF);
   // should have default values again
-  EXPECT_EQ(urdfModel->getGlobalScaling(), 1.0);
-  EXPECT_EQ(urdfModel->getMassScaling(), 1.0);
-  EXPECT_EQ(
+  CORRADE_COMPARE(urdfModel->getGlobalScaling(), 1.0);
+  CORRADE_COMPARE(urdfModel->getMassScaling(), 1.0);
+  CORRADE_COMPARE(
       urdfModel->getLink(1)->m_collisionArray.back().m_geometry.m_meshScale,
       Mn::Vector3{1.0});
-  EXPECT_EQ(urdfModel->getLink(1)->m_inertia.m_mass, 4.0);
+  CORRADE_COMPARE(urdfModel->getLink(1)->m_inertia.m_mass, 4.0);
 }
 
 /**
  * @brief Test basic JSON file processing
  */
-TEST(IOTest, JsonTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::JsonTest() {
   std::string s = "{\"test\":[1,2,3,4]}";
   const auto& json = esp::io::parseJsonString(s);
   std::vector<int> t;
   esp::io::toIntVector(json["test"], &t);
-  EXPECT_EQ(t[1], 2);
-  EXPECT_EQ(esp::io::jsonToString(json), s);
+  CORRADE_COMPARE(t[1], 2);
+  CORRADE_COMPARE(esp::io::jsonToString(json), s);
 
   // test io
   auto testFilepath =
       Corrade::Utility::Directory::join(dataDir, "../io_test_json.json");
-  EXPECT_TRUE(writeJsonToFile(json, testFilepath));
+  CORRADE_VERIFY(esp::io::writeJsonToFile(json, testFilepath));
   const auto& loadedJson = esp::io::parseJsonFile(testFilepath);
-  EXPECT_EQ(esp::io::jsonToString(loadedJson), s);
+  CORRADE_COMPARE(esp::io::jsonToString(loadedJson), s);
   Corrade::Utility::Directory::rm(testFilepath);
 
   // test basic attributes populating
@@ -210,15 +232,15 @@ TEST(IOTest, JsonTest) {
       jsonDoc, "scale", [attributes](const Magnum::Vector3& scale) {
         attributes->setScale(scale);
       });
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getScale()[1], 2);
+  CORRADE_COMPARE(success, true);
+  CORRADE_COMPARE(attributes->getScale()[1], 2);
 
   // test double
   success = esp::io::jsonIntoSetter<double>(
       jsonDoc, "mass",
       [attributes](double mass) { attributes->setMass(mass); });
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getMass(), 0.066);
+  CORRADE_COMPARE(success, true);
+  CORRADE_COMPARE(attributes->getMass(), 0.066);
 
   // test bool
   success = esp::io::jsonIntoSetter<bool>(
@@ -226,184 +248,181 @@ TEST(IOTest, JsonTest) {
       [attributes](bool join_collision_meshes) {
         attributes->setJoinCollisionMeshes(join_collision_meshes);
       });
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getJoinCollisionMeshes(), false);
+  CORRADE_COMPARE(success, true);
+  CORRADE_COMPARE(attributes->getJoinCollisionMeshes(), false);
 
   // test string
   success = esp::io::jsonIntoConstSetter<std::string>(
       jsonDoc, "render asset", [attributes](const std::string& render_asset) {
         attributes->setRenderAssetHandle(render_asset);
       });
-  EXPECT_EQ(success, true);
-  EXPECT_EQ(attributes->getRenderAssetHandle(), "banana.glb");
+  CORRADE_COMPARE(success, true);
+  CORRADE_COMPARE(attributes->getRenderAssetHandle(), "banana.glb");
 }
 
 // Serialize/deserialize the 7 rapidjson builtin types using
-// io::addMember/readMember and assert equality.
-TEST(IOTest, JsonBuiltinTypesTest) {
-  logging::LoggingContext loggingContext;
+// io::esp::io::addMember/esp::io::readMember and assert equality.
+void IOTest::JsonBuiltinTypesTest() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
   {
     int x{std::numeric_limits<int>::lowest()};
-    addMember(d, "myint", x, allocator);
+    esp::io::addMember(d, "myint", x, allocator);
     int x2{0};
-    EXPECT_TRUE(readMember(d, "myint", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "myint", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     unsigned x{std::numeric_limits<unsigned>::max()};
-    addMember(d, "myunsigned", x, allocator);
+    esp::io::addMember(d, "myunsigned", x, allocator);
     unsigned x2{0};
-    EXPECT_TRUE(readMember(d, "myunsigned", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "myunsigned", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     int64_t x{std::numeric_limits<int64_t>::lowest()};
-    addMember(d, "myint64_t", x, allocator);
+    esp::io::addMember(d, "myint64_t", x, allocator);
     int64_t x2{0};
-    EXPECT_TRUE(readMember(d, "myint64_t", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "myint64_t", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     uint64_t x{std::numeric_limits<uint64_t>::max()};
-    addMember(d, "myuint64_t", x, allocator);
+    esp::io::addMember(d, "myuint64_t", x, allocator);
     uint64_t x2{0};
-    EXPECT_TRUE(readMember(d, "myuint64_t", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "myuint64_t", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     float x{1.0 / 7};
-    addMember(d, "myfloat", x, allocator);
+    esp::io::addMember(d, "myfloat", x, allocator);
     float x2{0};
-    EXPECT_TRUE(readMember(d, "myfloat", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "myfloat", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     double x{1.0 / 13};
-    addMember(d, "mydouble", x, allocator);
+    esp::io::addMember(d, "mydouble", x, allocator);
     double x2{0};
-    EXPECT_TRUE(readMember(d, "mydouble", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "mydouble", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   {
     bool x{true};
-    addMember(d, "mybool", x, allocator);
+    esp::io::addMember(d, "mybool", x, allocator);
     bool x2{false};
-    EXPECT_TRUE(readMember(d, "mybool", x2));
-    EXPECT_EQ(x2, x);
+    CORRADE_VERIFY(esp::io::readMember(d, "mybool", x2));
+    CORRADE_COMPARE(x2, x);
   }
 
   // verify failure to read bool into int
   {
     int x2{0};
-    EXPECT_FALSE(readMember(d, "mybool", x2));
+    CORRADE_VERIFY(!esp::io::readMember(d, "mybool", x2));
   }
 
   // verify failure to read missing tag
   {
     int x2{0};
-    EXPECT_FALSE(readMember(d, "my_missing_int", x2));
+    CORRADE_VERIFY(!esp::io::readMember(d, "my_missing_int", x2));
   }
 }
 
-// Serialize/deserialize a few stl types using io::addMember/readMember and
-// assert equality.
-TEST(IOTest, JsonStlTypesTest) {
-  logging::LoggingContext loggingContext;
+// Serialize/deserialize a few stl types using
+// io::esp::io::addMember/esp::io::readMember and assert equality.
+void IOTest::JsonStlTypesTest() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
   std::string s{"hello world"};
-  addMember(d, "s", s, allocator);
+  esp::io::addMember(d, "s", s, allocator);
   std::string s2;
-  EXPECT_TRUE(readMember(d, "s", s2));
-  EXPECT_EQ(s2, s);
+  CORRADE_VERIFY(esp::io::readMember(d, "s", s2));
+  CORRADE_COMPARE(s2, s);
 
   // test a vector of ints
   std::vector<int> vec{3, 4, 5, 6};
-  addMember(d, "vec", vec, allocator);
+  esp::io::addMember(d, "vec", vec, allocator);
   std::vector<int> vec2;
-  EXPECT_TRUE(readMember(d, "vec", vec2));
-  EXPECT_EQ(vec2, vec);
+  CORRADE_VERIFY(esp::io::readMember(d, "vec", vec2));
+  CORRADE_COMPARE(vec2, vec);
 
   // test an empty vector
   std::vector<float> emptyVec{};
-  addMember(d, "emptyVec", emptyVec, allocator);
+  esp::io::addMember(d, "emptyVec", emptyVec, allocator);
   std::vector<float> emptyVec2;
-  EXPECT_TRUE(readMember(d, "emptyVec", emptyVec2));
-  EXPECT_EQ(emptyVec2, emptyVec);
+  CORRADE_VERIFY(esp::io::readMember(d, "emptyVec", emptyVec2));
+  CORRADE_COMPARE(emptyVec2, emptyVec);
 
   // test reading a vector of wrong type
   std::vector<std::string> vec3;
-  EXPECT_FALSE(readMember(d, "vec", vec3));
+  CORRADE_VERIFY(!esp::io::readMember(d, "vec", vec3));
 }
 
-// Serialize/deserialize a few Magnum types using io::addMember/readMember and
+// Serialize/deserialize a few Magnum types using
+// io::esp::io::addMember/esp::io::readMember and
 // assert equality.
-TEST(IOTest, JsonMagnumTypesTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::JsonMagnumTypesTest() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
   Magnum::Vector3 vec{1, 2, 3};
-  addMember(d, "myvec", vec, allocator);
+  esp::io::addMember(d, "myvec", vec, allocator);
   Magnum::Vector3 vec2;
-  EXPECT_TRUE(readMember(d, "myvec", vec2));
-  EXPECT_EQ(vec2, vec);
+  CORRADE_VERIFY(esp::io::readMember(d, "myvec", vec2));
+  CORRADE_COMPARE(vec2, vec);
 
   Magnum::Quaternion quat{{1, 2, 3}, 4};
-  addMember(d, "myquat", quat, allocator);
+  esp::io::addMember(d, "myquat", quat, allocator);
   Magnum::Quaternion quat2;
-  EXPECT_TRUE(readMember(d, "myquat", quat2));
-  EXPECT_EQ(quat2, quat);
+  CORRADE_VERIFY(esp::io::readMember(d, "myquat", quat2));
+  CORRADE_COMPARE(quat2, quat);
 
   // test reading the wrong type (wrong number of fields)
   Magnum::Quaternion quat3;
-  EXPECT_FALSE(readMember(d, "myvec", quat3));
+  CORRADE_VERIFY(!esp::io::readMember(d, "myvec", quat3));
 
   // test reading the wrong type (wrong number of fields)
   Magnum::Vector3 vec3;
-  EXPECT_FALSE(readMember(d, "myquat", vec3));
+  CORRADE_VERIFY(!esp::io::readMember(d, "myquat", vec3));
 
   // test reading the wrong type (array elements aren't numbers)
   std::vector<std::string> vecOfStrings{"1", "2", "3"};
-  addMember(d, "myVecOfStrings", vecOfStrings, allocator);
-  EXPECT_FALSE(readMember(d, "myVecOfStrings", vec3));
+  esp::io::addMember(d, "myVecOfStrings", vecOfStrings, allocator);
+  CORRADE_VERIFY(!esp::io::readMember(d, "myVecOfStrings", vec3));
 }
 
-// Serialize/deserialize a few esp types using io::addMember/readMember and
-// assert equality.
-TEST(IOTest, JsonEspTypesTest) {
-  logging::LoggingContext loggingContext;
+// Serialize/deserialize a few esp types using
+// io::esp::io::addMember/esp::io::readMember and assert equality.
+void IOTest::JsonEspTypesTest() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
   {
     // vec3f
     esp::vec3f vec{1, 2, 3};
-    addMember(d, "myvec3f", vec, allocator);
+    esp::io::addMember(d, "myvec3f", vec, allocator);
     esp::vec3f vec2;
-    EXPECT_TRUE(readMember(d, "myvec3f", vec2));
-    EXPECT_EQ(vec2, vec);
+    CORRADE_VERIFY(esp::io::readMember(d, "myvec3f", vec2));
+    CORRADE_COMPARE(vec2, vec);
 
     // test reading the wrong type (wrong number of fields)
     std::vector<float> wrongNumFieldsVec{1, 3, 4, 4};
-    addMember(d, "mywrongNumFieldsVec", wrongNumFieldsVec, allocator);
+    esp::io::addMember(d, "mywrongNumFieldsVec", wrongNumFieldsVec, allocator);
     esp::vec3f vec3;
-    EXPECT_FALSE(readMember(d, "mywrongNumFieldsVec", vec3));
+    CORRADE_VERIFY(!esp::io::readMember(d, "mywrongNumFieldsVec", vec3));
 
     // test reading the wrong type (array elements aren't numbers)
     std::vector<std::string> vecOfStrings{"1", "2", "3"};
-    addMember(d, "myVecOfStrings", vecOfStrings, allocator);
-    EXPECT_FALSE(readMember(d, "myVecOfStrings", vec3));
+    esp::io::addMember(d, "myVecOfStrings", vecOfStrings, allocator);
+    CORRADE_VERIFY(!esp::io::readMember(d, "myVecOfStrings", vec3));
   }
 
   {
@@ -412,13 +431,13 @@ TEST(IOTest, JsonEspTypesTest) {
         "test_filepath", Magnum::Vector3(1.f, 2.f, 3.f),
         esp::assets::RenderAssetInstanceCreationInfo::Flags(),
         "test_light_setup");
-    addMember(d, "creationInfo", creationInfo, allocator);
+    esp::io::addMember(d, "creationInfo", creationInfo, allocator);
     esp::assets::RenderAssetInstanceCreationInfo creationInfo2;
-    EXPECT_TRUE(readMember(d, "creationInfo", creationInfo2));
-    EXPECT_EQ(creationInfo2.filepath, creationInfo.filepath);
-    EXPECT_EQ(creationInfo2.scale, creationInfo.scale);
-    EXPECT_EQ(creationInfo2.flags, creationInfo.flags);
-    EXPECT_EQ(creationInfo2.lightSetupKey, creationInfo.lightSetupKey);
+    CORRADE_VERIFY(esp::io::readMember(d, "creationInfo", creationInfo2));
+    CORRADE_COMPARE(creationInfo2.filepath, creationInfo.filepath);
+    CORRADE_VERIFY(creationInfo2.scale == creationInfo.scale);
+    CORRADE_VERIFY(creationInfo2.flags == creationInfo.flags);
+    CORRADE_VERIFY(creationInfo2.lightSetupKey == creationInfo.lightSetupKey);
   }
 
   {
@@ -432,18 +451,20 @@ TEST(IOTest, JsonEspTypesTest) {
         4.f,
         true,
         false};
-    addMember(d, "assetInfo", assetInfo, allocator);
+    esp::io::addMember(d, "assetInfo", assetInfo, allocator);
     esp::assets::AssetInfo assetInfo2;
-    EXPECT_TRUE(readMember(d, "assetInfo", assetInfo2));
-    EXPECT_EQ(assetInfo2.type, assetInfo.type);
-    EXPECT_EQ(assetInfo2.filepath, assetInfo.filepath);
-    EXPECT_EQ(assetInfo2.frame.up(), assetInfo.frame.up());
-    EXPECT_EQ(assetInfo2.frame.front(), assetInfo.frame.front());
-    EXPECT_EQ(assetInfo2.frame.origin(), assetInfo.frame.origin());
-    EXPECT_EQ(assetInfo2.virtualUnitToMeters, assetInfo.virtualUnitToMeters);
-    EXPECT_EQ(assetInfo2.requiresLighting, assetInfo.requiresLighting);
-    EXPECT_EQ(assetInfo2.splitInstanceMesh, assetInfo.splitInstanceMesh);
-    EXPECT_TRUE(assetInfo2.overridePhongMaterial == Cr::Containers::NullOpt);
+    CORRADE_VERIFY(esp::io::readMember(d, "assetInfo", assetInfo2));
+    CORRADE_VERIFY(assetInfo2.type == assetInfo.type);
+    CORRADE_COMPARE(assetInfo2.filepath, assetInfo.filepath);
+    CORRADE_VERIFY(assetInfo2.frame.up().isApprox(assetInfo.frame.up()));
+    CORRADE_VERIFY(assetInfo2.frame.front().isApprox(assetInfo.frame.front()));
+    CORRADE_VERIFY(
+        assetInfo2.frame.origin().isApprox(assetInfo.frame.origin()));
+    CORRADE_COMPARE(assetInfo2.virtualUnitToMeters,
+                    assetInfo.virtualUnitToMeters);
+    CORRADE_COMPARE(assetInfo2.requiresLighting, assetInfo.requiresLighting);
+    CORRADE_COMPARE(assetInfo2.splitInstanceMesh, assetInfo.splitInstanceMesh);
+    CORRADE_VERIFY(assetInfo2.overridePhongMaterial == Cr::Containers::NullOpt);
     // now test again with override material
     assetInfo.overridePhongMaterial = esp::assets::PhongMaterialColor();
     assetInfo.overridePhongMaterial->ambientColor =
@@ -452,16 +473,17 @@ TEST(IOTest, JsonEspTypesTest) {
         Mn::Color4(0.2, 0.3, 0.4, 0.5);
     assetInfo.overridePhongMaterial->specularColor =
         Mn::Color4(0.3, 0.4, 0.5, 0.6);
-    EXPECT_FALSE(assetInfo.overridePhongMaterial == Cr::Containers::NullOpt);
-    addMember(d, "assetInfoColorOverride", assetInfo, allocator);
-    EXPECT_TRUE(readMember(d, "assetInfoColorOverride", assetInfo2));
-    EXPECT_FALSE(assetInfo2.overridePhongMaterial == Cr::Containers::NullOpt);
-    EXPECT_EQ(assetInfo2.overridePhongMaterial->ambientColor,
-              assetInfo.overridePhongMaterial->ambientColor);
-    EXPECT_EQ(assetInfo2.overridePhongMaterial->diffuseColor,
-              assetInfo.overridePhongMaterial->diffuseColor);
-    EXPECT_EQ(assetInfo2.overridePhongMaterial->specularColor,
-              assetInfo.overridePhongMaterial->specularColor);
+    CORRADE_VERIFY(assetInfo.overridePhongMaterial != Cr::Containers::NullOpt);
+    esp::io::addMember(d, "assetInfoColorOverride", assetInfo, allocator);
+    CORRADE_VERIFY(
+        esp::io::readMember(d, "assetInfoColorOverride", assetInfo2));
+    CORRADE_VERIFY(assetInfo2.overridePhongMaterial != Cr::Containers::NullOpt);
+    CORRADE_COMPARE(assetInfo2.overridePhongMaterial->ambientColor,
+                    assetInfo.overridePhongMaterial->ambientColor);
+    CORRADE_COMPARE(assetInfo2.overridePhongMaterial->diffuseColor,
+                    assetInfo.overridePhongMaterial->diffuseColor);
+    CORRADE_COMPARE(assetInfo2.overridePhongMaterial->specularColor,
+                    assetInfo.overridePhongMaterial->specularColor);
   }
 
   {
@@ -471,11 +493,11 @@ TEST(IOTest, JsonEspTypesTest) {
          Magnum::Quaternion::rotation(Magnum::Rad{1.f},
                                       Magnum::Vector3(0.f, 1.f, 0.f))},
         4};
-    addMember(d, "state", state, allocator);
+    esp::io::addMember(d, "state", state, allocator);
     // read and compare RenderAssetInstanceState
     esp::gfx::replay::RenderAssetInstanceState state2;
-    EXPECT_TRUE(readMember(d, "state", state2));
-    EXPECT_EQ(state2, state);
+    CORRADE_VERIFY(esp::io::readMember(d, "state", state2));
+    CORRADE_VERIFY(state2 == state);
   }
 }
 
@@ -492,48 +514,52 @@ struct MyOuterStruct {
 
 // Beware, toJsonValue/fromJsonValue should generally go in JsonAllTypes.h,
 // not scattered in user code as done here.
-inline JsonGenericValue toJsonValue(const MyNestedStruct& x,
-                                    JsonAllocator& allocator) {
-  JsonGenericValue obj(rapidjson::kObjectType);
-  addMember(obj, "a", x.a, allocator);
+inline esp::io::JsonGenericValue toJsonValue(
+    const MyNestedStruct& x,
+    esp::io::JsonAllocator& allocator) {
+  esp::io::JsonGenericValue obj(rapidjson::kObjectType);
+  esp::io::addMember(obj, "a", x.a, allocator);
   return obj;
 }
 
-bool fromJsonValue(const JsonGenericValue& obj, MyNestedStruct& x) {
-  readMember(obj, "a", x.a);
+bool fromJsonValue(const esp::io::JsonGenericValue& obj, MyNestedStruct& x) {
+  esp::io::readMember(obj, "a", x.a);
   return true;
 }
 
-inline JsonGenericValue toJsonValue(const MyOuterStruct& x,
-                                    JsonAllocator& allocator) {
-  JsonGenericValue obj(rapidjson::kObjectType);
-  addMember(obj, "nested", x.nested, allocator);
-  addMember(obj, "b", x.b, allocator);
+inline esp::io::JsonGenericValue toJsonValue(
+    const MyOuterStruct& x,
+    esp::io::JsonAllocator& allocator) {
+  esp::io::JsonGenericValue obj(rapidjson::kObjectType);
+  esp::io::addMember(obj, "nested", x.nested, allocator);
+  esp::io::addMember(obj, "b", x.b, allocator);
   return obj;
 }
 
-bool fromJsonValue(const JsonGenericValue& obj, MyOuterStruct& x) {
-  readMember(obj, "nested", x.nested);
-  readMember(obj, "b", x.b);
+bool fromJsonValue(const esp::io::JsonGenericValue& obj, MyOuterStruct& x) {
+  esp::io::readMember(obj, "nested", x.nested);
+  esp::io::readMember(obj, "b", x.b);
   return true;
 }
 }  // namespace
 
-// Serialize/deserialize MyOuterStruct using io::addMember/readMember and assert
+// Serialize/deserialize MyOuterStruct using
+// io::esp::io::addMember/esp::io::readMember and assert
 // equality.
-TEST(IOTest, JsonUserTypeTest) {
-  logging::LoggingContext loggingContext;
+void IOTest::JsonUserTypeTest() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
 
   MyOuterStruct myStruct{{"hello world"}, 2.f};
-  addMember(d, "myStruct", myStruct, allocator);
+  esp::io::addMember(d, "myStruct", myStruct, allocator);
 
   MyOuterStruct myStruct2;
-  readMember(d, "myStruct", myStruct2);
+  esp::io::readMember(d, "myStruct", myStruct2);
 
-  EXPECT_EQ(myStruct2.nested.a, myStruct.nested.a);
-  EXPECT_EQ(myStruct2.b, myStruct.b);
+  CORRADE_COMPARE(myStruct2.nested.a, myStruct.nested.a);
+  CORRADE_COMPARE(myStruct2.b, myStruct.b);
 }
-}  // namespace io
-}  // namespace esp
+
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::IOTest)

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -21,7 +21,7 @@ namespace Cr = Corrade;
 using esp::metadata::attributes::AbstractObjectAttributes;
 using esp::metadata::attributes::ObjectAttributes;
 
-namespace Test {
+namespace {
 const std::string dataDir =
     Corrade::Utility::Directory::join(SCENE_DATASETS, "../");
 
@@ -560,6 +560,6 @@ void IOTest::testJsonUserType() {
   CORRADE_COMPARE(myStruct2.b, myStruct.b);
 }
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::IOTest)
+CORRADE_TEST_MAIN(IOTest)

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -473,11 +473,11 @@ void IOTest::testJsonEspTypes() {
         Mn::Color4(0.2, 0.3, 0.4, 0.5);
     assetInfo.overridePhongMaterial->specularColor =
         Mn::Color4(0.3, 0.4, 0.5, 0.6);
-    CORRADE_VERIFY(assetInfo.overridePhongMaterial != Cr::Containers::NullOpt);
+    CORRADE_VERIFY(assetInfo.overridePhongMaterial);
     esp::io::addMember(d, "assetInfoColorOverride", assetInfo, allocator);
     CORRADE_VERIFY(
         esp::io::readMember(d, "assetInfoColorOverride", assetInfo2));
-    CORRADE_VERIFY(assetInfo2.overridePhongMaterial != Cr::Containers::NullOpt);
+    CORRADE_VERIFY(assetInfo2.overridePhongMaterial);
     CORRADE_COMPARE(assetInfo2.overridePhongMaterial->ambientColor,
                     assetInfo.overridePhongMaterial->ambientColor);
     CORRADE_COMPARE(assetInfo2.overridePhongMaterial->diffuseColor,

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -16,7 +16,7 @@ namespace Attrs = esp::metadata::attributes;
 
 using esp::metadata::MetadataMediator;
 
-namespace Test {
+namespace {
 
 const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
@@ -564,6 +564,6 @@ void MetadataMediatorTest::testDatasetDelete() {
 
 }  // testDatasetDelete
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::MetadataMediatorTest)
+CORRADE_TEST_MAIN(MetadataMediatorTest)

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 #include "esp/metadata/MetadataMediator.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
@@ -236,8 +237,8 @@ void MetadataMediatorTest::testDataset0() {
   // verify set to values in dataset_config file
   newRenderAssetHandle = objAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
-  CORRADE_VERIFY(newRenderAssetHandle.find("dataset_test_object3.glb") !=
-                 std::string::npos);
+  CORRADE_COMPARE_AS(newRenderAssetHandle.find("dataset_test_object3.glb"),
+                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
   // verify values set correctly
 
   CORRADE_COMPARE(objAttr->getMass(), 1.1);
@@ -339,14 +340,16 @@ void MetadataMediatorTest::testDataset0() {
   //
   // default lighting name
   const std::string lightHandle = sceneAttrs->getLightingHandle();
-  CORRADE_VERIFY(lightHandle.find("modified_test_lights") != std::string::npos);
+  CORRADE_COMPARE_AS(lightHandle.find("modified_test_lights"),
+                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
   // navmesh
   const std::string navmeshHandle = sceneAttrs->getNavmeshHandle();
-  CORRADE_VERIFY(navmeshHandle.find("navmesh_path1") != std::string::npos);
+  CORRADE_COMPARE_AS(navmeshHandle.find("navmesh_path1"), std::string::npos,
+                     Cr::TestSuite::Compare::NotEqual);
   // ssd
   const std::string ssdHandle = sceneAttrs->getSemanticSceneHandle();
-  CORRADE_VERIFY(ssdHandle.find("semantic_descriptor_path1") !=
-                 std::string::npos);
+  CORRADE_COMPARE_AS(ssdHandle.find("semantic_descriptor_path1"),
+                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
 
   //
   // test stage instance
@@ -354,7 +357,8 @@ void MetadataMediatorTest::testDataset0() {
   const auto stageInstanceAttrs = sceneAttrs->getStageInstance();
   // verify name
   const std::string stageName = stageInstanceAttrs->getHandle();
-  CORRADE_VERIFY(stageName.find("modified_test_stage") != std::string::npos);
+  CORRADE_COMPARE_AS(stageName.find("modified_test_stage"), std::string::npos,
+                     Cr::TestSuite::Compare::NotEqual);
   // verify translation origin to be asset_local
   CORRADE_COMPARE(stageInstanceAttrs->getTranslationOrigin(), assetLocalInt);
   // verify translation amount to be expected amount
@@ -373,7 +377,8 @@ void MetadataMediatorTest::testDataset0() {
       objInstanceAttrs[0];
   // name
   std::string objName = objAttr0->getHandle();
-  CORRADE_VERIFY(objName.find("dataset_test_object1") != std::string::npos);
+  CORRADE_COMPARE_AS(objName.find("dataset_test_object1"), std::string::npos,
+                     Cr::TestSuite::Compare::NotEqual);
   // translation
   CORRADE_COMPARE(objAttr0->getTranslation(), Magnum::Vector3(0.1, 0.2, 0.3));
   // translation origin
@@ -384,7 +389,8 @@ void MetadataMediatorTest::testDataset0() {
       objInstanceAttrs[1];
   // name
   objName = objAttr1->getHandle();
-  CORRADE_VERIFY(objName.find("dataset_test_object2") != std::string::npos);
+  CORRADE_COMPARE_AS(objName.find("dataset_test_object2"), std::string::npos,
+                     Cr::TestSuite::Compare::NotEqual);
   // translation
   CORRADE_COMPARE(objAttr1->getTranslation(), Magnum::Vector3(0.3, 0.4, 0.5));
   // translation origin

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <gtest/gtest.h>
+#include <Corrade/TestSuite/Tester.h>
 #include "esp/metadata/MetadataMediator.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
 #include "esp/metadata/managers/AttributesManagerBase.h"
@@ -11,12 +11,12 @@
 #include "esp/metadata/managers/StageAttributesManager.h"
 
 #include "configure.h"
-
-namespace {
 namespace AttrMgrs = esp::metadata::managers;
 namespace Attrs = esp::metadata::attributes;
 
 using esp::metadata::MetadataMediator;
+
+namespace Test {
 
 const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
@@ -35,12 +35,12 @@ const std::string sceneDatasetConfigFile_1 = Cr::Utility::Directory::join(
     datasetTestDirs,
     "dataset_1/test_dataset_1.scene_dataset_config.json");
 
-class MetadataMediatorTest : public testing::Test {
- protected:
-  void SetUp() override {
+struct MetadataMediatorTest : Cr::TestSuite::Tester {
+  explicit MetadataMediatorTest();
+
+  void reset() {
     // create new MM with blank cfg
     MM_ = MetadataMediator::create();
-
     // reference alternate dataset
   };
 
@@ -67,12 +67,26 @@ class MetadataMediatorTest : public testing::Test {
     ESP_WARNING() << "\nActive Dataset Details : \n" << dsInfoReport << "\n";
   }
 
+  // tests
+  void testDataset0();
+  void testDataset1();
+
+  void testDatasetDelete();
+
   esp::logging::LoggingContext loggingContext;
   MetadataMediator::ptr MM_ = nullptr;
 
-};  // class MetadataMediatorTest
+};  // struct MetadataMediatorTest
 
-TEST_F(MetadataMediatorTest, testDataset0) {
+MetadataMediatorTest::MetadataMediatorTest() {
+  MM_ = MetadataMediator::create();
+  addTests({&MetadataMediatorTest::testDataset0,
+            &MetadataMediatorTest::testDataset1,
+            &MetadataMediatorTest::testDatasetDelete});
+
+}  // ctor
+
+void MetadataMediatorTest::testDataset0() {
   // setup dataset 0 for test
   initDataset0();
 
@@ -81,81 +95,82 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // should be 7 - one for default NONE stage, one original JSON, one based on
   // original but changed, and one new, and 3 built from .glb files
-  ASSERT_EQ(numStageHandles, 7);
+  CORRADE_COMPARE(numStageHandles, 7);
   // get list of handles matching glb-based attributes
   auto glbBasedStageAttrHandles =
       stageAttributesMgr->getObjectHandlesBySubstring(".glb", true);
-  ASSERT_EQ(glbBasedStageAttrHandles.size(), 3);
+  CORRADE_COMPARE(glbBasedStageAttrHandles.size(), 3);
   for (const auto& attrHandle : glbBasedStageAttrHandles) {
     auto glbStageAttr = stageAttributesMgr->getObjectCopyByHandle(attrHandle);
     // verify that all attributes' names are the same as the render handles
     // (which were the original files)
-    ASSERT_EQ(glbStageAttr->getHandle(), glbStageAttr->getRenderAssetHandle());
+    CORRADE_COMPARE(glbStageAttr->getHandle(),
+                    glbStageAttr->getRenderAssetHandle());
   }
 
   // get list of matching handles for base - should always only be 1
   auto stageAttrHandles = stageAttributesMgr->getObjectHandlesBySubstring(
       "dataset_test_stage.stage_config.json", true);
-  ASSERT_EQ(stageAttrHandles.size(), 1);
+  CORRADE_COMPARE(stageAttrHandles.size(), 1);
   // get copy of attributes
   auto stageAttr =
       stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // get render asset handle for later comparison
   auto renderAssetHandle = stageAttr->getRenderAssetHandle();
   // verify existence
-  ASSERT_NE(nullptr, stageAttr);
+  CORRADE_VERIFY(stageAttr != nullptr);
   // verify set to values in file
-  ASSERT_EQ(stageAttr->getScale(), Magnum::Vector3(2, 2, 2));
-  ASSERT_EQ(stageAttr->getRequiresLighting(), true);
-  ASSERT_EQ(stageAttr->getMargin(), 0.03);
-  ASSERT_EQ(stageAttr->getFrictionCoefficient(), 0.3);
-  ASSERT_EQ(stageAttr->getRestitutionCoefficient(), 0.3);
-  ASSERT_EQ(stageAttr->getOrigin(), Magnum::Vector3(0, 0, 0));
-  ASSERT_EQ(stageAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
-  ASSERT_EQ(stageAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 2, 2));
+  CORRADE_VERIFY(stageAttr->getRequiresLighting());
+  CORRADE_COMPARE(stageAttr->getMargin(), 0.03);
+  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.3);
+  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.3);
+  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(0, 0, 0));
+  CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+  CORRADE_COMPARE(stageAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
 
   // get list of matching handles for modified base - should always only be 1
   stageAttrHandles = stageAttributesMgr->getObjectHandlesBySubstring(
       "modified_test_stage", true);
-  ASSERT_EQ(stageAttrHandles.size(), 1);
+  CORRADE_COMPARE(stageAttrHandles.size(), 1);
   // get copy of attributes
   stageAttr = stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, stageAttr);
+  CORRADE_VERIFY(stageAttr != nullptr);
   // verify set to override values in dataset_config file
-  ASSERT_EQ(stageAttr->getScale(), Magnum::Vector3(1, 1, 1));
-  ASSERT_EQ(stageAttr->getMargin(), 0.041);
-  ASSERT_EQ(stageAttr->getFrictionCoefficient(), 0.4);
-  ASSERT_EQ(stageAttr->getRestitutionCoefficient(), 0.5);
-  ASSERT_EQ(stageAttr->getUnitsToMeters(), 1.0);
+  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(1, 1, 1));
+  CORRADE_COMPARE(stageAttr->getMargin(), 0.041);
+  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.4);
+  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.5);
+  CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 1.0);
 
   // get list of matching handles for new - should always only be 1
   stageAttrHandles =
       stageAttributesMgr->getObjectHandlesBySubstring("new_test_stage", true);
-  ASSERT_EQ(stageAttrHandles.size(), 1);
+  CORRADE_COMPARE(stageAttrHandles.size(), 1);
   // get copy of attributes
   stageAttr = stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, stageAttr);
+  CORRADE_VERIFY(stageAttr != nullptr);
   // verify set to values in dataset_config file
   auto newRenderAssetHandle = stageAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
-  ASSERT_EQ(renderAssetHandle, newRenderAssetHandle);
+  CORRADE_COMPARE(renderAssetHandle, newRenderAssetHandle);
   // verify values set correctly
-  ASSERT_EQ(stageAttr->getOrientUp(), Magnum::Vector3(0, -1, 0));
-  ASSERT_EQ(stageAttr->getScale(), Magnum::Vector3(2, 2, 2));
-  ASSERT_EQ(stageAttr->getGravity(), Magnum::Vector3(0, 9.8, 0));
-  ASSERT_EQ(stageAttr->getFrictionCoefficient(), 0.35);
-  ASSERT_EQ(stageAttr->getRestitutionCoefficient(), 0.25);
-  ASSERT_EQ(stageAttr->getUnitsToMeters(), 2.0);
-  ASSERT_EQ(stageAttr->getRequiresLighting(), false);
+  CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(0, -1, 0));
+  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 2, 2));
+  CORRADE_COMPARE(stageAttr->getGravity(), Magnum::Vector3(0, 9.8, 0));
+  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.35);
+  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.25);
+  CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 2.0);
+  CORRADE_VERIFY(!stageAttr->getRequiresLighting());
 
   // get new attributes but don't register
   stageAttr = stageAttributesMgr->createObject("new_default_attributes", false);
   // verify existence
-  ASSERT_NE(nullptr, stageAttr);
+  CORRADE_VERIFY(stageAttr != nullptr);
   // verify contains default attributes value
-  ASSERT_EQ(stageAttr->getOrigin(), Magnum::Vector3(1.0, 2.0, 3.0));
+  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1.0, 2.0, 3.0));
 
   // end test LoadStages
 
@@ -165,77 +180,77 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   int numObjHandles = objectAttributesMgr->getNumFileTemplateObjects();
   // should be 6 file-based templates - 4 original, one based on an original
   // but changed, and one new
-  ASSERT_EQ(numObjHandles, 6);
+  CORRADE_COMPARE(numObjHandles, 6);
 
   // get list of matching handles for base object - should always only be 1
   auto objAttrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
       "dataset_test_object1.object_config.json", true);
-  ASSERT_EQ(objAttrHandles.size(), 1);
+  CORRADE_COMPARE(objAttrHandles.size(), 1);
   // get copy of attributes
   auto objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, objAttr);
+  CORRADE_VERIFY(objAttr != nullptr);
   // verify set to values in file
-  ASSERT_EQ(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
-  ASSERT_EQ(objAttr->getRequiresLighting(), true);
-  ASSERT_EQ(objAttr->getMargin(), 0.03);
-  ASSERT_EQ(objAttr->getMass(), 0.038);
-  ASSERT_EQ(objAttr->getFrictionCoefficient(), 0.5);
-  ASSERT_EQ(objAttr->getRestitutionCoefficient(), 0.2);
-  ASSERT_EQ(objAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
-  ASSERT_EQ(objAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
-  ASSERT_EQ(objAttr->getUnitsToMeters(), 1.0);
-  ASSERT_EQ(objAttr->getBoundingBoxCollisions(), false);
-  ASSERT_EQ(objAttr->getJoinCollisionMeshes(), true);
+  CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
+  CORRADE_VERIFY(objAttr->getRequiresLighting());
+  CORRADE_COMPARE(objAttr->getMargin(), 0.03);
+  CORRADE_COMPARE(objAttr->getMass(), 0.038);
+  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.5);
+  CORRADE_COMPARE(objAttr->getRestitutionCoefficient(), 0.2);
+  CORRADE_COMPARE(objAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+  CORRADE_COMPARE(objAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+  CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.0);
+  CORRADE_VERIFY(!objAttr->getBoundingBoxCollisions());
+  CORRADE_VERIFY(objAttr->getJoinCollisionMeshes());
 
   // get list of matching handles for modified base - should always only be 1
   objAttrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
       "modified_test_object1_1_slick_heavy", true);
-  ASSERT_EQ(objAttrHandles.size(), 1);
+  CORRADE_COMPARE(objAttrHandles.size(), 1);
   // get copy of attributes
   objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, objAttr);
+  CORRADE_VERIFY(objAttr != nullptr);
   // verify identical to copied object except for override values in
   // dataset_config file
-  ASSERT_EQ(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
-  ASSERT_EQ(objAttr->getRequiresLighting(), true);
-  ASSERT_EQ(objAttr->getMargin(), 0.03);
-  ASSERT_EQ(objAttr->getMass(), 3.5);
-  ASSERT_EQ(objAttr->getFrictionCoefficient(), 0.2);
-  ASSERT_EQ(objAttr->getRestitutionCoefficient(), 0.2);
-  ASSERT_EQ(objAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
-  ASSERT_EQ(objAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
-  ASSERT_EQ(objAttr->getUnitsToMeters(), 1.0);
-  ASSERT_EQ(objAttr->getBoundingBoxCollisions(), false);
-  ASSERT_EQ(objAttr->getJoinCollisionMeshes(), true);
+  CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
+  CORRADE_VERIFY(objAttr->getRequiresLighting());
+  CORRADE_COMPARE(objAttr->getMargin(), 0.03);
+  CORRADE_COMPARE(objAttr->getMass(), 3.5);
+  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.2);
+  CORRADE_COMPARE(objAttr->getRestitutionCoefficient(), 0.2);
+  CORRADE_COMPARE(objAttr->getOrientUp(), Magnum::Vector3(0, 1, 0));
+  CORRADE_COMPARE(objAttr->getOrientFront(), Magnum::Vector3(0, 0, -1));
+  CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.0);
+  CORRADE_VERIFY(!objAttr->getBoundingBoxCollisions());
+  CORRADE_VERIFY(objAttr->getJoinCollisionMeshes());
 
   // get list of matching handles for new - should always only be 1
   objAttrHandles = objectAttributesMgr->getObjectHandlesBySubstring(
       "new_test_object3", true);
-  ASSERT_EQ(objAttrHandles.size(), 1);
+  CORRADE_COMPARE(objAttrHandles.size(), 1);
   // get copy of attributes
   objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, objAttr);
+  CORRADE_VERIFY(objAttr != nullptr);
   // verify set to values in dataset_config file
   newRenderAssetHandle = objAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
-  ASSERT_NE(std::string::npos,
-            newRenderAssetHandle.find("dataset_test_object3.glb"));
+  CORRADE_VERIFY(newRenderAssetHandle.find("dataset_test_object3.glb") !=
+                 std::string::npos);
   // verify values set correctly
 
-  ASSERT_EQ(objAttr->getMass(), 1.1);
-  ASSERT_EQ(objAttr->getFrictionCoefficient(), 0.1);
-  ASSERT_EQ(objAttr->getInertia(), Magnum::Vector3(3, 2, 1));
+  CORRADE_COMPARE(objAttr->getMass(), 1.1);
+  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.1);
+  CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(3, 2, 1));
 
   // get new attributes but don't register
   objAttr = objectAttributesMgr->createObject("new_default_attributes", false);
   // verify existence
-  ASSERT_NE(nullptr, objAttr);
+  CORRADE_VERIFY(objAttr != nullptr);
   // verify contains default attributes value
-  ASSERT_EQ(objAttr->getMass(), 10.0);
-  ASSERT_EQ(objAttr->getInertia(), Magnum::Vector3(3, 2, 1));
+  CORRADE_COMPARE(objAttr->getMass(), 10.0);
+  CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(3, 2, 1));
 
   // end test LoadObjects
 
@@ -246,46 +261,46 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   // get # of loaded light layout attributes.
   int numLightAttrHandles = lightsLayoutAttributesMgr->getNumObjects();
   // Should be 3 : file based, copy and new
-  ASSERT_EQ(numLightAttrHandles, 3);
+  CORRADE_COMPARE(numLightAttrHandles, 3);
   // get list of matching handles for base light config - should always only
   // be 1
   auto lightAttrHandles =
       lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
           "dataset_test_lights.lighting_config.json", true);
-  ASSERT_EQ(lightAttrHandles.size(), 1);
+  CORRADE_COMPARE(lightAttrHandles.size(), 1);
   // get copy of attributes
   auto lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, lightAttr);
+  CORRADE_VERIFY(lightAttr != nullptr);
   // verify the number of lights within the lighting layout
-  ASSERT_EQ(12, lightAttr->getNumLightInstances());
+  CORRADE_COMPARE(12, lightAttr->getNumLightInstances());
 
   // get list of matching handles for modified light config - should always
   // only be 1
   lightAttrHandles = lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
       "modified_test_lights", true);
-  ASSERT_EQ(lightAttrHandles.size(), 1);
+  CORRADE_COMPARE(lightAttrHandles.size(), 1);
   // get copy of attributes
   lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, lightAttr);
+  CORRADE_VERIFY(lightAttr != nullptr);
   // verify the number of lights within the lighting layout
-  ASSERT_EQ(12, lightAttr->getNumLightInstances());
+  CORRADE_COMPARE(lightAttr->getNumLightInstances(), 12);
 
   // get list of matching handles for new light config - should always only be
   // 1
   lightAttrHandles = lightsLayoutAttributesMgr->getObjectHandlesBySubstring(
       "new_test_lights_0", true);
-  ASSERT_EQ(lightAttrHandles.size(), 1);
+  CORRADE_COMPARE(lightAttrHandles.size(), 1);
   // get copy of attributes
   lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  ASSERT_NE(nullptr, lightAttr);
+  CORRADE_VERIFY(lightAttr != nullptr);
   // verify the number of lights within the lighting layout
-  ASSERT_EQ(3, lightAttr->getNumLightInstances());
+  CORRADE_COMPARE(lightAttr->getNumLightInstances(), 3);
 
   // end test LoadLights
 
@@ -298,12 +313,12 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   // get # of loaded scene attributes.
   int numSceneHandles = sceneAttributesMgr->getNumObjects();
   // should be 1
-  ASSERT_EQ(numSceneHandles, 1);
+  CORRADE_COMPARE(numSceneHandles, 1);
   // get handle list matching passed handle
   auto sceneAttrHandles = sceneAttributesMgr->getObjectHandlesBySubstring(
       "dataset_test_scene", true);
   // make sure there is only 1 matching dataset_test_scene
-  ASSERT_EQ(sceneAttrHandles.size(), 1);
+  CORRADE_COMPARE(sceneAttrHandles.size(), 1);
 
   const std::string activeSceneName = sceneAttrHandles[0];
   ESP_WARNING() << "testLoadSceneInstances : Scene instance attr handle :"
@@ -312,10 +327,10 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   // metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
   auto sceneAttrs = MM_->getSceneAttributesByName(activeSceneName);
   // this should be a scene instance attributes with specific stage and object
-  ASSERT_NE(sceneAttrs, nullptr);
+  CORRADE_VERIFY(sceneAttrs != nullptr);
   // verify default value for translation origin
-  ASSERT_EQ(sceneAttrs->getTranslationOrigin(),
-            static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
+  CORRADE_COMPARE(sceneAttrs->getTranslationOrigin(),
+                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
   const int assetLocalInt =
       static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal);
 
@@ -324,13 +339,14 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   //
   // default lighting name
   const std::string lightHandle = sceneAttrs->getLightingHandle();
-  ASSERT_NE(lightHandle.find("modified_test_lights"), std::string::npos);
+  CORRADE_VERIFY(lightHandle.find("modified_test_lights") != std::string::npos);
   // navmesh
   const std::string navmeshHandle = sceneAttrs->getNavmeshHandle();
-  ASSERT_NE(navmeshHandle.find("navmesh_path1"), std::string::npos);
+  CORRADE_VERIFY(navmeshHandle.find("navmesh_path1") != std::string::npos);
   // ssd
   const std::string ssdHandle = sceneAttrs->getSemanticSceneHandle();
-  ASSERT_NE(ssdHandle.find("semantic_descriptor_path1"), std::string::npos);
+  CORRADE_VERIFY(ssdHandle.find("semantic_descriptor_path1") !=
+                 std::string::npos);
 
   //
   // test stage instance
@@ -338,41 +354,41 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   const auto stageInstanceAttrs = sceneAttrs->getStageInstance();
   // verify name
   const std::string stageName = stageInstanceAttrs->getHandle();
-  ASSERT_NE(stageName.find("modified_test_stage"), std::string::npos);
+  CORRADE_VERIFY(stageName.find("modified_test_stage") != std::string::npos);
   // verify translation origin to be asset_local
-  ASSERT_EQ(stageInstanceAttrs->getTranslationOrigin(), assetLocalInt);
+  CORRADE_COMPARE(stageInstanceAttrs->getTranslationOrigin(), assetLocalInt);
   // verify translation amount to be expected amount
-  ASSERT_EQ(stageInstanceAttrs->getTranslation(),
-            Magnum::Vector3(1.1, 2.2, 3.3));
+  CORRADE_COMPARE(stageInstanceAttrs->getTranslation(),
+                  Magnum::Vector3(1.1, 2.2, 3.3));
   //
   // test object instances
   //
   // get all instances
   const std::vector<Attrs::SceneObjectInstanceAttributes::cptr>
       objInstanceAttrs = sceneAttrs->getObjectInstances();
-  ASSERT_EQ(objInstanceAttrs.size(), 2);
+  CORRADE_COMPARE(objInstanceAttrs.size(), 2);
 
   // first object instance
   const Attrs::SceneObjectInstanceAttributes::cptr& objAttr0 =
       objInstanceAttrs[0];
   // name
   std::string objName = objAttr0->getHandle();
-  ASSERT_NE(objName.find("dataset_test_object1"), std::string::npos);
+  CORRADE_VERIFY(objName.find("dataset_test_object1") != std::string::npos);
   // translation
-  ASSERT_EQ(objAttr0->getTranslation(), Magnum::Vector3(0.1, 0.2, 0.3));
+  CORRADE_COMPARE(objAttr0->getTranslation(), Magnum::Vector3(0.1, 0.2, 0.3));
   // translation origin
-  ASSERT_EQ(objAttr0->getTranslationOrigin(), assetLocalInt);
+  CORRADE_COMPARE(objAttr0->getTranslationOrigin(), assetLocalInt);
 
   // second object instance
   const Attrs::SceneObjectInstanceAttributes::cptr& objAttr1 =
       objInstanceAttrs[1];
   // name
   objName = objAttr1->getHandle();
-  ASSERT_NE(objName.find("dataset_test_object2"), std::string::npos);
+  CORRADE_VERIFY(objName.find("dataset_test_object2") != std::string::npos);
   // translation
-  ASSERT_EQ(objAttr1->getTranslation(), Magnum::Vector3(0.3, 0.4, 0.5));
+  CORRADE_COMPARE(objAttr1->getTranslation(), Magnum::Vector3(0.3, 0.4, 0.5));
   // translation origin
-  ASSERT_EQ(objAttr1->getTranslationOrigin(), assetLocalInt);
+  CORRADE_COMPARE(objAttr1->getTranslationOrigin(), assetLocalInt);
 
   // end test LoadSceneInstances
 
@@ -381,14 +397,14 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   const std::map<std::string, std::string> navmeshMap =
       MM_->getActiveNavmeshMap();
   // should have 2
-  ASSERT_EQ(navmeshMap.size(), 2);
+  CORRADE_COMPARE(navmeshMap.size(), 2);
 
   // should hold 2 keys
-  ASSERT_NE(navmeshMap.count("navmesh_path1"), 0);
-  ASSERT_NE(navmeshMap.count("navmesh_path2"), 0);
+  CORRADE_VERIFY(navmeshMap.count("navmesh_path1") > 0);
+  CORRADE_VERIFY(navmeshMap.count("navmesh_path2") > 0);
   // each key should hold specific value
-  ASSERT_EQ(navmeshMap.at("navmesh_path1"), "test_navmesh_path1");
-  ASSERT_EQ(navmeshMap.at("navmesh_path2"), "test_navmesh_path2");
+  CORRADE_COMPARE(navmeshMap.at("navmesh_path1"), "test_navmesh_path1");
+  CORRADE_COMPARE(navmeshMap.at("navmesh_path2"), "test_navmesh_path2");
   // end test LoadNavmesh
 
   ESP_DEBUG() << "Starting test LoadSemanticScene";
@@ -396,22 +412,22 @@ TEST_F(MetadataMediatorTest, testDataset0) {
   const std::map<std::string, std::string> semanticMap =
       MM_->getActiveSemanticSceneDescriptorMap();
   // should have 2
-  ASSERT_EQ(semanticMap.size(), 2);
+  CORRADE_COMPARE(semanticMap.size(), 2);
   // should hold 2 keys
-  ASSERT_NE(semanticMap.count("semantic_descriptor_path1"), 0);
-  ASSERT_NE(semanticMap.count("semantic_descriptor_path2"), 0);
+  CORRADE_VERIFY(semanticMap.count("semantic_descriptor_path1") > 0);
+  CORRADE_VERIFY(semanticMap.count("semantic_descriptor_path2") > 0);
   // each key should hold specific value
-  ASSERT_EQ(semanticMap.at("semantic_descriptor_path1"),
-            "test_semantic_descriptor_path1");
-  ASSERT_EQ(semanticMap.at("semantic_descriptor_path2"),
-            "test_semantic_descriptor_path2");
+  CORRADE_COMPARE(semanticMap.at("semantic_descriptor_path1"),
+                  "test_semantic_descriptor_path1");
+  CORRADE_COMPARE(semanticMap.at("semantic_descriptor_path2"),
+                  "test_semantic_descriptor_path2");
 
   // end test LoadSemanticScene
   displayDSReports();
 
 }  // testDataset0
 
-TEST_F(MetadataMediatorTest, testDataset1) {
+void MetadataMediatorTest::testDataset1() {
   // primarily testing glob file wildcard loading
   initDataset1();
 
@@ -420,14 +436,14 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   int numStageHandles = stageAttributesMgr->getNumObjects();
   // shoudld be 6 : one for default NONE stage, glob lookup yields 2 stages +
   // 2 modified and 1 new stage in scene dataset config
-  ASSERT_EQ(numStageHandles, 6);
+  CORRADE_COMPARE(numStageHandles, 6);
   // end test LoadStages
 
   ESP_DEBUG() << "Starting test LoadObjects";
   const auto& objectAttributesMgr = MM_->getObjectAttributesManager();
   int numObjHandles = objectAttributesMgr->getNumFileTemplateObjects();
   // glob lookup yields 4 files + 2 modified in config
-  ASSERT_EQ(numObjHandles, 6);
+  CORRADE_COMPARE(numObjHandles, 6);
   // end test LoadObjects
 
   ESP_DEBUG() << "Starting test LoadLights";
@@ -436,7 +452,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // get # of loaded light layout attributes.
   int numLightAttrHandles = lightsLayoutAttributesMgr->getNumObjects();
   // Should be 4 : 2 file based, copy and new
-  ASSERT_EQ(numLightAttrHandles, 4);
+  CORRADE_COMPARE(numLightAttrHandles, 4);
 
   // end test LoadLights
 
@@ -449,7 +465,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // get # of loaded scene attributes.
   int numSceneHandles = sceneAttributesMgr->getNumObjects();
   // should be 2 - 2 file based
-  ASSERT_EQ(numSceneHandles, 2);
+  CORRADE_COMPARE(numSceneHandles, 2);
 
   // end test LoadSceneInstances
 
@@ -459,7 +475,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   // verify # of urdf filepaths loaded - should be 6;
   const std::map<std::string, std::string>& urdfTestFilenames =
       MM_->getArticulatedObjectModelFilenames();
-  ASSERT_EQ(urdfTestFilenames.size(), 6);
+  CORRADE_COMPARE(urdfTestFilenames.size(), 6);
   // test that each stub name key corresponds to the actual file name passed
   // through the key making process
   for (std::map<std::string, std::string>::const_iterator iter =
@@ -472,14 +488,14 @@ TEST_F(MetadataMediatorTest, testDataset1) {
             Dir::splitExtension(Dir::filename(iter->second)).first)
             .first;
     // test that map key constructed as shortened handle.
-    ASSERT_EQ(shortHandle, iter->first);
+    CORRADE_COMPARE(shortHandle, iter->first);
     // test that file name ends in ".urdf"
-    ASSERT_EQ(Dir::splitExtension(Dir::filename(iter->second))
-                  .second.compare(".urdf"),
-              0);
+    CORRADE_COMPARE(Dir::splitExtension(Dir::filename(iter->second))
+                        .second.compare(".urdf"),
+                    0);
     // test that file actually exists
     const std::string filename = iter->second;
-    ASSERT_EQ(Dir::exists(filename), true);
+    CORRADE_VERIFY(Dir::exists(filename));
   }
   // end test LoadArticulatedObjects
 
@@ -488,7 +504,7 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   const std::map<std::string, std::string> navmeshMap =
       MM_->getActiveNavmeshMap();
   // should have 3
-  ASSERT_EQ(navmeshMap.size(), 3);
+  CORRADE_COMPARE(navmeshMap.size(), 3);
   // end test LoadNavmesh
 
   ESP_DEBUG() << "Starting test LoadSemanticScene";
@@ -496,56 +512,58 @@ TEST_F(MetadataMediatorTest, testDataset1) {
   const std::map<std::string, std::string> semanticMap =
       MM_->getActiveSemanticSceneDescriptorMap();
   // should have 3
-  ASSERT_EQ(semanticMap.size(), 3);
+  CORRADE_COMPARE(semanticMap.size(), 3);
   // testLoadSemanticScene
   // display info report
   displayDSReports();
 
 }  // testDataset1
 
-TEST_F(MetadataMediatorTest, testDatasetDelete) {
+void MetadataMediatorTest::testDatasetDelete() {
   // load dataset 1 and make active
   initDataset1();
   const std::string nameDS1 = MM_->getActiveSceneDatasetName();
   // verify the dataset has been added
-  ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), true);
+  CORRADE_VERIFY(MM_->sceneDatasetExists(nameDS1));
   // verify the active dataset is the expected name
-  ASSERT_EQ(nameDS1, sceneDatasetConfigFile_1);
+  CORRADE_COMPARE(nameDS1, sceneDatasetConfigFile_1);
   // get the stage attributes manager for the scene dataset
   const auto& stageAttrMgr_DS1 = MM_->getStageAttributesManager();
   // verify not nullptr
-  ASSERT_NE(stageAttrMgr_DS1, nullptr);
+  CORRADE_VERIFY(stageAttrMgr_DS1 != nullptr);
 
   // load datsaet 0 and make active
   initDataset0();
   // get new active dataset
   const std::string nameDS0 = MM_->getActiveSceneDatasetName();
   // verify the dataset has been added
-  ASSERT_EQ(MM_->sceneDatasetExists(nameDS0), true);
+  CORRADE_VERIFY(MM_->sceneDatasetExists(nameDS0));
   // verify the active dataset is the expected name
-  ASSERT_EQ(nameDS0, sceneDatasetConfigFile_0);
+  CORRADE_COMPARE(nameDS0, sceneDatasetConfigFile_0);
 
   // delete dataset 1 and verify delete
-  ASSERT_EQ(MM_->removeSceneDataset(nameDS1), true);
+  CORRADE_VERIFY(MM_->removeSceneDataset(nameDS1));
   // verify the dataset does not exist anymore
-  ASSERT_EQ(MM_->sceneDatasetExists(nameDS1), false);
+  CORRADE_VERIFY(!MM_->sceneDatasetExists(nameDS1));
 
   // verify deleted scene dataset's stage manager is nullptr
-  ASSERT_EQ(stageAttrMgr_DS1, nullptr);
+  CORRADE_COMPARE(stageAttrMgr_DS1, nullptr);
 
   // attempt to delete dataset 0 and verify fails - cannot delete active dataset
-  ASSERT_EQ(MM_->removeSceneDataset(nameDS0), false);
+  CORRADE_VERIFY(!MM_->removeSceneDataset(nameDS0));
 
   // switch to default active dataset
   MM_->setActiveSceneDatasetName("default");
   // attempt to delete dataset 0 and verify delete
-  ASSERT_EQ(MM_->removeSceneDataset(nameDS0), true);
+  CORRADE_VERIFY(MM_->removeSceneDataset(nameDS0));
   // verify the dataset does not exist anymore
-  ASSERT_EQ(MM_->sceneDatasetExists(nameDS0), false);
+  CORRADE_VERIFY(!MM_->sceneDatasetExists(nameDS0));
 
   // display info report
   displayDSReports();
 
 }  // testDatasetDelete
 
-}  // namespace
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::MetadataMediatorTest)

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -237,8 +237,8 @@ void MetadataMediatorTest::testDataset0() {
   // verify set to values in dataset_config file
   newRenderAssetHandle = objAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
-  CORRADE_COMPARE_AS(newRenderAssetHandle.find("dataset_test_object3.glb"),
-                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(newRenderAssetHandle.find("dataset_test_object3.glb") !=
+                 std::string::npos);
   // verify values set correctly
 
   CORRADE_COMPARE(objAttr->getMass(), 1.1);
@@ -340,16 +340,14 @@ void MetadataMediatorTest::testDataset0() {
   //
   // default lighting name
   const std::string lightHandle = sceneAttrs->getLightingHandle();
-  CORRADE_COMPARE_AS(lightHandle.find("modified_test_lights"),
-                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(lightHandle.find("modified_test_lights") != std::string::npos);
   // navmesh
   const std::string navmeshHandle = sceneAttrs->getNavmeshHandle();
-  CORRADE_COMPARE_AS(navmeshHandle.find("navmesh_path1"), std::string::npos,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(navmeshHandle.find("navmesh_path1") != std::string::npos);
   // ssd
   const std::string ssdHandle = sceneAttrs->getSemanticSceneHandle();
-  CORRADE_COMPARE_AS(ssdHandle.find("semantic_descriptor_path1"),
-                     std::string::npos, Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(ssdHandle.find("semantic_descriptor_path1") !=
+                 std::string::npos);
 
   //
   // test stage instance
@@ -357,8 +355,7 @@ void MetadataMediatorTest::testDataset0() {
   const auto stageInstanceAttrs = sceneAttrs->getStageInstance();
   // verify name
   const std::string stageName = stageInstanceAttrs->getHandle();
-  CORRADE_COMPARE_AS(stageName.find("modified_test_stage"), std::string::npos,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(stageName.find("modified_test_stage") != std::string::npos);
   // verify translation origin to be asset_local
   CORRADE_COMPARE(stageInstanceAttrs->getTranslationOrigin(), assetLocalInt);
   // verify translation amount to be expected amount

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -118,7 +118,7 @@ void MetadataMediatorTest::testDataset0() {
   // get render asset handle for later comparison
   auto renderAssetHandle = stageAttr->getRenderAssetHandle();
   // verify existence
-  CORRADE_VERIFY(stageAttr != nullptr);
+  CORRADE_VERIFY(stageAttr);
   // verify set to values in file
   CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 2, 2));
   CORRADE_VERIFY(stageAttr->getRequiresLighting());
@@ -136,7 +136,7 @@ void MetadataMediatorTest::testDataset0() {
   // get copy of attributes
   stageAttr = stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(stageAttr != nullptr);
+  CORRADE_VERIFY(stageAttr);
   // verify set to override values in dataset_config file
   CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(1, 1, 1));
   CORRADE_COMPARE(stageAttr->getMargin(), 0.041);
@@ -151,7 +151,7 @@ void MetadataMediatorTest::testDataset0() {
   // get copy of attributes
   stageAttr = stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(stageAttr != nullptr);
+  CORRADE_VERIFY(stageAttr);
   // verify set to values in dataset_config file
   auto newRenderAssetHandle = stageAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
@@ -168,7 +168,7 @@ void MetadataMediatorTest::testDataset0() {
   // get new attributes but don't register
   stageAttr = stageAttributesMgr->createObject("new_default_attributes", false);
   // verify existence
-  CORRADE_VERIFY(stageAttr != nullptr);
+  CORRADE_VERIFY(stageAttr);
   // verify contains default attributes value
   CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1.0, 2.0, 3.0));
 
@@ -189,7 +189,7 @@ void MetadataMediatorTest::testDataset0() {
   // get copy of attributes
   auto objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(objAttr != nullptr);
+  CORRADE_VERIFY(objAttr);
   // verify set to values in file
   CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
   CORRADE_VERIFY(objAttr->getRequiresLighting());
@@ -210,7 +210,7 @@ void MetadataMediatorTest::testDataset0() {
   // get copy of attributes
   objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(objAttr != nullptr);
+  CORRADE_VERIFY(objAttr);
   // verify identical to copied object except for override values in
   // dataset_config file
   CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(1, 1, 1));
@@ -232,7 +232,7 @@ void MetadataMediatorTest::testDataset0() {
   // get copy of attributes
   objAttr = objectAttributesMgr->getObjectCopyByHandle(objAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(objAttr != nullptr);
+  CORRADE_VERIFY(objAttr);
   // verify set to values in dataset_config file
   newRenderAssetHandle = objAttr->getRenderAssetHandle();
   // verify same renderasset handle to loaded stage attributes
@@ -247,7 +247,7 @@ void MetadataMediatorTest::testDataset0() {
   // get new attributes but don't register
   objAttr = objectAttributesMgr->createObject("new_default_attributes", false);
   // verify existence
-  CORRADE_VERIFY(objAttr != nullptr);
+  CORRADE_VERIFY(objAttr);
   // verify contains default attributes value
   CORRADE_COMPARE(objAttr->getMass(), 10.0);
   CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(3, 2, 1));
@@ -272,7 +272,7 @@ void MetadataMediatorTest::testDataset0() {
   auto lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(lightAttr != nullptr);
+  CORRADE_VERIFY(lightAttr);
   // verify the number of lights within the lighting layout
   CORRADE_COMPARE(12, lightAttr->getNumLightInstances());
 
@@ -285,7 +285,7 @@ void MetadataMediatorTest::testDataset0() {
   lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(lightAttr != nullptr);
+  CORRADE_VERIFY(lightAttr);
   // verify the number of lights within the lighting layout
   CORRADE_COMPARE(lightAttr->getNumLightInstances(), 12);
 
@@ -298,7 +298,7 @@ void MetadataMediatorTest::testDataset0() {
   lightAttr =
       lightsLayoutAttributesMgr->getObjectCopyByHandle(lightAttrHandles[0]);
   // verify existence
-  CORRADE_VERIFY(lightAttr != nullptr);
+  CORRADE_VERIFY(lightAttr);
   // verify the number of lights within the lighting layout
   CORRADE_COMPARE(lightAttr->getNumLightInstances(), 3);
 
@@ -327,7 +327,7 @@ void MetadataMediatorTest::testDataset0() {
   // metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
   auto sceneAttrs = MM_->getSceneAttributesByName(activeSceneName);
   // this should be a scene instance attributes with specific stage and object
-  CORRADE_VERIFY(sceneAttrs != nullptr);
+  CORRADE_VERIFY(sceneAttrs);
   // verify default value for translation origin
   CORRADE_COMPARE(sceneAttrs->getTranslationOrigin(),
                   static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
@@ -530,7 +530,7 @@ void MetadataMediatorTest::testDatasetDelete() {
   // get the stage attributes manager for the scene dataset
   const auto& stageAttrMgr_DS1 = MM_->getStageAttributesManager();
   // verify not nullptr
-  CORRADE_VERIFY(stageAttrMgr_DS1 != nullptr);
+  CORRADE_VERIFY(stageAttrMgr_DS1);
 
   // load datsaet 0 and make active
   initDataset0();
@@ -547,7 +547,7 @@ void MetadataMediatorTest::testDatasetDelete() {
   CORRADE_VERIFY(!MM_->sceneDatasetExists(nameDS1));
 
   // verify deleted scene dataset's stage manager is nullptr
-  CORRADE_COMPARE(stageAttrMgr_DS1, nullptr);
+  CORRADE_VERIFY(!stageAttrMgr_DS1);
 
   // attempt to delete dataset 0 and verify fails - cannot delete active dataset
   CORRADE_VERIFY(!MM_->removeSceneDataset(nameDS0));

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -42,10 +42,9 @@ void Mp3dTest::testLoad() {
                                            alignFront * alignGravity);
   ESP_DEBUG() << "House{nobjects:" << house.count("objects")
               << ",nlevels:" << house.count("levels")
-              << ",nregions:" << house.count("regions") << ",ncategories:"
-              << house.count("categories")
-              //<< ",bbox:" << house.aabb()
-              << "}";
+              << ",nregions:" << house.count("regions")
+              << ",ncategories:" << house.count("categories")
+              << ",bbox:" << Mn::Range3D{house.aabb()} << "}";
   ESP_DEBUG() << "~~~~~~~~~~~ Categories : " << house.categories().size();
   CORRADE_COMPARE(house.categories().size(), 1659);
   for (auto& category : house.categories()) {
@@ -56,20 +55,15 @@ void Mp3dTest::testLoad() {
   ESP_DEBUG() << "~~~~~~~~~~~ Levels : " << house.levels().size();
   CORRADE_COMPARE(house.levels().size(), 1);
   for (auto& level : house.levels()) {
-    ESP_DEBUG() << "Level{id:"
-                << level->id()
-                //<< ",aabb:" << level->aabb()
-                << "}";
+    ESP_DEBUG() << "Level{id:" << level->id()
+                << ",aabb:" << Mn::Range3D{level->aabb()} << "}";
     for (auto& region : level->regions()) {
-      ESP_DEBUG() << "Region{id:"
-                  << region->id()
-                  //<< ",aabb:" << region->aabb()
+      ESP_DEBUG() << "Region{id:" << region->id()
+                  << ",aabb:" << Mn::Range3D{region->aabb()}
                   << ",category:" << region->category()->name()
                   << ",index:" << region->category()->index() << "}";
       for (auto& object : region->objects()) {
-        ESP_DEBUG() << "Object{id:"
-                    << object->id()
-                    //<< ",obb:" << object->obb()
+        ESP_DEBUG() << "Object{id:" << object->id() << ",obb:" << object->obb()
                     << ",category:" << object->category()->name() << "}";
       }  // per object
     }    // per region

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -12,7 +12,7 @@
 
 namespace Cr = Corrade;
 
-namespace Test {
+namespace {
 
 struct Mp3dTest : Cr::TestSuite::Tester {
   explicit Mp3dTest();
@@ -70,6 +70,6 @@ void Mp3dTest::testLoad() {
   }      // per level
 }
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::Mp3dTest)
+CORRADE_TEST_MAIN(Mp3dTest)

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -17,7 +17,7 @@
 
 namespace Cr = Corrade;
 
-namespace Test {
+namespace {
 
 void printPathPoint(int run, int step, const esp::vec3f& p, float distance) {
   ESP_VERY_VERBOSE() << run << "," << step << "," << Mn::Vector3{p} << ","
@@ -185,6 +185,6 @@ void NavTest::PathFinderTestMeshData() {
   CORRADE_COMPARE(meshData->vbo.size(), 63);
   CORRADE_COMPARE(meshData->ibo.size(), 63);
 }
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::NavTest)
+CORRADE_TEST_MAIN(NavTest)

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -156,13 +156,15 @@ void NavTest::PathFinderTestSeed() {
   esp::vec3f firstPoint2 = pf.getRandomNavigablePoint();
   pf.seed(3);
   esp::vec3f secondPoint2 = pf.getRandomNavigablePoint();
-  CORRADE_VERIFY(firstPoint2 != secondPoint2);
+  CORRADE_COMPARE_AS(firstPoint2, secondPoint2,
+                     Cr::TestSuite::Compare::NotEqual);
 
   // One seed should produce different points when sampled twice
   pf.seed(4);
   esp::vec3f firstPoint3 = pf.getRandomNavigablePoint();
   esp::vec3f secondPoint3 = pf.getRandomNavigablePoint();
-  CORRADE_VERIFY(firstPoint3 != secondPoint3);
+  CORRADE_COMPARE_AS(firstPoint3, secondPoint3,
+                     Cr::TestSuite::Compare::NotEqual);
 }
 
 void NavTest::PathFinderTestMeshData() {

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -298,7 +298,8 @@ void PhysicsTest::testCollisionBoundingBox() {
           Magnum::Vector3 position = objectWrapper->getTranslation();
 
           // object is being pushed, so should be moving
-          CORRADE_VERIFY(position != prevPosition);
+          CORRADE_COMPARE_AS(position, prevPosition,
+                             Cr::TestSuite::Compare::NotEqual);
           Magnum::Rad q_angle = Magnum::Math::angle(
               orientation, Magnum::Quaternion({0, 0, 0}, 1));
           if (i == 1) {
@@ -307,7 +308,8 @@ void PhysicsTest::testCollisionBoundingBox() {
                                Cr::TestSuite::Compare::LessOrEqual);
           } else {
             // no bounding box, so the sphere should be rolling
-            CORRADE_VERIFY(orientation != prevOrientation);
+            CORRADE_COMPARE_AS(orientation, prevOrientation,
+                               Cr::TestSuite::Compare::NotEqual);
           }
 
           prevOrientation = orientation;
@@ -756,7 +758,8 @@ void PhysicsTest::testSceneNodeAttachment() {
     objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
     CORRADE_VERIFY(objectWrapper);
     physicsManager_->removeObject(objectWrapper->getID(), true, true);
-    CORRADE_VERIFY(root.children().last() != newNode);
+    CORRADE_COMPARE_AS(root.children().last(), newNode,
+                       Cr::TestSuite::Compare::NotEqual);
   }  // for resetCreateRendererFlag false and true
 }  // PhysicsTest::testSceneNodeAttachment
 

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -37,7 +37,7 @@ const std::string physicsConfigFile =
     Cr::Utility::Directory::join(SCENE_DATASETS,
                                  "../default.physics_config.json");
 
-namespace Test {
+namespace {
 struct PhysicsTest : Cr::TestSuite::Tester {
   explicit PhysicsTest();
 
@@ -1029,6 +1029,6 @@ void PhysicsTest::testRemoveSleepingSupport() {
   }  // for resetCreateRendererFlag false and true
 }  // PhysicsTest::testRemoveSleepingSupport
 
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::PhysicsTest)
+CORRADE_TEST_MAIN(PhysicsTest)

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -148,357 +148,117 @@ struct PhysicsTest : Cr::TestSuite::Tester {
 
   int sceneID_;
 };  // struct PhysicsTest
+const struct {
+  const char* name;
+  bool enabled;
+} RendererEnabledData[]{{"", true}, {"renderer disabled", false}};
 
 PhysicsTest::PhysicsTest() {
-  addTests(
+  addInstancedTests(
       {&PhysicsTest::testJoinCompound, &PhysicsTest::testCollisionBoundingBox,
        &PhysicsTest::testDiscreteContactTest,
        &PhysicsTest::testBulletCompoundShapeMargins,
        &PhysicsTest::testConfigurableScaling, &PhysicsTest::testVelocityControl,
        &PhysicsTest::testSceneNodeAttachment, &PhysicsTest::testMotionTypes,
        &PhysicsTest::testNumActiveContactPoints,
-       &PhysicsTest::testRemoveSleepingSupport});
+       &PhysicsTest::testRemoveSleepingSupport},
+      Cr::Containers::arraySize(RendererEnabledData));
 }
 
 void PhysicsTest::testJoinCompound() {
-  ESP_DEBUG() << "Starting physics test: JoinCompound";
-
   std::string stageFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/scenes/simple_room.glb");
   std::string objectFile = Cr::Utility::Directory::join(
       dataDir, "test_assets/objects/nested_box.glb");
 
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-    initStage(stageFile);
+  initStage(stageFile);
 
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      // if we have a simulation implementation then test a joined vs. unjoined
-      // object
-      // ObjectAttributes ObjectAttributes;
-      ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
-      ObjectAttributes->setRenderAssetHandle(objectFile);
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
-      objectAttributesManager->registerObject(ObjectAttributes, objectFile);
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    // if we have a simulation implementation then test a joined vs. unjoined
+    // object
+    // ObjectAttributes ObjectAttributes;
+    ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
+    ObjectAttributes->setRenderAssetHandle(objectFile);
+    auto objectAttributesManager =
+        metadataMediator_->getObjectAttributesManager();
+    objectAttributesManager->registerObject(ObjectAttributes, objectFile);
 
-      // get a reference to the stored template to edit
-      ObjectAttributes::ptr objectTemplate =
-          objectAttributesManager->getObjectCopyByHandle(objectFile);
+    // get a reference to the stored template to edit
+    ObjectAttributes::ptr objectTemplate =
+        objectAttributesManager->getObjectCopyByHandle(objectFile);
 
-      for (int i = 0; i < 2; i++) {
-        // mark the object not joined
-        if (i == 0) {
-          objectTemplate->setJoinCollisionMeshes(false);
-        } else {
-          objectTemplate->setJoinCollisionMeshes(true);
-        }
-        objectAttributesManager->registerObject(objectTemplate);
-        physicsManager_->reset();
-
-        // add and simulate objects
-        int num_objects = 7;
-        for (int o = 0; o < num_objects; o++) {
-          auto objWrapper = rigidObjectManager_->addObjectByHandle(objectFile);
-
-          esp::scene::SceneNode* node = objWrapper->getSceneNode();
-
-          Magnum::Matrix4 R{
-              Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
-              Magnum::Matrix4::rotationY(Magnum::Math::Rad<float>(-0.25))};
-          float boxHeight = 2.0 + (o * 2);
-          Magnum::Vector3 initialPosition{0.0, boxHeight + 1.5f, 0.0};
-          objWrapper->setRotation(
-              Magnum::Quaternion::fromMatrix(R.rotationNormalized()));
-          objWrapper->setTranslation(initialPosition);
-
-          CORRADE_COMPARE(node->absoluteTranslation(), initialPosition);
-        }
-
-        float timeToSim = 20.0;
-        while (physicsManager_->getWorldTime() < timeToSim) {
-          physicsManager_->stepPhysics(0.1);
-        }
-        int numActiveObjects = physicsManager_->checkActiveObjects();
-        ESP_DEBUG() << "Number of active objects:" << numActiveObjects
-                    << "| Num Total Objects :"
-                    << physicsManager_->getNumRigidObjects();
-
-        if (i == 1) {
-          // when collision meshes are joined, objects should be stable
-          CORRADE_COMPARE(numActiveObjects, 0);
-          CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
-        }
-
-        rigidObjectManager_->removeAllObjects();
+    for (int i = 0; i < 2; i++) {
+      // mark the object not joined
+      if (i == 0) {
+        objectTemplate->setJoinCollisionMeshes(false);
+      } else {
+        objectTemplate->setJoinCollisionMeshes(true);
       }
+      objectAttributesManager->registerObject(objectTemplate);
+      physicsManager_->reset();
+
+      // add and simulate objects
+      int num_objects = 7;
+      for (int o = 0; o < num_objects; o++) {
+        auto objWrapper = rigidObjectManager_->addObjectByHandle(objectFile);
+
+        esp::scene::SceneNode* node = objWrapper->getSceneNode();
+
+        Magnum::Matrix4 R{
+            Magnum::Matrix4::rotationX(Magnum::Math::Rad<float>(-1.56)) *
+            Magnum::Matrix4::rotationY(Magnum::Math::Rad<float>(-0.25))};
+        float boxHeight = 2.0 + (o * 2);
+        Magnum::Vector3 initialPosition{0.0, boxHeight + 1.5f, 0.0};
+        objWrapper->setRotation(
+            Magnum::Quaternion::fromMatrix(R.rotationNormalized()));
+        objWrapper->setTranslation(initialPosition);
+
+        CORRADE_COMPARE(node->absoluteTranslation(), initialPosition);
+      }
+
+      float timeToSim = 20.0;
+      while (physicsManager_->getWorldTime() < timeToSim) {
+        physicsManager_->stepPhysics(0.1);
+      }
+      int numActiveObjects = physicsManager_->checkActiveObjects();
+      ESP_DEBUG() << "Number of active objects:" << numActiveObjects
+                  << "| Num Total Objects :"
+                  << physicsManager_->getNumRigidObjects();
+
+      if (i == 1) {
+        // when collision meshes are joined, objects should be stable
+        CORRADE_COMPARE(numActiveObjects, 0);
+        CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
+      }
+
+      rigidObjectManager_->removeAllObjects();
     }
-  }  // for resetCreateRendererFlag false and true
+  }
 }  // PhysicsTest::testJoinCompound
 
 #ifdef ESP_BUILD_WITH_BULLET
 void PhysicsTest::testCollisionBoundingBox() {
-  ESP_DEBUG() << "Starting physics test: CollisionBoundingBox";
-
   std::string stageFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
   std::string objectFile =
       Cr::Utility::Directory::join(dataDir, "test_assets/objects/sphere.glb");
 
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-    initStage(stageFile);
+  initStage(stageFile);
 
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      // if we have a simulation implementation then test bounding box vs mesh
-      // for sphere object
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    // if we have a simulation implementation then test bounding box vs mesh
+    // for sphere object
 
-      ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
-      ObjectAttributes->setRenderAssetHandle(objectFile);
-      ObjectAttributes->setMargin(0.0);
-      ObjectAttributes->setJoinCollisionMeshes(false);
-
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
-      objectAttributesManager->registerObject(ObjectAttributes, objectFile);
-
-      // get a reference to the stored template to edit
-      ObjectAttributes::ptr objectTemplate =
-          objectAttributesManager->getObjectCopyByHandle(objectFile);
-
-      for (int i = 0; i < 2; i++) {
-        if (i == 0) {
-          objectTemplate->setBoundingBoxCollisions(false);
-        } else {
-          objectTemplate->setBoundingBoxCollisions(true);
-        }
-        objectAttributesManager->registerObject(objectTemplate);
-        physicsManager_->reset();
-
-        auto objectWrapper = makeObjectGetWrapper(
-            objectFile, &sceneManager_->getSceneGraph(sceneID_).getDrawables());
-        CORRADE_VERIFY(objectWrapper);
-
-        Magnum::Vector3 initialPosition{0.0, 0.25, 0.0};
-        objectWrapper->setTranslation(initialPosition);
-
-        Magnum::Quaternion prevOrientation = objectWrapper->getRotation();
-        Magnum::Vector3 prevPosition = objectWrapper->getTranslation();
-        float timeToSim = 3.0;
-        while (physicsManager_->getWorldTime() < timeToSim) {
-          Magnum::Vector3 force{2.0, 0.0, 0.0};
-          objectWrapper->applyForce(force, Magnum::Vector3{});
-          physicsManager_->stepPhysics(0.1);
-
-          Magnum::Quaternion orientation = objectWrapper->getRotation();
-          Magnum::Vector3 position = objectWrapper->getTranslation();
-
-          // object is being pushed, so should be moving
-          CORRADE_COMPARE_AS(position, prevPosition,
-                             Cr::TestSuite::Compare::NotEqual);
-          Magnum::Rad q_angle = Magnum::Math::angle(
-              orientation, Magnum::Quaternion({0, 0, 0}, 1));
-          if (i == 1) {
-            // bounding box for collision, so the sphere should not be rolling
-            CORRADE_COMPARE_AS(q_angle, Magnum::Rad{0.1},
-                               Cr::TestSuite::Compare::LessOrEqual);
-          } else {
-            // no bounding box, so the sphere should be rolling
-            CORRADE_COMPARE_AS(orientation, prevOrientation,
-                               Cr::TestSuite::Compare::NotEqual);
-          }
-
-          prevOrientation = orientation;
-          prevPosition = position;
-        }
-
-        rigidObjectManager_->removePhysObjectByID(objectWrapper->getID());
-      }
-    }
-  }  // for resetCreateRendererFlag false and true
-}  // PhysicsTest::testCollisionBoundingBox
-
-void PhysicsTest::testDiscreteContactTest() {
-  ESP_DEBUG() << "Starting physics test: DiscreteContactTest";
-
-  std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
-
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
-
-    initStage(stageFile);
-
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
-      ObjectAttributes->setRenderAssetHandle(objectFile);
-      ObjectAttributes->setMargin(0.0);
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
-      objectAttributesManager->registerObject(ObjectAttributes, objectFile);
-
-      // generate two centered boxes with dimension 2x2x2
-      auto objWrapper0 = rigidObjectManager_->addObjectByHandle(objectFile);
-      auto objWrapper1 = rigidObjectManager_->addObjectByHandle(objectFile);
-
-      // place them in collision free location (0.1 about ground plane and 0.2
-      // apart)
-      objWrapper0->setTranslation(Magnum::Vector3{0, 1.1, 0});
-      objWrapper1->setTranslation(Magnum::Vector3{2.2, 1.1, 0});
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-
-      // move box 0 into floor
-      objWrapper0->setTranslation(Magnum::Vector3{0, 0.9, 0});
-      CORRADE_VERIFY(objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-      // set box 0 STATIC (STATIC vs STATIC stage)
-      objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      // set box 0 KINEMATIC (KINEMATIC vs STATIC stage)
-      objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      // reset to DYNAMIC
-      objWrapper0->setMotionType(esp::physics::MotionType::DYNAMIC);
-
-      // set stage to non-collidable
-      CORRADE_VERIFY(physicsManager_->getStageIsCollidable());
-      physicsManager_->setStageIsCollidable(false);
-      CORRADE_VERIFY(!physicsManager_->getStageIsCollidable());
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-
-      // move box 0 into box 1
-      objWrapper0->setTranslation(Magnum::Vector3{1.1, 1.1, 0});
-      CORRADE_VERIFY(objWrapper0->contactTest());
-      CORRADE_VERIFY(objWrapper1->contactTest());
-      // set box 0 STATIC (STATIC vs DYNAMIC)
-      objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
-      CORRADE_VERIFY(objWrapper0->contactTest());
-      CORRADE_VERIFY(objWrapper1->contactTest());
-      // set box 1 STATIC (STATIC vs STATIC)
-      objWrapper1->setMotionType(esp::physics::MotionType::STATIC);
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-      // set box 0 KINEMATIC (KINEMATIC vs STATIC)
-      objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-      // set box 1 KINEMATIC (KINEMATIC vs KINEMATIC)
-      objWrapper1->setMotionType(esp::physics::MotionType::KINEMATIC);
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-      // reset box 0 DYNAMIC (DYNAMIC vs KINEMATIC)
-      objWrapper0->setMotionType(esp::physics::MotionType::DYNAMIC);
-      CORRADE_VERIFY(objWrapper0->contactTest());
-      CORRADE_VERIFY(objWrapper1->contactTest());
-
-      // set box 0 to non-collidable
-      CORRADE_VERIFY(objWrapper0->getCollidable());
-      objWrapper0->setCollidable(false);
-      CORRADE_VERIFY(!objWrapper0->getCollidable());
-      CORRADE_VERIFY(!objWrapper0->contactTest());
-      CORRADE_VERIFY(!objWrapper1->contactTest());
-    }
-  }  // for resetCreateRendererFlag false and true
-}  // PhysicsTest::testDiscreteContactTest
-
-void PhysicsTest::testBulletCompoundShapeMargins() {
-  // test that all different construction methods for a simple shape result in
-  // the same Aabb for the given margin
-  ESP_DEBUG() << "Starting physics test: BulletCompoundShapeMargins";
-
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
-
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
-    initStage(objectFile);
-
-    if (physicsManager_->getPhysicsSimulationLibrary() ==
-        PhysicsManager::PhysicsSimulationLibrary::Bullet) {
-      // test joined vs. unjoined
-      ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
-      ObjectAttributes->setRenderAssetHandle(objectFile);
-      ObjectAttributes->setMargin(0.1);
-
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
-      objectAttributesManager->registerObject(ObjectAttributes, objectFile);
-
-      // get a reference to the stored template to edit
-      ObjectAttributes::ptr objectTemplate =
-          objectAttributesManager->getObjectCopyByHandle(objectFile);
-
-      auto* drawables = &sceneManager_->getSceneGraph(sceneID_).getDrawables();
-
-      // add the unjoined object
-      objectTemplate->setJoinCollisionMeshes(false);
-      objectAttributesManager->registerObject(objectTemplate);
-      auto objectWrapper0 = makeObjectGetWrapper(objectFile, drawables);
-      CORRADE_VERIFY(objectWrapper0);
-
-      // add the joined object
-      objectTemplate->setJoinCollisionMeshes(true);
-      objectAttributesManager->registerObject(objectTemplate);
-
-      auto objectWrapper1 = makeObjectGetWrapper(objectFile, drawables);
-      CORRADE_VERIFY(objectWrapper1);
-
-      // add bounding box object
-      objectTemplate->setBoundingBoxCollisions(true);
-      objectAttributesManager->registerObject(objectTemplate);
-      auto objectWrapper2 = makeObjectGetWrapper(objectFile, drawables);
-      CORRADE_VERIFY(objectWrapper2);
-
-      esp::physics::BulletPhysicsManager* bPhysManager =
-          static_cast<esp::physics::BulletPhysicsManager*>(
-              physicsManager_.get());
-
-      const Magnum::Range3D AabbStage =
-          bPhysManager->getStageCollisionShapeAabb();
-
-      const Magnum::Range3D AabbOb0 = objectWrapper0->getCollisionShapeAabb();
-      const Magnum::Range3D AabbOb1 = objectWrapper1->getCollisionShapeAabb();
-      const Magnum::Range3D AabbOb2 = objectWrapper2->getCollisionShapeAabb();
-
-      Magnum::Range3D objectGroundTruth({-1.1, -1.1, -1.1}, {1.1, 1.1, 1.1});
-      Magnum::Range3D stageGroundTruth({-1.04, -1.04, -1.04},
-                                       {1.04, 1.04, 1.04});
-
-      CORRADE_COMPARE(AabbStage, stageGroundTruth);
-      CORRADE_COMPARE(AabbOb0, objectGroundTruth);
-      CORRADE_COMPARE(AabbOb1, objectGroundTruth);
-      CORRADE_COMPARE(AabbOb2, objectGroundTruth);
-    }
-  }  // for resetCreateRendererFlag false and true
-}  // PhysicsTest::testBulletCompoundShapeMargins
-#endif
-
-void PhysicsTest::testConfigurableScaling() {
-  // test scaling of objects via template configuration (visual and collision)
-  ESP_DEBUG() << "Starting physics test: ConfigurableScaling";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
-
-    std::string stageFile =
-        Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
-
-    std::string objectFile = Cr::Utility::Directory::join(
-        dataDir, "test_assets/objects/transform_box.glb");
-
-    initStage(stageFile);
-
-    // test joined vs. unjoined
     ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
     ObjectAttributes->setRenderAssetHandle(objectFile);
     ObjectAttributes->setMargin(0.0);
+    ObjectAttributes->setJoinCollisionMeshes(false);
 
     auto objectAttributesManager =
         metadataMediator_->getObjectAttributesManager();
@@ -508,64 +268,68 @@ void PhysicsTest::testConfigurableScaling() {
     ObjectAttributes::ptr objectTemplate =
         objectAttributesManager->getObjectCopyByHandle(objectFile);
 
-    std::vector<Magnum::Vector3> testScales{
-        {1.0, 1.0, 1.0},  {4.0, 3.0, 2.0},    {0.1, 0.2, 0.3},
-        {0.0, 0.0, 0.0},  {-1.0, -1.0, -1.0}, {-1.0, 1.0, 1.0},
-        {4.0, -3.0, 2.0}, {0.1, -0.2, -0.3}};
-
-    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
-
-    std::vector<int> objectIDs;
-    for (auto& testScale : testScales) {
-      objectTemplate->setScale(testScale);
+    for (int i = 0; i < 2; i++) {
+      if (i == 0) {
+        objectTemplate->setBoundingBoxCollisions(false);
+      } else {
+        objectTemplate->setBoundingBoxCollisions(true);
+      }
       objectAttributesManager->registerObject(objectTemplate);
+      physicsManager_->reset();
 
-      Magnum::Range3D boundsGroundTruth(-abs(testScale), abs(testScale));
-
-      auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables);
+      auto objectWrapper = makeObjectGetWrapper(
+          objectFile, &sceneManager_->getSceneGraph(sceneID_).getDrawables());
       CORRADE_VERIFY(objectWrapper);
 
-      objectIDs.push_back(objectWrapper->getID());
+      Magnum::Vector3 initialPosition{0.0, 0.25, 0.0};
+      objectWrapper->setTranslation(initialPosition);
 
-      const Magnum::Range3D& visualBounds =
-          objectWrapper->getSceneNode()->getCumulativeBB();
+      Magnum::Quaternion prevOrientation = objectWrapper->getRotation();
+      Magnum::Vector3 prevPosition = objectWrapper->getTranslation();
+      float timeToSim = 3.0;
+      while (physicsManager_->getWorldTime() < timeToSim) {
+        Magnum::Vector3 force{2.0, 0.0, 0.0};
+        objectWrapper->applyForce(force, Magnum::Vector3{});
+        physicsManager_->stepPhysics(0.1);
 
-      CORRADE_COMPARE(visualBounds, boundsGroundTruth);
+        Magnum::Quaternion orientation = objectWrapper->getRotation();
+        Magnum::Vector3 position = objectWrapper->getTranslation();
 
-// Test Bullet collision shape scaling
-#ifdef ESP_BUILD_WITH_BULLET
-      if (physicsManager_->getPhysicsSimulationLibrary() ==
-          PhysicsManager::PhysicsSimulationLibrary::Bullet) {
-        Magnum::Range3D aabb = objectWrapper->getCollisionShapeAabb();
+        // object is being pushed, so should be moving
+        CORRADE_COMPARE_AS(position, prevPosition,
+                           Cr::TestSuite::Compare::NotEqual);
+        Magnum::Rad q_angle =
+            Magnum::Math::angle(orientation, Magnum::Quaternion({0, 0, 0}, 1));
+        if (i == 1) {
+          // bounding box for collision, so the sphere should not be rolling
+          CORRADE_COMPARE_AS(q_angle, Magnum::Rad{0.1},
+                             Cr::TestSuite::Compare::LessOrEqual);
+        } else {
+          // no bounding box, so the sphere should be rolling
+          CORRADE_COMPARE_AS(orientation, prevOrientation,
+                             Cr::TestSuite::Compare::NotEqual);
+        }
 
-        CORRADE_COMPARE(aabb, boundsGroundTruth);
+        prevOrientation = orientation;
+        prevPosition = position;
       }
-#endif
+
+      rigidObjectManager_->removePhysObjectByID(objectWrapper->getID());
     }
+  }
+}  // PhysicsTest::testCollisionBoundingBox
 
-    // check that scales are stored and queried correctly
-    for (size_t ix = 0; ix < objectIDs.size(); ix++) {
-      CORRADE_COMPARE(
-          rigidObjectManager_->getObjectCopyByID(objectIDs[ix])->getScale(),
-          testScales[ix]);
-    }
-  }  // for resetCreateRendererFlag false and true
-}  // PhysicsTest::testConfigurableScaling
+void PhysicsTest::testDiscreteContactTest() {
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
 
-void PhysicsTest::testVelocityControl() {
-  // test scaling of objects via template configuration (visual and collision)
-  ESP_DEBUG() << "Starting physics test: TestVelocityControl";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
+  initStage(stageFile);
 
-    std::string objectFile = Cr::Utility::Directory::join(
-        dataDir, "test_assets/objects/transform_box.glb");
-
-    std::string stageFile =
-        Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
-
-    initStage(stageFile);
-
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
     ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
     ObjectAttributes->setRenderAssetHandle(objectFile);
     ObjectAttributes->setMargin(0.0);
@@ -573,463 +337,669 @@ void PhysicsTest::testVelocityControl() {
         metadataMediator_->getObjectAttributesManager();
     objectAttributesManager->registerObject(ObjectAttributes, objectFile);
 
-    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+    // generate two centered boxes with dimension 2x2x2
+    auto objWrapper0 = rigidObjectManager_->addObjectByHandle(objectFile);
+    auto objWrapper1 = rigidObjectManager_->addObjectByHandle(objectFile);
 
-    auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables);
-    CORRADE_VERIFY(objectWrapper);
+    // place them in collision free location (0.1 about ground plane and 0.2
+    // apart)
+    objWrapper0->setTranslation(Magnum::Vector3{0, 1.1, 0});
+    objWrapper1->setTranslation(Magnum::Vector3{2.2, 1.1, 0});
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
 
-    objectWrapper->setTranslation(Magnum::Vector3{0, 1.0, 0});
+    // move box 0 into floor
+    objWrapper0->setTranslation(Magnum::Vector3{0, 0.9, 0});
+    CORRADE_VERIFY(objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
+    // set box 0 STATIC (STATIC vs STATIC stage)
+    objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    // set box 0 KINEMATIC (KINEMATIC vs STATIC stage)
+    objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    // reset to DYNAMIC
+    objWrapper0->setMotionType(esp::physics::MotionType::DYNAMIC);
 
-    Magnum::Vector3 commandLinVel(1.0, 1.0, 1.0);
-    Magnum::Vector3 commandAngVel(1.0, 1.0, 1.0);
+    // set stage to non-collidable
+    CORRADE_VERIFY(physicsManager_->getStageIsCollidable());
+    physicsManager_->setStageIsCollidable(false);
+    CORRADE_VERIFY(!physicsManager_->getStageIsCollidable());
+    CORRADE_VERIFY(!objWrapper0->contactTest());
 
-    // test results of getting/setting
-    if (physicsManager_->getPhysicsSimulationLibrary() ==
-        PhysicsManager::PhysicsSimulationLibrary::Bullet) {
-      objectWrapper->setLinearVelocity(commandLinVel);
-      objectWrapper->setAngularVelocity(commandAngVel);
+    // move box 0 into box 1
+    objWrapper0->setTranslation(Magnum::Vector3{1.1, 1.1, 0});
+    CORRADE_VERIFY(objWrapper0->contactTest());
+    CORRADE_VERIFY(objWrapper1->contactTest());
+    // set box 0 STATIC (STATIC vs DYNAMIC)
+    objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
+    CORRADE_VERIFY(objWrapper0->contactTest());
+    CORRADE_VERIFY(objWrapper1->contactTest());
+    // set box 1 STATIC (STATIC vs STATIC)
+    objWrapper1->setMotionType(esp::physics::MotionType::STATIC);
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
+    // set box 0 KINEMATIC (KINEMATIC vs STATIC)
+    objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
+    // set box 1 KINEMATIC (KINEMATIC vs KINEMATIC)
+    objWrapper1->setMotionType(esp::physics::MotionType::KINEMATIC);
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
+    // reset box 0 DYNAMIC (DYNAMIC vs KINEMATIC)
+    objWrapper0->setMotionType(esp::physics::MotionType::DYNAMIC);
+    CORRADE_VERIFY(objWrapper0->contactTest());
+    CORRADE_VERIFY(objWrapper1->contactTest());
 
-      CORRADE_COMPARE(objectWrapper->getLinearVelocity(), commandLinVel);
-      CORRADE_COMPARE(objectWrapper->getAngularVelocity(), commandAngVel);
+    // set box 0 to non-collidable
+    CORRADE_VERIFY(objWrapper0->getCollidable());
+    objWrapper0->setCollidable(false);
+    CORRADE_VERIFY(!objWrapper0->getCollidable());
+    CORRADE_VERIFY(!objWrapper0->contactTest());
+    CORRADE_VERIFY(!objWrapper1->contactTest());
+  }
+}  // PhysicsTest::testDiscreteContactTest
 
-    } else if (physicsManager_->getPhysicsSimulationLibrary() ==
-               PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      objectWrapper->setLinearVelocity(commandLinVel);
-      objectWrapper->setAngularVelocity(commandAngVel);
+void PhysicsTest::testBulletCompoundShapeMargins() {
+  // test that all different construction methods for a simple shape result in
+  // the same Aabb for the given margin
 
-      // default kinematics always 0 velocity when queried
-      CORRADE_COMPARE(objectWrapper->getLinearVelocity(), Magnum::Vector3{});
-      CORRADE_COMPARE(objectWrapper->getAngularVelocity(), Magnum::Vector3{});
-    }
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
 
-    // test constant velocity control mechanism
-    esp::physics::VelocityControl::ptr velControl =
-        objectWrapper->getVelocityControl();
-    velControl->controllingAngVel = true;
-    velControl->controllingLinVel = true;
-    velControl->linVel = Magnum::Vector3{1.0, -1.0, 1.0};
-    velControl->angVel = Magnum::Vector3{1.0, 0, 0};
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
+  initStage(objectFile);
 
-    // first kinematic
-    objectWrapper->setMotionType(esp::physics::MotionType::KINEMATIC);
-    objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
-
-    float targetTime = 2.0;
-    while (physicsManager_->getWorldTime() < targetTime) {
-      physicsManager_->stepPhysics(targetTime -
-                                   physicsManager_->getWorldTime());
-    }
-    Magnum::Vector3 posGroundTruth{2.0, 0.0, 2.0};
-    Magnum::Quaternion qGroundTruth{{0.842602, 0, 0}, 0.538537};
-
-    float errorEps = 0.015;  // fairly loose due to discrete timestep
-    CORRADE_COMPARE_AS(
-        (objectWrapper->getTranslation() - posGroundTruth).length(), errorEps,
-        Cr::TestSuite::Compare::LessOrEqual);
-    Magnum::Rad angleError =
-        Magnum::Math::angle(objectWrapper->getRotation(), qGroundTruth);
-
-    CORRADE_COMPARE_AS(float(angleError), errorEps,
-                       Cr::TestSuite::Compare::LessOrEqual);
-
-    if (physicsManager_->getPhysicsSimulationLibrary() ==
-        PhysicsManager::PhysicsSimulationLibrary::Bullet) {
-      objectWrapper->setMotionType(esp::physics::MotionType::DYNAMIC);
-      objectWrapper->resetTransformation();
-      objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
-      physicsManager_->setGravity({});  // 0 gravity interference
-      physicsManager_->reset();         // reset time to 0
-
-      // should closely follow kinematic result while uninhibited in 0 gravity
-      float targetTime = 0.5;
-      esp::core::RigidState initialObjectState(objectWrapper->getRotation(),
-                                               objectWrapper->getTranslation());
-      esp::core::RigidState kinematicResult =
-          velControl->integrateTransform(targetTime, initialObjectState);
-      while (physicsManager_->getWorldTime() < targetTime) {
-        physicsManager_->stepPhysics(physicsManager_->getTimestep());
-      }
-      CORRADE_COMPARE_AS(
-          (objectWrapper->getTranslation() - kinematicResult.translation)
-              .length(),
-          errorEps, Cr::TestSuite::Compare::LessOrEqual);
-      angleError = Magnum::Math::angle(objectWrapper->getRotation(),
-                                       kinematicResult.rotation);
-      CORRADE_COMPARE_AS(float(angleError), errorEps,
-                         Cr::TestSuite::Compare::LessOrEqual);
-
-      // should then get blocked by ground plane collision
-      targetTime = 2.0;
-      while (physicsManager_->getWorldTime() < targetTime) {
-        physicsManager_->stepPhysics(physicsManager_->getTimestep());
-      }
-      CORRADE_COMPARE_AS(objectWrapper->getTranslation()[1], 1.0 - errorEps,
-                         Cr::TestSuite::Compare::GreaterOrEqual);
-    }
-
-    // test local velocity
-    objectWrapper->setMotionType(esp::physics::MotionType::KINEMATIC);
-    objectWrapper->resetTransformation();
-    objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
-
-    velControl->linVel = Magnum::Vector3{0.0, 0.0, -1.0};
-    velControl->angVel = Magnum::Vector3{1.0, 0, 0};
-    velControl->angVelIsLocal = true;
-    velControl->linVelIsLocal = true;
-
-    targetTime = 10.0;
-    physicsManager_->reset();  // reset time to 0
-    while (physicsManager_->getWorldTime() < targetTime) {
-      physicsManager_->stepPhysics(physicsManager_->getTimestep());
-    }
-
-    Magnum::Vector3 posLocalGroundTruth{0, 3.83589, 0.543553};
-    Magnum::Quaternion qLocalGroundTruth{{-0.95782, 0, 0}, 0.287495};
-    qLocalGroundTruth = qLocalGroundTruth.normalized();
-
-    // test zero velocity kinematic integration (should not change state)
-    velControl->linVel = Magnum::Vector3{0.0, 0.0, 0.0};
-    velControl->angVel = Magnum::Vector3{0.0, 0.0, 0.0};
-    physicsManager_->stepPhysics(physicsManager_->getTimestep());
-
-    CORRADE_COMPARE_AS(
-        (objectWrapper->getTranslation() - posLocalGroundTruth).length(),
-        errorEps, Cr::TestSuite::Compare::LessOrEqual);
-    Magnum::Rad angleErrorLocal =
-        Magnum::Math::angle(objectWrapper->getRotation(), qLocalGroundTruth);
-
-    CORRADE_COMPARE_AS(float(angleErrorLocal), errorEps,
-                       Cr::TestSuite::Compare::LessOrEqual);
-  }  // for resetCreateRendererFlag false and true
-}  // PhysicsTest::testVelocityControl
-
-void PhysicsTest::testSceneNodeAttachment() {
-  // test attaching/detaching existing SceneNode to/from physical simulation
-  ESP_DEBUG() << "Starting physics test: TestSceneNodeAttachment";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
-
-    std::string objectFile = Cr::Utility::Directory::join(
-        dataDir, "test_assets/objects/transform_box.glb");
-
-    std::string stageFile =
-        Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
-
-    initStage(stageFile);
-
+  if (physicsManager_->getPhysicsSimulationLibrary() ==
+      PhysicsManager::PhysicsSimulationLibrary::Bullet) {
+    // test joined vs. unjoined
     ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
     ObjectAttributes->setRenderAssetHandle(objectFile);
+    ObjectAttributes->setMargin(0.1);
+
     auto objectAttributesManager =
         metadataMediator_->getObjectAttributesManager();
     objectAttributesManager->registerObject(ObjectAttributes, objectFile);
 
-    esp::scene::SceneNode& root =
-        sceneManager_->getSceneGraph(sceneID_).getRootNode();
-    esp::scene::SceneNode* newNode = &root.createChild();
-    CORRADE_COMPARE(root.children().last(), newNode);
+    // get a reference to the stored template to edit
+    ObjectAttributes::ptr objectTemplate =
+        objectAttributesManager->getObjectCopyByHandle(objectFile);
 
-    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+    auto* drawables = &sceneManager_->getSceneGraph(sceneID_).getDrawables();
 
-    // Test attaching newNode to a RigidBody
+    // add the unjoined object
+    objectTemplate->setJoinCollisionMeshes(false);
+    objectAttributesManager->registerObject(objectTemplate);
+    auto objectWrapper0 = makeObjectGetWrapper(objectFile, drawables);
+    CORRADE_VERIFY(objectWrapper0);
 
-    auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
+    // add the joined object
+    objectTemplate->setJoinCollisionMeshes(true);
+    objectAttributesManager->registerObject(objectTemplate);
+
+    auto objectWrapper1 = makeObjectGetWrapper(objectFile, drawables);
+    CORRADE_VERIFY(objectWrapper1);
+
+    // add bounding box object
+    objectTemplate->setBoundingBoxCollisions(true);
+    objectAttributesManager->registerObject(objectTemplate);
+    auto objectWrapper2 = makeObjectGetWrapper(objectFile, drawables);
+    CORRADE_VERIFY(objectWrapper2);
+
+    esp::physics::BulletPhysicsManager* bPhysManager =
+        static_cast<esp::physics::BulletPhysicsManager*>(physicsManager_.get());
+
+    const Magnum::Range3D AabbStage =
+        bPhysManager->getStageCollisionShapeAabb();
+
+    const Magnum::Range3D AabbOb0 = objectWrapper0->getCollisionShapeAabb();
+    const Magnum::Range3D AabbOb1 = objectWrapper1->getCollisionShapeAabb();
+    const Magnum::Range3D AabbOb2 = objectWrapper2->getCollisionShapeAabb();
+
+    Magnum::Range3D objectGroundTruth({-1.1, -1.1, -1.1}, {1.1, 1.1, 1.1});
+    Magnum::Range3D stageGroundTruth({-1.04, -1.04, -1.04}, {1.04, 1.04, 1.04});
+
+    CORRADE_COMPARE(AabbStage, stageGroundTruth);
+    CORRADE_COMPARE(AabbOb0, objectGroundTruth);
+    CORRADE_COMPARE(AabbOb1, objectGroundTruth);
+    CORRADE_COMPARE(AabbOb2, objectGroundTruth);
+  }
+}  // PhysicsTest::testBulletCompoundShapeMargins
+#endif
+
+void PhysicsTest::testConfigurableScaling() {
+  // test scaling of objects via template configuration (visual and collision)
+
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
+
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
+
+  initStage(stageFile);
+
+  // test joined vs. unjoined
+  ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
+  ObjectAttributes->setRenderAssetHandle(objectFile);
+  ObjectAttributes->setMargin(0.0);
+
+  auto objectAttributesManager =
+      metadataMediator_->getObjectAttributesManager();
+  objectAttributesManager->registerObject(ObjectAttributes, objectFile);
+
+  // get a reference to the stored template to edit
+  ObjectAttributes::ptr objectTemplate =
+      objectAttributesManager->getObjectCopyByHandle(objectFile);
+
+  std::vector<Magnum::Vector3> testScales{
+      {1.0, 1.0, 1.0},  {4.0, 3.0, 2.0},    {0.1, 0.2, 0.3},
+      {0.0, 0.0, 0.0},  {-1.0, -1.0, -1.0}, {-1.0, 1.0, 1.0},
+      {4.0, -3.0, 2.0}, {0.1, -0.2, -0.3}};
+
+  auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+
+  std::vector<int> objectIDs;
+  for (auto& testScale : testScales) {
+    objectTemplate->setScale(testScale);
+    objectAttributesManager->registerObject(objectTemplate);
+
+    Magnum::Range3D boundsGroundTruth(-abs(testScale), abs(testScale));
+
+    auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables);
     CORRADE_VERIFY(objectWrapper);
 
-    CORRADE_COMPARE(objectWrapper->getSceneNode(), newNode);
+    objectIDs.push_back(objectWrapper->getID());
 
-    // Test updating newNode position with PhysicsManager
-    Magnum::Vector3 newPos{1.0, 3.0, 0.0};
-    objectWrapper->setTranslation(newPos);
-    CORRADE_COMPARE(objectWrapper->getTranslation(), newPos);
-    CORRADE_COMPARE(newNode->translation(), newPos);
+    const Magnum::Range3D& visualBounds =
+        objectWrapper->getSceneNode()->getCumulativeBB();
 
-    // Test leaving newNode without visualNode_ after destroying the RigidBody
-    physicsManager_->removeObject(objectWrapper->getID(), false, true);
-    CORRADE_VERIFY(newNode->children().isEmpty());
+    CORRADE_COMPARE(visualBounds, boundsGroundTruth);
 
-    // Test leaving the visualNode attached to newNode after destroying the
-    // RigidBody
-    objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
-    CORRADE_VERIFY(objectWrapper);
-    physicsManager_->removeObject(objectWrapper->getID(), false, false);
-    CORRADE_VERIFY(!newNode->children().isEmpty());
+// Test Bullet collision shape scaling
+#ifdef ESP_BUILD_WITH_BULLET
+    if (physicsManager_->getPhysicsSimulationLibrary() ==
+        PhysicsManager::PhysicsSimulationLibrary::Bullet) {
+      Magnum::Range3D aabb = objectWrapper->getCollisionShapeAabb();
 
-    // Test destroying newNode with the RigidBody
-    objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
-    CORRADE_VERIFY(objectWrapper);
-    physicsManager_->removeObject(objectWrapper->getID(), true, true);
-    CORRADE_COMPARE_AS(root.children().last(), newNode,
-                       Cr::TestSuite::Compare::NotEqual);
-  }  // for resetCreateRendererFlag false and true
+      CORRADE_COMPARE(aabb, boundsGroundTruth);
+    }
+#endif
+  }
+
+  // check that scales are stored and queried correctly
+  for (size_t ix = 0; ix < objectIDs.size(); ix++) {
+    CORRADE_COMPARE(
+        rigidObjectManager_->getObjectCopyByID(objectIDs[ix])->getScale(),
+        testScales[ix]);
+  }
+}  // PhysicsTest::testConfigurableScaling
+
+void PhysicsTest::testVelocityControl() {
+  // test scaling of objects via template configuration (visual and collision)
+
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
+
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
+
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+
+  initStage(stageFile);
+
+  ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
+  ObjectAttributes->setRenderAssetHandle(objectFile);
+  ObjectAttributes->setMargin(0.0);
+  auto objectAttributesManager =
+      metadataMediator_->getObjectAttributesManager();
+  objectAttributesManager->registerObject(ObjectAttributes, objectFile);
+
+  auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+
+  auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables);
+  CORRADE_VERIFY(objectWrapper);
+
+  objectWrapper->setTranslation(Magnum::Vector3{0, 1.0, 0});
+
+  Magnum::Vector3 commandLinVel(1.0, 1.0, 1.0);
+  Magnum::Vector3 commandAngVel(1.0, 1.0, 1.0);
+
+  // test results of getting/setting
+  if (physicsManager_->getPhysicsSimulationLibrary() ==
+      PhysicsManager::PhysicsSimulationLibrary::Bullet) {
+    objectWrapper->setLinearVelocity(commandLinVel);
+    objectWrapper->setAngularVelocity(commandAngVel);
+
+    CORRADE_COMPARE(objectWrapper->getLinearVelocity(), commandLinVel);
+    CORRADE_COMPARE(objectWrapper->getAngularVelocity(), commandAngVel);
+
+  } else if (physicsManager_->getPhysicsSimulationLibrary() ==
+             PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    objectWrapper->setLinearVelocity(commandLinVel);
+    objectWrapper->setAngularVelocity(commandAngVel);
+
+    // default kinematics always 0 velocity when queried
+    CORRADE_COMPARE(objectWrapper->getLinearVelocity(), Magnum::Vector3{});
+    CORRADE_COMPARE(objectWrapper->getAngularVelocity(), Magnum::Vector3{});
+  }
+
+  // test constant velocity control mechanism
+  esp::physics::VelocityControl::ptr velControl =
+      objectWrapper->getVelocityControl();
+  velControl->controllingAngVel = true;
+  velControl->controllingLinVel = true;
+  velControl->linVel = Magnum::Vector3{1.0, -1.0, 1.0};
+  velControl->angVel = Magnum::Vector3{1.0, 0, 0};
+
+  // first kinematic
+  objectWrapper->setMotionType(esp::physics::MotionType::KINEMATIC);
+  objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
+
+  float targetTime = 2.0;
+  while (physicsManager_->getWorldTime() < targetTime) {
+    physicsManager_->stepPhysics(targetTime - physicsManager_->getWorldTime());
+  }
+  Magnum::Vector3 posGroundTruth{2.0, 0.0, 2.0};
+  Magnum::Quaternion qGroundTruth{{0.842602, 0, 0}, 0.538537};
+
+  float errorEps = 0.015;  // fairly loose due to discrete timestep
+  CORRADE_COMPARE_AS(
+      (objectWrapper->getTranslation() - posGroundTruth).length(), errorEps,
+      Cr::TestSuite::Compare::LessOrEqual);
+  Magnum::Rad angleError =
+      Magnum::Math::angle(objectWrapper->getRotation(), qGroundTruth);
+
+  CORRADE_COMPARE_AS(float(angleError), errorEps,
+                     Cr::TestSuite::Compare::LessOrEqual);
+
+  if (physicsManager_->getPhysicsSimulationLibrary() ==
+      PhysicsManager::PhysicsSimulationLibrary::Bullet) {
+    objectWrapper->setMotionType(esp::physics::MotionType::DYNAMIC);
+    objectWrapper->resetTransformation();
+    objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
+    physicsManager_->setGravity({});  // 0 gravity interference
+    physicsManager_->reset();         // reset time to 0
+
+    // should closely follow kinematic result while uninhibited in 0 gravity
+    float targetTime = 0.5;
+    esp::core::RigidState initialObjectState(objectWrapper->getRotation(),
+                                             objectWrapper->getTranslation());
+    esp::core::RigidState kinematicResult =
+        velControl->integrateTransform(targetTime, initialObjectState);
+    while (physicsManager_->getWorldTime() < targetTime) {
+      physicsManager_->stepPhysics(physicsManager_->getTimestep());
+    }
+    CORRADE_COMPARE_AS(
+        (objectWrapper->getTranslation() - kinematicResult.translation)
+            .length(),
+        errorEps, Cr::TestSuite::Compare::LessOrEqual);
+    angleError = Magnum::Math::angle(objectWrapper->getRotation(),
+                                     kinematicResult.rotation);
+    CORRADE_COMPARE_AS(float(angleError), errorEps,
+                       Cr::TestSuite::Compare::LessOrEqual);
+
+    // should then get blocked by ground plane collision
+    targetTime = 2.0;
+    while (physicsManager_->getWorldTime() < targetTime) {
+      physicsManager_->stepPhysics(physicsManager_->getTimestep());
+    }
+    CORRADE_COMPARE_AS(objectWrapper->getTranslation()[1], 1.0 - errorEps,
+                       Cr::TestSuite::Compare::GreaterOrEqual);
+  }
+
+  // test local velocity
+  objectWrapper->setMotionType(esp::physics::MotionType::KINEMATIC);
+  objectWrapper->resetTransformation();
+  objectWrapper->setTranslation(Magnum::Vector3{0, 2.0, 0});
+
+  velControl->linVel = Magnum::Vector3{0.0, 0.0, -1.0};
+  velControl->angVel = Magnum::Vector3{1.0, 0, 0};
+  velControl->angVelIsLocal = true;
+  velControl->linVelIsLocal = true;
+
+  targetTime = 10.0;
+  physicsManager_->reset();  // reset time to 0
+  while (physicsManager_->getWorldTime() < targetTime) {
+    physicsManager_->stepPhysics(physicsManager_->getTimestep());
+  }
+
+  Magnum::Vector3 posLocalGroundTruth{0, 3.83589, 0.543553};
+  Magnum::Quaternion qLocalGroundTruth{{-0.95782, 0, 0}, 0.287495};
+  qLocalGroundTruth = qLocalGroundTruth.normalized();
+
+  // test zero velocity kinematic integration (should not change state)
+  velControl->linVel = Magnum::Vector3{0.0, 0.0, 0.0};
+  velControl->angVel = Magnum::Vector3{0.0, 0.0, 0.0};
+  physicsManager_->stepPhysics(physicsManager_->getTimestep());
+
+  CORRADE_COMPARE_AS(
+      (objectWrapper->getTranslation() - posLocalGroundTruth).length(),
+      errorEps, Cr::TestSuite::Compare::LessOrEqual);
+  Magnum::Rad angleErrorLocal =
+      Magnum::Math::angle(objectWrapper->getRotation(), qLocalGroundTruth);
+
+  CORRADE_COMPARE_AS(float(angleErrorLocal), errorEps,
+                     Cr::TestSuite::Compare::LessOrEqual);
+}  // PhysicsTest::testVelocityControl
+
+void PhysicsTest::testSceneNodeAttachment() {
+  // test attaching/detaching existing SceneNode to/from physical simulation
+
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
+
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
+
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+
+  initStage(stageFile);
+
+  ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
+  ObjectAttributes->setRenderAssetHandle(objectFile);
+  auto objectAttributesManager =
+      metadataMediator_->getObjectAttributesManager();
+  objectAttributesManager->registerObject(ObjectAttributes, objectFile);
+
+  esp::scene::SceneNode& root =
+      sceneManager_->getSceneGraph(sceneID_).getRootNode();
+  esp::scene::SceneNode* newNode = &root.createChild();
+  CORRADE_COMPARE(root.children().last(), newNode);
+
+  auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+
+  // Test attaching newNode to a RigidBody
+
+  auto objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
+  CORRADE_VERIFY(objectWrapper);
+
+  CORRADE_COMPARE(objectWrapper->getSceneNode(), newNode);
+
+  // Test updating newNode position with PhysicsManager
+  Magnum::Vector3 newPos{1.0, 3.0, 0.0};
+  objectWrapper->setTranslation(newPos);
+  CORRADE_COMPARE(objectWrapper->getTranslation(), newPos);
+  CORRADE_COMPARE(newNode->translation(), newPos);
+
+  // Test leaving newNode without visualNode_ after destroying the RigidBody
+  physicsManager_->removeObject(objectWrapper->getID(), false, true);
+  CORRADE_VERIFY(newNode->children().isEmpty());
+
+  // Test leaving the visualNode attached to newNode after destroying the
+  // RigidBody
+  objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
+  CORRADE_VERIFY(objectWrapper);
+  physicsManager_->removeObject(objectWrapper->getID(), false, false);
+  CORRADE_VERIFY(!newNode->children().isEmpty());
+
+  // Test destroying newNode with the RigidBody
+  objectWrapper = makeObjectGetWrapper(objectFile, &drawables, newNode);
+  CORRADE_VERIFY(objectWrapper);
+  physicsManager_->removeObject(objectWrapper->getID(), true, true);
+  CORRADE_COMPARE_AS(root.children().last(), newNode,
+                     Cr::TestSuite::Compare::NotEqual);
 }  // PhysicsTest::testSceneNodeAttachment
 
 void PhysicsTest::testMotionTypes() {
   // test setting motion types and expected simulation behaviors
-  ESP_DEBUG() << "Starting physics test: TestMotionTypes";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
 
-    std::string objectFile = Cr::Utility::Directory::join(
-        dataDir, "test_assets/objects/transform_box.glb");
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-    std::string stageFile =
-        Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+  std::string objectFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/objects/transform_box.glb");
 
-    initStage(stageFile);
+  std::string stageFile =
+      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
 
-    // ensure that changing default timestep does not affect results
-    physicsManager_->setTimestep(0.0041666666);
+  initStage(stageFile);
 
-    // We need dynamics to test this.
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      float boxHalfExtent = 0.2;
+  // ensure that changing default timestep does not affect results
+  physicsManager_->setTimestep(0.0041666666);
 
-      ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
-      ObjectAttributes->setRenderAssetHandle(objectFile);
-      ObjectAttributes->setBoundingBoxCollisions(true);
-      ObjectAttributes->setScale({boxHalfExtent, boxHalfExtent, boxHalfExtent});
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
+  // We need dynamics to test this.
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    float boxHalfExtent = 0.2;
 
-      int boxId =
-          objectAttributesManager->registerObject(ObjectAttributes, objectFile);
-      auto objTemplate = objectAttributesManager->getObjectByID(boxId);
+    ObjectAttributes::ptr ObjectAttributes = ObjectAttributes::create();
+    ObjectAttributes->setRenderAssetHandle(objectFile);
+    ObjectAttributes->setBoundingBoxCollisions(true);
+    ObjectAttributes->setScale({boxHalfExtent, boxHalfExtent, boxHalfExtent});
+    auto objectAttributesManager =
+        metadataMediator_->getObjectAttributesManager();
 
-      auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+    int boxId =
+        objectAttributesManager->registerObject(ObjectAttributes, objectFile);
+    auto objTemplate = objectAttributesManager->getObjectByID(boxId);
 
-      float stageCollisionMargin = 0.04;
+    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
 
-      for (int testId = 0; testId < 3; testId++) {
-        auto objWrapper0 =
-            makeObjectGetWrapper(objTemplate->getHandle(), &drawables);
-        auto objWrapper1 =
-            makeObjectGetWrapper(objTemplate->getHandle(), &drawables);
+    float stageCollisionMargin = 0.04;
 
-        switch (testId) {
-          case 0: {
-            // test 0: stacking two DYNAMIC objects
-            objWrapper0->setTranslation(
-                {0, stageCollisionMargin + boxHalfExtent, 0});
-            objWrapper1->setTranslation(
-                {0, stageCollisionMargin + boxHalfExtent * 3, 0});
+    for (int testId = 0; testId < 3; testId++) {
+      auto objWrapper0 =
+          makeObjectGetWrapper(objTemplate->getHandle(), &drawables);
+      auto objWrapper1 =
+          makeObjectGetWrapper(objTemplate->getHandle(), &drawables);
 
-            while (physicsManager_->getWorldTime() < 6.0) {
-              physicsManager_->stepPhysics(0.1);
-            }
-            CORRADE_VERIFY(!objWrapper0->isActive());
-            CORRADE_VERIFY(!objWrapper1->isActive());
-            CORRADE_COMPARE_AS(
-                (objWrapper0->getTranslation() -
-                 Magnum::Vector3{0.0, stageCollisionMargin + boxHalfExtent,
-                                 0.0})
-                    .length(),
-                1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
-            CORRADE_COMPARE_AS(
-                (objWrapper1->getTranslation() -
-                 Magnum::Vector3{0.0, stageCollisionMargin + boxHalfExtent * 3,
-                                 0.0})
-                    .length(),
-                1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
-          } break;
-          case 1: {
-            // test 1: stacking a DYNAMIC object on a STATIC object
-            objWrapper0->setTranslation({0, boxHalfExtent * 2, 0});
-            objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
-            objWrapper1->setTranslation({0, boxHalfExtent * 5, 0});
+      switch (testId) {
+        case 0: {
+          // test 0: stacking two DYNAMIC objects
+          objWrapper0->setTranslation(
+              {0, stageCollisionMargin + boxHalfExtent, 0});
+          objWrapper1->setTranslation(
+              {0, stageCollisionMargin + boxHalfExtent * 3, 0});
 
-            while (physicsManager_->getWorldTime() < 6.0) {
-              physicsManager_->stepPhysics(0.1);
-            }
-            CORRADE_VERIFY(!objWrapper1->isActive());
-            CORRADE_COMPARE_AS((objWrapper0->getTranslation() -
-                                Magnum::Vector3{0.0, boxHalfExtent * 2, 0.0})
-                                   .length(),
-                               1.0e-4, Cr::TestSuite::Compare::LessOrEqual);
-            CORRADE_COMPARE_AS((objWrapper1->getTranslation() -
-                                Magnum::Vector3{0.0, boxHalfExtent * 4, 0.0})
-                                   .length(),
-                               2.0e-4, Cr::TestSuite::Compare::LessOrEqual);
-          } break;
-          case 2: {
-            // test 2: stacking a DYNAMIC object on a moving KINEMATIC object
-            objWrapper0->setTranslation({0, boxHalfExtent * 2, 0});
-            objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
+          while (physicsManager_->getWorldTime() < 6.0) {
+            physicsManager_->stepPhysics(0.1);
+          }
+          CORRADE_VERIFY(!objWrapper0->isActive());
+          CORRADE_VERIFY(!objWrapper1->isActive());
+          CORRADE_COMPARE_AS(
+              (objWrapper0->getTranslation() -
+               Magnum::Vector3{0.0, stageCollisionMargin + boxHalfExtent, 0.0})
+                  .length(),
+              1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
+          CORRADE_COMPARE_AS(
+              (objWrapper1->getTranslation() -
+               Magnum::Vector3{0.0, stageCollisionMargin + boxHalfExtent * 3,
+                               0.0})
+                  .length(),
+              1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
+        } break;
+        case 1: {
+          // test 1: stacking a DYNAMIC object on a STATIC object
+          objWrapper0->setTranslation({0, boxHalfExtent * 2, 0});
+          objWrapper0->setMotionType(esp::physics::MotionType::STATIC);
+          objWrapper1->setTranslation({0, boxHalfExtent * 5, 0});
 
-            esp::physics::VelocityControl::ptr velCon =
-                objWrapper0->getVelocityControl();
-            velCon->controllingLinVel = true;
-            velCon->linVel = {0.2, 0, 0};
+          while (physicsManager_->getWorldTime() < 6.0) {
+            physicsManager_->stepPhysics(0.1);
+          }
+          CORRADE_VERIFY(!objWrapper1->isActive());
+          CORRADE_COMPARE_AS((objWrapper0->getTranslation() -
+                              Magnum::Vector3{0.0, boxHalfExtent * 2, 0.0})
+                                 .length(),
+                             1.0e-4, Cr::TestSuite::Compare::LessOrEqual);
+          CORRADE_COMPARE_AS((objWrapper1->getTranslation() -
+                              Magnum::Vector3{0.0, boxHalfExtent * 4, 0.0})
+                                 .length(),
+                             2.0e-4, Cr::TestSuite::Compare::LessOrEqual);
+        } break;
+        case 2: {
+          // test 2: stacking a DYNAMIC object on a moving KINEMATIC object
+          objWrapper0->setTranslation({0, boxHalfExtent * 2, 0});
+          objWrapper0->setMotionType(esp::physics::MotionType::KINEMATIC);
 
-            objWrapper1->setTranslation({0, boxHalfExtent * 5, 0});
+          esp::physics::VelocityControl::ptr velCon =
+              objWrapper0->getVelocityControl();
+          velCon->controllingLinVel = true;
+          velCon->linVel = {0.2, 0, 0};
 
-            while (physicsManager_->getWorldTime() < 3.0) {
-              // take single sub-steps for velocity control precision
-              physicsManager_->stepPhysics(-1);
-            }
-            CORRADE_COMPARE_AS((objWrapper0->getTranslation() -
-                                Magnum::Vector3{0.6, boxHalfExtent * 2, 0.0})
-                                   .length(),
-                               1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
-            CORRADE_COMPARE_AS(
-                (objWrapper1->getTranslation() -
-                 Magnum::Vector3{0.559155, boxHalfExtent * 4, 0.0})
-                    .length(),
-                2.0e-3, Cr::TestSuite::Compare::LessOrEqual);
-          } break;
-        }
+          objWrapper1->setTranslation({0, boxHalfExtent * 5, 0});
 
-        // reset the scene
-        rigidObjectManager_->removeAllObjects();
-        physicsManager_->reset();  // time=0
+          while (physicsManager_->getWorldTime() < 3.0) {
+            // take single sub-steps for velocity control precision
+            physicsManager_->stepPhysics(-1);
+          }
+          CORRADE_COMPARE_AS((objWrapper0->getTranslation() -
+                              Magnum::Vector3{0.6, boxHalfExtent * 2, 0.0})
+                                 .length(),
+                             1.0e-3, Cr::TestSuite::Compare::LessOrEqual);
+          CORRADE_COMPARE_AS((objWrapper1->getTranslation() -
+                              Magnum::Vector3{0.559155, boxHalfExtent * 4, 0.0})
+                                 .length(),
+                             2.0e-3, Cr::TestSuite::Compare::LessOrEqual);
+        } break;
       }
+
+      // reset the scene
+      rigidObjectManager_->removeAllObjects();
+      physicsManager_->reset();  // time=0
     }
-  }  // for resetCreateRendererFlag false and true
+  }
 }  // PhysicsTest::testMotionTypes
 
 void PhysicsTest::testNumActiveContactPoints() {
-  ESP_DEBUG() << "Starting physics test: TestNumActiveContactPoints";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-    std::string stageFile = Cr::Utility::Directory::join(
-        dataDir, "test_assets/scenes/simple_room.glb");
+  std::string stageFile = Cr::Utility::Directory::join(
+      dataDir, "test_assets/scenes/simple_room.glb");
 
-    initStage(stageFile);
-    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+  initStage(stageFile);
+  auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
 
-    // We need dynamics to test this.
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
+  // We need dynamics to test this.
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    auto objectAttributesManager =
+        metadataMediator_->getObjectAttributesManager();
 
-      std::string cubeHandle =
-          objectAttributesManager->getObjectHandlesBySubstring("cubeSolid")[0];
+    std::string cubeHandle =
+        objectAttributesManager->getObjectHandlesBySubstring("cubeSolid")[0];
 
-      // add a single cube
-      Mn::Vector3 stackBase(0.21964, 1.29183, -0.0897472);
-      auto objWrapper0 = makeObjectGetWrapper(cubeHandle, &drawables);
-      objWrapper0->setTranslation(stackBase);
+    // add a single cube
+    Mn::Vector3 stackBase(0.21964, 1.29183, -0.0897472);
+    auto objWrapper0 = makeObjectGetWrapper(cubeHandle, &drawables);
+    objWrapper0->setTranslation(stackBase);
 
-      // no active contact points at start
-      CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
+    // no active contact points at start
+    CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
 
-      // simulate to let cube fall and hit the ground
-      while (physicsManager_->getWorldTime() < 2.0) {
-        physicsManager_->stepPhysics(0.1);
-      }
-
-      auto allContactPoints = physicsManager_->getContactPoints();
-      // expect 4 active contact points for cube
-      CORRADE_COMPARE(allContactPoints.size(), 4);
-      CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 4);
-      float totalNormalForce = 0;
-      for (auto& cp : allContactPoints) {
-        // contacts are still active
-        CORRADE_VERIFY(cp.isActive);
-        // normal direction is unit Y (world up)
-        CORRADE_COMPARE_AS(
-            (cp.contactNormalOnBInWS - Magnum::Vector3{0.0, 1.0, 0.0}).length(),
-            1.0e-4, Cr::TestSuite::Compare::LessOrEqual);
-        // one object is the cube (0), other is the stage (-1)
-        CORRADE_COMPARE(cp.objectIdA, 0);
-        CORRADE_COMPARE(cp.objectIdB, -1);
-        // accumulate the normal force
-        totalNormalForce += cp.normalForce;
-        // solver should keep the cube at the contact boundary (~0 penetration)
-        CORRADE_COMPARE_AS(cp.contactDistance, 1.0e-4,
-                           Cr::TestSuite::Compare::LessOrEqual);
-      }
-      // mass 1 cube under gravity should require normal contact force of ~9.8
-      CORRADE_COMPARE_AS(totalNormalForce - 9.8, 3.0e-4,
-                         Cr::TestSuite::Compare::LessOrEqual);
-
-      // continue simulation until the cube is stable and sleeping
-      while (physicsManager_->getWorldTime() < 4.0) {
-        physicsManager_->stepPhysics(0.1);
-      }
-      // 4 inactive contact points at end
-      CORRADE_COMPARE(physicsManager_->getContactPoints().size(), 4);
-      // no active contact points at end
-      CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
+    // simulate to let cube fall and hit the ground
+    while (physicsManager_->getWorldTime() < 2.0) {
+      physicsManager_->stepPhysics(0.1);
     }
-  }  // for resetCreateRendererFlag false and true
+
+    auto allContactPoints = physicsManager_->getContactPoints();
+    // expect 4 active contact points for cube
+    CORRADE_COMPARE(allContactPoints.size(), 4);
+    CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 4);
+    float totalNormalForce = 0;
+    for (auto& cp : allContactPoints) {
+      // contacts are still active
+      CORRADE_VERIFY(cp.isActive);
+      // normal direction is unit Y (world up)
+      CORRADE_COMPARE_AS(
+          (cp.contactNormalOnBInWS - Magnum::Vector3{0.0, 1.0, 0.0}).length(),
+          1.0e-4, Cr::TestSuite::Compare::LessOrEqual);
+      // one object is the cube (0), other is the stage (-1)
+      CORRADE_COMPARE(cp.objectIdA, 0);
+      CORRADE_COMPARE(cp.objectIdB, -1);
+      // accumulate the normal force
+      totalNormalForce += cp.normalForce;
+      // solver should keep the cube at the contact boundary (~0 penetration)
+      CORRADE_COMPARE_AS(cp.contactDistance, 1.0e-4,
+                         Cr::TestSuite::Compare::LessOrEqual);
+    }
+    // mass 1 cube under gravity should require normal contact force of ~9.8
+    CORRADE_COMPARE_AS(totalNormalForce - 9.8, 3.0e-4,
+                       Cr::TestSuite::Compare::LessOrEqual);
+
+    // continue simulation until the cube is stable and sleeping
+    while (physicsManager_->getWorldTime() < 4.0) {
+      physicsManager_->stepPhysics(0.1);
+    }
+    // 4 inactive contact points at end
+    CORRADE_COMPARE(physicsManager_->getContactPoints().size(), 4);
+    // no active contact points at end
+    CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
+  }
 }  // PhysicsTest::testNumActiveContactPoints
 
 void PhysicsTest::testRemoveSleepingSupport() {
   // test that removing a sleeping support object wakes its collision island
-  ESP_DEBUG() << "Starting physics test: TestRemoveSleepingSupport";
-  for (bool resetRender : {false, true}) {
-    resetCreateRendererFlag(resetRender);
+  resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-    std::string stageFile = "NONE";
+  std::string stageFile = "NONE";
 
-    initStage(stageFile);
-    auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
+  initStage(stageFile);
+  auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();
 
-    // We need dynamics to test this.
-    if (physicsManager_->getPhysicsSimulationLibrary() !=
-        PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
-      auto objectAttributesManager =
-          metadataMediator_->getObjectAttributesManager();
+  // We need dynamics to test this.
+  if (physicsManager_->getPhysicsSimulationLibrary() !=
+      PhysicsManager::PhysicsSimulationLibrary::NoPhysics) {
+    auto objectAttributesManager =
+        metadataMediator_->getObjectAttributesManager();
 
-      std::string cubeHandle =
-          objectAttributesManager->getObjectHandlesBySubstring("cubeSolid")[0];
+    std::string cubeHandle =
+        objectAttributesManager->getObjectHandlesBySubstring("cubeSolid")[0];
 
-      // create a stack of cubes in free space
-      Mn::Vector3 stackBase(0.21964, 1.29183, -0.0897472);
-      std::vector<esp::physics::ManagedRigidObject::ptr> cubes;
-      int stackSize = 4;
-      for (int i = 0; i < stackSize; ++i) {
-        auto cubeWrapper = makeObjectGetWrapper(cubeHandle, &drawables);
-        cubeWrapper->setTranslation((Mn::Vector3(0, 0.2, 0) * i) + stackBase);
-        cubes.push_back(cubeWrapper);
-      }
-
-      cubes[0]->setMotionType(esp::physics::MotionType::STATIC);
-
-      for (int testCase = 0; testCase < 2; ++testCase) {
-        // reset time to 0, should not otherwise modify state
-        physicsManager_->reset();
-        CORRADE_COMPARE_AS(physicsManager_->getNumRigidObjects(), 0,
-                           Cr::TestSuite::Compare::Greater);
-
-        // simulate to stabilize the stack and populate collision islands
-        while (physicsManager_->getWorldTime() < 4.0) {
-          physicsManager_->stepPhysics(0.1);
-        }
-
-        // cubes should be sleeping
-        for (auto cube : cubes) {
-          CORRADE_VERIFY(!cube->isActive());
-        }
-
-        // no active contact points
-        CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
-
-        if (testCase == 0) {
-          // first remove the bottom-most DYNAMIC object, expecting those above
-          // to fall
-          rigidObjectManager_->removePhysObjectByID(cubes[1]->getID());
-          cubes.erase(cubes.begin() + 1);
-        } else if (testCase == 1) {
-          // second remove the STATIC bottom cube
-          rigidObjectManager_->removePhysObjectByID(cubes[0]->getID());
-          cubes.erase(cubes.begin());
-        }
-
-        // remaining cubes should now be awake
-        for (auto cube : cubes) {
-          if (cube->getMotionType() != esp::physics::MotionType::STATIC) {
-            CORRADE_VERIFY(cube->isActive());
-          }
-        }
-        CORRADE_COMPARE_AS(physicsManager_->getNumActiveContactPoints(), 0,
-                           Cr::TestSuite::Compare::Greater);
-      }
+    // create a stack of cubes in free space
+    Mn::Vector3 stackBase(0.21964, 1.29183, -0.0897472);
+    std::vector<esp::physics::ManagedRigidObject::ptr> cubes;
+    int stackSize = 4;
+    for (int i = 0; i < stackSize; ++i) {
+      auto cubeWrapper = makeObjectGetWrapper(cubeHandle, &drawables);
+      cubeWrapper->setTranslation((Mn::Vector3(0, 0.2, 0) * i) + stackBase);
+      cubes.push_back(cubeWrapper);
     }
-  }  // for resetCreateRendererFlag false and true
+
+    cubes[0]->setMotionType(esp::physics::MotionType::STATIC);
+
+    for (int testCase = 0; testCase < 2; ++testCase) {
+      // reset time to 0, should not otherwise modify state
+      physicsManager_->reset();
+      CORRADE_COMPARE_AS(physicsManager_->getNumRigidObjects(), 0,
+                         Cr::TestSuite::Compare::Greater);
+
+      // simulate to stabilize the stack and populate collision islands
+      while (physicsManager_->getWorldTime() < 4.0) {
+        physicsManager_->stepPhysics(0.1);
+      }
+
+      // cubes should be sleeping
+      for (auto cube : cubes) {
+        CORRADE_VERIFY(!cube->isActive());
+      }
+
+      // no active contact points
+      CORRADE_COMPARE(physicsManager_->getNumActiveContactPoints(), 0);
+
+      if (testCase == 0) {
+        // first remove the bottom-most DYNAMIC object, expecting those above
+        // to fall
+        rigidObjectManager_->removePhysObjectByID(cubes[1]->getID());
+        cubes.erase(cubes.begin() + 1);
+      } else if (testCase == 1) {
+        // second remove the STATIC bottom cube
+        rigidObjectManager_->removePhysObjectByID(cubes[0]->getID());
+        cubes.erase(cubes.begin());
+      }
+
+      // remaining cubes should now be awake
+      for (auto cube : cubes) {
+        if (cube->getMotionType() != esp::physics::MotionType::STATIC) {
+          CORRADE_VERIFY(cube->isActive());
+        }
+      }
+      CORRADE_COMPARE_AS(physicsManager_->getNumActiveContactPoints(), 0,
+                         Cr::TestSuite::Compare::Greater);
+    }
+  }
 }  // PhysicsTest::testRemoveSleepingSupport
 
 }  // namespace

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -45,10 +45,8 @@ ResourceManagerTest::ResourceManagerTest() {
   addTests({&ResourceManagerTest::createJoinedCollisionMesh,
 #ifdef ESP_BUILD_WITH_VHACD
             &ResourceManagerTest::VHACDUsageTest,
-            &ResourceManagerTest::loadAndCreateRenderAssetInstance});
-#else
-            &ResourceManagerTest::loadAndCreateRenderAssetInstance});
 #endif
+            &ResourceManagerTest::loadAndCreateRenderAssetInstance});
 }
 
 void ResourceManagerTest::createJoinedCollisionMesh() {

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -27,7 +27,7 @@ using esp::assets::ResourceManager;
 using esp::metadata::MetadataMediator;
 using esp::scene::SceneManager;
 
-namespace Test {
+namespace {
 
 struct ResourceManagerTest : Cr::TestSuite::Tester {
   explicit ResourceManagerTest();
@@ -191,6 +191,6 @@ void ResourceManagerTest::loadAndCreateRenderAssetInstance() {
       info, creation, &sceneManager_, tempIDs);
   CORRADE_VERIFY(node);
 }
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::ResourceManagerTest)
+CORRADE_TEST_MAIN(ResourceManagerTest)

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -2,7 +2,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/TestSuite/Compare/Container.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/EigenIntegration/Integration.h>
@@ -90,29 +93,25 @@ void ResourceManagerTest::createJoinedCollisionMesh() {
   CORRADE_COMPARE(numVerts, 24);
   CORRADE_COMPARE(numIndices, 36);
 
-  std::vector<Magnum::Vector3> vertGroundTruth{
-      {-1, 1, 1},  {-1, 1, -1}, {-1, -1, -1}, {-1, -1, 1},  {1, 1, 1},
-      {1, -1, -1}, {1, 1, -1},  {1, -1, 1},   {1, 1, -1},   {-1, -1, -1},
-      {-1, 1, -1}, {1, -1, -1}, {1, 1, 1},    {-1, 1, -1},  {-1, 1, 1},
-      {1, 1, -1},  {1, -1, 1},  {-1, -1, 1},  {-1, -1, -1}, {1, -1, -1},
-      {1, 1, 1},   {-1, 1, 1},  {-1, -1, 1},  {1, -1, 1}};
+  CORRADE_COMPARE_AS(
+      Cr::Containers::arrayCast<const Mn::Vector3>(
+          Cr::Containers::arrayView(joinedBox->vbo)),
+      Cr::Containers::arrayView<Magnum::Vector3>(
+          {{-1, 1, 1},  {-1, 1, -1}, {-1, -1, -1}, {-1, -1, 1},  {1, 1, 1},
+           {1, -1, -1}, {1, 1, -1},  {1, -1, 1},   {1, 1, -1},   {-1, -1, -1},
+           {-1, 1, -1}, {1, -1, -1}, {1, 1, 1},    {-1, 1, -1},  {-1, 1, 1},
+           {1, 1, -1},  {1, -1, 1},  {-1, -1, 1},  {-1, -1, -1}, {1, -1, -1},
+           {1, 1, 1},   {-1, 1, 1},  {-1, -1, 1},  {1, -1, 1}}),
+      Cr::TestSuite::Compare::Container);
 
-  std::vector<uint32_t> indexGroundTruth{
-      0,  1,  2,  0,  2,  3,  4,  5,  6,  4,  7,  5,  8,  9,  10, 8,  11, 9,
-      12, 13, 14, 12, 15, 13, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23};
+  CORRADE_COMPARE_AS(Cr::Containers::arrayView(joinedBox->ibo),
+                     Cr::Containers::arrayView<uint32_t>(
+                         {0,  1,  2,  0,  2,  3,  4,  5,  6,  4,  7,  5,
+                          8,  9,  10, 8,  11, 9,  12, 13, 14, 12, 15, 13,
+                          16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23}),
+                     Cr::TestSuite::Compare::Container);
 
-  for (size_t vix = 0; vix < joinedBox->vbo.size(); vix++) {
-    // ESP_DEBUG() << joinedBox->vbo[vix]   << "vs" <<
-    // vertGroundTruth[vix];
-    CORRADE_COMPARE(vertGroundTruth[vix], Magnum::Vector3(joinedBox->vbo[vix]));
-  }
-
-  for (size_t iix = 0; iix < joinedBox->ibo.size(); iix++) {
-    // ESP_DEBUG() << joinedBox->ibo[iix]   << "vs" <<
-    // indexGroundTruth[iix];
-    CORRADE_COMPARE(indexGroundTruth[iix], joinedBox->ibo[iix]);
-  }
-}
+}  // namespace Test
 
 #ifdef ESP_BUILD_WITH_VHACD
 void ResourceManagerTest::VHACDUsageTest() {

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -3,10 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Math/Range.h>
-#include <gtest/gtest.h>
 #include <string>
 
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
@@ -24,150 +24,181 @@ using esp::assets::ResourceManager;
 using esp::metadata::MetadataMediator;
 using esp::scene::SceneManager;
 
-TEST(ResourceManagerTest, createJoinedCollisionMesh) {
+namespace Test {
+
+struct ResourceManagerTest : Cr::TestSuite::Tester {
+  explicit ResourceManagerTest();
+  void createJoinedCollisionMesh();
+
+#ifdef ESP_BUILD_WITH_VHACD
+  void VHACDUsageTest();
+#endif
+
+  void loadAndCreateRenderAssetInstance();
+
   esp::logging::LoggingContext loggingContext;
-  esp::gfx::WindowlessContext::uptr context_ =
-      esp::gfx::WindowlessContext::create_unique(0);
+};  // struct ResourceManagerTest
+ResourceManagerTest::ResourceManagerTest() {
+  addTests({&ResourceManagerTest::createJoinedCollisionMesh,
+#ifdef ESP_BUILD_WITH_VHACD
+            &ResourceManagerTest::VHACDUsageTest
+             &ResourceManagerTest::loadAndCreateRenderAssetInstance
+#else
+       &ResourceManagerTest::loadAndCreateRenderAssetInstance});
+#endif
 
-  std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
+}
 
-  // must declare these in this order due to avoid deallocation errors
-  auto cfg = esp::sim::SimulatorConfiguration{};
-  // setting values for stage load
-  cfg.loadSemanticMesh = false;
-  cfg.forceSeparateSemanticSceneGraph = false;
-  auto MM = MetadataMediator::create(cfg);
-  ResourceManager resourceManager(MM);
-  SceneManager sceneManager_;
-  auto stageAttributesMgr = MM->getStageAttributesManager();
-  std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+void ResourceManagerTest::createJoinedCollisionMesh() {
+    esp::gfx::WindowlessContext::uptr context_ =
+        esp::gfx::WindowlessContext::create_unique(0);
 
-  // create stage attributes file
-  auto stageAttributes = stageAttributesMgr->createObject(boxFile, true);
+    std::shared_ptr<esp::gfx::Renderer> renderer_ =
+        esp::gfx::Renderer::create();
 
-  int sceneID = sceneManager_.initSceneGraph();
-  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
-  const esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
+    // must declare these in this order due to avoid deallocation errors
+    auto cfg = esp::sim::SimulatorConfiguration{};
+    // setting values for stage load
+    cfg.loadSemanticMesh = false;
+    cfg.forceSeparateSemanticSceneGraph = false;
+    auto MM = MetadataMediator::create(cfg);
+    ResourceManager resourceManager(MM);
+    SceneManager sceneManager_;
+    auto stageAttributesMgr = MM->getStageAttributesManager();
+    std::string boxFile =
+        Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
 
-  std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
-                                          &sceneManager_, tempIDs);
+    // create stage attributes file
+    auto stageAttributes = stageAttributesMgr->createObject(boxFile, true);
 
-  esp::assets::MeshData::uptr joinedBox =
-      resourceManager.createJoinedCollisionMesh(boxFile);
+    int sceneID = sceneManager_.initSceneGraph();
+    auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+    const esp::assets::AssetInfo info =
+        esp::assets::AssetInfo::fromPath(boxFile);
 
-  // transform_box.glb is composed of 6 identical triangulated plane meshes
-  // transformed into a cube via a transform heirarchy. Combined, the resulting
-  // mesh should have 24 vertices and 36 indices with corners at the unit corner
-  // coordinates as defined in the ground truth vectors below.
-  int numVerts = joinedBox->vbo.size();
-  int numIndices = joinedBox->ibo.size();
+    std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
+    bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
+                                            &sceneManager_, tempIDs);
 
-  ASSERT_EQ(numVerts, 24);
-  ASSERT_EQ(numIndices, 36);
+    esp::assets::MeshData::uptr joinedBox =
+        resourceManager.createJoinedCollisionMesh(boxFile);
 
-  std::vector<Magnum::Vector3> vertGroundTruth{
-      {-1, 1, 1},  {-1, 1, -1}, {-1, -1, -1}, {-1, -1, 1},  {1, 1, 1},
-      {1, -1, -1}, {1, 1, -1},  {1, -1, 1},   {1, 1, -1},   {-1, -1, -1},
-      {-1, 1, -1}, {1, -1, -1}, {1, 1, 1},    {-1, 1, -1},  {-1, 1, 1},
-      {1, 1, -1},  {1, -1, 1},  {-1, -1, 1},  {-1, -1, -1}, {1, -1, -1},
-      {1, 1, 1},   {-1, 1, 1},  {-1, -1, 1},  {1, -1, 1}};
+    // transform_box.glb is composed of 6 identical triangulated plane meshes
+    // transformed into a cube via a transform heirarchy. Combined, the
+    // resulting mesh should have 24 vertices and 36 indices with corners at the
+    // unit corner coordinates as defined in the ground truth vectors below.
+    int numVerts = joinedBox->vbo.size();
+    int numIndices = joinedBox->ibo.size();
 
-  std::vector<uint32_t> indexGroundTruth{
-      0,  1,  2,  0,  2,  3,  4,  5,  6,  4,  7,  5,  8,  9,  10, 8,  11, 9,
-      12, 13, 14, 12, 15, 13, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23};
+    CORRADE_COMPARE(numVerts, 24);
+    CORRADE_COMPARE(numIndices, 36);
 
-  for (size_t vix = 0; vix < joinedBox->vbo.size(); vix++) {
-    // ESP_DEBUG() << joinedBox->vbo[vix]   << "vs" <<
-    // vertGroundTruth[vix];
-    ASSERT_EQ(vertGroundTruth[vix], Magnum::Vector3(joinedBox->vbo[vix]));
-  }
+    std::vector<Magnum::Vector3> vertGroundTruth{
+        {-1, 1, 1},  {-1, 1, -1}, {-1, -1, -1}, {-1, -1, 1},  {1, 1, 1},
+        {1, -1, -1}, {1, 1, -1},  {1, -1, 1},   {1, 1, -1},   {-1, -1, -1},
+        {-1, 1, -1}, {1, -1, -1}, {1, 1, 1},    {-1, 1, -1},  {-1, 1, 1},
+        {1, 1, -1},  {1, -1, 1},  {-1, -1, 1},  {-1, -1, -1}, {1, -1, -1},
+        {1, 1, 1},   {-1, 1, 1},  {-1, -1, 1},  {1, -1, 1}};
 
-  for (size_t iix = 0; iix < joinedBox->ibo.size(); iix++) {
-    // ESP_DEBUG() << joinedBox->ibo[iix]   << "vs" <<
-    // indexGroundTruth[iix];
-    ASSERT_EQ(indexGroundTruth[iix], joinedBox->ibo[iix]);
-  }
+    std::vector<uint32_t> indexGroundTruth{
+        0,  1,  2,  0,  2,  3,  4,  5,  6,  4,  7,  5,  8,  9,  10, 8,  11, 9,
+        12, 13, 14, 12, 15, 13, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23};
+
+    for (size_t vix = 0; vix < joinedBox->vbo.size(); vix++) {
+      // ESP_DEBUG() << joinedBox->vbo[vix]   << "vs" <<
+      // vertGroundTruth[vix];
+      CORRADE_COMPARE(vertGroundTruth[vix],
+                      Magnum::Vector3(joinedBox->vbo[vix]));
+    }
+
+    for (size_t iix = 0; iix < joinedBox->ibo.size(); iix++) {
+      // ESP_DEBUG() << joinedBox->ibo[iix]   << "vs" <<
+      // indexGroundTruth[iix];
+      CORRADE_COMPARE(indexGroundTruth[iix], joinedBox->ibo[iix]);
+    }
 }
 
 #ifdef ESP_BUILD_WITH_VHACD
-TEST(ResourceManagerTest, VHACDUsageTest) {
-  esp::logging::LoggingContext loggingContext;
-  esp::gfx::WindowlessContext::uptr context_ =
-      esp::gfx::WindowlessContext::create_unique(0);
+void ResourceManagerTest::VHACDUsageTest() {
+    esp::gfx::WindowlessContext::uptr context_ =
+        esp::gfx::WindowlessContext::create_unique(0);
 
-  std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
+    std::shared_ptr<esp::gfx::Renderer> renderer_ =
+        esp::gfx::Renderer::create();
 
-  // must declare these in this order due to avoid deallocation errors
-  // must declare these in this order due to avoid deallocation errors
-  auto cfg = esp::sim::SimulatorConfiguration{};
-  // setting values for stage load
-  cfg.loadSemanticMesh = false;
-  cfg.forceSeparateSemanticSceneGraph = false;
-  auto MM = MetadataMediator::create(cfg);
-  ResourceManager resourceManager(MM);
-  SceneManager sceneManager_;
-  auto stageAttributesMgr = MM->getStageAttributesManager();
-  std::string donutFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/donut.glb");
-  std::string CHdonutFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/CHdonut.glb");
+    // must declare these in this order due to avoid deallocation errors
+    // must declare these in this order due to avoid deallocation errors
+    auto cfg = esp::sim::SimulatorConfiguration{};
+    // setting values for stage load
+    cfg.loadSemanticMesh = false;
+    cfg.forceSeparateSemanticSceneGraph = false;
+    auto MM = MetadataMediator::create(cfg);
+    ResourceManager resourceManager(MM);
+    SceneManager sceneManager_;
+    auto stageAttributesMgr = MM->getStageAttributesManager();
+    std::string donutFile =
+        Cr::Utility::Directory::join(TEST_ASSETS, "objects/donut.glb");
+    std::string CHdonutFile =
+        Cr::Utility::Directory::join(TEST_ASSETS, "objects/CHdonut.glb");
 
-  // create stage attributes file
-  auto stageAttributes = stageAttributesMgr->createObject(donutFile, true);
+    // create stage attributes file
+    auto stageAttributes = stageAttributesMgr->createObject(donutFile, true);
 
-  int sceneID = sceneManager_.initSceneGraph();
-  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
-  const esp::assets::AssetInfo info =
-      esp::assets::AssetInfo::fromPath(donutFile);
+    int sceneID = sceneManager_.initSceneGraph();
+    auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+    const esp::assets::AssetInfo info =
+        esp::assets::AssetInfo::fromPath(donutFile);
 
-  std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
-                                          &sceneManager_, tempIDs);
+    std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
+    bool result = resourceManager.loadStage(stageAttributes, nullptr, nullptr,
+                                            &sceneManager_, tempIDs);
 
-  esp::assets::MeshData::uptr joinedBox =
-      resourceManager.createJoinedCollisionMesh(donutFile);
+    esp::assets::MeshData::uptr joinedBox =
+        resourceManager.createJoinedCollisionMesh(donutFile);
 
-  esp::assets::ResourceManager::VHACDParameters params;
-  // params.setMaxNumVerticesPerCH(10);
-  params.m_resolution = 1000000;
-  CORRADE_INTERNAL_ASSERT(!resourceManager.isAssetDataRegistered(CHdonutFile));
-  resourceManager.createConvexHullDecomposition(donutFile, CHdonutFile, params,
-                                                true);
+    esp::assets::ResourceManager::VHACDParameters params;
+    // params.setMaxNumVerticesPerCH(10);
+    params.m_resolution = 1000000;
+    CORRADE_VERIFY(!resourceManager.isAssetDataRegistered(CHdonutFile));
+    resourceManager.createConvexHullDecomposition(donutFile, CHdonutFile,
+                                                  params, true);
 
-  CORRADE_INTERNAL_ASSERT(resourceManager.isAssetDataRegistered(CHdonutFile));
+    CORRADE_VERIFY(resourceManager.isAssetDataRegistered(CHdonutFile));
 }
 #endif
 
 // Load and create a render asset instance and assert success
-TEST(ResourceManagerTest, loadAndCreateRenderAssetInstance) {
-  esp::logging::LoggingContext loggingContext;
-  esp::gfx::WindowlessContext::uptr context_ =
-      esp::gfx::WindowlessContext::create_unique(0);
+void ResourceManagerTest::loadAndCreateRenderAssetInstance() {
+    esp::gfx::WindowlessContext::uptr context_ =
+        esp::gfx::WindowlessContext::create_unique(0);
 
-  std::shared_ptr<esp::gfx::Renderer> renderer_ = esp::gfx::Renderer::create();
+    std::shared_ptr<esp::gfx::Renderer> renderer_ =
+        esp::gfx::Renderer::create();
 
-  // must declare these in this order due to avoid deallocation errors
-  auto MM = MetadataMediator::create();
-  ResourceManager resourceManager(MM);
-  SceneManager sceneManager_;
-  std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+    // must declare these in this order due to avoid deallocation errors
+    auto MM = MetadataMediator::create();
+    ResourceManager resourceManager(MM);
+    SceneManager sceneManager_;
+    std::string boxFile =
+        Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
 
-  int sceneID = sceneManager_.initSceneGraph();
-  auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
-  const esp::assets::AssetInfo info = esp::assets::AssetInfo::fromPath(boxFile);
+    int sceneID = sceneManager_.initSceneGraph();
+    auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
+    const esp::assets::AssetInfo info =
+        esp::assets::AssetInfo::fromPath(boxFile);
 
-  const std::string lightSetupKey = "";
-  esp::assets::RenderAssetInstanceCreationInfo::Flags flags;
-  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
-  flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
-  esp::assets::RenderAssetInstanceCreationInfo creation(
-      boxFile, Corrade::Containers::NullOpt, flags, lightSetupKey);
+    const std::string lightSetupKey = "";
+    esp::assets::RenderAssetInstanceCreationInfo::Flags flags;
+    flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
+    flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
+    esp::assets::RenderAssetInstanceCreationInfo creation(
+        boxFile, Corrade::Containers::NullOpt, flags, lightSetupKey);
 
-  std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
-  auto* node = resourceManager.loadAndCreateRenderAssetInstance(
-      info, creation, &sceneManager_, tempIDs);
-  CORRADE_INTERNAL_ASSERT(node);
+    std::vector<int> tempIDs{sceneID, esp::ID_UNDEFINED};
+    auto* node = resourceManager.loadAndCreateRenderAssetInstance(
+        info, creation, &sceneManager_, tempIDs);
+    CORRADE_VERIFY(node);
 }
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::ResourceManagerTest)

--- a/src/tests/SceneGraphTest.cpp
+++ b/src/tests/SceneGraphTest.cpp
@@ -2,40 +2,45 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <gtest/gtest.h>
+#include <Corrade/TestSuite/Tester.h>
 
 #include "esp/scene/SceneGraph.h"
 
 using esp::gfx::DrawableGroup;
 using esp::scene::SceneGraph;
 
-class SceneGraphTest : public ::testing::Test {
- protected:
-  void SetUp() override { numInitialGroups = g.getDrawableGroups().size(); }
-
+namespace Test {
+struct SceneGraphTest : Cr::TestSuite::Tester {
+  explicit SceneGraphTest();
+  void testGetDrawableGroup();
+  void testDeleteDrawableGroup();
   esp::logging::LoggingContext loggingContext_;
   size_t numInitialGroups;
   SceneGraph g;
   const std::string groupName = "testGroup";
 };
-
-TEST_F(SceneGraphTest, GetDrawableGroup) {
-  EXPECT_EQ(g.getDrawableGroup("not created"), nullptr);
-
-  DrawableGroup* group = g.createDrawableGroup(groupName);
-  ASSERT_NE(group, nullptr);
-  EXPECT_EQ(g.getDrawableGroups().size(), numInitialGroups + 1);
-  ASSERT_EQ(g.getDrawableGroup(groupName), group);
+SceneGraphTest::SceneGraphTest() {
+  numInitialGroups = g.getDrawableGroups().size();
+  addTests({&SceneGraphTest::testGetDrawableGroup,
+            &SceneGraphTest::testDeleteDrawableGroup});
 }
 
-TEST_F(SceneGraphTest, DeleteDrawableGroup) {
-  EXPECT_FALSE(g.deleteDrawableGroup("not created"));
+void SceneGraphTest::testGetDrawableGroup() {
+  CORRADE_VERIFY(g.getDrawableGroup("not created") == nullptr);
 
   DrawableGroup* group = g.createDrawableGroup(groupName);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(g.getDrawableGroup(groupName), group);
-
-  ASSERT_TRUE(g.deleteDrawableGroup(groupName));
-  EXPECT_EQ(g.getDrawableGroups().size(), numInitialGroups);
-  ASSERT_EQ(g.getDrawableGroup(groupName), nullptr);
+  CORRADE_VERIFY(group != nullptr);
+  CORRADE_COMPARE(g.getDrawableGroups().size(), numInitialGroups + 1);
+  CORRADE_COMPARE(g.getDrawableGroup(groupName), group);
 }
+
+void SceneGraphTest::testDeleteDrawableGroup() {
+  CORRADE_VERIFY(!g.deleteDrawableGroup("not created"));
+
+  CORRADE_VERIFY(g.deleteDrawableGroup(groupName));
+  CORRADE_COMPARE(g.getDrawableGroups().size(), numInitialGroups);
+  CORRADE_VERIFY(g.getDrawableGroup(groupName) == nullptr);
+}
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::SceneGraphTest)

--- a/src/tests/SceneGraphTest.cpp
+++ b/src/tests/SceneGraphTest.cpp
@@ -9,7 +9,7 @@
 using esp::gfx::DrawableGroup;
 using esp::scene::SceneGraph;
 
-namespace Test {
+namespace {
 struct SceneGraphTest : Cr::TestSuite::Tester {
   explicit SceneGraphTest();
   void testGetDrawableGroup();
@@ -41,6 +41,6 @@ void SceneGraphTest::testDeleteDrawableGroup() {
   CORRADE_COMPARE(g.getDrawableGroups().size(), numInitialGroups);
   CORRADE_VERIFY(g.getDrawableGroup(groupName) == nullptr);
 }
-}  // namespace Test
+}  // namespace
 
-CORRADE_TEST_MAIN(Test::SceneGraphTest)
+CORRADE_TEST_MAIN(SceneGraphTest)

--- a/src/tests/SceneGraphTest.cpp
+++ b/src/tests/SceneGraphTest.cpp
@@ -29,7 +29,7 @@ void SceneGraphTest::testGetDrawableGroup() {
   CORRADE_VERIFY(g.getDrawableGroup("not created") == nullptr);
 
   DrawableGroup* group = g.createDrawableGroup(groupName);
-  CORRADE_VERIFY(group != nullptr);
+  CORRADE_VERIFY(group);
   CORRADE_COMPARE(g.getDrawableGroups().size(), numInitialGroups + 1);
   CORRADE_COMPARE(g.getDrawableGroup(groupName), group);
 }

--- a/src/tests/SensorTest.cpp
+++ b/src/tests/SensorTest.cpp
@@ -14,6 +14,7 @@ namespace Cr = Corrade;
 using namespace esp::sensor;
 using namespace esp::scene;
 
+namespace {
 // TODO: Add tests for different Sensors
 struct SensorTest : Cr::TestSuite::Tester {
   explicit SensorTest();
@@ -375,5 +376,6 @@ void SensorTest::testSetParent() {
   CORRADE_COMPARE(child2Node.getNodeSensors().size(), 1);
   CORRADE_COMPARE(child2Node.getSubtreeSensors().size(), 1);
 }
+}  // namespace
 
 CORRADE_TEST_MAIN(SensorTest)

--- a/src/tests/SensorTest.cpp
+++ b/src/tests/SensorTest.cpp
@@ -44,10 +44,10 @@ void SensorTest::testSensorFactory() {
   auto& rootNode = sceneGraph.getRootNode();
   SceneNode& parentNode = rootNode.createChild();
   parentNode.setId(1);
-  CORRADE_VERIFY(parentNode.getId() == 1);
+  CORRADE_COMPARE(parentNode.getId(), 1);
   SceneNode& childNode = parentNode.createChild();
   childNode.setId(2);
-  CORRADE_VERIFY(childNode.getId() == 2);
+  CORRADE_COMPARE(childNode.getId(), 2);
 
   // Add different uuid sensors to same node and assert increase
   auto sensorSpecA = CameraSensorSpec::create();
@@ -55,40 +55,40 @@ void SensorTest::testSensorFactory() {
   auto sensorSpecB = CameraSensorSpec::create();
   sensorSpecB->uuid = "B";
   SensorFactory::createSensors(parentNode, {sensorSpecA, sensorSpecB});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 2);
 
   // Add different uuid sensors to different nodes and assert increase
   auto sensorSpecC = CameraSensorSpec::create();
   sensorSpecC->uuid = "C";
   SensorFactory::createSensors(parentNode, {sensorSpecC});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 3);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 3);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 3);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 3);
 
   auto sensorSpecD = CameraSensorSpec::create();
   sensorSpecD->uuid = "D";
   auto sensorSpecE = CameraSensorSpec::create();
   sensorSpecE->uuid = "E";
   SensorFactory::createSensors(childNode, {sensorSpecD, sensorSpecE});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 2);
 
   // Add same uuid sensor to same node and assert that only one sensor was added
   auto sensorSpecF = CameraSensorSpec::create();
   sensorSpecF->uuid = "F";
   SensorFactory::createSensors(parentNode, {sensorSpecF, sensorSpecF});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 6);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 6);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 6);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 6);
 }
 
 void SensorTest::testSensorDestructors() {
@@ -101,19 +101,19 @@ void SensorTest::testSensorDestructors() {
   auto& rootNode = sceneGraph.getRootNode();
   SceneNode& parentNode = rootNode.createChild();
   parentNode.setId(1);
-  CORRADE_VERIFY(parentNode.getId() == 1);
+  CORRADE_COMPARE(parentNode.getId(), 1);
   SceneNode& childNode = parentNode.createChild();
   childNode.setId(2);
-  CORRADE_VERIFY(childNode.getId() == 2);
+  CORRADE_COMPARE(childNode.getId(), 2);
   SceneNode& grandchildNode = childNode.createChild();
   grandchildNode.setId(3);
-  CORRADE_VERIFY(grandchildNode.getId() == 3);
+  CORRADE_COMPARE(grandchildNode.getId(), 3);
   SceneNode& grandchild2Node = childNode.createChild();
   grandchild2Node.setId(4);
-  CORRADE_VERIFY(grandchild2Node.getId() == 4);
+  CORRADE_COMPARE(grandchild2Node.getId(), 4);
   SceneNode& greatgrandchildNode = grandchildNode.createChild();
   greatgrandchildNode.setId(5);
-  CORRADE_VERIFY(greatgrandchildNode.getId() == 5);
+  CORRADE_COMPARE(greatgrandchildNode.getId(), 5);
 
   // Add sensors to parent node
   auto sensorSpec1A = CameraSensorSpec::create();
@@ -121,10 +121,10 @@ void SensorTest::testSensorDestructors() {
   auto sensorSpec1B = CameraSensorSpec::create();
   sensorSpec1B->uuid = "1B";
   SensorFactory::createSensors(parentNode, {sensorSpec1A, sensorSpec1B});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 2);
 
   // Add sensors to child node
   auto sensorSpec2A = CameraSensorSpec::create();
@@ -135,12 +135,12 @@ void SensorTest::testSensorDestructors() {
   sensorSpec2C->uuid = "2C";
   SensorFactory::createSensors(childNode,
                                {sensorSpec2A, sensorSpec2B, sensorSpec2C});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 3);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 3);
 
   // Add sensors to grandchild node
   auto sensorSpec3A = CameraSensorSpec::create();
@@ -153,14 +153,14 @@ void SensorTest::testSensorDestructors() {
   sensorSpec3D->uuid = "3D";
   SensorFactory::createSensors(
       grandchildNode, {sensorSpec3A, sensorSpec3B, sensorSpec3C, sensorSpec3D});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 7);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 4);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 7);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 4);
 
   // Add sensors to grandchild2 node
   auto sensorSpec4A = CameraSensorSpec::create();
@@ -168,16 +168,16 @@ void SensorTest::testSensorDestructors() {
   auto sensorSpec4B = CameraSensorSpec::create();
   sensorSpec4B->uuid = "4B";
   SensorFactory::createSensors(grandchild2Node, {sensorSpec4A, sensorSpec4B});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 4);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 4);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
 
   // Add sensors to greatgrandchild node
   auto sensorSpec5A = CameraSensorSpec::create();
@@ -186,108 +186,108 @@ void SensorTest::testSensorDestructors() {
   sensorSpec5B->uuid = "5B";
   SensorFactory::createSensors(greatgrandchildNode,
                                {sensorSpec5A, sensorSpec5B});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 13);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 13);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 6);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 13);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 13);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 6);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getSubtreeSensors().size(), 2);
 
   // Remove sensor from parentNode
   SensorFactory::deleteSubtreeSensor(parentNode, "1A");
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 12);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 12);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 6);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 12);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 12);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 6);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getSubtreeSensors().size(), 2);
 
   // Remove sensor from child node
   SensorFactory::deleteSubtreeSensor(parentNode, "2A");
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 11);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 10);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 4);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 6);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 11);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 10);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 4);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 6);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getSubtreeSensors().size(), 2);
 
   // Remove sensor from grandchild node
   SensorFactory::deleteSubtreeSensor(parentNode, "3A");
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 10);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 10);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 10);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 10);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getSubtreeSensors().size(), 2);
 
   // Remove sensor from greatgrandchild node
   SensorFactory::deleteSubtreeSensor(parentNode, "5A");
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 9);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 8);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 3);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 4);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(greatgrandchildNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(greatgrandchildNode.getSubtreeSensors().size() == 1);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 9);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 8);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 3);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 4);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(greatgrandchildNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(greatgrandchildNode.getSubtreeSensors().size(), 1);
 
   // Remove grandchild node and assert grandchild2Node still exists
   // Before, verify that childNode has 2 children nodes
   auto* grandchild = childNode.children().first();
-  CORRADE_VERIFY(grandchild != nullptr);
+  CORRADE_VERIFY(grandchild);
   // remaining grandchild is grandchild2 with id 4
-  CORRADE_VERIFY(dynamic_cast<SceneNode*>(grandchild)->getId() == 3);
-  CORRADE_VERIFY(dynamic_cast<SceneNode*>(grandchild->nextSibling())->getId() ==
-                 4);
+  CORRADE_COMPARE(dynamic_cast<SceneNode*>(grandchild)->getId(), 3);
+  CORRADE_COMPARE(dynamic_cast<SceneNode*>(grandchild->nextSibling())->getId(),
+                  4);
 
   delete (&grandchildNode);
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 5);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 4);
-  CORRADE_VERIFY(grandchild2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(grandchild2Node.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 5);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 4);
+  CORRADE_COMPARE(grandchild2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(grandchild2Node.getSubtreeSensors().size(), 2);
 
   // After, verify that childNode has 1 child node with id 4 (grandchild2Node)
   // and 2 children nodes with id 2, and no other children
   grandchild = childNode.children().first();
-  CORRADE_VERIFY(grandchild != nullptr);
+  CORRADE_VERIFY(grandchild);
   // remaining grandchild is grandchild2 with id 4
-  CORRADE_VERIFY(dynamic_cast<SceneNode*>(grandchild)->getId() == 4);
+  CORRADE_COMPARE(dynamic_cast<SceneNode*>(grandchild)->getId(), 4);
   auto* nextGrandchild = grandchild->nextSibling();
-  CORRADE_VERIFY(dynamic_cast<SceneNode*>(nextGrandchild)->getId() == 2);
+  CORRADE_COMPARE(dynamic_cast<SceneNode*>(nextGrandchild)->getId(), 2);
   nextGrandchild = nextGrandchild->nextSibling();
-  CORRADE_VERIFY(dynamic_cast<SceneNode*>(nextGrandchild)->getId() == 2);
+  CORRADE_COMPARE(dynamic_cast<SceneNode*>(nextGrandchild)->getId(), 2);
   nextGrandchild = nextGrandchild->nextSibling();
   CORRADE_VERIFY(!nextGrandchild);
 
@@ -307,16 +307,16 @@ void SensorTest::testSetParent() {
   auto& rootNode = sceneGraph.getRootNode();
   SceneNode& parentNode = rootNode.createChild();
   parentNode.setId(1);
-  CORRADE_VERIFY(parentNode.getId() == 1);
+  CORRADE_COMPARE(parentNode.getId(), 1);
   SceneNode& childNode = parentNode.createChild();
   childNode.setId(2);
-  CORRADE_VERIFY(childNode.getId() == 2);
+  CORRADE_COMPARE(childNode.getId(), 2);
   SceneNode& grandchildNode = childNode.createChild();
   grandchildNode.setId(3);
-  CORRADE_VERIFY(grandchildNode.getId() == 3);
+  CORRADE_COMPARE(grandchildNode.getId(), 3);
   SceneNode& child2Node = childNode.createChild();
   child2Node.setId(4);
-  CORRADE_VERIFY(child2Node.getId() == 4);
+  CORRADE_COMPARE(child2Node.getId(), 4);
 
   // Add sensors to child2 node and assert correct number of sensors in child
   // and parent subtreeSensorSuites
@@ -325,55 +325,55 @@ void SensorTest::testSetParent() {
   auto sensorSpec4B = CameraSensorSpec::create();
   sensorSpec4B->uuid = "4B";
   SensorFactory::createSensors(child2Node, {sensorSpec4A, sensorSpec4B});
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 2);
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 0);
-  CORRADE_VERIFY(child2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(child2Node.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 2);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 0);
+  CORRADE_COMPARE(child2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(child2Node.getSubtreeSensors().size(), 2);
 
   // Set parent of child2 node to parentNode and assert correct number of
   // sensors in child and parent subtreeSensorSuites
   child2Node.setParent(&parentNode);
   // Assert rootNode SensorSuites unchanged
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 2);
   // Assert parentNode subtreeSensorSuite unchanged
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 2);
   // Assert childNode subtreeSensorSuite no longer holds sensors
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 0);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 0);
   // Assert grandchildNode subtreeSensorSuite unchanged
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 0);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 0);
   // Assert child2Node subtreeSensorSuite unchanged
-  CORRADE_VERIFY(child2Node.getNodeSensors().size() == 2);
-  CORRADE_VERIFY(child2Node.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(child2Node.getNodeSensors().size(), 2);
+  CORRADE_COMPARE(child2Node.getSubtreeSensors().size(), 2);
 
   // Set parent of sensor to grandchildNode and assert correct number of sensors
   // in sensorSuites
   parentNode.getSubtreeSensorSuite().get("4A").node().setParent(
       &grandchildNode);
   // Assert rootNode SensorSuites unchanged
-  CORRADE_VERIFY(rootNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(rootNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(rootNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(rootNode.getSubtreeSensors().size(), 2);
   // Assert parentNode subtreeSensorSuite unchanged
-  CORRADE_VERIFY(parentNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(parentNode.getSubtreeSensors().size() == 2);
+  CORRADE_COMPARE(parentNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(parentNode.getSubtreeSensors().size(), 2);
   // Assert childNode subtreeSensorSuite no longer holds sensors
-  CORRADE_VERIFY(childNode.getNodeSensors().size() == 0);
-  CORRADE_VERIFY(childNode.getSubtreeSensors().size() == 1);
+  CORRADE_COMPARE(childNode.getNodeSensors().size(), 0);
+  CORRADE_COMPARE(childNode.getSubtreeSensors().size(), 1);
   // Assert grandchildNode subtreeSensorSuite unchanged
-  CORRADE_VERIFY(grandchildNode.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(grandchildNode.getSubtreeSensors().size() == 1);
+  CORRADE_COMPARE(grandchildNode.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(grandchildNode.getSubtreeSensors().size(), 1);
   // Assert child2Node subtreeSensorSuite decreases
-  CORRADE_VERIFY(child2Node.getNodeSensors().size() == 1);
-  CORRADE_VERIFY(child2Node.getSubtreeSensors().size() == 1);
+  CORRADE_COMPARE(child2Node.getNodeSensors().size(), 1);
+  CORRADE_COMPARE(child2Node.getSubtreeSensors().size(), 1);
 }
 
 CORRADE_TEST_MAIN(SensorTest)

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -140,7 +140,8 @@ struct SimTest : Cr::TestSuite::Tester {
   LightSetup lightSetup2{{Magnum::Vector4{0.0f, 0.5f, 1.0f, 0.0f},
                           {0.0, 5.0, 5.0},
                           LightPositionModel::Camera}};
-};
+};  // struct SimTest
+
 struct {
   // display name for sim being tested
   const char* name;

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -328,7 +328,8 @@ void SimTest::getDefaultLightingRGBAObservation() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -345,7 +346,8 @@ void SimTest::getCustomLightingRGBAObservation() {
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -362,7 +364,8 @@ void SimTest::updateLightSetupRGBAObservation() {
   // update default lighting
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -376,7 +379,8 @@ void SimTest::updateLightSetupRGBAObservation() {
   // update custom lighting
   objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -396,7 +400,8 @@ void SimTest::updateObjectLightSetupRGBAObservation() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
   checkPinholeCameraRGBAObservation(
       *simulator, "SimTestExpectedDefaultLighting.png", maxThreshold, 0.71f);
@@ -423,12 +428,14 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({0.0f, 0.5f, -0.5f}, objectID);
 
   int otherObjectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_VERIFY(otherObjectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(otherObjectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({2.0f, 0.5f, -0.5f}, otherObjectID);
 
   checkPinholeCameraRGBAObservation(
@@ -524,7 +531,8 @@ void SimTest::loadingObjectTemplates() {
           Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
   CORRADE_VERIFY(!templateIndices.empty());
   for (auto index : templateIndices) {
-    CORRADE_VERIFY(index != esp::ID_UNDEFINED);
+    CORRADE_COMPARE_AS(index, esp::ID_UNDEFINED,
+                       Cr::TestSuite::Compare::NotEqual);
   }
 
   // reload again and ensure that old loaded indices are returned
@@ -560,15 +568,16 @@ void SimTest::loadingObjectTemplates() {
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
   newTemplate->setRenderAssetHandle(boxPath);
   int templateIndex = objectAttribsMgr->registerObject(newTemplate, boxPath);
-
-  CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(templateIndex, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   // change render asset for object template named boxPath
   std::string chairPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/chair.glb");
   newTemplate->setRenderAssetHandle(chairPath);
   int templateIndex2 = objectAttribsMgr->registerObject(newTemplate, boxPath);
 
-  CORRADE_VERIFY(templateIndex2 != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(templateIndex2, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   CORRADE_COMPARE(templateIndex2, templateIndex);
   ObjectAttributes::ptr newTemplate2 =
       objectAttribsMgr->getObjectCopyByHandle(boxPath);
@@ -604,7 +613,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     // valid values to be used to construct magnum primitives
     for (int i = 0; i < numPrimsExpected; ++i) {
       std::string handle = primObjAssetHandles[i];
-      CORRADE_VERIFY(handle != "");
+      CORRADE_VERIFY(!handle.empty());
       primAttr = assetAttribsMgr->getObjectCopyByHandle(handle);
       CORRADE_VERIFY(primAttr);
       CORRADE_VERIFY(primAttr->isValidTemplate());
@@ -614,8 +623,10 @@ void SimTest::buildingPrimAssetObjectTemplates() {
           esp::metadata::managers::AssetAttributesManager::PrimitiveNames3DMap
               .at(static_cast<esp::metadata::PrimObjTypes>(
                   primAttr->getPrimObjType()));
-      CORRADE_VERIFY((primAttr->getHandle() == handle) &&
-                     (handle.find(className) != std::string::npos));
+
+      CORRADE_COMPARE(primAttr->getHandle(), handle);
+      CORRADE_COMPARE_AS(handle.find(className), std::string::npos,
+                         Cr::TestSuite::Compare::NotEqual);
     }
   }
   // empty vector of handles
@@ -632,7 +643,8 @@ void SimTest::buildingPrimAssetObjectTemplates() {
                        Cr::TestSuite::Compare::Greater);
     // coneSolid should appear in handle
     std::string checkStr("coneSolid");
-    CORRADE_VERIFY(primObjAssetHandles[0].find(checkStr) != std::string::npos);
+    CORRADE_COMPARE_AS(primObjAssetHandles[0].find(checkStr), std::string::npos,
+                       Cr::TestSuite::Compare::NotEqual);
     // empty vector of handles
     primObjAssetHandles.clear();
 
@@ -669,12 +681,15 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     // verify that internal name of attributes has changed due to essential
     // quantity being modified
     std::string newHandle = primAttr->getHandle();
-    CORRADE_VERIFY(newHandle != origCylinderHandle);
+
+    CORRADE_COMPARE_AS(newHandle, origCylinderHandle,
+                       Cr::TestSuite::Compare::NotEqual);
     // set bogus file directory, to validate that copy is reggistered
     primAttr->setFileDirectory("test0");
     // register new attributes
     int idx = assetAttribsMgr->registerObject(primAttr);
-    CORRADE_VERIFY(idx != esp::ID_UNDEFINED);
+    CORRADE_COMPARE_AS(idx, esp::ID_UNDEFINED,
+                       Cr::TestSuite::Compare::NotEqual);
     // set new test label, to validate against retrieved copy
     primAttr->setFileDirectory("test1");
     // retrieve registered attributes copy
@@ -683,8 +698,10 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     // verify pre-reg and post-reg are named the same
     CORRADE_COMPARE(primAttr->getHandle(), primAttr2->getHandle());
     // verify retrieved attributes is copy, not original
-    CORRADE_VERIFY(primAttr->getFileDirectory() !=
-                   primAttr2->getFileDirectory());
+
+    CORRADE_COMPARE_AS(primAttr->getFileDirectory(),
+                       primAttr2->getFileDirectory(),
+                       Cr::TestSuite::Compare::NotEqual);
     // remove modified attributes
     AbstractPrimitiveAttributes::ptr primAttr3 =
         assetAttribsMgr->removeObjectByHandle(newHandle);
@@ -714,7 +731,8 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     CORRADE_VERIFY(newCylObjAttr);
     // create object with new attributes
     int objectID = simulator->addObjectByHandle(newHandle);
-    CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+    CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                       Cr::TestSuite::Compare::NotEqual);
   }
   // empty vector of handles
   primObjAssetHandles.clear();
@@ -727,14 +745,15 @@ void SimTest::addObjectByHandle() {
   setTestCaseDescription(data.name);
   auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
 
-  int objectId = simulator->addObjectByHandle("invalid_handle");
-  CORRADE_COMPARE(objectId, esp::ID_UNDEFINED);
+  int objectID = simulator->addObjectByHandle("invalid_handle");
+  CORRADE_COMPARE(objectID, esp::ID_UNDEFINED);
 
   // pass valid object_config.json filepath as handle to addObjectByHandle
   const auto validHandle = Cr::Utility::Directory::join(
       TEST_ASSETS, "objects/nested_box.object_config.json");
-  objectId = simulator->addObjectByHandle(validHandle);
-  CORRADE_VERIFY(objectId != esp::ID_UNDEFINED);
+  objectID = simulator->addObjectByHandle(validHandle);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
 }
 
 void SimTest::addSensorToObject() {
@@ -746,7 +765,8 @@ void SimTest::addSensorToObject() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("icosphereSolid");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   esp::scene::SceneNode& objectNode = *simulator->getObjectSceneNode(objectID);
 
   // Add sensor to sphere object
@@ -766,7 +786,8 @@ void SimTest::addSensorToObject() {
 
   auto objs2 = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID2 = simulator->addObjectByHandle(objs[0]);
-  CORRADE_VERIFY(objectID2 != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID2, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID2);
   esp::scene::SceneNode& objectNode2 =
       *simulator->getObjectSceneNode(objectID2);
@@ -823,7 +844,8 @@ void SimTest::createMagnumRenderingOff() {
   // check that adding a primitive object works
   objectID = simulator->addObjectByHandle("cubeSolid");
   simulator->setTranslation({10.0f, 10.0f, 10.0f}, objectID);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   esp::scene::SceneNode* objectNode = simulator->getObjectSceneNode(objectID);
 
   auto distanceBetween = [](Mn::Vector3 a, Mn::Vector3 b) {
@@ -872,7 +894,8 @@ void SimTest::createMagnumRenderingOff() {
   simulator->removeObject(objectID);
   objectID = simulator->addObjectByHandle("cubeWireframe");
   simulator->setTranslation({10.0f, 10.0f, 10.0f}, objectID);
-  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
+  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
+                     Cr::TestSuite::Compare::NotEqual);
   objectNode = simulator->getObjectSceneNode(objectID);
   testRaycast();
   testBoundingBox();

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -329,8 +329,7 @@ void SimTest::getDefaultLightingRGBAObservation() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -347,8 +346,7 @@ void SimTest::getCustomLightingRGBAObservation() {
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -365,8 +363,7 @@ void SimTest::updateLightSetupRGBAObservation() {
   // update default lighting
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -380,8 +377,7 @@ void SimTest::updateLightSetupRGBAObservation() {
   // update custom lighting
   objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
 
   checkPinholeCameraRGBAObservation(
@@ -401,8 +397,7 @@ void SimTest::updateObjectLightSetupRGBAObservation() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID);
   checkPinholeCameraRGBAObservation(
       *simulator, "SimTestExpectedDefaultLighting.png", maxThreshold, 0.71f);
@@ -429,14 +424,12 @@ void SimTest::multipleLightingSetupsRGBAObservation() {
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   simulator->setTranslation({0.0f, 0.5f, -0.5f}, objectID);
 
   int otherObjectID =
       simulator->addObjectByHandle(objs[0], nullptr, "custom_lighting_1");
-  CORRADE_COMPARE_AS(otherObjectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(otherObjectID != esp::ID_UNDEFINED);
   simulator->setTranslation({2.0f, 0.5f, -0.5f}, otherObjectID);
 
   checkPinholeCameraRGBAObservation(
@@ -532,8 +525,7 @@ void SimTest::loadingObjectTemplates() {
           Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
   CORRADE_VERIFY(!templateIndices.empty());
   for (auto index : templateIndices) {
-    CORRADE_COMPARE_AS(index, esp::ID_UNDEFINED,
-                       Cr::TestSuite::Compare::NotEqual);
+    CORRADE_VERIFY(index != esp::ID_UNDEFINED);
   }
 
   // reload again and ensure that old loaded indices are returned
@@ -569,16 +561,15 @@ void SimTest::loadingObjectTemplates() {
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
   newTemplate->setRenderAssetHandle(boxPath);
   int templateIndex = objectAttribsMgr->registerObject(newTemplate, boxPath);
-  CORRADE_COMPARE_AS(templateIndex, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+
+  CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
   // change render asset for object template named boxPath
   std::string chairPath =
       Cr::Utility::Directory::join(TEST_ASSETS, "objects/chair.glb");
   newTemplate->setRenderAssetHandle(chairPath);
   int templateIndex2 = objectAttribsMgr->registerObject(newTemplate, boxPath);
 
-  CORRADE_COMPARE_AS(templateIndex2, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(templateIndex2 != esp::ID_UNDEFINED);
   CORRADE_COMPARE(templateIndex2, templateIndex);
   ObjectAttributes::ptr newTemplate2 =
       objectAttribsMgr->getObjectCopyByHandle(boxPath);
@@ -626,8 +617,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
                   primAttr->getPrimObjType()));
 
       CORRADE_COMPARE(primAttr->getHandle(), handle);
-      CORRADE_COMPARE_AS(handle.find(className), std::string::npos,
-                         Cr::TestSuite::Compare::NotEqual);
+      CORRADE_VERIFY(handle.find(className) != std::string::npos);
     }
   }
   // empty vector of handles
@@ -644,8 +634,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
                        Cr::TestSuite::Compare::Greater);
     // coneSolid should appear in handle
     std::string checkStr("coneSolid");
-    CORRADE_COMPARE_AS(primObjAssetHandles[0].find(checkStr), std::string::npos,
-                       Cr::TestSuite::Compare::NotEqual);
+    CORRADE_VERIFY(primObjAssetHandles[0].find(checkStr) != std::string::npos);
     // empty vector of handles
     primObjAssetHandles.clear();
 
@@ -689,8 +678,8 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     primAttr->setFileDirectory("test0");
     // register new attributes
     int idx = assetAttribsMgr->registerObject(primAttr);
-    CORRADE_COMPARE_AS(idx, esp::ID_UNDEFINED,
-                       Cr::TestSuite::Compare::NotEqual);
+
+    CORRADE_VERIFY(idx != esp::ID_UNDEFINED);
     // set new test label, to validate against retrieved copy
     primAttr->setFileDirectory("test1");
     // retrieve registered attributes copy
@@ -732,8 +721,8 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     CORRADE_VERIFY(newCylObjAttr);
     // create object with new attributes
     int objectID = simulator->addObjectByHandle(newHandle);
-    CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                       Cr::TestSuite::Compare::NotEqual);
+
+    CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   }
   // empty vector of handles
   primObjAssetHandles.clear();
@@ -753,8 +742,7 @@ void SimTest::addObjectByHandle() {
   const auto validHandle = Cr::Utility::Directory::join(
       TEST_ASSETS, "objects/nested_box.object_config.json");
   objectID = simulator->addObjectByHandle(validHandle);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
 }
 
 void SimTest::addSensorToObject() {
@@ -766,8 +754,7 @@ void SimTest::addSensorToObject() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("icosphereSolid");
   int objectID = simulator->addObjectByHandle(objs[0]);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   esp::scene::SceneNode& objectNode = *simulator->getObjectSceneNode(objectID);
 
   // Add sensor to sphere object
@@ -787,8 +774,8 @@ void SimTest::addSensorToObject() {
 
   auto objs2 = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");
   int objectID2 = simulator->addObjectByHandle(objs[0]);
-  CORRADE_COMPARE_AS(objectID2, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+
+  CORRADE_VERIFY(objectID2 != esp::ID_UNDEFINED);
   simulator->setTranslation({1.0f, 0.5f, -0.5f}, objectID2);
   esp::scene::SceneNode& objectNode2 =
       *simulator->getObjectSceneNode(objectID2);
@@ -845,8 +832,7 @@ void SimTest::createMagnumRenderingOff() {
   // check that adding a primitive object works
   objectID = simulator->addObjectByHandle("cubeSolid");
   simulator->setTranslation({10.0f, 10.0f, 10.0f}, objectID);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   esp::scene::SceneNode* objectNode = simulator->getObjectSceneNode(objectID);
 
   auto distanceBetween = [](Mn::Vector3 a, Mn::Vector3 b) {
@@ -895,8 +881,7 @@ void SimTest::createMagnumRenderingOff() {
   simulator->removeObject(objectID);
   objectID = simulator->addObjectByHandle("cubeWireframe");
   simulator->setTranslation({10.0f, 10.0f, 10.0f}, objectID);
-  CORRADE_COMPARE_AS(objectID, esp::ID_UNDEFINED,
-                     Cr::TestSuite::Compare::NotEqual);
+  CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
   objectNode = simulator->getObjectSceneNode(objectID);
   testRaycast();
   testBoundingBox();

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -874,18 +874,18 @@ void SimTest::createMagnumRenderingOff() {
     // check that we can still compute bounding box of the object
     Magnum::Range3D meshbb = objectNode->getCumulativeBB();
     float eps = 0.001;
-    CORRADE_COMPARE_AS(abs(meshbb.left() - -0.1), eps,
-                       Cr::TestSuite::Compare::Less);
-    CORRADE_COMPARE_AS(abs(meshbb.right() - 0.1), eps,
-                       Cr::TestSuite::Compare::Less);
-    CORRADE_COMPARE_AS(abs(meshbb.bottom() - -0.1), eps,
-                       Cr::TestSuite::Compare::Less);
-    CORRADE_COMPARE_AS(abs(meshbb.top() - 0.1), eps,
-                       Cr::TestSuite::Compare::Less);
-    CORRADE_COMPARE_AS(abs(meshbb.back() - -0.1), eps,
-                       Cr::TestSuite::Compare::Less);
-    CORRADE_COMPARE_AS(abs(meshbb.front() - 0.1), eps,
-                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_WITH(meshbb.left(), -0.1,
+                         Cr::TestSuite::Compare::around(eps));
+    CORRADE_COMPARE_WITH(meshbb.right(), 0.1,
+                         Cr::TestSuite::Compare::around(eps));
+    CORRADE_COMPARE_WITH(meshbb.bottom(), -0.1,
+                         Cr::TestSuite::Compare::around(eps));
+    CORRADE_COMPARE_WITH(meshbb.top(), 0.1,
+                         Cr::TestSuite::Compare::around(eps));
+    CORRADE_COMPARE_WITH(meshbb.back(), -0.1,
+                         Cr::TestSuite::Compare::around(eps));
+    CORRADE_COMPARE_WITH(meshbb.front(), 0.1,
+                         Cr::TestSuite::Compare::around(eps));
   };
   // test raycast and bounding box for cubeSolid
   testRaycast();

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <Corrade/Containers/StridedArrayView.h>
+#include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/Directory.h>
 #include <Magnum/DebugTools/CompareImage.h>
@@ -195,7 +196,7 @@ void SimTest::reconfigure() {
   Simulator simulator(cfg);
   PathFinder::ptr pathfinder = simulator.getPathFinder();
   simulator.reconfigure(cfg);
-  CORRADE_VERIFY(pathfinder == simulator.getPathFinder());
+  CORRADE_COMPARE(pathfinder, simulator.getPathFinder());
   SimulatorConfiguration cfg2;
   cfg2.activeSceneName = skokloster;
   simulator.reconfigure(cfg2);
@@ -208,7 +209,7 @@ void SimTest::reconfigure() {
   Simulator simulator_mm(cfg_mm, MM);
   PathFinder::ptr pathfinder_mm = simulator_mm.getPathFinder();
   simulator_mm.reconfigure(cfg_mm);
-  CORRADE_VERIFY(pathfinder_mm == simulator_mm.getPathFinder());
+  CORRADE_COMPARE(pathfinder_mm, simulator_mm.getPathFinder());
   SimulatorConfiguration cfg2_mm;
   cfg2_mm.activeSceneName = skokloster;
   simulator_mm.reconfigure(cfg2_mm);
@@ -235,9 +236,9 @@ void SimTest::reset() {
 
     auto stateFinal = AgentState::create();
     agent->getState(stateFinal);
-    CORRADE_VERIFY(stateOrig->position == stateFinal->position);
-    CORRADE_VERIFY(stateOrig->rotation == stateFinal->rotation);
-    CORRADE_VERIFY(pathfinder == simulator.getPathFinder());
+    CORRADE_COMPARE(stateOrig->position, stateFinal->position);
+    CORRADE_COMPARE(stateOrig->rotation, stateFinal->rotation);
+    CORRADE_COMPARE(pathfinder, simulator.getPathFinder());
   };
 
   SimulatorConfiguration cfg;
@@ -530,14 +531,14 @@ void SimTest::loadingObjectTemplates() {
   std::vector<int> templateIndices2 =
       objectAttribsMgr->loadAllJSONConfigsFromPath(
           Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
-  CORRADE_VERIFY(templateIndices2 == templateIndices);
+  CORRADE_COMPARE(templateIndices2, templateIndices);
 
   // test the loaded assets and accessing them by name
   // verify that getting the template handles with empty string returns all
   int numLoadedTemplates = templateIndices2.size();
   std::vector<std::string> templateHandles =
       objectAttribsMgr->getFileTemplateHandlesBySubstring();
-  CORRADE_VERIFY(numLoadedTemplates == templateHandles.size());
+  CORRADE_COMPARE(numLoadedTemplates, templateHandles.size());
 
   // verify that querying with sub string returns template handle corresponding
   // to that substring
@@ -550,7 +551,7 @@ void SimTest::loadingObjectTemplates() {
   // get all handles that match 2nd half of known handle
   std::vector<std::string> matchTmpltHandles =
       objectAttribsMgr->getObjectHandlesBySubstring(tmpHndl);
-  CORRADE_VERIFY(matchTmpltHandles[0] == fullTmpHndl);
+  CORRADE_COMPARE(matchTmpltHandles[0], fullTmpHndl);
 
   // test fresh template as smart pointer
   ObjectAttributes::ptr newTemplate =
@@ -568,10 +569,10 @@ void SimTest::loadingObjectTemplates() {
   int templateIndex2 = objectAttribsMgr->registerObject(newTemplate, boxPath);
 
   CORRADE_VERIFY(templateIndex2 != esp::ID_UNDEFINED);
-  CORRADE_VERIFY(templateIndex2 == templateIndex);
+  CORRADE_COMPARE(templateIndex2, templateIndex);
   ObjectAttributes::ptr newTemplate2 =
       objectAttribsMgr->getObjectCopyByHandle(boxPath);
-  CORRADE_VERIFY(newTemplate2->getRenderAssetHandle() == chairPath);
+  CORRADE_COMPARE(newTemplate2->getRenderAssetHandle(), chairPath);
 }
 
 void SimTest::buildingPrimAssetObjectTemplates() {
@@ -595,7 +596,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
   int numPrimsExpected =
       static_cast<int>(esp::metadata::PrimObjTypes::END_PRIM_OBJ_TYPES);
   // verify the number of primitive templates
-  CORRADE_VERIFY(numPrimsExpected == primObjAssetHandles.size());
+  CORRADE_COMPARE(numPrimsExpected, primObjAssetHandles.size());
 
   AbstractPrimitiveAttributes::ptr primAttr;
   {
@@ -625,9 +626,10 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     primObjAssetHandles =
         objectAttribsMgr->getSynthTemplateHandlesBySubstring("CONESOLID");
     // should only be one handle in this vector
-    CORRADE_VERIFY(1 == primObjAssetHandles.size());
+    CORRADE_COMPARE(primObjAssetHandles.size(), 1);
     // handle should not be empty and be long enough to hold class name prefix
-    CORRADE_VERIFY(9 < primObjAssetHandles[0].length());
+    CORRADE_COMPARE_AS(primObjAssetHandles[0].length(), 9,
+                       Cr::TestSuite::Compare::Greater);
     // coneSolid should appear in handle
     std::string checkStr("coneSolid");
     CORRADE_VERIFY(primObjAssetHandles[0].find(checkStr) != std::string::npos);
@@ -639,9 +641,9 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     primObjAssetHandles = objectAttribsMgr->getSynthTemplateHandlesBySubstring(
         "CONESOLID", false);
     // should be all handles but coneSolid handle here
-    CORRADE_VERIFY((numPrimsExpected - 1) == primObjAssetHandles.size());
+    CORRADE_COMPARE((numPrimsExpected - 1), primObjAssetHandles.size());
     for (auto primObjAssetHandle : primObjAssetHandles) {
-      CORRADE_VERIFY(primObjAssetHandle.find(checkStr) == std::string::npos);
+      CORRADE_COMPARE(primObjAssetHandle.find(checkStr), std::string::npos);
     }
   }
   // empty vector of handles
@@ -654,12 +656,12 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     primObjAssetHandles = assetAttribsMgr->getTemplateHandlesByPrimType(
         esp::metadata::PrimObjTypes::CYLINDER_SOLID);
     // should only be one handle in this vector
-    CORRADE_VERIFY(1 == primObjAssetHandles.size());
+    CORRADE_COMPARE(primObjAssetHandles.size(), 1);
     // primitive render object uses primitive render asset as handle
     std::string origCylinderHandle = primObjAssetHandles[0];
     primAttr = assetAttribsMgr->getObjectCopyByHandle(origCylinderHandle);
     // verify that the origin handle matches what is expected
-    CORRADE_VERIFY(primAttr->getHandle() == origCylinderHandle);
+    CORRADE_COMPARE(primAttr->getHandle(), origCylinderHandle);
     // get original number of rings for this cylinder
     int origNumRings = primAttr->getNumRings();
     // modify attributes - this will change handle
@@ -679,14 +681,14 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     AbstractPrimitiveAttributes::ptr primAttr2 =
         assetAttribsMgr->getObjectCopyByHandle(newHandle);
     // verify pre-reg and post-reg are named the same
-    CORRADE_VERIFY(primAttr->getHandle() == primAttr2->getHandle());
+    CORRADE_COMPARE(primAttr->getHandle(), primAttr2->getHandle());
     // verify retrieved attributes is copy, not original
     CORRADE_VERIFY(primAttr->getFileDirectory() !=
                    primAttr2->getFileDirectory());
     // remove modified attributes
     AbstractPrimitiveAttributes::ptr primAttr3 =
         assetAttribsMgr->removeObjectByHandle(newHandle);
-    CORRADE_VERIFY(nullptr != primAttr3);
+    CORRADE_VERIFY(primAttr3);
   }
   // empty vector of handles
   primObjAssetHandles.clear();
@@ -709,7 +711,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
     // create object template with modified primitive asset attributes, by
     // passing handle.  defaults to register object template
     auto newCylObjAttr = objectAttribsMgr->createObject(newHandle);
-    CORRADE_VERIFY(nullptr != newCylObjAttr);
+    CORRADE_VERIFY(newCylObjAttr);
     // create object with new attributes
     int objectID = simulator->addObjectByHandle(newHandle);
     CORRADE_VERIFY(objectID != esp::ID_UNDEFINED);
@@ -726,7 +728,7 @@ void SimTest::addObjectByHandle() {
   auto simulator = data.creator(*this, planeStage, esp::NO_LIGHT_KEY);
 
   int objectId = simulator->addObjectByHandle("invalid_handle");
-  CORRADE_VERIFY(objectId == esp::ID_UNDEFINED);
+  CORRADE_COMPARE(objectId, esp::ID_UNDEFINED);
 
   // pass valid object_config.json filepath as handle to addObjectByHandle
   const auto validHandle = Cr::Utility::Directory::join(
@@ -833,26 +835,34 @@ void SimTest::createMagnumRenderingOff() {
     // cast a ray at the object to check that the object is actually there
     auto raycastresults = simulator->castRay(
         esp::geo::Ray({10.0, 9.0, 10.0}, {0.0, 1.0, 0.0}), 100.0, 0);
-    CORRADE_VERIFY(raycastresults.hits[0].objectId == objectID);
+    CORRADE_COMPARE(raycastresults.hits[0].objectId, objectID);
     auto point = raycastresults.hits[0].point;
-    CORRADE_VERIFY(distanceBetween(point, {10.0, 9.9, 10.0}) < 0.001);
+    CORRADE_COMPARE_AS(distanceBetween(point, {10.0, 9.9, 10.0}), 0.001,
+                       Cr::TestSuite::Compare::Less);
     raycastresults = simulator->castRay(
         esp::geo::Ray({10.0, 11.0, 10.0}, {0.0, -1.0, 0.0}), 100.0, 0);
-    CORRADE_VERIFY(raycastresults.hits[0].objectId == objectID);
+    CORRADE_COMPARE(raycastresults.hits[0].objectId, objectID);
     point = raycastresults.hits[0].point;
-    CORRADE_VERIFY(distanceBetween(point, {10.0, 10.1, 10.0}) < 0.001);
+    CORRADE_COMPARE_AS(distanceBetween(point, {10.0, 10.1, 10.0}), 0.001,
+                       Cr::TestSuite::Compare::Less);
   };
 
   auto testBoundingBox = [&]() {
     // check that we can still compute bounding box of the object
     Magnum::Range3D meshbb = objectNode->getCumulativeBB();
     float eps = 0.001;
-    CORRADE_VERIFY(abs(meshbb.left() - -0.1) < eps);
-    CORRADE_VERIFY(abs(meshbb.right() - 0.1) < eps);
-    CORRADE_VERIFY(abs(meshbb.bottom() - -0.1) < eps);
-    CORRADE_VERIFY(abs(meshbb.top() - 0.1) < eps);
-    CORRADE_VERIFY(abs(meshbb.back() - -0.1) < eps);
-    CORRADE_VERIFY(abs(meshbb.front() - 0.1) < eps);
+    CORRADE_COMPARE_AS(abs(meshbb.left() - -0.1), eps,
+                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_AS(abs(meshbb.right() - 0.1), eps,
+                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_AS(abs(meshbb.bottom() - -0.1), eps,
+                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_AS(abs(meshbb.top() - 0.1), eps,
+                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_AS(abs(meshbb.back() - -0.1), eps,
+                       Cr::TestSuite::Compare::Less);
+    CORRADE_COMPARE_AS(abs(meshbb.front() - 0.1), eps,
+                       Cr::TestSuite::Compare::Less);
   };
   // test raycast and bounding box for cubeSolid
   testRaycast();
@@ -882,7 +892,7 @@ void SimTest::createMagnumRenderingOff() {
 
   // check that there is no renderer
   CORRADE_VERIFY(!simulator->getRenderer());
-  CORRADE_VERIFY(cameraSensor.getObservation(*simulator, observation) == false);
+  CORRADE_VERIFY(!cameraSensor.getObservation(*simulator, observation));
 }
 
 }  // namespace

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -605,7 +605,7 @@ void SimTest::buildingPrimAssetObjectTemplates() {
       std::string handle = primObjAssetHandles[i];
       CORRADE_VERIFY(handle != "");
       primAttr = assetAttribsMgr->getObjectCopyByHandle(handle);
-      CORRADE_VERIFY(primAttr != nullptr);
+      CORRADE_VERIFY(primAttr);
       CORRADE_VERIFY(primAttr->isValidTemplate());
       // verify that the attributes contains the handle, and the handle contains
       // the expected class name
@@ -881,7 +881,7 @@ void SimTest::createMagnumRenderingOff() {
   Observation observation;
 
   // check that there is no renderer
-  CORRADE_VERIFY(simulator->getRenderer() == nullptr);
+  CORRADE_VERIFY(!simulator->getRenderer());
   CORRADE_VERIFY(cameraSensor.getObservation(*simulator, observation) == false);
 }
 

--- a/src/tests/SuncgTest.cpp
+++ b/src/tests/SuncgTest.cpp
@@ -11,7 +11,7 @@
 
 namespace Cr = Corrade;
 
-namespace Test {
+namespace {
 
 struct SuncgTest : Cr::TestSuite::Tester {
   explicit SuncgTest();
@@ -51,6 +51,5 @@ void SuncgTest::testLoad() {
     }
   }
 }
-}  // namespace Test
-
-CORRADE_TEST_MAIN(Test::SuncgTest)
+}  // namespace
+CORRADE_TEST_MAIN(SuncgTest)

--- a/src/tests/SuncgTest.cpp
+++ b/src/tests/SuncgTest.cpp
@@ -38,19 +38,14 @@ void SuncgTest::testLoad() {
 
   CORRADE_VERIFY(house.levels().size() > 0);
   for (auto& level : house.levels()) {
-    ESP_DEBUG() << "Level{id:"
-                << level->id()
-                // << ",aabb:" << level->aabb()
-                << "}";
+    ESP_DEBUG() << "Level{id:" << level->id()
+                << ",aabb:" << Mn::Range3D{level->aabb()} << "}";
     for (auto& region : level->regions()) {
-      ESP_DEBUG() << "Region{id:"
-                  << region->id()
-                  //<< ",aabb:" << region->aabb()
+      ESP_DEBUG() << "Region{id:" << region->id()
+                  << ",aabb:" << Mn::Range3D{region->aabb()}
                   << ",category:" << region->category()->name() << "}";
       for (auto& object : region->objects()) {
-        ESP_DEBUG() << "Object{id:"
-                    << object->id()
-                    //<< ",obb:" << object->obb()
+        ESP_DEBUG() << "Object{id:" << object->id() << ",obb:" << object->obb()
                     << ",category:" << object->category()->name() << "}";
       }
     }

--- a/src/tests/SuncgTest.cpp
+++ b/src/tests/SuncgTest.cpp
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/Directory.h>
-#include <gtest/gtest.h>
 
 #include "esp/scene/SemanticScene.h"
 
@@ -11,32 +11,51 @@
 
 namespace Cr = Corrade;
 
-namespace esp {
-namespace scene {
+namespace Test {
 
-TEST(SuncgTest, Load) {
-  logging::LoggingContext loggingContext;
+struct SuncgTest : Cr::TestSuite::Tester {
+  explicit SuncgTest();
+
+  void testLoad();
+  esp::logging::LoggingContext loggingContext;
+
+};  // struct SuncgTest
+
+SuncgTest::SuncgTest() {
+  addTests({&SuncgTest::testLoad});
+}
+
+void SuncgTest::testLoad() {
   const std::string filename = Cr::Utility::Directory::join(
       SCENE_DATASETS, "suncg/0a0b9b45a1db29832dd84e80c1347854.json");
-  if (!Cr::Utility::Directory::exists(filename))
-    GTEST_SKIP_("SUNCG dataset not found.");
+  if (!Cr::Utility::Directory::exists(filename)) {
+    CORRADE_SKIP("SUNCG dataset not found.");
+  }
 
-  SemanticScene house;
-  SemanticScene::loadSuncgHouse(filename, house);
-  ESP_DEBUG() << "House, bbox:" << house.aabb();
+  esp::scene::SemanticScene house;
+  esp::scene::SemanticScene::loadSuncgHouse(filename, house);
+  // ESP_DEBUG() << "House, bbox:" << house.aabb();
 
+  CORRADE_VERIFY(house.levels().size() > 0);
   for (auto& level : house.levels()) {
-    ESP_DEBUG() << "Level{id:" << level->id() << ",aabb:" << level->aabb()
+    ESP_DEBUG() << "Level{id:"
+                << level->id()
+                // << ",aabb:" << level->aabb()
                 << "}";
     for (auto& region : level->regions()) {
-      ESP_DEBUG() << "Region{id:" << region->id() << ",aabb:" << region->aabb()
+      ESP_DEBUG() << "Region{id:"
+                  << region->id()
+                  //<< ",aabb:" << region->aabb()
                   << ",category:" << region->category()->name() << "}";
       for (auto& object : region->objects()) {
-        ESP_DEBUG() << "Object{id:" << object->id() << ",obb:" << object->obb()
+        ESP_DEBUG() << "Object{id:"
+                    << object->id()
+                    //<< ",obb:" << object->obb()
                     << ",category:" << object->category()->name() << "}";
       }
     }
   }
 }
-}  // namespace scene
-}  // namespace esp
+}  // namespace Test
+
+CORRADE_TEST_MAIN(Test::SuncgTest)

--- a/src/tests/VoxelGridTest.cpp
+++ b/src/tests/VoxelGridTest.cpp
@@ -14,6 +14,8 @@
 namespace Cr = Corrade;
 namespace Mn = Magnum;
 
+namespace {
+
 // Test is not compiled if --vhacd is not enabled
 struct VoxelGridTest : Cr::TestSuite::Tester {
   explicit VoxelGridTest();
@@ -181,5 +183,6 @@ void VoxelGridTest::testVoxelUtilityFunctions() {
   }
   CORRADE_VERIFY(valuesAreInRange);
 }
+}  // namespace
 
 CORRADE_TEST_MAIN(VoxelGridTest)

--- a/src/tests/VoxelGridTest.cpp
+++ b/src/tests/VoxelGridTest.cpp
@@ -53,7 +53,7 @@ void VoxelGridTest::testVoxelGridWithVHACD() {
       voxelization->getGlobalCoordsFromVoxelIndex(voxelIndex);
   Mn::Vector3i deconvertedVoxelIndex =
       voxelization->getVoxelIndexFromGlobalCoords(globalCoords);
-  CORRADE_VERIFY(voxelIndex == deconvertedVoxelIndex);
+  CORRADE_COMPARE(voxelIndex, deconvertedVoxelIndex);
 
   // "Golden Value Tests" - Verify that certain values return the correct
   // coordinates
@@ -66,10 +66,12 @@ void VoxelGridTest::testVoxelGridWithVHACD() {
       std::vector<Mn::Vector3>{Mn::Vector3(-9.75916, -0.390074, 0.973851),
                                Mn::Vector3(8.89573, 7.07188, 25.5983)};
   for (int i = 0; i < voxel_indices.size(); i++) {
-    CORRADE_VERIFY(voxelization->getGlobalCoordsFromVoxelIndex(
-                       voxel_indices[i]) == global_coords[i]);
-    CORRADE_VERIFY(voxelization->getVoxelIndexFromGlobalCoords(
-                       global_coords[i]) == voxel_indices[i]);
+    CORRADE_COMPARE(
+        voxelization->getGlobalCoordsFromVoxelIndex(voxel_indices[i]),
+        global_coords[i]);
+    CORRADE_COMPARE(
+        voxelization->getVoxelIndexFromGlobalCoords(global_coords[i]),
+        voxel_indices[i]);
   }
 
   // Ensure voxel grid setters and getters work, specifically direct grid


### PR DESCRIPTION
## Motivation and Context
This PR refactors all the existing c++ tests in esp/tests/ to use the Corrade test suite instead of google test.  The eventual goal is to remove the gtest suite entirely.  

This is the first of 2 PRs to address this and only addresses the tests in the esp/tests/ directory.  Part 2 of this series of PRs will move all tests that reside elsewhere to be in esp/tests/ directory, and will also refactor any other remaining c++ tests to use the Corrade test suite.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ tests locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
