### PR TITLE
[Refactor]--Cleaup;Remove unused field/methods.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,4 +43,9 @@ if [ "$RUN_TESTS" = true ] ; then
   PYTHONPATH=${here}/src_python ctest -V
 fi
 
-echo "Add src_python to PYTHONPATH, i.e. \`export PYTHONPATH=${here}/src_python:\${PYTHONPATH}\`"
+# Check if src_python has been added to python path, otherwise remind user
+if [[ "$PYTHONPATH" == *"src_python"* ]]; then
+  echo "\`src_python\` subdir found in PYTHONPATH : \`$PYTHONPATH\`"
+else
+  echo "Add src_python to PYTHONPATH, i.e. \`export PYTHONPATH=${here}/src_python:\${PYTHONPATH}\`"
+fi

--- a/data/default.physics_config.json
+++ b/data/default.physics_config.json
@@ -3,8 +3,5 @@
     "timestep": 0.008,
     "gravity": [0,-9.8,0],
     "friction_coefficient": 0.4,
-    "restitution_coefficient": 0.1,
-    "rigid object paths":[
-        "objects"
-    ]
+    "restitution_coefficient": 0.1
 }

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -137,14 +137,6 @@ class BaseMesh {
   }
 
   /**
-   * @brief Any transformations applied to the original mesh after loading are
-   * stored here.
-   *
-   * See @ref ResourceManager::translateMesh.
-   */
-  Magnum::Matrix4 meshTransform_;
-
-  /**
    * @brief Axis aligned bounding box of the mesh.
    *
    * Computed automatically on mesh load. See @ref

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1072,18 +1072,6 @@ std::vector<Mn::Matrix4> ResourceManager::computeAbsoluteTransformations(
   return absTransforms;
 }
 
-void ResourceManager::translateMesh(BaseMesh* meshDataGL,
-                                    Mn::Vector3 translation) {
-  CollisionMeshData& meshData = meshDataGL->getCollisionMeshData();
-
-  Mn::Matrix4 transform = Mn::Matrix4::translation(translation);
-  Mn::MeshTools::transformPointsInPlace(transform, meshData.positions);
-  // save the mesh transformation for future query
-  meshDataGL->meshTransform_ = transform * meshDataGL->meshTransform_;
-
-  meshDataGL->BB = meshDataGL->BB.translated(translation);
-}  // ResourceManager::translateMesh
-
 void ResourceManager::buildPrimitiveAssetData(
     const std::string& primTemplateHandle) {
   // retrieves -actual- template, not a copy

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -323,19 +323,6 @@ class ResourceManager {
   }
 
   /**
-   * @brief Retrieve the composition of all transforms applied to a mesh
-   * since it was loaded.
-   *
-   * See @ref translateMesh.
-   * @param meshIndex Index of the mesh in @ref meshes_.
-   * @return The transformation matrix mapping from the original state to
-   * its current state.
-   */
-  const Mn::Matrix4& getMeshTransformation(const int meshIndex) const {
-    return meshes_.at(meshIndex)->meshTransform_;
-  }
-
-  /**
    * @brief Retrieve the meta data for a particular asset.
    *
    * This includes identifiers for meshes, textures, materials, and a
@@ -1054,15 +1041,6 @@ class ResourceManager {
                               const Mn::ResourceKey& lightSetupKey) const;
 
   // ======== Geometry helper functions, data structures ========
-
-  /**
-   * @brief Apply a translation to the vertices of a mesh asset and store that
-   * transformation in @ref BaseMesh::meshTransform_.
-   *
-   * @param meshDataGL The mesh data.
-   * @param translation The translation transform to apply.
-   */
-  void translateMesh(BaseMesh* meshDataGL, Mn::Vector3 translation);
 
   /**
    * @brief Compute and return the axis aligned bounding box of a mesh in mesh

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -391,17 +391,6 @@ class Simulator {
   }
 
   /**
-   * @brief Registers a voxel wrapper in a dictionary. This ensures that two
-   * assets with the same render asset handle and voxelization resolution share
-   * the same underlying Voxel Grid.
-   *
-   * @param voxelWrapper The voxel wrapper to be registered.
-   * @param key The name underwhich to register the voxel wrapper
-   */
-  void registerVoxelGrid(esp::geo::VoxelWrapper& voxelWrapper,
-                         const std::string& key);
-
-  /**
    * @brief Discrete collision check for contact between an object and the
    * collision world.
    * @param objectId The object ID and key identifying the object in @ref


### PR DESCRIPTION
## Motivation and Context
In preparation for rewriting the asset load pipeline, I'm coming across some unused code in ResourceManager and the various mesh constructs, among other places.  This PR is for removing these methods, so that the pending asset load functionality PRs will retain their focus :) .  This PR also has a few minor refactors/cleanups that I've come across :

- Remove unused/unimplemented voxel function declaration from Simulator.h
- Make build script 'src_python' message a bit more relevant to the user
- Remove deprecated config field from default physics config

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All local c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
