### PR TITLE
--Remove unused/superfluous dependency, Sophus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "src/deps/glfw"]
 	path = src/deps/glfw
 	url = https://github.com/glfw/glfw
-[submodule "src/deps/Sophus"]
-	path = src/deps/Sophus
-	url = https://github.com/strasdat/Sophus
 [submodule "src/deps/recastnavigation"]
 	path = src/deps/recastnavigation
 	url = https://github.com/erikwijmans/recastnavigation.git

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -39,9 +39,6 @@ if(NOT IMGUI_DIR)
   set(IMGUI_DIR "${DEPS_DIR}/imgui")
 endif()
 
-# sophus
-include_directories(SYSTEM "${DEPS_DIR}/Sophus")
-
 # tinyxml2
 include_directories("${DEPS_DIR}/tinyxml2")
 add_subdirectory("${DEPS_DIR}/tinyxml2")

--- a/src/esp/assets/Mp3dInstanceMeshData.cpp
+++ b/src/esp/assets/Mp3dInstanceMeshData.cpp
@@ -8,8 +8,6 @@
 #include <sstream>
 #include <vector>
 
-#include <sophus/so3.hpp>
-
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Containers/ArrayViewStl.h>

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <fstream>
 #include <map>
-#include <sophus/se3.hpp>
 #include <sstream>
 #include <string>
 

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -136,13 +136,28 @@ void ReplicaSceneTest::testSemanticSceneLoading() {
   CORRADE_VERIFY(scene);
   CORRADE_COMPARE(scene->objects().size(), 94);
 
-  CORRADE_VERIFY(scene->objects()[12]);
-  CORRADE_COMPARE(scene->objects()[12]->id(), "_12");
+  const auto obj12 = scene->objects()[12];
 
-  CORRADE_VERIFY(scene->objects()[12]->category());
+  CORRADE_VERIFY(obj12);
+  CORRADE_COMPARE(obj12->id(), "_12");
+  // obj12's obb
+  // Eigen Calc
+  // center:[3.52103,-1.00543,-1.02705]
+  // halfextents:[0.169882,0.160166,0.01264]
+  // rotational quat coefficients:[-0.70592,0.0131598,0.0157815,0.707994]
+  // Sophus calc:
+  // {c:[3.52103,-1.00543,-1.02705],h:[0.169882,0.160166,0.01264],r:[-0.70592,0.0131598,0.0157815,0.707994]}
 
-  CORRADE_COMPARE(scene->objects()[12]->category()->index(), 13);
-  CORRADE_COMPARE(scene->objects()[12]->category()->name(), "book");
+  CORRADE_VERIFY(
+      obj12->obb().center().isApprox(esp::vec3f{3.52103, -1.00543, -1.02705}));
+  CORRADE_VERIFY(obj12->obb().halfExtents().isApprox(
+      esp::vec3f{0.169882, 0.160166, 0.01264}));
+  CORRADE_VERIFY(obj12->obb().rotation().coeffs().isApprox(
+      esp::vec4f{-0.70592, 0.0131598, 0.0157815, 0.707994}));
+
+  CORRADE_VERIFY(obj12->category());
+  CORRADE_COMPARE(obj12->category()->index(), 13);
+  CORRADE_COMPARE(obj12->category()->name(), "book");
 }
 
 void ReplicaSceneTest::testSemanticSceneDescriptorReplicaCAD() {

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -145,7 +145,7 @@ void ReplicaSceneTest::testSemanticSceneLoading() {
   // center:[3.52103,-1.00543,-1.02705]
   // halfextents:[0.169882,0.160166,0.01264]
   // rotational quat coefficients:[-0.70592,0.0131598,0.0157815,0.707994]
-  // Sophus calc:
+  // Old Sophus calc:
   // {c:[3.52103,-1.00543,-1.02705],h:[0.169882,0.160166,0.01264],r:[-0.70592,0.0131598,0.0157815,0.707994]}
 
   CORRADE_VERIFY(

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -10,7 +10,6 @@
 
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/FormatStl.h>
-#include <sophus/so3.hpp>
 #include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -45,7 +45,6 @@
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Renderer.h>
-#include <sophus/so3.hpp>
 #include "esp/core/Esp.h"
 #include "esp/core/Utility.h"
 #include "esp/gfx/Drawable.h"

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <ctime>
 #include <fstream>
+#include <iostream>
 
 #include <Magnum/configure.h>
 #include <Magnum/ImGuiIntegration/Context.hpp>


### PR DESCRIPTION
## Motivation and Context
This PR gets rid of a superfluous dependency, Sophus, which was accessed only in 1 place, building a Special Euclidean group transform (translate and rotate but no reflection) for Replica semantic object bounding boxes. The calc was easily replaced using Eigen Isometry transforms.  A test was added to ReplicaSceneTest to verify that the results using Isometries are approximately the same result as what Sophus was giving us.

 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
