### PR TITLE
[Bugfix]: make corrade plugins static

### DIFF
--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -11,9 +11,9 @@ if(NOT USE_SYSTEM_MAGNUM)
   # for slightly faster builds. If you need any of these, simply delete a line.
   set(WITH_INTERCONNECT OFF CACHE BOOL "" FORCE)
   # Ensure Corrade should be built statically if Magnum is.
-  set(BUILD_PLUGINS_STATIC ON CACHE BOOL "BUILD_PLUGINS_STATIC" FORCE)
-  set(BUILD_STATIC ON CACHE BOOL "BUILD_STATIC" FORCE)
-  set(BUILD_STATIC_PIC ON CACHE BOOL "BUILD_STATIC_PIC" FORCE)
+  set(BUILD_PLUGINS_STATIC ON CACHE BOOL "" FORCE)
+  set(BUILD_STATIC ON CACHE BOOL "" FORCE)
+  set(BUILD_STATIC_PIC ON CACHE BOOL "" FORCE)
   add_subdirectory("${DEPS_DIR}/corrade")
 endif()
 find_package(Corrade REQUIRED Utility)
@@ -172,9 +172,7 @@ endif()
 
 # Magnum. Use a system package, if preferred.
 if(NOT USE_SYSTEM_MAGNUM)
-  set(BUILD_PLUGINS_STATIC ON CACHE BOOL "BUILD_PLUGINS_STATIC" FORCE)
-  set(BUILD_STATIC ON CACHE BOOL "BUILD_STATIC" FORCE)
-  set(BUILD_STATIC_PIC ON CACHE BOOL "BUILD_STATIC_PIC" FORCE)
+  # Magnum is already set to be build statically when Corrade is above.
 
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -10,6 +10,9 @@ if(NOT USE_SYSTEM_MAGNUM)
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.
   set(WITH_INTERCONNECT OFF CACHE BOOL "" FORCE)
+  set(BUILD_PLUGINS_STATIC ON CACHE BOOL "BUILD_PLUGINS_STATIC" FORCE)
+  set(BUILD_STATIC ON CACHE BOOL "BUILD_STATIC" FORCE)
+  set(BUILD_STATIC_PIC ON CACHE BOOL "BUILD_STATIC_PIC" FORCE)
   add_subdirectory("${DEPS_DIR}/corrade")
 endif()
 find_package(Corrade REQUIRED Utility)

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -10,6 +10,7 @@ if(NOT USE_SYSTEM_MAGNUM)
   # These are enabled by default but we don't need them right now -- disabling
   # for slightly faster builds. If you need any of these, simply delete a line.
   set(WITH_INTERCONNECT OFF CACHE BOOL "" FORCE)
+  # Ensure Corrade should be built statically if Magnum is.
   set(BUILD_PLUGINS_STATIC ON CACHE BOOL "BUILD_PLUGINS_STATIC" FORCE)
   set(BUILD_STATIC ON CACHE BOOL "BUILD_STATIC" FORCE)
   set(BUILD_STATIC_PIC ON CACHE BOOL "BUILD_STATIC_PIC" FORCE)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Previously our corrade plugins were not statically linked which complicated the rpath resolution. Apparently, this was a bug and can be fixed with a simple cmake change which ensure that corrade is built statically as well.
* Now that this change is made, it vastly simplifies the rpath issues we were having before since Magnum and Habitat-Sim are both separately and statically linked.
* Fixes a bug where importing magnum would fail if habitat_sim was not imported first (due to shared lib dependencies installed in the habitat_sim folder.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally on OSX and on CI.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
