### PR TITLE
OverrideCollisionGroup for BulletArticulatedObject

### DIFF
--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -666,7 +666,7 @@ void BulletArticulatedObject::overrideCollisionGroup(CollisionGroup group) {
 
   // override separate base link object group
   auto* baseCollider = btMultiBody_->getBaseCollider();
-  bWorld_->btCollisionWorld::removeCollisionObject(baseCollider);
+  bWorld_->removeCollisionObject(baseCollider);
   bWorld_->addCollisionObject(baseCollider, collisionFilterGroup,
                               collisionFilterMask);
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -345,6 +345,12 @@ class BulletArticulatedObject : public ArticulatedObject {
   //! clamp current pose to joint limits
   void clampJointLimits() override;
 
+  /**
+   * @brief Manually set the collision group for all links of the object.
+   * @param group The desired CollisionGroup for the object.
+   */
+  void overrideCollisionGroup(CollisionGroup group) override;
+
   //============ Joint Motor Constraints =============
 
   //! Bullet supports vel/pos control joint motors for revolute and prismatic

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -581,6 +581,7 @@ def test_collision_groups():
         # get the rigid object manager, which provides direct
         # access to objects
         rigid_obj_mgr = sim.get_rigid_object_manager()
+        ao_mgr = sim.get_articulated_object_manager()
 
         if (
             sim.get_physics_simulation_library()
@@ -617,6 +618,21 @@ def test_collision_groups():
             cube_obj1.override_collision_group(cg.UserGroup1)
             assert not cube_obj1.contact_test()
             assert not cube_obj2.contact_test()
+
+            # add an ArticulatedObject in contact with cube 2
+            ao = ao_mgr.add_articulated_object_from_urdf(
+                filepath="data/test_assets/urdf/amass_male.urdf"
+            )
+            ao.translation = [1.1, 0.0, 4.6]
+            assert ao.contact_test()
+            assert cube_obj2.contact_test()
+            assert not cube_obj1.contact_test()
+            # set to non-collidable and check no contacts
+            ao.override_collision_group(cg.Noncollidable)
+            assert not ao.contact_test()
+            assert not cube_obj2.contact_test()
+            assert not cube_obj1.contact_test()
+
             # override cube2 to a new group and configure custom mask to interact with it
             cgh.set_mask_for_group(cg.UserGroup1, new_user_group_1_mask | cg.UserGroup2)
             # NOTE: changing group settings requires overriding object group again


### PR DESCRIPTION
## Motivation and Context

This function was previously only implemented for RigidObjects. Without this, it is not possible to turn off collisions for ArticulatedObjects programmatically (i.e., without modifying the URDF). 
The implementation in this PR only covers uniform override of all links. Individual link overrides should be added in a later PR.

## How Has This Been Tested

Added a python test verifying group override.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
