### PR TITLE
[Bugfix]--Fix HM3D Semantic Object ID construction

### DIFF
--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -158,7 +158,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
             static_cast<scene::HM3DObjectInstance&>(*ssdObjs[i]);
         const Mn::Vector3ub ssdColor = ssdObj.getColor();
         const uint32_t colorInt = colorAsInt(ssdColor);
-        int semanticID = ssdObj.getSemanticID();
+        int semanticID = ssdObj.semanticID();
         int regionIDX =
             static_cast<scene::HM3DSemanticRegion&>(*ssdObj.region())
                 .getIndex();

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -172,6 +172,7 @@ void initSceneBindings(py::module& m) {
       .def_property_readonly("id", &SemanticObject::id,
                              "The ID of the object, of the form "
                              "``<level_id>_<region_id>_<object_id>``")
+      .def_property_readonly("semantic_id", &SemanticObject::semanticID)
       .def_property_readonly("region", &SemanticObject::region)
       .def_property_readonly("aabb", &SemanticObject::aabb)
       .def_property_readonly("obb", &SemanticObject::obb)

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -39,22 +39,20 @@ class HM3DSemanticRegion : public SemanticRegion {
 
 class HM3DObjectInstance : public SemanticObject {
  public:
-  HM3DObjectInstance(int id,
-                     int objInstanceId,
+  HM3DObjectInstance(int objInstanceID,
+                     int objCatID,
                      const std::string& name,
                      const Mn::Vector3ub& clr)
-      : id_(id), objInstanceId_(objInstanceId), name_(name), color_(clr) {}
+      : SemanticObject(), objCatID_(objCatID), name_(name), color_(clr) {
+    index_ = objInstanceID;
+  }
   Mn::Vector3ub getColor() const { return color_; }
 
   std::string id() const override { return name_; }
 
-  int getSemanticID() const { return id_; }
-
  protected:
-  // semantic ID of the object instance in the file
-  const int id_;
-  // instance ID of this particular instance within the category it belongs in
-  const int objInstanceId_;
+  // idx of this particular object instance within the category it belongs in
+  const int objCatID_;
   // unique name for this instance
   const std::string name_;
   // specified color for this object instance.

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -335,6 +335,11 @@ class SemanticObject {
     }
   }
 
+  /**
+   * @brief Retrieve the unique semantic ID corresponding to this object
+   */
+  int semanticID() const { return index_; }
+
   SemanticRegion::ptr region() const { return region_; }
 
   box3f aabb() const { return obb_.toAABB(); }
@@ -344,7 +349,14 @@ class SemanticObject {
   SemanticCategory::ptr category() const { return category_; }
 
  protected:
+  /**
+   * @brief The unique semantic ID corresponding to this object
+   */
   int index_{};
+
+  /**
+   * @brief References the parent region for this object
+   */
   int parentIndex_{};
   std::shared_ptr<SemanticCategory> category_;
   geo::OBB obb_;


### PR DESCRIPTION
## Motivation and Context
This PR fixes how the Semantic Object ID is constructed for the HM3D dataset.  Previously, it was constructing the Semantic Object ID to be "<category>_<int idx within category>" (i.e. "wall_1") but this was incorrect - the current standard in engine is to have the final value of the Semantic Object ID be a unique int across all categories, corresponding to the Semantic ID in the Scene Node.  This PR fixes this.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
