### PR TITLE
Fix semantic rendering

### DIFF
--- a/habitat_sim/agent/agent.py
+++ b/habitat_sim/agent/agent.py
@@ -95,7 +95,7 @@ class AgentState:
 class AgentConfiguration:
     height: float = 1.5
     radius: float = 0.1
-    sensor_specifications: List[hsim.SensorSpec] = []
+    sensor_specifications: List[hsim.SensorSpec] = attr.Factory(list)
     action_space: Dict[Any, ActionSpec] = attr.Factory(_default_action_space)
     body_type: str = "cylinder"
 

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -88,9 +88,9 @@ struct Renderer::Impl {
     acquireGlContext();
     if (visualSensor.specification()->sensorType ==
         sensor::SensorType::Semantic) {
-      ESP_CHECK(sim.semanticSceneExists(),
+      ESP_CHECK(sim.semanticSceneGraphExists(),
                 "Renderer::Impl::draw(): SemanticSensor observation requested "
-                "but no SemanticScene is loaded");
+                "but no SemanticSceneGraph is loaded");
     }
     visualSensor.drawObservation(sim);
   }

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -92,10 +92,14 @@ class Simulator {
     return sceneManager_->getSceneGraph(activeSceneID_);
   }
 
+  /** @brief Check to see if there is a SemanticSceneGraph for rendering */
+  bool semanticSceneGraphExists() const {
+    return std::size_t(activeSemanticSceneID_) < sceneID_.size();
+  }
+
   /** @brief get the semantic scene's SceneGraph for rendering */
   scene::SceneGraph& getActiveSemanticSceneGraph() {
-    CORRADE_INTERNAL_ASSERT(std::size_t(activeSemanticSceneID_) <
-                            sceneID_.size());
+    CORRADE_INTERNAL_ASSERT(semanticSceneGraphExists());
     return sceneManager_->getSceneGraph(activeSemanticSceneID_);
   }
   std::shared_ptr<gfx::replay::ReplayManager> getGfxReplayManager() {

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -52,3 +52,25 @@ def test_unproject():
         assert np.allclose(
             test_ray_2.direction, np.array([0.569653, -0.581161, -0.581161]), atol=0.07
         )
+
+
+@pytest.mark.parametrize(
+    "sensor_type",
+    [
+        habitat_sim.SensorType.COLOR,
+        habitat_sim.SensorType.DEPTH,
+        habitat_sim.SensorType.SEMANTIC,
+    ],
+)
+def test_empty_scene(sensor_type):
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.scene_id = "NONE"
+
+    agent_cfg = habitat_sim.AgentConfiguration()
+    agent_cfg.sensor_specifications = [habitat_sim.CameraSensorSpec()]
+    agent_cfg.sensor_specifications[-1].sensor_type = sensor_type
+
+    with habitat_sim.Simulator(
+        habitat_sim.Configuration(backend_cfg, [agent_cfg])
+    ) as sim:
+        _ = sim.get_sensor_observations()


### PR DESCRIPTION
## Motivation and Context

Semantic rendering requires an activeSemenaticSceneGraph, not a semenaticScene. The former is the Magnum SceneGraph used for rendering while the latter contains information about semantic annotations. We are currently checking for the latter while needing the former.

## How Has This Been Tested

Via the new test.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

