### PR TITLE
Fix performance issues with calc MOBB

### DIFF
--- a/src/esp/geo/OBB.cpp
+++ b/src/esp/geo/OBB.cpp
@@ -4,6 +4,7 @@
 
 #include "OBB.h"
 
+#include <array>
 #include <vector>
 
 #include "esp/geo/Geo.h"
@@ -129,6 +130,7 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
   };
 
   std::vector<vec2f> in_plane_points;
+  in_plane_points.reserve(points.size());
   for (const auto& pt : points) {
     vec3f aligned_pt = align_gravity * pt;
     in_plane_points.emplace_back(aligned_pt[0], aligned_pt[1]);
@@ -138,6 +140,7 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
   CORRADE_INTERNAL_ASSERT(hull.size() > 0);
 
   std::vector<vec2f> edge_dirs;
+  edge_dirs.reserve(hull.size());
   for (size_t i = 0; i < hull.size(); ++i) {
     edge_dirs.emplace_back(
         (hull[(i + 1) % hull.size()] - hull[i]).normalized());
@@ -174,7 +177,7 @@ OBB computeGravityAlignedMOBB(const vec3f& gravity,
   float best_area = 1e10;
   vec2f best_bottom_dir = vec2f(NAN, NAN);
   for (size_t i = 0; i < hull.size(); ++i) {
-    const std::vector<float> angles(
+    const std::array<float, 4> angles(
         {std::acos(left_dir.dot(edge_dirs[left_idx])),
          std::acos(right_dir.dot(edge_dirs[right_idx])),
          std::acos(top_dir.dot(edge_dirs[top_idx])),


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fixes 2 minor performance issues. 
1.  is that all std::vectors in this algorithm are of known sizes at runtime and should reserve the appropiate amount of heap space for their calculation
1. There is an std::vector that was being treated more as a tuple. I replaced it with an std::array since the size is known at compile time.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* PyTest and CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
