### PR TITLE
--Expand Viewer scene paging functionality

### DIFF
--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -189,6 +189,17 @@ class MetadataMediator {
   }
 
   /**
+   * @brief Get a list of all stage attributes available in the currently active
+   * dataset. This is useful if current dataset does not have scene instances
+   * defined, and instead builds them on the fly for each stage.
+   */
+  std::vector<std::string> getAllStageAttributesHandles() {
+    return getActiveDSAttribs()
+        ->getStageAttributesManager()
+        ->getObjectHandlesBySubstring();
+  }
+
+  /**
    * @brief Return copy of map of current active dataset's navmesh handles.
    */
   std::map<std::string, std::string> getActiveNavmeshMap() {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -549,6 +549,18 @@ class Simulator {
   double getWorldTime();
 
   /**
+   * @brief Get the simplified name of the @ref
+   * esp::metadata::attributes::SceneInstanceAttributes used to create the scene
+   * currently being simulated/displayed.
+   */
+  const std::string getCurSceneInstanceName() {
+    if (curSceneInstanceAttributes_ == nullptr) {
+      return "NONE";
+    }
+    return curSceneInstanceAttributes_->getSimplifiedHandle();
+  }
+
+  /**
    * @brief Set the gravity in a physical scene.
    */
   void setGravity(const Magnum::Vector3& gravity, int sceneID = 0) {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -553,7 +553,7 @@ class Simulator {
    * esp::metadata::attributes::SceneInstanceAttributes used to create the scene
    * currently being simulated/displayed.
    */
-  const std::string getCurSceneInstanceName() {
+  std::string getCurSceneInstanceName() const {
     if (curSceneInstanceAttributes_ == nullptr) {
       return "NONE";
     }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -894,7 +894,8 @@ void Viewer::initSimPostReconfigure() {
   } else {
     setWindowTitle("Viewer @ Scene : " + sceneInstName);
   }
-
+  // clear any semantic tags from previoius scene
+  semanticTag_ = "";
   // NavMesh customization options
   if (disableNavmesh_) {
     if (simulator_->getPathFinder()->isLoaded()) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -888,6 +888,13 @@ Viewer::Viewer(const Arguments& arguments)
 }  // end Viewer::Viewer
 
 void Viewer::initSimPostReconfigure() {
+  const auto sceneInstName = simulator_->getCurSceneInstanceName();
+  if (sceneInstName == "NONE") {
+    setWindowTitle("Viewer");
+  } else {
+    setWindowTitle("Viewer @ Scene : " + sceneInstName);
+  }
+
   // NavMesh customization options
   if (disableNavmesh_) {
     if (simulator_->getPathFinder()->isLoaded()) {
@@ -1260,6 +1267,9 @@ void Viewer::setSceneInstanceFromListAndShow(int nextSceneInstanceIDX) {
 
   // initialize sim navmesh, agent, sensors after creation/reconfigure
   initSimPostReconfigure();
+  // run this in case we are currently displaying something other than visual
+  // sensor
+  bindRenderTarget();
 }  // Viewer::setSceneInstanceFromListAndShow
 
 float timeSinceLastSimulation = 0.0;


### PR DESCRIPTION
## Motivation and Context
This PR adds the following functionality to viewer to facilitate paging through scene datasets : 

- If only 1 scene instance exists, will page through existing stage-based scenes instead.  This is useful for datasets such as HM3D that do not have explicit scene instance json configurations but rather build them on the fly.
- Preserve render target binding through reconfigure.  This is useful when viewing depth or semantic scene views that the viewer might wish to continue viewing on subsequent scenes.
- Display the name of the currently displayed scene instance to the viewer's title bar

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
It's viewer! It Just Works (tested locally)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
