### PR TITLE
[bugfix] - index torques by link DoF

### DIFF
--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -500,8 +500,8 @@ std::vector<float> BulletArticulatedObject::getJointMotorTorques(
       auto& btMotor = articulatedJointMotors.at(motor.first);
       btScalar impulse = btMotor->getAppliedImpulse(0);
       float force = impulse / float(fixedTimeStep);
-      torques[motor.second->index] += force;
-
+      int link_dof = btMultiBody_->getLink(motor.second->index).m_dofOffset;
+      torques[link_dof] += force;
     } else {
       ESP_CHECK(
           false,


### PR DESCRIPTION
## Motivation and Context

Should be indexing positions by link index and torques/velocities by link DoF index as these vectors can have different sizes.

## How Has This Been Tested

Tests pass CI, but should add another URDF to test this kind of mismatch in the future.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
