### PR TITLE
Fix Double PathFinder

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -121,12 +121,14 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     sceneManager_ = scene::SceneManager::create_unique();
   }
 
-  if (!pathfinder_) {
-    pathfinder_ = nav::PathFinder::create();
-  }
-
   // if configuration is unchanged, just reset and return
   if (cfg == config_) {
+    // This is a check to make sure that pathfinder_ is not null after
+    // a reconfigure. We check to see if it's null so that an existing
+    // one isn't overwritten.
+    if (!pathfinder_) {
+      pathfinder_ = nav::PathFinder::create();
+    }
     reset();
     return;
   }
@@ -211,6 +213,7 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   ESP_DEBUG() << "Navmesh file location in scene instance :" << navmeshFileLoc;
   // Get name of navmesh and use to create pathfinder and load navmesh
   // create pathfinder and load navmesh if available
+  pathfinder_ = nav::PathFinder::create();
   if (FileUtil::exists(navmeshFileLoc)) {
     ESP_DEBUG() << "Loading navmesh from" << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -121,6 +121,10 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     sceneManager_ = scene::SceneManager::create_unique();
   }
 
+  if (!pathfinder_) {
+    pathfinder_ = nav::PathFinder::create();
+  }
+
   // if configuration is unchanged, just reset and return
   if (cfg == config_) {
     reset();
@@ -207,7 +211,6 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   ESP_DEBUG() << "Navmesh file location in scene instance :" << navmeshFileLoc;
   // Get name of navmesh and use to create pathfinder and load navmesh
   // create pathfinder and load navmesh if available
-  pathfinder_ = nav::PathFinder::create();
   if (FileUtil::exists(navmeshFileLoc)) {
     ESP_DEBUG() << "Loading navmesh from" << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);


### PR DESCRIPTION
## Motivation and Context

Due to legacy reasons, we create a pathfinder object in the python sim _after_ the cpp sim has been initialized. This means that the navmesh loaded via the scene dataset get's unloaded!

## How Has This Been Tested

Via tests. We have a lot of tests that require the navmesh to be loaded correctly and I do not see python saying it loaded the navmesh, so cpp must be doing it correctly!

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
