### PR TITLE
Add option to preserve URDF link ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,8 +626,6 @@ jobs:
       - restore_cache:
           keys:
             - conda-{{ checksum "habitat-sim/.circleci/config.yml" }}
-      - run: *install_conda
-      - run: *install_deps
       - run:
           name: Build conda Linux packages
           no_output_timeout: 240m

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -286,6 +286,7 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
 
           "filepath"_a, "fixed_base"_a = false, "global_scale"_a = 1.0,
           "mass_scale"_a = 1.0, "force_reload"_a = false,
+          "maintain_link_order"_a = false,
           "light_setup_key"_a = DEFAULT_LIGHTING_KEY,
           R"(Load and parse a URDF file using the given 'filepath' into a model,
           then use this model to instantiate an Articulated Object in the world.

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -207,6 +207,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
   }
 
   // Get all link elements including shapes
+  int link_index = 0;
   for (const XMLElement* link_xml = robot_xml->FirstChildElement("link");
        link_xml; link_xml = link_xml->NextSiblingElement("link")) {
     std::shared_ptr<Link> link = std::make_shared<Link>();
@@ -238,6 +239,9 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
 
         // register the new link
         urdfModel->m_links[link->m_name] = link;
+        link->m_linkIndex = link_index;
+        urdfModel->m_linkIndicesToNames[link->m_linkIndex] = link->m_name;
+        link_index++;
       }
     } else {
       ESP_ERROR() << "Failed to parse link. Aborting parse/load for"
@@ -935,17 +939,11 @@ bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
   }
 
   // search for children that have no parent, those are 'root'
-  int index = 0;
   for (auto itr = model->m_links.begin(); itr != model->m_links.end(); itr++) {
     auto link = itr->second;
-
-    link->m_linkIndex = index;
-    model->m_linkIndicesToNames[link->m_linkIndex] = link->m_name;
-
     if (!link->m_parentLink.lock()) {
       model->m_rootLinks.push_back(link);
     }
-    index++;
   }
 
   if (model->m_rootLinks.size() > 1) {

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -288,7 +288,7 @@ int PhysicsManager::addArticulatedObjectInstance(
   int aObjID = this->addArticulatedObjectFromURDF(
       filepath, &drawables, aObjInstAttributes->getFixedBase(),
       aObjInstAttributes->getUniformScale(), aObjInstAttributes->getMassScale(),
-      false, lightSetup);
+      false, false, lightSetup);
   if (aObjID == ID_UNDEFINED) {
     // instancing failed for some reason.
     ESP_ERROR() << "Articulated Object create failed for model filepath"

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -493,6 +493,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref BulletArticulatedObject, allocated from
@@ -504,6 +506,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float globalScale = 1.0,
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
+      CORRADE_UNUSED bool maintainLinkOrder = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;
@@ -526,6 +529,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -538,6 +543,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float globalScale = 1.0,
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
+      CORRADE_UNUSED bool maintainLinkOrder = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -104,7 +104,7 @@ void BulletArticulatedObject::initializeFromURDF(
                 return a.m_index < b.m_index;
               });
 
-    if (allIndices.size() + 1 >= parentTransforms.size()) {
+    if (allIndices.size() + 1 > parentTransforms.size()) {
       parentTransforms.resize(allIndices.size() + 1);
     }
     for (size_t i = 0; i < allIndices.size(); ++i) {

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -104,7 +104,10 @@ void BulletArticulatedObject::initializeFromURDF(
                 return a.m_index < b.m_index;
               });
 
-    for (int i = 0; i < allIndices.size(); i++) {
+    if (allIndices.size() + 1 >= parentTransforms.size()) {
+      parentTransforms.resize(allIndices.size() + 1);
+    }
+    for (size_t i = 0; i < allIndices.size(); ++i) {
       int urdfLinkIndex = allIndices[i].m_index;
       int parentIndex = allIndices[i].m_parentIndex;
       Mn::Matrix4 parentTr = parentIndex >= 0 ? parentTransforms[parentIndex]
@@ -112,9 +115,6 @@ void BulletArticulatedObject::initializeFromURDF(
       Mn::Matrix4 tr = u2b.convertURDF2BulletInternal(
           urdfLinkIndex, parentTr, bWorld_.get(), linkCompoundShapes_,
           linkChildShapes_, recursive);
-      if ((urdfLinkIndex + 1) >= parentTransforms.size()) {
-        parentTransforms.resize(urdfLinkIndex + 1);
-      }
       parentTransforms[urdfLinkIndex] = tr;
     }
   }

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -110,11 +110,12 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     float globalScale,
     float massScale,
     bool forceReload,
+    bool maintainLinkOrder,
     const std::string& lightSetup) {
   auto& drawables = simulator_->getDrawableGroup();
   return addArticulatedObjectFromURDF(filepath, &drawables, fixedBase,
                                       globalScale, massScale, forceReload,
-                                      lightSetup);
+                                      maintainLinkOrder, lightSetup);
 }
 
 int BulletPhysicsManager::addArticulatedObjectFromURDF(
@@ -124,6 +125,7 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     float globalScale,
     float massScale,
     bool forceReload,
+    bool maintainLinkOrder,
     const std::string& lightSetup) {
   ESP_CHECK(
       urdfImporter_->loadURDF(filepath, globalScale, massScale, forceReload),
@@ -148,6 +150,9 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
 
   // TODO: set these flags up better
   u2b->flags = 0;
+  if (maintainLinkOrder) {
+    u2b->flags |= CUF_MAINTAIN_LINK_ORDER;
+  }
   u2b->initURDF2BulletCache();
 
   articulatedObject->initializeFromURDF(*urdfImporter_, {}, physicsNode_);
@@ -162,20 +167,20 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
   }
 
   // attach link visual shapes
-  int urdfLinkIx = 0;
-  for (auto& link : urdfImporter_->getModel()->m_links) {
-    if (link.second->m_visualArray.size() > 0) {
+  for (size_t urdfLinkIx = 0; urdfLinkIx < u2b->getModel()->m_links.size();
+       ++urdfLinkIx) {
+    auto urdfLink = u2b->getModel()->getLink(urdfLinkIx);
+    if (urdfLink->m_visualArray.size() > 0) {
       int bulletLinkIx =
           u2b->cache->m_urdfLinkIndices2BulletLinkIndices[urdfLinkIx];
       ArticulatedLink& linkObject = articulatedObject->getLink(bulletLinkIx);
       ESP_CHECK(
-          attachLinkGeometry(&linkObject, link.second, drawables, lightSetup),
+          attachLinkGeometry(&linkObject, urdfLink, drawables, lightSetup),
           "BulletPhysicsManager::addArticulatedObjectFromURDF(): Failed to "
           "instance render asset (attachGeometry) for link"
               << urdfLinkIx << ".");
       linkObject.node().computeCumulativeBB();
     }
-    urdfLinkIx++;
   }
 
   // clear the cache

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -78,6 +78,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -89,6 +91,7 @@ class BulletPhysicsManager : public PhysicsManager {
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
+      bool maintainLinkOrder = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
 
   /**
@@ -106,6 +109,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -118,6 +123,7 @@ class BulletPhysicsManager : public PhysicsManager {
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
+      bool maintainLinkOrder = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
 
   /**

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -647,12 +647,5 @@ Mn::Matrix4 BulletURDFImporter::convertURDF2BulletInternal(
   return linkTransformInWorldSpace;
 }
 
-Mn::Debug& operator<<(Mn::Debug& debug, const childParentIndex cpi) {
-  debug << "childParentIndex";
-  return debug << "\nindex: " << cpi.m_index << "\n mbIndex: " << cpi.m_mbIndex
-               << "\n parentIndex: " << cpi.m_parentIndex
-               << "\n parentMBIndex: " << cpi.m_parentMBIndex;
-}
-
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -196,7 +196,7 @@ void BulletURDFImporter::getAllIndices(
       parentIndex >= 0 ? cache->getMbIndexFromUrdfIndex(parentIndex) : -1;
   cp.m_parentMBIndex = parentMbIndex;
 
-  allIndices.push_back(cp);
+  allIndices.emplace_back(std::move(cp));
   std::vector<int> urdfChildIndices;
   getLinkChildIndices(urdfLinkIndex, urdfChildIndices);
   int numChildren = urdfChildIndices.size();

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -121,7 +121,7 @@ btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
 }
 
 btCompoundShape* BulletURDFImporter::convertLinkCollisionShapes(
-    int linkIndex,
+    int urdfLinkIndex,
     const btTransform& localInertiaFrame,
     std::vector<std::unique_ptr<btCollisionShape>>& linkChildShapes) {
   // TODO: smart pointer
@@ -129,55 +129,39 @@ btCompoundShape* BulletURDFImporter::convertLinkCollisionShapes(
 
   compoundShape->setMargin(gUrdfDefaultCollisionMargin);
 
-  ESP_VERY_VERBOSE() << "num links =" << activeModel_->m_links.size();
+  auto link = activeModel_->getLink(urdfLinkIndex);
 
-  auto itr = activeModel_->m_links.begin();
-  for (int i = 0; (i < linkIndex && itr != activeModel_->m_links.end()); i++) {
-    itr++;
-  }
-  if (itr != activeModel_->m_links.end()) {
-    std::shared_ptr<io::URDF::Link> link = itr->second;
+  for (size_t v = 0; v < link->m_collisionArray.size(); ++v) {
+    const io::URDF::CollisionShape& col = link->m_collisionArray[v];
+    btCollisionShape* childShape =
+        convertURDFToCollisionShape(&col, linkChildShapes);
+    if (childShape) {
+      Magnum::Matrix4 childTrans = col.m_linkLocalFrame;
+      ESP_VERY_VERBOSE() << "col.m_linkLocalFrame:"
+                         << Magnum::Matrix4(col.m_linkLocalFrame);
 
-    for (size_t v = 0; v < link->m_collisionArray.size(); ++v) {
-      const io::URDF::CollisionShape& col = link->m_collisionArray[v];
-      btCollisionShape* childShape =
-          convertURDFToCollisionShape(&col, linkChildShapes);
-      if (childShape) {
-        Magnum::Matrix4 childTrans = col.m_linkLocalFrame;
-        ESP_VERY_VERBOSE() << "col.m_linkLocalFrame:"
-                           << Magnum::Matrix4(col.m_linkLocalFrame);
-
-        compoundShape->addChildShape(
-            localInertiaFrame.inverse() * btTransform(childTrans), childShape);
-      }
+      compoundShape->addChildShape(
+          localInertiaFrame.inverse() * btTransform(childTrans), childShape);
     }
-  } else {
-    ESP_VERY_VERBOSE() << "E - No link:" << linkIndex;
   }
 
   return compoundShape;
 }
 
-int BulletURDFImporter::getCollisionGroupAndMask(int linkIndex,
+int BulletURDFImporter::getCollisionGroupAndMask(int urdfLinkIndex,
                                                  int& colGroup,
                                                  int& colMask) const {
   int result = 0;
-  auto itr = activeModel_->m_links.begin();
-  for (int i = 0; (i < linkIndex && itr != activeModel_->m_links.end()); i++) {
-    itr++;
-  }
-  if (itr != activeModel_->m_links.end()) {
-    std::shared_ptr<io::URDF::Link> link = itr->second;
-    for (size_t v = 0; v < link->m_collisionArray.size(); ++v) {
-      const io::URDF::CollisionShape& col = link->m_collisionArray[v];
-      if ((col.m_flags & io::URDF::HAS_COLLISION_GROUP) != 0) {
-        colGroup = col.m_collisionGroup;
-        result |= io::URDF::HAS_COLLISION_GROUP;
-      }
-      if ((col.m_flags & io::URDF::HAS_COLLISION_MASK) != 0) {
-        colMask = col.m_collisionMask;
-        result |= io::URDF::HAS_COLLISION_MASK;
-      }
+  std::shared_ptr<io::URDF::Link> link = activeModel_->getLink(urdfLinkIndex);
+  for (size_t v = 0; v < link->m_collisionArray.size(); ++v) {
+    const io::URDF::CollisionShape& col = link->m_collisionArray[v];
+    if ((col.m_flags & io::URDF::HAS_COLLISION_GROUP) != 0) {
+      colGroup = col.m_collisionGroup;
+      result |= io::URDF::HAS_COLLISION_GROUP;
+    }
+    if ((col.m_flags & io::URDF::HAS_COLLISION_MASK) != 0) {
+      colMask = col.m_collisionMask;
+      result |= io::URDF::HAS_COLLISION_MASK;
     }
   }
   return result;
@@ -194,6 +178,30 @@ void BulletURDFImporter::computeTotalNumberOfJoints(int linkIndex) {
   for (size_t i = 0; i < childIndices.size(); i++) {
     int childIndex = childIndices[i];
     computeTotalNumberOfJoints(childIndex);
+  }
+}
+
+void BulletURDFImporter::getAllIndices(
+    int urdfLinkIndex,
+    int parentIndex,
+    std::vector<childParentIndex>& allIndices) {
+  childParentIndex cp;
+  cp.m_index = urdfLinkIndex;
+  cp.m_link_name = activeModel_->getLink(urdfLinkIndex)->m_name;
+  int mbIndex = cache->getMbIndexFromUrdfIndex(urdfLinkIndex);
+  cp.m_mbIndex = mbIndex;
+  cp.m_parentIndex = parentIndex;
+  int parentMbIndex =
+      parentIndex >= 0 ? cache->getMbIndexFromUrdfIndex(parentIndex) : -1;
+  cp.m_parentMBIndex = parentMbIndex;
+
+  allIndices.push_back(cp);
+  std::vector<int> urdfChildIndices;
+  getLinkChildIndices(urdfLinkIndex, urdfChildIndices);
+  int numChildren = urdfChildIndices.size();
+  for (int i = 0; i < numChildren; i++) {
+    int urdfChildLinkIndex = urdfChildIndices[i];
+    getAllIndices(urdfChildLinkIndex, urdfLinkIndex, allIndices);
   }
 }
 
@@ -277,9 +285,11 @@ Mn::Matrix4 BulletURDFImporter::convertURDF2BulletInternal(
     btMultiBodyDynamicsWorld* world1,
     std::map<int, std::unique_ptr<btCompoundShape>>& linkCompoundShapes,
     std::map<int, std::vector<std::unique_ptr<btCollisionShape>>>&
-        linkChildShapes) {
+        linkChildShapes,
+    bool recursive) {
   ESP_VERY_VERBOSE() << "++++++++++++++++++++++++++++++++++++++";
   ESP_VERY_VERBOSE() << "convertURDF2BulletInternal...";
+  ESP_VERY_VERBOSE() << "   recursive = " << recursive;
 
   Mn::Matrix4 linkTransformInWorldSpace;
 
@@ -618,20 +628,30 @@ Mn::Matrix4 BulletURDFImporter::convertURDF2BulletInternal(
     }
   }
 
-  ESP_VERY_VERBOSE() << "about to recurse";
+  if (recursive) {
+    ESP_VERY_VERBOSE() << "about to recurse";
 
-  std::vector<int> urdfChildIndices;
-  getLinkChildIndices(urdfLinkIndex, urdfChildIndices);
+    std::vector<int> urdfChildIndices;
+    getLinkChildIndices(urdfLinkIndex, urdfChildIndices);
 
-  int numChildren = urdfChildIndices.size();
+    int numChildren = urdfChildIndices.size();
 
-  for (int i = 0; i < numChildren; i++) {
-    int urdfChildLinkIndex = urdfChildIndices[i];
+    for (int i = 0; i < numChildren; i++) {
+      int urdfChildLinkIndex = urdfChildIndices[i];
 
-    convertURDF2BulletInternal(urdfChildLinkIndex, linkTransformInWorldSpace,
-                               world1, linkCompoundShapes, linkChildShapes);
+      convertURDF2BulletInternal(urdfChildLinkIndex, linkTransformInWorldSpace,
+                                 world1, linkCompoundShapes, linkChildShapes,
+                                 recursive);
+    }
   }
   return linkTransformInWorldSpace;
+}
+
+Mn::Debug& operator<<(Mn::Debug& debug, const childParentIndex cpi) {
+  debug << "childParentIndex";
+  return debug << "\nindex: " << cpi.m_index << "\n mbIndex: " << cpi.m_mbIndex
+               << "\n parentIndex: " << cpi.m_parentIndex
+               << "\n parentMBIndex: " << cpi.m_parentMBIndex;
 }
 
 }  // namespace physics

--- a/src/esp/physics/bullet/BulletURDFImporter.h
+++ b/src/esp/physics/bullet/BulletURDFImporter.h
@@ -43,8 +43,6 @@ struct childParentIndex {
   std::string m_link_name;
 };
 
-Mn::Debug& operator<<(Mn::Debug& debug, const childParentIndex cpi);
-
 /**
  * @brief Structure to hold construction time multi-body data.
  */

--- a/src/esp/physics/bullet/BulletURDFImporter.h
+++ b/src/esp/physics/bullet/BulletURDFImporter.h
@@ -32,6 +32,20 @@ struct JointLimitConstraintInfo {
 };
 
 /**
+ * @brief struct to encapsulate mapping between child and parent links ids.
+ */
+struct childParentIndex {
+  int m_index;
+  int m_mbIndex;
+  int m_parentIndex;
+  int m_parentMBIndex;
+
+  std::string m_link_name;
+};
+
+Mn::Debug& operator<<(Mn::Debug& debug, const childParentIndex cpi);
+
+/**
  * @brief Structure to hold construction time multi-body data.
  */
 struct URDF2BulletCached {
@@ -85,11 +99,18 @@ class BulletURDFImporter : public URDFImporter {
       btMultiBodyDynamicsWorld* world1,
       std::map<int, std::unique_ptr<btCompoundShape>>& linkCompoundShapes,
       std::map<int, std::vector<std::unique_ptr<btCollisionShape>>>&
-          linkChildShapes);
+          linkChildShapes,
+      bool recursive = false);
 
   //! The temporary Bullet multibody cache initialized by
   //! convertURDF2BulletInternal and cleared after instancing the object
   std::shared_ptr<URDF2BulletCached> cache = nullptr;
+
+  //! Recursively get all indices from the model with mappings between parents
+  //! and children
+  void getAllIndices(int urdfLinkIndex,
+                     int parentIndex,
+                     std::vector<childParentIndex>& allIndices);
 
  protected:
   //! Construct a set of Bullet collision shapes from the URDF::CollisionShape

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -36,10 +36,12 @@ ArticulatedObjectManager::addArticulatedObjectFromURDF(
     float globalScale,
     float massScale,
     bool forceReload,
+    bool maintainLinkOrder,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
     int newAObjID = physMgr->addArticulatedObjectFromURDF(
-        filepath, fixedBase, globalScale, massScale, forceReload, lightSetup);
+        filepath, fixedBase, globalScale, massScale, forceReload,
+        maintainLinkOrder, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;
@@ -53,11 +55,12 @@ ArticulatedObjectManager::addArticulatedObjectFromURDFWithDrawables(
     float globalScale,
     float massScale,
     bool forceReload,
+    bool maintainLinkOrder,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
     int newAObjID = physMgr->addArticulatedObjectFromURDF(
         filepath, drawables, fixedBase, globalScale, massScale, forceReload,
-        lightSetup);
+        maintainLinkOrder, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.h
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.h
@@ -36,6 +36,8 @@ class ArticulatedObjectManager
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -46,6 +48,7 @@ class ArticulatedObjectManager
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
+      bool maintainLinkOrder = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /**
@@ -62,6 +65,8 @@ class ArticulatedObjectManager
    * the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -73,10 +78,12 @@ class ArticulatedObjectManager
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
+      bool maintainLinkOrder = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     return std::static_pointer_cast<ManagedBulletArticulatedObject>(
         addArticulatedObjectFromURDF(filepath, fixedBase, globalScale,
-                                     massScale, forceReload, lightSetup));
+                                     massScale, forceReload, maintainLinkOrder,
+                                     lightSetup));
   }
 
   /**
@@ -94,6 +101,8 @@ class ArticulatedObjectManager
    * all the components of the @ref ArticulatedObject.
    * @param forceReload If true, reload the source URDF from file, replacing
    * the cached model.
+   * @param maintainLinkOrder If true, maintain the order of link definitions
+   * from the URDF file as the link indices.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -106,6 +115,7 @@ class ArticulatedObjectManager
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
+      bool maintainLinkOrder = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
  protected:


### PR DESCRIPTION
## Motivation and Context

For consistency with other simulators (e.g. pybullet), this PR adds an option to preserve the order of links parsed from URDF files as link indices.

To use this option:
`add_articulated_object_from_urdf(urdf_filename, maintain_link_order=true)`

## How Has This Been Tested

Added a pytest.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
