### PR TITLE
[CI/Bugfix]--fix ci to use non-buggy mypy vers, hypothesis vers compat w/python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
                 export PATH=$HOME/miniconda/bin:$PATH
                 conda create -y -n habitat python=3.6
                 . activate habitat
-                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
+                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis=6.29.3
                 pip install pytest-sugar pytest-xdist pytest-benchmark
               fi
       - run:
@@ -220,9 +220,9 @@ jobs:
                 flake8-comprehensions \
                 flake8-return \
                 flake8-simplify \
-                hypothesis \
+                hypothesis==6.29.3 \
                 isort \
-                mypy \
+                mypy==v0.910 \
                 numpy \
                 pytest \
                 sphinx \


### PR DESCRIPTION
## Motivation and Context
This PR restricts CI to use expected versions of mypy and hypothesis, since both have recently had changes which either [have bugs](https://github.com/python/mypy/issues/11853) or [dropped support for python 3.6](https://hypothesis.readthedocs.io/en/latest/changes.html#v6-32-0).  This PR restricts mypy to v0.910 and hypothesis to 6.29.3 (conda-available version that supports python 3.6).  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all tests pass, and versions are available.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
