### PR TITLE
[Bugfix]--Move .ply transform to before all potential vert-based calcs

### DIFF
--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -57,6 +57,17 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
   srcMeshData.positions3DInto(Cr::Containers::arrayCast<Mn::Vector3>(
       Cr::Containers::arrayView(semanticData->cpu_vbo_)));
+
+  if (semanticFilename.find(".ply") != std::string::npos) {
+    // Generic Semantic PLY meshes have -Z gravity
+    const quatf T_esp_scene =
+        quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY);
+
+    for (auto& xyz : semanticData->cpu_vbo_) {
+      xyz = T_esp_scene * xyz;
+    }
+  }
+
   srcMeshData.indicesInto(semanticData->cpu_ibo_);
   /* Assuming colors are 8-bit RGB to avoid expanding them to float and then
      packing back */
@@ -265,16 +276,6 @@ GenericSemanticMeshData::buildSemanticMeshData(
             Cr::Containers::stridedArrayView(objectIds)),
         Cr::Containers::arrayCast<2, Mn::UnsignedShort>(
             Cr::Containers::stridedArrayView(semanticData->objectIds_)));
-  }
-
-  if (semanticFilename.find(".ply") != std::string::npos) {
-    // Generic Semantic PLY meshes have -Z gravity
-    const quatf T_esp_scene =
-        quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY);
-
-    for (auto& xyz : semanticData->cpu_vbo_) {
-      xyz = T_esp_scene * xyz;
-    }
   }
 
   // build output vector of meshdata unique pointers


### PR DESCRIPTION
## Motivation and Context
Minor bugfix to move .ply-file-based transformation of semantic mesh vertices to be before any vert-based calcs might occur so that transform is reflected in calculations.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
