### PR TITLE
Update datasource with changes for RearrangeGenerator

### DIFF
--- a/habitat_sim/utils/datasets_download.py
+++ b/habitat_sim/utils/datasets_download.py
@@ -95,10 +95,10 @@ def initialize_test_data_sources(data_path):
             "version": "1.0",
         },
         "replica_cad_dataset": {
-            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_dataset_v1.1.zip",
-            "package_name": "ReplicaCAD_dataset_v1.1.zip",
+            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_dataset_v1.2.zip",
+            "package_name": "ReplicaCAD_dataset_v1.2.zip",
             "link": data_path + "replica_cad",
-            "version": "1.1",
+            "version": "1.2",
         },
         "replica_cad_baked_lighting": {
             "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_baked_lighting_v1.1.zip",
@@ -107,10 +107,10 @@ def initialize_test_data_sources(data_path):
             "version": "1.1",
         },
         "ycb": {
-            "source": "https://dl.fbaipublicfiles.com/habitat/ycb/hab_ycb_v1.0.zip",
-            "package_name": "hab_ycb_v1.0.zip",
+            "source": "https://dl.fbaipublicfiles.com/habitat/ycb/hab_ycb_v1.1.zip",
+            "package_name": "hab_ycb_v1.1.zip",
             "link": data_path + "objects/ycb",
-            "version": "1.0",
+            "version": "1.1",
         },
         "hab_fetch": {
             "source": "http://dl.fbaipublicfiles.com/habitat/hab_fetch_v1.0.zip",


### PR DESCRIPTION
## Motivation and Context

ReplicaCAD and YCB datasources were modified during development of the EpisodeGenerator [Hab-lab PR 715](https://github.com/facebookresearch/habitat-lab/pull/715).

TODO: we also need to update `rearrange_pick_dataset_v0` to contain a new format RearrangeDataset in order for tests to pass.
TODO: any other known asset issues should be addressed as well.

## How Has This Been Tested

Testing in Hab-lab.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
