### PR TITLE
--Bug fixes: Navmesh building and reconfigure in viewer.py

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -219,11 +219,13 @@ class HabitatSimInteractiveViewer(Application):
                 # we need to force a reset, so change the internal config scene name
                 self.sim.config.sim_cfg.scene_id = "NONE"
             self.sim.reconfigure(self.cfg)
-
+        # post reconfigure
         self.active_scene_graph = self.sim.get_active_scene_graph()
         self.default_agent = self.sim.get_agent(self.agent_id)
         self.agent_body_node = self.default_agent.scene_node
         self.render_camera = self.agent_body_node.node_sensor_suite.get("color_sensor")
+        # set sim_settings scene name as actual loaded scene
+        self.sim_settings["scene"] = self.sim.curr_scene_name
 
         Timer.start()
         self.step = -1

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -114,6 +114,9 @@ void initSimBindings(py::module& m) {
           R"(Enable or disable wireframe visualization of current pathfinder's NavMesh.)")
       .def_property_readonly("gpu_device", &Simulator::gpuDevice)
       .def_property_readonly("random", &Simulator::random)
+      .def_property_readonly(
+          "curr_scene_name", &Simulator::getCurSceneInstanceName,
+          R"(The simplified, but unique, name of the currently loaded scene.)")
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -795,9 +795,8 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                                  bool includeStaticObjects) {
   CORRADE_ASSERT(config_.createRenderer,
                  "::recomputeNavMesh: "
-                 "SimulatorConfiguration::createRenderer is "
-                 "false. Scene geometry is required to recompute navmesh. No "
-                 "geometry is "
+                 "SimulatorConfiguration::createRenderer is false. Scene "
+                 "geometry is required to recompute navmesh. No geometry is "
                  "loaded without renderer initialization.",
                  false);
 
@@ -888,6 +887,13 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
       }
     }
   }
+  CORRADE_ASSERT(
+      joinedMesh->vbo.size() > 0,
+      "::recomputeNavMesh: "
+      "Unable to compute a navmesh upon a non-existent mesh - "
+      "the underlying joined collision mesh has no vertices. This is "
+      "probably due to the current scene being NONE.",
+      false);
 
   if (!pathfinder.build(navMeshSettings, *joinedMesh)) {
     ESP_ERROR() << "Failed to build navmesh";

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -887,13 +887,11 @@ bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
       }
     }
   }
-  CORRADE_ASSERT(
-      joinedMesh->vbo.size() > 0,
-      "::recomputeNavMesh: "
-      "Unable to compute a navmesh upon a non-existent mesh - "
-      "the underlying joined collision mesh has no vertices. This is "
-      "probably due to the current scene being NONE.",
-      false);
+  ESP_CHECK(joinedMesh->vbo.size() > 0,
+            "::recomputeNavMesh: "
+            "Unable to compute a navmesh upon a non-existent mesh - "
+            "the underlying joined collision mesh has no vertices. This is "
+            "probably due to the current scene being NONE. Aborting");
 
   if (!pathfinder.build(navMeshSettings, *joinedMesh)) {
     ESP_ERROR() << "Failed to build navmesh";


### PR DESCRIPTION
## Motivation and Context
This small PR fixes 2 bugs : 

- Viewer.py : Update the locally maintained scene name to be the unique, minimal, name of the currently loaded scene. This is necessary if the user requested a scene by some non-unique substring of a scene name (in which case the first match would be the scene rendered)
- Do not build a navmesh on a joined collision mesh devoid of vertices.  **If this is attempted, the process will assert.** Reviewers, please share if you feel this is the appropriate response.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all python and c++ tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
