### PR TITLE
[CI]: Add hooks to ban blanket lint ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,12 @@ repos:
     -   id: pretty-format-toml
         args: [--autofix]
 
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0  # Use the ref you want to point at
+    hooks:
+    -   id: python-check-blanket-noqa
+    -   id: python-check-blanket-type-ignore
+
 -   repo: https://github.com/timothycrosley/isort
     rev: 5.9.3
     hooks:
@@ -51,8 +57,8 @@ repos:
 -   repo: https://github.com/ambv/black
     rev: 21.9b0
     hooks:
-    - id: black
-      exclude: ^examples/tutorials/(nb_python|colabs)
+    -   id: black
+        exclude: ^examples/tutorials/(nb_python|colabs)
 
 -   repo: https://github.com/myint/autoflake
     rev: v1.4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path = [
 ] + sys.path
 
 
-import habitat_sim  # NOQA
+import habitat_sim
 
 # TODO: remove once m.css handles class hierarchies better
 habitat_sim.logging.HabitatSimFormatter.formatStack.__doc__ = ""

--- a/habitat_sim/agent/__init__.py
+++ b/habitat_sim/agent/__init__.py
@@ -4,9 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# type: ignore
-
 from .agent import *  # noqa: F403
 from .controls import *  # noqa: F403
 
-__all__ = agent.__all__ + controls.__all__  # noqa: F405
+__all__ = agent.__all__ + controls.__all__  # type: ignore[name-defined] # noqa: F405

--- a/habitat_sim/agent/controls/default_controls.py
+++ b/habitat_sim/agent/controls/default_controls.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
+from typing import List, Optional
 
 import magnum as mn
 import numpy as np
@@ -14,7 +14,7 @@ from habitat_sim.geo import FRONT
 from habitat_sim.registry import registry
 from habitat_sim.scene import SceneNode
 
-__all__ = []  # type: ignore
+__all__: List[str] = []
 
 
 _X_AXIS = 0

--- a/habitat_sim/logging.py
+++ b/habitat_sim/logging.py
@@ -33,7 +33,7 @@ def format_message(record: LogRecord) -> str:
 class HabitatSimFormatter(logging.Formatter):
     def format(self, record: LogRecord) -> str:
         record_message = "[Sim] %s" % (format_message(record),)
-        record.getMessage = lambda: record_message  # type: ignore
+        record.getMessage = lambda: record_message  # type:ignore[assignment]
         return logging.Formatter.format(self, record)
 
 

--- a/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/habitat_sim/nav/greedy_geodesic_follower.py
@@ -6,11 +6,7 @@ import numpy as np
 from habitat_sim import errors, scene
 from habitat_sim.agent.agent import Agent
 from habitat_sim.agent.controls.controls import ActuationSpec
-from habitat_sim.nav import (  # type: ignore
-    GreedyFollowerCodes,
-    GreedyGeodesicFollowerImpl,
-    PathFinder,
-)
+from habitat_sim.nav import GreedyFollowerCodes, GreedyGeodesicFollowerImpl, PathFinder
 from habitat_sim.utils.common import quat_to_magnum
 
 

--- a/habitat_sim/registry.py
+++ b/habitat_sim/registry.py
@@ -69,9 +69,7 @@ class _Registry:
 
             cls._mapping["move_fn"][
                 _camel_to_snake(controller.__name__) if name is None else name
-            ] = controller(
-                body_action  # type: ignore
-            )
+            ] = controller(body_action)
 
             return controller
 

--- a/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -138,7 +138,7 @@ class RedwoodDepthNoiseModel(SensorNoiseModel):
                 noisy_depth = torch.empty_like(gt_depth)
                 rows, cols = gt_depth.size()
                 self._impl.simulate_from_gpu(
-                    gt_depth.data_ptr(), rows, cols, noisy_depth.data_ptr()  # type: ignore
+                    gt_depth.data_ptr(), rows, cols, noisy_depth.data_ptr()  # type: ignore[attr-defined]
                 )
                 return noisy_depth
         else:

--- a/habitat_sim/utils/viz_utils.py
+++ b/habitat_sim/utils/viz_utils.py
@@ -96,7 +96,7 @@ def display_video(video_file: str, height: int = 400):
         )
     else:
         if sys.platform == "win32":
-            os.startfile(video_file)  # type: ignore
+            os.startfile(video_file)  # type: ignore[attr-defined]
         else:
             opener = "open" if sys.platform == "darwin" else "xdg-open"
             subprocess.call([opener, video_file])

--- a/tests/test_data_extraction.py
+++ b/tests/test_data_extraction.py
@@ -70,7 +70,7 @@ def test_extractor_cache():
     cache.add(2, "two")
     cache.add(3, "three")
     assert cache[next(reversed(list(cache._order)))] == "three"
-    accessed_data = cache[2]  # noqa : F841
+    accessed_data = cache[2]  # noqa: F841
     assert cache[next(reversed(list(cache._order)))] == "two"
     cache.remove_from_back()
     assert 1 not in cache

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -103,7 +103,7 @@ def test_kinematics():
         for _ in range(2):
             # do some kinematics here (todo: translating or rotating instead of absolute)
             cheezit_box.translation = np.random.rand(3)
-            T = cheezit_box.transformation  # noqa : F841
+            T = cheezit_box.transformation  # noqa: F841
 
             # test getting observation
             sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))
@@ -217,7 +217,7 @@ def test_kinematics_no_physics():
         for _ in range(2):
             # do some kinematics here (todo: translating or rotating instead of absolute)
             cheezit_box.translation = np.random.rand(3)
-            T = cheezit_box.transformation  # noqa : F841
+            T = cheezit_box.transformation  # noqa: F841
 
             # test getting observation
             sim.step(random.choice(list(hab_cfg.agents[0].action_space.keys())))


### PR DESCRIPTION
## Motivation and Context
* Cleans up the linting type / noqa ignores to ensure that any new errors aren't accidentally masked by previous type ignores.
* Adds a pre-commit hook which forbids blanket noqas and type:ignores. All linter ignore must now be specific.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
* Locally with CI
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
