### PR TITLE
[TechDebt]--Move Managed Containers to their own namespace

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -32,8 +32,8 @@ using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
-using esp::core::AbstractFileBasedManagedObject;
-using esp::core::AbstractManagedObject;
+using esp::core::managedContainers::AbstractFileBasedManagedObject;
+using esp::core::managedContainers::AbstractManagedObject;
 
 namespace esp {
 namespace metadata {
@@ -45,12 +45,12 @@ void initAttributesBindings(py::module& m) {
       m, "AbstractManagedObject");
   // ==== AbstractFileBasedManagedObject ====
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<AbstractFileBasedManagedObject, esp::core::AbstractManagedObject,
+  py::class_<AbstractFileBasedManagedObject, AbstractManagedObject,
              AbstractFileBasedManagedObject::ptr>(
       m, "AbstractFileBasedManagedObject");
 
   // ==== AbstractAttributes ====
-  py::class_<AbstractAttributes, esp::core::AbstractFileBasedManagedObject,
+  py::class_<AbstractAttributes, AbstractFileBasedManagedObject,
              esp::core::config::Configuration, AbstractAttributes::ptr>(
       m, "AbstractAttributes")
       .def(py::init(

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -34,6 +34,7 @@ using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
+using esp::core::managedContainers::ManagedObjectAccess;
 
 namespace esp {
 namespace metadata {
@@ -48,7 +49,7 @@ namespace managers {
  * @param classStrPrefix string prefix for python class name specification.
  */
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 void declareBaseAttributesManager(py::module& m,
                                   const std::string& attrType,
                                   const std::string& classStrPrefix) {
@@ -267,12 +268,12 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Primitive Asset Attributes Template manager ====
   declareBaseAttributesManager<AbstractPrimitiveAttributes,
-                               core::ManagedObjectAccess::Copy>(
-      m, "Primitive Asset", "BaseAsset");
-  py::class_<AssetAttributesManager,
-             AttributesManager<AbstractPrimitiveAttributes,
-                               core::ManagedObjectAccess::Copy>,
-             AssetAttributesManager::ptr>(m, "AssetAttributesManager")
+                               ManagedObjectAccess::Copy>(m, "Primitive Asset",
+                                                          "BaseAsset");
+  py::class_<
+      AssetAttributesManager,
+      AttributesManager<AbstractPrimitiveAttributes, ManagedObjectAccess::Copy>,
+      AssetAttributesManager::ptr>(m, "AssetAttributesManager")
       // AssetAttributesMangaer-specific bindings
       // return appropriately cast capsule templates
       .def("get_default_capsule_template",
@@ -352,22 +353,20 @@ void initAttributesManagersBindings(py::module& m) {
 
   // ==== Light Layout Attributes Template manager ====
   declareBaseAttributesManager<LightLayoutAttributes,
-                               core::ManagedObjectAccess::Copy>(
-      m, "LightLayout", "BaseLightLayout");
+                               ManagedObjectAccess::Copy>(m, "LightLayout",
+                                                          "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
       LightLayoutAttributesManager,
-      AttributesManager<LightLayoutAttributes, core::ManagedObjectAccess::Copy>,
+      AttributesManager<LightLayoutAttributes, ManagedObjectAccess::Copy>,
       LightLayoutAttributesManager::ptr>(m, "LightLayoutAttributesManager");
   // ==== Object Attributes Template manager ====
-  declareBaseAttributesManager<ObjectAttributes,
-                               core::ManagedObjectAccess::Copy>(
+  declareBaseAttributesManager<ObjectAttributes, ManagedObjectAccess::Copy>(
       m, "ObjectAttributes", "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<
-      ObjectAttributesManager,
-      AttributesManager<ObjectAttributes, core::ManagedObjectAccess::Copy>,
-      ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
+  py::class_<ObjectAttributesManager,
+             AttributesManager<ObjectAttributes, ManagedObjectAccess::Copy>,
+             ObjectAttributesManager::ptr>(m, "ObjectAttributesManager")
 
       // ObjectAttributesManager-specific bindings
       .def("load_object_configs",
@@ -418,25 +417,23 @@ void initAttributesManagersBindings(py::module& m) {
           template chosen from the existing ObjectAttributes templates being managed.)");
 
   // ==== Stage Attributes Template manager ====
-  declareBaseAttributesManager<StageAttributes,
-                               core::ManagedObjectAccess::Copy>(
+  declareBaseAttributesManager<StageAttributes, ManagedObjectAccess::Copy>(
       m, "StageAttributes", "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<
-      StageAttributesManager,
-      AttributesManager<StageAttributes, core::ManagedObjectAccess::Copy>,
-      StageAttributesManager::ptr>(m, "StageAttributesManager");
+  py::class_<StageAttributesManager,
+             AttributesManager<StageAttributes, ManagedObjectAccess::Copy>,
+             StageAttributesManager::ptr>(m, "StageAttributesManager");
 
   // ==== Physics World/Manager Template manager ====
 
   declareBaseAttributesManager<PhysicsManagerAttributes,
-                               core::ManagedObjectAccess::Copy>(
+                               ManagedObjectAccess::Copy>(
       m, "PhysicsAttributes", "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<PhysicsAttributesManager,
-             AttributesManager<PhysicsManagerAttributes,
-                               core::ManagedObjectAccess::Copy>,
-             PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
+  py::class_<
+      PhysicsAttributesManager,
+      AttributesManager<PhysicsManagerAttributes, ManagedObjectAccess::Copy>,
+      PhysicsAttributesManager::ptr>(m, "PhysicsAttributesManager");
 
 }  // initAttributesManagersBindings
 }  // namespace managers

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -18,6 +18,7 @@ namespace py = pybind11;
 using py::literals::operator""_a;
 
 namespace PhysWraps = esp::physics;
+using esp::core::managedContainers::AbstractManagedObject;
 using PhysWraps::ManagedArticulatedObject;
 using PhysWraps::ManagedRigidObject;
 

--- a/src/esp/core/managedContainers/AbstractFileBasedManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractFileBasedManagedObject.h
@@ -10,6 +10,8 @@
 
 namespace esp {
 namespace core {
+
+namespace managedContainers {
 class AbstractFileBasedManagedObject : public AbstractManagedObject {
  public:
   /**
@@ -38,7 +40,7 @@ class AbstractFileBasedManagedObject : public AbstractManagedObject {
  public:
   ESP_SMART_POINTERS(AbstractFileBasedManagedObject)
 };  // class AbstractFileBasedManagedObject
-
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp
 

--- a/src/esp/core/managedContainers/AbstractManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractManagedObject.h
@@ -9,6 +9,7 @@
 
 namespace esp {
 namespace core {
+namespace managedContainers {
 /**
  * @brief This abstract base class provides the interface of expected
  * functionality for an object to be manageable by @ref
@@ -71,6 +72,7 @@ class AbstractManagedObject {
   ESP_SMART_POINTERS(AbstractManagedObject)
 };  // class AbstractManagedObject
 
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp
 #endif  // ESP_CORE_ABSTRACTMANAGEDOBJECT_H_

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -14,6 +14,7 @@
 
 namespace esp {
 namespace core {
+namespace managedContainers {
 
 /**
  * @brief This enum describes how objects held in the @ref ManagedConatainer are
@@ -696,6 +697,7 @@ auto ManagedContainer<T, Access>::removeObjectInternal(
   return managedObject;
 }  // ManagedContainer::removeObjectInternal
 
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp
 

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -11,6 +11,7 @@ namespace Cr = Corrade;
 namespace esp {
 namespace core {
 
+namespace managedContainers {
 bool ManagedContainerBase::setLock(const std::string& objectHandle, bool lock) {
   // if managed object does not currently exist then do not attempt to modify
   // its lock state
@@ -245,5 +246,6 @@ std::string ManagedContainerBase::getUniqueHandleFromCandidatePerType(
   return name + handleIncrement;
 }  // ManagedContainerBase::getUniqueHandleFromCandidatePerType
 
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -24,7 +24,7 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace core {
-
+namespace managedContainers {
 /**
  * @brief Base class of Managed Container, holding template-type-independent
  * functionality
@@ -482,6 +482,7 @@ class ManagedContainerBase {
   ESP_SMART_POINTERS(ManagedContainerBase)
 };  // class ManagedContainerBase
 
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp
 

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -23,6 +23,8 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace core {
+
+namespace managedContainers {
 /**
  * @brief Class template defining file-io-based responsibilities and
  * functionality for managing @ref esp::core::AbstractFileBasedManagedObject
@@ -164,7 +166,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (fileDirectory.empty()) {
       fileDirectory = obj->getFileDirectory();
     }
-    // construct filename candidate from given filename
+    // construct filename candidate from given fully qualified filename
+    // This will make sure written file will have appropriate extension
     const std::string fileName =
         FileUtil::splitExtension(
             FileUtil::splitExtension(FileUtil::filename(fullFilename)).first)
@@ -383,7 +386,7 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
   }
   return this->saveManagedObjectToFileInternal(obj, fileName, fileDirectory);
 }  // ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile
-
+}  // namespace managedContainers
 }  // namespace core
 }  // namespace esp
 #endif  // ESP_CORE_MANAGEDFILEBASEDCONTAINER_H_

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -30,8 +30,9 @@ const extern std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
  * esp::core::AbstractFileBasedManagedObject so the attributes can be managed by
  * a @ref esp::core::ManagedContainer.
  */
-class AbstractAttributes : public esp::core::AbstractFileBasedManagedObject,
-                           public esp::core::config::Configuration {
+class AbstractAttributes
+    : public esp::core::managedContainers::AbstractFileBasedManagedObject,
+      public esp::core::config::Configuration {
  public:
   AbstractAttributes(const std::string& attributesClassKey,
                      const std::string& handle);

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -7,6 +7,7 @@
 namespace esp {
 namespace metadata {
 namespace attributes {
+using esp::core::managedContainers::ManagedObjectAccess;
 
 SceneDatasetAttributes::SceneDatasetAttributes(
     const std::string& datasetName,
@@ -25,8 +26,8 @@ SceneDatasetAttributes::SceneDatasetAttributes(
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const attributes::SceneAttributes::ptr& sceneInstance) {
   // info display message prefix
-  std::string infoPrefix =
-      Cr::Utility::formatString("Dataset : '{}' : ", getSimplifiedHandle());
+  std::string infoPrefix = Cr::Utility::formatString(
+      "Dataset : '{}' : ", this->getSimplifiedHandle());
 
   const std::string sceneInstanceName = sceneInstance->getHandle();
   // verify stage in sceneInstance (required) exists in SceneDatasetAttributes,

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -21,6 +21,8 @@
 namespace esp {
 namespace metadata {
 namespace attributes {
+using esp::core::managedContainers::ManagedContainerBase;
+
 class SceneDatasetAttributes : public AbstractAttributes {
  public:
   SceneDatasetAttributes(
@@ -354,7 +356,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    */
   inline std::string getFullAttrNameFromStr(
       const std::string& attrName,
-      const esp::core::ManagedContainerBase::ptr& attrMgr) {
+      const ManagedContainerBase::ptr& attrMgr) {
     auto handleList = attrMgr->getObjectHandlesBySubstring(attrName);
     if (handleList.size() > 0) {
       return handleList[0];

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -28,7 +28,7 @@ namespace managers {
  * of this class works with.  Must inherit from @ref
  * esp::metadata::attributes::AbstractObjectAttributes.
  */
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
@@ -163,7 +163,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
 /////////////////////////////
 // Class Template Method Definitions
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 auto AbstractObjectAttributesManager<T, Access>::createObject(
     const std::string& attributesTemplateHandle,
     bool registerTemplate) -> AbsObjAttrPtr {
@@ -188,7 +188,7 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
 
 }  // AbstractObjectAttributesManager<T>::createObject
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 auto AbstractObjectAttributesManager<T, Access>::
     loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
                                          const io::JsonGenericValue& jsonDoc)
@@ -303,7 +303,7 @@ auto AbstractObjectAttributesManager<T, Access>::
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 std::string
 AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
     AbsObjAttrPtr attributes,

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -18,6 +18,7 @@ using attributes::CubePrimitiveAttributes;
 using attributes::CylinderPrimitiveAttributes;
 using attributes::IcospherePrimitiveAttributes;
 using attributes::UVSpherePrimitiveAttributes;
+using core::managedContainers::ManagedObjectAccess;
 namespace managers {
 
 const std::map<PrimObjTypes, const char*>
@@ -37,9 +38,10 @@ const std::map<PrimObjTypes, const char*>
         {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
 
 AssetAttributesManager::AssetAttributesManager()
-    : AttributesManager<attributes::AbstractPrimitiveAttributes,
-                        core::ManagedObjectAccess::Copy>::
-          AttributesManager("Primitive Asset", "prim_config.json") {
+    : AttributesManager<
+          attributes::AbstractPrimitiveAttributes,
+          ManagedObjectAccess::Copy>::AttributesManager("Primitive Asset",
+                                                        "prim_config.json") {
   // function pointers to asset attributes constructors
   primTypeConstructorMap_["capsule3DSolid"] =
       &AssetAttributesManager::createPrimAttributes<

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -75,9 +75,12 @@ enum class PrimObjTypes : uint32_t {
   END_PRIM_OBJ_TYPES
 };
 namespace managers {
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
+
 class AssetAttributesManager
     : public AttributesManager<attributes::AbstractPrimitiveAttributes,
-                               core::ManagedObjectAccess::Copy> {
+                               ManagedObjectAccess::Copy> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -401,8 +404,9 @@ class AssetAttributesManager
 
   /**
    * @brief Set the object to provide default values upon construction of @ref
-   * esp::core::AbstractManagedObject.  Override if object should not have
-   * defaults.  Currently not supported for AbstractPrimitiveAttributes.
+   * esp::core::managedContainers::AbstractManagedObject.  Override if object
+   * should not have defaults.  Currently not supported for
+   * AbstractPrimitiveAttributes.
    * @param _defaultObj the object to use for defaults;
    */
   void setDefaultObject(
@@ -430,7 +434,7 @@ class AssetAttributesManager
    * attributesManager-specific upon template removal, such as removing a
    * specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
-   * esp::core::ManagedContainerBase.
+   * esp::core::managedContainers::ManagedContainerBase.
    *
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -18,11 +18,17 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace core {
+namespace managedContainers {
 enum class ManagedObjectAccess;
 class ManagedFileBasedContainerBase;
+}  // namespace managedContainers
 }  // namespace core
 namespace metadata {
 namespace managers {
+
+using core::config::Configuration;
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
 
 /**
  * @brief Class template defining responsibilities and functionality for
@@ -34,9 +40,8 @@ namespace managers {
  * container provides copies of the objects held, or the actual objects
  * themselves.
  */
-template <class T, core::ManagedObjectAccess Access>
-class AttributesManager
-    : public esp::core::ManagedFileBasedContainer<T, Access> {
+template <class T, ManagedObjectAccess Access>
+class AttributesManager : public ManagedFileBasedContainer<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
                 "AttributesManager :: Managed object type must be derived from "
@@ -44,9 +49,19 @@ class AttributesManager
 
   typedef std::shared_ptr<T> AttribsPtr;
 
+  /**
+   * @brief Construct an attributes manager to manage shared pointers of
+   * attributes of type T.
+   * @param attrType A string describing the type of attributes, for
+   * @param JSONTypeExt The attributes JSON file extension, which must be of the
+   * form 'XXXXXX.json', where XXXXXX represents the sub extension specific to
+   * the managed type of attributes (i.e. "stage_config.json" for configurations
+   * describing stages).
+   */
   AttributesManager(const std::string& attrType, const std::string& JSONTypeExt)
-      : esp::core::ManagedFileBasedContainer<T, Access>::
-            ManagedFileBasedContainer(attrType, JSONTypeExt) {}
+      : ManagedFileBasedContainer<T, Access>::ManagedFileBasedContainer(
+            attrType,
+            JSONTypeExt) {}
   ~AttributesManager() override = default;
 
   /**
@@ -227,7 +242,7 @@ class AttributesManager
 
 /////////////////////////////
 // Class Template Method Definitions
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
@@ -260,7 +275,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
   return templateIndices;
 }  // AttributesManager<T, Access>::loadAllObjectTemplates
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     const std::string& path,
     const std::string& extType,
@@ -305,7 +320,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   return templateIndices;
 }  // AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const std::string& configDir,
     const std::string& extType,
@@ -337,7 +352,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
               << "templates.";
 }  // AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     const std::string& filename,
     std::string& msg,
@@ -381,7 +396,7 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   return attrs;
 }  // AttributesManager<T, Access>::createFromJsonFileOrDefaultInternal
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
     const attributes::AbstractAttributes::ptr& attribs,
     const io::JsonGenericValue& jsonConfig) const {
@@ -397,7 +412,7 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
     } else {
       const std::string subGroupName = "user_defined";
       // get pointer to user_defined subgroup configuration
-      std::shared_ptr<core::config::Configuration> subGroupPtr =
+      std::shared_ptr<Configuration> subGroupPtr =
           attribs->getUserConfiguration();
       // get json object referenced by tag subGroupName
       const io::JsonGenericValue& jsonObj = jsonConfig[subGroupName.c_str()];
@@ -414,7 +429,7 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
   return false;
 }  // AttributesManager<T, Access>::parseUserDefinedJsonVals
 
-template <class T, core::ManagedObjectAccess Access>
+template <class T, ManagedObjectAccess Access>
 bool AttributesManager<T, Access>::saveManagedObjectToFileInternal(
     const AttribsPtr& attribs,
     const std::string& filename,

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -13,6 +13,8 @@ namespace metadata {
 using attributes::LightInstanceAttributes;
 using attributes::LightLayoutAttributes;
 namespace managers {
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
 
 LightLayoutAttributes::ptr LightLayoutAttributesManager::createObject(
     const std::string& lightConfigName,

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -15,13 +15,17 @@ namespace Cr = Corrade;
 namespace esp {
 namespace metadata {
 namespace managers {
+
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
+
 class LightLayoutAttributesManager
     : public AttributesManager<attributes::LightLayoutAttributes,
-                               core::ManagedObjectAccess::Copy> {
+                               ManagedObjectAccess::Copy> {
  public:
   LightLayoutAttributesManager()
       : AttributesManager<attributes::LightLayoutAttributes,
-                          core::ManagedObjectAccess::Copy>::
+                          ManagedObjectAccess::Copy>::
             AttributesManager("Lighting Layout", "lighting_config.json") {
     // build this manager's copy constructor map
     this->copyConstructorMap_["LightLayoutAttributes"] =
@@ -98,7 +102,7 @@ class LightLayoutAttributesManager
   /**
    * @brief This method will perform any necessary updating that is
    * attributesManager-specific upon template removal.  This should only be
-   * called from @ref esp::core::ManagedContainerBase.
+   * called from @ref esp::core::managedContainers::ManagedContainerBase.
    *
    * @param templateID the ID of the template to remove
    * @param templateHandle the string key of the attributes desired.

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -15,6 +15,7 @@ namespace Cr = Corrade;
 namespace esp {
 
 using assets::AssetType;
+
 namespace metadata {
 
 using attributes::AbstractObjectAttributes;

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -15,16 +15,19 @@
 namespace esp {
 namespace metadata {
 namespace managers {
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
+
 /**
  * @brief single instance class managing templates describing physical objects
  */
 class ObjectAttributesManager
     : public AbstractObjectAttributesManager<attributes::ObjectAttributes,
-                                             core::ManagedObjectAccess::Copy> {
+                                             ManagedObjectAccess::Copy> {
  public:
   ObjectAttributesManager()
       : AbstractObjectAttributesManager<attributes::ObjectAttributes,
-                                        core::ManagedObjectAccess::Copy>::
+                                        ManagedObjectAccess::Copy>::
             AbstractObjectAttributesManager("Object", "object_config.json") {
     // build this manager's copy constructor map
     this->copyConstructorMap_["ObjectAttributes"] =

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -17,13 +17,16 @@ namespace Cr = Corrade;
 namespace esp {
 namespace metadata {
 namespace managers {
+using core::managedContainers::ManagedFileBasedContainer;
+using core::managedContainers::ManagedObjectAccess;
+
 class PhysicsAttributesManager
     : public AttributesManager<attributes::PhysicsManagerAttributes,
-                               core::ManagedObjectAccess::Copy> {
+                               ManagedObjectAccess::Copy> {
  public:
   PhysicsAttributesManager()
       : AttributesManager<attributes::PhysicsManagerAttributes,
-                          core::ManagedObjectAccess::Copy>::
+                          ManagedObjectAccess::Copy>::
             AttributesManager("Physics Manager", "physics_config.json") {
     this->copyConstructorMap_["PhysicsManagerAttributes"] =
         &PhysicsAttributesManager::createObjectCopy<

--- a/src/esp/metadata/managers/SceneAttributesManager.h
+++ b/src/esp/metadata/managers/SceneAttributesManager.h
@@ -12,14 +12,15 @@ namespace esp {
 namespace metadata {
 
 namespace managers {
+using esp::core::managedContainers::ManagedObjectAccess;
 
 class SceneAttributesManager
     : public AttributesManager<attributes::SceneAttributes,
-                               core::ManagedObjectAccess::Copy> {
+                               ManagedObjectAccess::Copy> {
  public:
   SceneAttributesManager()
       : AttributesManager<attributes::SceneAttributes,
-                          core::ManagedObjectAccess::Copy>::
+                          ManagedObjectAccess::Copy>::
             AttributesManager("Scene Instance", "scene_instance.json") {
     // build this manager's copy constructor map
     this->copyConstructorMap_["SceneAttributes"] =

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -7,6 +7,7 @@
 #include "esp/io/Json.h"
 
 namespace esp {
+using core::managedContainers::ManagedObjectAccess;
 namespace metadata {
 
 using attributes::SceneDatasetAttributes;
@@ -14,8 +15,7 @@ namespace managers {
 
 SceneDatasetAttributesManager::SceneDatasetAttributesManager(
     PhysicsAttributesManager::ptr physicsAttributesMgr)
-    : AttributesManager<attributes::SceneDatasetAttributes,
-                        core::ManagedObjectAccess::Share>::
+    : AttributesManager<SceneDatasetAttributes, ManagedObjectAccess::Share>::
           AttributesManager("Dataset", "scene_dataset_config.json"),
       physicsAttributesManager_(std::move(physicsAttributesMgr)) {
   // build this manager's copy ctor map

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -15,9 +15,11 @@
 namespace esp {
 namespace metadata {
 namespace managers {
+using esp::core::managedContainers::ManagedObjectAccess;
+
 class SceneDatasetAttributesManager
     : public AttributesManager<attributes::SceneDatasetAttributes,
-                               core::ManagedObjectAccess::Share> {
+                               ManagedObjectAccess::Share> {
  public:
   explicit SceneDatasetAttributesManager(
       PhysicsAttributesManager::ptr physicsAttributesMgr);
@@ -89,7 +91,7 @@ class SceneDatasetAttributesManager
   /**
    * @brief Verify a particular subcell exists within the
    * dataset_config.JSON file, and if so, handle reading the possible JSON
-   * sub-cells it might hold. using the passed attributesManager for the
+   * sub-cells it might hold, using the passed attributesManager for the
    * dataset being processed.
    * @tparam the type of the attributes manager.
    * @param dsDir The root directory of the dataset attributes being built.

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -16,6 +16,8 @@
 
 namespace esp {
 using assets::AssetType;
+using core::managedContainers::ManagedObjectAccess;
+
 namespace metadata {
 
 using attributes::AbstractObjectAttributes;
@@ -26,7 +28,7 @@ StageAttributesManager::StageAttributesManager(
     ObjectAttributesManager::ptr objectAttributesMgr,
     PhysicsAttributesManager::ptr physicsAttributesManager)
     : AbstractObjectAttributesManager<StageAttributes,
-                                      core::ManagedObjectAccess::Copy>::
+                                      ManagedObjectAccess::Copy>::
           AbstractObjectAttributesManager("Stage", "stage_config.json"),
       objectAttributesMgr_(std::move(objectAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -16,9 +16,11 @@ enum class AssetType;
 }  // namespace assets
 namespace metadata {
 namespace managers {
+using esp::core::managedContainers::ManagedObjectAccess;
+
 class StageAttributesManager
     : public AbstractObjectAttributesManager<attributes::StageAttributes,
-                                             core::ManagedObjectAccess::Copy> {
+                                             ManagedObjectAccess::Copy> {
  public:
   StageAttributesManager(
       ObjectAttributesManager::ptr objectAttributesMgr,

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -15,8 +15,10 @@
 
 namespace esp {
 namespace core {
+namespace managedContainers {
 enum class ManagedObjectAccess;
 class ManagedContainerBase;
+}  // namespace managedContainers
 }  // namespace core
 namespace physics {
 
@@ -30,11 +32,15 @@ namespace physics {
  */
 template <class T>
 class PhysicsObjectBaseManager
-    : public esp::core::ManagedContainer<T, core::ManagedObjectAccess::Copy> {
+    : public esp::core::managedContainers::ManagedContainer<
+          T,
+          core::managedContainers::ManagedObjectAccess::Copy> {
  public:
   typedef std::shared_ptr<T> ObjWrapperPtr;
   explicit PhysicsObjectBaseManager(const std::string& objType)
-      : esp::core::ManagedContainer<T, core::ManagedObjectAccess::Copy>::
+      : core::managedContainers::ManagedContainer<
+            T,
+            core::managedContainers::ManagedObjectAccess::Copy>::
             ManagedContainer(objType) {}
   ~PhysicsObjectBaseManager() override = default;
 
@@ -42,7 +48,7 @@ class PhysicsObjectBaseManager
    * @brief set the weak reference to the physics manager that owns this wrapper
    * manager
    */
-  void setPhysicsManager(std::weak_ptr<esp::physics::PhysicsManager> physMgr) {
+  void setPhysicsManager(std::weak_ptr<physics::PhysicsManager> physMgr) {
     weakPhysManager_ = std::move(physMgr);
   }
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -18,7 +18,8 @@ namespace physics {
  * enable Managed Container access.
  */
 template <class T>
-class AbstractManagedPhysicsObject : public esp::core::AbstractManagedObject {
+class AbstractManagedPhysicsObject
+    : public esp::core::managedContainers::AbstractManagedObject {
  public:
   static_assert(
       std::is_base_of<esp::physics::PhysicsObjectBase, T>::value,


### PR DESCRIPTION
## Motivation and Context
This PR moves the base functionality for the ManagedContainers and AbstractManagedObjects into its own namespace ("managedContainers") subordinate to esp::core, where this functionality is now.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally passes all c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
