### PR TITLE
Add proper clang-format to pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Check Code Style using pre-commit
           command: |
-            SKIP=clang-format,eslint pre-commit run --show-diff-on-failure --all-files
+            SKIP=eslint pre-commit run --show-diff-on-failure --all-files
   test_conda_build:
     <<: *gpu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
           command: mypy
   cpp_lint:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: buildpack-deps:trusty
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,22 +243,6 @@ jobs:
       - run:
           name: run mypy
           command: mypy
-  cpp_lint:
-    docker:
-      - image: buildpack-deps:trusty
-    steps:
-      - checkout
-      - run:
-          name: setup
-          command: |
-              sudo apt-get update -y
-              sudo apt-get install -y clang-format-12
-              sudo ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
-              clang-format --version
-      - run:
-          name: run clang-format
-          command: |
-            find . -not -path "*/\.*" -not -path "*/deps/*" -not -path "*/obsolete/*" -not -path "*/build/*" | grep -E ".*\.(cpp|h|cu|hpp|cuh)$" | xargs -I {} bash -c "diff -u <(cat {}) <(clang-format -style=file {})"
 
   js_lint:
     docker:
@@ -699,7 +683,6 @@ workflows:
   install_and_test:
     jobs:
       - python_lint
-      - cpp_lint
       - js_lint
       - lab_build_habitat
       - test_conda_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,8 @@ jobs:
           name: setup
           command: |
               sudo apt-get update -y
-              sudo apt-get install -y clang-format-8
-              sudo ln -s /usr/bin/clang-format-8 /usr/bin/clang-format
+              sudo apt-get install -y clang-format-12
+              sudo ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
               clang-format --version
       - run:
           name: run clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         exclude: docs/
 
 -   repo: https://github.com/ambv/black
-    rev: 21.7b0
+    rev: 21.9b0
     hooks:
     - id: black
       exclude: ^examples/tutorials/(nb_python|colabs)
@@ -82,7 +82,7 @@ repos:
         - attrs
 
 -   repo: https://github.com/seddonym/import-linter
-    rev: v1.2.4
+    rev: v1.2.6
     hooks:
     -   id: import-linter
 
@@ -92,7 +92,7 @@ repos:
     -   id: nbstripout
 
 -   repo: https://github.com/mwouts/jupytext
-    rev: v1.11.4
+    rev: v1.13.0
     hooks:
     -   id: jupytext
         files: '^examples/tutorials/(colabs|nb_python)/(.*\.py|.*\.ipynb)$'
@@ -103,7 +103,7 @@ repos:
             - isort
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v12.0.1
+    rev: fdd6cd7821ce22929625f134bc97488ed699e256 # frozen: 12.0.1
     hooks:
     -   id: clang-format
 
@@ -114,7 +114,7 @@ repos:
         exclude: (^src/(cmake/Find|deps)|configure\.h\.cmake$)
 
 -   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.32.0
+    rev: v8.0.0-rc.0
     hooks:
     -   id: eslint
         args: [--fix, --ext .html,.js]
@@ -131,6 +131,6 @@ repos:
     -   id: shellcheck
 
 -   repo: https://github.com/AleksaC/circleci-cli-py
-    rev: v0.1.15824
+    rev: v0.1.15973
     hooks:
     -   id: circle-ci-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,15 +102,10 @@ repos:
             - black
             - isort
 
--   repo: local
+-   repo: https://github.com/ssciwr/clang-format-hook
+    rev: v12.0.1
     hooks:
-    - id: clang-format
-      name: Run clang-format
-      exclude: src/deps
-      entry: clang-format -i -style=file
-      types: [text]
-      files: '.*\.(cpp|h|hpp|cu|cuh)$'
-      language: system
+    -   id: clang-format
 
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
         exclude: (^src/(cmake/Find|deps)|configure\.h\.cmake$)
 
 -   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.0.0-rc.0
+    rev: v7.32.0
     hooks:
     -   id: eslint
         args: [--fix, --ext .html,.js]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,7 @@ repos:
             - black
             - isort
 
--   repo: https://github.com/ssciwr/clang-format-hook
+-   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v12.0.1
     hooks:
     -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     rev: fdd6cd7821ce22929625f134bc97488ed699e256 # frozen: 12.0.1
     hooks:
     -   id: clang-format
-        types_or: [c++, c, c#, cuda]
+        types_or: [c++, c, c#, cuda] # also run on CUDA
 
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,7 @@ repos:
     rev: fdd6cd7821ce22929625f134bc97488ed699e256 # frozen: 12.0.1
     hooks:
     -   id: clang-format
+        types_or: [c++, c, c#, cuda]
 
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -18,7 +18,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -13,7 +13,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/ECCV_2020_Navigation.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Navigation.py
@@ -13,7 +13,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
+++ b/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
@@ -14,7 +14,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/asset_viewer.py
+++ b/examples/tutorials/nb_python/asset_viewer.py
@@ -14,7 +14,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/examples/tutorials/nb_python/rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/rigid_object_tutorial.py
@@ -12,7 +12,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.11.4
+#       jupytext_version: 1.13.0
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3


### PR DESCRIPTION
## Motivation and Context
* Makes clang-format a proper pre-commit hook using a new pip package we created for PyBind11
* Automatically handles clang-format versioning and dependencies with the new hook
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
