### PR TITLE
[Part 1 of 2]--SceneInstanceAttributes rename; Attributes testing improvements

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -220,14 +220,14 @@ bool ResourceManager::loadSemanticSceneDescriptor(
       success = scene::SemanticScene::loadSemanticSceneDescriptor(
           ssdFilename, *semanticScene_);
       if (success) {
-        ESP_DEBUG() << "SSD with SceneAttributes-provided name " << ssdFilename
-                    << "successfully found and loaded";
+        ESP_DEBUG() << "SSD with SceneInstanceAttributes-provided name "
+                    << ssdFilename << "successfully found and loaded";
       } else {
         // here if provided file exists but does not correspond to appropriate
         // SSD
-        ESP_ERROR()
-            << "SSD Load Failure! File with SceneAttributes-provided name "
-            << ssdFilename << "exists but was unable to be loaded.";
+        ESP_ERROR() << "SSD Load Failure! File with "
+                       "SceneInstanceAttributes-provided name "
+                    << ssdFilename << "exists but was unable to be loaded.";
       }
       return success;
       // if not success then try to construct a name
@@ -255,12 +255,12 @@ bool ResourceManager::loadSemanticSceneDescriptor(
       } else {
         // neither provided non-empty filename nor constructed filename
         // exists. This is probably due to an incorrect naming in the
-        // SceneAttributes
-        ESP_WARNING()
-            << "SSD File Naming Issue! Neither SceneAttributes-provided name :"
-            << ssdFilename
-            << " nor constructed filename :" << constructedFilename
-            << "exist on disk.";
+        // SceneInstanceAttributes
+        ESP_WARNING() << "SSD File Naming Issue! Neither "
+                         "SceneInstanceAttributes-provided name :"
+                      << ssdFilename
+                      << " nor constructed filename :" << constructedFilename
+                      << "exist on disk.";
         return false;
       }
     }  // if given SSD file name specified exists

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -12,7 +12,7 @@
 #include "esp/metadata/attributes/ObjectAttributes.h"
 #include "esp/metadata/attributes/PhysicsManagerAttributes.h"
 #include "esp/metadata/attributes/PrimitiveAssetAttributes.h"
-#include "esp/metadata/attributes/SceneAttributes.h"
+#include "esp/metadata/attributes/SceneInstanceAttributes.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -664,8 +664,8 @@ class Configuration {
 
   /**
    * @brief Populate a json object with all the first-level values held in this
-   * configuration.  May be overwritten to handle special cases for root-level
-   * configuration.
+   * configuration.  May be overridden to handle special cases for root-level
+   * configuration of Attributes classes derived from Configuration.
    */
   virtual void writeValuesToJson(io::JsonGenericValue& jsonObj,
                                  io::JsonAllocator& allocator) const;
@@ -680,6 +680,10 @@ class Configuration {
   /**
    * @brief Take the passed @p key and query the config value for that key,
    * writing it to @p jsonName within the passed jsonObj.
+   * @param key The key of the data in the configuration
+   * @param jsonName The tag to use in the json file
+   * @param jsonObj The json object to write to
+   * @param allocator The json allocator to use to build the json object
    */
   void writeValueToJson(const char* key,
                         const char* jsonName,

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -16,8 +16,8 @@ set(
   attributes/PhysicsManagerAttributes.cpp
   attributes/PrimitiveAssetAttributes.h
   attributes/PrimitiveAssetAttributes.cpp
-  attributes/SceneAttributes.h
-  attributes/SceneAttributes.cpp
+  attributes/SceneInstanceAttributes.h
+  attributes/SceneInstanceAttributes.cpp
   attributes/SceneDatasetAttributes.h
   attributes/SceneDatasetAttributes.cpp
   managers/AttributesManagerBase.h
@@ -30,8 +30,8 @@ set(
   managers/ObjectAttributesManager.cpp
   managers/PhysicsAttributesManager.h
   managers/PhysicsAttributesManager.cpp
-  managers/SceneAttributesManager.h
-  managers/SceneAttributesManager.cpp
+  managers/SceneInstanceAttributesManager.h
+  managers/SceneInstanceAttributesManager.cpp
   managers/SceneDatasetAttributesManager.h
   managers/SceneDatasetAttributesManager.cpp
   managers/StageAttributesManager.h

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -242,7 +242,7 @@ MetadataMediator::getSceneInstanceAttributesByName(
   // get list of scene attributes handles that contain sceneName as a substring
   auto sceneList = dsSceneAttrMgr->getObjectHandlesBySubstring(sceneName);
   // sceneName can legally match any one of the following conditions :
-  if (sceneList.size() > 0) {
+  if (!sceneList.empty()) {
     // 1.  Existing, registered SceneInstanceAttributes in current active
     // dataset.
     //    In this case the SceneInstanceAttributes is returned.
@@ -273,7 +273,7 @@ MetadataMediator::getSceneInstanceAttributesByName(
       // get list of stage attributes handles that contain sceneName as a
       // substring
       auto stageList = dsStageAttrMgr->getObjectHandlesBySubstring(sceneName);
-      if (stageList.size() > 0) {
+      if (!stageList.empty()) {
         // 3.  Existing, registered StageAttributes in current active dataset.
         //    In this case, a SceneInstanceAttributes is created amd registered
         //    using sceneName, referencing the StageAttributes of the same name;

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -220,7 +220,8 @@ bool MetadataMediator::setActiveSceneDatasetName(
   return success;
 }  // MetadataMediator::setActiveSceneDatasetName
 
-attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
+attributes::SceneInstanceAttributes::ptr
+MetadataMediator::getSceneInstanceAttributesByName(
     const std::string& sceneName) {
   // get current dataset attributes
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
@@ -232,38 +233,41 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   // directory to look for attributes for this dataset
   const std::string dsDir = datasetAttr->getFileDirectory();
   // get appropriate attr managers for the current dataset
-  managers::SceneAttributesManager::ptr dsSceneAttrMgr =
-      datasetAttr->getSceneAttributesManager();
+  managers::SceneInstanceAttributesManager::ptr dsSceneAttrMgr =
+      datasetAttr->getSceneInstanceAttributesManager();
   managers::StageAttributesManager::ptr dsStageAttrMgr =
       datasetAttr->getStageAttributesManager();
 
-  attributes::SceneAttributes::ptr sceneAttributes = nullptr;
+  attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes = nullptr;
   // get list of scene attributes handles that contain sceneName as a substring
   auto sceneList = dsSceneAttrMgr->getObjectHandlesBySubstring(sceneName);
   // sceneName can legally match any one of the following conditions :
   if (sceneList.size() > 0) {
-    // 1.  Existing, registered SceneAttributes in current active dataset.
-    //    In this case the SceneAttributes is returned.
+    // 1.  Existing, registered SceneInstanceAttributes in current active
+    // dataset.
+    //    In this case the SceneInstanceAttributes is returned.
     ESP_DEBUG() << "Query dataset :" << activeSceneDataset_
-                << "for SceneAttributes named :" << sceneName << "yields"
-                << sceneList.size() << "candidates.  Using" << sceneList[0]
-                << Mn::Debug::nospace << ".";
-    sceneAttributes = dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
+                << "for SceneInstanceAttributes named :" << sceneName
+                << "yields" << sceneList.size() << "candidates.  Using"
+                << sceneList[0] << Mn::Debug::nospace << ".";
+    sceneInstanceAttributes =
+        dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
   } else {
     const std::string sceneFilenameCandidate =
         dsSceneAttrMgr->getFormattedJSONFileName(sceneName);
 
     if (Cr::Utility::Directory::exists(sceneFilenameCandidate)) {
-      // 2.  Existing, valid SceneAttributes file on disk, but not in dataset.
-      //    If this is the case, then the SceneAttributes should be loaded,
-      //    registered, added to the dataset and returned.
+      // 2.  Existing, valid SceneInstanceAttributes file on disk, but not in
+      // dataset.
+      //    If this is the case, then the SceneInstanceAttributes should be
+      //    loaded, registered, added to the dataset and returned.
       ESP_DEBUG() << "Dataset :" << activeSceneDataset_
-                  << "does not reference a SceneAttributes named" << sceneName
-                  << "but a SceneAttributes config named"
+                  << "does not reference a SceneInstanceAttributes named"
+                  << sceneName << "but a SceneInstanceAttributes config named"
                   << sceneFilenameCandidate
                   << "was found on disk, so "
                      "loading.";
-      sceneAttributes = dsSceneAttrMgr->createObjectFromJSONFile(
+      sceneInstanceAttributes = dsSceneAttrMgr->createObjectFromJSONFile(
           sceneFilenameCandidate, true);
     } else {
       // get list of stage attributes handles that contain sceneName as a
@@ -271,18 +275,19 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
       auto stageList = dsStageAttrMgr->getObjectHandlesBySubstring(sceneName);
       if (stageList.size() > 0) {
         // 3.  Existing, registered StageAttributes in current active dataset.
-        //    In this case, a SceneAttributes is created amd registered using
-        //    sceneName, referencing the StageAttributes of the same name; This
-        //    sceneAttributes is returned.
-        ESP_DEBUG() << "No existing scene instance attributes containing name"
-                    << sceneName << "found in Dataset :" << activeSceneDataset_
-                    << "but" << stageList.size()
-                    << "StageAttributes found.  Using" << stageList[0]
-                    << "as stage and to construct a SceneAttributes with same "
-                       "name that will be added to Dataset.";
-        // create a new SceneAttributes, and give it a
+        //    In this case, a SceneInstanceAttributes is created amd registered
+        //    using sceneName, referencing the StageAttributes of the same name;
+        //    This sceneInstanceAttributes is returned.
+        ESP_DEBUG()
+            << "No existing scene instance attributes containing name"
+            << sceneName << "found in Dataset :" << activeSceneDataset_ << "but"
+            << stageList.size() << "StageAttributes found.  Using"
+            << stageList[0]
+            << "as stage and to construct a SceneInstanceAttributes with same "
+               "name that will be added to Dataset.";
+        // create a new SceneInstanceAttributes, and give it a
         // SceneObjectInstanceAttributes for the stage with the same name.
-        sceneAttributes = makeSceneAndReferenceStage(
+        sceneInstanceAttributes = makeSceneAndReferenceStage(
             datasetAttr, dsStageAttrMgr->getObjectByHandle(stageList[0]),
             dsSceneAttrMgr, sceneName);
 
@@ -290,18 +295,19 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
         // 4.  Existing stage config/asset on disk, but not in current dataset.
         //    In this case, a stage attributes is loaded and registered, then
         //    added to current dataset, and then 3. is performed.
-        ESP_DEBUG()
-            << "Dataset :" << activeSceneDataset_
-            << "has no preloaded SceneAttributes or StageAttributes named :"
-            << sceneName
-            << "so loading/creating a new StageAttributes with this "
-               "name, and then creating a SceneAttributes with the same name "
-               "that references this stage.";
+        ESP_DEBUG() << "Dataset :" << activeSceneDataset_
+                    << "has no preloaded SceneInstanceAttributes or "
+                       "StageAttributes named :"
+                    << sceneName
+                    << "so loading/creating a new StageAttributes with this "
+                       "name, and then creating a SceneInstanceAttributes with "
+                       "the same name "
+                       "that references this stage.";
         // create and register stage
         auto stageAttributes = dsStageAttrMgr->createObject(sceneName, true);
-        // create a new SceneAttributes, and give it a
+        // create a new SceneInstanceAttributes, and give it a
         // SceneObjectInstanceAttributes for the stage with the same name.
-        sceneAttributes = makeSceneAndReferenceStage(
+        sceneInstanceAttributes = makeSceneAndReferenceStage(
             datasetAttr, stageAttributes, dsSceneAttrMgr, sceneName);
       }
     }
@@ -309,16 +315,17 @@ attributes::SceneAttributes::ptr MetadataMediator::getSceneAttributesByName(
   // make sure that all stage, object and lighting attributes referenced in
   // scene attributes are loaded in dataset, as well as the scene attributes
   // itself.
-  datasetAttr->addNewSceneInstanceToDataset(sceneAttributes);
+  datasetAttr->addNewSceneInstanceToDataset(sceneInstanceAttributes);
 
-  return sceneAttributes;
+  return sceneInstanceAttributes;
 
-}  // MetadataMediator::getSceneAttributesByName
+}  // MetadataMediator::getSceneInstanceAttributesByName
 
-attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
+attributes::SceneInstanceAttributes::ptr
+MetadataMediator::makeSceneAndReferenceStage(
     const attributes::SceneDatasetAttributes::ptr& datasetAttr,
     const attributes::StageAttributes::ptr& stageAttributes,
-    const managers::SceneAttributesManager::ptr& dsSceneAttrMgr,
+    const managers::SceneInstanceAttributesManager::ptr& dsSceneAttrMgr,
     const std::string& sceneName) {
   ESP_CHECK(datasetAttr != nullptr && stageAttributes != nullptr &&
                 dsSceneAttrMgr != nullptr,
@@ -327,10 +334,10 @@ attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
                 << Mn::Debug::nospace << sceneName << Mn::Debug::nospace
                 << "'.  Likely an invalid scene name.");
   // create scene attributes with passed name
-  attributes::SceneAttributes::ptr sceneAttributes =
+  attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes =
       dsSceneAttrMgr->createDefaultObject(sceneName, false);
   // create stage instance attributes and set its name (from stage attributes)
-  sceneAttributes->setStageInstance(
+  sceneInstanceAttributes->setStageInstance(
       dsSceneAttrMgr->createEmptyInstanceAttributes(
           stageAttributes->getHandle()));
 
@@ -351,7 +358,7 @@ attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
   // scene instance.  NOTE : the key may have changed from what was passed if a
   // collision occurred with same key but different value, so we need to add
   // this key to the scene instance attributes.
-  sceneAttributes->setNavmeshHandle(navmeshEntry.first);
+  sceneInstanceAttributes->setNavmeshHandle(navmeshEntry.first);
 
   // add a ref to semantic scene descriptor ("house file") from stage attributes
   // to scene attributes, giving it an appropriately obvious name.  This entails
@@ -364,11 +371,11 @@ attributes::SceneAttributes::ptr MetadataMediator::makeSceneAndReferenceStage(
   // NOTE : the key may have changed from what was passed if a collision
   // occurred with same key but different value, so we need to add this key to
   // the scene instance attributes.
-  sceneAttributes->setSemanticSceneHandle(ssdEntry.first);
+  sceneInstanceAttributes->setSemanticSceneHandle(ssdEntry.first);
 
-  // register SceneAttributes object
-  dsSceneAttrMgr->registerObject(sceneAttributes);
-  return sceneAttributes;
+  // register SceneInstanceAttributes object
+  dsSceneAttrMgr->registerObject(sceneInstanceAttributes);
+  return sceneInstanceAttributes;
 }  // MetadataMediator::makeSceneAndReferenceStage
 
 bool MetadataMediator::getCreateRenderer() const {

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -150,12 +150,14 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to scene instance
    * attributes for current dataset.
-   * @return The current dataset's @ref managers::SceneAttributesManager::ptr,
-   * or nullptr if no current dataset.
+   * @return The current dataset's @ref
+   * managers::SceneInstanceAttributesManager::ptr, or nullptr if no current
+   * dataset.
    */
-  const managers::SceneAttributesManager::ptr& getSceneAttributesManager() {
-    return getActiveDSAttribs()->getSceneAttributesManager();
-  }  // MetadataMediator::getSceneAttributesManager
+  const managers::SceneInstanceAttributesManager::ptr&
+  getSceneInstanceAttributesManager() {
+    return getActiveDSAttribs()->getSceneInstanceAttributesManager();
+  }  // MetadataMediator::getSceneInstanceAttributesManager
 
   /**
    * @brief Return manager for construction and access to stage attributes for
@@ -182,7 +184,7 @@ class MetadataMediator {
    */
   std::vector<std::string> getAllSceneInstanceHandles() {
     return getActiveDSAttribs()
-        ->getSceneAttributesManager()
+        ->getSceneInstanceAttributesManager()
         ->getObjectHandlesBySubstring();
   }
 
@@ -243,7 +245,7 @@ class MetadataMediator {
    * @return A valid SceneInstanceAttributes - registered in current dataset,
    * with all references also registered in current dataset.
    */
-  attributes::SceneAttributes::ptr getSceneAttributesByName(
+  attributes::SceneInstanceAttributes::ptr getSceneInstanceAttributesByName(
       const std::string& sceneName);
 
   /**
@@ -427,27 +429,28 @@ class MetadataMediator {
   }  // getFilePathForHandle
 
   /**
-   * @brief This will create a new, empty @ref SceneAttributes with the passed
-   * name, and create a SceneObjectInstance for the stage also using the passed
-   * name. It is assuming that the dataset has the stage registered, and that
-   * the calling function will register the created SceneInstance with the
+   * @brief This will create a new, empty @ref SceneInstanceAttributes with the
+   * passed name, and create a SceneObjectInstance for the stage also using the
+   * passed name. It is assuming that the dataset has the stage registered, and
+   * that the calling function will register the created SceneInstance with the
    * dataset.  This method will also register navmesh and scene descriptor file
-   * paths that are synthesized for newly made SceneAttributes. TODO: get rid of
-   * these fields in stageAttributes.
+   * paths that are synthesized for newly made SceneInstanceAttributes. TODO:
+   * get rid of these fields in stageAttributes.
    *
    * @param datasetAttr The current dataset attributes
    * @param stageAttributes Readonly version of stage to use to synthesize scene
    * instance.
-   * @param dsSceneAttrMgr The current dataset's SceneAttributesManager
+   * @param dsSceneAttrMgr The current dataset's SceneInstanceAttributesManager
    * @param sceneName The name for the scene and also the stage within the
    * scene.
-   * @return The created SceneAttributes, with the stage's SceneInstanceObject
-   * to be intialized to reference the stage also named with @p sceneName .
+   * @return The created SceneInstanceAttributes, with the stage's
+   * SceneInstanceObject to be intialized to reference the stage also named with
+   * @p sceneName .
    */
-  attributes::SceneAttributes::ptr makeSceneAndReferenceStage(
+  attributes::SceneInstanceAttributes::ptr makeSceneAndReferenceStage(
       const attributes::SceneDatasetAttributes::ptr& datasetAttr,
       const attributes::StageAttributes::ptr& stageAttributes,
-      const managers::SceneAttributesManager::ptr& dsSceneAttrMgr,
+      const managers::SceneInstanceAttributesManager::ptr& dsSceneAttrMgr,
       const std::string& sceneName);
 
   /**

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -138,9 +138,9 @@ StageAttributes::StageAttributes(const std::string& handle)
   // TODO remove this once ShaderType support is complete
   setForceFlatShading(true);
   // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh
-  setCollisionAssetType(0);
+  setCollisionAssetType(static_cast<int>(esp::assets::AssetType::UNKNOWN));
   // 4 corresponds to esp::assets::AssetType::INSTANCE_MESH
-  setSemanticAssetType(4);
+  setSemanticAssetType(static_cast<int>(esp::assets::AssetType::INSTANCE_MESH));
   // set empty defaults for handles
   set("nav_asset", "");
   set("semantic_asset", "");

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -242,8 +242,9 @@ class AbstractObjectAttributes : public AbstractAttributes {
 
   /**
    * @brief Populate a json object with all the first-level values held in this
-   * configuration.  May be overwritten to handle special cases for root-level
-   * configuration.
+   * configuration.  Default is overridden to handle special cases for
+   * AbstractObjectAttributes and deriving (ObjectAttributes and
+   * StageAttributes) classes.
    */
   void writeValuesToJson(io::JsonGenericValue& jsonObj,
                          io::JsonAllocator& allocator) const override;
@@ -384,11 +385,21 @@ class StageAttributes : public AbstractObjectAttributes {
   void setGravity(const Magnum::Vector3& gravity) { set("gravity", gravity); }
   Magnum::Vector3 getGravity() const { return get<Magnum::Vector3>("gravity"); }
 
+  /**
+   * @brief Text file that describes the hierharchy of semantic information
+   * embedded in the Semantic Asset mesh.  May be overridden by value specified
+   * in Scene Instance Attributes.
+   */
   void setSemanticDescriptorFilename(
       const std::string& semantic_descriptor_filename) {
     set("semantic_descriptor_filename", semantic_descriptor_filename);
     setIsDirty();
   }
+  /**
+   * @brief Text file that describes the hierharchy of semantic information
+   * embedded in the Semantic Asset mesh.  May be overridden by value specified
+   * in Scene Instance Attributes.
+   */
   std::string getSemanticDescriptorFilename() const {
     return get<std::string>("semantic_descriptor_filename");
   }
@@ -404,9 +415,12 @@ class StageAttributes : public AbstractObjectAttributes {
   }
   int getSemanticAssetType() { return get<int>("semantic_asset_type"); }
 
+  // Currently not supported
   void setLoadSemanticMesh(bool loadSemanticMesh) {
     set("loadSemanticMesh", loadSemanticMesh);
   }
+
+  // Currently not supported
   bool getLoadSemanticMesh() { return get<bool>("loadSemanticMesh"); }
 
   void setNavmeshAssetHandle(const std::string& nav_asset) {
@@ -434,6 +448,7 @@ class StageAttributes : public AbstractObjectAttributes {
    * @brief set frustum culling for stage.  Default value comes from
    * @ref esp::sim::SimulatorConfiguration, is overridden by any value set in
    * json, if exists.
+   * Currently only set from SimulatorConfiguration
    */
   void setFrustumCulling(bool frustumCulling) {
     set("frustum_culling", frustumCulling);

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -18,13 +18,14 @@ SceneDatasetAttributes::SceneDatasetAttributes(
       managers::LightLayoutAttributesManager::create();
   objectAttributesManager_ = managers::ObjectAttributesManager::create();
   objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
-  sceneAttributesManager_ = managers::SceneAttributesManager::create();
+  sceneInstanceAttributesManager_ =
+      managers::SceneInstanceAttributesManager::create();
   stageAttributesManager_ = managers::StageAttributesManager::create(
       objectAttributesManager_, physAttrMgr);
 }  // ctor
 
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
-    const attributes::SceneAttributes::ptr& sceneInstance) {
+    const attributes::SceneInstanceAttributes::ptr& sceneInstance) {
   // info display message prefix
   std::string infoPrefix = Cr::Utility::formatString(
       "Dataset : '{}' : ", this->getSimplifiedHandle());
@@ -93,14 +94,14 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
                 << "specified in Scene Attributes exists in dataset library.";
   }
 
-  const std::string fullSceneInstanceName =
-      getFullAttrNameFromStr(sceneInstanceName, sceneAttributesManager_);
+  const std::string fullSceneInstanceName = getFullAttrNameFromStr(
+      sceneInstanceName, sceneInstanceAttributesManager_);
 
   // add scene attributes to scene attributes manager
   if (fullSceneInstanceName == "") {
     ESP_DEBUG() << infoPrefix << "Scene Attributes" << sceneInstanceName
                 << "does not exist in dataset so adding.";
-    sceneAttributesManager_->registerObject(sceneInstance);
+    sceneInstanceAttributesManager_->registerObject(sceneInstance);
   }
   return true;
 }  // SceneDatasetAttributes::addSceneInstanceToDataset
@@ -219,8 +220,9 @@ std::string concatStrings(const std::string& header,
 std::string SceneDatasetAttributes::getObjectInfoInternal() const {
   // provide a summary for all info for this scene dataset
   // scene instances
-  std::string res = concatStrings(
-      "Scene Instances", sceneAttributesManager_->getObjectInfoStrings());
+  std::string res =
+      concatStrings("Scene Instances",
+                    sceneInstanceAttributesManager_->getObjectInfoStrings());
 
   // stages
   Cr::Utility::formatInto(
@@ -271,7 +273,7 @@ std::string SceneDatasetAttributes::getDatasetSummaryHeader() {
 std::string SceneDatasetAttributes::getDatasetSummary() const {
   return Cr::Utility::formatString(
       "{},{},{},{},{},{},{},{},{},", getSimplifiedHandle(),
-      sceneAttributesManager_->getNumObjects(),
+      sceneInstanceAttributesManager_->getNumObjects(),
       stageAttributesManager_->getNumObjects(),
       objectAttributesManager_->getNumObjects(), articulatedObjPaths.size(),
       lightLayoutAttributesManager_->getNumObjects(),

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -358,7 +358,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& attrName,
       const ManagedContainerBase::ptr& attrMgr) {
     auto handleList = attrMgr->getObjectHandlesBySubstring(attrName);
-    if (handleList.size() > 0) {
+    if (!handleList.empty()) {
       return handleList[0];
     }
     return "";

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -15,7 +15,7 @@
 #include "esp/metadata/managers/AssetAttributesManager.h"
 #include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
-#include "esp/metadata/managers/SceneAttributesManager.h"
+#include "esp/metadata/managers/SceneInstanceAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"
 
 namespace esp {
@@ -36,7 +36,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
     assetAttributesManager_ = nullptr;
     lightLayoutAttributesManager_ = nullptr;
     objectAttributesManager_ = nullptr;
-    sceneAttributesManager_ = nullptr;
+    sceneInstanceAttributesManager_ = nullptr;
     stageAttributesManager_ = nullptr;
     navmeshMap_.clear();
     semanticSceneDescrMap_.clear();
@@ -69,9 +69,9 @@ class SceneDatasetAttributes : public AbstractAttributes {
   /**
    * @brief Return manager for construction and access to scene attributes.
    */
-  const managers::SceneAttributesManager::ptr& getSceneAttributesManager()
-      const {
-    return sceneAttributesManager_;
+  const managers::SceneInstanceAttributesManager::ptr&
+  getSceneInstanceAttributesManager() const {
+    return sceneInstanceAttributesManager_;
   }
 
   /**
@@ -182,7 +182,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * @return whether this sceneInstance was successfully added to the dataset.
    */
   bool addNewSceneInstanceToDataset(
-      const attributes::SceneAttributes::ptr& sceneInstance);
+      const attributes::SceneInstanceAttributes::ptr& sceneInstance);
 
   /**
    * @brief Returns stage attributes corresponding to passed handle as
@@ -417,7 +417,8 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * @brief Manages all construction and access to scene instance attributes
    * from this dataset.
    */
-  managers::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
+  managers::SceneInstanceAttributesManager::ptr
+      sceneInstanceAttributesManager_ = nullptr;
 
   /**
    * @brief Manages all construction and access to stage attributes from this

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "SceneAttributes.h"
+#include "SceneInstanceAttributes.h"
 #include "esp/physics/RigidBase.h"
 namespace esp {
 namespace metadata {
@@ -122,8 +122,8 @@ std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
   return initPoseStr;
 }  // SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal()
 
-SceneAttributes::SceneAttributes(const std::string& handle)
-    : AbstractAttributes("SceneAttributes", handle) {
+SceneInstanceAttributes::SceneInstanceAttributes(const std::string& handle)
+    : AbstractAttributes("SceneInstanceAttributes", handle) {
   // defaults to no lights
   setLightingHandle(NO_LIGHT_KEY);
   // defaults to asset local
@@ -136,7 +136,8 @@ SceneAttributes::SceneAttributes(const std::string& handle)
   artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
 }
 
-SceneAttributes::SceneAttributes(const SceneAttributes& otr)
+SceneInstanceAttributes::SceneInstanceAttributes(
+    const SceneInstanceAttributes& otr)
     : AbstractAttributes(otr),
       availableObjInstIDs_(otr.availableObjInstIDs_),
       availableArtObjInstIDs_(otr.availableArtObjInstIDs_) {
@@ -148,7 +149,8 @@ SceneAttributes::SceneAttributes(const SceneAttributes& otr)
   copySubconfigIntoMe<SceneAOInstanceAttributes>(otr.artObjInstConfig_,
                                                  artObjInstConfig_);
 }
-SceneAttributes::SceneAttributes(SceneAttributes&& otr) noexcept
+SceneInstanceAttributes::SceneInstanceAttributes(
+    SceneInstanceAttributes&& otr) noexcept
     : AbstractAttributes(std::move(static_cast<AbstractAttributes>(otr))),
       availableObjInstIDs_(std::move(otr.availableObjInstIDs_)),
       availableArtObjInstIDs_(std::move(otr.availableArtObjInstIDs_)) {
@@ -158,7 +160,8 @@ SceneAttributes::SceneAttributes(SceneAttributes&& otr) noexcept
   artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
 }
 
-SceneAttributes& SceneAttributes::operator=(const SceneAttributes& otr) {
+SceneInstanceAttributes& SceneInstanceAttributes::operator=(
+    const SceneInstanceAttributes& otr) {
   if (this != &otr) {
     this->AbstractAttributes::operator=(otr);
     availableObjInstIDs_ = otr.availableObjInstIDs_;
@@ -173,7 +176,8 @@ SceneAttributes& SceneAttributes::operator=(const SceneAttributes& otr) {
   }
   return *this;
 }
-SceneAttributes& SceneAttributes::operator=(SceneAttributes&& otr) noexcept {
+SceneInstanceAttributes& SceneInstanceAttributes::operator=(
+    SceneInstanceAttributes&& otr) noexcept {
   availableObjInstIDs_ = std::move(otr.availableObjInstIDs_);
   availableArtObjInstIDs_ = std::move(otr.availableArtObjInstIDs_);
   this->AbstractAttributes::operator=(
@@ -183,7 +187,7 @@ SceneAttributes& SceneAttributes::operator=(SceneAttributes&& otr) noexcept {
   artObjInstConfig_ = editSubconfig<Configuration>("ao_instances");
   return *this;
 }
-std::string SceneAttributes::getObjectInfoInternal() const {
+std::string SceneInstanceAttributes::getObjectInfoInternal() const {
   // scene-specific info constants
   // default translation origin
 
@@ -228,7 +232,7 @@ std::string SceneAttributes::getObjectInfoInternal() const {
                           "End of data for Scene Instance {}\n",
                           getSimplifiedHandle());
   return res;
-}  // SceneAttributes::getObjectInfoInternal
+}  // SceneInstanceAttributes::getObjectInfoInternal
 
 }  // namespace attributes
 }  // namespace metadata

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_METADATA_ATTRIBUTES_SCENEATTRIBUTES_H_
-#define ESP_METADATA_ATTRIBUTES_SCENEATTRIBUTES_H_
+#ifndef ESP_METADATA_ATTRIBUTES_SCENEINSTANCEATTRIBUTES_H_
+#define ESP_METADATA_ATTRIBUTES_SCENEINSTANCEATTRIBUTES_H_
 
 #include <deque>
 #include <utility>
@@ -312,15 +312,15 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
 
 };  // class SceneAOInstanceAttributes
 
-class SceneAttributes : public AbstractAttributes {
+class SceneInstanceAttributes : public AbstractAttributes {
  public:
-  explicit SceneAttributes(const std::string& handle);
+  explicit SceneInstanceAttributes(const std::string& handle);
 
-  SceneAttributes(const SceneAttributes& otr);
-  SceneAttributes(SceneAttributes&& otr) noexcept;
+  SceneInstanceAttributes(const SceneInstanceAttributes& otr);
+  SceneInstanceAttributes(SceneInstanceAttributes&& otr) noexcept;
 
-  SceneAttributes& operator=(const SceneAttributes& otr);
-  SceneAttributes& operator=(SceneAttributes&& otr) noexcept;
+  SceneInstanceAttributes& operator=(const SceneInstanceAttributes& otr);
+  SceneInstanceAttributes& operator=(SceneInstanceAttributes&& otr) noexcept;
 
   /**
    * @brief Set a value representing the mechanism used to create this scene
@@ -487,7 +487,7 @@ class SceneAttributes : public AbstractAttributes {
 
   /**
    * @brief Smartpointer to created object instance configuration. The
-   * configuration is created on SceneAttributes construction.
+   * configuration is created on SceneInstanceAttributes construction.
    */
   std::shared_ptr<Configuration> objInstConfig_{};
   /**
@@ -498,7 +498,7 @@ class SceneAttributes : public AbstractAttributes {
 
   /**
    * @brief Smartpointer to created articulated object instance configuration.
-   * The configuratio is created on SceneAttributes construction.
+   * The configuratio is created on SceneInstanceAttributes construction.
    */
   std::shared_ptr<Configuration> artObjInstConfig_{};
 
@@ -510,11 +510,11 @@ class SceneAttributes : public AbstractAttributes {
   std::deque<int> availableArtObjInstIDs_;
 
  public:
-  ESP_SMART_POINTERS(SceneAttributes)
-};  // class SceneAttributes
+  ESP_SMART_POINTERS(SceneInstanceAttributes)
+};  // class SceneInstanceAttributes
 
 }  // namespace attributes
 }  // namespace metadata
 }  // namespace esp
 
-#endif  // ESP_METADATA_ATTRIBUTES_SCENEATTRIBUTES_H_
+#endif  // ESP_METADATA_ATTRIBUTES_SCENEINSTANCEATTRIBUTES_H_

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -181,7 +181,7 @@ void ObjectAttributesManager::setDefaultAssetNameBasedAttributes(
     attributes->setOrientUp({0, 1, 0});
     attributes->setOrientFront({0, 0, -1});
   }
-}  // SceneAttributesManager::setDefaultAssetNameBasedAttributes
+}  // SceneInstanceAttributesManager::setDefaultAssetNameBasedAttributes
 
 int ObjectAttributesManager::registerObjectFinalize(
     ObjectAttributes::ptr objectTemplate,

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -231,7 +231,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
 
   // process scene instances - implement handling scene instances
   readDatasetJSONCell(dsDir, "scene_instances", jsonConfig,
-                      dsAttribs->getSceneAttributesManager());
+                      dsAttribs->getSceneInstanceAttributesManager());
 
   // process navmesh instances
   loadAndValidateMap(dsDir, "navmesh_instances", jsonConfig,

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "SceneAttributesManager.h"
+#include "SceneInstanceAttributesManager.h"
 
 #include <Corrade/Utility/FormatStl.h>
 #include "esp/metadata/MetadataUtils.h"
@@ -14,16 +14,16 @@ namespace esp {
 namespace metadata {
 
 using attributes::SceneAOInstanceAttributes;
-using attributes::SceneAttributes;
+using attributes::SceneInstanceAttributes;
 using attributes::SceneObjectInstanceAttributes;
 
 namespace managers {
 
-SceneAttributes::ptr SceneAttributesManager::createObject(
+SceneInstanceAttributes::ptr SceneInstanceAttributesManager::createObject(
     const std::string& sceneInstanceHandle,
     bool registerTemplate) {
   std::string msg;
-  SceneAttributes::ptr attrs = this->createFromJsonOrDefaultInternal(
+  SceneInstanceAttributes::ptr attrs = this->createFromJsonOrDefaultInternal(
       sceneInstanceHandle, msg, registerTemplate);
 
   if (nullptr != attrs) {
@@ -31,25 +31,26 @@ SceneAttributes::ptr SceneAttributesManager::createObject(
                 << (registerTemplate ? "and registered." : ".");
   }
   return attrs;
-}  // SceneAttributesManager::createObject
+}  // SceneInstanceAttributesManager::createObject
 
-SceneAttributes::ptr SceneAttributesManager::initNewObjectInternal(
+SceneInstanceAttributes::ptr
+SceneInstanceAttributesManager::initNewObjectInternal(
     const std::string& sceneInstanceHandle,
     bool) {
-  SceneAttributes::ptr newAttributes =
+  SceneInstanceAttributes::ptr newAttributes =
       this->constructFromDefault(sceneInstanceHandle);
   if (nullptr == newAttributes) {
-    newAttributes = SceneAttributes::create(sceneInstanceHandle);
+    newAttributes = SceneInstanceAttributes::create(sceneInstanceHandle);
   }
   // attempt to set source directory if exists
   this->setFileDirectoryFromHandle(newAttributes);
 
   // any internal default configuration here
   return newAttributes;
-}  // SceneAttributesManager::initNewObjectInternal
+}  // SceneInstanceAttributesManager::initNewObjectInternal
 
-void SceneAttributesManager::setValsFromJSONDoc(
-    SceneAttributes::ptr attribs,
+void SceneInstanceAttributesManager::setValsFromJSONDoc(
+    SceneInstanceAttributes::ptr attribs,
     const io::JsonGenericValue& jsonConfig) {
   const std::string attribsDispName = attribs->getSimplifiedHandle();
   // Check for translation origin.  Default to unknown.
@@ -137,20 +138,20 @@ void SceneAttributesManager::setValsFromJSONDoc(
   // check for user defined attributes
   this->parseUserDefinedJsonVals(attribs, jsonConfig);
 
-}  // SceneAttributesManager::setValsFromJSONDoc
+}  // SceneInstanceAttributesManager::setValsFromJSONDoc
 
 SceneObjectInstanceAttributes::ptr
-SceneAttributesManager::createInstanceAttributesFromJSON(
+SceneInstanceAttributesManager::createInstanceAttributesFromJSON(
     const io::JsonGenericValue& jCell) {
   SceneObjectInstanceAttributes::ptr instanceAttrs =
       createEmptyInstanceAttributes("");
   // populate attributes
   this->loadAbstractObjectAttributesFromJson(instanceAttrs, jCell);
   return instanceAttrs;
-}  // SceneAttributesManager::createInstanceAttributesFromJSON
+}  // SceneInstanceAttributesManager::createInstanceAttributesFromJSON
 
 SceneAOInstanceAttributes::ptr
-SceneAttributesManager::createAOInstanceAttributesFromJSON(
+SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
     const io::JsonGenericValue& jCell) {
   SceneAOInstanceAttributes::ptr instanceAttrs =
       createEmptyAOInstanceAttributes("");
@@ -191,7 +192,7 @@ SceneAttributesManager::createAOInstanceAttributesFromJSON(
           jCell, "initial_joint_pose", instanceAttrs->copyIntoInitJointPose());
     } else {
       ESP_WARNING()
-          << "SceneAttributesManager::"
+          << "SceneInstanceAttributesManager::"
              "createAOInstanceAttributesFromJSON : Unknown format for "
              "initial_joint_pose specified for instance"
           << instanceAttrs->getHandle()
@@ -218,7 +219,7 @@ SceneAttributesManager::createAOInstanceAttributesFromJSON(
           instanceAttrs->copyIntoInitJointVelocities());
     } else {
       ESP_WARNING()
-          << "SceneAttributesManager::"
+          << "SceneInstanceAttributesManager::"
              "createAOInstanceAttributesFromJSON : Unknown format for "
              "initial_joint_velocities specified for instance"
           << instanceAttrs->getHandle()
@@ -227,9 +228,9 @@ SceneAttributesManager::createAOInstanceAttributesFromJSON(
   }
   return instanceAttrs;
 
-}  // SceneAttributesManager::createAOInstanceAttributesFromJSON
+}  // SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON
 
-void SceneAttributesManager::loadAbstractObjectAttributesFromJson(
+void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
     const attributes::SceneObjectInstanceAttributes::ptr& instanceAttrs,
     const io::JsonGenericValue& jCell) const {
   // template handle describing stage/object instance
@@ -293,9 +294,9 @@ void SceneAttributesManager::loadAbstractObjectAttributesFromJson(
   // check for user defined attributes
   this->parseUserDefinedJsonVals(instanceAttrs, jCell);
 
-}  // SceneAttributesManager::loadAbstractObjectAttributesFromJson
+}  // SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson
 
-std::string SceneAttributesManager::getTranslationOriginVal(
+std::string SceneInstanceAttributesManager::getTranslationOriginVal(
     const io::JsonGenericValue& jsonDoc) const {
   // Check for translation origin.  Default to unknown.
   std::string transOrigin = getTranslationOriginName(
@@ -321,19 +322,19 @@ std::string SceneAttributesManager::getTranslationOriginVal(
     }
   }
   return transOrigin;
-}  // SceneAttributesManager::getTranslationOriginVal
+}  // SceneInstanceAttributesManager::getTranslationOriginVal
 
-int SceneAttributesManager::registerObjectFinalize(
-    SceneAttributes::ptr sceneAttributes,
-    const std::string& sceneAttributesHandle,
+int SceneInstanceAttributesManager::registerObjectFinalize(
+    SceneInstanceAttributes::ptr sceneInstanceAttributes,
+    const std::string& sceneInstanceAttributesHandle,
     bool) {
   // adds template to library, and returns either the ID of the existing
-  // template referenced by sceneAttributesHandle, or the next available ID
-  // if not found.
-  int datasetTemplateID =
-      this->addObjectToLibrary(sceneAttributes, sceneAttributesHandle);
+  // template referenced by sceneInstanceAttributesHandle, or the next available
+  // ID if not found.
+  int datasetTemplateID = this->addObjectToLibrary(
+      sceneInstanceAttributes, sceneInstanceAttributesHandle);
   return datasetTemplateID;
-}  // SceneAttributesManager::registerObjectFinalize
+}  // SceneInstanceAttributesManager::registerObjectFinalize
 
 }  // namespace managers
 }  // namespace metadata

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.h
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.h
@@ -2,11 +2,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_
-#define ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+#ifndef ESP_METADATA_MANAGERS_SCENEINSTANCEATTRIBUTEMANAGER_H_
+#define ESP_METADATA_MANAGERS_SCENEINSTANCEATTRIBUTEMANAGER_H_
 
 #include "AttributesManagerBase.h"
-#include "esp/metadata/attributes/SceneAttributes.h"
+#include "esp/metadata/attributes/SceneInstanceAttributes.h"
 
 namespace esp {
 namespace metadata {
@@ -14,17 +14,18 @@ namespace metadata {
 namespace managers {
 using esp::core::managedContainers::ManagedObjectAccess;
 
-class SceneAttributesManager
-    : public AttributesManager<attributes::SceneAttributes,
+class SceneInstanceAttributesManager
+    : public AttributesManager<attributes::SceneInstanceAttributes,
                                ManagedObjectAccess::Copy> {
  public:
-  SceneAttributesManager()
-      : AttributesManager<attributes::SceneAttributes,
+  SceneInstanceAttributesManager()
+      : AttributesManager<attributes::SceneInstanceAttributes,
                           ManagedObjectAccess::Copy>::
             AttributesManager("Scene Instance", "scene_instance.json") {
     // build this manager's copy constructor map
-    this->copyConstructorMap_["SceneAttributes"] =
-        &SceneAttributesManager::createObjectCopy<attributes::SceneAttributes>;
+    this->copyConstructorMap_["SceneInstanceAttributes"] =
+        &SceneInstanceAttributesManager::createObjectCopy<
+            attributes::SceneInstanceAttributes>;
   }
 
   /**
@@ -43,7 +44,7 @@ class SceneAttributesManager
    * template.
    * @return a reference to the newly-created template.
    */
-  attributes::SceneAttributes::ptr createObject(
+  attributes::SceneInstanceAttributes::ptr createObject(
       const std::string& sceneInstanceHandle,
       bool registerTemplate = true) override;
 
@@ -53,7 +54,7 @@ class SceneAttributesManager
    * @param attribs (out) an existing attributes to be modified.
    * @param jsonConfig json document to parse
    */
-  void setValsFromJSONDoc(attributes::SceneAttributes::ptr attribs,
+  void setValsFromJSONDoc(attributes::SceneInstanceAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
   /**
@@ -130,10 +131,10 @@ class SceneAttributesManager
    * attributes
    * @param builtFromConfig Whether this scene is being constructed from a
    * config file or from some other source.
-   * @return Newly created but unregistered SceneAttributes pointer, with only
-   * default values set.
+   * @return Newly created but unregistered SceneInstanceAttributes pointer,
+   * with only default values set.
    */
-  attributes::SceneAttributes::ptr initNewObjectInternal(
+  attributes::SceneInstanceAttributes::ptr initNewObjectInternal(
       const std::string& sceneInstanceHandle,
       bool builtFromConfig) override;
 
@@ -164,16 +165,18 @@ class SceneAttributesManager
    * set properly.  We are doing this since these values can be modified by the
    * user.
    *
-   * @param sceneAttributes The attributes template.
-   * @param sceneAttributesHandle The key for referencing the template in the
+   * @param sceneInstanceAttributes The attributes template.
+   * @param sceneInstanceAttributesHandle The key for referencing the template
+   * in the
    * @ref objectLibrary_.
    * @param forceRegistration Will register object even if conditional
    * registration checks fail.
    * @return The index in the @ref objectLibrary_ of the registered template.
    */
-  int registerObjectFinalize(attributes::SceneAttributes::ptr sceneAttributes,
-                             const std::string& sceneAttributesHandle,
-                             CORRADE_UNUSED bool forceRegistration) override;
+  int registerObjectFinalize(
+      attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes,
+      const std::string& sceneInstanceAttributesHandle,
+      CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief This function is meaningless for this manager's ManagedObjects.
@@ -186,12 +189,12 @@ class SceneAttributesManager
   }
 
  public:
-  ESP_SMART_POINTERS(SceneAttributesManager)
+  ESP_SMART_POINTERS(SceneInstanceAttributesManager)
 
-};  // class SceneAttributesManager
+};  // class SceneInstanceAttributesManager
 
 }  // namespace managers
 }  // namespace metadata
 }  // namespace esp
 
-#endif  // ESP_METADATA_MANAGERS_SCENEATTRIBUTEMANAGER_H_
+#endif  // ESP_METADATA_MANAGERS_SCENEINSTANCEATTRIBUTEMANAGER_H_

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -206,15 +206,16 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
 
 }  // Simulator::reconfigure
 
-metadata::attributes::SceneAttributes::cptr
+metadata::attributes::SceneInstanceAttributes::cptr
 Simulator::setSceneInstanceAttributes(const std::string& activeSceneName) {
   // Get scene instance attributes corresponding to passed active scene name
   // This will retrieve, or construct, an appropriately configured scene
   // instance attributes, depending on what exists in the Scene Dataset library
   // for the current dataset.
 
-  metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
-      metadataMediator_->getSceneAttributesByName(activeSceneName);
+  metadata::attributes::SceneInstanceAttributes::cptr
+      curSceneInstanceAttributes =
+          metadataMediator_->getSceneInstanceAttributesByName(activeSceneName);
   // check if attributes is null - should not happen
   ESP_CHECK(
       curSceneInstanceAttributes,
@@ -277,8 +278,8 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   }
   // 1. initial setup for scene instancing - sets or creates the
   // current scene instance to correspond to the given name.
-  metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
-      setSceneInstanceAttributes(activeSceneName);
+  metadata::attributes::SceneInstanceAttributes::cptr
+      curSceneInstanceAttributes = setSceneInstanceAttributes(activeSceneName);
 
   // 2. (re)seat & (re)init physics manager using the physics manager
   // attributes specified in current simulator configuration held in
@@ -347,7 +348,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 }  // Simulator::createSceneInstance
 
 bool Simulator::instanceStageForActiveScene(
-    const metadata::attributes::SceneAttributes::cptr&
+    const metadata::attributes::SceneInstanceAttributes::cptr&
         curSceneInstanceAttributes) {
   // Load stage specified by Scene Instance Attributes
   // Get Stage Instance Attributes - contains name of stage and initial
@@ -472,7 +473,7 @@ bool Simulator::instanceStageForActiveScene(
 }  // Simulator::instanceStageForActiveScene()
 
 bool Simulator::instanceObjectsForActiveScene(
-    const metadata::attributes::SceneAttributes::cptr&
+    const metadata::attributes::SceneInstanceAttributes::cptr&
         curSceneInstanceAttributes) {
   // 5. Load object instances as spceified by Scene Instance Attributes.
   // Get all instances of objects described in scene
@@ -521,7 +522,7 @@ bool Simulator::instanceObjectsForActiveScene(
 }  // Simulator::instanceObjectsForActiveScene()
 
 bool Simulator::instanceArticulatedObjectsForActiveScene(
-    const metadata::attributes::SceneAttributes::cptr&
+    const metadata::attributes::SceneInstanceAttributes::cptr&
         curSceneInstanceAttributes) {
   // 6. Load all articulated object instances
   // Get all instances of articulated objects described in scene

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -1371,10 +1371,11 @@ class Simulator {
   Simulator() = default;
   /**
    * @brief Builds a scene instance and populates it with initial object layout,
-   * if appropriate, based on @ref esp::metadata::attributes::SceneAttributes
-   * referenced by @p activeSceneName .
-   * @param activeSceneName The name of the desired SceneAttributes to use to
-   * instantiate a scene.
+   * if appropriate, based on @ref
+   * esp::metadata::attributes::SceneInstanceAttributes referenced by @p
+   * activeSceneName .
+   * @param activeSceneName The name of the desired SceneInstanceAttributes to
+   * use to instantiate a scene.
    * @return Whether successful or not.
    */
   bool createSceneInstance(const std::string& activeSceneName);
@@ -1387,8 +1388,8 @@ class Simulator {
    * specified in Simulator Configuration.
    * @return a constant pointer to the current scene instance attributes.
    */
-  metadata::attributes::SceneAttributes::cptr setSceneInstanceAttributes(
-      const std::string& activeSceneName);
+  metadata::attributes::SceneInstanceAttributes::cptr
+  setSceneInstanceAttributes(const std::string& activeSceneName);
 
   /**
    * @brief Instance the stage for the current scene based on the current active
@@ -1398,7 +1399,7 @@ class Simulator {
    * @return whether stage creation is completed successfully
    */
   bool instanceStageForActiveScene(
-      const metadata::attributes::SceneAttributes::cptr&
+      const metadata::attributes::SceneInstanceAttributes::cptr&
           curSceneInstanceAttributes);
 
   /**
@@ -1409,7 +1410,7 @@ class Simulator {
    * @return whether object creation and placement is completed successfully
    */
   bool instanceObjectsForActiveScene(
-      const metadata::attributes::SceneAttributes::cptr&
+      const metadata::attributes::SceneInstanceAttributes::cptr&
           curSceneInstanceAttributes);
 
   /**
@@ -1421,7 +1422,7 @@ class Simulator {
    * successfully
    */
   bool instanceArticulatedObjectsForActiveScene(
-      const metadata::attributes::SceneAttributes::cptr&
+      const metadata::attributes::SceneInstanceAttributes::cptr&
           curSceneInstanceAttributes);
 
   /**

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -1,0 +1,966 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <Corrade/TestSuite/Compare/Numeric.h>
+#include <Corrade/TestSuite/Tester.h>
+#include <string>
+
+#include "esp/metadata/MetadataMediator.h"
+#include "esp/metadata/managers/AttributesManagerBase.h"
+#include "esp/metadata/managers/ObjectAttributesManager.h"
+#include "esp/metadata/managers/PhysicsAttributesManager.h"
+#include "esp/metadata/managers/StageAttributesManager.h"
+
+#include "esp/physics/RigidBase.h"
+
+#include "configure.h"
+
+namespace Cr = Corrade;
+
+using Magnum::Math::Literals::operator""_radf;
+namespace AttrMgrs = esp::metadata::managers;
+namespace Attrs = esp::metadata::attributes;
+
+using esp::metadata::MetadataMediator;
+using esp::metadata::PrimObjTypes;
+
+using esp::physics::MotionType;
+
+using AttrMgrs::AttributesManager;
+using Attrs::ObjectAttributes;
+using Attrs::PhysicsManagerAttributes;
+using Attrs::SceneAttributes;
+using Attrs::StageAttributes;
+using Attrs::UVSpherePrimitiveAttributes;
+
+namespace {
+
+// base directory to save test attributes
+const std::string testAttrSaveDir =
+    Cr::Utility::Directory::join(DATA_DIR, "test_assets");
+
+/**
+ * @brief Test attributes/configuration functionality via setting values from
+ * JSON string, saving JSON to file and loading verifying saved JSON matches
+ * expectations upon load.
+ */
+
+struct AttributesConfigsTest : Cr::TestSuite::Tester {
+  explicit AttributesConfigsTest();
+
+  // Test helper functions
+
+  /**
+   * @brief Test saving and loading from JSON string
+   * @tparam T Class of attributes manager
+   * @tparam U Class of attributes
+   * @param mgr the Attributes Manager being tested
+   * @param jsonString the json to build the template from
+   * @param registerObject whether or not to register the Attributes constructed
+   * by the passed JSON string.
+   * @param tmpltName The name to give the template
+   * @return attributes template built from JSON parsed from string
+   */
+  template <typename T, typename U>
+  std::shared_ptr<U> testBuildAttributesFromJSONString(
+      std::shared_ptr<T> mgr,
+      const std::string& jsonString,
+      const bool registerObject,
+      const std::string& tmpltName = "new_template_from_json");
+
+  /**
+   * @brief remove added template built from JSON string.
+   * @param tmpltName name of template to remove.
+   * @param mgr the Attributes Manager being tested
+   * @param handle the handle of the attributes to remove
+   */
+  template <typename T>
+  void testRemoveAttributesBuiltByJSONString(
+      std::shared_ptr<T> mgr,
+      const std::string& tmpltName = "new_template_from_json");
+
+  /**
+   * @brief This method will test the user-defined configuration values to see
+   * that they match with expected passed values.  The config is expected to
+   * hold one of each type that it supports.
+   * @param userConfig The configuration object whose contents are to be
+   * tested
+   * @param str_val Expected string value
+   * @param bool_val Expected boolean value
+   * @param double_val Exptected double value
+   * @param vec_val Expected Magnum::Vector3 value
+   * @param quat_val Expected Quaternion value - note that the JSON is read
+   * with scalar at idx 0, whereas the quaternion constructor takes the vector
+   * component in the first position and the scalar in the second.
+   */
+  void testUserDefinedConfigVals(
+      std::shared_ptr<esp::core::config::Configuration> userConfig,
+      const std::string& str_val,
+      bool bool_val,
+      int int_val,
+      double double_val,
+      Magnum::Vector3 vec_val,
+      Magnum::Quaternion quat_val);
+
+  /**
+   * @brief This test will verify that the physics attributes' managers' JSON
+   * loading process is working as expected.
+   */
+  void testPhysicsAttrVals(
+      std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
+          physMgrAttr);
+  /**
+   * @brief This test will verify that the Light Attributes' managers' JSON
+   * loading process is working as expected.
+   */
+  void testLightAttrVals(
+      std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
+          lightLayoutAttr);
+
+  /**
+   * @brief This test will verify that the Scene Instance attributes' managers'
+   * JSON loading process is working as expected.
+   */
+  void testSceneInstanceAttrVals(
+      std::shared_ptr<esp::metadata::attributes::SceneAttributes>
+          sceneInstAttr);
+  /**
+   * @brief This test will verify that the Stage attributes' managers' JSON
+   * loading process is working as expected.
+   */
+  void testStageAttrVals(
+      std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
+      const std::string& assetPath);
+
+  /**
+   * @brief This test will verify that the Object attributes' managers' JSON
+   * loading process is working as expected.
+   */
+  void testObjectAttrVals(
+      std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
+      const std::string& assetPath);
+
+  // actual test functions
+  // These tests build strings containing legal JSON config data to use to build
+  // an appropriate attributes configuration.  The resultant configuration is
+  // then tested for accuracy.  These functions also save a copy to a json file,
+  // and then reload the copy, to make sure the saving and loading process is
+  // correct.
+  void testPhysicsJSONLoad();
+  void testLightJSONLoad();
+  void testSceneInstanceJSONLoad();
+  void testStageJSONLoad();
+  void testObjectJSONLoad();
+
+  // test member vars
+
+  esp::logging::LoggingContext loggingContext_;
+  AttrMgrs::LightLayoutAttributesManager::ptr lightLayoutAttributesManager_ =
+      nullptr;
+  AttrMgrs::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
+  AttrMgrs::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
+  AttrMgrs::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
+  AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
+
+};  // struct AttributesConfigsTest
+
+AttributesConfigsTest::AttributesConfigsTest() {
+  // set up a default simulation config to initialize MM
+  auto cfg = esp::sim::SimulatorConfiguration{};
+  auto MM = MetadataMediator::create(cfg);
+  // get attributes managers for default dataset
+  lightLayoutAttributesManager_ = MM->getLightLayoutAttributesManager();
+  objectAttributesManager_ = MM->getObjectAttributesManager();
+  physicsAttributesManager_ = MM->getPhysicsAttributesManager();
+  sceneAttributesManager_ = MM->getSceneAttributesManager();
+  stageAttributesManager_ = MM->getStageAttributesManager();
+
+  addTests({
+      &AttributesConfigsTest::testPhysicsJSONLoad,
+      &AttributesConfigsTest::testLightJSONLoad,
+      &AttributesConfigsTest::testSceneInstanceJSONLoad,
+      &AttributesConfigsTest::testStageJSONLoad,
+      &AttributesConfigsTest::testObjectJSONLoad,
+  });
+}
+
+template <typename T, typename U>
+std::shared_ptr<U> AttributesConfigsTest::testBuildAttributesFromJSONString(
+    std::shared_ptr<T> mgr,
+    const std::string& jsonString,
+    const bool registerObject,
+    const std::string& tmpltName) {  // create JSON document
+  try {
+    esp::io::JsonDocument tmp = esp::io::parseJsonString(jsonString);
+    // io::JsonGenericValue :
+    const esp::io::JsonGenericValue jsonDoc = tmp.GetObject();
+    // create an new template from jsonDoc
+    std::shared_ptr<U> attrTemplate1 =
+        mgr->buildManagedObjectFromDoc(tmpltName, jsonDoc);
+
+    // register attributes
+    if (registerObject) {
+      mgr->registerObject(attrTemplate1);
+    }
+    return attrTemplate1;
+  } catch (...) {
+    CORRADE_FAIL_IF(true, "testBuildAttributesFromJSONString : Failed to parse"
+                              << jsonString << "as JSON.");
+    return nullptr;
+  }
+}  // testBuildAttributesFromJSONString
+
+template <typename T>
+void AttributesConfigsTest::testRemoveAttributesBuiltByJSONString(
+    std::shared_ptr<T> mgr,
+    const std::string& tmpltName) {
+  if (mgr->getObjectLibHasHandle(tmpltName)) {
+    mgr->removeObjectByHandle(tmpltName);
+  }
+}
+
+void AttributesConfigsTest::testUserDefinedConfigVals(
+    std::shared_ptr<esp::core::config::Configuration> userConfig,
+    const std::string& str_val,
+    bool bool_val,
+    int int_val,
+    double double_val,
+    Magnum::Vector3 vec_val,
+    Magnum::Quaternion quat_val) {
+  // user defined attributes from light instance
+  CORRADE_VERIFY(userConfig);
+  CORRADE_COMPARE(userConfig->get<std::string>("user_string"), str_val);
+  CORRADE_COMPARE(userConfig->get<bool>("user_bool"), bool_val);
+  CORRADE_COMPARE(userConfig->get<int>("user_int"), int_val);
+  CORRADE_COMPARE(userConfig->get<double>("user_double"), double_val);
+  CORRADE_COMPARE(userConfig->get<Magnum::Vector3>("user_vec3"), vec_val);
+  CORRADE_COMPARE(userConfig->get<Magnum::Quaternion>("user_quat"), quat_val);
+
+}  // AttributesConfigsTest::testUserDefinedConfigVals
+
+/////////////  Begin JSON String-based tests
+
+void AttributesConfigsTest::testPhysicsAttrVals(
+    std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
+        physMgrAttr) {
+  // match values set in test JSON
+
+  CORRADE_COMPARE(physMgrAttr->getGravity(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(physMgrAttr->getTimestep(), 1.0);
+  CORRADE_COMPARE(physMgrAttr->getSimulator(), "bullet_test");
+  CORRADE_COMPARE(physMgrAttr->getFrictionCoefficient(), 1.4);
+  CORRADE_COMPARE(physMgrAttr->getRestitutionCoefficient(), 1.1);
+  // test physics manager attributes-level user config vals
+  testUserDefinedConfigVals(physMgrAttr->getUserConfiguration(),
+                            "pm defined string", true, 15, 12.6,
+                            Magnum::Vector3(215.4, 217.6, 2110.1),
+                            Magnum::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f));
+  // remove added template
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltByJSONString(physicsAttributesManager_,
+                                        physMgrAttr->getHandle());
+}
+
+void AttributesConfigsTest::testPhysicsJSONLoad() {
+  // build JSON sample config
+  // add dummy test so that test will run
+  CORRADE_VERIFY(true);
+  const std::string& jsonString = R"({
+  "physics_simulator": "bullet_test",
+  "timestep": 1.0,
+  "gravity": [1,2,3],
+  "friction_coefficient": 1.4,
+  "restitution_coefficient": 1.1,
+  "user_defined" : {
+      "user_string" : "pm defined string",
+      "user_bool" : true,
+      "user_int" : 15,
+      "user_double" : 12.6,
+      "user_vec3" : [215.4, 217.6, 2110.1],
+      "user_quat" : [0.2, 5.2, 6.2, 7.2]
+  }
+})";
+  auto physMgrAttr =
+      testBuildAttributesFromJSONString<AttrMgrs::PhysicsAttributesManager,
+                                        Attrs::PhysicsManagerAttributes>(
+          physicsAttributesManager_, jsonString, true);
+  // verify exists
+  CORRADE_VERIFY(physMgrAttr);
+
+  // before test, save attributes with new name
+  std::string newAttrName = Cr::Utility::formatString(
+      "{}/testPhysicsAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      physicsAttributesManager_->getJSONTypeExt());
+
+  bool success = physicsAttributesManager_->saveManagedObjectToFile(
+      physMgrAttr->getHandle(), newAttrName);
+
+  ESP_DEBUG() << "About to test string-based physMgrAttr ";
+  // test json string to verify format, this deletes physMgrAttr from registry
+  testPhysicsAttrVals(physMgrAttr);
+  ESP_DEBUG() << "Tested physMgrAttr ";
+
+  physMgrAttr = nullptr;
+
+  // load attributes from new name and retest
+  auto physMgrAttr2 =
+      physicsAttributesManager_->createObjectFromJSONFile(newAttrName, true);
+
+  // verify file-based config exists
+  CORRADE_VERIFY(physMgrAttr2);
+
+  ESP_DEBUG() << "About to test saved physMgrAttr2 :"
+              << physMgrAttr2->getHandle();
+  // test json string to verify format, this deletes physMgrAttr2 from
+  // registry
+  testPhysicsAttrVals(physMgrAttr2);
+  ESP_DEBUG() << "Tested physMgrAttr ";
+
+  // delete file-based config
+  Cr::Utility::Directory::rm(newAttrName);
+
+}  // AttributesManagers_PhysicsJSONLoadTest
+
+void AttributesConfigsTest::testLightAttrVals(
+    std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
+        lightLayoutAttr) {
+  // test light layout attributes-level user config vals
+  testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
+                            "light attribs defined string", true, 23, 2.3,
+                            Magnum::Vector3(1.1, 3.3, 5.5),
+                            Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
+  CORRADE_COMPARE(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
+  CORRADE_COMPARE(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
+  auto lightAttr0 = lightLayoutAttr->getLightInstance("test0");
+  // verify that lightAttr0 exists
+  CORRADE_VERIFY(lightAttr0);
+
+  // match values set in test JSON
+
+  CORRADE_COMPARE(lightAttr0->getDirection(), Magnum::Vector3(1.0, -1.0, 1.0));
+  CORRADE_COMPARE(lightAttr0->getColor(), Magnum::Vector3(0.6, 0.7, 0.8));
+
+  CORRADE_COMPARE(lightAttr0->getIntensity(), -0.1);
+  CORRADE_COMPARE(static_cast<int>(lightAttr0->getType()),
+                  static_cast<int>(esp::gfx::LightType::Directional));
+  CORRADE_COMPARE(static_cast<int>(lightAttr0->getPositionModel()),
+                  static_cast<int>(esp::gfx::LightPositionModel::Camera));
+  CORRADE_COMPARE(lightAttr0->getInnerConeAngle(), 0.25_radf);
+  CORRADE_COMPARE(lightAttr0->getOuterConeAngle(), -1.57_radf);
+
+  auto lightAttr1 = lightLayoutAttr->getLightInstance("test1");
+  // verify that lightAttr1 exists
+  CORRADE_VERIFY(lightAttr1);
+
+  CORRADE_COMPARE(lightAttr1->getPosition(), Magnum::Vector3(2.5, 0.1, 3.8));
+  CORRADE_COMPARE(lightAttr1->getColor(), Magnum::Vector3(0.5, 0.3, 0.1));
+
+  CORRADE_COMPARE(lightAttr1->getIntensity(), -1.2);
+  CORRADE_COMPARE(static_cast<int>(lightAttr1->getType()),
+                  static_cast<int>(esp::gfx::LightType::Point));
+  CORRADE_COMPARE(static_cast<int>(lightAttr1->getPositionModel()),
+                  static_cast<int>(esp::gfx::LightPositionModel::Global));
+  CORRADE_COMPARE(lightAttr1->getInnerConeAngle(), -0.75_radf);
+  CORRADE_COMPARE(lightAttr1->getOuterConeAngle(), -1.7_radf);
+
+  // test user defined attributes from light instance
+  testUserDefinedConfigVals(lightAttr1->getUserConfiguration(),
+                            "light instance defined string", false, 42, 1.2,
+                            Magnum::Vector3(0.1, 2.3, 4.5),
+                            Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltByJSONString(lightLayoutAttributesManager_,
+                                        lightLayoutAttr->getHandle());
+}
+void AttributesConfigsTest::testLightJSONLoad() {
+  // build JSON sample config
+  const std::string& jsonString = R"({
+  "lights":{
+      "test0":{
+        "direction": [1.0,-1.0,1.0],
+        "intensity": -0.1,
+        "color": [0.6,0.7,0.8],
+        "type": "directional",
+        "position_model" : "camera",
+        "spot": {
+          "innerConeAngle": 0.25,
+          "outerConeAngle": -1.57
+        }
+      },
+      "test1":{
+        "position": [2.5,0.1,3.8],
+        "intensity": -1.2,
+        "color": [0.5,0.3,0.1],
+        "type": "point",
+        "position_model" : "global",
+        "spot": {
+          "innerConeAngle": -0.75,
+          "outerConeAngle": -1.7
+        },
+        "user_defined" : {
+            "user_string" : "light instance defined string",
+            "user_bool" : false,
+            "user_int" : 42,
+            "user_double" : 1.2,
+            "user_vec3" : [0.1, 2.3, 4.5],
+            "user_quat" : [0.1, 0.2, 0.3, 0.4]
+        }
+      }
+    },
+    "user_defined" : {
+        "user_string" : "light attribs defined string",
+        "user_bool" : true,
+        "user_int" : 23,
+        "user_double" : 2.3,
+        "user_vec3" : [1.1, 3.3, 5.5],
+        "user_quat" : [0.5, 0.6, 0.7, 0.8]
+    },
+    "positive_intensity_scale" : 2.0,
+    "negative_intensity_scale" : 1.5
+  })";
+
+  auto lightLayoutAttr =
+      testBuildAttributesFromJSONString<AttrMgrs::LightLayoutAttributesManager,
+                                        Attrs::LightLayoutAttributes>(
+          lightLayoutAttributesManager_, jsonString, true);
+  // verify exists
+  CORRADE_VERIFY(lightLayoutAttr);
+  // before test, save attributes with new name
+  std::string newAttrName = Cr::Utility::formatString(
+      "{}/testLightLayoutAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      lightLayoutAttributesManager_->getJSONTypeExt());
+
+  bool success = lightLayoutAttributesManager_->saveManagedObjectToFile(
+      lightLayoutAttr->getHandle(), newAttrName);
+
+  ESP_DEBUG() << "About to test string-based lightLayoutAttr";
+  // test json string to verify format
+  testLightAttrVals(lightLayoutAttr);
+  ESP_DEBUG() << "Tested lightLayoutAttr";
+  lightLayoutAttr = nullptr;
+
+  // load attributes from new name and retest
+  auto lightLayoutAttr2 =
+      lightLayoutAttributesManager_->createObjectFromJSONFile(newAttrName);
+
+  // verify file-based config exists
+  CORRADE_VERIFY(lightLayoutAttr2);
+
+  // test json string to verify format, this deletes lightLayoutAttr2 from
+  // registry
+  ESP_DEBUG() << "About to test saved lightLayoutAttr2 :"
+              << lightLayoutAttr2->getHandle();
+  testLightAttrVals(lightLayoutAttr2);
+  ESP_DEBUG() << "About to test lightLayoutAttr2";
+
+  // delete file-based config
+  Cr::Utility::Directory::rm(newAttrName);
+
+}  // AttributesManagers_LightJSONLoadTest
+
+void AttributesConfigsTest::testSceneInstanceAttrVals(
+    std::shared_ptr<esp::metadata::attributes::SceneAttributes> sceneAttr) {
+  // match values set in test JSON
+  CORRADE_COMPARE(
+      static_cast<int>(sceneAttr->getTranslationOrigin()),
+      static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal));
+
+  CORRADE_COMPARE(sceneAttr->getLightingHandle(),
+                  "test_lighting_configuration");
+  CORRADE_COMPARE(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
+  CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
+                  "test_semantic_descriptor_path1");
+  // test scene instance attributes-level user config vals
+  testUserDefinedConfigVals(sceneAttr->getUserConfiguration(),
+                            "scene instance defined string", true, 99, 9.1,
+                            Magnum::Vector3(12.3, 32.5, 25.07),
+                            Magnum::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f));
+
+  // verify stage populated properly
+  auto stageInstance = sceneAttr->getStageInstance();
+  CORRADE_COMPARE(stageInstance->getHandle(), "test_stage_template");
+  CORRADE_COMPARE(stageInstance->getTranslation(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(stageInstance->getRotation(),
+                  Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
+  // test stage instance attributes-level user config vals
+  testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
+                            "stage instance defined string", true, 11, 2.2,
+                            Magnum::Vector3(1.2, 3.4, 5.6),
+                            Magnum::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f));
+  // make sure that is not default value "flat"
+  CORRADE_COMPARE(static_cast<int>(stageInstance->getShaderType()),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
+
+  // verify objects
+  auto objectInstanceList = sceneAttr->getObjectInstances();
+  CORRADE_COMPARE(objectInstanceList.size(), 2);
+  auto objInstance = objectInstanceList[0];
+  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template0");
+  CORRADE_COMPARE(static_cast<int>(objInstance->getTranslationOrigin()),
+                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
+  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, 1, 2));
+  CORRADE_COMPARE(objInstance->getRotation(),
+                  Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
+  CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
+                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
+
+  // test object 0 instance attributes-level user config vals
+  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
+                            "obj0 instance defined string", false, 12, 2.3,
+                            Magnum::Vector3(1.3, 3.5, 5.7),
+                            Magnum::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f));
+
+  objInstance = objectInstanceList[1];
+  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template1");
+  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, -1, -2));
+  CORRADE_COMPARE(objInstance->getRotation(),
+                  Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
+  CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
+                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
+
+  // test object 0 instance attributes-level user config vals
+  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
+                            "obj1 instance defined string", false, 1, 1.1,
+                            Magnum::Vector3(10.3, 30.5, -5.07),
+                            Magnum::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f));
+
+  // verify articulated object instances
+  auto artObjInstances = sceneAttr->getArticulatedObjectInstances();
+  CORRADE_COMPARE(artObjInstances.size(), 2);
+  auto artObjInstance = artObjInstances[0];
+  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template0");
+  CORRADE_COMPARE(static_cast<int>(artObjInstance->getTranslationOrigin()),
+                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
+  CORRADE_COMPARE(artObjInstance->getFixedBase(), false);
+  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
+
+  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
+  CORRADE_COMPARE(static_cast<int>(artObjInstance->getMotionType()),
+                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
+  // verify init join pose
+  const auto& initJointPoseMap = artObjInstance->getInitJointPose();
+  const std::vector<float> jtPoseVals{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+  int idx = 0;
+  for (std::map<std::string, float>::const_iterator iter =
+           initJointPoseMap.begin();
+       iter != initJointPoseMap.end(); ++iter) {
+    CORRADE_COMPARE(iter->second, jtPoseVals[idx++]);
+  }
+  // verify init joint vels
+  const auto& initJoinVelMap = artObjInstance->getInitJointVelocities();
+  const std::vector<float> jtVelVals{1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6};
+  idx = 0;
+  for (std::map<std::string, float>::const_iterator iter =
+           initJoinVelMap.begin();
+       iter != initJoinVelMap.end(); ++iter) {
+    CORRADE_COMPARE(iter->second, jtVelVals[idx++]);
+  }
+
+  // test test_urdf_template0 ao instance attributes-level user config vals
+  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
+                            "test_urdf_template0 instance defined string",
+                            false, 2, 1.22,
+                            Magnum::Vector3(120.3f, 302.5f, -25.07f),
+                            Magnum::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f));
+
+  // test nested configuration
+  auto artObjNestedConfig =
+      artObjInstance->getUserConfiguration()
+          ->getSubconfigCopy<esp::core::config::Configuration>("user_def_obj");
+  CORRADE_VERIFY(artObjNestedConfig);
+  CORRADE_VERIFY(artObjNestedConfig->getNumEntries() > 0);
+  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("position"),
+                  Magnum::Vector3(0.1f, 0.2f, 0.3f));
+  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("rotation"),
+                  Magnum::Vector3(0.5f, 0.3f, 0.1f));
+
+  artObjInstance = artObjInstances[1];
+  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template1");
+  CORRADE_VERIFY(artObjInstance->getFixedBase());
+  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
+  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
+  CORRADE_COMPARE(static_cast<int>(artObjInstance->getMotionType()),
+                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
+  // test test_urdf_template0 ao instance attributes-level user config vals
+  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
+                            "test_urdf_template1 instance defined string",
+                            false, 21, 11.22,
+                            Magnum::Vector3(190.3f, 902.5f, -95.07f),
+                            Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltByJSONString(sceneAttributesManager_,
+                                        sceneAttr->getHandle());
+}
+
+void AttributesConfigsTest::testSceneInstanceJSONLoad() {
+  // build JSON sample config
+  const std::string& jsonString = R"({
+  "translation_origin" : "Asset_Local",
+  "stage_instance":{
+      "template_name": "test_stage_template",
+      "translation": [1,2,3],
+      "rotation": [0.1, 0.2, 0.3, 0.4],
+      "shader_type" : "pbr",
+      "user_defined" : {
+          "user_string" : "stage instance defined string",
+          "user_bool" : true,
+          "user_int" : 11,
+          "user_double" : 2.2,
+          "user_vec3" : [1.2, 3.4, 5.6],
+          "user_quat" : [0.4, 0.5, 0.6, 0.7]
+      }
+  },
+  "object_instances": [
+      {
+          "template_name": "test_object_template0",
+          "translation_origin": "COM",
+          "translation": [0,1,2],
+          "rotation": [0.2, 0.3, 0.4, 0.5],
+          "motion_type": "KINEMATIC",
+          "user_defined" : {
+              "user_string" : "obj0 instance defined string",
+              "user_bool" : false,
+              "user_int" : 12,
+              "user_double" : 2.3,
+              "user_vec3" : [1.3, 3.5, 5.7],
+              "user_quat" : [0.3, 0.2, 0.6, 0.1]
+          }
+      },
+      {
+          "template_name": "test_object_template1",
+          "translation": [0,-1,-2],
+          "rotation": [0.5, 0.6, 0.7, 0.8],
+          "motion_type": "DYNAMIC",
+          "user_defined" : {
+              "user_string" : "obj1 instance defined string",
+              "user_bool" : false,
+              "user_int" : 1,
+              "user_double" : 1.1,
+              "user_vec3" : [10.3, 30.5, -5.07],
+              "user_quat" : [1.3, 1.2, 1.6, 1.1]
+          }
+      }
+      ],
+      "articulated_object_instances": [
+          {
+              "template_name": "test_urdf_template0",
+              "translation_origin": "COM",
+              "fixed_base": false,
+              "auto_clamp_joint_limits" : true,
+              "translation": [5,4,5],
+              "rotation": [0.2, 0.3, 0.4, 0.5],
+              "initial_joint_pose": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+              "initial_joint_velocities": [1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6],
+              "motion_type": "DYNAMIC",
+              "user_defined" : {
+                  "user_string" : "test_urdf_template0 instance defined string",
+                  "user_bool" : false,
+                  "user_int" : 2,
+                  "user_double" : 1.22,
+                  "user_vec3" : [120.3, 302.5, -25.07],
+                  "user_quat" : [1.23, 1.22, 1.26, 1.21],
+                  "user_def_obj" : {
+                      "position" : [0.1, 0.2, 0.3],
+                      "rotation" : [0.5, 0.3, 0.1]
+                  }
+              }
+          },
+          {
+              "template_name": "test_urdf_template1",
+              "fixed_base" : true,
+              "auto_clamp_joint_limits" : true,
+              "translation": [3, 2, 1],
+              "rotation": [0.5, 0.6, 0.7, 0.8],
+              "motion_type": "KINEMATIC",
+              "user_defined" : {
+                  "user_string" : "test_urdf_template1 instance defined string",
+                  "user_bool" : false,
+                  "user_int" : 21,
+                  "user_double" : 11.22,
+                  "user_vec3" : [190.3, 902.5, -95.07],
+                  "user_quat" : [1.25, 9.22, 9.26, 0.21]
+              }
+          }
+      ],
+      "default_lighting":  "test_lighting_configuration",
+      "navmesh_instance": "test_navmesh_path1",
+      "semantic_scene_instance": "test_semantic_descriptor_path1",
+      "user_defined" : {
+          "user_string" : "scene instance defined string",
+          "user_bool" : true,
+          "user_int" : 99,
+          "user_double" : 9.1,
+          "user_vec3" : [12.3, 32.5, 25.07],
+          "user_quat" : [0.3, 3.2, 2.6, 5.1]
+      }
+     })";
+
+  auto sceneAttr =
+      testBuildAttributesFromJSONString<AttrMgrs::SceneAttributesManager,
+                                        Attrs::SceneAttributes>(
+          sceneAttributesManager_, jsonString, true);
+  // verify exists
+  CORRADE_VERIFY(sceneAttr);
+
+  // before test, save attributes with new name
+  std::string newAttrName = Cr::Utility::formatString(
+      "{}/testSceneAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      sceneAttributesManager_->getJSONTypeExt());
+
+  bool success = sceneAttributesManager_->saveManagedObjectToFile(
+      sceneAttr->getHandle(), newAttrName);
+
+  // test json string to verify format - this also deletes sceneAttr from
+  // manager
+  ESP_DEBUG() << "About to test string-based sceneAttr :";
+  testSceneInstanceAttrVals(sceneAttr);
+  ESP_DEBUG() << "Tested string-based sceneAttr :";
+  sceneAttr = nullptr;
+
+  // load attributes from new name and retest
+  auto sceneAttr2 =
+      sceneAttributesManager_->createObjectFromJSONFile(newAttrName);
+
+  // verify file-based config exists
+  CORRADE_VERIFY(sceneAttr2);
+
+  // test json string to verify format, this deletes sceneAttr2 from
+  // registry
+  ESP_DEBUG() << "Not testing integrity of saved Scene Attributes.";
+  // ESP_DEBUG() << "About to test saved sceneAttr2 :";
+  // testSceneInstanceAttrVals(sceneAttr2);
+  // ESP_DEBUG() << "Tested saved sceneAttr2 :";
+  // delete file-based config
+  // Cr::Utility::Directory::rm(newAttrName);
+
+}  // AttributesManagers_SceneInstanceJSONLoadTest
+
+void AttributesConfigsTest::testStageAttrVals(
+    std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
+    const std::string& assetPath) {
+  // match values set in test JSON
+  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 3, 4));
+  CORRADE_COMPARE(stageAttr->getMargin(), 0.9);
+  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.321);
+  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.456);
+  CORRADE_VERIFY(!stageAttr->getForceFlatShading());
+  CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 1.1);
+  CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
+  CORRADE_COMPARE(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
+  CORRADE_COMPARE(stageAttr->getRenderAssetHandle(), assetPath);
+  CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(), assetPath);
+  CORRADE_VERIFY(!stageAttr->getIsCollidable());
+  // stage-specific attributes
+  CORRADE_COMPARE(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
+  // make sure that is not default value "flat"
+  CORRADE_COMPARE(static_cast<int>(stageAttr->getShaderType()),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
+  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
+  CORRADE_COMPARE(stageAttr->getSemanticAssetHandle(), assetPath);
+  CORRADE_COMPARE(stageAttr->getNavmeshAssetHandle(), assetPath);
+  // test stage attributes-level user config vals
+  testUserDefinedConfigVals(stageAttr->getUserConfiguration(),
+                            "stage defined string", false, 3, 0.8,
+                            Magnum::Vector3(5.4, 7.6, 10.1),
+                            Magnum::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltByJSONString(stageAttributesManager_,
+                                        stageAttr->getHandle());
+}  // AttributesConfigsTest::testStageAttrVals
+void AttributesConfigsTest::testStageJSONLoad() {
+  // build JSON sample config
+  const std::string& jsonString =
+      R"({
+        "scale":[2,3,4],
+        "margin": 0.9,
+        "friction_coefficient": 0.321,
+        "restitution_coefficient": 0.456,
+        "force_flat_shading": false,
+        "units_to_meters": 1.1,
+        "up":[2.1, 0, 0],
+        "front":[0, 2.1, 0],
+        "render_asset": "testJSONRenderAsset.glb",
+        "collision_asset": "testJSONCollisionAsset.glb",
+        "is_collidable": false,
+        "gravity": [9,8,7],
+        "origin":[1,2,3],
+        "semantic_asset":"testJSONSemanticAsset.glb",
+        "nav_asset":"testJSONNavMeshAsset.glb",
+        "shader_type" : "material",
+        "user_defined" : {
+            "user_string" : "stage defined string",
+            "user_bool" : false,
+            "user_int" : 3,
+            "user_double" : 0.8,
+            "user_vec3" : [5.4, 7.6, 10.1],
+            "user_quat" : [0.1, 1.5, 2.6, 3.7]
+        }
+      })";
+
+  auto stageAttr =
+      testBuildAttributesFromJSONString<AttrMgrs::StageAttributesManager,
+                                        Attrs::StageAttributes>(
+          stageAttributesManager_, jsonString, false);
+  // verify exists
+  CORRADE_VERIFY(stageAttr);
+  // now need to change the render and collision assets to make sure they are
+  // legal so test can proceed (needs to be actual existing file)
+  const std::string stageAsset =
+      Cr::Utility::Directory::join(testAttrSaveDir, "scenes/plane.glb");
+
+  stageAttr->setRenderAssetHandle(stageAsset);
+  stageAttr->setCollisionAssetHandle(stageAsset);
+  stageAttr->setSemanticAssetHandle(stageAsset);
+  stageAttr->setNavmeshAssetHandle(stageAsset);
+  // now register so can be saved to disk
+  stageAttributesManager_->registerObject(stageAttr);
+
+  // before test, save attributes with new name
+  std::string newAttrName = Cr::Utility::formatString(
+      "{}/testStageAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      stageAttributesManager_->getJSONTypeExt());
+
+  bool success = stageAttributesManager_->saveManagedObjectToFile(
+      stageAttr->getHandle(), newAttrName);
+
+  // test json string to verify format - this also deletes stageAttr from
+  // manager
+  testStageAttrVals(stageAttr, stageAsset);
+  stageAttr = nullptr;
+
+  // load attributes from new name and retest
+  auto stageAttr2 =
+      stageAttributesManager_->createObjectFromJSONFile(newAttrName);
+
+  // verify file-based config exists
+  CORRADE_VERIFY(stageAttr2);
+
+  // test json string to verify format, this deletes stageAttr2 from
+  // registry
+  testStageAttrVals(stageAttr2, stageAsset);
+
+  // delete file-based config
+  Cr::Utility::Directory::rm(newAttrName);
+
+}  // AttributesManagers_StageJSONLoadTest
+
+void AttributesConfigsTest::testObjectAttrVals(
+    std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
+    const std::string& assetPath) {
+  // match values set in test JSON
+
+  CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(2, 3, 4));
+  CORRADE_COMPARE(objAttr->getMargin(), 0.9);
+  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.321);
+  CORRADE_COMPARE(objAttr->getRestitutionCoefficient(), 0.456);
+  CORRADE_VERIFY(objAttr->getForceFlatShading());
+  CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.1);
+  CORRADE_COMPARE(objAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
+  CORRADE_COMPARE(objAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
+  CORRADE_COMPARE(objAttr->getRenderAssetHandle(), assetPath);
+  CORRADE_COMPARE(objAttr->getCollisionAssetHandle(), assetPath);
+  CORRADE_VERIFY(!objAttr->getIsCollidable());
+  CORRADE_COMPARE(objAttr->getSemanticId(), 7);
+  // object-specific attributes
+  CORRADE_COMPARE(objAttr->getMass(), 9);
+  CORRADE_COMPARE(static_cast<int>(objAttr->getShaderType()),
+                  static_cast<int>(Attrs::ObjectInstanceShaderType::Phong));
+  CORRADE_VERIFY(objAttr->getBoundingBoxCollisions());
+  CORRADE_VERIFY(objAttr->getJoinCollisionMeshes());
+  CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(1.1, 0.9, 0.3));
+  CORRADE_COMPARE(objAttr->getCOM(), Magnum::Vector3(0.1, 0.2, 0.3));
+  // test object attributes-level user config vals
+  testUserDefinedConfigVals(objAttr->getUserConfiguration(),
+                            "object defined string", true, 5, 2.6,
+                            Magnum::Vector3(15.4, 17.6, 110.1),
+                            Magnum::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f));
+
+  // remove json-string built attributes added for test
+  testRemoveAttributesBuiltByJSONString(objectAttributesManager_,
+                                        objAttr->getHandle());
+
+}  // AttributesConfigsTest::testObjectAttrVals
+
+void AttributesConfigsTest::testObjectJSONLoad() {
+  // build JSON sample config
+  const std::string& jsonString = R"({
+  "scale":[2,3,4],
+  "margin": 0.9,
+  "friction_coefficient": 0.321,
+  "restitution_coefficient": 0.456,
+  "force_flat_shading": true,
+  "units_to_meters": 1.1,
+  "up":[2.1,0,0],
+  "front":[0,2.1,0],
+  "render_asset": "testJSONRenderAsset.glb",
+  "collision_asset": "testJSONCollisionAsset.glb",
+  "is_collidable": false,
+  "mass": 9,
+  "use_bounding_box_for_collision": true,
+  "join_collision_meshes":true,
+  "inertia": [1.1, 0.9, 0.3],
+  "semantic_id" : 7,
+  "COM": [0.1,0.2,0.3],
+  "shader_type" : "phong",
+  "user_defined" : {
+      "user_string" : "object defined string",
+      "user_bool" : true,
+      "user_int" : 5,
+      "user_double" : 2.6,
+      "user_vec3" : [15.4, 17.6, 110.1],
+      "user_quat" : [0.7, 5.5, 6.6, 7.7]
+  }
+})";
+  auto objAttr =
+      testBuildAttributesFromJSONString<AttrMgrs::ObjectAttributesManager,
+                                        Attrs::ObjectAttributes>(
+          objectAttributesManager_, jsonString, false);
+  // verify exists
+  CORRADE_VERIFY(objAttr);
+  // now need to change the render and collision assets to make sure they are
+  // legal so test can proceed (needs to be actual existing file)
+  const std::string objAsset =
+      Cr::Utility::Directory::join(testAttrSaveDir, "objects/donut.glb");
+
+  objAttr->setRenderAssetHandle(objAsset);
+  objAttr->setCollisionAssetHandle(objAsset);
+  // now register so can be saved to disk
+  objectAttributesManager_->registerObject(objAttr);
+
+  // before test, save attributes with new name
+  std::string newAttrName = Cr::Utility::formatString(
+      "{}/testObjectAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      objectAttributesManager_->getJSONTypeExt());
+
+  bool success = objectAttributesManager_->saveManagedObjectToFile(
+      objAttr->getHandle(), newAttrName);
+
+  // test json string to verify format - this also deletes objAttr from
+  // manager
+  testObjectAttrVals(objAttr, objAsset);
+  objAttr = nullptr;
+
+  // load attributes from new name and retest
+  auto objAttr2 =
+      objectAttributesManager_->createObjectFromJSONFile(newAttrName);
+
+  // verify file-based config exists
+  CORRADE_VERIFY(objAttr2);
+
+  // test json string to verify format, this deletes objAttr2 from
+  // registry
+  testObjectAttrVals(objAttr2, objAsset);
+
+  // delete file-based config
+  Cr::Utility::Directory::rm(newAttrName);
+
+  // load attributes from new name and retest
+}  // AttributesConfigsTest::testObjectJSONLoadTest
+
+}  // namespace
+
+CORRADE_TEST_MAIN(AttributesConfigsTest)

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -30,7 +30,7 @@ using esp::physics::MotionType;
 using AttrMgrs::AttributesManager;
 using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
-using Attrs::SceneAttributes;
+using Attrs::SceneInstanceAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
 
@@ -123,7 +123,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * JSON loading process is working as expected.
    */
   void testSceneInstanceAttrVals(
-      std::shared_ptr<esp::metadata::attributes::SceneAttributes>
+      std::shared_ptr<esp::metadata::attributes::SceneInstanceAttributes>
           sceneInstAttr);
   /**
    * @brief This test will verify that the Stage attributes' managers' JSON
@@ -160,7 +160,8 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
       nullptr;
   AttrMgrs::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
   AttrMgrs::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
-  AttrMgrs::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
+  AttrMgrs::SceneInstanceAttributesManager::ptr
+      sceneInstanceAttributesManager_ = nullptr;
   AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
 
 };  // struct AttributesConfigsTest
@@ -173,7 +174,7 @@ AttributesConfigsTest::AttributesConfigsTest() {
   lightLayoutAttributesManager_ = MM->getLightLayoutAttributesManager();
   objectAttributesManager_ = MM->getObjectAttributesManager();
   physicsAttributesManager_ = MM->getPhysicsAttributesManager();
-  sceneAttributesManager_ = MM->getSceneAttributesManager();
+  sceneInstanceAttributesManager_ = MM->getSceneInstanceAttributesManager();
   stageAttributesManager_ = MM->getStageAttributesManager();
 
   addTests({
@@ -461,7 +462,8 @@ void AttributesConfigsTest::testLightJSONLoad() {
 }  // AttributesManagers_LightJSONLoadTest
 
 void AttributesConfigsTest::testSceneInstanceAttrVals(
-    std::shared_ptr<esp::metadata::attributes::SceneAttributes> sceneAttr) {
+    std::shared_ptr<esp::metadata::attributes::SceneInstanceAttributes>
+        sceneAttr) {
   // match values set in test JSON
   CORRADE_COMPARE(
       static_cast<int>(sceneAttr->getTranslationOrigin()),
@@ -591,7 +593,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                             Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
 
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(sceneAttributesManager_,
+  testRemoveAttributesBuiltByJSONString(sceneInstanceAttributesManager_,
                                         sceneAttr->getHandle());
 }
 
@@ -698,19 +700,18 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
       }
      })";
 
-  auto sceneAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::SceneAttributesManager,
-                                        Attrs::SceneAttributes>(
-          sceneAttributesManager_, jsonString, true);
+  auto sceneAttr = testBuildAttributesFromJSONString<
+      AttrMgrs::SceneInstanceAttributesManager, Attrs::SceneInstanceAttributes>(
+      sceneInstanceAttributesManager_, jsonString, true);
   // verify exists
   CORRADE_VERIFY(sceneAttr);
 
   // before test, save attributes with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testSceneAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      sceneAttributesManager_->getJSONTypeExt());
+      sceneInstanceAttributesManager_->getJSONTypeExt());
 
-  bool success = sceneAttributesManager_->saveManagedObjectToFile(
+  bool success = sceneInstanceAttributesManager_->saveManagedObjectToFile(
       sceneAttr->getHandle(), newAttrName);
 
   // test json string to verify format - this also deletes sceneAttr from
@@ -722,7 +723,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
 
   // load attributes from new name and retest
   auto sceneAttr2 =
-      sceneAttributesManager_->createObjectFromJSONFile(newAttrName);
+      sceneInstanceAttributesManager_->createObjectFromJSONFile(newAttrName);
 
   // verify file-based config exists
   CORRADE_VERIFY(sceneAttr2);
@@ -734,7 +735,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
   // testSceneInstanceAttrVals(sceneAttr2);
   // ESP_DEBUG() << "Tested saved sceneAttr2 :";
   // delete file-based config
-  // Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Directory::rm(newAttrName);
 
 }  // AttributesManagers_SceneInstanceJSONLoadTest
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -34,7 +34,7 @@ using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
 using Attrs::ObjectAttributes;
 using Attrs::PhysicsManagerAttributes;
-using Attrs::SceneAttributes;
+using Attrs::SceneInstanceAttributes;
 using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
 
@@ -208,7 +208,8 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
       nullptr;
   AttrMgrs::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
   AttrMgrs::PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
-  AttrMgrs::SceneAttributesManager::ptr sceneAttributesManager_ = nullptr;
+  AttrMgrs::SceneInstanceAttributesManager::ptr
+      sceneInstanceAttributesManager_ = nullptr;
   AttrMgrs::StageAttributesManager::ptr stageAttributesManager_ = nullptr;
 
 };  // struct AttributesManagersTest
@@ -222,7 +223,7 @@ AttributesManagersTest::AttributesManagersTest() {
   lightLayoutAttributesManager_ = MM->getLightLayoutAttributesManager();
   objectAttributesManager_ = MM->getObjectAttributesManager();
   physicsAttributesManager_ = MM->getPhysicsAttributesManager();
-  sceneAttributesManager_ = MM->getSceneAttributesManager();
+  sceneInstanceAttributesManager_ = MM->getSceneInstanceAttributesManager();
   stageAttributesManager_ = MM->getStageAttributesManager();
 
   addTests({

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -80,7 +80,7 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
    * @param handle the handle of the attributes to remove
    */
   template <typename T>
-  void testRemoveAttributesBuiltJSONString(
+  void testRemoveAttributesBuiltByJSONString(
       std::shared_ptr<T> mgr,
       const std::string& tmpltName = "new_template_from_json");
 
@@ -126,8 +126,7 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
    * that registration won't fail.
    */
 
-  // ignore for physics attributes
-
+  // specialization so we can ignore this for physics attributes
   void processTemplateRenderAsset(
       std::shared_ptr<AttrMgrs::PhysicsAttributesManager> mgr,
       std::shared_ptr<Attrs::PhysicsManagerAttributes> newAttrTemplate0,
@@ -284,7 +283,7 @@ std::shared_ptr<U> AttributesManagersTest::testBuildAttributesFromJSONString(
 }  // testBuildAttributesFromJSONString
 
 template <typename T>
-void AttributesManagersTest::testRemoveAttributesBuiltJSONString(
+void AttributesManagersTest::testRemoveAttributesBuiltByJSONString(
     std::shared_ptr<T> mgr,
     const std::string& tmpltName) {
   if (mgr->getObjectLibHasHandle(tmpltName)) {
@@ -686,8 +685,8 @@ void AttributesManagersTest::testPhysicsAttrVals(
                             Magnum::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f));
   // remove added template
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltJSONString(physicsAttributesManager_,
-                                      physMgrAttr->getHandle());
+  testRemoveAttributesBuiltByJSONString(physicsAttributesManager_,
+                                        physMgrAttr->getHandle());
 }
 
 void AttributesManagersTest::testPhysicsJSONLoad() {
@@ -803,8 +802,8 @@ void AttributesManagersTest::testLightAttrVals(
                             Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
 
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltJSONString(lightLayoutAttributesManager_,
-                                      lightLayoutAttr->getHandle());
+  testRemoveAttributesBuiltByJSONString(lightLayoutAttributesManager_,
+                                        lightLayoutAttr->getHandle());
 }
 void AttributesManagersTest::testLightJSONLoad() {
   // build JSON sample config
@@ -1028,8 +1027,8 @@ void AttributesManagersTest::testSceneInstanceAttrVals(
                             Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
 
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltJSONString(sceneAttributesManager_,
-                                      sceneAttr->getHandle());
+  testRemoveAttributesBuiltByJSONString(sceneAttributesManager_,
+                                        sceneAttr->getHandle());
 }
 
 void AttributesManagersTest::testSceneInstanceJSONLoad() {
@@ -1171,7 +1170,7 @@ void AttributesManagersTest::testSceneInstanceJSONLoad() {
   // testSceneInstanceAttrVals(sceneAttr2);
   // ESP_DEBUG() << "Tested saved sceneAttr2 :";
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  // Cr::Utility::Directory::rm(newAttrName);
 
 }  // AttributesManagers_SceneInstanceJSONLoadTest
 
@@ -1209,8 +1208,8 @@ void AttributesManagersTest::testStageAttrVals(
                             Magnum::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f));
 
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltJSONString(stageAttributesManager_,
-                                      stageAttr->getHandle());
+  testRemoveAttributesBuiltByJSONString(stageAttributesManager_,
+                                        stageAttr->getHandle());
 }  // AttributesManagersTest::testStageAttrVals
 void AttributesManagersTest::testStageJSONLoad() {
   // build JSON sample config
@@ -1326,8 +1325,8 @@ void AttributesManagersTest::testObjectAttrVals(
                             Magnum::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f));
 
   // remove json-string built attributes added for test
-  testRemoveAttributesBuiltJSONString(objectAttributesManager_,
-                                      objAttr->getHandle());
+  testRemoveAttributesBuiltByJSONString(objectAttributesManager_,
+                                        objAttr->getHandle());
 
 }  // AttributesManagersTest::testObjectAttrVals
 

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -13,13 +13,10 @@
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"
 
-#include "esp/physics/RigidBase.h"
-
 #include "configure.h"
 
 namespace Cr = Corrade;
 
-using Magnum::Math::Literals::operator""_radf;
 namespace AttrMgrs = esp::metadata::managers;
 namespace Attrs = esp::metadata::attributes;
 
@@ -46,43 +43,12 @@ const std::string physicsConfigFile =
     Cr::Utility::Directory::join(DATA_DIR,
                                  "test_assets/testing.physics_config.json");
 
-// base directory to save test attributes
-const std::string testAttrSaveDir =
-    Cr::Utility::Directory::join(DATA_DIR, "test_assets");
-
+/**
+ * @brief Test attributesManagers' functionality via loading, creating, copying
+ * and deleting Attributes.
+ */
 struct AttributesManagersTest : Cr::TestSuite::Tester {
   explicit AttributesManagersTest();
-
-  // Test helper functions
-
-  /**
-   * @brief Test saving and loading from JSON string
-   * @tparam T Class of attributes manager
-   * @tparam U Class of attributes
-   * @param mgr the Attributes Manager being tested
-   * @param jsonString the json to build the template from
-   * @param registerObject whether or not to register the Attributes constructed
-   * by the passed JSON string.
-   * @param tmpltName The name to give the template
-   * @return attributes template built from JSON parsed from string
-   */
-  template <typename T, typename U>
-  std::shared_ptr<U> testBuildAttributesFromJSONString(
-      std::shared_ptr<T> mgr,
-      const std::string& jsonString,
-      const bool registerObject,
-      const std::string& tmpltName = "new_template_from_json");
-
-  /**
-   * @brief remove added template built from JSON string.
-   * @param tmpltName name of template to remove.
-   * @param mgr the Attributes Manager being tested
-   * @param handle the handle of the attributes to remove
-   */
-  template <typename T>
-  void testRemoveAttributesBuiltByJSONString(
-      std::shared_ptr<T> mgr,
-      const std::string& tmpltName = "new_template_from_json");
 
   /**
    * @brief Test creation, copying and removal of templates for Object,
@@ -100,7 +66,6 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
    * @param mgr the Attributes Manager being tested,
    * @param handle the handle of the desired attributes template to work with
    */
-
   void testCreateAndRemoveLights(
       AttrMgrs::LightLayoutAttributesManager::ptr mgr,
       const std::string& handle);
@@ -189,32 +154,50 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
   void testAssetAttributesTemplateCreateFromHandle(
       const std::string& newTemplateName);
 
-  void testPhysicsAttrVals(
-      std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
-          physMgrAttr);
-  void testLightAttrVals(
-      std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
-          lightLayoutAttr);
-  void testSceneInstanceAttrVals(
-      std::shared_ptr<esp::metadata::attributes::SceneAttributes>
-          sceneInstAttr);
-  void testStageAttrVals(
-      std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
-      const std::string& assetPath);
-  void testObjectAttrVals(
-      std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
-      const std::string& assetPath);
-
-  // actual test functions
-  void testPhysicsJSONLoad();
-  void testLightJSONLoad();
-  void testSceneInstanceJSONLoad();
-  void testStageJSONLoad();
-  void testObjectJSONLoad();
+  /**
+   * @brief This test will test creating, modifying, registering and deleting
+   * Attributes via the AttributesManager for PhysicsManagerAttributes. These
+   * tests should be consistent with most types of future attributes managers
+   * specializing the AttributesManager class template that follow the same
+   * expected behavior paths as extent attributes/attributesManagers.  Note :
+   * PrimitiveAssetAttributes exhibit slightly different behavior and need their
+   * own tests.
+   */
   void testPhysicsAttributesManagersCreate();
+
+  /**
+   * @brief This test will test creating, modifying, registering and deleting
+   * Attributes via the AttributesManager for StageAttributes.  These
+   * tests should be consistent with most types of future attributes managers
+   * specializing the AttributesManager class template that follow the same
+   * expected behavior paths as extent attributes/attributesManagers.  Note :
+   * PrimitiveAssetAttributes exhibit slightly different behavior and need their
+   * own tests.
+   */
   void testStageAttributesManagersCreate();
+
+  /**
+   * @brief This test will test creating, modifying, registering and deleting
+   * Attributes via the AttributesManager for ObjectAttributes.  These
+   * tests should be consistent with most types of future attributes managers
+   * specializing the AttributesManager class template that follow the same
+   * expected behavior paths as extent attributes/attributesManagers.  Note :
+   * PrimitiveAssetAttributes exhibit slightly different behavior and need their
+   * own tests.
+   */
   void testObjectAttributesManagersCreate();
+
+  /**
+   * @brief This test will test creating, modifying, registering and deleting
+   * Attributes via the AttributesManager for LightLayoutsAttributes
+   */
   void testLightLayoutAttributesManager();
+
+  /**
+   * @brief test primitive asset attributes functionality in attirbutes
+   * managers. This includes testing handle auto-gen when relevant fields in
+   * asset attributes are changed.
+   */
   void testPrimitiveAssetAttributes();
 
   // test member vars
@@ -243,52 +226,12 @@ AttributesManagersTest::AttributesManagersTest() {
   stageAttributesManager_ = MM->getStageAttributesManager();
 
   addTests({
-      &AttributesManagersTest::testPhysicsJSONLoad,
-      &AttributesManagersTest::testLightJSONLoad,
-      &AttributesManagersTest::testSceneInstanceJSONLoad,
-      &AttributesManagersTest::testStageJSONLoad,
-      &AttributesManagersTest::testObjectJSONLoad,
       &AttributesManagersTest::testPhysicsAttributesManagersCreate,
       &AttributesManagersTest::testStageAttributesManagersCreate,
       &AttributesManagersTest::testObjectAttributesManagersCreate,
       &AttributesManagersTest::testLightLayoutAttributesManager,
       &AttributesManagersTest::testPrimitiveAssetAttributes,
   });
-}
-
-template <typename T, typename U>
-std::shared_ptr<U> AttributesManagersTest::testBuildAttributesFromJSONString(
-    std::shared_ptr<T> mgr,
-    const std::string& jsonString,
-    const bool registerObject,
-    const std::string& tmpltName) {  // create JSON document
-  try {
-    esp::io::JsonDocument tmp = esp::io::parseJsonString(jsonString);
-    // io::JsonGenericValue :
-    const esp::io::JsonGenericValue jsonDoc = tmp.GetObject();
-    // create an new template from jsonDoc
-    std::shared_ptr<U> attrTemplate1 =
-        mgr->buildManagedObjectFromDoc(tmpltName, jsonDoc);
-
-    // register attributes
-    if (registerObject) {
-      mgr->registerObject(attrTemplate1);
-    }
-    return attrTemplate1;
-  } catch (...) {
-    CORRADE_FAIL_IF(true, "testBuildAttributesFromJSONString : Failed to parse"
-                              << jsonString << "as JSON.");
-    return nullptr;
-  }
-}  // testBuildAttributesFromJSONString
-
-template <typename T>
-void AttributesManagersTest::testRemoveAttributesBuiltByJSONString(
-    std::shared_ptr<T> mgr,
-    const std::string& tmpltName) {
-  if (mgr->getObjectLibHasHandle(tmpltName)) {
-    mgr->removeObjectByHandle(tmpltName);
-  }
 }
 
 /**
@@ -382,13 +325,6 @@ void AttributesManagersTest::testCreateAndRemove(std::shared_ptr<T> mgr,
   CORRADE_COMPARE(orignNumTemplates, mgr->getNumObjects());
 
 }  // AttributesManagersTest::testCreateAndRemove
-
-/**
- * @brief Test creation, copying and removal of templates for lights
- * attributes managers.
- * @param mgr the Attributes Manager being tested,
- * @param handle the handle of the desired attributes template to work with
- */
 
 void AttributesManagersTest::testCreateAndRemoveLights(
     AttrMgrs::LightLayoutAttributesManager::ptr mgr,
@@ -527,51 +463,6 @@ void AttributesManagersTest::testCreateAndRemoveDefault(
 
 }  // AttributesManagersTest::testCreateAndRemoveDefault
 
-/**
- * @brief This method will test the user-defined configuration values to see
- * that they match with expected passed values.  The config is expected to
- * hold one of each type that it supports.
- * @param userConfig The configuration object whose contents are to be
- * tested
- * @param str_val Expected string value
- * @param bool_val Expected boolean value
- * @param double_val Exptected double value
- * @param vec_val Expected Magnum::Vector3 value
- * @param quat_val Expected Quaternion value - note that the JSON is read
- * with scalar at idx 0, whereas the quaternion constructor takes the vector
- * component in the first position and the scalar in the second.
- */
-void AttributesManagersTest::testUserDefinedConfigVals(
-    std::shared_ptr<esp::core::config::Configuration> userConfig,
-    const std::string& str_val,
-    bool bool_val,
-    int int_val,
-    double double_val,
-    Magnum::Vector3 vec_val,
-    Magnum::Quaternion quat_val) {
-  // user defined attributes from light instance
-  CORRADE_VERIFY(userConfig);
-  CORRADE_COMPARE(userConfig->get<std::string>("user_string"), str_val);
-  CORRADE_COMPARE(userConfig->get<bool>("user_bool"), bool_val);
-  CORRADE_COMPARE(userConfig->get<int>("user_int"), int_val);
-  CORRADE_COMPARE(userConfig->get<double>("user_double"), double_val);
-  CORRADE_COMPARE(userConfig->get<Magnum::Vector3>("user_vec3"), vec_val);
-  CORRADE_COMPARE(userConfig->get<Magnum::Quaternion>("user_quat"), quat_val);
-
-}  // AttributesManagersTest::testUserDefinedConfigVals
-
-/**
- * @brief Test creation, copying and removal of templates for primitive
- * assets.
- * @tparam Class of attributes being managed
- * @param defaultAttribs the default template of the passed type T
- * @param ctorModField the name of the modified field of type @ref U that
- * impacts the constructor.
- * @param legalVal a legal value of ctorModField; This should be different
- * than template default for @ref ctorModField.
- * @param illegalVal a legal value of ctorModField.  If null ptr then no
- * illegal values possible.
- */
 template <typename T>
 void AttributesManagersTest::testAssetAttributesModRegRemove(
     std::shared_ptr<T> defaultAttribs,
@@ -661,760 +552,6 @@ void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
 
 }  // AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle
 
-/////////////  Begin JSON String-based tests
-
-/**
- * @brief This test will verify that the physics attributes' managers' JSON
- * loading process is working as expected.
- */
-
-void AttributesManagersTest::testPhysicsAttrVals(
-    std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
-        physMgrAttr) {
-  // match values set in test JSON
-
-  CORRADE_COMPARE(physMgrAttr->getGravity(), Magnum::Vector3(1, 2, 3));
-  CORRADE_COMPARE(physMgrAttr->getTimestep(), 1.0);
-  CORRADE_COMPARE(physMgrAttr->getSimulator(), "bullet_test");
-  CORRADE_COMPARE(physMgrAttr->getFrictionCoefficient(), 1.4);
-  CORRADE_COMPARE(physMgrAttr->getRestitutionCoefficient(), 1.1);
-  // test physics manager attributes-level user config vals
-  testUserDefinedConfigVals(physMgrAttr->getUserConfiguration(),
-                            "pm defined string", true, 15, 12.6,
-                            Magnum::Vector3(215.4, 217.6, 2110.1),
-                            Magnum::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f));
-  // remove added template
-  // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(physicsAttributesManager_,
-                                        physMgrAttr->getHandle());
-}
-
-void AttributesManagersTest::testPhysicsJSONLoad() {
-  // build JSON sample config
-  // add dummy test so that test will run
-  CORRADE_VERIFY(true);
-  const std::string& jsonString = R"({
-  "physics_simulator": "bullet_test",
-  "timestep": 1.0,
-  "gravity": [1,2,3],
-  "friction_coefficient": 1.4,
-  "restitution_coefficient": 1.1,
-  "user_defined" : {
-      "user_string" : "pm defined string",
-      "user_bool" : true,
-      "user_int" : 15,
-      "user_double" : 12.6,
-      "user_vec3" : [215.4, 217.6, 2110.1],
-      "user_quat" : [0.2, 5.2, 6.2, 7.2]
-  }
-})";
-  auto physMgrAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::PhysicsAttributesManager,
-                                        Attrs::PhysicsManagerAttributes>(
-          physicsAttributesManager_, jsonString, true);
-  // verify exists
-  CORRADE_VERIFY(physMgrAttr);
-
-  // before test, save attributes with new name
-  std::string newAttrName = Cr::Utility::formatString(
-      "{}/testPhysicsAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      physicsAttributesManager_->getJSONTypeExt());
-
-  bool success = physicsAttributesManager_->saveManagedObjectToFile(
-      physMgrAttr->getHandle(), newAttrName);
-
-  ESP_DEBUG() << "About to test string-based physMgrAttr ";
-  // test json string to verify format, this deletes physMgrAttr from registry
-  testPhysicsAttrVals(physMgrAttr);
-  ESP_DEBUG() << "Tested physMgrAttr ";
-
-  physMgrAttr = nullptr;
-
-  // load attributes from new name and retest
-  auto physMgrAttr2 =
-      physicsAttributesManager_->createObjectFromJSONFile(newAttrName, true);
-
-  // verify file-based config exists
-  CORRADE_VERIFY(physMgrAttr2);
-
-  ESP_DEBUG() << "About to test saved physMgrAttr2 :"
-              << physMgrAttr2->getHandle();
-  // test json string to verify format, this deletes physMgrAttr2 from
-  // registry
-  testPhysicsAttrVals(physMgrAttr2);
-  ESP_DEBUG() << "Tested physMgrAttr ";
-
-  // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
-
-}  // AttributesManagers_PhysicsJSONLoadTest
-
-/**
- * @brief This test will verify that the Light Attributes' managers' JSON
- * loading process is working as expected.
- */
-void AttributesManagersTest::testLightAttrVals(
-    std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
-        lightLayoutAttr) {
-  // test light layout attributes-level user config vals
-  testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
-                            "light attribs defined string", true, 23, 2.3,
-                            Magnum::Vector3(1.1, 3.3, 5.5),
-                            Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
-  CORRADE_COMPARE(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
-  CORRADE_COMPARE(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
-  auto lightAttr0 = lightLayoutAttr->getLightInstance("test0");
-  // verify that lightAttr0 exists
-  CORRADE_VERIFY(lightAttr0);
-
-  // match values set in test JSON
-
-  CORRADE_COMPARE(lightAttr0->getDirection(), Magnum::Vector3(1.0, -1.0, 1.0));
-  CORRADE_COMPARE(lightAttr0->getColor(), Magnum::Vector3(0.6, 0.7, 0.8));
-
-  CORRADE_COMPARE(lightAttr0->getIntensity(), -0.1);
-  CORRADE_COMPARE(static_cast<int>(lightAttr0->getType()),
-                  static_cast<int>(esp::gfx::LightType::Directional));
-  CORRADE_COMPARE(static_cast<int>(lightAttr0->getPositionModel()),
-                  static_cast<int>(esp::gfx::LightPositionModel::Camera));
-  CORRADE_COMPARE(lightAttr0->getInnerConeAngle(), 0.25_radf);
-  CORRADE_COMPARE(lightAttr0->getOuterConeAngle(), -1.57_radf);
-
-  auto lightAttr1 = lightLayoutAttr->getLightInstance("test1");
-  // verify that lightAttr1 exists
-  CORRADE_VERIFY(lightAttr1);
-
-  CORRADE_COMPARE(lightAttr1->getPosition(), Magnum::Vector3(2.5, 0.1, 3.8));
-  CORRADE_COMPARE(lightAttr1->getColor(), Magnum::Vector3(0.5, 0.3, 0.1));
-
-  CORRADE_COMPARE(lightAttr1->getIntensity(), -1.2);
-  CORRADE_COMPARE(static_cast<int>(lightAttr1->getType()),
-                  static_cast<int>(esp::gfx::LightType::Point));
-  CORRADE_COMPARE(static_cast<int>(lightAttr1->getPositionModel()),
-                  static_cast<int>(esp::gfx::LightPositionModel::Global));
-  CORRADE_COMPARE(lightAttr1->getInnerConeAngle(), -0.75_radf);
-  CORRADE_COMPARE(lightAttr1->getOuterConeAngle(), -1.7_radf);
-
-  // test user defined attributes from light instance
-  testUserDefinedConfigVals(lightAttr1->getUserConfiguration(),
-                            "light instance defined string", false, 42, 1.2,
-                            Magnum::Vector3(0.1, 2.3, 4.5),
-                            Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
-
-  // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(lightLayoutAttributesManager_,
-                                        lightLayoutAttr->getHandle());
-}
-void AttributesManagersTest::testLightJSONLoad() {
-  // build JSON sample config
-  const std::string& jsonString = R"({
-  "lights":{
-      "test0":{
-        "direction": [1.0,-1.0,1.0],
-        "intensity": -0.1,
-        "color": [0.6,0.7,0.8],
-        "type": "directional",
-        "position_model" : "camera",
-        "spot": {
-          "innerConeAngle": 0.25,
-          "outerConeAngle": -1.57
-        }
-      },
-      "test1":{
-        "position": [2.5,0.1,3.8],
-        "intensity": -1.2,
-        "color": [0.5,0.3,0.1],
-        "type": "point",
-        "position_model" : "global",
-        "spot": {
-          "innerConeAngle": -0.75,
-          "outerConeAngle": -1.7
-        },
-        "user_defined" : {
-            "user_string" : "light instance defined string",
-            "user_bool" : false,
-            "user_int" : 42,
-            "user_double" : 1.2,
-            "user_vec3" : [0.1, 2.3, 4.5],
-            "user_quat" : [0.1, 0.2, 0.3, 0.4]
-        }
-      }
-    },
-    "user_defined" : {
-        "user_string" : "light attribs defined string",
-        "user_bool" : true,
-        "user_int" : 23,
-        "user_double" : 2.3,
-        "user_vec3" : [1.1, 3.3, 5.5],
-        "user_quat" : [0.5, 0.6, 0.7, 0.8]
-    },
-    "positive_intensity_scale" : 2.0,
-    "negative_intensity_scale" : 1.5
-  })";
-
-  auto lightLayoutAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::LightLayoutAttributesManager,
-                                        Attrs::LightLayoutAttributes>(
-          lightLayoutAttributesManager_, jsonString, true);
-  // verify exists
-  CORRADE_VERIFY(lightLayoutAttr);
-  // before test, save attributes with new name
-  std::string newAttrName = Cr::Utility::formatString(
-      "{}/testLightLayoutAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      lightLayoutAttributesManager_->getJSONTypeExt());
-
-  bool success = lightLayoutAttributesManager_->saveManagedObjectToFile(
-      lightLayoutAttr->getHandle(), newAttrName);
-
-  ESP_DEBUG() << "About to test string-based lightLayoutAttr";
-  // test json string to verify format
-  testLightAttrVals(lightLayoutAttr);
-  ESP_DEBUG() << "Tested lightLayoutAttr";
-  lightLayoutAttr = nullptr;
-
-  // load attributes from new name and retest
-  auto lightLayoutAttr2 =
-      lightLayoutAttributesManager_->createObjectFromJSONFile(newAttrName);
-
-  // verify file-based config exists
-  CORRADE_VERIFY(lightLayoutAttr2);
-
-  // test json string to verify format, this deletes lightLayoutAttr2 from
-  // registry
-  ESP_DEBUG() << "About to test saved lightLayoutAttr2 :"
-              << lightLayoutAttr2->getHandle();
-  testLightAttrVals(lightLayoutAttr2);
-  ESP_DEBUG() << "About to test lightLayoutAttr2";
-
-  // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
-
-}  // AttributesManagers_LightJSONLoadTest
-
-/**
- * @brief This test will verify that the Scene Instance attributes' managers'
- * JSON loading process is working as expected.
- */
-
-void AttributesManagersTest::testSceneInstanceAttrVals(
-    std::shared_ptr<esp::metadata::attributes::SceneAttributes> sceneAttr) {
-  // match values set in test JSON
-  CORRADE_COMPARE(
-      static_cast<int>(sceneAttr->getTranslationOrigin()),
-      static_cast<int>(Attrs::SceneInstanceTranslationOrigin::AssetLocal));
-
-  CORRADE_COMPARE(sceneAttr->getLightingHandle(),
-                  "test_lighting_configuration");
-  CORRADE_COMPARE(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
-  CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
-                  "test_semantic_descriptor_path1");
-  // test scene instance attributes-level user config vals
-  testUserDefinedConfigVals(sceneAttr->getUserConfiguration(),
-                            "scene instance defined string", true, 99, 9.1,
-                            Magnum::Vector3(12.3, 32.5, 25.07),
-                            Magnum::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f));
-
-  // verify stage populated properly
-  auto stageInstance = sceneAttr->getStageInstance();
-  CORRADE_COMPARE(stageInstance->getHandle(), "test_stage_template");
-  CORRADE_COMPARE(stageInstance->getTranslation(), Magnum::Vector3(1, 2, 3));
-  CORRADE_COMPARE(stageInstance->getRotation(),
-                  Magnum::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f));
-  // test stage instance attributes-level user config vals
-  testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
-                            "stage instance defined string", true, 11, 2.2,
-                            Magnum::Vector3(1.2, 3.4, 5.6),
-                            Magnum::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f));
-  // make sure that is not default value "flat"
-  CORRADE_COMPARE(static_cast<int>(stageInstance->getShaderType()),
-                  static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
-
-  // verify objects
-  auto objectInstanceList = sceneAttr->getObjectInstances();
-  CORRADE_COMPARE(objectInstanceList.size(), 2);
-  auto objInstance = objectInstanceList[0];
-  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template0");
-  CORRADE_COMPARE(static_cast<int>(objInstance->getTranslationOrigin()),
-                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
-  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, 1, 2));
-  CORRADE_COMPARE(objInstance->getRotation(),
-                  Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
-  CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
-                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
-
-  // test object 0 instance attributes-level user config vals
-  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
-                            "obj0 instance defined string", false, 12, 2.3,
-                            Magnum::Vector3(1.3, 3.5, 5.7),
-                            Magnum::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f));
-
-  objInstance = objectInstanceList[1];
-  CORRADE_COMPARE(objInstance->getHandle(), "test_object_template1");
-  CORRADE_COMPARE(objInstance->getTranslation(), Magnum::Vector3(0, -1, -2));
-  CORRADE_COMPARE(objInstance->getRotation(),
-                  Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
-  CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
-                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
-
-  // test object 0 instance attributes-level user config vals
-  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
-                            "obj1 instance defined string", false, 1, 1.1,
-                            Magnum::Vector3(10.3, 30.5, -5.07),
-                            Magnum::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f));
-
-  // verify articulated object instances
-  auto artObjInstances = sceneAttr->getArticulatedObjectInstances();
-  CORRADE_COMPARE(artObjInstances.size(), 2);
-  auto artObjInstance = artObjInstances[0];
-  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template0");
-  CORRADE_COMPARE(static_cast<int>(artObjInstance->getTranslationOrigin()),
-                  static_cast<int>(Attrs::SceneInstanceTranslationOrigin::COM));
-  CORRADE_COMPARE(artObjInstance->getFixedBase(), false);
-  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
-
-  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(5, 4, 5));
-  CORRADE_COMPARE(static_cast<int>(artObjInstance->getMotionType()),
-                  static_cast<int>(esp::physics::MotionType::DYNAMIC));
-  // verify init join pose
-  const auto& initJointPoseMap = artObjInstance->getInitJointPose();
-  const std::vector<float> jtPoseVals{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
-  int idx = 0;
-  for (std::map<std::string, float>::const_iterator iter =
-           initJointPoseMap.begin();
-       iter != initJointPoseMap.end(); ++iter) {
-    CORRADE_COMPARE(iter->second, jtPoseVals[idx++]);
-  }
-  // verify init joint vels
-  const auto& initJoinVelMap = artObjInstance->getInitJointVelocities();
-  const std::vector<float> jtVelVals{1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6};
-  idx = 0;
-  for (std::map<std::string, float>::const_iterator iter =
-           initJoinVelMap.begin();
-       iter != initJoinVelMap.end(); ++iter) {
-    CORRADE_COMPARE(iter->second, jtVelVals[idx++]);
-  }
-
-  // test test_urdf_template0 ao instance attributes-level user config vals
-  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
-                            "test_urdf_template0 instance defined string",
-                            false, 2, 1.22,
-                            Magnum::Vector3(120.3f, 302.5f, -25.07f),
-                            Magnum::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f));
-
-  // test nested configuration
-  auto artObjNestedConfig =
-      artObjInstance->getUserConfiguration()
-          ->getSubconfigCopy<esp::core::config::Configuration>("user_def_obj");
-  CORRADE_VERIFY(artObjNestedConfig);
-  CORRADE_VERIFY(artObjNestedConfig->getNumEntries() > 0);
-  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("position"),
-                  Magnum::Vector3(0.1f, 0.2f, 0.3f));
-  CORRADE_COMPARE(artObjNestedConfig->template get<Magnum::Vector3>("rotation"),
-                  Magnum::Vector3(0.5f, 0.3f, 0.1f));
-
-  artObjInstance = artObjInstances[1];
-  CORRADE_COMPARE(artObjInstance->getHandle(), "test_urdf_template1");
-  CORRADE_VERIFY(artObjInstance->getFixedBase());
-  CORRADE_VERIFY(artObjInstance->getAutoClampJointLimits());
-  CORRADE_COMPARE(artObjInstance->getTranslation(), Magnum::Vector3(3, 2, 1));
-  CORRADE_COMPARE(static_cast<int>(artObjInstance->getMotionType()),
-                  static_cast<int>(esp::physics::MotionType::KINEMATIC));
-  // test test_urdf_template0 ao instance attributes-level user config vals
-  testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
-                            "test_urdf_template1 instance defined string",
-                            false, 21, 11.22,
-                            Magnum::Vector3(190.3f, 902.5f, -95.07f),
-                            Magnum::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f));
-
-  // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(sceneAttributesManager_,
-                                        sceneAttr->getHandle());
-}
-
-void AttributesManagersTest::testSceneInstanceJSONLoad() {
-  // build JSON sample config
-  const std::string& jsonString = R"({
-  "translation_origin" : "Asset_Local",
-  "stage_instance":{
-      "template_name": "test_stage_template",
-      "translation": [1,2,3],
-      "rotation": [0.1, 0.2, 0.3, 0.4],
-      "shader_type" : "pbr",
-      "user_defined" : {
-          "user_string" : "stage instance defined string",
-          "user_bool" : true,
-          "user_int" : 11,
-          "user_double" : 2.2,
-          "user_vec3" : [1.2, 3.4, 5.6],
-          "user_quat" : [0.4, 0.5, 0.6, 0.7]
-      }
-  },
-  "object_instances": [
-      {
-          "template_name": "test_object_template0",
-          "translation_origin": "COM",
-          "translation": [0,1,2],
-          "rotation": [0.2, 0.3, 0.4, 0.5],
-          "motion_type": "KINEMATIC",
-          "user_defined" : {
-              "user_string" : "obj0 instance defined string",
-              "user_bool" : false,
-              "user_int" : 12,
-              "user_double" : 2.3,
-              "user_vec3" : [1.3, 3.5, 5.7],
-              "user_quat" : [0.3, 0.2, 0.6, 0.1]
-          }
-      },
-      {
-          "template_name": "test_object_template1",
-          "translation": [0,-1,-2],
-          "rotation": [0.5, 0.6, 0.7, 0.8],
-          "motion_type": "DYNAMIC",
-          "user_defined" : {
-              "user_string" : "obj1 instance defined string",
-              "user_bool" : false,
-              "user_int" : 1,
-              "user_double" : 1.1,
-              "user_vec3" : [10.3, 30.5, -5.07],
-              "user_quat" : [1.3, 1.2, 1.6, 1.1]
-          }
-      }
-      ],
-      "articulated_object_instances": [
-          {
-              "template_name": "test_urdf_template0",
-              "translation_origin": "COM",
-              "fixed_base": false,
-              "auto_clamp_joint_limits" : true,
-              "translation": [5,4,5],
-              "rotation": [0.2, 0.3, 0.4, 0.5],
-              "initial_joint_pose": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
-              "initial_joint_velocities": [1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6],
-              "motion_type": "DYNAMIC",
-              "user_defined" : {
-                  "user_string" : "test_urdf_template0 instance defined string",
-                  "user_bool" : false,
-                  "user_int" : 2,
-                  "user_double" : 1.22,
-                  "user_vec3" : [120.3, 302.5, -25.07],
-                  "user_quat" : [1.23, 1.22, 1.26, 1.21],
-                  "user_def_obj" : {
-                      "position" : [0.1, 0.2, 0.3],
-                      "rotation" : [0.5, 0.3, 0.1]
-                  }
-              }
-          },
-          {
-              "template_name": "test_urdf_template1",
-              "fixed_base" : true,
-              "auto_clamp_joint_limits" : true,
-              "translation": [3, 2, 1],
-              "rotation": [0.5, 0.6, 0.7, 0.8],
-              "motion_type": "KINEMATIC",
-              "user_defined" : {
-                  "user_string" : "test_urdf_template1 instance defined string",
-                  "user_bool" : false,
-                  "user_int" : 21,
-                  "user_double" : 11.22,
-                  "user_vec3" : [190.3, 902.5, -95.07],
-                  "user_quat" : [1.25, 9.22, 9.26, 0.21]
-              }
-          }
-      ],
-      "default_lighting":  "test_lighting_configuration",
-      "navmesh_instance": "test_navmesh_path1",
-      "semantic_scene_instance": "test_semantic_descriptor_path1",
-      "user_defined" : {
-          "user_string" : "scene instance defined string",
-          "user_bool" : true,
-          "user_int" : 99,
-          "user_double" : 9.1,
-          "user_vec3" : [12.3, 32.5, 25.07],
-          "user_quat" : [0.3, 3.2, 2.6, 5.1]
-      }
-     })";
-
-  auto sceneAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::SceneAttributesManager,
-                                        Attrs::SceneAttributes>(
-          sceneAttributesManager_, jsonString, true);
-  // verify exists
-  CORRADE_VERIFY(sceneAttr);
-
-  // before test, save attributes with new name
-  std::string newAttrName = Cr::Utility::formatString(
-      "{}/testSceneAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      sceneAttributesManager_->getJSONTypeExt());
-
-  bool success = sceneAttributesManager_->saveManagedObjectToFile(
-      sceneAttr->getHandle(), newAttrName);
-
-  // test json string to verify format - this also deletes sceneAttr from
-  // manager
-  ESP_DEBUG() << "About to test string-based sceneAttr :";
-  testSceneInstanceAttrVals(sceneAttr);
-  ESP_DEBUG() << "Tested string-based sceneAttr :";
-  sceneAttr = nullptr;
-
-  // load attributes from new name and retest
-  auto sceneAttr2 =
-      sceneAttributesManager_->createObjectFromJSONFile(newAttrName);
-
-  // verify file-based config exists
-  CORRADE_VERIFY(sceneAttr2);
-
-  // test json string to verify format, this deletes sceneAttr2 from
-  // registry
-  ESP_DEBUG() << "Not testing integrity of saved Scene Attributes.";
-  // ESP_DEBUG() << "About to test saved sceneAttr2 :";
-  // testSceneInstanceAttrVals(sceneAttr2);
-  // ESP_DEBUG() << "Tested saved sceneAttr2 :";
-  // delete file-based config
-  // Cr::Utility::Directory::rm(newAttrName);
-
-}  // AttributesManagers_SceneInstanceJSONLoadTest
-
-/**
- * @brief This test will verify that the Stage attributes' managers' JSON
- * loading process is working as expected.
- */
-void AttributesManagersTest::testStageAttrVals(
-    std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
-    const std::string& assetPath) {
-  // match values set in test JSON
-  CORRADE_COMPARE(stageAttr->getScale(), Magnum::Vector3(2, 3, 4));
-  CORRADE_COMPARE(stageAttr->getMargin(), 0.9);
-  CORRADE_COMPARE(stageAttr->getFrictionCoefficient(), 0.321);
-  CORRADE_COMPARE(stageAttr->getRestitutionCoefficient(), 0.456);
-  CORRADE_VERIFY(!stageAttr->getForceFlatShading());
-  CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 1.1);
-  CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
-  CORRADE_COMPARE(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
-  CORRADE_COMPARE(stageAttr->getRenderAssetHandle(), assetPath);
-  CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(), assetPath);
-  CORRADE_VERIFY(!stageAttr->getIsCollidable());
-  // stage-specific attributes
-  CORRADE_COMPARE(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
-  // make sure that is not default value "flat"
-  CORRADE_COMPARE(static_cast<int>(stageAttr->getShaderType()),
-                  static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
-  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
-  CORRADE_COMPARE(stageAttr->getSemanticAssetHandle(), assetPath);
-  CORRADE_COMPARE(stageAttr->getNavmeshAssetHandle(), assetPath);
-  // test stage attributes-level user config vals
-  testUserDefinedConfigVals(stageAttr->getUserConfiguration(),
-                            "stage defined string", false, 3, 0.8,
-                            Magnum::Vector3(5.4, 7.6, 10.1),
-                            Magnum::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f));
-
-  // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(stageAttributesManager_,
-                                        stageAttr->getHandle());
-}  // AttributesManagersTest::testStageAttrVals
-void AttributesManagersTest::testStageJSONLoad() {
-  // build JSON sample config
-  const std::string& jsonString =
-      R"({
-        "scale":[2,3,4],
-        "margin": 0.9,
-        "friction_coefficient": 0.321,
-        "restitution_coefficient": 0.456,
-        "force_flat_shading": false,
-        "units_to_meters": 1.1,
-        "up":[2.1, 0, 0],
-        "front":[0, 2.1, 0],
-        "render_asset": "testJSONRenderAsset.glb",
-        "collision_asset": "testJSONCollisionAsset.glb",
-        "is_collidable": false,
-        "gravity": [9,8,7],
-        "origin":[1,2,3],
-        "semantic_asset":"testJSONSemanticAsset.glb",
-        "nav_asset":"testJSONNavMeshAsset.glb",
-        "shader_type" : "material",
-        "user_defined" : {
-            "user_string" : "stage defined string",
-            "user_bool" : false,
-            "user_int" : 3,
-            "user_double" : 0.8,
-            "user_vec3" : [5.4, 7.6, 10.1],
-            "user_quat" : [0.1, 1.5, 2.6, 3.7]
-        }
-      })";
-
-  auto stageAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::StageAttributesManager,
-                                        Attrs::StageAttributes>(
-          stageAttributesManager_, jsonString, false);
-  // verify exists
-  CORRADE_VERIFY(stageAttr);
-  // now need to change the render and collision assets to make sure they are
-  // legal
-  const std::string stageAsset =
-      Cr::Utility::Directory::join(testAttrSaveDir, "scenes/plane.glb");
-
-  stageAttr->setRenderAssetHandle(stageAsset);
-  stageAttr->setCollisionAssetHandle(stageAsset);
-  stageAttr->setSemanticAssetHandle(stageAsset);
-  stageAttr->setNavmeshAssetHandle(stageAsset);
-  // now register so can be saved to disk
-  stageAttributesManager_->registerObject(stageAttr);
-
-  // before test, save attributes with new name
-  std::string newAttrName = Cr::Utility::formatString(
-      "{}/testStageAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      stageAttributesManager_->getJSONTypeExt());
-
-  bool success = stageAttributesManager_->saveManagedObjectToFile(
-      stageAttr->getHandle(), newAttrName);
-
-  // test json string to verify format - this also deletes stageAttr from
-  // manager
-  testStageAttrVals(stageAttr, stageAsset);
-  stageAttr = nullptr;
-
-  // load attributes from new name and retest
-  auto stageAttr2 =
-      stageAttributesManager_->createObjectFromJSONFile(newAttrName);
-
-  // verify file-based config exists
-  CORRADE_VERIFY(stageAttr2);
-
-  // test json string to verify format, this deletes stageAttr2 from
-  // registry
-  testStageAttrVals(stageAttr2, stageAsset);
-
-  // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
-
-}  // AttributesManagers_StageJSONLoadTest
-
-/**
- * @brief This test will verify that the Object attributes' managers' JSON
- * loading process is working as expected.
- */
-
-void AttributesManagersTest::testObjectAttrVals(
-    std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
-    const std::string& assetPath) {
-  // match values set in test JSON
-
-  CORRADE_COMPARE(objAttr->getScale(), Magnum::Vector3(2, 3, 4));
-  CORRADE_COMPARE(objAttr->getMargin(), 0.9);
-  CORRADE_COMPARE(objAttr->getFrictionCoefficient(), 0.321);
-  CORRADE_COMPARE(objAttr->getRestitutionCoefficient(), 0.456);
-  CORRADE_VERIFY(objAttr->getForceFlatShading());
-  CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.1);
-  CORRADE_COMPARE(objAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
-  CORRADE_COMPARE(objAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
-  CORRADE_COMPARE(objAttr->getRenderAssetHandle(), assetPath);
-  CORRADE_COMPARE(objAttr->getCollisionAssetHandle(), assetPath);
-  CORRADE_VERIFY(!objAttr->getIsCollidable());
-  CORRADE_COMPARE(objAttr->getSemanticId(), 7);
-  // object-specific attributes
-  CORRADE_COMPARE(objAttr->getMass(), 9);
-  CORRADE_COMPARE(static_cast<int>(objAttr->getShaderType()),
-                  static_cast<int>(Attrs::ObjectInstanceShaderType::Phong));
-  CORRADE_VERIFY(objAttr->getBoundingBoxCollisions());
-  CORRADE_VERIFY(objAttr->getJoinCollisionMeshes());
-  CORRADE_COMPARE(objAttr->getInertia(), Magnum::Vector3(1.1, 0.9, 0.3));
-  CORRADE_COMPARE(objAttr->getCOM(), Magnum::Vector3(0.1, 0.2, 0.3));
-  // test object attributes-level user config vals
-  testUserDefinedConfigVals(objAttr->getUserConfiguration(),
-                            "object defined string", true, 5, 2.6,
-                            Magnum::Vector3(15.4, 17.6, 110.1),
-                            Magnum::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f));
-
-  // remove json-string built attributes added for test
-  testRemoveAttributesBuiltByJSONString(objectAttributesManager_,
-                                        objAttr->getHandle());
-
-}  // AttributesManagersTest::testObjectAttrVals
-
-void AttributesManagersTest::testObjectJSONLoad() {
-  // build JSON sample config
-  const std::string& jsonString = R"({
-  "scale":[2,3,4],
-  "margin": 0.9,
-  "friction_coefficient": 0.321,
-  "restitution_coefficient": 0.456,
-  "force_flat_shading": true,
-  "units_to_meters": 1.1,
-  "up":[2.1,0,0],
-  "front":[0,2.1,0],
-  "render_asset": "testJSONRenderAsset.glb",
-  "collision_asset": "testJSONCollisionAsset.glb",
-  "is_collidable": false,
-  "mass": 9,
-  "use_bounding_box_for_collision": true,
-  "join_collision_meshes":true,
-  "inertia": [1.1, 0.9, 0.3],
-  "semantic_id" : 7,
-  "COM": [0.1,0.2,0.3],
-  "shader_type" : "phong",
-  "user_defined" : {
-      "user_string" : "object defined string",
-      "user_bool" : true,
-      "user_int" : 5,
-      "user_double" : 2.6,
-      "user_vec3" : [15.4, 17.6, 110.1],
-      "user_quat" : [0.7, 5.5, 6.6, 7.7]
-  }
-})";
-  auto objAttr =
-      testBuildAttributesFromJSONString<AttrMgrs::ObjectAttributesManager,
-                                        Attrs::ObjectAttributes>(
-          objectAttributesManager_, jsonString, false);
-  // verify exists
-  CORRADE_VERIFY(objAttr);
-  // now need to change the render and collision assets to make sure they are
-  // legal
-  const std::string objAsset =
-      Cr::Utility::Directory::join(testAttrSaveDir, "objects/donut.glb");
-
-  objAttr->setRenderAssetHandle(objAsset);
-  objAttr->setCollisionAssetHandle(objAsset);
-  // now register so can be saved to disk
-  objectAttributesManager_->registerObject(objAttr);
-
-  // before test, save attributes with new name
-  std::string newAttrName = Cr::Utility::formatString(
-      "{}/testObjectAttrConfig_saved_JSON.{}", testAttrSaveDir,
-      objectAttributesManager_->getJSONTypeExt());
-
-  bool success = objectAttributesManager_->saveManagedObjectToFile(
-      objAttr->getHandle(), newAttrName);
-
-  // test json string to verify format - this also deletes objAttr from
-  // manager
-  testObjectAttrVals(objAttr, objAsset);
-  objAttr = nullptr;
-
-  // load attributes from new name and retest
-  auto objAttr2 =
-      objectAttributesManager_->createObjectFromJSONFile(newAttrName);
-
-  // verify file-based config exists
-  CORRADE_VERIFY(objAttr2);
-
-  // test json string to verify format, this deletes objAttr2 from
-  // registry
-  testObjectAttrVals(objAttr2, objAsset);
-
-  // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
-
-  // load attributes from new name and retest
-}  // AttributesManagersTest::testObjectJSONLoadTest
-
-/**
- * @brief This test will test creating, modifying, registering and deleting
- * Attributes via Attributes Mangers for PhysicsManagerAttributes. These
- * tests should be consistent with most types of future attributes managers
- * specializing the AttributesManager class template that follow the same
- * expected behavior paths as extent attributes/attributesManagers.  Note :
- * PrimitiveAssetAttributes exhibit slightly different behavior and need their
- * own tests.
- */
 void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
@@ -1428,15 +565,6 @@ void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
       physicsAttributesManager_, physicsConfigFile, false);
 }  // AttributesManagersTest::PhysicsAttributesManagersCreate
 
-/**
- * @brief This test will test creating, modifying, registering and deleting
- * Attributes via Attributes Mangers for StageAttributes.  These
- * tests should be consistent with most types of future attributes managers
- * specializing the AttributesManager class template that follow the same
- * expected behavior paths as extent attributes/attributesManagers.  Note :
- * PrimitiveAssetAttributes exhibit slightly different behavior and need their
- * own tests.
- */
 void AttributesManagersTest::testStageAttributesManagersCreate() {
   std::string stageConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/scenes/simple_room.glb");
@@ -1454,15 +582,6 @@ void AttributesManagersTest::testStageAttributesManagersCreate() {
 
 }  // AttributesManagersTest::StageAttributesManagersCreate
 
-/**
- * @brief This test will test creating, modifying, registering and deleting
- * Attributes via Attributes Mangers for ObjectAttributes.  These
- * tests should be consistent with most types of future attributes managers
- * specializing the AttributesManager class template that follow the same
- * expected behavior paths as extent attributes/attributesManagers.  Note :
- * PrimitiveAssetAttributes exhibit slightly different behavior and need their
- * own tests.
- */
 void AttributesManagersTest::testObjectAttributesManagersCreate() {
   std::string objectConfigFile = Cr::Utility::Directory::join(
       DATA_DIR, "test_assets/objects/chair.object_config.json");
@@ -1517,11 +636,6 @@ void AttributesManagersTest::testLightLayoutAttributesManager() {
 
 }  // AttributesManagersTest::LightLayoutAttributesManagerTest
 
-/**
- * @brief test primitive asset attributes functionality in attirbutes
- * managers. This includes testing handle auto-gen when relevant fields in
- * asset attributes are changed.
- */
 void AttributesManagersTest::testPrimitiveAssetAttributes() {
   /**
    * Primitive asset attributes require slightly different testing since a

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,6 +6,16 @@ configure_file(
 )
 
 corrade_add_test(
+  AttributesConfigsTest
+  AttributesConfigsTest.cpp
+  LIBRARIES
+  core
+  assets
+  metadata
+)
+target_include_directories(AttributesConfigsTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+corrade_add_test(
   AttributesManagersTest
   AttributesManagersTest.cpp
   LIBRARIES

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -317,14 +317,16 @@ void MetadataMediatorTest::testDataset0() {
   // SHOULD NOT BE REFERENCED DIRECTLY IN USER CODE, but rather desired scene
   // instance should be acquired through MM.
   //
-  const auto& sceneAttributesMgr = MM_->getSceneAttributesManager();
+  const auto& sceneInstanceAttributesMgr =
+      MM_->getSceneInstanceAttributesManager();
   // get # of loaded scene attributes.
-  int numSceneHandles = sceneAttributesMgr->getNumObjects();
+  int numSceneHandles = sceneInstanceAttributesMgr->getNumObjects();
   // should be 1
   CORRADE_COMPARE(numSceneHandles, 1);
   // get handle list matching passed handle
-  auto sceneAttrHandles = sceneAttributesMgr->getObjectHandlesBySubstring(
-      "dataset_test_scene", true);
+  auto sceneAttrHandles =
+      sceneInstanceAttributesMgr->getObjectHandlesBySubstring(
+          "dataset_test_scene", true);
   // make sure there is only 1 matching dataset_test_scene
   CORRADE_COMPARE(sceneAttrHandles.size(), 1);
 
@@ -332,8 +334,9 @@ void MetadataMediatorTest::testDataset0() {
   ESP_WARNING() << "testLoadSceneInstances : Scene instance attr handle :"
                 << activeSceneName;
   // get scene instance attributes ref
-  // metadata::attributes::SceneAttributes::cptr curSceneInstanceAttributes =
-  auto sceneAttrs = MM_->getSceneAttributesByName(activeSceneName);
+  // metadata::attributes::SceneInstanceAttributes::cptr
+  // curSceneInstanceAttributes =
+  auto sceneAttrs = MM_->getSceneInstanceAttributesByName(activeSceneName);
   // this should be a scene instance attributes with specific stage and object
   CORRADE_VERIFY(sceneAttrs);
   // verify default value for translation origin
@@ -474,9 +477,10 @@ void MetadataMediatorTest::testDataset1() {
   // SHOULD NOT BE REFERENCED DIRECTLY IN USER CODE, but rather desired scene
   // instance should be acquired through MM.
   //
-  const auto& sceneAttributesMgr = MM_->getSceneAttributesManager();
+  const auto& sceneInstanceAttributesMgr =
+      MM_->getSceneInstanceAttributesManager();
   // get # of loaded scene attributes.
-  int numSceneHandles = sceneAttributesMgr->getNumObjects();
+  int numSceneHandles = sceneInstanceAttributesMgr->getNumObjects();
   // should be 2 - 2 file based
   CORRADE_COMPARE(numSceneHandles, 2);
 


### PR DESCRIPTION
## Motivation and Context
This PR is the first of 2 PRs intended to expand Attributes support, specifically to enable saving SceneInstanceAttributes to JSON correctly.  This PR focuses on some necessary refactoring and cleanup to facilitate the new functionality.

Details of PR functionality : 

- Rename SceneAttributes -> SceneInstanceAttributes
- Split existing AttributesManagersTests  (which was growing very large and unruly) into two test files, AttributesConfigsTests (which is focused on accurately setting Attributes values from a given JSON string, saving to JSON files, and validating reload of saved JSON) and AttributesManagersTests (which is focused on creating, copying, modifying and deleting configs via AttributesManagers functionality).

The work in this PR forms the basis for the 2nd part, which will introduce SceneInstanceAttributes "snapshotting' and saving to JSON.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All local c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
