### PR TITLE
[HM3D]--Semantic scene support/bugfixes.

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -10,7 +10,7 @@ Github page with download links: [https://github.com/matterport/habitat-matterpo
 
 After getting access to the dataset, you can download manually or programmatically via Habitat's data download utility.
 
-## Downloading with the download utility
+### Downloading HM3D with the download utility
 
 First, you will need to generate a matterport API Token:
 

--- a/DATASETS.md
+++ b/DATASETS.md
@@ -39,6 +39,8 @@ Note that this download script requires python 2.7 to run.
 
 You only need the habitat zip archive and not the entire Matterport3D dataset.
 
+Once you have the habitat zip archive, you should download [this SceneDatasetConfig file](http://dl.fbaipublicfiles.com/habitat/mp3d/config_v1/mp3d.scene_dataset_config.json) and place it in the root directory for the Matterport3D dataset (e.g. habitat-sim/data/scene_datasets/mp3d/).
+
 ## Gibson and 3DSceneGraph datasets
 
 - The Gibson dataset for use with Habitat can be downloaded by agreeing to the terms of use in the [Gibson](https://github.com/StanfordVL/GibsonEnv#database) repository.

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -52,8 +52,6 @@ GenericSemanticMeshData::buildSemanticMeshData(
             msgPrefix << "has no vertex colors defined, which are required.");
 
   semanticData->cpu_cbo_.resize(srcMeshData.vertexCount());
-  const Mn::VertexFormat colorFormat =
-      srcMeshData.attributeFormat(Mn::Trade::MeshAttribute::Color);
 
   Cr::Containers::Array<Mn::Color3ub> meshColors{Mn::NoInit,
                                                  srcMeshData.vertexCount()};

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -49,7 +49,8 @@ GenericSemanticMeshData::buildSemanticMeshData(
   /* Assuming colors are 8-bit RGB to avoid expanding them to float and then
      packing back */
   ESP_CHECK(srcMeshData.hasAttribute(Mn::Trade::MeshAttribute::Color),
-            msgPrefix << "has no vertex colors defined, which are required.");
+            msgPrefix << "has no vertex colors defined, which are required for "
+                         "semantic meshes.");
 
   semanticData->cpu_cbo_.resize(srcMeshData.vertexCount());
 

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -32,6 +32,10 @@ GenericSemanticMeshData::buildSemanticMeshData(
     const bool splitMesh,
     std::vector<Magnum::Vector3ub>& colorMapToUse,
     const std::shared_ptr<scene::SemanticScene>& semanticScene) {
+  // build text prefix used in log messages
+  const std::string msgPrefix =
+      Cr::Utility::formatString("Parsing Semantic File {} :", semanticFilename);
+
   /* Copy attributes to the vectors. Positions and indices can be copied
      directly using the convenience APIs as we store them in the full type.
      The importer always provides an indexed mesh with positions, so no need
@@ -43,9 +47,6 @@ GenericSemanticMeshData::buildSemanticMeshData(
   srcMeshData.positions3DInto(Cr::Containers::arrayCast<Mn::Vector3>(
       Cr::Containers::arrayView(semanticData->cpu_vbo_)));
   srcMeshData.indicesInto(semanticData->cpu_ibo_);
-
-  const std::string msgPrefix =
-      Cr::Utility::formatString("Parsing Semantic File {} :", semanticFilename);
   /* Assuming colors are 8-bit RGB to avoid expanding them to float and then
      packing back */
   ESP_CHECK(srcMeshData.hasAttribute(Mn::Trade::MeshAttribute::Color),

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -256,8 +256,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
             Cr::Containers::stridedArrayView(semanticData->objectIds_)));
   }
 
-  // TODO make this selectable via argument
-  {
+  if (semanticFilename.find(".ply") != std::string::npos) {
     // Generic Semantic PLY meshes have -Z gravity
     const quatf T_esp_scene =
         quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY);

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -31,6 +31,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
     const std::string& semanticFilename,
     const bool splitMesh,
     std::vector<Magnum::Vector3ub>& colorMapToUse,
+    bool convertToSRGB,
     const std::shared_ptr<scene::SemanticScene>& semanticScene) {
   // build text prefix used in log messages
   const std::string msgPrefix =
@@ -62,11 +63,18 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
   Cr::Containers::Array<Mn::Color3ub> meshColors{Mn::NoInit, numVerts};
 
-  Mn::Math::packInto(Cr::Containers::arrayCast<2, float>(
-                         stridedArrayView(srcMeshData.colorsAsArray()))
-                         .except({0, 1}),
-                     Cr::Containers::arrayCast<2, Mn::UnsignedByte>(
-                         stridedArrayView(meshColors)));
+  if (convertToSRGB) {
+    auto colors = srcMeshData.colorsAsArray();
+    for (std::size_t i = 0; i != colors.size(); ++i) {
+      meshColors[i] = colors[i].rgb().toSrgb<Mn::UnsignedByte>();
+    }
+  } else {
+    Mn::Math::packInto(Cr::Containers::arrayCast<2, float>(
+                           stridedArrayView(srcMeshData.colorsAsArray()))
+                           .except({0, 1}),
+                       Cr::Containers::arrayCast<2, Mn::UnsignedByte>(
+                           stridedArrayView(meshColors)));
+  }
 
   Cr::Utility::copy(meshColors,
                     Cr::Containers::arrayCast<Mn::Color3ub>(

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -49,6 +49,8 @@ class GenericSemanticMeshData : public BaseMesh {
    * @param plyFile Fully qualified filename of .ply file to load
    * @param splitMesh Whether or not the resultant mesh should be split into
    * multiple components based on objectIds, for frustum culling.
+   * @param convertToSRGB Whether the source vertex colors from the @p meshData
+   * should be converted to SRGB
    * @param semanticScene The SSD for the instance mesh being loaded.
    * @return vector holding one or more mesh results from the .ply file.
    */
@@ -59,6 +61,7 @@ class GenericSemanticMeshData : public BaseMesh {
       const std::string& semanticFilename,
       bool splitMesh,
       std::vector<Magnum::Vector3ub>& colorMapToUse,
+      bool convertToSRGB,
       const std::shared_ptr<scene::SemanticScene>& semanticScene = nullptr);
 
   // ==== rendering ====

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1270,8 +1270,6 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
   const std::string& filename = info.filepath;
 
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
-  ESP_DEBUG() << "Frame orientation :" << info.frame.toString()
-              << "instance mesh :" << filename;
 
   /* Open the file. On error the importer already prints a diagnostic message,
      so no need to do that here. The importer implicitly converts per-face
@@ -1317,7 +1315,7 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
       meshMetaData.root.children[meshIDLocal].meshIDLocal = meshIDLocal;
     }
   }
-  // meshMetaData.setRootFrameOrientation(info.frame);
+  meshMetaData.setRootFrameOrientation(info.frame);
   // update the dictionary
   resourceDict_.emplace(filename,
                         LoadedAssetData{info, std::move(meshMetaData)});
@@ -1343,16 +1341,18 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceIMesh(
   int end = indexPair.second;
 
   scene::SceneNode* instanceRoot = &parent->createChild();
+  instanceRoot->MagnumObject::setTransformation(
+      meshMetaData.root.transformFromLocalToParent);
 
   for (int iMesh = start; iMesh <= end; ++iMesh) {
     scene::SceneNode& node = instanceRoot->createChild();
 
-    // Instance mesh does NOT have normal texture, so do not bother to
+    // Semantic mesh does NOT have normal texture, so do not bother to
     // query if the mesh data contain tangent or bitangent.
     gfx::Drawable::Flags meshAttributeFlags{
         gfx::Drawable::Flag::HasVertexColor};
     // WARNING:
-    // This is to initiate drawables for instance mesh, and the instance mesh
+    // This is to initiate drawables for semantic mesh, and the semantic mesh
     // data is NOT stored in the meshData_ in the BaseMesh.
     // That means One CANNOT query the data like e.g.,
     // meshes_.at(iMesh)->getMeshData()->hasAttribute(Mn::Trade::MeshAttribute::Tangent)

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -167,7 +167,7 @@ void ResourceManager::initDefaultPrimAttributes() {
 
   auto wfCube = primitiveImporter_->mesh(cubeMeshName);
   primitive_meshes_[nextPrimitiveMeshId++] =
-      std::make_unique<Magnum::GL::Mesh>(Magnum::MeshTools::compile(*wfCube));
+      std::make_unique<Mn::GL::Mesh>(Mn::MeshTools::compile(*wfCube));
 
 }  // initDefaultPrimAttributes
 
@@ -562,9 +562,9 @@ ResourceManager::createStageAssetInfosFromAttributes(
 
 esp::geo::CoordinateFrame ResourceManager::buildFrameFromAttributes(
     const std::string& attribName,
-    const Magnum::Vector3& up,
-    const Magnum::Vector3& front,
-    const Magnum::Vector3& origin) {
+    const Mn::Vector3& up,
+    const Mn::Vector3& front,
+    const Mn::Vector3& origin) {
   const vec3f upEigen{Mn::EigenIntegration::cast<vec3f>(up)};
   const vec3f frontEigen{Mn::EigenIntegration::cast<vec3f>(front)};
   if (upEigen.isOrthogonal(frontEigen)) {
@@ -930,7 +930,7 @@ bool ResourceManager::loadObjectMeshDataFromFile(
   return success;
 }  // loadObjectMeshDataFromFile
 
-Magnum::Range3D ResourceManager::computeMeshBB(BaseMesh* meshDataGL) {
+Mn::Range3D ResourceManager::computeMeshBB(BaseMesh* meshDataGL) {
   CollisionMeshData& meshData = meshDataGL->getCollisionMeshData();
   return Mn::Math::minmax(meshData.positions);
 }
@@ -978,7 +978,7 @@ void ResourceManager::computeGeneralMeshAbsoluteAABBs(
   for (uint32_t iEntry = 0; iEntry < absTransforms.size(); ++iEntry) {
     const int meshID = staticDrawableInfo[iEntry].meshID;
 
-    Cr::Containers::Optional<Magnum::Trade::MeshData>& meshData =
+    Cr::Containers::Optional<Mn::Trade::MeshData>& meshData =
         meshes_.at(meshID)->getMeshData();
     CORRADE_ASSERT(meshData,
                    "::computeGeneralMeshAbsoluteAABBs: The mesh "
@@ -1072,11 +1072,11 @@ std::vector<Mn::Matrix4> ResourceManager::computeAbsoluteTransformations(
 }
 
 void ResourceManager::translateMesh(BaseMesh* meshDataGL,
-                                    Magnum::Vector3 translation) {
+                                    Mn::Vector3 translation) {
   CollisionMeshData& meshData = meshDataGL->getCollisionMeshData();
 
-  Magnum::Matrix4 transform = Magnum::Matrix4::translation(translation);
-  Magnum::MeshTools::transformPointsInPlace(transform, meshData.positions);
+  Mn::Matrix4 transform = Mn::Matrix4::translation(translation);
+  Mn::MeshTools::transformPointsInPlace(transform, meshData.positions);
   // save the mesh transformation for future query
   meshDataGL->meshTransform_ = transform * meshDataGL->meshTransform_;
 
@@ -1246,7 +1246,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
       for (int jSubmesh = 0; jSubmesh < pTexMeshData->getSize(); ++jSubmesh) {
         scene::SceneNode& node = instanceRoot->createChild();
         const quatf transform = info.frame.rotationFrameToWorld();
-        node.setRotation(Magnum::Quaternion(transform));
+        node.setRotation(Mn::Quaternion(transform));
         node.addFeature<gfx::PTexMeshDrawable>(*pTexMeshData, jSubmesh,
                                                shaderManager_, drawables);
         staticDrawableInfo.emplace_back(StaticDrawableInfo{node, jSubmesh});
@@ -1259,7 +1259,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
       for (int jSubmesh = 0; jSubmesh < pTexMeshData->getSize(); ++jSubmesh) {
         scene::SceneNode& node = instanceRoot->createChild();
         const quatf transform = info.frame.rotationFrameToWorld();
-        node.setRotation(Magnum::Quaternion(transform));
+        node.setRotation(Mn::Quaternion(transform));
         node.addFeature<gfx::PTexMeshDrawable>(*pTexMeshData, jSubmesh,
                                                shaderManager_, drawables);
         staticDrawableInfo.emplace_back(StaticDrawableInfo{node, jSubmesh});
@@ -1744,15 +1744,15 @@ int ResourceManager::loadNavMeshVisualization(esp::nav::PathFinder& pathFinder,
   }
 
   // create the mesh
-  std::vector<Magnum::UnsignedInt> indices;
-  std::vector<Magnum::Vector3> positions;
+  std::vector<Mn::UnsignedInt> indices;
+  std::vector<Mn::Vector3> positions;
 
   const MeshData::ptr navMeshData = pathFinder.getNavMeshData();
 
   // add the vertices
   positions.resize(navMeshData->vbo.size());
   for (size_t vix = 0; vix < navMeshData->vbo.size(); vix++) {
-    positions[vix] = Magnum::Vector3{navMeshData->vbo[vix]};
+    positions[vix] = Mn::Vector3{navMeshData->vbo[vix]};
   }
 
   indices.resize(navMeshData->ibo.size() * 2);
@@ -1780,8 +1780,8 @@ int ResourceManager::loadNavMeshVisualization(esp::nav::PathFinder& pathFinder,
 
   // compile and add the new mesh to the structure
   navMeshPrimitiveID = nextPrimitiveMeshId;
-  primitive_meshes_[nextPrimitiveMeshId++] = std::make_unique<Magnum::GL::Mesh>(
-      Magnum::MeshTools::compile(visualNavMesh));
+  primitive_meshes_[nextPrimitiveMeshId++] =
+      std::make_unique<Mn::GL::Mesh>(Mn::MeshTools::compile(visualNavMesh));
 
   if (parent != nullptr && drawables != nullptr &&
       navMeshPrimitiveID != ID_UNDEFINED) {
@@ -1795,7 +1795,7 @@ int ResourceManager::loadNavMeshVisualization(esp::nav::PathFinder& pathFinder,
 namespace {
 /**
  * @brief given passed @ref metadata::attributes::ObjectInstanceShaderType @p
- * typeToCheck and given @ref Magnum::Trade::MaterialData, verify that the
+ * typeToCheck and given @ref Mn::Trade::MaterialData, verify that the
  * material's intrinsic type is the same as inferred by @p typeToCheck. Ignore
  * flat, since all shaders already support flat.
  * @param typeToCheck The type of shader being specified.
@@ -2130,13 +2130,12 @@ void ResourceManager::loadTextures(Importer& importer,
 
   for (int iTexture = 0; iTexture < importer.textureCount(); ++iTexture) {
     auto currentTextureID = textureStart + iTexture;
-    textures_.emplace(currentTextureID,
-                      std::make_shared<Magnum::GL::Texture2D>());
+    textures_.emplace(currentTextureID, std::make_shared<Mn::GL::Texture2D>());
     auto& currentTexture = textures_.at(currentTextureID);
 
     auto textureData = importer.texture(iTexture);
     if (!textureData ||
-        textureData->type() != Magnum::Trade::TextureType::Texture2D) {
+        textureData->type() != Mn::Trade::TextureType::Texture2D) {
       ESP_ERROR() << "Cannot load texture" << iTexture << "skipping";
       currentTexture = nullptr;
       continue;
@@ -2342,7 +2341,7 @@ void ResourceManager::addComponent(
   // Add a drawable if the object has a mesh and the mesh is loaded
   if (meshIDLocal != ID_UNDEFINED) {
     const int meshID = metaData.meshIndex.first + meshIDLocal;
-    Magnum::GL::Mesh* mesh = meshes_.at(meshID)->getMagnumGLMesh();
+    Mn::GL::Mesh* mesh = meshes_.at(meshID)->getMagnumGLMesh();
     if (getCreateRenderer()) {
       CORRADE_ASSERT(mesh,
                      "::addComponent() : GL mesh expected but not found", );
@@ -2480,7 +2479,7 @@ void ResourceManager::initDefaultMaterials() {
   shaderManager_.set<gfx::MaterialData>(DEFAULT_MATERIAL_KEY,
                                         new gfx::PhongMaterialData{});
   auto* whiteMaterialData = new gfx::PhongMaterialData;
-  whiteMaterialData->ambientColor = Magnum::Color4{1.0};
+  whiteMaterialData->ambientColor = Mn::Color4{1.0};
   shaderManager_.set<gfx::MaterialData>(WHITE_MATERIAL_KEY, whiteMaterialData);
   auto* perVertexObjectId = new gfx::PhongMaterialData{};
   perVertexObjectId->perVertexObjectId = true;
@@ -2492,7 +2491,7 @@ void ResourceManager::initDefaultMaterials() {
 
 bool ResourceManager::isLightSetupCompatible(
     const LoadedAssetData& loadedAssetData,
-    const Magnum::ResourceKey& lightSetupKey) const {
+    const Mn::ResourceKey& lightSetupKey) const {
   // if light setup has lights in it, but asset was loaded in as flat shaded,
   // there may be an error when rendering.
   return lightSetupKey == Mn::ResourceKey{NO_LIGHT_KEY} ||
@@ -2505,8 +2504,8 @@ void ResourceManager::joinHierarchy(
     MeshData& mesh,
     const MeshMetaData& metaData,
     const MeshTransformNode& node,
-    const Magnum::Matrix4& transformFromParentToWorld) const {
-  Magnum::Matrix4 transformFromLocalToWorld =
+    const Mn::Matrix4& transformFromParentToWorld) const {
+  Mn::Matrix4 transformFromLocalToWorld =
       transformFromParentToWorld * node.transformFromLocalToParent;
 
   if (node.meshIDLocal != ID_UNDEFINED) {
@@ -2515,7 +2514,7 @@ void ResourceManager::joinHierarchy(
             ->getCollisionMeshData();
     int lastIndex = mesh.vbo.size();
     for (auto& pos : meshData.positions) {
-      mesh.vbo.push_back(Magnum::EigenIntegration::cast<vec3f>(
+      mesh.vbo.push_back(Mn::EigenIntegration::cast<vec3f>(
           transformFromLocalToWorld.transformPoint(pos)));
     }
     for (auto& index : meshData.indices) {
@@ -2536,7 +2535,7 @@ std::unique_ptr<MeshData> ResourceManager::createJoinedCollisionMesh(
 
   const MeshMetaData& metaData = getMeshMetaData(filename);
 
-  Magnum::Matrix4 identity;
+  Mn::Matrix4 identity;
   joinHierarchy(*mesh, metaData, metaData.root, identity);
 
   return mesh;
@@ -2639,14 +2638,14 @@ void ResourceManager::createConvexHullDecomposition(
     // for each convex hull, transfer the data to a newly created  MeshData
     interfaceVHACD->GetConvexHull(p, ch);
 
-    std::vector<Magnum::Vector3> positions;
+    std::vector<Mn::Vector3> positions;
 
     // add the vertices
     positions.resize(ch.m_nPoints);
     for (size_t vix = 0; vix < ch.m_nPoints; vix++) {
       positions[vix] =
-          Magnum::Vector3(ch.m_points[vix * 3], ch.m_points[vix * 3 + 1],
-                          ch.m_points[vix * 3 + 2]);
+          Mn::Vector3(ch.m_points[vix * 3], ch.m_points[vix * 3 + 1],
+                      ch.m_points[vix * 3 + 2]);
     }
 
     // add indices
@@ -2709,7 +2708,7 @@ void ResourceManager::createConvexHullDecomposition(
       resourceDict_.emplace(chdFilename, std::move(loadedAssetData));
   if (saveChdToObj) {
     std::string objDirectory = Cr::Utility::Directory::join(
-        Corrade::Utility::Directory::current(), "data/VHACD_outputs");
+        Cr::Utility::Directory::current(), "data/VHACD_outputs");
     std::string new_filename =
         Cr::Utility::Directory::filename(
             Cr::Utility::Directory::splitExtension(chdFilename).first) +

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1315,7 +1315,7 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
       if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
               fileImporter_->mesh(i)) {
         meshVec.push_back(std::move(*mesh));
-        meshView.push_back(meshVec.back());
+        meshView.emplace_back(meshVec.back());
       }
     }
     // build concatenated meshData from container of meshes.

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -723,12 +723,11 @@ class ResourceManager {
   void buildPrimitiveAssetData(const std::string& primTemplateHandle);
 
   /**
-   * @brief Configure the importerManager_ appropriately based on compilation
-   * flags, before general assets are imported
-   * @param dispFileName the filename of the asset being imported, used for
-   * informational/debugging purposes only.
+   * @brief Configure the importerManager_ GL Extensions appropriately based on
+   * compilation flags, before any general assets are imported.  This should
+   * only occur if a gl context exists.
    */
-  void ConfigureImporterManager(const std::string& dispFileName);
+  void ConfigureImporterManagerGLExtensions();
 
  protected:
   // ======== Structs and Types only used locally ========

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -303,6 +303,10 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
         [newAttributes](auto&& PH1) {
           newAttributes->setSemanticAssetType(std::forward<decltype(PH1)>(PH1));
         });
+    // TODO : get rid of this once the hardcoded mesh-type handling is removed,
+    // but for now force all semantic assets to be instance_mesh
+    newAttributes->setSemanticAssetType(
+        static_cast<int>(AssetType::INSTANCE_MESH));
   }
   // set default physical quantities specified in physics manager attributes
   if (physicsAttributesManager_->getObjectLibHasHandle(

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -37,9 +37,10 @@ bool SemanticScene::
         std::ifstream ifs = std::ifstream(ssdFileName);
         std::string header;
         std::getline(ifs, header);
-        if (header == "ASCII 1.1") {
+        if (header.find("ASCII 1.1") != std::string::npos) {
           success = buildMp3dHouse(ifs, scene, rotation);
-        } else if (header == "HM3D Semantic Annotations") {
+        } else if (header.find("HM3D Semantic Annotations") !=
+                   std::string::npos) {
           success = buildHM3DHouse(ifs, scene, rotation);
         }
       } catch (...) {

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -87,7 +87,7 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>> meshVec =
       GenericSemanticMeshData::buildSemanticMeshData(
-          *meshData, semanticFilename, false, dummyColormap);
+          *meshData, semanticFilename, false, dummyColormap, false);
   // verify result vector holds a mesh
   CORRADE_VERIFY(!meshVec.empty());
   // verify first entry exists

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -55,8 +55,8 @@ MeshData SceneLoader::load(const AssetInfo& info) {
             "Error loading instance mesh data from file {}", info.filepath));
 
     std::vector<GenericSemanticMeshData::uptr> instanceMeshData =
-        GenericSemanticMeshData::buildSemanticMeshData(*meshData, info.filepath,
-                                                       false, dummyColormap);
+        GenericSemanticMeshData::buildSemanticMeshData(
+            *meshData, info.filepath, false, dummyColormap, false);
 
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();
     const auto& cbo = instanceMeshData[0]->getColorBufferObjectCPU();

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -75,10 +75,10 @@ def initialize_test_data_sources(data_path):
             "version": "0.2",
         },
         "mp3d_example_scene": {
-            "source": "http://dl.fbaipublicfiles.com/habitat/mp3d_example.zip",
-            "package_name": "mp3d_example.zip",
+            "source": "http://dl.fbaipublicfiles.com/habitat/mp3d/mp3d_example_v1.1.zip",
+            "package_name": "mp3d_example_v1.1.zip",
             "link": data_path + "scene_datasets/mp3d_example",
-            "version": "1.0",
+            "version": "1.1",
         },
         "coda_scene": {
             "source": "https://dl.fbaipublicfiles.com/habitat/coda_v1.0.zip",

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -79,6 +79,9 @@ def _render_and_load_gt(sim, scene, sensor_type, gpu2gpu):
     return obs, gt
 
 
+# List of tuples holding scene ID and Scene Dataset Configuration to use.
+# Scene Dataset Config is required to provide transform for semantic mesh,
+# which, in Mp3d dataset, is oriented orthogonally to the render mesh
 _semantic_scenes = [
     (
         osp.abspath(
@@ -87,7 +90,12 @@ _semantic_scenes = [
                 "../data/scene_datasets/mp3d/1LXtFkjw3qL/1LXtFkjw3qL.glb",
             )
         ),
-        "default",
+        osp.abspath(
+            osp.join(
+                osp.dirname(__file__),
+                "../data/scene_datasets/mp3d/mp3d.scene_dataset_config.json",
+            )
+        ),
     ),
     (
         osp.abspath(
@@ -105,6 +113,7 @@ _semantic_scenes = [
     ),
 ]
 
+# Non-semantic meshes can use default, built-in scene dataset config
 _non_semantic_scenes = [
     (
         osp.abspath(


### PR DESCRIPTION
## Motivation and Context
This PR adds various functions and refactors required to implement support for HM3D semantic scenes in the correct format.  Included are : 
- Better vertex color handling in semantic mesh load
- More rigorous string verification for sentinel string denoting Semantic Scene Descriptor file type
- Proper application of frame re-orientation to Semantic Mesh data.  This is required to enable any semantic meshes to be re-oriented in engine.
- Force all semantic meshes to be treated as Instance Meshes (temporary so that vertex colors and vertex ids are supported).

Also, some refactors to improve efficiency and debug message content in Resource Manager are included.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
