### PR TITLE
--Flatten compound semantic scenes whilst preserving submesh transforms.

### DIFF
--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(
          Magnum::Magnum
          Magnum::MeshTools
          Magnum::SceneGraph
+         Magnum::SceneTools
          Magnum::Shaders
          Magnum::Trade
          Magnum::Primitives

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1313,6 +1313,7 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
     // build view
     Cr::Containers::Array<Cr::Containers::Reference<const Mn::Trade::MeshData>>
         meshView;
+    Cr::Containers::arrayReserve(meshView, flattenedMeshes.size());
     for (const auto& mesh : flattenedMeshes) {
       arrayAppend(meshView, mesh);
     }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1293,6 +1293,29 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
     // only one mesh, treat as before
     meshData = fileImporter_->mesh(0);
   } else {
+    // Cr::Containers::Optional<Mn::Trade::SceneData> scene =
+    //     fileImporter_->scene(fileImporter_->defaultScene());
+    // // build list of meshDatas from importer
+    // std::vector<Mn::Trade::MeshData> meshVec;
+    // meshVec.reserve(meshCount);
+    // // build view
+    // std::vector<Cr::Containers::Reference<const Mn::Trade::MeshData>>
+    // meshView; meshView.reserve(meshCount);
+
+    // Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
+    // for (const Cr::Containers::Triple<Mn::UnsignedInt, Mn::Int, Mn::Matrix4>&
+    //          meshTransformation :
+    //      Mn::SceneTools::flattenMeshHierarchy3D(scene)) {
+    //   if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
+    //           fileImporter_->mesh(meshTransformation.first())) {
+    //     arrayAppend(flattenedMeshes, Mn::MeshTools::transform3D(
+    //                                      mesh, meshTransformation.third()));
+
+    //     meshVec.push_back(std::move(*mesh));
+    //     meshView.emplace_back(meshVec.back());
+    //   }
+    // }
+
     // build list of meshDatas from importer
     std::vector<Mn::Trade::MeshData> meshVec;
     meshVec.reserve(meshCount);

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1311,10 +1311,10 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
     }
 
     // build view
-    std::vector<Cr::Containers::Reference<const Mn::Trade::MeshData>> meshView;
-    meshView.reserve(meshCount);
+    Cr::Containers::Array<Cr::Containers::Reference<const Mn::Trade::MeshData>>
+        meshView;
     for (const auto& mesh : flattenedMeshes) {
-      meshView.emplace_back(mesh);
+      arrayAppend(meshView, mesh);
     }
     // build concatenated meshData from container of meshes.
     meshData = Mn::MeshTools::concatenate(meshView);

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -8,6 +8,7 @@
 #include <Corrade/Containers/GrowableArray.h>
 #include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/PointerStl.h>
+#include <Corrade/Containers/Triple.h>
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/PluginManager/PluginMetadata.h>
 #include <Corrade/Utility/Assert.h>
@@ -31,6 +32,7 @@
 #include <Magnum/MeshTools/Reference.h>
 #include <Magnum/PixelFormat.h>
 #include <Magnum/SceneGraph/Object.h>
+#include <Magnum/SceneTools/FlattenMeshHierarchy.h>
 #include <Magnum/Trade/AbstractImporter.h>
 #include <Magnum/Trade/FlatMaterialData.h>
 #include <Magnum/Trade/ImageData.h>
@@ -1293,41 +1295,26 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
     // only one mesh, treat as before
     meshData = fileImporter_->mesh(0);
   } else {
-    // Cr::Containers::Optional<Mn::Trade::SceneData> scene =
-    //     fileImporter_->scene(fileImporter_->defaultScene());
-    // // build list of meshDatas from importer
+    Cr::Containers::Optional<Mn::Trade::SceneData> scene =
+        fileImporter_->scene(fileImporter_->defaultScene());
     // std::vector<Mn::Trade::MeshData> meshVec;
     // meshVec.reserve(meshCount);
-    // // build view
-    // std::vector<Cr::Containers::Reference<const Mn::Trade::MeshData>>
-    // meshView; meshView.reserve(meshCount);
+    Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
+    for (const Cr::Containers::Triple<Mn::UnsignedInt, Mn::Int, Mn::Matrix4>&
+             meshTransformation :
+         Mn::SceneTools::flattenMeshHierarchy3D(*scene)) {
+      if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
+              fileImporter_->mesh(meshTransformation.first())) {
+        arrayAppend(flattenedMeshes, Mn::MeshTools::transform3D(
+                                         *mesh, meshTransformation.third()));
+      }
+    }
 
-    // Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
-    // for (const Cr::Containers::Triple<Mn::UnsignedInt, Mn::Int, Mn::Matrix4>&
-    //          meshTransformation :
-    //      Mn::SceneTools::flattenMeshHierarchy3D(scene)) {
-    //   if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
-    //           fileImporter_->mesh(meshTransformation.first())) {
-    //     arrayAppend(flattenedMeshes, Mn::MeshTools::transform3D(
-    //                                      mesh, meshTransformation.third()));
-
-    //     meshVec.push_back(std::move(*mesh));
-    //     meshView.emplace_back(meshVec.back());
-    //   }
-    // }
-
-    // build list of meshDatas from importer
-    std::vector<Mn::Trade::MeshData> meshVec;
-    meshVec.reserve(meshCount);
     // build view
     std::vector<Cr::Containers::Reference<const Mn::Trade::MeshData>> meshView;
     meshView.reserve(meshCount);
-    for (int i = 0; i < meshCount; ++i) {
-      if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
-              fileImporter_->mesh(i)) {
-        meshVec.push_back(std::move(*mesh));
-        meshView.emplace_back(meshVec.back());
-      }
+    for (const auto& mesh : flattenedMeshes) {
+      meshView.emplace_back(mesh);
     }
     // build concatenated meshData from container of meshes.
     meshData = Mn::MeshTools::concatenate(meshView);


### PR DESCRIPTION
## Motivation and Context
This PR adds new functionality where individual submesh transforms can be queried and applied on semantic mesh load before a compound mesh is flattened into a single mesh.  Previously, compound semantic meshes were aggregated without preserving their transformations.  This is particularly relevant with HM3D dataset semantic meshes that were annotated using mtl+obj source and have embedded transforms.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
