### PR TITLE
Fixing macOS linking bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,3 +206,8 @@ if(BUILD_GUI_VIEWERS)
   message("Building GUI viewer")
   add_subdirectory(utils/viewer)
 endif()
+
+IF(APPLE)
+# Fix linking on 10.14+. See https://stackoverflow.com/questions/54068035
+LINK_DIRECTORIES(/usr/local/lib)
+ENDIF()


### PR DESCRIPTION
## Motivation and Context

Build from source on macOS fails at the linking step:
"ld: library not found for -lminizip"

Searching online the problem seems to be homebrew's cmake since Mojave:
https://stackoverflow.com/questions/54068035/linking-not-working-in-homebrews-cmake-since-mojave

## How Has This Been Tested

By localing building on my mac. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
