### PR TITLE
[Logging]--Minimize "nospace" directives; add timestamp to log messages

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -578,9 +578,9 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
     // nodeType==OBJECT, and they will be drawn for both RGBD and Semantic
     // sensors.
     if (!(creation.isSemantic() && creation.isRGBD())) {
-      ESP_WARNING() << "unsupported instance creation flags for asset ["
-                    << Mn::Debug::nospace << assetInfo.filepath
-                    << Mn::Debug::nospace << "]";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "unsupported instance creation flags for asset ["
+          << assetInfo.filepath << "]";
       return nullptr;
     }
     sceneID = activeSceneIDs[0];
@@ -589,9 +589,9 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
       if (activeSceneIDs[1] != activeSceneIDs[0]) {
         // Because we have a separate semantic scene graph, we can't support a
         // static instance with both isSemantic and isRGBD.
-        ESP_WARNING()
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
             << "unsupported instance creation flags for asset ["
-            << Mn::Debug::nospace << assetInfo.filepath << Mn::Debug::nospace
+            << assetInfo.filepath
             << "] with "
                "SimulatorConfiguration::forceSeparateSemanticSceneGraph=true.";
         return nullptr;
@@ -601,9 +601,9 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
       if (activeSceneIDs[1] == activeSceneIDs[0]) {
         // A separate semantic scene graph wasn't constructed, so we can't
         // support a Semantic-only (or RGBD-only) instance.
-        ESP_WARNING()
-            << "unsupported instance creation flags for asset ["
-            << Mn::Debug::nospace << assetInfo.filepath << Mn::Debug::nospace
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
+            << "Unsupported instance creation flags for asset ["
+            << assetInfo.filepath
             << "] with "
                "SimulatorConfiguration::forceSeparateSemanticSceneGraph=false.";
         return nullptr;

--- a/src/esp/core/Logging.cpp
+++ b/src/esp/core/Logging.cpp
@@ -6,6 +6,7 @@
 #include "Check.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 
 #include <Corrade/Containers/Array.h>
@@ -132,9 +133,22 @@ Cr::Containers::String buildMessagePrefix(Subsystem subsystem,
                                           const std::string& function,
                                           int line) {
   auto baseFileName = Cr::Utility::Directory::filename(filename);
+
+  const auto timePassed =
+      std::chrono::high_resolution_clock::now().time_since_epoch();
+  const auto timePassedSeconds =
+      std::chrono::duration_cast<std::chrono::seconds>(timePassed);
+  // for micro time
+  const auto nowMicros = std::chrono::duration_cast<std::chrono::microseconds>(
+      timePassed - timePassedSeconds);
+  std::time_t t = std::time_t(timePassedSeconds.count());
+  // format hour,min, second
+  std::tm timeNow = *std::localtime(&t);
+
   return Cr::Utility::formatString(
-      "[{}] {}({})::{} : ", subsystemNames[uint8_t(subsystem)], baseFileName,
-      line, function);
+      "[{:.02d}:{:.02d}:{:.02d}:{:.06d}]:[{}] {}({})::{} : ", timeNow.tm_hour,
+      timeNow.tm_min, timeNow.tm_sec, nowMicros.count(),
+      subsystemNames[uint8_t(subsystem)], baseFileName, line, function);
 }
 
 }  // namespace logging

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -128,10 +128,10 @@ class ManagedContainer : public ManagedContainerBase {
                      const std::string& objectHandle = "",
                      bool forceRegistration = false) {
     if (nullptr == managedObject) {
-      ESP_ERROR() << "<" << Corrade::Utility::Debug::nospace
-                  << this->objectType_ << Corrade::Utility::Debug::nospace
-                  << "> : Invalid (null) managed object passed to "
-                     "registration. Aborting.";
+      ESP_ERROR(Magnum::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : Invalid (null) managed object passed to "
+             "registration. Aborting.";
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
@@ -140,10 +140,10 @@ class ManagedContainer : public ManagedContainerBase {
     }
     std::string handleToSet = managedObject->getHandle();
     if ("" == handleToSet) {
-      ESP_ERROR() << "<" << Corrade::Utility::Debug::nospace
-                  << this->objectType_ << Corrade::Utility::Debug::nospace
-                  << "> : No valid handle specified for" << objectType_
-                  << "managed object to register. Aborting.";
+      ESP_ERROR(Magnum::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : No valid handle specified to register this "
+          << this->objectType_ << " managed object. Aborting.";
       return ID_UNDEFINED;
     }
     return registerObjectFinalize(managedObject, handleToSet,

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -174,10 +174,10 @@ int ManagedContainerBase::getObjectIDByHandleOrNew(
         ->getID();
   }
   if (!getNext) {
-    ESP_ERROR() << "<" << Cr::Utility::Debug::nospace << this->objectType_
-                << Cr::Utility::Debug::nospace << "> : No" << objectType_
-                << "managed object with handle" << objectHandle
-                << "exists. Aborting";
+    ESP_ERROR(Magnum::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : No " << objectType_
+        << " managed object with handle " << objectHandle
+        << " exists. Aborting.";
     return ID_UNDEFINED;
   }
   return getUnusedObjectID();

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -67,10 +67,10 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     std::unique_ptr<io::JsonDocument> docConfig{};
     bool success = this->verifyLoadDocument(filename, docConfig);
     if (!success) {
-      ESP_ERROR() << "<" << Mn::Debug::nospace << this->objectType_
-                  << Mn::Debug::nospace
-                  << "> : Failure reading document as JSON :" << filename
-                  << ". Aborting.";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : Failure reading document as JSON : " << filename
+          << ". Aborting.";
       return nullptr;
     }
     // convert doc to const value
@@ -91,10 +91,10 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   template <typename U>
   ManagedFileIOPtr buildManagedObjectFromDoc(const std::string& filename,
                                              CORRADE_UNUSED const U& config) {
-    ESP_ERROR()
-        << "<" << Mn::Debug::nospace << this->objectType_ << Mn::Debug::nospace
-        << "> : Failure loading attributes from document of unknown type :"
-        << filename << ". Aborting.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_
+        << "> : Failure loading attributes from document :" << filename
+        << " of unknown type :" << typeid(U).name() << ". Aborting.";
   }
   /**
    * @brief Method to load a Managed Object's data from a file.  This is the
@@ -138,7 +138,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
                                bool overwrite) const {
     if (!this->getObjectLibHasHandle(objectHandle)) {
       // Object not found
-      ESP_ERROR()
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << ">::saveManagedObjectToFile : No object exists with handle "
           << objectHandle << " to save as JSON. Aborting.";
@@ -177,7 +177,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
                                const std::string& fullFilename) const {
     if (!this->getObjectLibHasHandle(objectHandle)) {
       // Object not found
-      ESP_ERROR()
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << ">::saveManagedObjectToFile : No object exists with handle "
           << objectHandle << " to save as JSON. Aborting.";
@@ -218,11 +218,11 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
 
     if (!FileUtil::exists(fileDirectory)) {
       // output directory not found
-      ESP_ERROR() << "<" << this->objectType_ << "> : Destination directory "
-                  << fileDirectory << " does not exist to save "
-                  << managedObject->getSimplifiedHandle()
-                  << "object with requested filename" << fileName
-                  << ". Aborting.";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_ << "> : Destination directory "
+          << fileDirectory << " does not exist to save "
+          << managedObject->getSimplifiedHandle()
+          << " object with requested filename :" << fileName << ". Aborting.";
       return false;
     }
 
@@ -280,9 +280,9 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
    */
   bool saveManagedObjectToFileInternal(const ManagedFileIOPtr& managedObject,
                                        const std::string& fullFilename) const {
-    ESP_DEBUG() << "<" << Mn::Debug::nospace << this->objectType_
-                << Mn::Debug::nospace << ">:Attempting to save object named"
-                << managedObject->getHandle() << "to Filename:" << fullFilename;
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : Attempting to save object named "
+        << managedObject->getHandle() << " to Filename: " << fullFilename;
 
     // write AbstractFileBasedManagedObject to JSON file
     // bypassed constructor defaults due to "0 as null" warning they throw
@@ -295,10 +295,10 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     // save to file
     bool success = io::writeJsonToFile(doc, fullFilename, true, 7);
 
-    ESP_DEBUG() << "<" << Mn::Debug::nospace << this->objectType_
-                << Mn::Debug::nospace
-                << ">:Attempt to save to Filename:" << fullFilename << ":"
-                << (success ? "Successful." : "Failed.");
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_
+        << "> : Attempt to save to Filename: " << fullFilename << " : "
+        << (success ? "Successful." : "Failed.");
 
     return success;
   }
@@ -319,9 +319,10 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   bool verifyLoadDocument(const std::string& filename,
                           CORRADE_UNUSED std::unique_ptr<U>& resDoc) {
     // by here always fail - means document type U is unsupported
-    ESP_ERROR() << "<" << Mn::Debug::nospace << this->objectType_
-                << Mn::Debug::nospace << "> : File" << filename
-                << "failed due to unsupported file type :" << typeid(U).name();
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : Load file : " << filename
+        << " failed due to unsupported file type : `" << typeid(U).name()
+        << "`";
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
   /**
@@ -430,15 +431,14 @@ std::string ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt(
       std::string::npos) {
     resHandle = Cr::Utility::Directory::splitExtension(filename).first + "." +
                 fileTypeExt;
-    ESP_VERY_VERBOSE() << "<" << Mn::Debug::nospace << this->objectType_
-                       << Mn::Debug::nospace << "> : Filename :" << filename
-                       << "changed to proposed" << fileTypeExt
-                       << "filename :" << resHandle;
+    ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : Filename :" << filename
+        << " changed to proposed " << fileTypeExt
+        << " filename : " << resHandle;
   } else {
-    ESP_VERY_VERBOSE() << "<" << Mn::Debug::nospace << this->objectType_
-                       << Mn::Debug::nospace << "> : Filename :" << filename
-                       << "contains requested file extension" << fileTypeExt
-                       << "already.";
+    ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : Filename : " << filename
+        << " contains requested file extension " << fileTypeExt << " already.";
   }
   return resHandle;
 }  // ManagedFileBasedContainer<T, Access>::convertFilenameToPassedExt
@@ -451,17 +451,17 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
     try {
       jsonDoc = std::make_unique<io::JsonDocument>(io::parseJsonFile(filename));
     } catch (...) {
-      ESP_ERROR() << "<" << Mn::Debug::nospace << this->objectType_
-                  << Mn::Debug::nospace << "> : Failed to parse" << filename
-                  << "as JSON.";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_ << "> : Failed to parse " << filename
+          << " as JSON.";
       return false;
     }
     return true;
   } else {
     // by here always fail
-    ESP_ERROR() << "<" << Mn::Debug::nospace << this->objectType_
-                << Mn::Debug::nospace << "> : File" << filename
-                << "does not exist";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "<" << this->objectType_ << "> : File " << filename
+        << " does not exist";
     return false;
   }
 }  // ManagedFileBasedContainer<T, Access>::verifyLoadDocument

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -117,8 +117,8 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     const auto& creation = pair.second;
     if (assetInfos_.count(creation.filepath) == 0u) {
       if (failedFilepaths_.count(creation.filepath) == 0u) {
-        ESP_WARNING() << "Missing asset info for [" << Mn::Debug::nospace
-                      << creation.filepath << Mn::Debug::nospace << "]";
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
+            << "Missing asset info for [" << creation.filepath << "]";
         failedFilepaths_.insert(creation.filepath);
       }
       continue;
@@ -128,8 +128,8 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
         assetInfos_[creation.filepath], creation);
     if (!node) {
       if (failedFilepaths_.count(creation.filepath) == 0u) {
-        ESP_WARNING() << "Load failed for asset [" << Mn::Debug::nospace
-                      << creation.filepath << Mn::Debug::nospace << "]";
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
+            << "Load failed for asset [" << creation.filepath << "]";
         failedFilepaths_.insert(creation.filepath);
       }
       continue;

--- a/src/esp/gfx/replay/ReplayManager.cpp
+++ b/src/esp/gfx/replay/ReplayManager.cpp
@@ -13,8 +13,8 @@ std::shared_ptr<Player> ReplayManager::readKeyframesFromFile(
   auto player = std::make_shared<Player>(playerCallback_);
   player->readKeyframesFromFile(filepath);
   if (player->getNumKeyframes() == 0) {
-    ESP_ERROR() << "Failed to load any keyframes from [" << Mn::Debug::nospace
-                << filepath << Mn::Debug::nospace << "]";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Failed to load any keyframes from [" << filepath << "]";
     return nullptr;
   }
   return player;

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -38,16 +38,15 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
   const std::string fullStageName =
       getFullAttrNameFromStr(stageHandle, stageAttributesManager_);
   if (fullStageName == "") {
-    ESP_DEBUG()
-        << infoPrefix << "Stage Attributes '" << Mn::Debug::nospace
-        << stageHandle << Mn::Debug::nospace
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << infoPrefix << "Stage Attributes '" << stageHandle
         << "' specified in Scene Attributes but does not exist in dataset, so "
            "creating.";
     stageAttributesManager_->createObject(stageHandle, true);
   } else {
-    ESP_DEBUG() << infoPrefix << "Stage Attributes '" << Mn::Debug::nospace
-                << stageHandle << Mn::Debug::nospace
-                << "' specified in Scene Attributes exists in dataset library.";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << infoPrefix << "Stage Attributes '" << stageHandle
+        << "' specified in Scene Attributes exists in dataset library.";
   }
 
   // verify each object in sceneInstance exists in SceneDatasetAttributes
@@ -57,15 +56,14 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
     const std::string fullObjHandle =
         getFullAttrNameFromStr(objHandle, objectAttributesManager_);
     if (fullObjHandle == "") {
-      ESP_DEBUG() << infoPrefix << "Object Attributes '" << Mn::Debug::nospace
-                  << objHandle << Mn::Debug::nospace
-                  << "' specified in Scene Attributes but does not exist in "
-                     "dataset, so creating.";
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << infoPrefix << "Object Attributes '" << objHandle
+          << "' specified in Scene Attributes but does not exist in "
+             "dataset, so creating.";
       objectAttributesManager_->createObject(objHandle, true);
     } else {
-      ESP_DEBUG()
-          << infoPrefix << "Object Attributes '" << Mn::Debug::nospace
-          << objHandle << Mn::Debug::nospace
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << infoPrefix << "Object Attributes '" << objHandle
           << "' specified in Scene Attributes exists in dataset library.";
     }
   }
@@ -83,9 +81,8 @@ bool SceneDatasetAttributes::addNewSceneInstanceToDataset(
   const std::string fullLightLayoutAttrName =
       getFullAttrNameFromStr(lightHandle, lightLayoutAttributesManager_);
   if (fullLightLayoutAttrName == "") {
-    ESP_DEBUG()
-        << infoPrefix << "Lighting Layout Attributes '" << Mn::Debug::nospace
-        << lightHandle << Mn::Debug::nospace
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << infoPrefix << "Lighting Layout Attributes '" << lightHandle
         << "' specified in Scene Attributes but does not exist in dataset, so "
            "creating.";
     lightLayoutAttributesManager_->createObject(lightHandle, true);
@@ -133,9 +130,9 @@ std::pair<std::string, std::string> SceneDatasetAttributes::addNewValToMap(
           ss << key << "_" << iter++;
           newKey = ss.str();
         } while (map.count(newKey) > 0);
-        ESP_WARNING()
-            << descString << ": Provided key '" << Mn::Debug::nospace << key
-            << Mn::Debug::nospace
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
+            << descString << " : Provided key '" << key
+
             << "' already references a different value in "
                "map. Modifying key to be"
             << newKey

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -333,13 +333,12 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
       typeVal =
           static_cast<int>(attributes::AssetTypeNamesMap.at(strToLookFor));
     } else {
-      ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
-                    << Magnum::Debug::nospace
-                    << "> : Value in json @ tag :" << jsonMeshTypeTag << ": `"
-                    << tmpVal
-                    << "` does not map to a valid "
-                       "AbstractObjectAttributes::AssetTypeNamesMap value, so "
-                       "defaulting mesh type to AssetType::UNKNOWN.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : Value in json @ tag :" << jsonMeshTypeTag << ": `" << tmpVal
+          << "` does not map to a valid "
+             "AbstractObjectAttributes::AssetTypeNamesMap value, so "
+             "defaulting mesh type to AssetType::UNKNOWN.";
       typeVal = static_cast<int>(esp::assets::AssetType::UNKNOWN);
     }
     // value found so override current value, otherwise do not.

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -107,8 +107,7 @@ AssetAttributesManager::AssetAttributesManager()
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
 
-  ESP_DEBUG() << "Built default "
-                 "primitive asset templates :"
+  ESP_DEBUG() << "Built default primitive asset templates :"
               << std::to_string(defaultPrimAttributeHandles_.size());
 }  // AssetAttributesManager::ctor
 

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -254,9 +254,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
       templateIndices[i] = tmplt->getID();
     }
   }
-  ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-              << Magnum::Debug::nospace << "> : Loaded file-based templates:"
-              << std::to_string(paths.size());
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "<" << this->objectType_
+      << "> : Loaded file-based templates: " << std::to_string(paths.size());
   return templateIndices;
 }  // AttributesManager<T, Access>::loadAllObjectTemplates
 
@@ -272,9 +272,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   // Check if directory
   const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
-    ESP_DEBUG() << "Parsing" << this->objectType_
-                << "library directory: " + path + " for \'" + extType +
-                       "\' files";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Parsing " << this->objectType_
+        << " library directory: " + path + " for \'" + extType + "\' files";
     for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
       std::string absoluteSubfilePath = Dir::join(path, file);
       if (Cr::Utility::String::endsWith(absoluteSubfilePath, extType)) {
@@ -290,11 +290,10 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     if (fileExists) {
       paths.push_back(attributesFilepath);
     } else {  // neither a directory or a file
-      ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
-                    << Magnum::Debug::nospace << "> : Parsing"
-                    << this->objectType_ << ": Cannot find" << path
-                    << "as directory or" << attributesFilepath
-                    << "as config file. Aborting parse.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_ << "> : Parsing" << this->objectType_
+          << ": Cannot find " << path << " as directory or "
+          << attributesFilepath << " as config file. Aborting parse.";
       return templateIndices;
     }  // if fileExists else
   }    // if dirExists else
@@ -330,11 +329,9 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
       ESP_WARNING() << "No Glob path result for" << absolutePath;
     }
   }
-  ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-              << Magnum::Debug::nospace
-              << ">:" << std::to_string(filePaths.Size())
-              << "paths specified in JSON doc for" << this->objectType_
-              << "templates.";
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "<" << this->objectType_ << ">:" << std::to_string(filePaths.Size())
+      << "paths specified in JSON doc for" << this->objectType_ << "templates.";
 }  // AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
 
 template <class T, ManagedObjectAccess Access>
@@ -352,11 +349,11 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   // Check if this configuration file exists and if so use it to build
   // attributes
   bool jsonFileExists = Cr::Utility::Directory::exists(jsonAttrFileName);
-  ESP_DEBUG() << "<" << Magnum::Debug::nospace << this->objectType_
-              << Magnum::Debug::nospace
-              << ">: Proposing JSON name :" << jsonAttrFileName
-              << "from original name :" << filename << "| This file"
-              << (jsonFileExists ? " exists." : " does not exist.");
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "<" << this->objectType_
+      << ">: Proposing JSON name : " << jsonAttrFileName
+      << " from original name : " << filename << "| This file"
+      << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
     attrs = this->createObjectFromJSONFile(jsonAttrFileName, registerObj);
@@ -388,11 +385,11 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
   // check for user defined attributes and verify it is an object
   if (jsonConfig.HasMember("user_defined")) {
     if (!jsonConfig["user_defined"].IsObject()) {
-      ESP_WARNING() << "<" << Magnum::Debug::nospace << this->objectType_
-                    << Magnum::Debug::nospace
-                    << "> :" << attribs->getSimplifiedHandle()
-                    << "attributes specifies user_defined attributes but they "
-                       "are not of the correct format. Skipping.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : " << attribs->getSimplifiedHandle()
+          << " attributes specifies user_defined attributes but they are not "
+             "of the correct format. Skipping.";
       return false;
     } else {
       const std::string subGroupName = "user_defined";

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -28,9 +28,9 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
-    ESP_ERROR() << "No primitive with handle '" << Mn::Debug::nospace
-                << primAttrTemplateHandle << Mn::Debug::nospace
-                << "' exists so cannot build physical object.  Aborting.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "No primitive with handle '" << primAttrTemplateHandle
+        << "' exists so cannot build physical object.  Aborting.";
     return nullptr;
   }
 

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -212,9 +212,8 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
           }
 
           if (pathsWarn) {
-            ESP_WARNING()
-                << "\"" << tag << ".paths[" << Mn::Debug::nospace
-                << pathsWarnType << Mn::Debug::nospace
+            ESP_WARNING(Mn::Debug::Flag::NoSpace)
+                << "\"" << tag << ".paths[" << pathsWarnType
                 << "] cell in JSON config unable to be parsed as an array to "
                    "determine search paths for json configs so skipping.";
           }
@@ -279,7 +278,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
     const U& attrMgr) {
   if (jsonConfig.HasMember(tag)) {
     if (!jsonConfig[tag].IsObject()) {
-      ESP_WARNING()
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "\"" << tag
           << "\" cell in JSON config not appropriately configured. Skipping.";
 
@@ -290,8 +289,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       // specified type.
       if (jCell.HasMember("default_attributes")) {
         if (!jCell["default_attributes"].IsObject()) {
-          ESP_WARNING()
-              << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
+          ESP_WARNING(Mn::Debug::Flag::NoSpace)
+              << "\"" << tag
               << ".default_attributes\" cell in JSON config unable to "
                  "be parsed to set default attributes so skipping.";
         } else {
@@ -306,8 +305,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           } else {
             // set attributes as defaultObject_ in attrMgr.
             attrMgr->setDefaultObject(attr);
-            ESP_WARNING()
-                << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
+            ESP_WARNING(Mn::Debug::Flag::NoSpace)
+                << "\"" << tag
                 << ".default_attributes\" set in Attributes Manager from JSON.";
           }
         }  // if is an object
@@ -318,7 +317,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
       if (jCell.HasMember("paths")) {
         if (!jCell["paths"].IsObject()) {
           ESP_WARNING()
-              << "\"" << Mn::Debug::nospace << tag << Mn::Debug::nospace
+              << "\"" << tag
               << ".paths\" cell in JSON config unable to be parsed as "
                  "a JSON object to determine search paths so skipping.";
         } else {
@@ -345,9 +344,8 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
           }
           // TODO support other extension tags
           if (pathsWarn) {
-            ESP_WARNING()
-                << "\"" << tag << ".paths\"[" << Mn::Debug::nospace
-                << pathsWarnType << Mn::Debug::nospace
+            ESP_WARNING(Mn::Debug::Flag::NoSpace)
+                << "\"" << tag << ".paths\"[" << pathsWarnType
                 << "] cell in JSON config unable to be parsed as an array to "
                    "determine search paths for json configs so skipping.";
           }

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -254,12 +254,11 @@ void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
       // only set value if specified in json
       instanceAttrs->setMotionType(strToLookFor);
     } else {
-      ESP_WARNING()
-          << ": motion_type value in json  : `" << Mn::Debug::nospace << tmpVal
-          << Mn::Debug::nospace << "`|`" << Mn::Debug::nospace << strToLookFor
-          << Mn::Debug::nospace
-          << "` does not map to a valid physics::MotionType value, so "
-             "not setting instance motion type value.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << ": motion_type value in json  : `" << tmpVal << "`|`"
+          << strToLookFor
+          << "` does not map to a valid physics::MotionType value, so not "
+             "setting instance motion type value.";
     }
   }
 
@@ -308,13 +307,12 @@ std::string SceneInstanceAttributesManager::getTranslationOriginVal(
     if (found != attributes::InstanceTranslationOriginMap.end()) {
       transOrigin = std::move(tmpTransOriginVal);
     } else {
-      ESP_WARNING()
-          << ": translation_origin value in json :`" << Mn::Debug::nospace
-          << tmpTransOriginVal << Mn::Debug::nospace << "`|`"
-          << Mn::Debug::nospace << strToLookFor << Mn::Debug::nospace
-          << "` does not map to a valid "
-             "SceneInstanceTranslationOrigin value, so defaulting "
-             "translation origin to SceneInstanceTranslationOrigin::Unknown.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << ": translation_origin value in json :`" << tmpTransOriginVal
+          << "`|`" << strToLookFor
+          << "` does not map to a valid SceneInstanceTranslationOrigin value, "
+             "so defaulting translation origin to "
+             "SceneInstanceTranslationOrigin::Unknown.";
     }
   }
   return transOrigin;

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -134,9 +134,9 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
     bool registerTemplate) {
   // verify that a primitive asset with the given handle exists
   if (!StageAttributesManager::isValidPrimitiveAttributes(primAssetHandle)) {
-    ESP_ERROR() << "No primitive with handle '" << Mn::Debug::nospace
-                << primAssetHandle << Mn::Debug::nospace
-                << "' exists so cannot build physical object.  Aborting.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "No primitive with handle '" << primAssetHandle
+        << "' exists so cannot build physical object.  Aborting.";
     return nullptr;
   }
 

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -102,9 +102,9 @@ class PhysicsObjectBaseManager
       CORRADE_UNUSED bool builtFromConfig) override {
     // construct a new wrapper based on the passed object
     if (managedObjTypeConstructorMap_.count(objectTypeName) == 0) {
-      ESP_ERROR() << "<" << Magnum::Debug::nospace << this->objectType_
-                  << Magnum::Debug::nospace << "> Unknown constructor type"
-                  << objectTypeName << ".  Aborting.";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_ << "> Unknown constructor type"
+          << objectTypeName << ".  Aborting.";
       return nullptr;
     }
     auto newWrapper = (*this.*managedObjTypeConstructorMap_[objectTypeName])();

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -178,9 +178,9 @@ class SemanticScene {
   static bool checkFileExists(const std::string& filename,
                               const std::string& srcFunc) {
     if (!Cr::Utility::Directory::exists(filename)) {
-      ESP_WARNING() << "::" << Magnum::Debug::nospace << srcFunc
-                    << Magnum::Debug::nospace << ": File" << filename
-                    << "does not exist.  Aborting load.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "::" << srcFunc << ": File" << filename
+          << "does not exist.  Aborting load.";
       return false;
     }
     return true;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -242,9 +242,9 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);
     ESP_DEBUG() << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
   } else {
-    ESP_WARNING() << "Navmesh file not found, checked at filename : '"
-                  << Mn::Debug::nospace << navmeshFileLoc << Mn::Debug::nospace
-                  << "'";
+    ESP_WARNING(Mn::Debug::Flag::NoSpace)
+        << "Navmesh file not found, checked at filename : '" << navmeshFileLoc
+        << "'";
   }
   // Calling to seeding needs to be done after the pathfinder creation but
   // before anything else.

--- a/src/tests/LoggingTest.cpp
+++ b/src/tests/LoggingTest.cpp
@@ -52,34 +52,37 @@ struct LoggingTest : Cr::TestSuite::Tester {
 
 constexpr const struct {
   const char* envString;
-  const char* expected;
+  const char* dfltDebug;
+  const char* dfltWarning;
+  const char* simDebug;
+  const char* simWarning;
+  const char* gfxDebug;
+  const char* gfxWarning;
 } EnvVarTestData[]{
-    {nullptr,
-     "[Default] LoggingTest.cpp(99)::envVarTest : DebugDefault\n[Default] "
-     "LoggingTest.cpp(100)::envVarTest : WarningDefault\n"
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
-     "LoggingTest.cpp(26)::warning : WarningSim\n"
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
-     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
-    {"debug",
-     "[Default] LoggingTest.cpp(99)::envVarTest : DebugDefault\n[Default] "
-     "LoggingTest.cpp(100)::envVarTest : WarningDefault\n"
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
-     "LoggingTest.cpp(26)::warning : WarningSim\n"
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
-     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
-    {"quiet", ""},
-    {"error", ""},
-    {"quiet:Sim,Gfx=verbose",
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n[Sim] "
-     "LoggingTest.cpp(26)::warning : WarningSim\n[Gfx] "
-     "LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
-     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
-    {"warning:Gfx=debug",
-     "[Default] LoggingTest.cpp(100)::envVarTest : WarningDefault\n"
-     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n[Gfx] "
-     "LoggingTest.cpp(36)::debug : DebugGfx\n[Gfx] "
-     "LoggingTest.cpp(39)::warning : WarningGfx\n"},
+    {nullptr, "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault",
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault",
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+    {"debug", "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault",
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault",
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+    {"quiet", "", "", "", "", "", ""},
+    {"error", "", "", "", "", "", ""},
+    {"quiet:Sim,Gfx=verbose", "", "",
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+    {"warning:Gfx=debug", "",
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault", "",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
 };  // EnvVarTestData
 
 LoggingTest::LoggingTest() {
@@ -95,18 +98,33 @@ void LoggingTest::envVarTest() {
   std::ostringstream out;
   Cr::Utility::Debug debugCapture{&out};
   Cr::Utility::Warning warnCapture{&out};
+  // use contains to bypass issue with timestamp
 
   ESP_DEBUG() << "DebugDefault";
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.dfltDebug}));
+  out.str("");
   ESP_WARNING() << "WarningDefault";
-
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.dfltWarning}));
+  out.str("");
   esp::sim::test::debug("DebugSim");
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.simDebug}));
+  out.str("");
   esp::sim::test::warning("WarningSim");
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.simWarning}));
+  out.str("");
 
   esp::gfx::test::debug("DebugGfx");
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.gfxDebug}));
+  out.str("");
   esp::gfx::test::warning("WarningGfx");
-
-  CORRADE_COMPARE(Cr::Containers::StringView{out.str()},
-                  Cr::Containers::StringView{data.expected});
+  CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
+      Cr::Containers::StringView{data.gfxWarning}));
+  out.str("");
 }
 
 }  // namespace

--- a/src/tests/LoggingTest.cpp
+++ b/src/tests/LoggingTest.cpp
@@ -52,37 +52,37 @@ struct LoggingTest : Cr::TestSuite::Tester {
 
 constexpr const struct {
   const char* envString;
-  const char* dfltDebug;
-  const char* dfltWarning;
+  const char* defaultDebug;
+  const char* defaultWarning;
   const char* simDebug;
   const char* simWarning;
   const char* gfxDebug;
   const char* gfxWarning;
 } EnvVarTestData[]{
-    {nullptr, "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault",
-     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault",
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
-     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
-     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
-    {"debug", "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault",
-     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault",
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
-     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
-     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+    {nullptr, "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault\n",
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault\n",
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx\n"},
+    {"debug", "[Default] LoggingTest.cpp(103)::envVarTest : DebugDefault\n",
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault\n",
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx\n"},
     {"quiet", "", "", "", "", "", ""},
     {"error", "", "", "", "", "", ""},
     {"quiet:Sim,Gfx=verbose", "", "",
-     "[Sim] LoggingTest.cpp(23)::debug : DebugSim",
-     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
-     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+     "[Sim] LoggingTest.cpp(23)::debug : DebugSim\n",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx\n"},
     {"warning:Gfx=debug", "",
-     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault", "",
-     "[Sim] LoggingTest.cpp(26)::warning : WarningSim",
-     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx",
-     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx"},
+     "[Default] LoggingTest.cpp(107)::envVarTest : WarningDefault\n", "",
+     "[Sim] LoggingTest.cpp(26)::warning : WarningSim\n",
+     "[Gfx] LoggingTest.cpp(36)::debug : DebugGfx\n",
+     "[Gfx] LoggingTest.cpp(39)::warning : WarningGfx\n"},
 };  // EnvVarTestData
 
 LoggingTest::LoggingTest() {
@@ -102,11 +102,11 @@ void LoggingTest::envVarTest() {
 
   ESP_DEBUG() << "DebugDefault";
   CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
-      Cr::Containers::StringView{data.dfltDebug}));
+      Cr::Containers::StringView{data.defaultDebug}));
   out.str("");
   ESP_WARNING() << "WarningDefault";
   CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(
-      Cr::Containers::StringView{data.dfltWarning}));
+      Cr::Containers::StringView{data.defaultWarning}));
   out.str("");
   esp::sim::test::debug("DebugSim");
   CORRADE_VERIFY(Cr::Containers::StringView{out.str()}.contains(


### PR DESCRIPTION
## Motivation and Context
This PR cleans up a lot of the "::nospace" directives in the various log messages - if any message has more than 2 of these, the log macro itself is directed to use the nospace flag instead.

This PR also introduces a timestamp to the log messages, with resolution to microsecond (using std::chrono::high_resolution_clock).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally. Logging c++ test modified to validate output properly while ignoring timestamp.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
