### PR TITLE
Increase timeout for osx conda build 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
                 export PATH=$HOME/miniconda/bin:$PATH
                 conda create -y -n habitat python=3.6
                 . activate habitat
-                conda install -q -y -c conda-forge ninja numpy pytest pytest-covv=3.0 ccache hypothesis=6.29.3
+                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov=3.0 ccache hypothesis=6.29.3
                 pip install pytest-sugar pytest-xdist pytest-benchmark
               fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ jobs:
             conda init "$(basename "${SHELL}")"
       - run:
           name: Conda OSX build
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: |
             export PATH=$HOME/miniconda/bin:$PATH
             source ~/.bash_profile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
                 export PATH=$HOME/miniconda/bin:$PATH
                 conda create -y -n habitat python=3.6
                 . activate habitat
-                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis=6.29.3
+                conda install -q -y -c conda-forge ninja numpy pytest pytest-covv=3.0 ccache hypothesis=6.29.3
                 pip install pytest-sugar pytest-xdist pytest-benchmark
               fi
       - run:

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -49,10 +49,7 @@ def make_cfg(settings):
     sim_cfg = habitat_sim.SimulatorConfiguration()
     if "scene_dataset_config_file" in settings:
         sim_cfg.scene_dataset_config_file = settings["scene_dataset_config_file"]
-    if "frustum_culling" in settings:
-        sim_cfg.frustum_culling = settings["frustum_culling"]
-    else:
-        sim_cfg.frustum_culling = False
+    sim_cfg.frustum_culling = settings.get("frustum_culling", False)
     if "enable_physics" in settings:
         sim_cfg.enable_physics = settings["enable_physics"]
     if "physics_config_file" in settings:


### PR DESCRIPTION
## Motivation and Context
This PR fixes some CI issues:
- OSX conda build times out occasionally, failing CI. Increase the timeout duration to reduce incidence of this problem.
- Fix the pytest-cov version (3.0) to prevent issues caused by automatic fetch of an older version (2.5)
- Fix a python style nit from flake failing the python-lint test

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
