### PR TITLE
[HM3D Annotation] --HM3D SSD file support; Misc SSD Fixes

### DIFF
--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -45,7 +45,7 @@ enum SupportedMeshType {
    * Instance meshes loaded from sources including segmented object
    * identifier data (e.g. semantic data: chair, table, etc...). Sources include
    * .ply files and reconstructions of Matterport scans. Object is likely of
-   * type @ref GenericInstanceMeshData or Mp3dInstanceMeshData.
+   * type @ref GenericSemanticMeshData or Mp3dInstanceMeshData.
    */
   INSTANCE_MESH = 0,
 

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -5,8 +5,8 @@ set(
   BaseMesh.cpp
   BaseMesh.h
   CollisionMeshData.h
-  GenericInstanceMeshData.cpp
-  GenericInstanceMeshData.h
+  GenericSemanticMeshData.cpp
+  GenericSemanticMeshData.h
   GenericMeshData.cpp
   GenericMeshData.h
   MeshData.h

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "GenericInstanceMeshData.h"
+#include "GenericSemanticMeshData.h"
 
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/ArrayView.h>
@@ -288,8 +288,8 @@ Cr::Containers::Optional<InstancePlyData> parsePly(
 
 }  // namespace
 
-std::vector<std::unique_ptr<GenericInstanceMeshData>>
-GenericInstanceMeshData::fromPLY(
+std::vector<std::unique_ptr<GenericSemanticMeshData>>
+GenericSemanticMeshData::fromPLY(
     Mn::Trade::AbstractImporter& importer,
     const std::string& plyFile,
     const bool splitMesh,
@@ -302,7 +302,7 @@ GenericInstanceMeshData::fromPLY(
     return {};
   }
 
-  std::vector<GenericInstanceMeshData::uptr> splitMeshData;
+  std::vector<GenericSemanticMeshData::uptr> splitMeshData;
   if (splitMesh &&
       (parseResult->objIdsFromPly || parseResult->objPartitionsFromSSD)) {
     std::vector<uint16_t>& meshPartitionIds = parseResult->objIdsFromPly
@@ -319,7 +319,7 @@ GenericInstanceMeshData::fromPLY(
       // if not found in map to data create new mesh
       if (partitionIdToObjectData.find(partitionId) ==
           partitionIdToObjectData.end()) {
-        auto instanceMesh = GenericInstanceMeshData::create_unique();
+        auto instanceMesh = GenericSemanticMeshData::create_unique();
         partitionIdToObjectData.emplace(
             partitionId, PerPartitionIdMeshBuilder{*instanceMesh, partitionId});
         splitMeshData.emplace_back(std::move(instanceMesh));
@@ -334,7 +334,7 @@ GenericInstanceMeshData::fromPLY(
     }
   } else {
     // ply should not be split - ids were synthesized
-    auto meshData = GenericInstanceMeshData::create_unique();
+    auto meshData = GenericSemanticMeshData::create_unique();
     meshData->cpu_vbo_ = std::move(parseResult->cpu_vbo);
     meshData->cpu_cbo_ = std::move(parseResult->cpu_cbo);
     meshData->cpu_ibo_ = std::move(parseResult->cpu_ibo);
@@ -349,9 +349,9 @@ GenericInstanceMeshData::fromPLY(
   }
   return splitMeshData;
 
-}  // GenericInstanceMeshData::fromPLY
+}  // GenericSemanticMeshData::fromPLY
 
-void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
+void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
   if (forceReload) {
     buffersOnGPU_ = false;
   }
@@ -368,7 +368,7 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
       Mn::GL::BufferUsage::StaticDraw);
 
   renderingBuffer_ =
-      std::make_unique<GenericInstanceMeshData::RenderingBuffer>();
+      std::make_unique<GenericSemanticMeshData::RenderingBuffer>();
   renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
       .setCount(cpu_ibo_.size())
       .addVertexBuffer(
@@ -388,21 +388,21 @@ void GenericInstanceMeshData::uploadBuffersToGPU(bool forceReload) {
   buffersOnGPU_ = true;
 }
 
-Magnum::GL::Mesh* GenericInstanceMeshData::getMagnumGLMesh() {
+Magnum::GL::Mesh* GenericSemanticMeshData::getMagnumGLMesh() {
   if (renderingBuffer_ == nullptr) {
     return nullptr;
   }
   return &(renderingBuffer_->mesh);
 }
 
-void GenericInstanceMeshData::updateCollisionMeshData() {
+void GenericSemanticMeshData::updateCollisionMeshData() {
   collisionMeshData_.positions = Cr::Containers::arrayCast<Mn::Vector3>(
       Cr::Containers::arrayView(cpu_vbo_));
   collisionMeshData_.indices = Cr::Containers::arrayCast<Mn::UnsignedInt>(
       Cr::Containers::arrayView(cpu_ibo_));
 }
 
-void GenericInstanceMeshData::PerPartitionIdMeshBuilder::addVertex(
+void GenericSemanticMeshData::PerPartitionIdMeshBuilder::addVertex(
     uint32_t vertexId,
     const vec3f& position,
     const vec3uc& color,

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -166,11 +166,10 @@ Cr::Containers::Optional<InstancePlyData> parsePly(
       // region to move all verts whose region is
 
       int maxRegion = -1;
-      int maxSemanticID = -1;
       // temporary map keyed by semantic ID and value being actual color for
       // that ID. We need this since we do not know how many, if any, unique
       // colors that do not have Semantic Mappings exist on the mesh
-      std::unordered_map<int, Mn::Vector3ub> tmpDestSSDColorMap;
+      std::map<int, Mn::Vector3ub> tmpDestSSDColorMap;
       for (int i = 0; i < numSSDObjs; ++i) {
         const auto& ssdObj =
             static_cast<scene::HM3DObjectInstance&>(*ssdObjs[i]);
@@ -185,9 +184,9 @@ Cr::Containers::Optional<InstancePlyData> parsePly(
         tmpDestSSDColorMap[semanticID] = ssdColor;
 
         maxRegion = Mn::Math::max(regionIDX, maxRegion);
-        maxSemanticID = Mn::Math::max(semanticID, maxSemanticID);
       }
-
+      // find largest key in map
+      int maxSemanticID = tmpDestSSDColorMap.rbegin()->first;
       // increment maxRegion to use for unknown regions whose colors are not
       // mapped
       ++maxRegion;
@@ -254,7 +253,7 @@ Cr::Containers::Optional<InstancePlyData> parsePly(
       // provided semantic IDs (so that ID is IDX of semantic color in map) and
       // any overflow colors uniquely map 1-to-1 to an unmapped semantic ID as
       // their index.
-      colorMapToUse.resize(tmpDestSSDColorMap.size());
+      colorMapToUse.resize(tmpDestSSDColorMap.rbegin()->first + 1);
       for (const auto& elem : tmpDestSSDColorMap) {
         colorMapToUse[elem.first] = elem.second;
       }

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -22,20 +22,26 @@ class SemanticScene;
 }  // namespace scene
 namespace assets {
 
-class GenericInstanceMeshData : public BaseMesh {
+/**
+ * @brief Mesh data storage and loading for ply format assets used primarily for
+ * Semantic Scene meshes, including manage vertex colors and vertex IDs for
+ * semantic visualization and rendering. See @ref
+ * ResourceManager::loadRenderAssetIMesh.
+ */
+class GenericSemanticMeshData : public BaseMesh {
  public:
   struct RenderingBuffer {
     Magnum::GL::Mesh mesh;
   };
 
-  explicit GenericInstanceMeshData(SupportedMeshType type) : BaseMesh{type} {};
-  explicit GenericInstanceMeshData()
-      : GenericInstanceMeshData{SupportedMeshType::INSTANCE_MESH} {};
+  explicit GenericSemanticMeshData(SupportedMeshType type) : BaseMesh{type} {};
+  explicit GenericSemanticMeshData()
+      : GenericSemanticMeshData{SupportedMeshType::INSTANCE_MESH} {};
 
-  ~GenericInstanceMeshData() override = default;
+  ~GenericSemanticMeshData() override = default;
 
   /**
-   * @brief Load a .ply file into one ore more @ref GenericInstanceMeshData,
+   * @brief Load a .ply file into one ore more @ref GenericSemanticMeshData,
    * splitting the result into multiples if specified and if the source file's
    * objectIds are compatibly configured to do so.
    * @param importer The importer to use to load the .ply file
@@ -46,7 +52,7 @@ class GenericInstanceMeshData : public BaseMesh {
    * @return vector holding one or more mesh results from the .ply file.
    */
 
-  static std::vector<std::unique_ptr<GenericInstanceMeshData>> fromPLY(
+  static std::vector<std::unique_ptr<GenericSemanticMeshData>> fromPLY(
       Magnum::Trade::AbstractImporter& importer,
       const std::string& plyFile,
       bool splitMesh,
@@ -77,7 +83,7 @@ class GenericInstanceMeshData : public BaseMesh {
  protected:
   class PerPartitionIdMeshBuilder {
    public:
-    PerPartitionIdMeshBuilder(GenericInstanceMeshData& data,
+    PerPartitionIdMeshBuilder(GenericSemanticMeshData& data,
                               uint16_t partitionId)
         : data_{data}, partitionId{partitionId} {}
 
@@ -87,7 +93,7 @@ class GenericInstanceMeshData : public BaseMesh {
                    int objectId);
 
    private:
-    GenericInstanceMeshData& data_;
+    GenericSemanticMeshData& data_;
     uint16_t partitionId;
     std::unordered_map<uint32_t, size_t> vertexIdToVertexIndex_;
   };
@@ -101,7 +107,7 @@ class GenericInstanceMeshData : public BaseMesh {
   std::vector<uint32_t> cpu_ibo_;
   std::vector<uint16_t> objectIds_;
 
-  ESP_SMART_POINTERS(GenericInstanceMeshData)
+  ESP_SMART_POINTERS(GenericSemanticMeshData)
 };
 
 }  // namespace assets

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -55,7 +55,7 @@ class GenericSemanticMeshData : public BaseMesh {
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>>
   buildSemanticMeshData(
-      const Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData,
+      const Magnum::Trade::MeshData& meshData,
       const std::string& semanticFilename,
       bool splitMesh,
       std::vector<Magnum::Vector3ub>& colorMapToUse,

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -41,10 +41,11 @@ class GenericSemanticMeshData : public BaseMesh {
   ~GenericSemanticMeshData() override = default;
 
   /**
-   * @brief Load a .ply file into one ore more @ref GenericSemanticMeshData,
-   * splitting the result into multiples if specified and if the source file's
-   * objectIds are compatibly configured to do so.
-   * @param importer The importer to use to load the .ply file
+   * @brief Build one ore more @ref GenericSemanticMeshData based on the
+   * contents of the passed @p meshData, splitting the result into multiples if
+   * specified and if the source file's objectIds are compatibly configured to
+   * do so.
+   * @param meshData The imported meshData.
    * @param plyFile Fully qualified filename of .ply file to load
    * @param splitMesh Whether or not the resultant mesh should be split into
    * multiple components based on objectIds, for frustum culling.
@@ -52,9 +53,10 @@ class GenericSemanticMeshData : public BaseMesh {
    * @return vector holding one or more mesh results from the .ply file.
    */
 
-  static std::vector<std::unique_ptr<GenericSemanticMeshData>> fromPLY(
-      Magnum::Trade::AbstractImporter& importer,
-      const std::string& plyFile,
+  static std::vector<std::unique_ptr<GenericSemanticMeshData>>
+  buildSemanticMeshData(
+      const Corrade::Containers::Optional<Magnum::Trade::MeshData>& meshData,
+      const std::string& semanticFilename,
       bool splitMesh,
       std::vector<Magnum::Vector3ub>& colorMapToUse,
       const std::shared_ptr<scene::SemanticScene>& semanticScene = nullptr);

--- a/src/esp/assets/Mp3dInstanceMeshData.h
+++ b/src/esp/assets/Mp3dInstanceMeshData.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "BaseMesh.h"
-#include "GenericInstanceMeshData.h"
+#include "GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 
 namespace esp {
@@ -23,10 +23,10 @@ namespace assets {
  * MP3D object instance segmented mesh
  * Holds a vbo where each vertex is (x, y, z, objectId)
  */
-class Mp3dInstanceMeshData : public GenericInstanceMeshData {
+class Mp3dInstanceMeshData : public GenericSemanticMeshData {
  public:
   Mp3dInstanceMeshData()
-      : GenericInstanceMeshData(SupportedMeshType::INSTANCE_MESH) {}
+      : GenericSemanticMeshData(SupportedMeshType::INSTANCE_MESH) {}
   ~Mp3dInstanceMeshData() override = default;
 
   //! Loads an MP3D house segmentations PLY file

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1259,7 +1259,7 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
 
   std::vector<GenericSemanticMeshData::uptr> instanceMeshes =
       GenericSemanticMeshData::buildSemanticMeshData(
-          meshData, filename, info.splitInstanceMesh,
+          *meshData, filename, info.splitInstanceMesh,
           semanticColorMapBeingUsed_, semanticScene_);
 
   ESP_CHECK(!instanceMeshes.empty(),

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -59,8 +59,8 @@
 #endif
 
 #include "CollisionMeshData.h"
-#include "GenericInstanceMeshData.h"
 #include "GenericMeshData.h"
+#include "GenericSemanticMeshData.h"
 #include "MeshData.h"
 
 #ifdef ESP_BUILD_PTEX_SUPPORT
@@ -441,7 +441,7 @@ bool ResourceManager::buildMeshGroups(
     if (info.type == AssetType::INSTANCE_MESH) {
       // PLY Instance mesh
       colMeshGroupSuccess =
-          buildStageCollisionMeshGroup<GenericInstanceMeshData>(info.filepath,
+          buildStageCollisionMeshGroup<GenericSemanticMeshData>(info.filepath,
                                                                 meshGroup);
     } else if (info.type == AssetType::MP3D_MESH ||
                info.type == AssetType::UNKNOWN) {
@@ -988,7 +988,7 @@ void ResourceManager::computeInstanceMeshAbsoluteAABBs(
 
     // convert std::vector<vec3f> to std::vector<Mn::Vector3>
     const std::vector<vec3f>& vertexPositions =
-        dynamic_cast<GenericInstanceMeshData&>(*meshes_.at(meshID))
+        dynamic_cast<GenericSemanticMeshData&>(*meshes_.at(meshID))
             .getVertexBufferObjectCPU();
     std::vector<Mn::Vector3> transformedPositions{vertexPositions.begin(),
                                                   vertexPositions.end()};
@@ -1246,8 +1246,8 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
   CORRADE_INTERNAL_ASSERT_OUTPUT(
       importer = importerManager_.loadAndInstantiate("StanfordImporter"));
 
-  std::vector<GenericInstanceMeshData::uptr> instanceMeshes =
-      GenericInstanceMeshData::fromPLY(
+  std::vector<GenericSemanticMeshData::uptr> instanceMeshes =
+      GenericSemanticMeshData::fromPLY(
           *importer, filename, info.splitInstanceMesh,
           semanticColorMapBeingUsed_, semanticScene_);
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -17,6 +17,7 @@
 
 #include <Corrade/Containers/EnumSet.h>
 #include <Corrade/Containers/Optional.h>
+#include <Magnum/DebugTools/ColorMap.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/MeshTools/Compile.h>
@@ -69,8 +70,9 @@ class Recorder;
 }
 }  // namespace gfx
 namespace scene {
+class SemanticScene;
 struct SceneConfiguration;
-}
+}  // namespace scene
 namespace physics {
 class PhysicsManager;
 class RigidObject;
@@ -169,6 +171,36 @@ class ResourceManager {
       scene::SceneNode* parent,
       const metadata::attributes::PhysicsManagerAttributes::ptr&
           physicsManagerAttributes);
+
+  /**
+   * @brief Return the currently loaded @ref esp::scene::SemanticScene .
+   */
+  std::shared_ptr<scene::SemanticScene> getSemanticScene() {
+    return semanticScene_;
+  }
+
+  /**
+   * @brief Return a view of the currently set Semantic scene colormap.
+   */
+  Cr::Containers::ArrayView<const Mn::Vector3ub> getSemanticSceneColormap()
+      const {
+    // return Magnum::DebugTools::ColorMap::plasma();
+    return semanticColorMapBeingUsed_;
+  }
+
+  /** @brief check if the @ref esp::scene::SemanticScene exists.*/
+  bool semanticSceneExists() const { return (semanticScene_ != nullptr); }
+
+  /**
+   * @brief Load semantic scene descriptor file specified by @p ssdFilename ,
+   * for the passed @p activeSceneName .
+   * @param ssdFilename The fully qualified filename candidate for the ssd file.
+   * @param activeSceneName Name of the currently active scene that we will be
+   * loading the SSD for.
+   * @return whether loaded successfully or not.
+   */
+  bool loadSemanticSceneDescriptor(const std::string& ssdFilename,
+                                   const std::string& activeSceneName);
 
   /**
    * @brief Load a scene mesh and add it to the specified @ref DrawableGroup as
@@ -1177,6 +1209,16 @@ class ResourceManager {
    * @brief Importer used to load generic mesh files (AnySceneImporter)
    */
   Corrade::Containers::Pointer<Importer> fileImporter_;
+
+  /**
+   * @brief Reference to the currently loaded semanticScene Descriptor
+   */
+  std::shared_ptr<scene::SemanticScene> semanticScene_ = nullptr;
+
+  /**
+   * @brief Colormap to use for visualizing currently loaded semantic scene.
+   */
+  std::vector<Magnum::Vector3ub> semanticColorMapBeingUsed_{};
 
   // ======== Physical parameter data ========
 

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -362,8 +362,8 @@ void initAttributesBindings(py::module& m) {
           R"(Handle of the navmesh asset used for constructions built from
           this template.)")
       .def_property(
-          "house_filename", &StageAttributes::getHouseFilename,
-          &StageAttributes::setHouseFilename,
+          "house_filename", &StageAttributes::getSemanticDescriptorFilename,
+          &StageAttributes::setSemanticDescriptorFilename,
           R"(Handle for file containing semantic type maps and hierarchy for
           constructions built from this template.)")
       .def_property(

--- a/src/esp/gfx/Renderer.h
+++ b/src/esp/gfx/Renderer.h
@@ -92,8 +92,13 @@ class Renderer {
    * semantic
    */
   void visualize(sensor::VisualSensor& visualSensor,
-                 float colorMapOffset = 1.0f / 512.0f,
-                 float colorMapScale = 1.0f / 256.0f);
+                 float colorMapOffset,
+                 float colorMapScale);
+  /**
+   * @brief visualize the observation of a non-rgb visual sensor, e.g., depth,
+   * semantic, using already-specified offset and scale.
+   */
+  void visualize(sensor::VisualSensor& visualSensor);
 
 #ifdef ESP_BUILD_WITH_BACKGROUND_RENDERER
   /**
@@ -122,6 +127,15 @@ class Renderer {
    */
   void waitDrawJobs();
 #endif
+  /**
+   * @brief Sets the colormap for the @ref TextureVisualizerShader used for
+   * Semantic Scene rendering. Note, these colors are only used for
+   * visualization purposes.
+   * @param colormap The colormap to use, where idxs correspond to per-vertex
+   * semantic IDs.
+   */
+  void setSemanticVisualizerColormap(
+      Cr::Containers::ArrayView<const Mn::Vector3ub> colorMap);
 
   /**
    * @brief Acquires ownership of the scene graph from the background render

--- a/src/esp/gfx/TextureVisualizerShader.h
+++ b/src/esp/gfx/TextureVisualizerShader.h
@@ -47,11 +47,31 @@ class TextureVisualizerShader : public Magnum::GL::AbstractShaderProgram {
   explicit TextureVisualizerShader(Flags flags);
 
   /**
+   * @brief Build the colorMapTexture_ based on the passed @p colorMap of
+   * colors.
+   *
+   * @param colorMap The map of colors to use
+   * @param sampleWrapHandling Whether queries exceeding the length of @p
+   * colorMap will use the final color, or will wrap around on the texture.
+   * @param filterType Type of filter to use for when pxl size is incompatible
+   * with texture size. Options are @ref Magnum::GL::SamplerFilter::Nearest or
+   * @ref Magnum::GL::SamplerFilter::Linear.
+   * @return Reference to self (for method chaining)
+   */
+  TextureVisualizerShader& setColorMapTexture(
+      Corrade::Containers::ArrayView<const Magnum::Vector3ub> colorMap,
+      float offset,
+      float scale,
+      Magnum::GL::SamplerWrapping sampleWrapHandling,
+      Magnum::GL::SamplerFilter filterType);
+
+  /**
    * @brief
    * Offset and scale applied to each input pixel value from depth texture or
    * the ObjectId texture, resulting value is then used to fetch a color from a
-   * color map bound with bindColorMapTexture(). Here we use the Magnum built-in
-   * color map: Magnum::DebugTools::ColorMap::turbo();
+   * color map bound with bindColorMapTexture(). Here we use either the Magnum
+   * built-in color map: Magnum::DebugTools::ColorMap::turbo(), or a synthesized
+   * map based on semantic scene descriptor-specified vertex colors;
    *
    * Default Value (set in the constructor):
    * For depth texture, the initial value is 1.0f/512.0f and 1.0 / 1000.f.

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -359,7 +359,7 @@ attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
   // keyed by the ref that the scene attributes will use.
   std::pair<std::string, std::string> ssdEntry =
       datasetAttr->addSemanticSceneDescrPathEntry(
-          sceneName, stageAttributes->getHouseFilename(), false);
+          sceneName, stageAttributes->getSemanticDescriptorFilename(), false);
   // ssdEntry holds the ssd key in the dataset to use by this scene instance.
   // NOTE : the key may have changed from what was passed if a collision
   // occurred with same key but different value, so we need to add this key to

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -144,6 +144,7 @@ StageAttributes::StageAttributes(const std::string& handle)
   // set empty defaults for handles
   set("nav_asset", "");
   set("semantic_asset", "");
+  set("semantic_descriptor_filename", "");
 }  // StageAttributes ctor
 
 void StageAttributes::writeValuesToJsonInternal(
@@ -153,6 +154,7 @@ void StageAttributes::writeValuesToJsonInternal(
   writeValueToJson("gravity", jsonObj, allocator);
   writeValueToJson("semantic_asset", jsonObj, allocator);
   writeValueToJson("nav_asset", jsonObj, allocator);
+  writeValueToJson("semantic_descriptor_filename", jsonObj, allocator);
 
 }  // StageAttributes::writeValuesToJsonInternal
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -383,12 +383,14 @@ class StageAttributes : public AbstractObjectAttributes {
 
   void setGravity(const Magnum::Vector3& gravity) { set("gravity", gravity); }
   Magnum::Vector3 getGravity() const { return get<Magnum::Vector3>("gravity"); }
-  void setHouseFilename(const std::string& houseFilename) {
-    set("houseFilename", houseFilename);
+
+  void setSemanticDescriptorFilename(
+      const std::string& semantic_descriptor_filename) {
+    set("semantic_descriptor_filename", semantic_descriptor_filename);
     setIsDirty();
   }
-  std::string getHouseFilename() const {
-    return get<std::string>("houseFilename");
+  std::string getSemanticDescriptorFilename() const {
+    return get<std::string>("semantic_descriptor_filename");
   }
   void setSemanticAssetHandle(const std::string& semanticAssetHandle) {
     set("semantic_asset", semanticAssetHandle);

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -142,7 +142,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& path,
       bool overwrite = false) {
     return addNewValToMap(key, path, overwrite, semanticSceneDescrMap_,
-                          "<semanticSceneDescriptor");
+                          "<semanticSceneDescriptor>");
   }  // addNavmeshPathEntry
 
   /**

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -446,8 +446,8 @@ bool AttributesManager<T, Access>::saveManagedObjectToFileInternal(
   std::string fullFilename = Dir::join(fileDirectory, filename);
   ESP_DEBUG() << "Attempting to write file" << fullFilename << "to disk";
   // write configuration to file
-
-  rapidjson::Document doc(rapidjson::kObjectType);
+  // bypassed constructor defaults due to "0 as null" warning they throw
+  rapidjson::Document doc(rapidjson::kObjectType, nullptr, 1024, nullptr);
   rapidjson::Document::AllocatorType& allocator = doc.GetAllocator();
   // build Json from passed Configuration
   auto configJson = attribs->writeToJsonValue(allocator);

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -25,7 +25,7 @@
 #include "esp/assets/Asset.h"
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/CollisionMeshData.h"
-#include "esp/assets/GenericInstanceMeshData.h"
+#include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/assets/MeshData.h"
 #include "esp/assets/MeshMetaData.h"
 #include "esp/assets/ResourceManager.h"

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -7,7 +7,7 @@
 
 #include "esp/assets/Asset.h"
 #include "esp/assets/BaseMesh.h"
-#include "esp/assets/GenericInstanceMeshData.h"
+#include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/assets/MeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/VoxelWrapper.h"

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -15,7 +15,7 @@
 #include <Corrade/Containers/Reference.h>
 #include "esp/assets/Asset.h"
 #include "esp/assets/BaseMesh.h"
-#include "esp/assets/GenericInstanceMeshData.h"
+#include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/assets/MeshData.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/core/Esp.h"

--- a/src/esp/scene/CMakeLists.txt
+++ b/src/esp/scene/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(
   scene STATIC
   GibsonSemanticScene.cpp
   GibsonSemanticScene.h
+  HM3DSemanticScene.cpp
+  HM3DSemanticScene.h
   Mp3dSemanticScene.cpp
   Mp3dSemanticScene.h
   ObjectControls.cpp

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -80,7 +80,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   };
 
   // temp constructs
-  std::unordered_map<int, TempHM3DObject> objInstance;
+  std::map<int, TempHM3DObject> objInstance;
   std::map<int, TempHM3DRegion> regions;
   std::unordered_map<std::string, TempHM3DCategory> categories;
 

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "HM3DSemanticScene.h"
+#include "SemanticScene.h"
+
+#include <Corrade/Utility/FormatStl.h>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace Cr = Corrade;
+namespace esp {
+namespace scene {
+
+bool SemanticScene::loadHM3DHouse(
+    const std::string& houseFilename,
+    SemanticScene& scene,
+    const quatf& rotation /* = quatf::FromTwoVectors(-vec3f::UnitZ(),
+                                                       geo::ESP_GRAVITY) */ ) {
+  if (!checkFileExists(houseFilename, "loadHM3DHouse")) {
+    return false;
+  }
+  // open stream and determine house format version
+  std::ifstream ifs = std::ifstream(houseFilename);
+  std::string header;
+  std::getline(ifs, header);
+  if (header != "HM3D Semantic Annotations") {
+    ESP_ERROR() << "Unsupported HM3D House format header" << header
+                << "in file name" << houseFilename;
+    return false;
+  }
+
+  return buildHM3DHouse(ifs, scene, rotation);
+}  // SemanticScene::loadHM3DHouse
+
+namespace {
+
+// These structs are here to make constructing the actual Semantic objects
+// easier, due to the format of the HM3D ssd files.
+
+struct TempHM3DObject {
+  int objInstanceID;
+  std::string categoryName;
+  std::string objInstanceName;
+  Mn::Vector3ub color;
+  std::shared_ptr<SemanticRegion> region;
+
+  void setObjInstanceAndName(int _objInstanceID) {
+    objInstanceID = _objInstanceID;
+    objInstanceName =
+        Cr::Utility::formatString("{}_{}", categoryName, objInstanceID);
+  }
+};
+
+struct TempHM3DRegion {
+  int regionID;
+  std::vector<TempHM3DObject*> objInstances;
+};
+struct TempHM3DCategory {
+  int ID;
+  std::string name;
+  std::vector<TempHM3DObject*> objInstances;
+
+  std::shared_ptr<HM3DObjectCategory> category_;
+};
+
+}  // namespace
+
+bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
+                                   SemanticScene& scene,
+                                   const quatf& /*rotation*/) {
+  // convert a hex string containing 3 bytes to a vector3ub (represents a color)
+  auto getVec3ub = [](const std::string& hexValStr) -> Mn::Vector3ub {
+    const unsigned val = std::stoul(hexValStr, nullptr, 16);
+    return {uint8_t((val >> 16) & 0xff), uint8_t((val >> 8) & 0xff),
+            uint8_t((val >> 0) & 0xff)};
+  };
+
+  // temp constructs
+  std::unordered_map<int, TempHM3DObject> objInstance;
+  std::map<int, TempHM3DRegion> regions;
+  std::unordered_map<std::string, TempHM3DCategory> categories;
+
+  std::string line;
+  while (std::getline(ifs, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const std::vector<std::string> tokens =
+        Cr::Utility::String::splitWithoutEmptyParts(line, ',');
+    // Each line corresponds to a single instance of an annotated object.
+    // Line :
+    // Unique Instance ID (int), color (hex RGB), category name
+    // (string), room/region ID (int)
+    // instance ID is first token
+    int instanceID = std::stoi(tokens[0]);
+    // semantic color is 2nd token, as hex string
+    auto colorVec = getVec3ub(tokens[1]);
+    // object category name
+    // construct instance name by counting instances of same category
+    // get rid of quotes
+    std::string objCategoryName =
+        Cr::Utility::String::replaceAll(tokens[2], "\"", "");
+    // room/region
+    int regionID = std::stoi(tokens[3]);
+    // build initial temp object
+    TempHM3DObject obj{0, objCategoryName, "", colorVec};
+    objInstance[instanceID] = obj;
+    // find category, build if dne
+    TempHM3DCategory tmpCat{
+        static_cast<int>(categories.size()), objCategoryName, {}};
+    auto categoryIter = categories.emplace(objCategoryName, tmpCat);
+    categoryIter.first->second.objInstances.push_back(&objInstance[instanceID]);
+    // find region, build if dne
+    TempHM3DRegion tmpRegion{regionID, {}};
+    auto regionIter = regions.emplace(regionID, tmpRegion);
+    regionIter.first->second.objInstances.push_back(&objInstance[instanceID]);
+  }  // while
+
+  // construct object instance names for each object instance, by setting the
+  // instance ID as the idx in the category list
+  for (auto& item : categories) {
+    std::vector<TempHM3DObject*>& objsWithCat = item.second.objInstances;
+    int objCatIdx = 0;
+    for (TempHM3DObject* objItem : objsWithCat) {
+      objItem->setObjInstanceAndName(objCatIdx++);
+    }
+    // build category item and place within temp map
+    item.second.category_ = std::make_shared<HM3DObjectCategory>(
+        HM3DObjectCategory(item.second.ID, item.second.name));
+  }
+
+  // build all categories
+  // object categories
+  scene.categories_.clear();
+  scene.categories_.reserve(categories.size());
+  for (const auto& catItem : categories) {
+    scene.categories_.emplace_back(catItem.second.category_);
+  }
+  // build all regions
+  // regions
+  scene.regions_.clear();
+  scene.regions_.reserve(regions.size());
+  for (auto& regionItem : regions) {
+    auto regionPtr = HM3DSemanticRegion::create();
+    regionPtr->index_ = regionItem.second.regionID;
+    for (TempHM3DObject* objItem : regionItem.second.objInstances) {
+      objItem->region = regionPtr;
+    }
+    scene.regions_.emplace_back(regionPtr);
+  }
+
+  // build all object instances
+  // object instances
+  scene.objects_.clear();
+  scene.objects_.reserve(objInstance.size());
+  for (auto& item : objInstance) {
+    TempHM3DObject obj = item.second;
+    auto objPtr = std::make_shared<HM3DObjectInstance>(HM3DObjectInstance(
+        item.first, obj.objInstanceID, obj.objInstanceName, obj.color));
+    objPtr->category_ = categories[obj.categoryName].category_;
+    // set region
+    objPtr->parentIndex_ = obj.region->index_;
+    objPtr->region_ = obj.region;
+    objPtr->region_->objects_.push_back(objPtr);
+    scene.objects_.emplace_back(objPtr);
+  }
+  scene.hasVertColors_ = true;
+
+  scene.levels_.clear();  // Not used for Hm3d currently
+
+  return true;
+
+}  // SemanticScene::buildHM3DHouse
+
+}  // namespace scene
+}  // namespace esp

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -1,0 +1,68 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_SCENE_HM3DSEMANTICSCENE_H_
+#define ESP_SCENE_HM3DSEMANTICSCENE_H_
+
+#include "SemanticScene.h"
+
+namespace esp {
+namespace scene {
+class HM3DObjectCategory : public SemanticCategory {
+ public:
+  HM3DObjectCategory(const int id, const std::string& name)
+      : id_(id), name_(name) {}
+
+  int index(const std::string& /*mapping*/) const override { return id_; }
+
+  std::string name(const std::string& mapping) const override {
+    if (mapping == "category" || mapping == "") {
+      return name_;
+    } else {
+      ESP_ERROR() << "Unknown mapping type:" << mapping;
+      return "UNKNOWN";
+    }
+  }
+
+ protected:
+  int id_;
+  std::string name_;
+  ESP_SMART_POINTERS(HM3DObjectCategory)
+};
+
+class HM3DSemanticRegion : public SemanticRegion {
+ public:
+  int getIndex() const { return index_; }
+  ESP_SMART_POINTERS(HM3DSemanticRegion)
+};  // class HM3DSemanticRegion
+
+class HM3DObjectInstance : public SemanticObject {
+ public:
+  HM3DObjectInstance(int id,
+                     int objInstanceId,
+                     const std::string& name,
+                     const Mn::Vector3ub& clr)
+      : id_(id), objInstanceId_(objInstanceId), name_(name), color_(clr) {}
+  Mn::Vector3ub getColor() const { return color_; }
+
+  std::string id() const override { return name_; }
+
+  int getSemanticID() const { return id_; }
+
+ protected:
+  // semantic ID of the object instance in the file
+  const int id_;
+  // instance ID of this particular instance within the category it belongs in
+  const int objInstanceId_;
+  // unique name for this instance
+  const std::string name_;
+  // specified color for this object instance.
+  const Mn::Vector3ub color_;
+  ESP_SMART_POINTERS(HM3DObjectInstance)
+};
+
+}  // namespace scene
+}  // namespace esp
+
+#endif  // ESP_SCENE_HM3DSEMANTICSCENE_H_

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -85,7 +85,8 @@ class SemanticScene {
 
   /**
    * @brief Attempt to load SemanticScene descriptor from an unknown file type.
-   * @param filename the name of the house file to attempt to load
+   * @param filename the name of the semantic scene descriptor (house file) to
+   * attempt to load
    * @param scene reference to sceneNode to assign semantic scene to
    * @param rotation rotation to apply to semantic scene upon load.
    * @return successfully loaded
@@ -99,7 +100,8 @@ class SemanticScene {
   /**
    * @brief Attempt to load SemanticScene from a Gibson dataset house format
    * file
-   * @param filename the name of the house file to attempt to load
+   * @param filename the name of the semantic scene descriptor (house file) to
+   * attempt to load
    * @param scene reference to sceneNode to assign semantic scene to
    * @param rotation rotation to apply to semantic scene upon load.
    * @return successfully loaded
@@ -109,10 +111,28 @@ class SemanticScene {
       SemanticScene& scene,
       const quatf& rotation = quatf::FromTwoVectors(-vec3f::UnitZ(),
                                                     geo::ESP_GRAVITY));
+
+  /**
+   * @brief Attempt to load SemanticScene from a HM3D dataset house
+   * format file
+   * @param filename the name of the semantic scene descriptor (house file) to
+   * attempt to load
+   * @param scene reference to sceneNode to assign semantic scene to
+   * @param rotation rotation to apply to semantic scene upon load (currently
+   * not used for HM3D)
+   * @return successfully loaded
+   */
+  static bool loadHM3DHouse(const std::string& filename,
+                            SemanticScene& scene,
+                            CORRADE_UNUSED const quatf& rotation =
+                                quatf::FromTwoVectors(-vec3f::UnitZ(),
+                                                      geo::ESP_GRAVITY));
+
   /**
    * @brief Attempt to load SemanticScene from a Matterport3D dataset house
    * format file
-   * @param filename the name of the house file to attempt to load
+   * @param filename the name of the semantic scene descriptor (house file) to
+   * attempt to load
    * @param scene reference to sceneNode to assign semantic scene to
    * @param rotation rotation to apply to semantic scene upon load.
    * @return successfully loaded
@@ -126,7 +146,8 @@ class SemanticScene {
   /**
    * @brief Attempt to load SemanticScene from a Replica dataset house format
    * file
-   * @param filename the name of the house file to attempt to load
+   * @param filename the name of the semantic scene descriptor (house file) to
+   * attempt to load
    * @param scene reference to sceneNode to assign semantic scene to
    * @param rotation rotation to apply to semantic scene upon load.
    * @return successfully loaded
@@ -141,6 +162,11 @@ class SemanticScene {
   static bool loadSuncgHouse(const std::string& filename,
                              SemanticScene& scene,
                              const quatf& rotation = quatf::Identity());
+
+  /**
+   * @brief Whether the source file assigns colors to verts for Semantic Mesh.
+   */
+  bool hasVertColorsDefined() const { return hasVertColors_; }
 
  protected:
   /**
@@ -160,6 +186,21 @@ class SemanticScene {
     return true;
   }  // checkFileExists
 
+  /**
+   * @brief Build the HM3D semantic data from the passed file stream.  File
+   * being streamed is expected to be appropriate format.
+   * @param ifs The opened file stream describing the HM3D semantic annotations.
+   * @param scene reference to sceneNode to assign semantic scene to
+   * @param rotation rotation to apply to semantic scene upon load (currently
+   * not used for HM3D)
+   * @return successfully built. Currently only returns true, but retaining
+   * return value for future support.
+   */
+  static bool buildHM3DHouse(std::ifstream& ifs,
+                             SemanticScene& scene,
+                             CORRADE_UNUSED const quatf& rotation =
+                                 quatf::FromTwoVectors(-vec3f::UnitZ(),
+                                                       geo::ESP_GRAVITY));
   /**
    * @brief Build the mp3 semantic data from the passed file stream. File being
    * streamed is expected to be appropriate format.
@@ -208,6 +249,8 @@ class SemanticScene {
       const quatf& rotation = quatf::FromTwoVectors(-vec3f::UnitZ(),
                                                     geo::ESP_GRAVITY));
 
+  // Currently only supported by HM3D semantic files.
+  bool hasVertColors_ = false;
   std::string name_;
   std::string label_;
   box3f bbox_;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -802,8 +802,9 @@ int Simulator::addObject(const int objectLibId,
                          const std::string& lightSetupKey,
                          const int sceneID) {
   if (sceneHasPhysics(sceneID)) {
-    if (renderer_)
+    if (renderer_) {
       renderer_->acquireGlContext();
+    }
     // TODO: change implementation to support multi-world and physics worlds
     // to own reference to a sceneGraph to avoid this.
     auto& drawables = getDrawableGroup(sceneID);
@@ -818,8 +819,9 @@ int Simulator::addObjectByHandle(const std::string& objectLibHandle,
                                  const std::string& lightSetupKey,
                                  const int sceneID) {
   if (sceneHasPhysics(sceneID)) {
-    if (renderer_)
+    if (renderer_) {
       renderer_->acquireGlContext();
+    }
     // TODO: change implementation to support multi-world and physics worlds
     // to own reference to a sceneGraph to avoid this.
     auto& drawables = getDrawableGroup(sceneID);
@@ -851,8 +853,9 @@ double Simulator::stepWorld(const double dt) {
   if (physicsManager_ != nullptr) {
     physicsManager_->deferNodesUpdate();
     physicsManager_->stepPhysics(dt);
-    if (renderer_)
+    if (renderer_) {
       renderer_->waitSceneGraph();
+    }
 
     physicsManager_->updateNodes();
   }
@@ -888,8 +891,9 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
   // add STATIC collision objects
   if (includeStaticObjects) {
     // update nodes so SceneNode transforms are up-to-date
-    if (renderer_)
+    if (renderer_) {
       renderer_->waitSceneGraph();
+    }
 
     physicsManager_->updateNodes();
 
@@ -979,8 +983,9 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
 }
 
 bool Simulator::setNavMeshVisualization(bool visualize) {
-  if (renderer_)
+  if (renderer_) {
     renderer_->acquireGlContext();
+  }
   // clean-up the NavMesh visualization if necessary
   if (!visualize && navMeshVisNode_ != nullptr) {
     delete navMeshVisNode_;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1160,6 +1160,8 @@ class Simulator {
                             float colorMapOffset,
                             float colorMapScale);
 
+  bool visualizeObservation(int agentId, const std::string& sensorId);
+
   bool getAgentObservation(int agentId,
                            const std::string& sensorId,
                            sensor::Observation& observation);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -78,11 +78,13 @@ class Simulator {
 
   std::shared_ptr<gfx::Renderer> getRenderer() { return renderer_; }
   std::shared_ptr<scene::SemanticScene> getSemanticScene() {
-    return semanticScene_;
+    return resourceManager_->getSemanticScene();
   }
 
   /** @brief check if the semantic scene exists.*/
-  bool semanticSceneExists() const { return (semanticScene_ != nullptr); }
+  bool semanticSceneExists() const {
+    return resourceManager_->semanticSceneExists();
+  }
 
   /**
    * @brief get the current active scene graph
@@ -1493,7 +1495,7 @@ class Simulator {
   int activeSemanticSceneID_ = ID_UNDEFINED;
   std::vector<int> sceneID_;
 
-  std::shared_ptr<scene::SemanticScene> semanticScene_ = nullptr;
+  // std::shared_ptr<scene::SemanticScene> semanticScene_ = nullptr;
 
   std::shared_ptr<physics::PhysicsManager> physicsManager_ = nullptr;
 

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -16,12 +16,12 @@
 #include "esp/scene/SemanticScene.h"
 #include "esp/sim/Simulator.h"
 
-#include "esp/assets/GenericInstanceMeshData.h"
+#include "esp/assets/GenericSemanticMeshData.h"
 
 namespace Cr = Corrade;
 namespace Mn = Magnum;
 
-using esp::assets::GenericInstanceMeshData;
+using esp::assets::GenericSemanticMeshData;
 
 namespace {
 
@@ -74,8 +74,8 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
   // load ply but do not split
   // dummy colormap
   std::vector<Magnum::Vector3ub> dummyColormap;
-  static std::vector<std::unique_ptr<GenericInstanceMeshData>> meshVec =
-      GenericInstanceMeshData::fromPLY(
+  static std::vector<std::unique_ptr<GenericSemanticMeshData>> meshVec =
+      GenericSemanticMeshData::fromPLY(
           *importer,
           Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply"),
           false, dummyColormap);

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -72,11 +72,13 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
                               manager.loadAndInstantiate("StanfordImporter"));
 
   // load ply but do not split
+  // dummy colormap
+  std::vector<Magnum::Vector3ub> dummyColormap;
   static std::vector<std::unique_ptr<GenericInstanceMeshData>> meshVec =
       GenericInstanceMeshData::fromPLY(
           *importer,
           Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply"),
-          false);
+          false, dummyColormap);
   // verify result vector holds a mesh
   CORRADE_VERIFY(!meshVec.empty());
   // verify first entry exists

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -74,11 +74,20 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
   // load ply but do not split
   // dummy colormap
   std::vector<Magnum::Vector3ub> dummyColormap;
+  const std::string semanticFilename =
+      Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply");
+  /* Open the file. On error the importer already prints a diagnostic message,
+     so no need to do that here. The importer implicitly converts per-face
+     attributes to per-vertex, so nothing extra needs to be done. */
+  Cr::Containers::Optional<Mn::Trade::MeshData> meshData;
+  ESP_CHECK(
+      (importer->openFile(semanticFilename) && (meshData = importer->mesh(0))),
+      Cr::Utility::formatString("Error loading instance mesh data from file {}",
+                                semanticFilename));
+
   static std::vector<std::unique_ptr<GenericSemanticMeshData>> meshVec =
-      GenericSemanticMeshData::fromPLY(
-          *importer,
-          Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply"),
-          false, dummyColormap);
+      GenericSemanticMeshData::buildSemanticMeshData(meshData, semanticFilename,
+                                                     false, dummyColormap);
   // verify result vector holds a mesh
   CORRADE_VERIFY(!meshVec.empty());
   // verify first entry exists

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -86,8 +86,8 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
                                 semanticFilename));
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>> meshVec =
-      GenericSemanticMeshData::buildSemanticMeshData(meshData, semanticFilename,
-                                                     false, dummyColormap);
+      GenericSemanticMeshData::buildSemanticMeshData(
+          *meshData, semanticFilename, false, dummyColormap);
   // verify result vector holds a mesh
   CORRADE_VERIFY(!meshVec.empty());
   // verify first entry exists

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -10,7 +10,7 @@
 
 #include <Corrade/Utility/Directory.h>
 #include <sophus/so3.hpp>
-#include "esp/assets/GenericInstanceMeshData.h"
+#include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"
 
@@ -46,8 +46,8 @@ MeshData SceneLoader::load(const AssetInfo& info) {
         importer = importerManager_.loadAndInstantiate("StanfordImporter"));
     // dummy colormap
     std::vector<Magnum::Vector3ub> dummyColormap;
-    std::vector<GenericInstanceMeshData::uptr> instanceMeshData =
-        GenericInstanceMeshData::fromPLY(*importer, info.filepath, false,
+    std::vector<GenericSemanticMeshData::uptr> instanceMeshData =
+        GenericSemanticMeshData::fromPLY(*importer, info.filepath, false,
                                          dummyColormap);
 
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -44,8 +44,11 @@ MeshData SceneLoader::load(const AssetInfo& info) {
     Cr::Containers::Pointer<Importer> importer;
     CORRADE_INTERNAL_ASSERT_OUTPUT(
         importer = importerManager_.loadAndInstantiate("StanfordImporter"));
+    // dummy colormap
+    std::vector<Magnum::Vector3ub> dummyColormap;
     std::vector<GenericInstanceMeshData::uptr> instanceMeshData =
-        GenericInstanceMeshData::fromPLY(*importer, info.filepath, false);
+        GenericInstanceMeshData::fromPLY(*importer, info.filepath, false,
+                                         dummyColormap);
 
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();
     const auto& cbo = instanceMeshData[0]->getColorBufferObjectCPU();

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/FormatStl.h>
 #include <sophus/so3.hpp>
 #include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
@@ -46,9 +47,16 @@ MeshData SceneLoader::load(const AssetInfo& info) {
         importer = importerManager_.loadAndInstantiate("StanfordImporter"));
     // dummy colormap
     std::vector<Magnum::Vector3ub> dummyColormap;
+    Cr::Containers::Optional<Mn::Trade::MeshData> meshData;
+
+    ESP_CHECK(
+        (importer->openFile(info.filepath) && (meshData = importer->mesh(0))),
+        Cr::Utility::formatString(
+            "Error loading instance mesh data from file {}", info.filepath));
+
     std::vector<GenericSemanticMeshData::uptr> instanceMeshData =
-        GenericSemanticMeshData::fromPLY(*importer, info.filepath, false,
-                                         dummyColormap);
+        GenericSemanticMeshData::buildSemanticMeshData(meshData, info.filepath,
+                                                       false, dummyColormap);
 
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();
     const auto& cbo = instanceMeshData[0]->getColorBufferObjectCPU();

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -55,7 +55,7 @@ MeshData SceneLoader::load(const AssetInfo& info) {
             "Error loading instance mesh data from file {}", info.filepath));
 
     std::vector<GenericSemanticMeshData::uptr> instanceMeshData =
-        GenericSemanticMeshData::buildSemanticMeshData(meshData, info.filepath,
+        GenericSemanticMeshData::buildSemanticMeshData(*meshData, info.filepath,
                                                        false, dummyColormap);
 
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1300,9 +1300,10 @@ void Viewer::drawEvent() {
                                        1.0f / 512.0f,  // colorMapOffset
                                        1.0f / 12.0f);  // colorMapScale
     } else if (visualizeMode_ == VisualizeMode::Semantic) {
-      simulator_->visualizeObservation(defaultAgentId_, sensorId,
-                                       1.0f / 512.0f,  // colorMapOffset
-                                       1.0f / 50.0f);  // colorMapScale
+      simulator_->visualizeObservation(defaultAgentId_, sensorId);
+      // simulator_->visualizeObservation(defaultAgentId_, sensorId,
+      //                                  1.0f / 512.0f,  // colorMapOffset
+      //                                  1.0f / 50.0f);  // colorMapScale
     }
     sensorRenderTarget->blitRgbaToDefault();
   } else {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1661,20 +1661,20 @@ void Viewer::mousePressEvent(MouseEvent& event) {
           simulator_->getAgentObservation(defaultAgentId_, sensorId,
                                           observation);
 
-          uint32_t bufferIdx =
-              4 * (viewportPoint[0] +
-                   (observation.buffer->shape[1] *
-                    (observation.buffer->shape[0] - viewportPoint[1])));
-          uint32_t objIdx = 0;
+          uint32_t desiredIdx =
+              (viewportPoint[0] +
+               (observation.buffer->shape[1] *
+                (observation.buffer->shape[0] - viewportPoint[1])));
+          uint32_t objIdx = Corrade::Containers::arrayCast<int>(
+              observation.buffer->data)[desiredIdx];
+          // TODO : Change core::buffer to magnum image, then we can simplify
+          // access uint32_t objIdx =
+          // observation.buffer->pixels<uint32_t>().flipped<0>()[viewportPoint[1]][viewportPoint[0]];
 
-          // little endian
-          for (int n = sizeof(objIdx) - 1; n >= 0; --n) {
-            objIdx = (objIdx << 8) + observation.buffer->data[n + bufferIdx];
-          }
-          // subtract 1 to align
+          // subtract 1 to align with semanticObject array
           --objIdx;
           std::string tmpStr = "Unknown";
-          if (objIdx < semanticObjects.size()) {
+          if ((objIdx >= 0) && (objIdx < semanticObjects.size())) {
             tmpStr = semanticObjects[objIdx]->id();
           }
           semanticTag_ =

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -273,7 +273,7 @@ In LOOK mode (default):
     Read Semantic ID and tag of clicked object (Currently only HM3D);
   SHIFT-RIGHT:
     Click a mesh to highlight it.
-  CTRL-RIGHT:m
+  CTRL-RIGHT:
     (With 'enable-physics') Click on an object to voxelize it and display the voxelization.
   WHEEL:
     Modify orthographic camera zoom/perspective camera FOV (+SHIFT for fine grained control)


### PR DESCRIPTION
## Motivation and Context
This PR adds the following functionality for SSD support : 

- More intelligent default file name choices for stage atttributes (not only SSD but semantic mesh and navmesh as well)
- Function for setting the colormap to use for the TextureVisualizerShader, so that an external map can be used (instead of being forced to use the hard-coded Magnum turbo colormap)
- A colormap is synthesized when a file is loaded based on vertex colors, to be used for Semantic Scene visualizations.  The Magnum Turbo colormap is still supported as a fallback option.
- HM3D SSD file (house file) load and process supported based on the current annotation file format from Appen. 
- More consistent naming and access for SSD files from StageAttributes.
- Support parsing any Mn::Trade::Meshdata as a semantic scene mesh, not just ply files.

What's left is appropriate bindings and tests.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally C++ and Python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
