### PR TITLE
[Bugfix]--Fix CatmullRom Traj off-by-ones; add multiple colorspaces gradient support

### DIFF
--- a/src/esp/geo/Geo.cpp
+++ b/src/esp/geo/Geo.cpp
@@ -144,10 +144,10 @@ void buildCatmullRomTraj4Points(const std::vector<Mn::Vector3>& pts,
   // t values are based on distances between sequential points and type of
   // spline
   float t0 = 0.0f;
-  float t1 = ptKnotVals[stIdx];
-  float t2 = ptKnotVals[stIdx + 1] + t1;
-  float t3 = ptKnotVals[stIdx + 2] + t2;
-  float incr = (t2 - t1) / (1.0f * numInterp);
+  float t1 = ptKnotVals[stIdx + 1];
+  float t2 = ptKnotVals[stIdx + 2] + t1;
+  float t3 = ptKnotVals[stIdx + 3] + t2;
+  float incr = (t2 - t1) / (1.0f * (numInterp - 1));
   for (int i = 0; i < numInterp; ++i) {
     float t = t1 + i * incr;
     // don't allow float error to cause t to go past 3rd interpolated point in
@@ -173,8 +173,11 @@ std::vector<Mn::Vector3> buildCatmullRomTrajOfPoints(
   alpha = clamp(alpha, 0.0f, 1.0f);
   // points in trajectory
   std::vector<Mn::Vector3> trajectory;
+  trajectory.reserve(pts.size() * numInterp);
   std::vector<Mn::Vector3> tmpPoints;
+  tmpPoints.reserve(pts.size() + 2);
   std::vector<float> ptKnotVals;
+  ptKnotVals.reserve(pts.size() + 2);
   // build padded array of points to use to synthesize centripetal catmul-rom
   // trajectory by adding "ghost" point so we start drawing from initial point
   // in trajectory.
@@ -182,8 +185,7 @@ std::vector<Mn::Vector3> buildCatmullRomTrajOfPoints(
   ptKnotVals.emplace_back(calcWeightedDistance(tmpPoints[0], pts[0], alpha));
   for (int i = 0; i < pts.size(); ++i) {
     tmpPoints.emplace_back(pts[i]);
-    ptKnotVals.emplace_back(
-        calcWeightedDistance(tmpPoints[i], tmpPoints[i + 1], alpha));
+    ptKnotVals.emplace_back(calcWeightedDistance(tmpPoints[i], pts[i], alpha));
   }
   // add final ghost point in trajectory
   int lastIdx = pts.size() - 1;

--- a/src/esp/geo/Geo.cpp
+++ b/src/esp/geo/Geo.cpp
@@ -290,19 +290,6 @@ Mn::Trade::MeshData buildTrajectoryTubeSolid(
   const Mn::UnsignedInt numColors = interpColors.size();
   std::vector<Mn::Vector3> trajColors;
 
-  // // temp converter to vector of values in HSV space from RGB color
-  // auto convertClrToHSVArray = [](const Mn::Color3& clr) -> Mn::Vector3 {
-  //   Mn::ColorHsv tmpHsv = Mn::Math::pack<Mn::Color3ub>(clr).toHsv();
-  //   Mn::Vector3 tmpClr(tmpHsv.hue.operator float(), tmpHsv.saturation,
-  //                      tmpHsv.value);
-  //   return tmpClr;
-  // };
-  // // temp converter to RGB color from vector of HSV values
-  // auto convertHSVArrayToColor3ub =
-  //     [](const Mn::Vector3& hsvVec) -> Mn::Color3ub {
-  //   return Mn::Color3ub::fromHsv({Mn::Deg(hsvVec[0]), hsvVec[1], hsvVec[2]});
-  // };
-
   if (numColors == 1) {
     trajColors.reserve(trajSize);
     // with only 1 color, just make duplicates of color for every trajectory

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -18,6 +18,34 @@ namespace Cr = Corrade;
 namespace esp {
 namespace geo {
 
+/**
+ * @brief This enum describes the various colorspaces that colors in Habitat can
+ * occupy.  This is currently governed by the supported color space conversions
+ * built into the Magnum Color types. This is provided for easy user access to
+ * these conversion mechansims.
+ */
+enum class ColorSpace {
+  /**
+   * @brief
+   */
+  RGBA,
+  /**
+   * @brief
+   */
+  sRGBA,
+  /**
+   * @brief HSV represent Hue, Saturation and Value, where the color space is
+   * modeled on a cylinder, hue is an angle, saturation is a radius and value is
+   * measured along the height of the cylinder.
+   */
+  HSV,
+  /**
+   * @brief CIE XYZ, where Y is luminance, and x-z plane describes chromaticity.
+   */
+  XYZ
+
+};
+
 //! global/world up direction
 static const vec3f ESP_UP = vec3f::UnitY();
 //! global/world gravity (down) direction
@@ -120,6 +148,7 @@ std::vector<Mn::Vector3> buildCatmullRomTrajOfPoints(
  * @param smooth Whether to smooth the points or not
  * @param numInterp The number of interpolations between each trajectory
  * point, if smoothing
+ * @param clrSpace The color space to interpolate the given colrs in
  * @return The resultant meshdata for the tube
  */
 Mn::Trade::MeshData buildTrajectoryTubeSolid(
@@ -128,7 +157,8 @@ Mn::Trade::MeshData buildTrajectoryTubeSolid(
     int numSegments,
     float radius,
     bool smooth,
-    int numInterp);
+    int numInterp,
+    ColorSpace clrSpace = ColorSpace::HSV);
 
 template <typename T>
 T clamp(const T& n, const T& low, const T& high) {

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -25,13 +25,7 @@ namespace geo {
  * these conversion mechansims.
  */
 enum class ColorSpace {
-  /**
-   * @brief
-   */
   RGBA,
-  /**
-   * @brief
-   */
   sRGBA,
   /**
    * @brief HSV represent Hue, Saturation and Value, where the color space is


### PR DESCRIPTION
## Motivation and Context
This PR fixes a couple bugs with the CR spline trajectory tube calc.  The precalculated distances to be used as knot values were being accessed off-by-one, and the time interpolant itself was never reaching t2.

This PR also introduces support for other color spaces to traverse for the trajectory gradient.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
