### PR TITLE
Revert numpy version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imageio
 imageio-ffmpeg
 matplotlib
 numba
-numpy>=1.21
+numpy
 numpy-quaternion
 pillow
 scipy>=1.3.0

--- a/src_python/habitat_sim/robots/mobile_manipulator.py
+++ b/src_python/habitat_sim/robots/mobile_manipulator.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Set, Tuple
 import attr
 import magnum as mn
 import numpy as np
-import numpy.typing as npt
 
 from habitat_sim.physics import JointMotorSettings
 from habitat_sim.robots.robot_interface import RobotInterface
@@ -75,8 +74,8 @@ class MobileManipulatorParams:
     gripper_joints: List[int]
     wheel_joints: Optional[List[int]]
 
-    arm_init_params: Optional[npt.NDArray[np.float32]]
-    gripper_init_params: Optional[npt.NDArray[np.float32]]
+    arm_init_params: Optional[np.ndarray]
+    gripper_init_params: Optional[np.ndarray]
 
     ee_offset: mn.Vector3
     ee_link: int
@@ -84,8 +83,8 @@ class MobileManipulatorParams:
 
     cameras: Dict[str, RobotCameraParams]
 
-    gripper_closed_state: npt.NDArray[np.float32]
-    gripper_open_state: npt.NDArray[np.float32]
+    gripper_closed_state: np.ndarray
+    gripper_open_state: np.ndarray
     gripper_state_eps: float
 
     arm_mtr_pos_gain: float
@@ -119,7 +118,7 @@ class MobileManipulator(RobotInterface):
         super().__init__()
         self.urdf_path = urdf_path
         self.params = params
-        self._fix_joint_values: Optional[npt.NDArray[np.float32]] = None
+        self._fix_joint_values: Optional[np.ndarray] = None
 
         self._sim = sim
         self._limit_robo_joints = limit_robo_joints


### PR DESCRIPTION
## Motivation and Context
Reverts numpy version bump as this can cause some issues with Google Colab. Typing isn't worth hurting compatibility like that.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
