### PR TITLE
[TechDebt]--Minor changes to RM; Move root orientation calc to MeshMetaData

### DIFF
--- a/src/esp/assets/MeshMetaData.h
+++ b/src/esp/assets/MeshMetaData.h
@@ -11,6 +11,7 @@
  */
 
 #include "esp/core/Esp.h"
+#include "esp/geo/CoordinateFrame.h"
 #include "esp/gfx/magnum.h"
 
 namespace esp {
@@ -112,6 +113,17 @@ struct MeshMetaData {
   void setTextureIndices(int textureStart, int textureEnd) {
     textureIndex.first = textureStart;
     textureIndex.second = textureEnd;
+  }
+
+  /**
+   * @brief Set the root frame orientation based on passed frame
+   * @param frame target frame in world space
+   */
+  void setRootFrameOrientation(const geo::CoordinateFrame& frame) {
+    const quatf& transform = frame.rotationFrameToWorld();
+    Magnum::Matrix4 R = Magnum::Matrix4::from(
+        Magnum::Quaternion(transform).toMatrix(), Magnum::Vector3());
+    root.transformFromLocalToParent = R * root.transformFromLocalToParent;
   }
 };
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -685,6 +685,14 @@ class ResourceManager {
    */
   void buildPrimitiveAssetData(const std::string& primTemplateHandle);
 
+  /**
+   * @brief Configure the importerManager_ appropriately based on compilation
+   * flags, before general assets are imported
+   * @param dispFileName the filename of the asset being imported, used for
+   * informational/debugging purposes only.
+   */
+  void ConfigureImporterManager(const std::string& dispFileName);
+
  protected:
   // ======== Structs and Types only used locally ========
   /**


### PR DESCRIPTION
## Motivation and Context
This PR has a few minor changes to RM that did not make it in during TechDebt week.  Primary change is that a function was added to MeshMetaData to transform the root node given a frame.  This replaces numerous instances of code duplication in RM itself.  The second change was moving the configuration of the RM's importerManager_ based on compile flags to a separate function from ResourceManager::loadRenderAssetGeneral.  This was done partially in service to potential upcoming RM refactors and partially to decrease the size and clutter of the load function.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
