### PR TITLE
--Add keymap to display current scene dataset report

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -237,6 +237,11 @@ class Viewer : public Mn::Platform::Application {
   void switchCameraType();
   Mn::Vector3 randomDirection();
 
+  /**
+   * @brief Display information about the currently loaded scene.
+   */
+  void dispMetadataInfo();
+
   esp::agent::AgentConfiguration agentConfig_;
 
   void saveAgentAndSensorTransformToFile();
@@ -1438,6 +1443,12 @@ void Viewer::drawEvent() {
   redraw();
 }
 
+void Viewer::dispMetadataInfo() {  // display info report
+  std::string dsInfoReport = MM_->createDatasetReport();
+  ESP_DEBUG() << "\nActive Dataset Details : \n"
+              << dsInfoReport << "\nActive Dataset Report Details Done";
+}
+
 void Viewer::moveAndLook(int repetitions) {
   for (int i = 0; i < repetitions; i++) {
     if (keysPressed[KeyEvent::Key::Left]) {
@@ -1923,6 +1934,10 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       break;
     case KeyEvent::Key::O:
       addTemplateObject();
+      break;
+    case KeyEvent::Key::Slash:
+      // display current scene's metadata information
+      dispMetadataInfo();
       break;
     case KeyEvent::Key::Q:
       // query the agent state


### PR DESCRIPTION
## Motivation and Context
This tiny PR adds a keymapping to display the currently loaded scene dataset's detail report to the console.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
It's viewer! It always works!  Run locally to verify it works.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
