### PR TITLE
--Remove Mp3dInstanceMeshData from habitat-sim source

### DIFF
--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -11,8 +11,6 @@ set(
   GenericMeshData.h
   MeshData.h
   MeshMetaData.h
-  Mp3dInstanceMeshData.cpp
-  Mp3dInstanceMeshData.h
   RenderAssetInstanceCreationInfo.cpp
   RenderAssetInstanceCreationInfo.h
   ResourceManager.cpp

--- a/src/utils/datatool/CMakeLists.txt
+++ b/src/utils/datatool/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(Datatool_SOURCES Datatool.cpp SceneLoader.cpp)
+set(Datatool_SOURCES Datatool.cpp SceneLoader.cpp Mp3dInstanceMeshData.cpp)
 
 add_executable(Datatool ${Datatool_SOURCES})
 set(DEPS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../deps")

--- a/src/utils/datatool/Datatool.cpp
+++ b/src/utils/datatool/Datatool.cpp
@@ -11,7 +11,7 @@
 #define TINYOBJLOADER_IMPLEMENTATION
 #include <tiny_obj_loader.h>
 
-#include "esp/assets/Mp3dInstanceMeshData.h"
+#include "Mp3dInstanceMeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/scene/SemanticScene.h"

--- a/src/utils/datatool/Mp3dInstanceMeshData.h
+++ b/src/utils/datatool/Mp3dInstanceMeshData.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_ASSETS_MP3DINSTANCEDATA_H_
-#define ESP_ASSETS_MP3DINSTANCEDATA_H_
+#ifndef ESP_UTILS_DATATOOL_MP3DINSTANCEDATA_H_
+#define ESP_UTILS_DATATOOL_MP3DINSTANCEDATA_H_
 
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/Mesh.h>
@@ -12,8 +12,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "BaseMesh.h"
-#include "GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 
 namespace esp {
@@ -23,11 +21,10 @@ namespace assets {
  * MP3D object instance segmented mesh
  * Holds a vbo where each vertex is (x, y, z, objectId)
  */
-class Mp3dInstanceMeshData : public GenericSemanticMeshData {
+class Mp3dInstanceMeshData {
  public:
-  Mp3dInstanceMeshData()
-      : GenericSemanticMeshData(SupportedMeshType::INSTANCE_MESH) {}
-  ~Mp3dInstanceMeshData() override = default;
+  Mp3dInstanceMeshData() {}
+  ~Mp3dInstanceMeshData() = default;
 
   //! Loads an MP3D house segmentations PLY file
   bool loadMp3dPLY(const std::string& plyFile);
@@ -38,7 +35,9 @@ class Mp3dInstanceMeshData : public GenericSemanticMeshData {
       const std::unordered_map<int, int>& segmentIdToObjectIdMap);
 
  protected:
-  std::vector<vec3ui> cpu_ibo_;
+  std::vector<vec3f> cpu_vbo_;
+  std::vector<vec3uc> cpu_cbo_;
+  std::vector<vec3ui> perFaceIdxs_;
   std::vector<int> materialIds_;
   std::vector<int> segmentIds_;
   std::vector<int> categoryIds_;
@@ -47,4 +46,4 @@ class Mp3dInstanceMeshData : public GenericSemanticMeshData {
 }  // namespace assets
 }  // namespace esp
 
-#endif  // ESP_ASSETS_MP3DINSTANCEDATA_H_
+#endif  // ESP_UTILS_DATATOOL_MP3DINSTANCEDATA_H_


### PR DESCRIPTION
This PR moves the Mp3dInstanceMeshData .h/.cpp files to the datatool directory, since Datatool is the only consumer of this class.  This was also done in preparation for the upcoming migration to Magnum Meshdata as part of the planned unification of the asset loading pathways for instance and general meshes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
