### PR TITLE
Fixes bug that only allow constraints to be set in one direction of a singular axis

### DIFF
--- a/src_python/habitat_sim/agent/controls/default_controls.py
+++ b/src_python/habitat_sim/agent/controls/default_controls.py
@@ -42,8 +42,9 @@ def _rotate_local(
         if abs(float(rotation.angle())) > 0:
             ref_vector = mn.Vector3()
             ref_vector[axis] = 1
+            abs_rotation_axis = mn.Vector3(np.abs(rotation.axis().normalized()))
 
-            if mn.math.angle(ref_vector, rotation.axis().normalized()) > mn.Rad(1e-3):
+            if mn.math.angle(ref_vector, abs_rotation_axis) > mn.Rad(1e-3):
                 raise RuntimeError(
                     "Constrained look only works for a singular look action type"
                 )

--- a/src_python/habitat_sim/agent/controls/default_controls.py
+++ b/src_python/habitat_sim/agent/controls/default_controls.py
@@ -39,11 +39,13 @@ def _rotate_local(
     if constraint is not None:
         rotation = scene_node.rotation
 
-        if (abs(float(rotation.angle())) > 0
-            and 1.0 - abs(rotation.axis().normalized()[axis]) > 1e-3):
-                raise RuntimeError(
-                    "Constrained look only works for a singular look action type"
-                )
+        if (
+            abs(float(rotation.angle())) > 0
+            and 1.0 - abs(rotation.axis().normalized()[axis]) > 1e-3
+        ):
+            raise RuntimeError(
+                "Constrained look only works for a singular look action type"
+            )
 
         look_vector = rotation.transform_vector(FRONT)
         if axis == 0:

--- a/src_python/habitat_sim/agent/controls/default_controls.py
+++ b/src_python/habitat_sim/agent/controls/default_controls.py
@@ -40,11 +40,7 @@ def _rotate_local(
         rotation = scene_node.rotation
 
         if abs(float(rotation.angle())) > 0:
-            ref_vector = mn.Vector3()
-            ref_vector[axis] = 1
-            abs_rotation_axis = mn.Vector3(np.abs(rotation.axis().normalized()))
-
-            if mn.math.angle(ref_vector, abs_rotation_axis) > mn.Rad(1e-3):
+            if 1.0 - abs(rotation.axis().normalized()[axis]) > 1e-3:
                 raise RuntimeError(
                     "Constrained look only works for a singular look action type"
                 )

--- a/src_python/habitat_sim/agent/controls/default_controls.py
+++ b/src_python/habitat_sim/agent/controls/default_controls.py
@@ -39,8 +39,8 @@ def _rotate_local(
     if constraint is not None:
         rotation = scene_node.rotation
 
-        if abs(float(rotation.angle())) > 0:
-            if 1.0 - abs(rotation.axis().normalized()[axis]) > 1e-3:
+        if (abs(float(rotation.angle())) > 0
+            and 1.0 - abs(rotation.axis().normalized()[axis]) > 1e-3):
                 raise RuntimeError(
                     "Constrained look only works for a singular look action type"
                 )


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes bug that only allow constraints to be set in one direction of a singular axis

<!--- Please link to an existing issue here if one exists. -->
https://github.com/facebookresearch/habitat-sim/issues/1641

<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
It is a bug fix, discussed in the issue linked above. We have applied it already to our local implementation of habitat_sim. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
