### PR TITLE
Add pre-commit hook to strip unused noqas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,11 +73,11 @@ repos:
     -   id: flake8
         exclude: docs/
         additional_dependencies: &flake8_dependencies
-        - flake8-bugbear==21.4.3
+        - flake8-bugbear==21.9.2
         - flake8-builtins==1.5.3
-        - flake8-comprehensions==3.4.0
-        - flake8-return==1.1.2
-        - flake8-simplify==0.14.1
+        - flake8-comprehensions==3.6.1
+        - flake8-return==1.1.3
+        - flake8-simplify==0.14.2
 
 -   repo: https://github.com/asottile/yesqa
     rev: v1.2.3


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Occasionally, as the rules we select change or better options get added or code is refactored, some NOQAs may become useless (especially if they are explicitly ignored which the past PR fixes)
* This pre-commit hook will automatically delete all NOQAs that are no longer used
* I used some clever YAML reuse syntax to ensure we don't have to maintain two copies of the flake8 plugins.
* I also updated the pinned flake8 versions of various plugins
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and with CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
