### PR TITLE
--Scene Dataset default attributes filename wildcard handling.

### DIFF
--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -16,7 +16,17 @@ namespace asset {
 enum class AssetType;
 }
 namespace metadata {
+/**
+ * @brief A tag to search for in the default_attributes section of the Scene
+ * Dataset JSON configuration files denoting that an implementation of the
+ * attributes should replace this tag with the base filename (minus all paths
+ * and extensions)
+ */
+constexpr char CONFIG_NAME_AS_ASSET_FILENAME[] =
+    "%%CONFIG_NAME_AS_ASSET_FILENAME%%";
+
 namespace attributes {
+
 /**
  * @brief Constant static map to provide mappings from string tags to
  * @ref esp::assets::AssetType values.  This will be used to map values

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -151,7 +151,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
       AbsObjAttrPtr attributes,
       bool setFrame,
       const std::string& assetName,
-      std::function<void(int)> meshTypeSetter) = 0;
+      const std::function<void(int)>& meshTypeSetter) = 0;
 
   // ======== Typedefs and Instance Variables ========
 

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -227,7 +227,7 @@ void AssetAttributesManager::setValsFromJSONDoc(
   // check for user defined attributes
   // this->parseUserDefinedJsonVals(attribs, jsonConfig);
 
-}  // AssetAttributesManager::buildObjectFromJSONDoc
+}  // AssetAttributesManager::setValsFromJSONDoc
 
 }  // namespace managers
 }  // namespace metadata

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -245,6 +245,7 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
   if (nullptr == newAttributes) {
     newAttributes = attributes::LightLayoutAttributes::create(handleName);
   }
+  this->setFileDirectoryFromHandle(newAttributes);
   return newAttributes;
 }  // LightLayoutAttributesManager::initNewObjectInternal
 

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -245,6 +245,7 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
   if (nullptr == newAttributes) {
     newAttributes = attributes::LightLayoutAttributes::create(handleName);
   }
+  // set the attributes source filedirectory, from the attributes name
   this->setFileDirectoryFromHandle(newAttributes);
   return newAttributes;
 }  // LightLayoutAttributesManager::initNewObjectInternal

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -136,13 +136,17 @@ ObjectAttributes::ptr ObjectAttributesManager::initNewObjectInternal(
       this->constructFromDefault(attributesHandle);
   if (nullptr == newAttributes) {
     newAttributes = ObjectAttributes::create(attributesHandle);
+  } else {
+    // default exists and was used to create this attributes - investigate any
+    // filename fields that may have %%USE_FILENAME%% directive specified in the
+    // default attributes.
   }
   this->setFileDirectoryFromHandle(newAttributes);
 
-  // set default render and collision asset handle\
-  // only set handle defaults if attributesHandle is not a config file (which would
-  // never be a valid render or collision asset name).  Otherise, expect handles
-  // and types to be set when config is read.
+  // set default render and collision asset handle
+  // only set handle defaults if attributesHandle is not a config file (which
+  // would never be a valid render or collision asset name).  Otherise, expect
+  // handles and types to be set when config is read.
   if (!builtFromConfig) {
     newAttributes->setRenderAssetHandle(attributesHandle);
     newAttributes->setCollisionAssetHandle(attributesHandle);

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -148,8 +148,12 @@ ObjectAttributes::ptr ObjectAttributesManager::initNewObjectInternal(
   // would never be a valid render or collision asset name).  Otherise, expect
   // handles and types to be set when config is read.
   if (!builtFromConfig) {
-    newAttributes->setRenderAssetHandle(attributesHandle);
-    newAttributes->setCollisionAssetHandle(attributesHandle);
+    if (newAttributes->getRenderAssetHandle().empty()) {
+      newAttributes->setRenderAssetHandle(attributesHandle);
+    }
+    if (newAttributes->getCollisionAssetHandle().empty()) {
+      newAttributes->setCollisionAssetHandle(attributesHandle);
+    }
 
     // set defaults for passed render asset handles
     this->setDefaultAssetNameBasedAttributes(

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -191,7 +191,7 @@ class ObjectAttributesManager
       attributes::ObjectAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
-      std::function<void(int)> assetTypeSetter) override;
+      const std::function<void(int)>& assetTypeSetter) override;
 
   /**
    * @brief Used Internally.  Create and configure newly-created attributes

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -48,7 +48,7 @@ SceneDatasetAttributesManager::initNewObjectInternal(
     newAttributes = SceneDatasetAttributes::create(datasetFilename,
                                                    physicsAttributesManager_);
   }
-  // attempt to set source directory if exists
+  // set the attributes source filedirectory, from the attributes name
   this->setFileDirectoryFromHandle(newAttributes);
 
   // set the handle of the physics manager that is used for this newly-made

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -42,7 +42,7 @@ SceneInstanceAttributesManager::initNewObjectInternal(
   if (nullptr == newAttributes) {
     newAttributes = SceneInstanceAttributes::create(sceneInstanceHandle);
   }
-  // attempt to set source directory if exists
+  // set the attributes source filedirectory, from the attributes name
   this->setFileDirectoryFromHandle(newAttributes);
 
   // any internal default configuration here

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -169,20 +169,45 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
   bool createNewAttributes = (nullptr == newAttributes);
   if (createNewAttributes) {
     newAttributes = StageAttributes::create(attributesHandle);
-  } else {
+  }
+  // set the attributes source filedirectory, from the attributes name
+  this->setFileDirectoryFromHandle(newAttributes);
+
+  if (!createNewAttributes) {
     // default exists and was used to create this attributes - investigate any
     // filename fields that may have %%USE_FILENAME%% directive specified in the
     // default attributes.
-    const std::string baseAttrHandle = newAttributes->getSimplifiedHandle();
-    if (newAttributes->getRenderAssetHandle().find(USE_BASE_FILENAME) !=
-        std::string::npos) {
-      // replace the component of the string containing the tag with the base
-      // filename/handle, and verify it exists. Otherwise, clear it.
-    }
+    // Render asset handle
+    setHandleFromDefaultTag(newAttributes,
+                            newAttributes->getRenderAssetHandle(),
+                            [newAttributes](const std::string& newHandle) {
+                              newAttributes->setRenderAssetHandle(newHandle);
+                            });
+    // Collision asset handle
+    setHandleFromDefaultTag(newAttributes,
+                            newAttributes->getCollisionAssetHandle(),
+                            [newAttributes](const std::string& newHandle) {
+                              newAttributes->setCollisionAssetHandle(newHandle);
+                            });
+    // navmesh asset handle
+    setHandleFromDefaultTag(newAttributes,
+                            newAttributes->getNavmeshAssetHandle(),
+                            [newAttributes](const std::string& newHandle) {
+                              newAttributes->setNavmeshAssetHandle(newHandle);
+                            });
+    // Semantic Scene Descriptor text filehandle
+    setHandleFromDefaultTag(
+        newAttributes, newAttributes->getSemanticDescriptorFilename(),
+        [newAttributes](const std::string& newHandle) {
+          newAttributes->setSemanticDescriptorFilename(newHandle);
+        });
+    // Semantic Scene asset handle
+    setHandleFromDefaultTag(newAttributes,
+                            newAttributes->getSemanticAssetHandle(),
+                            [newAttributes](const std::string& newHandle) {
+                              newAttributes->setSemanticAssetHandle(newHandle);
+                            });
   }
-
-  // attempt to set source directory if exists
-  this->setFileDirectoryFromHandle(newAttributes);
 
   // set defaults that config files or other constructive processes might
   // override
@@ -297,7 +322,7 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
     StageAttributes::ptr attributes,
     bool setFrame,
     const std::string& fileName,
-    std::function<void(int)> assetTypeSetter) {
+    const std::function<void(int)>& assetTypeSetter) {
   // TODO : support future mesh-name specific type setting?
   using Corrade::Utility::String::endsWith;
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -169,16 +169,19 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
   bool createNewAttributes = (nullptr == newAttributes);
   if (createNewAttributes) {
     newAttributes = StageAttributes::create(attributesHandle);
+  } else {
+    // default exists and was used to create this attributes - investigate any
+    // filename fields that may have %%USE_FILENAME%% directive specified in the
+    // default attributes.
   }
+
   // attempt to set source directory if exists
   this->setFileDirectoryFromHandle(newAttributes);
 
   // set defaults that config files or other constructive processes might
   // override
-  newAttributes->setUseMeshCollision(true);
 
-  // set defaults from SimulatorConfig values; these can also be overridden by
-  // json, for example.
+  // set defaults from SimulatorConfig values;
   newAttributes->setLightSetupKey(cfgLightSetup_);
   newAttributes->setForceFlatShading(cfgLightSetup_ == NO_LIGHT_KEY);
   // set value from config so not necessary to be passed as argument

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -112,7 +112,7 @@ class StageAttributesManager
       attributes::StageAttributes::ptr attributes,
       bool setFrame,
       const std::string& meshHandle,
-      std::function<void(int)> assetTypeSetter) override;
+      const std::function<void(int)>& assetTypeSetter) override;
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with
    * any default values, before any specific values are set.


### PR DESCRIPTION
## Motivation and Context
This PR adds support for a wildcard/sentinel value in the name of the render or collision asset for object attributes or stage attributes (or the navmesh, Semantic Scene asset or Semantic Scene Descriptor text file for stages) in the "default_attributes" tag of the Scene Dataset configuration file.  This value, "%%CONFIG_NAME_AS_ASSET_FILENAME%%" will be replaced by the name used to synthesize the attributes upon instantiation, so a stage- or object-specific value can be requested at the Scene Dataset level, in one spot.  Any value synthesized using this tag will be verified to actually exist before it is written (otherwise the field is cleared).   

With datasets like HM3D, where the data is organized such that a scene's assets and other pertinent information is stored in a single directory specific to that scene, this enables fairly complex handling of subordinate assets without individual per-scene stage configurations.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
All c++ and python tests pass.  Verified to work with Appen POC HM3D scene annotations.
## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
