### PR TITLE
Viewer improvements - URDF and scene quick reload

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -247,6 +247,9 @@ class Viewer : public Mn::Platform::Application {
   // exists if a mouse grabbing constraint is active, destroyed on release
   std::unique_ptr<MouseGrabber> mouseGrabber_ = nullptr;
 
+  //! Most recently custom loaded URDF ('t' key)
+  std::string cachedURDF_ = "";
+
   /**
    * @brief Instance an object from an ObjectAttributes.
    * @param configHandle The handle referencing the object's template in the
@@ -388,6 +391,8 @@ Key Commands:
   'o': Instance a random file-based object in front of the agent.
   'u': Remove most recently instanced rigid object.
   't': Instance an ArticulatedObject in front of the camera from a URDF file by entering the filepath when prompted.
+    +ALT: Import the object with a fixed base.
+    +SHIFT Quick-reload the previously specified URDF.
   'b': Toggle display of object bounding boxes.
   'p': Save current simulation state to SceneInstanceAttributes JSON file (with non-colliding filename).
   'v': (physics) Invert gravity.
@@ -2147,10 +2152,20 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       showAgentStateMsg(true, true);
       break;
     case KeyEvent::Key::T: {
+      //+ALT for fixedBase
+      bool fixedBase = bool(event.modifiers() & MouseEvent::Modifier::Alt);
+
       // add an ArticulatedObject from provided filepath
-      ESP_DEBUG() << "Load URDF: provide a URDF filepath.";
       std::string urdfFilepath;
-      std::cin >> urdfFilepath;
+      if (event.modifiers() & MouseEvent::Modifier::Shift &&
+          !cachedURDF_.empty()) {
+        // quick-reload the most recently loaded URDF
+        ESP_DEBUG() << "URDF quick-reload: " << cachedURDF_;
+        urdfFilepath = cachedURDF_;
+      } else {
+        ESP_DEBUG() << "Load URDF: provide a URDF filepath.";
+        std::cin >> urdfFilepath;
+      }
 
       if (urdfFilepath.empty()) {
         ESP_DEBUG() << "... no input provided. Aborting.";
@@ -2158,8 +2173,11 @@ void Viewer::keyPressEvent(KeyEvent& event) {
                  !Cr::Utility::String::endsWith(urdfFilepath, ".URDF")) {
         ESP_DEBUG() << "... input is not a URDF. Aborting.";
       } else if (Cr::Utility::Directory::exists(urdfFilepath)) {
+        // cache the file for quick-reload with SHIFT-T
+        cachedURDF_ = urdfFilepath;
         auto aom = simulator_->getArticulatedObjectManager();
-        auto ao = aom->addArticulatedObjectFromURDF(urdfFilepath, true);
+        auto ao = aom->addArticulatedObjectFromURDF(urdfFilepath, fixedBase,
+                                                    1.0, 1.0, true);
         ao->setTranslation(
             defaultAgent_->node().transformation().transformPoint(
                 {0, 1.0, -1.5}));

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -355,7 +355,8 @@ Key Commands:
   esc: Exit the application.
   'H': Display this help message.
   'm': Toggle mouse mode (LOOK | GRAB).
-  TAB/Shift-TAB : Cycle to next/previous scene in scene dataset
+  TAB/Shift-TAB : Cycle to next/previous scene in scene dataset.
+  ALT+TAB: Reload the current scene.
 
   Agent Controls:
   'wasd': Move the agent's body forward/backward, left/right.
@@ -2007,13 +2008,17 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       exit(0);
       break;
     case KeyEvent::Key::Tab:
-      ESP_DEBUG() << "Cycling to"
-                  << ((event.modifiers() & MouseEvent::Modifier::Shift)
-                          ? "previous"
-                          : "next")
-                  << "SceneInstance";
-      setSceneInstanceFromListAndShow(getNextSceneInstanceIDX(
-          (event.modifiers() & MouseEvent::Modifier::Shift) ? -1 : 1));
+      if (event.modifiers() & MouseEvent::Modifier::Alt) {
+        setSceneInstanceFromListAndShow(curSceneInstanceIDX_);
+      } else {
+        ESP_DEBUG() << "Cycling to"
+                    << ((event.modifiers() & MouseEvent::Modifier::Shift)
+                            ? "previous"
+                            : "next")
+                    << "SceneInstance";
+        setSceneInstanceFromListAndShow(getNextSceneInstanceIDX(
+            (event.modifiers() & MouseEvent::Modifier::Shift) ? -1 : 1));
+      }
       break;
     case KeyEvent::Key::Space:
       simulating_ = !simulating_;


### PR DESCRIPTION
## Motivation and Context
Adds key combos to URDF loading for faster iteration and in-engine testing:
- `'t'` - load URDF from filepath console input (or drag file into console) 
- `SHIFT + 't'` - quick re-load the most recently loaded URDF (will re-parse the file to catch changes)
- `TAB + 't'` - load the URDF with a fixed base (works with quick re-load also)

Added scene quick re-load with `ALT+TAB` - instead of cycling scenes, clear and reload the current scene.

## How Has This Been Tested
Tested locally in viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
