### PR TITLE
[Bugfix/Refactor]--Acquire render context on object removal; Cleanup superfluous add objects

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -264,10 +264,12 @@ int PhysicsManager::addArticulatedObjectInstance(
         const esp::metadata::attributes::SceneAOInstanceAttributes>&
         aObjInstAttributes,
     const std::string& lightSetup) {
-  if (simulator_ != nullptr) {
-    // aquire context if available
-    simulator_->getRenderGLContext();
+  if (simulator_ == nullptr) {
+    return ID_UNDEFINED;
   }
+
+  // aquire context if available
+  simulator_->getRenderGLContext();
   // Get drawables from simulator. TODO: Support non-existent simulator?
   auto& drawables = simulator_->getDrawableGroup();
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -264,6 +264,10 @@ int PhysicsManager::addArticulatedObjectInstance(
         const esp::metadata::attributes::SceneAOInstanceAttributes>&
         aObjInstAttributes,
     const std::string& lightSetup) {
+  if (simulator_ != nullptr) {
+    // aquire context if available
+    simulator_->getRenderGLContext();
+  }
   // Get drawables from simulator. TODO: Support non-existent simulator?
   auto& drawables = simulator_->getDrawableGroup();
 
@@ -436,6 +440,10 @@ void PhysicsManager::removeObject(const int objectId,
 }  // PhysicsManager::removeObject
 
 void PhysicsManager::removeArticulatedObject(int objectId) {
+  if (simulator_ != nullptr) {
+    // aquire context if available
+    simulator_->getRenderGLContext();
+  }
   CORRADE_INTERNAL_ASSERT(existingArticulatedObjects_.count(objectId));
   scene::SceneNode* objectNode =
       &existingArticulatedObjects_.at(objectId)->node();

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -443,6 +443,7 @@ PhysicsManager::getArticulatedObjectWrapper() {
 void PhysicsManager::removeObject(const int objectId,
                                   bool deleteObjectNode,
                                   bool deleteVisualNode) {
+  simulator_->getRenderGLContext();
   assertRigidIdValidity(objectId);
   scene::SceneNode* objectNode = &existingObjects_.at(objectId)->node();
   scene::SceneNode* visualNode = existingObjects_.at(objectId)->visualNode_;

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -312,7 +312,18 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int addObject(const std::string& attributesHandle,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    esp::metadata::attributes::ObjectAttributes::ptr attributes =
+        resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
+            attributesHandle);
+    if (!attributes) {
+      ESP_ERROR() << "Object creation failed due to unknown attributes"
+                  << attributesHandle;
+      return ID_UNDEFINED;
+    }
+    // attributes exist, get drawables if valid simulator accessible
+    return addObjectQueryDrawables(attributes, attachmentNode, lightSetup);
+  }  // PhysicsManager::addObject
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template
@@ -328,64 +339,35 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int addObject(int attributesID,
                 scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
-
-  /** @brief Instance a physical object from an object properties template in
-   * the @ref esp::metadata::managers::ObjectAttributesManager.
-   *
-   * @param attributesHandle The handle of the object attributes used as the key
-   * to query @ref esp::metadata::managers::ObjectAttributesManager.
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
-   * @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
-  int addObject(const std::string& attributesHandle,
-                DrawableGroup* drawables,
-                scene::SceneNode* attachmentNode = nullptr,
-                const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    esp::metadata::attributes::ObjectAttributes::ptr attributes =
-        resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
-            attributesHandle);
-    if (!attributes) {
-      ESP_ERROR() << "Object creation failed due to unknown attributes handle :"
-                  << attributesHandle;
-      return ID_UNDEFINED;
-    }
-
-    return addObject(attributes, drawables, attachmentNode, lightSetup);
-  }  // addObject
-
-  /** @brief Instance a physical object from an object properties template in
-   * the @ref esp::metadata::managers::ObjectAttributesManager by template
-   * ID.
-   * @param attributesID The ID of the object's template in @ref
-   * esp::metadata::managers::ObjectAttributesManager
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
-   * @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
-  int addObject(const int attributesID,
-                DrawableGroup* drawables,
-                scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     const esp::metadata::attributes::ObjectAttributes::ptr attributes =
         resourceManager_.getObjectAttributesManager()->getObjectCopyByID(
             attributesID);
     if (!attributes) {
-      ESP_ERROR() << "Object creation failed due to unknown attributes ID :"
+      ESP_ERROR() << "Object creation failed due to unknown attributes ID"
                   << attributesID;
       return ID_UNDEFINED;
     }
-    return addObject(attributes, drawables, attachmentNode, lightSetup);
-  }  // addObject
+    // attributes exist, get drawables if valid simulator accessible
+    return addObjectQueryDrawables(attributes, attachmentNode, lightSetup);
+  }  // PhysicsManager::addObject
+
+  /** @brief Queries simulator for drawables, if simulator exists, otherwise
+   * passes nullptr, before instancing a physical object from an object
+   * properties template in the @ref
+   * esp::metadata::managers::ObjectAttributesManager by template handle.
+   * @param objectAttributes The object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObjectQueryDrawables(
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager by template

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -127,6 +127,10 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     bool forceReload,
     bool maintainLinkOrder,
     const std::string& lightSetup) {
+  if (simulator_ != nullptr) {
+    // aquire context if available
+    simulator_->getRenderGLContext();
+  }
   ESP_CHECK(
       urdfImporter_->loadURDF(filepath, globalScale, massScale, forceReload),
       "failed to parse/load URDF file" << filepath);

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -123,8 +123,12 @@ struct PhysicsTest : Cr::TestSuite::Tester {
     if (drawables == nullptr) {
       drawables = &sceneManager_->getSceneGraph(sceneID_).getDrawables();
     }
+    auto objAttr =
+        metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
+            objectFile);
+
     int objectId =
-        physicsManager_->addObject(objectFile, drawables, attachmentNode);
+        physicsManager_->addObject(objAttr, drawables, attachmentNode);
 #ifdef ESP_BUILD_WITH_BULLET
     esp::physics::ManagedBulletRigidObject::ptr objectWrapper =
         rigidObjectManager_


### PR DESCRIPTION
## Motivation and Context
This small PR adds the acquisition of the render context when objects are deleted in PhysicsManager, as well as when Articulated Objects are created (necessary now since we no longer pass through Simulator to instantiate these objects).  A few redundant "PhysicsManager::addObject" overloads were also removed.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests locally pass. 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
