### PR TITLE
--Vertex-based semantic annotation : Semantic object OBB gen

### DIFF
--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -98,19 +98,21 @@ void BaseMesh::buildSemanticOBBs(
     auto& ssdObj = *ssdObjs[semanticIDToSSOBJidx[semanticID]];
     esp::vec3f center{};
     esp::vec3f dims{};
+    const std::string debugStr = Cr::Utility::formatString(
+        "{} Semantic ID : {} : SSD object tag : {} present in {} verts | ",
+        msgPrefix, semanticID, ssdObj.id(), vertCounts[semanticID]);
+    std::string infoStr;
     if (vertCounts[semanticID] == 0) {
-      ESP_DEBUG() << Cr::Utility::formatString(
-          "{}No verts have semantic ID {} : {}", msgPrefix, semanticID,
-          ssdObj.id());
+      infoStr = "No verts have specified Semantic ID.";
     } else {
       center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
       dims = vertMax[semanticID] - vertMin[semanticID];
-      ESP_DEBUG() << Cr::Utility::formatString(
-          "{} idx : {} -> object : {} present in {} verts : BB Center "
-          "[{},{},{}] Dims [{},{},{}]",
-          msgPrefix, semanticID, ssdObj.id(), vertCounts[semanticID],
-          center.x(), center.y(), center.z(), dims.x(), dims.y(), dims.z());
+      infoStr = Cr::Utility::formatString(
+          "BB Center [{},{},{}] Dims [{},{},{}]", center.x(), center.y(),
+          center.z(), dims.x(), dims.y(), dims.z());
     }
+    ESP_DEBUG() << debugStr << infoStr;
+
     ssdObj.setObb(center, dims);
   }
 

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -95,7 +95,7 @@ void BaseMesh::buildSemanticOBBs(
     // semantic ID on vertex - valid values are 1->semanticIDToSSOBJidx.size().
     // Invalid/unknown semantic ids are > semanticIDToSSOBJidx.size()
     const auto semanticID = vertSemanticIDs[vertIdx];
-    if ((semanticID > 0) && (semanticID <= semanticIDToSSOBJidx.size())) {
+    if ((semanticID > 0) && (semanticID < semanticIDToSSOBJidx.size())) {
       const auto vert = vertices[vertIdx];
       // FOR VERT-BASED OBB CALC
       // only support bbs for known colors that map to semantic objects
@@ -115,7 +115,8 @@ void BaseMesh::buildSemanticOBBs(
     esp::vec3f dims{};
 
     const std::string debugStr = Cr::Utility::formatString(
-        "{}Semantic ID : {} : color : {} tag : {} present in {} verts | ",
+        "{} Semantic ID : {} : color : {} tag : {} present in {} "
+        "verts | ",
         msgPrefix, semanticID,
         getColorAsString(static_cast<Mn::Color3ub>(ssdObj.getColor())),
         ssdObj.id(), vertCounts[semanticID]);
@@ -131,7 +132,6 @@ void BaseMesh::buildSemanticOBBs(
     }
     ssdObj.setObb(center, dims);
   }
-
 }  // BaseMesh::buildSemanticOBBs
 
 }  // namespace assets

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -114,7 +114,7 @@ void BaseMesh::buildSemanticOBBs(
           "{}BB Center [{},{},{}] Dims [{},{},{}]", debugStr, center.x(),
           center.y(), center.z(), dims.x(), dims.y(), dims.z());
     }
-    debugMsgs.emplace_back(infoStr);
+    debugMsgs.emplace_back(std::move(infoStr));
 
     ssdObj.setObb(center, dims);
   }

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -3,8 +3,13 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "BaseMesh.h"
+#include <Corrade/Utility/FormatStl.h>
+#include <Magnum/Math/PackingBatch.h>
 #include <Magnum/MeshTools/Compile.h>
+#include "esp/scene/SemanticScene.h"
 
+namespace Cr = Corrade;
+namespace Mn = Magnum;
 namespace esp {
 namespace assets {
 
@@ -18,6 +23,98 @@ bool BaseMesh::setMeshType(SupportedMeshType type) {
   type_ = type;
   return true;
 }
+
+void BaseMesh::buildMeshColors(
+    const Mn::Trade::MeshData& srcMeshData,
+    bool convertToSRGB,
+    Cr::Containers::Array<Mn::Color3ub>& meshColors) const {
+  /* Assuming colors are 8-bit RGB to avoid expanding them to float and then
+     packing back */
+
+  if (convertToSRGB) {
+    auto colors = srcMeshData.colorsAsArray();
+    for (std::size_t i = 0; i != colors.size(); ++i) {
+      meshColors[i] = colors[i].rgb().toSrgb<Mn::UnsignedByte>();
+    }
+  } else {
+    Mn::Math::packInto(Cr::Containers::arrayCast<2, float>(
+                           stridedArrayView(srcMeshData.colorsAsArray()))
+                           .except({0, 1}),
+                       Cr::Containers::arrayCast<2, Mn::UnsignedByte>(
+                           stridedArrayView(meshColors)));
+  }
+}  // BaseMesh::buildMeshColors
+
+void BaseMesh::buildSemanticOBBs(
+    const std::vector<vec3f>& vertices,
+    const std::vector<uint16_t>& vertSemanticIDs,
+    const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
+    const std::string& msgPrefix) const {
+  // build per-SSD object vector of known semantic IDs
+  std::size_t numSSDObjs = ssdObjs.size();
+  // no semantic ID 0
+  std::vector<int> semanticIDToSSOBJidx(numSSDObjs + 1);
+  for (int i = 0; i < numSSDObjs; ++i) {
+    const auto& ssdObj = *ssdObjs[i];
+    int semanticID = ssdObj.semanticID();
+    if (semanticIDToSSOBJidx.size() <= semanticID) {
+      semanticIDToSSOBJidx.resize(semanticID + 1);
+    }
+    semanticIDToSSOBJidx[semanticID] = i;
+  }
+
+  // aggegates of per-semantic ID mins and maxes
+  std::vector<esp::vec3f> vertMax(
+      semanticIDToSSOBJidx.size(),
+      {-Mn::Constants::inf(), -Mn::Constants::inf(), -Mn::Constants::inf()});
+  std::vector<esp::vec3f> vertMin(
+      semanticIDToSSOBJidx.size(),
+      {Mn::Constants::inf(), Mn::Constants::inf(), Mn::Constants::inf()});
+  std::vector<int> vertCounts(semanticIDToSSOBJidx.size());
+
+  // for each vertex, map vert min and max for each known semantic ID
+  // Known semantic IDs are expected to be contiguous, and correspond to the
+  // number of unique ssdObjs mappings.
+
+  for (int vertIdx = 0; vertIdx < vertSemanticIDs.size(); ++vertIdx) {
+    // semantic ID on vertex - valid values are 1->semanticIDToSSOBJidx.size().
+    // Invalid/unknown semantic ids are > semanticIDToSSOBJidx.size()
+    const auto semanticID = vertSemanticIDs[vertIdx];
+    if ((semanticID > 0) && (semanticID <= semanticIDToSSOBJidx.size())) {
+      const auto vert = vertices[vertIdx];
+      // FOR VERT-BASED OBB CALC
+      // only support bbs for known colors that map to semantic objects
+      vertMax[semanticID] = vertMax[semanticID].cwiseMax(vert);
+      vertMin[semanticID] = vertMin[semanticID].cwiseMin(vert);
+      vertCounts[semanticID] += 1;
+    }
+  }
+
+  // with mins/maxs per ID, map to objs
+  // give each ssdObj the values to build its OBB
+  for (int semanticID = 1; semanticID < semanticIDToSSOBJidx.size();
+       ++semanticID) {
+    // get object with given semantic ID
+    auto& ssdObj = *ssdObjs[semanticIDToSSOBJidx[semanticID]];
+    esp::vec3f center{};
+    esp::vec3f dims{};
+    if (vertCounts[semanticID] == 0) {
+      ESP_DEBUG() << Cr::Utility::formatString(
+          "{}No verts have semantic ID {} : {}", msgPrefix, semanticID,
+          ssdObj.id());
+    } else {
+      center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
+      dims = vertMax[semanticID] - vertMin[semanticID];
+      ESP_DEBUG() << Cr::Utility::formatString(
+          "{} idx : {} -> object : {} present in {} verts : BB Center "
+          "[{},{},{}] Dims [{},{},{}]",
+          msgPrefix, semanticID, ssdObj.id(), vertCounts[semanticID],
+          center.x(), center.y(), center.z(), dims.x(), dims.y(), dims.z());
+    }
+    ssdObj.setObb(center, dims);
+  }
+
+}  // BaseMesh::buildSemanticOBBs
 
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -170,13 +170,14 @@ class BaseMesh {
    * mesh, both known in semantic scene descriptor, and unknown.  Known IDs are
    * expected to start at 1 and be contiguous, followed by unknown semantic IDs
    * @param ssdObjs The known semantic scene descriptor objects for the mesh
-   * @param msgPrefix Debug message prefix denoting caller.
+   * @param debugMsgs Debug messages documenting whether each ssdObj is present
+   * in mesh or not.
    */
   void buildSemanticOBBs(
       const std::vector<vec3f>& vertices,
       const std::vector<uint16_t>& vertSemanticIDs,
       const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
-      const std::string& msgPrefix = "") const;
+      std::vector<std::string>& debugMsgs) const;
 
   /**
    * @brief Identifies the derived type of this object and the format of the

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -23,7 +23,12 @@
 #include "esp/core/Esp.h"
 #include "esp/gfx/magnum.h"
 
+namespace Cr = Corrade;
+namespace Mn = Magnum;
 namespace esp {
+namespace scene {
+class SemanticObject;
+}  // namespace scene
 namespace assets {
 
 /**
@@ -145,6 +150,34 @@ class BaseMesh {
   Magnum::Range3D BB;
 
  protected:
+  /**
+   * @brief Build an array of colors found in the source mesh.
+   * Generally used for semantic processing/rendering.
+   * @param srcMeshData The source mesh data to read for the colors
+   * @param convertToSRGB Whether the source vertex colors from the @p
+   * srcMeshData should be converted to SRGB
+   * @param [out] meshColors The per-vertex array of colors to be built.
+   * @return a properly configured array of colors found in the mesh
+   */
+  void buildMeshColors(const Mn::Trade::MeshData& srcMeshData,
+                       bool convertToSRGB,
+                       Cr::Containers::Array<Mn::Color3ub>& meshColors) const;
+
+  /**
+   * @brief Build semantic OBBs based on presence of semantic IDs on vertices.
+   * @param vertices Ref to vertex array
+   * @param vertSemanticIDs Ref to per-vertex semantic IDs persent on source
+   * mesh, both known in semantic scene descriptor, and unknown.  Known IDs are
+   * expected to start at 1 and be contiguous, followed by unknown semantic IDs
+   * @param ssdObjs The known semantic scene descriptor objects for the mesh
+   * @param msgPrefix Debug message prefix denoting caller.
+   */
+  void buildSemanticOBBs(
+      const std::vector<vec3f>& vertices,
+      const std::vector<uint16_t>& vertSemanticIDs,
+      const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
+      const std::string& msgPrefix = "") const;
+
   /**
    * @brief Identifies the derived type of this object and the format of the
    * asset.

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -50,7 +50,7 @@ enum SupportedMeshType {
    * Instance meshes loaded from sources including segmented object
    * identifier data (e.g. semantic data: chair, table, etc...). Sources include
    * .ply files and reconstructions of Matterport scans. Object is likely of
-   * type @ref GenericSemanticMeshData or Mp3dInstanceMeshData.
+   * type @ref GenericSemanticMeshData.
    */
   INSTANCE_MESH = 0,
 
@@ -153,17 +153,16 @@ class BaseMesh {
   std::string getColorAsString(Magnum::Color3ub color) const;
 
   /**
-   * @brief Build an array of colors found in the source mesh.
-   * Generally used for semantic processing/rendering.
-   * @param srcMeshData The source mesh data to read for the colors
+   * @brief Populate an array of colors of the correct type from the given
+   * @p srcColors. Generally used for semantic processing/rendering.
+   * @param srcColors The source colors
    * @param convertToSRGB Whether the source vertex colors from the @p
    * srcMeshData should be converted to SRGB
-   * @param [out] meshColors The per-vertex array of colors to be built.
-   * @return a properly configured array of colors found in the mesh
+   * @param [out] destColors The per-element array of colors to be built.
    */
-  void buildMeshColors(const Mn::Trade::MeshData& srcMeshData,
-                       bool convertToSRGB,
-                       Cr::Containers::Array<Mn::Color3ub>& meshColors) const;
+  void convertMeshColors(const Mn::Trade::MeshData& srcMeshData,
+                         bool convertToSRGB,
+                         Cr::Containers::Array<Mn::Color3ub>& destColors) const;
 
   /**
    * @brief Build semantic OBBs based on presence of semantic IDs on vertices.

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -150,6 +150,8 @@ class BaseMesh {
   Magnum::Range3D BB;
 
  protected:
+  std::string getColorAsString(Magnum::Color3ub color) const;
+
   /**
    * @brief Build an array of colors found in the source mesh.
    * Generally used for semantic processing/rendering.
@@ -170,14 +172,13 @@ class BaseMesh {
    * mesh, both known in semantic scene descriptor, and unknown.  Known IDs are
    * expected to start at 1 and be contiguous, followed by unknown semantic IDs
    * @param ssdObjs The known semantic scene descriptor objects for the mesh
-   * @param debugMsgs Debug messages documenting whether each ssdObj is present
-   * in mesh or not.
+   * @param msgPrefix Debug message prefix, referencing caller.
    */
   void buildSemanticOBBs(
       const std::vector<vec3f>& vertices,
       const std::vector<uint16_t>& vertSemanticIDs,
       const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
-      std::vector<std::string>& debugMsgs) const;
+      const std::string& msgPrefix) const;
 
   /**
    * @brief Identifies the derived type of this object and the format of the

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -260,17 +260,17 @@ GenericSemanticMeshData::buildSemanticMeshData(
       debugMsgs.reserve(debugMsgs.size() + nonSSDVertColorIDs.size() + 1);
       // colors found on vertices not found in semantic lexicon :
       if (nonSSDVertColorIDs.size() == 0) {
-        debugMsgs.emplace_back(Cr::Utility::formatString(
-            "No unexpected colors found mapped to mesh verts."));
+        debugMsgs.emplace_back(
+            "No unexpected colors found mapped to mesh verts.");
       } else {
-        debugMsgs.emplace_back(Cr::Utility::formatString(
+        debugMsgs.emplace_back(std::move(Cr::Utility::formatString(
             "{} unexpected/unknown colors found mapped to mesh verts.",
-            nonSSDVertColorIDs.size()));
+            nonSSDVertColorIDs.size())));
         for (const std::pair<const uint32_t, int>& elem : nonSSDVertColorIDs) {
-          debugMsgs.emplace_back(Cr::Utility::formatString(
+          debugMsgs.emplace_back(std::move(Cr::Utility::formatString(
               "\t\tColor {} | # verts {} | applied Semantic ID {}.",
               colorAsStr(static_cast<Mn::Color3ub>(colorMapToUse[elem.second])),
-              nonSSDVertColorCounts.at(elem.first), elem.second));
+              nonSSDVertColorCounts.at(elem.first), elem.second)));
         }
       }
 

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -222,10 +222,13 @@ GenericSemanticMeshData::buildSemanticMeshData(
       // list of per-ssObj/color vertex Aggregations and counts
       std::vector<esp::vec3f> vertAggregate(semanticIDToSSOBJid.size(),
                                             {0, 0, 0});
-      std::vector<esp::vec3f> vertMax(semanticIDToSSOBJid.size(),
-                                      {-1000.0f, -1000.0f, -1000.0f});
-      std::vector<esp::vec3f> vertMin(semanticIDToSSOBJid.size(),
-                                      {1000.0f, 1000.0f, 1000.0f});
+      std::vector<esp::vec3f> vertMax(
+          semanticIDToSSOBJid.size(),
+          {-Mn::Constants::inf(), -Mn::Constants::inf(),
+           -Mn::Constants::inf()});
+      std::vector<esp::vec3f> vertMin(
+          semanticIDToSSOBJid.size(),
+          {Mn::Constants::inf(), Mn::Constants::inf(), Mn::Constants::inf()});
       std::vector<int> vertCounts(semanticIDToSSOBJid.size());
       std::vector<esp::vec3f> kahanC(semanticIDToSSOBJid.size(), {0, 0, 0});
 

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -30,7 +30,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
     const Mn::Trade::MeshData& srcMeshData,
     const std::string& semanticFilename,
     const bool splitMesh,
-    std::vector<Magnum::Vector3ub>& colorMapToUse,
+    std::vector<Mn::Vector3ub>& colorMapToUse,
     bool convertToSRGB,
     const std::shared_ptr<scene::SemanticScene>& semanticScene) {
   // build text prefix used in log messages
@@ -315,14 +315,13 @@ GenericSemanticMeshData::buildSemanticMeshData(
     // Store indices, facd_ids in Magnum MeshData3D format such that
     // later they can be accessed.
     // Note that normal and texture data are not stored
-    semanticData->collisionMeshData_.primitive =
-        Magnum::MeshPrimitive::Triangles;
+    semanticData->collisionMeshData_.primitive = Mn::MeshPrimitive::Triangles;
     semanticData->updateCollisionMeshData();
     splitMeshData.emplace_back(std::move(semanticData));
   }
   return splitMeshData;
 
-}  // GenericSemanticMeshData::loadSemanticMeshData
+}  // namespace assets
 
 void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
   if (forceReload) {
@@ -342,7 +341,7 @@ void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
 
   renderingBuffer_ =
       std::make_unique<GenericSemanticMeshData::RenderingBuffer>();
-  renderingBuffer_->mesh.setPrimitive(Magnum::GL::MeshPrimitive::Triangles)
+  renderingBuffer_->mesh.setPrimitive(Mn::GL::MeshPrimitive::Triangles)
       .setCount(cpu_ibo_.size())
       .addVertexBuffer(
           std::move(vertices), 0, Mn::Shaders::GenericGL3D::Position{},
@@ -361,7 +360,7 @@ void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
   buffersOnGPU_ = true;
 }
 
-Magnum::GL::Mesh* GenericSemanticMeshData::getMagnumGLMesh() {
+Mn::GL::Mesh* GenericSemanticMeshData::getMagnumGLMesh() {
   if (renderingBuffer_ == nullptr) {
     return nullptr;
   }

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -10,7 +10,7 @@
 #include <Corrade/Utility/Algorithms.h>
 #include <Corrade/Utility/FormatStl.h>
 #include <Magnum/DebugTools/ColorMap.h>
-#include <Magnum/Math/Algorithms/KahanSum.h>
+//#include <Magnum/Math/Algorithms/KahanSum.h>
 #include <Magnum/Math/FunctionsBatch.h>
 #include <Magnum/Math/PackingBatch.h>
 #include <Magnum/MeshTools/Interleave.h>
@@ -220,8 +220,8 @@ GenericSemanticMeshData::buildSemanticMeshData(
       // TEMP FOR VERT-BASED OBB CALC
 
       // list of per-ssObj/color vertex Aggregations and counts
-      std::vector<esp::vec3f> vertAggregate(semanticIDToSSOBJid.size(),
-                                            {0, 0, 0});
+      // std::vector<esp::vec3f> vertAggregate(semanticIDToSSOBJid.size(),
+      //                                       {0, 0, 0});
       std::vector<esp::vec3f> vertMax(
           semanticIDToSSOBJid.size(),
           {-Mn::Constants::inf(), -Mn::Constants::inf(),
@@ -230,7 +230,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
           semanticIDToSSOBJid.size(),
           {Mn::Constants::inf(), Mn::Constants::inf(), Mn::Constants::inf()});
       std::vector<int> vertCounts(semanticIDToSSOBJid.size());
-      std::vector<esp::vec3f> kahanC(semanticIDToSSOBJid.size(), {0, 0, 0});
+      // std::vector<esp::vec3f> kahanC(semanticIDToSSOBJid.size(), {0, 0, 0});
 
       for (int vertIdx = 0; vertIdx < numVerts; ++vertIdx) {
         Mn::Color3ub meshColor = meshColors[vertIdx];
@@ -251,8 +251,9 @@ GenericSemanticMeshData::buildSemanticMeshData(
           // aggregate
           auto vert = semanticData->cpu_vbo_[vertIdx];
           // Kahan sum
-          vertAggregate[semanticID] = Mn::Math::Algorithms::kahanSum(
-              &vert, &vert + 1, vertAggregate[semanticID], &kahanC[semanticID]);
+          // vertAggregate[semanticID] = Mn::Math::Algorithms::kahanSum(
+          //     &vert, &vert + 1, vertAggregate[semanticID],
+          //     &kahanC[semanticID]);
           // vertAggregate[semanticID] += vert;
           vertMax[semanticID] = vertMax[semanticID].cwiseMax(vert);
           vertMin[semanticID] = vertMin[semanticID].cwiseMin(vert);
@@ -299,14 +300,13 @@ GenericSemanticMeshData::buildSemanticMeshData(
               "In mesh {}, no verts have semantic ID {} : {}", semanticFilename,
               semanticID, ssdObj.id());
         } else {
-          center = vertAggregate[semanticID] / vertCounts[semanticID];
+          center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
           dims = vertMax[semanticID] - vertMin[semanticID];
-          // ESP_DEBUG() << Cr::Utility::formatString(
-          //     "In mesh {}, object : {} has examples {} center "
-          //     "[{},{},{}] dims [{},{},{}]",
-          //     semanticFilename, ssdObj.id(), vertCounts[semanticID],
-          //     center.x(), center.y(), center.z(), dims.x(), dims.y(),
-          //     dims.z());
+          ESP_DEBUG() << Cr::Utility::formatString(
+              "In mesh {}, idx : {} -> object : {} has examples {} center "
+              "[{},{},{}] dims [{},{},{}]",
+              semanticFilename, semanticID, ssdObj.id(), vertCounts[semanticID],
+              center.x(), center.y(), center.z(), dims.x(), dims.y(), dims.z());
         }
         ssdObj.setObb(center, dims);
       }

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -253,7 +253,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
                                       semanticData->objectIds_, ssdObjs,
                                       dbgMsgPrefix);
       // colors found on vertices not found in semantic lexicon :
-      if (nonSSDVertColorIDs.size() == 0) {
+      if (nonSSDVertColorIDs.empty()) {
         ESP_DEBUG() << dbgMsgPrefix
                     << "No unexpected colors found mapped to mesh verts.";
       } else {

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -302,11 +302,12 @@ GenericSemanticMeshData::buildSemanticMeshData(
         } else {
           center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
           dims = vertMax[semanticID] - vertMin[semanticID];
-          ESP_DEBUG() << Cr::Utility::formatString(
-              "In mesh {}, idx : {} -> object : {} has examples {} center "
-              "[{},{},{}] dims [{},{},{}]",
-              semanticFilename, semanticID, ssdObj.id(), vertCounts[semanticID],
-              center.x(), center.y(), center.z(), dims.x(), dims.y(), dims.z());
+          // ESP_DEBUG() << Cr::Utility::formatString(
+          //     "In mesh {}, idx : {} -> object : {} has examples {} center "
+          //     "[{},{},{}] dims [{},{},{}]",
+          //     semanticFilename, semanticID, ssdObj.id(),
+          //     vertCounts[semanticID], center.x(), center.y(), center.z(),
+          //     dims.x(), dims.y(), dims.z());
         }
         ssdObj.setObb(center, dims);
       }

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -157,9 +157,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
         const Mn::Vector3ub ssdColor = ssdObj.getColor();
         const uint32_t colorInt = colorAsInt(ssdColor);
         int semanticID = ssdObj.semanticID();
-        int regionIDX =
-            static_cast<scene::HM3DSemanticRegion&>(*ssdObj.region())
-                .getIndex();
+        int regionIDX = ssdObj.region()->getIndex();
         tmpColorMapToSSDidAndRegionIndex[colorInt] = {semanticID, regionIDX};
         if (colorMapToUse.size() <= semanticID) {
           colorMapToUse.resize(semanticID + 1);

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -166,18 +166,19 @@ GenericSemanticMeshData::buildSemanticMeshData(
         maxRegion = Mn::Math::max(regionIDX, maxRegion);
       }
       // largest possible known semanticID will be size of colorMapToUse at this
-      // point.  If unknown/unmapped colors are present in mesh, colorMapToUse
-      // will grow to hold them in subsequent step.
-      int maxSemanticID = colorMapToUse.size();
+      // point -1 due to idx 0 not being a valid map.  If unknown/unmapped
+      // colors are present in mesh, colorMapToUse will grow to hold them in
+      // subsequent step.
+      // 1st semantic ID for colors not found in SSD objects ==> 1 more than the
+      // current highest id in the colormap
+      std::size_t nonSSDObjID = colorMapToUse.size();
+
       // increment maxRegion to use largest value as unknown region for objects
       // whose colors are not mapped in given ssd data.
       ++maxRegion;
 
       // (re)build mesh objectIDs vector (objectID per vertex) based on
       // per vertex colors mapped
-
-      // 1st semantic ID for colors not found in SSD objects
-      std::size_t nonSSDObjID = maxSemanticID + 1;
 
       // map regionIDs to affected verts using semantic color provided in
       // SemanticScene, as specified in SSD file.
@@ -219,6 +220,9 @@ GenericSemanticMeshData::buildSemanticMeshData(
           auto nonSSDClrRes =
               nonSSDVertColorIDs.insert({meshColorInt, nonSSDObjID});
           if (nonSSDClrRes.second) {
+            ESP_DEBUG() << dbgMsgPrefix << "Inserted Unknown Color" << meshColor
+                        << "in map w/ nonSSDObjID ="
+                        << nonSSDClrRes.first->second;
             // inserted, so increment nonSSDObjID
             ++nonSSDObjID;
             nonSSDVertColorCounts.insert({meshColorInt, 1});
@@ -246,7 +250,6 @@ GenericSemanticMeshData::buildSemanticMeshData(
       semanticData->buildSemanticOBBs(semanticData->cpu_vbo_,
                                       semanticData->objectIds_, ssdObjs,
                                       dbgMsgPrefix);
-
       // colors found on vertices not found in semantic lexicon :
       if (nonSSDVertColorIDs.size() == 0) {
         ESP_DEBUG() << dbgMsgPrefix

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -220,12 +220,14 @@ GenericSemanticMeshData::buildSemanticMeshData(
       // TEMP FOR VERT-BASED OBB CALC
 
       // list of per-ssObj/color vertex Aggregations and counts
-      std::vector<esp::vec3f> vertAggregate(numSSDObjs, {0, 0, 0});
-      std::vector<esp::vec3f> vertMax(numSSDObjs,
+      std::vector<esp::vec3f> vertAggregate(semanticIDToSSOBJid.size(),
+                                            {0, 0, 0});
+      std::vector<esp::vec3f> vertMax(semanticIDToSSOBJid.size(),
                                       {-1000.0f, -1000.0f, -1000.0f});
-      std::vector<esp::vec3f> vertMin(numSSDObjs, {1000.0f, 1000.0f, 1000.0f});
-      std::vector<int> vertCounts(numSSDObjs);
-      std::vector<esp::vec3f> kahanC(numSSDObjs);
+      std::vector<esp::vec3f> vertMin(semanticIDToSSOBJid.size(),
+                                      {1000.0f, 1000.0f, 1000.0f});
+      std::vector<int> vertCounts(semanticIDToSSOBJid.size());
+      std::vector<esp::vec3f> kahanC(semanticIDToSSOBJid.size(), {0, 0, 0});
 
       for (int vertIdx = 0; vertIdx < numVerts; ++vertIdx) {
         Mn::Color3ub meshColor = meshColors[vertIdx];
@@ -379,7 +381,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
   }
   return splitMeshData;
 
-}  // namespace assets
+}  // GenericSemanticMeshData::buildSemanticMeshData
 
 void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
   if (forceReload) {

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -46,7 +46,7 @@ class GenericSemanticMeshData : public BaseMesh {
    * specified and if the source file's objectIds are compatibly configured to
    * do so.
    * @param meshData The imported meshData.
-   * @param plyFile Fully qualified filename of .ply file to load
+   * @param semanticFilename Path-less Filename of source mesh.
    * @param splitMesh Whether or not the resultant mesh should be split into
    * multiple components based on objectIds, for frustum culling.
    * @param convertToSRGB Whether the source vertex colors from the @p meshData

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1283,7 +1283,6 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
   /* Open the file. On error the importer already prints a diagnostic message,
      so no need to do that here. The importer implicitly converts per-face
      attributes to per-vertex, so nothing extra needs to be done. */
-  Cr::Containers::Optional<Mn::Trade::MeshData> meshData;
   ConfigureImporterManagerGLExtensions();
   ESP_CHECK(
       (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0)),
@@ -1296,6 +1295,9 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
       Magnum::Vector3());
 
   auto sceneID = fileImporter_->defaultScene();
+
+  Cr::Containers::Optional<Mn::Trade::MeshData> meshData;
+
   if (sceneID == -1) {
     // no default scene --- standalone OBJ/PLY files, for example
     // already verified at least one mesh exists, this means only one mesh,
@@ -1522,10 +1524,11 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   const std::string& filename = info.filepath;
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
   ConfigureImporterManagerGLExtensions();
-  if (!fileImporter_->openFile(filename)) {
-    ESP_ERROR() << "Cannot open file" << filename;
-    return false;
-  }
+
+  ESP_CHECK(
+      (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0)),
+      Cr::Utility::formatString("Error loading general mesh data from file {}",
+                                filename));
 
   // load file and add it to the dictionary
   LoadedAssetData loadedAssetData{info};

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1289,20 +1289,23 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
       (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0)),
       Cr::Utility::formatString("Error loading semantic mesh data from file {}",
                                 filename));
-
-  const auto meshCount = fileImporter_->meshCount();
   // Transform meshData by reframing rotation.  Doing this here so that
   // transformation is caught in OBB calc.
   Magnum::Matrix4 reframeTransform = Magnum::Matrix4::from(
       Magnum::Quaternion(info.frame.rotationFrameToWorld()).toMatrix(),
       Magnum::Vector3());
-  if (meshCount == 1) {
-    // only one mesh, treat as before
+
+  auto sceneID = fileImporter_->defaultScene();
+  if (sceneID == -1) {
+    // no default scene --- standalone OBJ/PLY files, for example
+    // already verified at least one mesh exists, this means only one mesh,
+    // treat as before
     meshData =
         Mn::MeshTools::transform3D(*fileImporter_->mesh(0), reframeTransform);
   } else {
     Cr::Containers::Optional<Mn::Trade::SceneData> scene =
-        fileImporter_->scene(fileImporter_->defaultScene());
+        fileImporter_->scene(sceneID);
+
     Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
     for (const Cr::Containers::Triple<Mn::UnsignedInt, Mn::Int, Mn::Matrix4>&
              meshTransformation :

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1291,7 +1291,7 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
                                 filename));
   // Transform meshData by reframing rotation.  Doing this here so that
   // transformation is caught in OBB calc.
-  Magnum::Matrix4 reframeTransform = Magnum::Matrix4::from(
+  const Magnum::Matrix4 reframeTransform = Magnum::Matrix4::from(
       Magnum::Quaternion(info.frame.rotationFrameToWorld()).toMatrix(),
       Magnum::Vector3());
 
@@ -1327,14 +1327,12 @@ bool ResourceManager::loadRenderAssetIMesh(const AssetInfo& info) {
     }
     // build concatenated meshData from container of meshes.
     meshData = Mn::MeshTools::concatenate(meshView);
-  }
-
-  // meshData = Mn::MeshTools::transform3D(*meshData, reframeTransform);
+  }  // flatten/reframe src meshes
 
   std::vector<GenericSemanticMeshData::uptr> instanceMeshes =
       GenericSemanticMeshData::buildSemanticMeshData(
-          *meshData, filename, info.splitInstanceMesh,
-          semanticColorMapBeingUsed_,
+          *meshData, Cr::Utility::Directory::filename(filename),
+          info.splitInstanceMesh, semanticColorMapBeingUsed_,
           (filename.find(".ply") == std::string::npos), semanticScene_);
 
   ESP_CHECK(!instanceMeshes.empty(),

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -184,7 +184,6 @@ class ResourceManager {
    */
   Cr::Containers::ArrayView<const Mn::Vector3ub> getSemanticSceneColormap()
       const {
-    // return Magnum::DebugTools::ColorMap::plasma();
     return semanticColorMapBeingUsed_;
   }
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -117,6 +117,10 @@ void initSimBindings(py::module& m) {
       .def_property_readonly(
           "curr_scene_name", &Simulator::getCurSceneInstanceName,
           R"(The simplified, but unique, name of the currently loaded scene.)")
+      .def_property_readonly(
+          "semantic_color_map", &Simulator::getSemanticSceneColormap,
+          R"(The list of semantic colors being used for semantic rendering. The index
+            in the list corresponds to the semantic ID.)")
       .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
                     &Simulator::setFrustumCullingEnabled,
                     R"(Enable or disable the frustum culling)")

--- a/src/esp/scene/GibsonSemanticScene.cpp
+++ b/src/esp/scene/GibsonSemanticScene.cpp
@@ -81,7 +81,7 @@ bool SemanticScene::buildGibsonHouse(const io::JsonDocument& jsonDoc,
         ESP_WARNING() << "Object size from" << categoryName
                       << "isn't provided.";
       }
-      object->obb_ = geo::OBB(center, size, quatf::Identity());
+      object->setObb(center, size, quatf::Identity());
     } else {
       ESP_WARNING() << "Object center coordinates from" << categoryName
                     << "aren't provided.";

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -27,7 +27,8 @@ bool SemanticScene::loadHM3DHouse(
   std::ifstream ifs = std::ifstream(houseFilename);
   std::string header;
   std::getline(ifs, header);
-  if (header != "HM3D Semantic Annotations") {
+
+  if (header.find("HM3D Semantic Annotations") == std::string::npos) {
     ESP_ERROR() << "Unsupported HM3D House format header" << header
                 << "in file name" << houseFilename;
     return false;

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -143,7 +143,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   scene.regions_.clear();
   scene.regions_.reserve(regions.size());
   for (auto& regionItem : regions) {
-    auto regionPtr = HM3DSemanticRegion::create();
+    auto regionPtr = SemanticRegion::create();
     regionPtr->index_ = regionItem.second.regionID;
     for (TempHM3DObject* objItem : regionItem.second.objInstances) {
       objItem->region = regionPtr;

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -37,10 +37,10 @@ class HM3DObjectInstance : public SemanticObject {
                      int objCatID,
                      const std::string& name,
                      const Mn::Vector3ub& clr)
-      : SemanticObject(), objCatID_(objCatID), name_(name), color_(clr) {
+      : SemanticObject(), objCatID_(objCatID), name_(name) {
     index_ = objInstanceID;
+    color_ = clr;
   }
-  Mn::Vector3ub getColor() const { return color_; }
 
   std::string id() const override { return name_; }
 
@@ -49,8 +49,7 @@ class HM3DObjectInstance : public SemanticObject {
   const int objCatID_;
   // unique name for this instance
   const std::string name_;
-  // specified color for this object instance.
-  const Mn::Vector3ub color_;
+
   ESP_SMART_POINTERS(HM3DObjectInstance)
 };
 

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -31,12 +31,6 @@ class HM3DObjectCategory : public SemanticCategory {
   ESP_SMART_POINTERS(HM3DObjectCategory)
 };
 
-class HM3DSemanticRegion : public SemanticRegion {
- public:
-  int getIndex() const { return index_; }
-  ESP_SMART_POINTERS(HM3DSemanticRegion)
-};  // class HM3DSemanticRegion
-
 class HM3DObjectInstance : public SemanticObject {
  public:
   HM3DObjectInstance(int objInstanceID,

--- a/src/esp/scene/Mp3dSemanticScene.cpp
+++ b/src/esp/scene/Mp3dSemanticScene.cpp
@@ -286,7 +286,7 @@ bool SemanticScene::buildMp3dHouse(std::ifstream& ifs,
       }
     }
   }
-
+  scene.hasVertColors_ = true;
   return true;
 
 }  // SemanticScene::buildMp3dHouse

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -85,20 +85,5 @@ bool SemanticScene::
 
 }  // SemanticScene::loadSemanticSceneDescriptor
 
-namespace {
-// TODO remove when/if Magnum ever supports this
-constexpr const char Hex[]{"0123456789abcdef"};
-}  // namespace
-std::string SemanticObject::getColorAsString() const {
-  char out[] = "#______";
-  out[1] = Hex[(color_.r() >> 4) & 0xf];
-  out[2] = Hex[(color_.r() >> 0) & 0xf];
-  out[3] = Hex[(color_.g() >> 4) & 0xf];
-  out[4] = Hex[(color_.g() >> 0) & 0xf];
-  out[5] = Hex[(color_.b() >> 4) & 0xf];
-  out[6] = Hex[(color_.b() >> 0) & 0xf];
-  return std::string(out);
-}
-
 }  // namespace scene
 }  // namespace esp

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -85,5 +85,20 @@ bool SemanticScene::
 
 }  // SemanticScene::loadSemanticSceneDescriptor
 
+namespace {
+// TODO remove when/if Magnum ever supports this
+constexpr const char Hex[]{"0123456789abcdef"};
+}  // namespace
+std::string SemanticObject::getColorAsString() const {
+  char out[] = "#______";
+  out[1] = Hex[(color_.r() >> 4) & 0xf];
+  out[2] = Hex[(color_.r() >> 0) & 0xf];
+  out[3] = Hex[(color_.g() >> 4) & 0xf];
+  out[4] = Hex[(color_.g() >> 0) & 0xf];
+  out[5] = Hex[(color_.b() >> 4) & 0xf];
+  out[6] = Hex[(color_.b() >> 0) & 0xf];
+  return std::string(out);
+}
+
 }  // namespace scene
 }  // namespace esp

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -354,11 +354,17 @@ class SemanticObject {
     obb_ = geo::OBB{center, dimensions, rotation};
   }
 
+  Mn::Vector3ub getColor() const { return color_; }
+  std::string getColorAsString() const;
+  void setColor(Mn::Vector3ub _color) { color_ = _color; }
+
  protected:
   /**
    * @brief The unique semantic ID corresponding to this object
    */
   int index_{};
+  // specified color for this object instance.
+  Mn::Vector3ub color_{};
 
   /**
    * @brief References the parent region for this object

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -355,7 +355,6 @@ class SemanticObject {
   }
 
   Mn::Vector3ub getColor() const { return color_; }
-  std::string getColorAsString() const;
   void setColor(Mn::Vector3ub _color) { color_ = _color; }
 
  protected:

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -348,6 +348,12 @@ class SemanticObject {
 
   SemanticCategory::ptr category() const { return category_; }
 
+  void setObb(const esp::vec3f& center,
+              const esp::vec3f& dimensions,
+              const esp::quatf& rotation = quatf::Identity()) {
+    obb_ = geo::OBB{center, dimensions, rotation};
+  }
+
  protected:
   /**
    * @brief The unique semantic ID corresponding to this object

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -298,7 +298,7 @@ class SemanticRegion {
       return "_" + std::to_string(index_);
     }
   }
-
+  int getIndex() const { return index_; }
   SemanticLevel::ptr level() const { return level_; }
 
   const std::vector<std::shared_ptr<SemanticObject>>& objects() const {

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -81,6 +81,14 @@ class Simulator {
     return resourceManager_->getSemanticScene();
   }
 
+  /**
+   * @brief Return a view of the currently set Semantic scene colormap.
+   */
+  Cr::Containers::ArrayView<const Mn::Vector3ub> getSemanticSceneColormap()
+      const {
+    return resourceManager_->getSemanticSceneColormap();
+  }
+
   inline void getRenderGLContext() {
     // acquire GL context from background thread, if background rendering
     // enabled.
@@ -1096,8 +1104,6 @@ class Simulator {
   int activeSceneID_ = ID_UNDEFINED;
   int activeSemanticSceneID_ = ID_UNDEFINED;
   std::vector<int> sceneID_;
-
-  // std::shared_ptr<scene::SemanticScene> semanticScene_ = nullptr;
 
   std::shared_ptr<physics::PhysicsManager> physicsManager_ = nullptr;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ endif()
 # want to have full log from others, so this is a compromise)
 set_tests_properties(
   GfxReplayTest
+  HM3DSceneTest
   MetadataMediatorTest
   Mp3dTest
   NavTest

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -59,6 +59,9 @@ target_include_directories(GfxReplayTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 corrade_add_test(GibsonSceneTest GibsonSceneTest.cpp LIBRARIES scene sim)
 target_include_directories(GibsonSceneTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+corrade_add_test(HM3DSceneTest HM3DSceneTest.cpp LIBRARIES scene sim)
+target_include_directories(HM3DSceneTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 corrade_add_test(IOTest IOTest.cpp LIBRARIES io metadata)
 target_include_directories(IOTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -35,8 +35,8 @@ struct HM3DSceneTest : Cr::TestSuite::Tester {
     // change config to be using new scene
     auto cfg =
         esp::sim::SimulatorConfiguration{MM_->getSimulatorConfiguration()};
-    ESP_DEBUG() << "Cfg made";
     cfg.activeSceneName = scene;
+    cfg.sceneDatasetConfigFile = HM3DTestConfigLoc;
     // create simulator with new scene and loaded MM holding dataset info
     auto sim = Simulator::create_unique(cfg, MM_);
 
@@ -67,7 +67,6 @@ const struct {
 HM3DSceneTest::HM3DSceneTest() {
   // set up a default simulation config to initialize MM
   auto cfg = esp::sim::SimulatorConfiguration{};
-  cfg.sceneDatasetConfigFile = HM3DTestConfigLoc;
   // build metadata mediator and initialize with cfg, loading test dataset info
   MM_ = esp::metadata::MetadataMediator::create(cfg);
   addInstancedTests(
@@ -76,6 +75,10 @@ HM3DSceneTest::HM3DSceneTest() {
 }
 
 void HM3DSceneTest::testHM3DScene() {
+  // If scene dataset does not exist, skip test for now
+  if (!Cr::Utility::Directory::exists(HM3DTestConfigLoc)) {
+    CORRADE_SKIP("HM3D dataset not found.");
+  }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
   setTestCaseDescription(testData.name);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
@@ -83,6 +86,10 @@ void HM3DSceneTest::testHM3DScene() {
 }
 
 void HM3DSceneTest::testHM3DSemanticScene() {
+  // If scene dataset does not exist, skip test for now
+  if (!Cr::Utility::Directory::exists(HM3DTestConfigLoc)) {
+    CORRADE_SKIP("HM3D dataset not found.");
+  }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
   setTestCaseDescription(testData.name);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -35,8 +35,8 @@ struct HM3DSceneTest : Cr::TestSuite::Tester {
     // change config to be using new scene
     auto cfg =
         esp::sim::SimulatorConfiguration{MM_->getSimulatorConfiguration()};
+    // scene should exist in scene dataset
     cfg.activeSceneName = scene;
-    cfg.sceneDatasetConfigFile = HM3DTestConfigLoc;
     // create simulator with new scene and loaded MM holding dataset info
     auto sim = Simulator::create_unique(cfg, MM_);
 
@@ -51,22 +51,26 @@ struct HM3DSceneTest : Cr::TestSuite::Tester {
 
   esp::logging::LoggingContext loggingContext;
 
-  // The MetadataMediator can exist independent of simulator
+  // The MetadataMediator can exist independently of simulator
   // and provides access to all managers for currently active scene dataset
+  // It loads all the necessary metadata for a dataset only once, speeding
+  // up asset load upon sim.reconfigure calls.
   std::shared_ptr<esp::metadata::MetadataMediator> MM_ = nullptr;
 };  // struct HM3DSceneTest
 
 const struct {
-  const char* name;
+  const char* sceneName;
 
   // index in HM3DTestScenes array for scene
   int testSceneIDX;
 
-} TestHM3DScenes[]{{"GLAQ4DNUx5U", 0}};
+} TestHM3DScenes[]{{"00861-GLAQ4DNUx5U", 0}};
 
 HM3DSceneTest::HM3DSceneTest() {
   // set up a default simulation config to initialize MM
   auto cfg = esp::sim::SimulatorConfiguration{};
+  // initialize with scene dataset name
+  cfg.sceneDatasetConfigFile = HM3DTestConfigLoc;
   // build metadata mediator and initialize with cfg, loading test dataset info
   MM_ = esp::metadata::MetadataMediator::create(cfg);
   addInstancedTests(
@@ -80,7 +84,7 @@ void HM3DSceneTest::testHM3DScene() {
     CORRADE_SKIP("HM3D dataset not found.");
   }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
-  setTestCaseDescription(testData.name);
+  setTestCaseDescription(testData.sceneName);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
   CORRADE_COMPARE(0, 0);
 }
@@ -91,7 +95,7 @@ void HM3DSceneTest::testHM3DSemanticScene() {
     CORRADE_SKIP("HM3D dataset not found.");
   }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
-  setTestCaseDescription(testData.name);
+  setTestCaseDescription(testData.sceneName);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
   CORRADE_COMPARE(0, 0);
 }

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -86,12 +86,6 @@ void HM3DSceneTest::testHM3DScene() {
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
   setTestCaseDescription(testData.sceneName);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
-  auto colorList = simulator->getSemanticSceneColormap();
-  // ESP_DEBUG() << "Size of color list for scene" << testData.sceneName << ":"
-  //             << colorList.size();
-  // for (const auto& colorVec : colorList) {
-  //   ESP_DEBUG() << "\t" << static_cast<Mn::Color3ub>(colorVec);
-  // }
   CORRADE_COMPARE(0, 0);
 }
 
@@ -103,7 +97,26 @@ void HM3DSceneTest::testHM3DSemanticScene() {
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
   setTestCaseDescription(testData.sceneName);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
-  CORRADE_COMPARE(0, 0);
+
+  // semantic color list
+  auto colorList = simulator->getSemanticSceneColormap();
+  CORRADE_VERIFY(colorList.size() > 0);
+  // semantic scene
+  auto semanticScene = simulator->getSemanticScene();
+  // unknown colors in colorlist will not have semantic objects in semantic
+  // scene
+  CORRADE_VERIFY(semanticScene);
+  auto semanticObjects = semanticScene->objects();
+  // verify there are at least as many colors defined as there are
+  // semanticObjects, plus one more for colorList's idx 0.
+  CORRADE_VERIFY(semanticObjects.size() < colorList.size());
+  // verify all colors in colormap correspond to expected colors in semantic
+  // scene descriptor objects
+  for (int i = 0; i < semanticObjects.size(); ++i) {
+    auto ssdObj = semanticObjects[i];
+    int semanticID = ssdObj->semanticID();
+    CORRADE_COMPARE(colorList[semanticID], ssdObj->getColor());
+  }
 }
 
 }  // namespace

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -86,6 +86,12 @@ void HM3DSceneTest::testHM3DScene() {
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
   setTestCaseDescription(testData.sceneName);
   auto simulator = getSimulatorWithScene(HM3DTestScenes[testData.testSceneIDX]);
+  auto colorList = simulator->getSemanticSceneColormap();
+  // ESP_DEBUG() << "Size of color list for scene" << testData.sceneName << ":"
+  //             << colorList.size();
+  // for (const auto& colorVec : colorList) {
+  //   ESP_DEBUG() << "\t" << static_cast<Mn::Color3ub>(colorVec);
+  // }
   CORRADE_COMPARE(0, 0);
 }
 

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#include <Corrade/TestSuite/Tester.h>
+#include <Corrade/Utility/Directory.h>
+#include <string>
+
+#include "esp/scene/SemanticScene.h"
+
+#include "configure.h"
+
+namespace Cr = Corrade;
+
+namespace {
+
+struct HM3DSceneTest : Cr::TestSuite::Tester {
+  explicit HM3DSceneTest();
+
+  void testHM3DScene();
+
+  void testHM3DSemanticScene();
+
+  esp::logging::LoggingContext loggingContext;
+
+};  // struct HM3DSceneTest
+HM3DSceneTest::HM3DSceneTest() {
+  addTests(
+      {&HM3DSceneTest::testHM3DScene, &HM3DSceneTest::testHM3DSemanticScene});
+}
+
+void HM3DSceneTest::testHM3DScene() {
+  CORRADE_COMPARE(0, 0);
+}
+
+void HM3DSceneTest::testHM3DSemanticScene() {
+  CORRADE_COMPARE(0, 0);
+}
+
+}  // namespace
+
+CORRADE_TEST_MAIN(HM3DSceneTest)

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -454,7 +454,8 @@ Key Commands:
   void buildSemanticPrims(int semanticID,
                           const std::string& semanticTag,
                           const Mn::Vector3& semanticCtr,
-                          const Mn::Vector3& semanticSize);
+                          const Mn::Vector3& semanticSize,
+                          const Mn::Quaternion& rotation);
 
   /**
    * @brief Set whether agent locations should be recorded or not. If toggling
@@ -1728,7 +1729,8 @@ void Viewer::createPickedObjectVisualizer(unsigned int objectId) {
 void Viewer::buildSemanticPrims(int semanticID,
                                 const std::string& objTag,
                                 const Mn::Vector3& semanticCtr,
-                                const Mn::Vector3& semanticSize) {
+                                const Mn::Vector3& semanticSize,
+                                const Mn::Quaternion& rotation) {
   auto rigidObjMgr = simulator_->getRigidObjectManager();
   if (semanticBBID_ != -1) {
     // delete semantic wireframe bounding box if it exists
@@ -1759,6 +1761,7 @@ void Viewer::buildSemanticPrims(int semanticID,
   // create bounding box wireframe
   auto bbWfObj = rigidObjMgr->addObjectByHandle(bbWfObjTemplate->getHandle());
   bbWfObj->setTranslation(semanticCtr);
+  bbWfObj->setRotation(rotation);
   bbWfObj->setMotionType(esp::physics::MotionType::STATIC);
   semanticBBID_ = bbWfObj->getID();
 }  // Viewer::buildSemanticPrims
@@ -1860,10 +1863,11 @@ void Viewer::mousePressEvent(MouseEvent& event) {
           if ((objIdx >= 0) && (objIdx < semanticObjects.size())) {
             const auto& semanticObj = semanticObjects[objIdx];
             tmpStr = semanticObj->id();
+            const auto obb = semanticObj->obb();
             // get center and scale of bb and use to build visualization reps
-            buildSemanticPrims((objIdx + 1), tmpStr,
-                               Mn::Vector3{semanticObj->obb().center()},
-                               Mn::Vector3{semanticObj->obb().sizes()});
+            buildSemanticPrims((objIdx + 1), tmpStr, Mn::Vector3{obb.center()},
+                               Mn::Vector3{obb.sizes()},
+                               Mn::Quaternion{obb.rotation()});
           }
           semanticTag_ =
               Cr::Utility::formatString("id:{}:{}", (objIdx + 1), tmpStr);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1368,9 +1368,9 @@ void Viewer::setSceneInstanceFromListAndShow(int nextSceneInstanceIDX) {
   activeSceneGraph_ = nullptr;
 
   // close and reconfigure
-  simulator_->close();
-  simulator_ = esp::sim::Simulator::create_unique(simConfig_, MM_);
-  // simulator_->reconfigure(simConfig_);
+  simulator_->close(false);
+  // simulator_ = esp::sim::Simulator::create_unique(simConfig_, MM_);
+  simulator_->reconfigure(simConfig_);
 
   // initialize sim navmesh, agent, sensors after creation/reconfigure
   initSimPostReconfigure();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -453,8 +453,8 @@ Key Commands:
    */
   void buildSemanticPrims(int semanticID,
                           const std::string& semanticTag,
-                          const Mn::Vector3 semanticCtr,
-                          const Mn::Vector3 semanticSize);
+                          const Mn::Vector3& semanticCtr,
+                          const Mn::Vector3& semanticSize);
 
   /**
    * @brief Set whether agent locations should be recorded or not. If toggling
@@ -1727,8 +1727,8 @@ void Viewer::createPickedObjectVisualizer(unsigned int objectId) {
 
 void Viewer::buildSemanticPrims(int semanticID,
                                 const std::string& objTag,
-                                const Mn::Vector3 semanticCtr,
-                                const Mn::Vector3 semanticSize) {
+                                const Mn::Vector3& semanticCtr,
+                                const Mn::Vector3& semanticSize) {
   auto rigidObjMgr = simulator_->getRigidObjectManager();
   if (semanticBBID_ != -1) {
     // delete semantic wireframe bounding box if it exists
@@ -1742,9 +1742,8 @@ void Viewer::buildSemanticPrims(int semanticID,
     semanticBBID_ = -1;
   }
   ESP_WARNING() << "Object ID : " << semanticID << " Tag : " << objTag
-                << " : Center : [" << semanticCtr.x() << "," << semanticCtr.y()
-                << "," << semanticCtr.z() << "] | size : [" << semanticSize.x()
-                << "," << semanticSize.y() << "," << semanticSize.z() << "]";
+                << " : Center : " << semanticCtr
+                << " | Size : " << semanticSize;
   // // build semantic wireframe bounding box
 
   auto bbWfObjTemplate = objectAttrManager_->getObjectCopyByHandle(


### PR DESCRIPTION
## Motivation and Context
This PR is to provide semantic object OBBs for semantic scenes that have per-vertex annotations of either semantic ID or semantic Color. 

This PR also adds functionality to c++ viewer to visualize these bbs when semantic regions are clicked.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
