### PR TITLE
Use a newer pip so the MacOS wheel gets installed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,6 +107,8 @@ repos:
     hooks:
     -   id: clang-format
         types_or: [c++, c, c#, cuda] # also run on CUDA
+        additional_dependencies:
+            - pip>=21
 
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13


### PR DESCRIPTION
## Motivation and Context

The MacOS wheel for clang-format requires pip>=21 to be installed (and building all of llvm is no fun).

## How Has This Been Tested

Locally.

## Types of changes
 Bug fix (non-breaking change which fixes an issue)
