### PR TITLE
[Bugfix]--Add default entries into configuration

### DIFF
--- a/src/esp/metadata/attributes/SceneAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneAttributes.cpp
@@ -19,8 +19,8 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   // defaults to unknown/undefined
   setMotionType(getMotionTypeName(esp::physics::MotionType::UNDEFINED));
   // set to no rotation
-  set("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
-  set("translation", Mn::Vector3());
+  setRotation(Mn::Quaternion(Mn::Math::IdentityInit));
+  setTranslation(Mn::Vector3());
   // don't override attributes-specified visibility.
   set("is_instance_visible", ID_UNDEFINED);
   // defaults to unknown so that obj instances use scene instance setting
@@ -129,6 +129,8 @@ SceneAttributes::SceneAttributes(const std::string& handle)
   // defaults to asset local
   setTranslationOrigin(
       getTranslationOriginName(SceneInstanceTranslationOrigin::AssetLocal));
+  setNavmeshHandle("");
+  setSemanticSceneHandle("");
   // get refs to internal subconfigs for object and ao instances
   objInstConfig_ = editSubconfig<Configuration>("object_instances");
   artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");


### PR DESCRIPTION
## Motivation and Context
This PR adds 2 missing default (empty string) entries (for "navmesh_instance" and "semantic_scene_instance") in SceneInstanceAttributes so the configuration will not throw an error if these values are not present when queried.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
