### PR TITLE
--Viewer : minor bugs; refactor drawEvent

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -545,6 +545,9 @@ class HabitatSimInteractiveViewer(Application):
         """
         self.navmesh_settings = habitat_sim.NavMeshSettings()
         self.navmesh_settings.set_defaults()
+        self.navmesh_settings.agent_height = self.cfg.agents[self.agent_id].height
+        self.navmesh_settings.agent_radius = self.cfg.agents[self.agent_id].radius
+
         self.sim.recompute_navmesh(
             self.sim.pathfinder,
             self.navmesh_settings,

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -979,6 +979,7 @@ void Viewer::initSimPostReconfigure() {
     esp::nav::NavMeshSettings navMeshSettings;
     navMeshSettings.agentHeight = agentConfig_.height;
     navMeshSettings.agentRadius = agentConfig_.radius;
+    navMeshSettings.agentMaxSlope = 55.0f;
     simulator_->recomputeNavMesh(*simulator_->getPathFinder().get(),
                                  navMeshSettings, true);
   } else if (!navmeshFilename_.empty()) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -611,7 +611,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho) {
         sensorType == esp::sensor::SensorType::Semantic) {
       spec->channels = 1;
     }
-    spec->position = {0.0f, 1.5f, 0.0f};
+    spec->position = {0.0f, rgbSensorHeight, 0.0f};
     spec->orientation = {0, 0, 0};
     spec->resolution = esp::vec2i(viewportSize[1], viewportSize[0]);
   };
@@ -977,6 +977,8 @@ void Viewer::initSimPostReconfigure() {
     }
   } else if (recomputeNavmesh_) {
     esp::nav::NavMeshSettings navMeshSettings;
+    navMeshSettings.agentHeight = agentConfig_.height;
+    navMeshSettings.agentRadius = agentConfig_.radius;
     simulator_->recomputeNavMesh(*simulator_->getPathFinder().get(),
                                  navMeshSettings, true);
   } else if (!navmeshFilename_.empty()) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -979,7 +979,6 @@ void Viewer::initSimPostReconfigure() {
     esp::nav::NavMeshSettings navMeshSettings;
     navMeshSettings.agentHeight = agentConfig_.height;
     navMeshSettings.agentRadius = agentConfig_.radius;
-    navMeshSettings.agentMaxSlope = 55.0f;
     simulator_->recomputeNavMesh(*simulator_->getPathFinder().get(),
                                  navMeshSettings, true);
   } else if (!navmeshFilename_.empty()) {


### PR DESCRIPTION
## Motivation and Context
This PR addresses a few minor bugs in viewer, where values that should have been mapped from constants were being mapped via magic numbers, or else not being mapped at all (such as the agent's dims if navmesh recalc is requested).

drawEvent functionality was also refactored to not recreate the Sensor Key string every frame when it only changed if sensorMode_ or visualizeMode_ changed.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
It's Viewer! It Always Works!
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
