### PR TITLE
[Bugfix]--Appropriately handle multiple meshes being assigned to the same transform node.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1588,6 +1588,8 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
     // If meshIDLocal != -1 then we have multiple meshes assigned to the same
     // MeshTransformNode.  We make subsequent meshes children of the first mesh
     // we've seen, and give them identity trasnforms.
+    // TODO: either drop MeshTransformNode in favor of SceneData or use
+    // Mn::SceneTools::convertToSingleFunctionObjects() when it's exposed.
     esp::assets::MeshTransformNode* tmpNode = &*node;
     if (node->meshIDLocal != -1) {
       node->children.emplace_back();


### PR DESCRIPTION
## Motivation and Context
This PR fixes an issue with attempting to load an asset with multiple meshes assigned to the same MeshTransformNode.  A recent change to the loading mechanism ignored all subsequent meshes that were assigned to the same transform; this PR fixes this by assigning these subsequent meshes as children in the MeshTransformNode.  This is what was done originally in the Magnum Importer.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally; All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
