### PR TITLE
[Cleanup]--Clean up tests.

### DIFF
--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -28,14 +28,6 @@ using esp::scene::SceneManager;
 // printed when you have accidentally unused variables or functions in the test
 namespace {
 
-class ResourceManagerExtended : public ResourceManager {
- public:
-  explicit ResourceManagerExtended(
-      esp::metadata::MetadataMediator::ptr& _metadataMediator)
-      : ResourceManager(_metadataMediator) {}
-  esp::gfx::ShaderManager& getShaderManager() { return shaderManager_; }
-};
-
 struct DrawableTest : Cr::TestSuite::Tester {
   explicit DrawableTest();
   // tests
@@ -46,7 +38,7 @@ struct DrawableTest : Cr::TestSuite::Tester {
   esp::gfx::WindowlessContext::uptr context_ =
       esp::gfx::WindowlessContext::create_unique(0);
   // must declare these in this order due to avoid deallocation errors
-  std::unique_ptr<ResourceManagerExtended> resourceManager_ = nullptr;
+  std::unique_ptr<ResourceManager> resourceManager_ = nullptr;
   SceneManager sceneManager_;
   // must create a GL context which will be used in the resource manager
   int sceneID_ = -1;
@@ -59,7 +51,7 @@ DrawableTest::DrawableTest() {
   cfg.loadSemanticMesh = false;
   cfg.forceSeparateSemanticSceneGraph = false;
   auto MM = MetadataMediator::create(cfg);
-  resourceManager_ = std::make_unique<ResourceManagerExtended>(MM);
+  resourceManager_ = std::make_unique<ResourceManager>(MM);
   //clang-format off
   addTests({&DrawableTest::addRemoveDrawables});
   //clang-format on


### PR DESCRIPTION
## Motivation and Context
This small PR cleans up 2 tests : 

- Removes the superfluous ResourceManager child class def from DrawableTest
- Refactors 3 tests in SimTest to always use the test instancing functionality that is used in all the other SimTest tests.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all c++ tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
