### PR TITLE
[BugFix]--Address when Bullet is available but physics is not enabled.

### DIFF
--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.h
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.h
@@ -66,17 +66,22 @@ class ArticulatedObjectManager
    *
    * @return A reference to the created ArticulatedObject
    */
-  std::shared_ptr<ManagedBulletArticulatedObject>
-  addBulletArticulatedObjectFromURDF(
+  std::shared_ptr<ManagedArticulatedObject> addBulletArticulatedObjectFromURDF(
       const std::string& filepath,
       bool fixedBase = false,
       float globalScale = 1.0,
       float massScale = 1.0,
       bool forceReload = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    return std::static_pointer_cast<ManagedBulletArticulatedObject>(
+    std::shared_ptr<ManagedArticulatedObject> objPtr =
         addArticulatedObjectFromURDF(filepath, fixedBase, globalScale,
-                                     massScale, forceReload, lightSetup));
+                                     massScale, forceReload, lightSetup);
+
+    if (std::shared_ptr<ManagedBulletArticulatedObject> castObjPtr =
+            std::dynamic_pointer_cast<ManagedBulletArticulatedObject>(objPtr)) {
+      return castObjPtr;
+    }
+    return objPtr;
   }
 
   /**

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -44,12 +44,18 @@ class RigidObjectManager
    * existing SceneNode.
    * @return a copy of the instanced object, appropriately cast, or nullptr.
    */
-  std::shared_ptr<ManagedBulletRigidObject> addBulletObjectByHandle(
+  std::shared_ptr<ManagedRigidObject> addBulletObjectByHandle(
       const std::string& attributesHandle,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    return std::static_pointer_cast<ManagedBulletRigidObject>(
-        addObjectByHandle(attributesHandle, attachmentNode, lightSetup));
+    std::shared_ptr<ManagedRigidObject> objPtr =
+        addObjectByHandle(attributesHandle, attachmentNode, lightSetup);
+
+    if (std::shared_ptr<ManagedBulletRigidObject> castObjPtr =
+            std::dynamic_pointer_cast<ManagedBulletRigidObject>(objPtr)) {
+      return castObjPtr;
+    }
+    return objPtr;
   }
 
   /** @brief Instance a physical object from an object properties template in
@@ -77,12 +83,17 @@ class RigidObjectManager
    * existing SceneNode.
    * @return a copy of the instanced object, appropriately cast, or nullptr.
    */
-  std::shared_ptr<ManagedBulletRigidObject> addBulletObjectByID(
+  std::shared_ptr<ManagedRigidObject> addBulletObjectByID(
       const int attributesID,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    return std::static_pointer_cast<ManagedBulletRigidObject>(
-        addObjectByID(attributesID, attachmentNode, lightSetup));
+    std::shared_ptr<ManagedRigidObject> objPtr =
+        addObjectByID(attributesID, attachmentNode, lightSetup);
+    if (std::shared_ptr<ManagedBulletRigidObject> castObjPtr =
+            std::dynamic_pointer_cast<ManagedBulletRigidObject>(objPtr)) {
+      return castObjPtr;
+    }
+    return objPtr;
   }
 
   /**

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -144,6 +144,120 @@ def test_kinematics():
     or not osp.exists("data/objects/example_objects/"),
     reason="Requires the habitat-test-scenes and habitat test objects",
 )
+def test_kinematics_no_physics():
+    cfg_settings = examples.settings.default_sim_settings.copy()
+
+    cfg_settings[
+        "scene"
+    ] = "data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"
+    # enable the physics simulator: also clears available actions to no-op
+    cfg_settings["enable_physics"] = False
+    cfg_settings["depth_sensor"] = True
+
+    # test loading the physical scene
+    hab_cfg = examples.settings.make_cfg(cfg_settings)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # get the rigid object attributes manager, which manages
+        # templates used to create objects
+        obj_template_mgr = sim.get_object_template_manager()
+        obj_template_mgr.load_configs("data/objects/example_objects/", True)
+        assert obj_template_mgr.get_num_templates() > 0
+        # get the rigid object manager, which provides direct
+        # access to objects
+        rigid_obj_mgr = sim.get_rigid_object_manager()
+
+        # test adding an object to the world
+        # get handle for object 0, used to test
+        obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
+        cheezit_box = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+        assert rigid_obj_mgr.get_num_objects() > 0
+        assert (
+            len(rigid_obj_mgr.get_object_handles()) == rigid_obj_mgr.get_num_objects()
+        )
+
+        # test setting the motion type
+        cheezit_box.motion_type = habitat_sim.physics.MotionType.STATIC
+        assert cheezit_box.motion_type == habitat_sim.physics.MotionType.STATIC
+        cheezit_box.motion_type = habitat_sim.physics.MotionType.KINEMATIC
+        assert cheezit_box.motion_type == habitat_sim.physics.MotionType.KINEMATIC
+
+        # test kinematics
+        I = np.identity(4)
+
+        # test get and set translation
+        cheezit_box.translation = [0.0, 1.0, 0.0]
+        assert np.allclose(cheezit_box.translation, np.array([0.0, 1.0, 0.0]))
+
+        # test object SceneNode
+        assert np.allclose(
+            cheezit_box.translation, cheezit_box.root_scene_node.translation
+        )
+
+        # test get and set transform
+        cheezit_box.transformation = I
+        assert np.allclose(cheezit_box.transformation, I)
+
+        # test get and set rotation
+        Q = quat_from_angle_axis(np.pi, np.array([0.0, 1.0, 0.0]))
+        expected = np.eye(4)
+        expected[0:3, 0:3] = quaternion.as_rotation_matrix(Q)
+        cheezit_box.rotation = quat_to_magnum(Q)
+        assert np.allclose(cheezit_box.transformation, expected)
+        assert np.allclose(quat_from_magnum(cheezit_box.rotation), Q)
+
+        # test object removal
+        rigid_obj_mgr.remove_object_by_id(cheezit_box.object_id)
+
+        assert rigid_obj_mgr.get_num_objects() == 0
+
+        obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
+        cheezit_box = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+
+        prev_time = 0.0
+        for _ in range(2):
+            # do some kinematics here (todo: translating or rotating instead of absolute)
+            cheezit_box.translation = np.random.rand(3)
+            T = cheezit_box.transformation  # noqa : F841
+
+            # test getting observation
+            sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
+
+            # check that time is increasing in the world
+            assert sim.get_world_time() > prev_time
+            prev_time = sim.get_world_time()
+
+        rigid_obj_mgr.remove_object_by_id(cheezit_box.object_id)
+
+        # test attaching/dettaching an Agent to/from physics simulation
+        agent_node = sim.agents[0].scene_node
+        obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
+        cheezit_agent = rigid_obj_mgr.add_object_by_template_handle(
+            obj_handle_list[0], agent_node
+        )
+
+        cheezit_agent.translation = np.random.rand(3)
+        assert np.allclose(agent_node.translation, cheezit_agent.translation)
+        rigid_obj_mgr.remove_object_by_id(
+            cheezit_agent.object_id, delete_object_node=False
+        )  # don't delete the agent's node
+        assert agent_node.translation
+
+        # test get/set RigidState
+        cheezit_box = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+        targetRigidState = habitat_sim.bindings.RigidState(
+            mn.Quaternion(), np.array([1.0, 2.0, 3.0])
+        )
+        cheezit_box.rigid_state = targetRigidState
+        objectRigidState = cheezit_box.rigid_state
+        assert np.allclose(objectRigidState.translation, targetRigidState.translation)
+        assert objectRigidState.rotation == targetRigidState.rotation
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb")
+    or not osp.exists("data/objects/example_objects/"),
+    reason="Requires the habitat-test-scenes and habitat test objects",
+)
 def test_dynamics():
     # This test assumes that default.phys_scene_config.json contains "physics simulator": "bullet".
     # TODO: enable dynamic override of this setting in simulation config structure


### PR DESCRIPTION
## Motivation and Context
When bullet is available at compilation time, but the user has disabled physics via  a runtime configuration setting (causing a base PhysicsManager to be created, instead of a BulletPhysicsManager), object wrappers were statically cast to ManagedBulletRigidObject / ManagedBulletArticulatedObject when accessed from python, causing them to be None (since BulletPhysicsManager is required to create Bullet-based objects, and this does not exist when physics is disabled).  This PR addresses this by attempting to dynamically cast the wrapper objects, and if this fails, returning instead the uncast wrapper.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally C++ and python.  Python test_physics.py test suite expanded to include kinematics test with physics disabled in configuration.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
