### PR TITLE
[Attributes]--Add semantic mesh orientation support

### DIFF
--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -69,6 +69,12 @@ Below are the handles and descriptors for various mesh assets used by a stage.
 "semantic_asset"
     - string
     - The name of the file describing the stage's semantic mesh.
+"nav_asset"
+    - string
+    - The name of the file describing the stage's nav mesh.
+"semantic_descriptor_filename"
+    - string
+    - The name of the file describing the semantic mappings for the stage.
 
 Stage Frame and Origin
 ----------------------
@@ -81,6 +87,12 @@ The tags below are used to build a coordinate frame for the stage, and will over
 "front"
     - 3-vector
     - Describes the **forward** direction for the stage in the asset's local space.
+"semantic_up"
+    - 3-vector
+    - Describes the **up** direction for the stage's **semantic mesh** in the asset's local space. If specified, the frame built from this vector will be used instead of the render asset's frame.
+"semantic_front"
+    - 3-vector
+    - Describes the **forward** direction for the stage's **semantic mesh** in the asset's local space. If specified, the frame built from this vector will be used instead of the render asset's frame.
 "origin"
     - 3-vector
     - Describes the **origin** of the stage in the world frame, for alignment purposes.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -575,16 +575,22 @@ class ResourceManager {
                                     int numInterp = 10);
 
   /**
-   * @brief Build a configuration frame from scene or object attributes values
-   * and return it
+   * @brief Build a configuration frame from specified up and front vectors
+   * and return it.  If up is not orthogonal to front, will return default
+   * frame.
    *
-   * @param attribs the attributes to query for the information.
+   * @param attribName the handle to the attributes the frame is being built
+   * for, for debug purposes.
+   * @param up The up vector to build the frame from
+   * @param front The front vector to build the frame from.
    * @param origin Either the origin of the stageAttributes or the COM value of
    * the objectAttributes.
    * @return the coordinate frame of the assets the passed attributes describes.
    */
   esp::geo::CoordinateFrame buildFrameFromAttributes(
-      const metadata::attributes::AbstractObjectAttributes::ptr& attribs,
+      const std::string& attribName,
+      const Magnum::Vector3& up,
+      const Magnum::Vector3& front,
       const Magnum::Vector3& origin);
 
   /**

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -347,6 +347,14 @@ void initAttributesBindings(py::module& m) {
           R"(The desired location of the origin of stages built from this
           template.)")
       .def_property(
+          "semantic_orient_up", &StageAttributes::getSemanticOrientUp,
+          &StageAttributes::setSemanticOrientUp,
+          R"(Up direction for semantic stage meshes built from this template.)")
+      .def_property(
+          "semantic_orient_front", &StageAttributes::getSemanticOrientFront,
+          &StageAttributes::setSemanticOrientFront,
+          R"(Forward direction for semantic stage meshes built from this template.)")
+      .def_property(
           "semantic_asset_handle", &StageAttributes::getSemanticAssetHandle,
           &StageAttributes::setSemanticAssetHandle,
           R"(Handle of the asset used for semantic segmentation of stages

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -18,6 +18,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setMargin(0.04);
   setOrientUp({0, 1, 0});
   setOrientFront({0, 0, -1});
+  setUseFrameForAllOrientation(true);
   // default rendering and collisions will be mesh for physics objects and
   // scenes. Primitive-based objects do not currently support mesh collisions,
   // however, due to issues with how non-triangle meshes (i.e. wireframes) are
@@ -120,6 +121,11 @@ StageAttributes::StageAttributes(const std::string& handle)
     : AbstractObjectAttributes("StageAttributes", handle) {
   setGravity({0, -9.8, 0});
   setOrigin({0, 0, 0});
+  setSemanticOrientUp({0, 1, 0});
+  setSemanticOrientFront({0, 0, -1});
+  // setting defaults for semantic frame will have changed this to false. change
+  // to true so that only used if actually changed.
+  setUseFrameForAllOrientation(true);
   // default to use material-derived shader unless otherwise specified in config
   // or instance config
   setShaderType(getShaderTypeName(ObjectInstanceShaderType::Material));
@@ -140,6 +146,12 @@ void StageAttributes::writeValuesToJsonInternal(
     io::JsonAllocator& allocator) const {
   writeValueToJson("origin", jsonObj, allocator);
   writeValueToJson("gravity", jsonObj, allocator);
+  // only save values if they were actually set specifically
+  if (!getUseFrameForAllOrientation()) {
+    writeValueToJson("semantic_orient_up", "semantic_up", jsonObj, allocator);
+    writeValueToJson("semantic_orient_front", "semantic_front", jsonObj,
+                     allocator);
+  }
   writeValueToJson("semantic_asset", jsonObj, allocator);
   writeValueToJson("nav_asset", jsonObj, allocator);
   writeValueToJson("semantic_descriptor_filename", jsonObj, allocator);

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -242,7 +242,25 @@ class AbstractObjectAttributes : public AbstractAttributes {
   void writeValuesToJson(io::JsonGenericValue& jsonObj,
                          io::JsonAllocator& allocator) const override;
 
+  /**
+   * @brief Whether to use the specified orientation frame for all orientation
+   * tasks for this asset.  This will always be true, except if an overriding
+   * semantic mesh-specific frame is specified for stages.
+   */
+  bool getUseFrameForAllOrientation() const {
+    return get<bool>("use_frame_for_all_orientation");
+  }
+
  protected:
+  /**
+   * @brief Whether to use the specified orientation frame for all orientation
+   * tasks for this asset.  This will always be true, except if an overriding
+   * semantic mesh-specific frame is specified for stages.
+   */
+  void setUseFrameForAllOrientation(bool useFrameForAllOrientation) {
+    set("use_frame_for_all_orientation", useFrameForAllOrientation);
+  }
+
   /**
    * @brief Write child-class-specific values to json object
    *
@@ -379,9 +397,55 @@ class StageAttributes : public AbstractObjectAttributes {
   Magnum::Vector3 getGravity() const { return get<Magnum::Vector3>("gravity"); }
 
   /**
+   * @brief set default up orientation for semantic mesh. This is to support
+   * stage aligning semantic meshes that have different orientations than the
+   * stage render mesh.
+   */
+  void setSemanticOrientUp(const Magnum::Vector3& semanticOrientUp) {
+    set("semantic_orient_up", semanticOrientUp);
+    // specify that semantic meshes should not use base class render asset
+    // orientation
+    setUseFrameForAllOrientation(false);
+  }
+  /**
+   * @brief get default up orientation for semantic mesh. This is to support
+   * stage aligning semantic meshes that have different orientations than the
+   * stage render mesh. Returns render asset up if no value for semantic asset
+   * was specifically set.
+   */
+  Magnum::Vector3 getSemanticOrientUp() const {
+    return (getUseFrameForAllOrientation()
+                ? getOrientUp()
+                : get<Magnum::Vector3>("semantic_orient_up"));
+  }
+
+  /**
+   * @brief set default forward orientation for semantic mesh. This is to
+   * support stage aligning semantic meshes that have different orientations
+   * than the stage render mesh.
+   */
+  void setSemanticOrientFront(const Magnum::Vector3& semanticOrientFront) {
+    set("semantic_orient_front", semanticOrientFront);
+    // specify that semantic meshes should not use base class render asset
+    // orientation
+    setUseFrameForAllOrientation(false);
+  }
+  /**
+   * @brief get default forward orientation for semantic mesh. This is to
+   * support stage aligning semantic meshes that have different orientations
+   * than the stage render mesh. Returns render asset front if no value for
+   * semantic asset was specifically set.
+   */
+  Magnum::Vector3 getSemanticOrientFront() const {
+    return (getUseFrameForAllOrientation()
+                ? getOrientFront()
+                : get<Magnum::Vector3>("semantic_orient_front"));
+  }
+
+  /**
    * @brief Text file that describes the hierharchy of semantic information
-   * embedded in the Semantic Asset mesh.  May be overridden by value specified
-   * in Scene Instance Attributes.
+   * embedded in the Semantic Asset mesh.  May be overridden by value
+   * specified in Scene Instance Attributes.
    */
   void setSemanticDescriptorFilename(
       const std::string& semantic_descriptor_filename) {
@@ -390,8 +454,8 @@ class StageAttributes : public AbstractObjectAttributes {
   }
   /**
    * @brief Text file that describes the hierharchy of semantic information
-   * embedded in the Semantic Asset mesh.  May be overridden by value specified
-   * in Scene Instance Attributes.
+   * embedded in the Semantic Asset mesh.  May be overridden by value
+   * specified in Scene Instance Attributes.
    */
   std::string getSemanticDescriptorFilename() const {
     return get<std::string>("semantic_descriptor_filename");

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -380,6 +380,19 @@ void StageAttributesManager::setValsFromJSONDoc(
         stageAttributes->setOrigin(std::forward<decltype(PH1)>(PH1));
       });
 
+  // load stage semantic asset specific up orientation
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonConfig, "semantic_up", [stageAttributes](const Magnum::Vector3& up) {
+        stageAttributes->setSemanticOrientUp(up);
+      });
+
+  // load stage semantic asset specific front orientation
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jsonConfig, "semantic_front",
+      [stageAttributes](const Magnum::Vector3& front) {
+        stageAttributes->setSemanticOrientFront(front);
+      });
+
   // populate specified semantic file name if specified in json - defaults
   // are overridden only if specified in json.
 

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -295,7 +295,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
   // verify exists
   CORRADE_VERIFY(physMgrAttr);
 
-  // before test, save attributes with new name
+  // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testPhysicsAttrConfig_saved_JSON.{}", testAttrSaveDir,
       physicsAttributesManager_->getJSONTypeExt());
@@ -434,7 +434,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
           lightLayoutAttributesManager_, jsonString, true);
   // verify exists
   CORRADE_VERIFY(lightLayoutAttr);
-  // before test, save attributes with new name
+  // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testLightLayoutAttrConfig_saved_JSON.{}", testAttrSaveDir,
       lightLayoutAttributesManager_->getJSONTypeExt());
@@ -712,7 +712,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
   // verify exists
   CORRADE_VERIFY(sceneAttr);
 
-  // before test, save attributes with new name
+  // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testSceneAttrConfig_saved_JSON.{}", testAttrSaveDir,
       sceneInstanceAttributesManager_->getJSONTypeExt());
@@ -756,6 +756,15 @@ void AttributesConfigsTest::testStageAttrVals(
   CORRADE_COMPARE(stageAttr->getUnitsToMeters(), 1.1);
   CORRADE_COMPARE(stageAttr->getOrientUp(), Magnum::Vector3(2.1, 0, 0));
   CORRADE_COMPARE(stageAttr->getOrientFront(), Magnum::Vector3(0, 2.1, 0));
+
+  // verify that we are set to not use the render asset frame for semantic
+  // meshes.
+  CORRADE_VERIFY(!stageAttr->getUseFrameForAllOrientation());
+  CORRADE_COMPARE(stageAttr->getSemanticOrientFront(),
+                  Magnum::Vector3(2.0, 0.0, 0.0));
+  CORRADE_COMPARE(stageAttr->getSemanticOrientUp(),
+                  Magnum::Vector3(0.0, 2.0, 0.0));
+
   CORRADE_COMPARE(stageAttr->getRenderAssetHandle(), assetPath);
   CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(), assetPath);
   CORRADE_VERIFY(!stageAttr->getIsCollidable());
@@ -813,6 +822,15 @@ void AttributesConfigsTest::testStageJSONLoad() {
           stageAttributesManager_, jsonString, false);
   // verify exists
   CORRADE_VERIFY(stageAttr);
+  // verify that we are set to use the render asset frame for all meshes.
+  CORRADE_VERIFY(stageAttr->getUseFrameForAllOrientation());
+  // set new frame for semantic assets to test functionality
+  stageAttr->setSemanticOrientFront(Magnum::Vector3(2.0, 0.0, 0.0));
+  stageAttr->setSemanticOrientUp(Magnum::Vector3(0.0, 2.0, 0.0));
+  // verify that we are now set to not use the render asset frame for semantic
+  // meshes.
+  CORRADE_VERIFY(!stageAttr->getUseFrameForAllOrientation());
+
   // now need to change the render and collision assets to make sure they are
   // legal so test can proceed (needs to be actual existing file)
   const std::string stageAssetFile =
@@ -825,7 +843,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
   // now register so can be saved to disk
   stageAttributesManager_->registerObject(stageAttr);
 
-  // before test, save attributes with new name
+  // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testStageAttrConfig_saved_JSON.{}", testAttrSaveDir,
       stageAttributesManager_->getJSONTypeExt());
@@ -941,7 +959,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
   // now register so can be saved to disk
   objectAttributesManager_->registerObject(objAttr);
 
-  // before test, save attributes with new name
+  // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
       "{}/testObjectAttrConfig_saved_JSON.{}", testAttrSaveDir,
       objectAttributesManager_->getJSONTypeExt());


### PR DESCRIPTION
## Motivation and Context
This PR introduces the ability to specify a frame to use for a semantic stage asset independent of the frame specified for the stage's render asset.  This is specifically needed for MP3D support, which has semantic plys that are orthogonal to the render glbs they correspond to.  Formerly, this was handled via hardcoded transforms, but these are incompatible with HM3D and other datasets with semantic meshes.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.  C++ attributes tests have been expanded to explicitly test this functionality.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
