### PR TITLE
[BugFix]--bypass test_sensor tests if no torch is found.

### DIFF
--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -152,6 +152,8 @@ def test_sensors(
 ):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
+    if gpu2gpu:
+        torch = pytest.skip("torch")  # noqa: F841
 
     if not habitat_sim.cuda_enabled and gpu2gpu:
         pytest.skip("Skipping GPU->GPU test")
@@ -259,6 +261,8 @@ def test_smoke_no_sensors(make_cfg_settings):
 def test_smoke_redwood_noise(scene, gpu2gpu, make_cfg_settings):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
+    if gpu2gpu:
+        torch = pytest.skip("torch")  # noqa: F841
 
     if not habitat_sim.cuda_enabled and gpu2gpu:
         pytest.skip("Skipping GPU->GPU test")

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,6 +3,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import importlib.util
 import itertools
 import json
 from os import path as osp
@@ -17,6 +18,9 @@ import habitat_sim
 import habitat_sim.errors
 from examples.settings import make_cfg
 from habitat_sim.utils.common import quat_from_coeffs
+
+torch_spec = importlib.util.find_spec("torch")
+_HAS_TORCH = torch_spec is not None
 
 
 def _render_scene(sim, scene, sensor_type, gpu2gpu):
@@ -152,10 +156,7 @@ def test_sensors(
 ):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
-    if gpu2gpu:
-        torch = pytest.skip("torch")  # noqa: F841
-
-    if not habitat_sim.cuda_enabled and gpu2gpu:
+    if gpu2gpu and (not habitat_sim.cuda_enabled or not _HAS_TORCH):
         pytest.skip("Skipping GPU->GPU test")
 
     # We only support adding more RGB Sensors if one is already in a scene
@@ -261,10 +262,7 @@ def test_smoke_no_sensors(make_cfg_settings):
 def test_smoke_redwood_noise(scene, gpu2gpu, make_cfg_settings):
     if not osp.exists(scene):
         pytest.skip("Skipping {}".format(scene))
-    if gpu2gpu:
-        torch = pytest.skip("torch")  # noqa: F841
-
-    if not habitat_sim.cuda_enabled and gpu2gpu:
+    if gpu2gpu and (not habitat_sim.cuda_enabled or not _HAS_TORCH):
         pytest.skip("Skipping GPU->GPU test")
 
     make_cfg_settings["depth_sensor"] = True


### PR DESCRIPTION
## Motivation and Context
Small PR to bypass sensor tests if gpu2gpu is specified and torch is not found.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
