### PR TITLE
[Bugfix]--address segfaults by catching nullptr attribs and exiting gracefully

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -217,6 +217,14 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
 
   metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
       metadataMediator_->getSceneAttributesByName(activeSceneName);
+  // check if attributes is null - should not happen
+  CORRADE_ASSERT(
+      curSceneInstanceAttributes,
+      Cr::Utility::formatString(
+          "Simulator::setSceneInstanceAttributes() : Attempt to load scene "
+          "instance :{} failed due to scene instance not being found. Aborting",
+          activeSceneName),
+      nullptr);
 
   // 1. Load navmesh specified in current scene instance attributes.
   const std::string& navmeshFileLoc = metadataMediator_->getNavmeshPathByHandle(
@@ -405,6 +413,16 @@ bool Simulator::instanceStageForActiveScene(
   const SceneObjectInstanceAttributes::cptr stageInstanceAttributes =
       curSceneInstanceAttributes->getStageInstance();
 
+  // check if attributes is null - should not happen
+  CORRADE_ASSERT(
+      stageInstanceAttributes,
+      Cr::Utility::formatString(
+          "Simulator::instanceStageForActiveScene() : Attempt to load stage "
+          "instance specified in current scene instance :{} failed due to "
+          "stage instance configuration not being found. Aborting",
+          config_.activeSceneName),
+      false);
+
   // Get full library name of StageAttributes
   const std::string stageAttributesHandle =
       metadataMediator_->getStageAttrFullHandle(
@@ -518,17 +536,28 @@ bool Simulator::instanceObjectsForActiveScene(
   // Iterate through instances, create object and implement initial
   // transformation.
   for (const auto& objInst : objectInstances) {
+    // check if attributes is null - should not happen
+    CORRADE_ASSERT(
+        objInst,
+        Cr::Utility::formatString(
+            "Simulator::instanceObjectsForActiveScene() : Attempt to load "
+            "object instance specified in current scene instance :{} failed "
+            "due to object instance configuration not being found. Aborting",
+            config_.activeSceneName),
+        false);
+
     const std::string objAttrFullHandle =
         metadataMediator_->getObjAttrFullHandle(objInst->getHandle());
-    if (objAttrFullHandle == "") {
-      ESP_ERROR() << "Error instancing scene :" << config_.activeSceneName
-                  << ":"
-                  << "Unable to find objectAttributes whose handle contains"
-                  << objInst->getHandle()
-                  << "as specified in object instance attributes.";
-      return false;
-    }
-
+    // make sure full handle is not empty
+    CORRADE_ASSERT(
+        !objAttrFullHandle.empty(),
+        Cr::Utility::formatString(
+            "Simulator::instanceObjectsForActiveScene() : Attempt to load "
+            "object instance specified in current scene instance :{} failed "
+            "due to object instance configuration handle '{}' being empty or "
+            "unknown. Aborting",
+            config_.activeSceneName, objInst->getHandle()),
+        false);
     // objID =
     physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
                                        defaultCOMCorrection, attachmentNode,
@@ -550,10 +579,31 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
   // Iterate through instances, create object and implement initial
   // transformation.
   for (const auto& artObjInst : artObjInstances) {
+    // check if instance attributes is null - should not happen
+    CORRADE_ASSERT(artObjInst,
+                   Cr::Utility::formatString(
+                       "Simulator::instanceArticulatedObjectsForActiveScene() "
+                       ": Attempt to load articulated object instance "
+                       "specified in current scene instance :{} failed due to "
+                       "AO instance configuration not being found. Aborting",
+                       config_.activeSceneName),
+                   false);
+
     // get model file name
     const std::string artObjFilePath =
         metadataMediator_->getArticulatedObjModelFullHandle(
             artObjInst->getHandle());
+
+    // make sure full handle is not empty
+    CORRADE_ASSERT(
+        !artObjFilePath.empty(),
+        Cr::Utility::formatString(
+            "Simulator::instanceArticulatedObjectsForActiveScene() : Attempt "
+            "to load articualted object instance specified in current scene "
+            "instance :{} failed due to AO instance configuration file handle "
+            "'{}' being empty or unknown. Aborting",
+            config_.activeSceneName, artObjInst->getHandle()),
+        false);
 
     // create articulated object
     // aoID =

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -218,13 +218,12 @@ Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
       metadataMediator_->getSceneAttributesByName(activeSceneName);
   // check if attributes is null - should not happen
-  CORRADE_ASSERT(
+  ESP_CHECK(
       curSceneInstanceAttributes,
       Cr::Utility::formatString(
           "Simulator::setSceneInstanceAttributes() : Attempt to load scene "
           "instance :{} failed due to scene instance not being found. Aborting",
-          activeSceneName),
-      nullptr);
+          activeSceneName));
 
   // 1. Load navmesh specified in current scene instance attributes.
   const std::string& navmeshFileLoc = metadataMediator_->getNavmeshPathByHandle(
@@ -414,14 +413,13 @@ bool Simulator::instanceStageForActiveScene(
       curSceneInstanceAttributes->getStageInstance();
 
   // check if attributes is null - should not happen
-  CORRADE_ASSERT(
+  ESP_CHECK(
       stageInstanceAttributes,
       Cr::Utility::formatString(
           "Simulator::instanceStageForActiveScene() : Attempt to load stage "
           "instance specified in current scene instance :{} failed due to "
           "stage instance configuration not being found. Aborting",
-          config_.activeSceneName),
-      false);
+          config_.activeSceneName));
 
   // Get full library name of StageAttributes
   const std::string stageAttributesHandle =
@@ -537,27 +535,25 @@ bool Simulator::instanceObjectsForActiveScene(
   // transformation.
   for (const auto& objInst : objectInstances) {
     // check if attributes is null - should not happen
-    CORRADE_ASSERT(
+    ESP_CHECK(
         objInst,
         Cr::Utility::formatString(
             "Simulator::instanceObjectsForActiveScene() : Attempt to load "
             "object instance specified in current scene instance :{} failed "
             "due to object instance configuration not being found. Aborting",
-            config_.activeSceneName),
-        false);
+            config_.activeSceneName));
 
     const std::string objAttrFullHandle =
         metadataMediator_->getObjAttrFullHandle(objInst->getHandle());
     // make sure full handle is not empty
-    CORRADE_ASSERT(
+    ESP_CHECK(
         !objAttrFullHandle.empty(),
         Cr::Utility::formatString(
             "Simulator::instanceObjectsForActiveScene() : Attempt to load "
             "object instance specified in current scene instance :{} failed "
             "due to object instance configuration handle '{}' being empty or "
             "unknown. Aborting",
-            config_.activeSceneName, objInst->getHandle()),
-        false);
+            config_.activeSceneName, objInst->getHandle()));
     // objID =
     physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
                                        defaultCOMCorrection, attachmentNode,
@@ -580,14 +576,13 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
   // transformation.
   for (const auto& artObjInst : artObjInstances) {
     // check if instance attributes is null - should not happen
-    CORRADE_ASSERT(artObjInst,
-                   Cr::Utility::formatString(
-                       "Simulator::instanceArticulatedObjectsForActiveScene() "
-                       ": Attempt to load articulated object instance "
-                       "specified in current scene instance :{} failed due to "
-                       "AO instance configuration not being found. Aborting",
-                       config_.activeSceneName),
-                   false);
+    ESP_CHECK(artObjInst,
+              Cr::Utility::formatString(
+                  "Simulator::instanceArticulatedObjectsForActiveScene() "
+                  ": Attempt to load articulated object instance "
+                  "specified in current scene instance :{} failed due to "
+                  "AO instance configuration not being found. Aborting",
+                  config_.activeSceneName));
 
     // get model file name
     const std::string artObjFilePath =
@@ -595,15 +590,14 @@ bool Simulator::instanceArticulatedObjectsForActiveScene(
             artObjInst->getHandle());
 
     // make sure full handle is not empty
-    CORRADE_ASSERT(
+    ESP_CHECK(
         !artObjFilePath.empty(),
         Cr::Utility::formatString(
             "Simulator::instanceArticulatedObjectsForActiveScene() : Attempt "
             "to load articualted object instance specified in current scene "
             "instance :{} failed due to AO instance configuration file handle "
             "'{}' being empty or unknown. Aborting",
-            config_.activeSceneName, artObjInst->getHandle()),
-        false);
+            config_.activeSceneName, artObjInst->getHandle()));
 
     // create articulated object
     // aoID =


### PR DESCRIPTION
## Motivation and Context
This PR addresses segfaults that would happen if, due to misspelling or other errors, a required or expected attributes necessary for scene building is not found (i.e. queries to MetadataMediator returned nullptr).  Now, should these queries fail, a salient message is displayed and the program ends via std::abort.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
