### PR TITLE
Workaround to support Annotated HM3D semantic-as-RGB observations

### DIFF
--- a/examples/tutorials/semantic_hm3d_tutorial.py
+++ b/examples/tutorials/semantic_hm3d_tutorial.py
@@ -1,0 +1,128 @@
+import math
+import os
+
+import magnum as mn
+import numpy as np
+from matplotlib import pyplot as plt
+from PIL import Image
+
+import habitat_sim
+from habitat_sim.utils.common import quat_from_angle_axis
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+output_path = os.path.join(dir_path, "semantic_hm3d_tutorial_output/")
+
+save_index = 0
+
+
+def save_img_pil(data):
+    global save_index
+    rgb_image = Image.fromarray(np.uint8(data))
+    filepath = output_path + str(save_index) + ".png"
+    rgb_image.save(filepath)
+    print("saved {}".format(filepath))
+    save_index += 1
+
+def show_img(data, save):
+    save_img_pil(data[0])
+    save_img_pil(data[1])
+
+
+def get_obs(sim, show, save):
+    # render sensor ouputs and optionally show them
+    # perf todo don't call get_sensor_observations() twice; this draws twice!
+    observations = sim.get_sensor_observations()
+    rgb_obs = observations["rgba_camera"]
+    semantic_obs = observations["semantic_camera"]
+    if show:
+        show_img((rgb_obs, semantic_obs), save)
+
+
+def place_agent(sim):
+    # place our agent in the scene
+    agent_state = habitat_sim.AgentState()
+    agent_state.position = [5.0, 0.0, 1.0]
+    agent_state.rotation = quat_from_angle_axis(
+        math.radians(70), np.array([0, 1.0, 0])
+    ) * quat_from_angle_axis(math.radians(-20), np.array([1.0, 0, 0]))
+    agent = sim.initialize_agent(0, agent_state)
+    return agent.scene_node.transformation_matrix()
+
+
+def make_configuration(scene_file, hm3d_data_path):
+    # simulator configuration
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.scene_id = scene_file
+    backend_cfg.scene_dataset_config_file = hm3d_data_path + "/hm3d_annotated_basis.scene_dataset_config.json"
+    backend_cfg.enable_physics = True
+
+    # sensor configurations
+    # Note: all sensors must have the same resolution
+    # setup rgb and semantic sensors
+    camera_resolution = [1080, 960]
+    sensor_specs = []
+
+    rgba_camera_spec = habitat_sim.CameraSensorSpec()
+    rgba_camera_spec.uuid = "rgba_camera"
+    rgba_camera_spec.sensor_type = habitat_sim.SensorType.COLOR
+    rgba_camera_spec.resolution = camera_resolution
+    rgba_camera_spec.position = [0.0, 1.5, 0.0]  # ::: fix y to be 0 later
+    rgba_camera_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
+    sensor_specs.append(rgba_camera_spec)
+
+    semantic_camera_spec = habitat_sim.CameraSensorSpec()
+    semantic_camera_spec.uuid = "semantic_camera"
+    semantic_camera_spec.sensor_type = habitat_sim.SensorType.SEMANTIC
+    semantic_camera_spec.resolution = camera_resolution
+    semantic_camera_spec.position = [0.0, 1.5, 0.0]
+    semantic_camera_spec.sensor_subtype = habitat_sim.SensorSubType.PINHOLE
+    sensor_specs.append(semantic_camera_spec)
+
+    # agent configuration
+    agent_cfg = habitat_sim.agent.AgentConfiguration()
+    agent_cfg.sensor_specifications = sensor_specs
+
+    return habitat_sim.Configuration(backend_cfg, [agent_cfg])
+
+
+# This is wrapped such that it can be added to a unit test
+def main(hm3d_data_path=None, show_imgs=True, save_imgs=False):
+    if save_imgs and not os.path.exists(output_path):
+        os.mkdir(output_path)
+
+    sim = None
+
+    test_scenes = [
+        hm3d_data_path + "/hm3d-minival-habitat/00800-TEEsavR23oF/TEEsavR23oF.basis.glb",
+    ]
+
+    for scene in test_scenes:
+        # reconfigure/construct the simulator with a new scene asset
+        cfg = make_configuration(scene_file=scene, hm3d_data_path=hm3d_data_path)
+        if sim:
+            sim.reconfigure(cfg)
+        else:
+            sim = habitat_sim.Simulator(cfg)
+        place_agent(sim)  # noqa: F841
+
+        agent_node = sim.get_agent(0).body.object
+
+        # some hard-coded positions for scene TEEsavR23oF; see also place_agent
+        positions = [
+            [2.0, 0.0, -2.0], [0.0, 0.0, -3.0], [-4.0, 0.0, -1.0], [-7.0, 0.0, -1.0],
+            [0.0, 3.0, -6.0], [-4.0, 3.0, -2.0]
+        ]
+
+        for agent_pos in positions:
+            agent_node.translation = agent_pos
+            get_obs(sim, show_imgs, save_imgs)
+        
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hm3d-data-path", required=True)
+    parser.add_argument("--no-save-images", dest="save_images", action="store_false")
+    parser.set_defaults(show_images=True, save_images=True)
+    args = parser.parse_args()
+    main(hm3d_data_path=args.hm3d_data_path, show_imgs=args.show_images, save_imgs=args.save_images)

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -61,6 +61,9 @@ struct AssetInfo {
   metadata::attributes::ObjectInstanceShaderType shaderTypeToUse =
       metadata::attributes::ObjectInstanceShaderType::Unspecified;
 
+  // asset will be used for semantic-as-RGB observations
+  bool isSemanticRGB = false;
+
   //! Populates a preset AssetInfo by matching against known filepaths
   static AssetInfo fromPath(const std::string& filepath);
 

--- a/src/esp/gfx/Renderer.cpp
+++ b/src/esp/gfx/Renderer.cpp
@@ -360,10 +360,12 @@ struct Renderer::Impl {
         break;
 
       case sensor::SensorType::Semantic:
-        if (bindingFlags & Flag::VisualizeTexture) {
-          renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
-        }
-        renderTargetFlags |= RenderTarget::Flag::ObjectIdAttachment;
+        // if (bindingFlags & Flag::VisualizeTexture) {
+        //   renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
+        // }
+        // renderTargetFlags |= RenderTarget::Flag::ObjectIdAttachment;
+        // temp hack: semantic as RGB
+        renderTargetFlags |= RenderTarget::Flag::RgbaAttachment;
         break;
 
       default:

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -626,7 +626,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho) {
                                   : esp::sensor::SensorSubType::Pinhole;
     spec->sensorType = sensorType;
     if (sensorType == esp::sensor::SensorType::Depth ||
-        sensorType == esp::sensor::SensorType::Semantic) {
+        false) { // temp sensorType == esp::sensor::SensorType::Semantic) {
       spec->channels = 1;
     }
     spec->position = {0.0f, rgbSensorHeight, 0.0f};
@@ -655,7 +655,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho) {
     spec->uuid = uuid;
     spec->sensorType = sensorType;
     if (sensorType == esp::sensor::SensorType::Depth ||
-        sensorType == esp::sensor::SensorType::Semantic) {
+        false) { // sensorType == esp::sensor::SensorType::Semantic) {
       spec->channels = 1;
     }
     spec->sensorSubType = esp::sensor::SensorSubType::Fisheye;
@@ -701,7 +701,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho) {
     spec->uuid = uuid;
     spec->sensorType = sensorType;
     if (sensorType == esp::sensor::SensorType::Depth ||
-        sensorType == esp::sensor::SensorType::Semantic) {
+        false) { // temp sensorType == esp::sensor::SensorType::Semantic) {
       spec->channels = 1;
     }
     spec->sensorSubType = esp::sensor::SensorSubType::Equirectangular;
@@ -1445,7 +1445,7 @@ void Viewer::drawEvent() {
 
   uint32_t visibles = renderCamera_->getPreviousNumVisibleDrawables();
 
-  if ((visualizeMode_ == VisualizeMode::RGBA) &&
+  if ((visualizeMode_ == VisualizeMode::RGBA || visualizeMode_ == VisualizeMode::Semantic) &&
       (sensorMode_ == VisualSensorMode::Camera)) {
     // Visualizing RGBA pinhole camera
     if (mouseGrabber_ != nullptr) {
@@ -1660,7 +1660,7 @@ void Viewer::bindRenderTarget() {
       esp::sensor::VisualSensor& visualSensor =
           static_cast<esp::sensor::VisualSensor&>(it.second.get());
       if (visualizeMode_ == VisualizeMode::Depth ||
-          visualizeMode_ == VisualizeMode::Semantic) {
+          false) { // temp visualizeMode_ == VisualizeMode::Semantic) {
         simulator_->getRenderer()->bindRenderTarget(
             visualSensor, {esp::gfx::Renderer::Flag::VisualizeTexture});
       } else {

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -591,13 +591,28 @@ class Sensor:
         else:
             size = self._sensor_object.framebuffer_size
             if self._spec.sensor_type == SensorType.SEMANTIC:
+                # temp hack: semantic as RGB
                 self._buffer = np.empty(
-                    (self._spec.resolution[0], self._spec.resolution[1]),
-                    dtype=np.uint32,
+                    (
+                        self._spec.resolution[0],
+                        self._spec.resolution[1],
+                        self._spec.channels,
+                    ),
+                    dtype=np.uint8,
                 )
                 self.view = mn.MutableImageView2D(
-                    mn.PixelFormat.R32UI, size, self._buffer
+                    mn.PixelFormat.RGBA8_UNORM,
+                    size,
+                    self._buffer.reshape(self._spec.resolution[0], -1),
                 )
+
+                # self._buffer = np.empty(
+                #     (self._spec.resolution[0], self._spec.resolution[1]),
+                #     dtype=np.uint32,
+                # )
+                # self.view = mn.MutableImageView2D(
+                #     mn.PixelFormat.R32UI, size, self._buffer
+                # )
             elif self._spec.sensor_type == SensorType.DEPTH:
                 self._buffer = np.empty(
                     (self._spec.resolution[0], self._spec.resolution[1]),
@@ -714,7 +729,9 @@ class Sensor:
                 obs = self._buffer.flip(0)  # type: ignore[union-attr]
         else:
             if self._spec.sensor_type == SensorType.SEMANTIC:
-                tgt.read_frame_object_id(self.view)
+                # tgt.read_frame_object_id(self.view)
+                # temp hack: semantic as RGB
+                tgt.read_frame_rgba(self.view)
             elif self._spec.sensor_type == SensorType.DEPTH:
                 tgt.read_frame_depth(self.view)
             else:


### PR DESCRIPTION
Do not merge. I'm documenting this `hm3d_semantic_as_rgb` branch.

This branch is a temporary workaround to support Annotated HM3D in Habitat. This branch makes some C++ and python changes to force semantic observations to render as (unfiltered) RGB images.

Two options to test this:
1. `build/utils/viewer/viewer path/to/hm3d/hm3d-minival-habitat/00800-TEEsavR23oF/TEEsavR23oF.basis.glb --dataset path/to/hm3d/hm3d_annotated_basis.scene_dataset_config.json --enable-physics --disable-navmesh`
    - After the scene loads, press `7` to toggle between RGB, depth, and semantic-as-RGB. Use arrow keys to move around.
2. `python examples/tutorials/semantic_hm3d_tutorial.py --hm3d-data-path="path/to/hm3d"`
    - Look for output png files.

For a semantic-as-RGB output image, the pixels should be mapped to semantic categories in python using e.g. `00800-TEEsavR23oF/TEEsavR23oF.semantic.txt`. This python code isn't implemented yet! Consider using `semantic_hm3d_tutorial.py` as a starting point to implement this.

This branch also checks that your dataset properly selects an HM3D semantic GLB as the stage semantic asset, e.g. `TEEsavR23oF.semantic.glb`. As long as you're using `path/to/hm3d_annotated_basis.scene_dataset_config.json` and you've downloaded semantic GLBs alongside your base HM3D data, this should all just work.

![4](https://user-images.githubusercontent.com/6557808/150876306-105ef416-9fb7-4cfe-b562-264f06d9a7ce.png)
![5](https://user-images.githubusercontent.com/6557808/150876317-fe8d6c97-a096-4b3f-9bd3-902afea7f827.png)