### PR TITLE
--Support multi-color gradient trajectories

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1455,9 +1455,9 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceGeneralPrimitive(
 bool ResourceManager::buildTrajectoryVisualization(
     const std::string& trajVisName,
     const std::vector<Mn::Vector3>& pts,
+    const std::vector<Mn::Color3>& colorVec,
     int numSegments,
     float radius,
-    const std::vector<Mn::Color3ub>& colorVec,
     bool smooth,
     int numInterp) {
   // enforce required minimum/reasonable values if illegal values specified

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -525,23 +525,22 @@ class ResourceManager {
    * @brief Generate a tube following the passed trajectory of points.
    * @param trajVisName The name to use for the trajectory visualization mesh.
    * @param pts The points of a trajectory, in order
+   * @param colorVec Array of Colors for trajectory tube.
    * @param numSegments The number of the segments around the circumference of
    * the tube. Must be greater than or equal to 3.
    * @param radius The radius of the tube.
-   * @param color Color for trajectory tube.
    * @param smooth Whether to smooth the points in the trajectory or not
    * @param numInterp The number of interpolations between each trajectory
    * point, if smoothing.
    * @return Whether the process was a success or not
    */
-  bool buildTrajectoryVisualization(
-      const std::string& trajVisName,
-      const std::vector<Mn::Vector3>& pts,
-      int numSegments = 3,
-      float radius = .001,
-      const std::vector<Mn::Color3ub>& colorVec = {{220, 25, 25}},
-      bool smooth = false,
-      int numInterp = 10);
+  bool buildTrajectoryVisualization(const std::string& trajVisName,
+                                    const std::vector<Mn::Vector3>& pts,
+                                    const std::vector<Mn::Color3>& colorVec,
+                                    int numSegments = 3,
+                                    float radius = .001,
+                                    bool smooth = false,
+                                    int numInterp = 10);
 
   /**
    * @brief Build a configuration frame from scene or object attributes values

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -422,39 +422,45 @@ void initSimBindings(py::module& m) {
           R"(Decomposite an object into its constituent convex hulls with specified VHACD parameters.)")
 #endif
 
-      .def("add_trajectory_object",
-           static_cast<int (Simulator::*)(
-               const std::string&, const std::vector<Mn::Vector3>&, int, float,
-               const Magnum::Color4&, bool, int)>(
-               &Simulator::addTrajectoryObject),
-           "traj_vis_name"_a, "points"_a, "num_segments"_a = 3,
-           "radius"_a = .001, "color"_a = Mn::Color4{0.9, 0.1, 0.1, 1.0},
-           "smooth"_a = false, "num_interpolations"_a = 10,
-           R"(Build a tube visualization around the passed trajectory of points.
+      .def(
+          "add_trajectory_object",
+          [](Simulator& self, const std::string& name,
+             const std::vector<Mn::Vector3>& pts, int numSegments, float radius,
+             const Magnum::Color4& color, bool smooth, int numInterps) {
+            return self.addTrajectoryObject(
+                name, pts, {Mn::Color3(color.rgb())}, numSegments, radius,
+                smooth, numInterps);
+          },
+          "traj_vis_name"_a, "points"_a, "num_segments"_a = 3,
+          "radius"_a = .001, "color"_a = Mn::Color4{0.9, 0.1, 0.1, 1.0},
+          "smooth"_a = false, "num_interpolations"_a = 10,
+          R"(Build a tube visualization around the passed trajectory of points.
               points : (list of 3-tuples of floats) key point locations to use to create trajectory tube.
               num_segments : (Integer) the number of segments around the tube to be used to make the visualization.
               radius : (Float) the radius of the resultant tube.
               color : (4-tuple of float) the color of the trajectory tube.
               smooth : (Bool) whether or not to smooth trajectory using a Catmull-Rom spline interpolating spline.
               num_interpolations : (Integer) the number of interpolation points to find between successive key points.)")
-      .def(
-          "add_gradient_trajectory_object",
-          static_cast<int (Simulator::*)(
-              const std::string&, const std::vector<Mn::Vector3>&, int, float,
-              const std::vector<Mn::Color3ub>&, bool, int)>(
-              &Simulator::addTrajectoryObject),
-          "traj_vis_name"_a, "points"_a, "num_segments"_a = 3,
-          "radius"_a = .001,
-          "colors"_a = std::vector<Mn::Color3ub>{Mn::Color3ub{220, 25, 25}},
-          "smooth"_a = false, "num_interpolations"_a = 10,
-          R"(Build a tube visualization around the passed trajectory of points, using the passed colors to build
+      .def("add_gradient_trajectory_object",
+           static_cast<int (Simulator::*)(
+               const std::string&, const std::vector<Mn::Vector3>&,
+               const std::vector<Mn::Color3>&, int, float, bool, int)>(
+               &Simulator::addTrajectoryObject),
+           "traj_vis_name"_a, "points"_a, "colors"_a, "num_segments"_a = 3,
+           "radius"_a = .001, "smooth"_a = false, "num_interpolations"_a = 10,
+           R"(Build a tube visualization around the passed trajectory of
+          points, using the passed colors to build
               a gradient along the length of the tube.
-              points : (list of 3-tuples of floats) key point locations to use to create trajectory tube.
-              num_segments : (Integer) the number of segments around the tube to be used to make the visualization.
-              radius : (Float) the radius of the resultant tube.
-              colors : (3-tuple of byte) the colors to build the gradient along the length of the trajectory tube.
-              smooth : (Bool) whether or not to smooth trajectory using a Catmull-Rom spline interpolating spline.
-              num_interpolations : (Integer) the number of interpolation points to find between successive key points.)")
+              points : (list of 3-tuples of floats) key point locations to
+              use to create trajectory tube. num_segments : (Integer) the
+              number of segments around the tube to be used to make the
+              visualization. radius : (Float) the radius of the resultant
+              tube. colors : (List of 3-tuple of byte) the colors to build
+              the gradient along the length of the trajectory tube. smooth :
+              (Bool) whether or not to smooth trajectory using a Catmull-Rom
+              spline interpolating spline. num_interpolations : (Integer) the
+              number of interpolation points to find between successive key
+              points.)")
       .def("get_light_setup", &Simulator::getLightSetup,
            "key"_a = DEFAULT_LIGHTING_KEY,
            R"(Get a copy of the LightSetup registered with a specific key.)")

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -124,7 +124,7 @@ std::vector<Mn::Vector3> buildCatmullRomTrajOfPoints(
  */
 Mn::Trade::MeshData buildTrajectoryTubeSolid(
     const std::vector<Mn::Vector3>& pts,
-    const std::vector<Mn::Color3ub>& interpColors,
+    const std::vector<Mn::Color3>& interpColors,
     int numSegments,
     float radius,
     bool smooth,

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1013,9 +1013,9 @@ bool Simulator::isNavMeshVisualizationActive() {
 
 int Simulator::addTrajectoryObject(const std::string& trajVisName,
                                    const std::vector<Mn::Vector3>& pts,
+                                   const std::vector<Mn::Color3>& colorVec,
                                    int numSegments,
                                    float radius,
-                                   const std::vector<Mn::Color3ub>& colorVec,
                                    bool smooth,
                                    int numInterp) {
   if (renderer_) {
@@ -1035,7 +1035,7 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
 
   // 1. create trajectory tube asset from points and save it
   bool success = resourceManager_->buildTrajectoryVisualization(
-      trajVisName, uniquePts, numSegments, radius, colorVec, smooth, numInterp);
+      trajVisName, uniquePts, colorVec, numSegments, radius, smooth, numInterp);
   if (!success) {
     ESP_ERROR() << "Failed to create Trajectory visualization mesh for"
                 << trajVisName;
@@ -1070,18 +1070,6 @@ int Simulator::addTrajectoryObject(const std::string& trajVisName,
   return trajVisID;
 
 }  // Simulator::addTrajectoryObject (vector of colors)
-
-int Simulator::addTrajectoryObject(const std::string& trajVisName,
-                                   const std::vector<Mn::Vector3>& pts,
-                                   int numSegments,
-                                   float radius,
-                                   const Magnum::Color4& color,
-                                   bool smooth,
-                                   int numInterp) {
-  return addTrajectoryObject(trajVisName, pts, numSegments, radius,
-                             {Mn::Math::pack<Mn::Color3ub>(color.rgb())},
-                             smooth, numInterp);
-}  // Simulator::showTrajectoryVisualization
 
 // Agents
 void Simulator::sampleRandomAgentState(agent::AgentState& agentState) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1002,10 +1002,10 @@ class Simulator {
    * @brief Compute a trajectory visualization for the passed points.
    * @param trajVisName The name to use for the trajectory visualization
    * @param pts The points of a trajectory, in order
+   * @param colorVec Array of colors for trajectory tube.
    * @param numSegments The number of the segments around the circumference of
    * the tube. Must be greater than or equal to 3.
    * @param radius The radius of the tube.
-   * @param color Color for trajectory tube.
    * @param smooth Whether to smooth the points in the trajectory or not. Will
    * build a much bigger mesh
    * @param numInterp The number of interpolations between each trajectory
@@ -1014,21 +1014,11 @@ class Simulator {
    */
   int addTrajectoryObject(const std::string& trajVisName,
                           const std::vector<Mn::Vector3>& pts,
+                          const std::vector<Mn::Color3>& colorVec,
                           int numSegments = 3,
                           float radius = .001,
-                          const Magnum::Color4& color = {0.9, 0.1, 0.1, 1.0},
                           bool smooth = false,
                           int numInterp = 10);
-
-  int addTrajectoryObject(const std::string& trajVisName,
-                          const std::vector<Mn::Vector3>& pts,
-                          int numSegments = 3,
-                          float radius = .001,
-                          const std::vector<Mn::Color3ub>& colorVec = {{220, 25,
-                                                                        25}},
-                          bool smooth = false,
-                          int numInterp = 10);
-
   /**
    * @brief Remove a trajectory visualization by name.
    * @param trajVisName The name of the trajectory visualization to remove.

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1071,11 +1071,11 @@ void Viewer::buildTrajectoryVis() {
                      "points, so nothing to build. Aborting.";
     return;
   }
-  std::vector<Mn::Color3ub> clrs;
+  std::vector<Mn::Color3> clrs;
   int numClrs = (singleColorTrajectory_ ? 1 : rand() % 4 + 2);
   clrs.reserve(numClrs);
   for (int i = 0; i < numClrs; ++i) {
-    clrs.emplace_back(Mn::Color3ub{randomDirection() * 255});
+    clrs.emplace_back(Mn::Color3{randomDirection()});
   }
   // synthesize a name for asset based on color, radius, point count
   std::string trajObjName = Cr::Utility::formatString(
@@ -1084,8 +1084,8 @@ void Viewer::buildTrajectoryVis() {
 
   ESP_DEBUG() << "Attempting to build trajectory tube for :"
               << agentLocs_.size() << "points with " << numClrs << "colors.";
-  int trajObjID = simulator_->addTrajectoryObject(
-      trajObjName, agentLocs_, 6, agentTrajRad_, clrs, true, 10);
+  int trajObjID = simulator_->addTrajectoryObject(trajObjName, agentLocs_, clrs,
+                                                  6, agentTrajRad_, true, 10);
   if (trajObjID != esp::ID_UNDEFINED) {
     ESP_DEBUG() << "Success!  Traj Obj Name :" << trajObjName
                 << "has object ID :" << trajObjID;


### PR DESCRIPTION
Interpolate a list of colors (in HSV space) of any length and map them to trajectory vertices; use vertex colors to render trajectory tube.

## Motivation and Context

This PR introduces the ability to generate trajectories with color gradients by interpolating a given list of colors (in HSV space) to produce per-trajectory prim ring colors that are then assigned to the vertices of the trajectory.  Any number of colors are supported, not just 2.

The existing functionality is still supported, but another functional binding has been added that supports the user specifying a list of Mn::Color3ub values to be used as the color interpolants.  NOTE : the existing code supported the user specifying a single Mn::Color4 (which was a float color w/alpha) even though the alpha was ignored for this construct.  A discussion should be had on whether we wish to refactor the old mechanism to support Color3ub, dispose of the old method entirely, or leave the old method (to not break existing code).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local c++ and python tests pass; Viewer.cpp has been expanded to enable the user to request a single random color or a random number of multiple random colors (up to 5) to illustrate the functionality.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
