### PR TITLE
Pyupgrade to modern typing syntax and enable pyupgrade pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,13 @@ repos:
     -   id: black
         exclude: ^examples/tutorials/(nb_python|colabs)
 
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+    -   id: pyupgrade
+        args: ["--py37-plus"]
+        exclude: "^setup.py$"
+
 -   repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -92,6 +99,8 @@ repos:
         pass_filenames: false
         additional_dependencies:
         - attrs
+        - numpy
+        - numpy-quaternion
 
 -   repo: https://github.com/seddonym/import-linter
     rev: v1.2.6

--- a/conda-build/common/delete_old_night_packages.py
+++ b/conda-build/common/delete_old_night_packages.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import argparse
 import re
 import subprocess
@@ -27,13 +29,11 @@ if not args.nightly:
 
 login_result = subprocess.run(
     ["anaconda", "login", "--username", args.username, "--password", args.password],
-    stderr=subprocess.PIPE,
-    stdout=subprocess.PIPE,
+    capture_output=True,
 )
 result = subprocess.run(
     ["anaconda", "show", "aihabitat-nightly/habitat-sim"],
-    stderr=subprocess.PIPE,
-    stdout=subprocess.PIPE,
+    capture_output=True,
 )
 versions = re.findall(
     r"\d\.\d\.\d\.\d{4}\.\d\d\.\d\d", str(result.stdout) + str(result.stderr)
@@ -50,6 +50,5 @@ result_remove = subprocess.run(
         "-f",
         *list(map(lambda x: f"aihabitat-nightly/habitat-sim/{x}", remove_versions)),
     ],
-    stderr=subprocess.PIPE,
-    stdout=subprocess.PIPE,
+    capture_output=True,
 )

--- a/conda-build/matrix_builder.py
+++ b/conda-build/matrix_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import builtins
 import itertools

--- a/examples/ab_test.py
+++ b/examples/ab_test.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import argparse
 import csv
 import distutils

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import argparse
 
 import demo_runner as dr

--- a/examples/demo_runner.py
+++ b/examples/demo_runner.py
@@ -3,6 +3,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import math
 import multiprocessing
 import os

--- a/examples/example.py
+++ b/examples/example.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import argparse
 
 import demo_runner as dr
@@ -74,7 +76,9 @@ for _i in range(1):
     print(
         " %d x %d, total time %0.2f s,"
         % (settings["width"], settings["height"], perf["total_time"]),
-        "frame time %0.3f ms (%0.1f FPS)" % (perf["frame_time"] * 1000.0, perf["fps"]),
+        "frame time {:0.3f} ms ({:0.1f} FPS)".format(
+            perf["frame_time"] * 1000.0, perf["fps"]
+        ),
     )
     print(" ============================================================== ")
 

--- a/examples/fairmotion_interface.py
+++ b/examples/fairmotion_interface.py
@@ -2,12 +2,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import json
 import math
 import os
 import random
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import magnum as mn
 from fairmotion.core import motion
@@ -51,16 +53,16 @@ class FairmotionInterface:
     ) -> None:
         # general interface attrs
         LoggingContext.reinitialize_from_env()
-        self.sim: Optional[habitat_sim.simulator.Simulator] = sim
+        self.sim: habitat_sim.simulator.Simulator | None = sim
         self.draw_fps: float = fps
         self.art_obj_mgr = self.sim.get_articulated_object_manager()
         self.rgd_obj_mgr = self.sim.get_rigid_object_manager()
-        self.motion: Optional[motion.Motion] = None
+        self.motion: motion.Motion | None = None
         self.user_metadata = {}
-        self.last_metadata_file: Optional[str] = None
+        self.last_metadata_file: str | None = None
         self.motion_stepper = 0
-        self.rotation_offset: Optional[mn.Quaternion] = None
-        self.translation_offset: Optional[mn.Vector3] = None
+        self.rotation_offset: mn.Quaternion | None = None
+        self.translation_offset: mn.Vector3 | None = None
         self.is_reversed = False
         self.activity: Activity = Activity.NONE
 
@@ -68,19 +70,19 @@ class FairmotionInterface:
         self.key_frames = None
         self.key_frame_models = []
         self.preview_mode: Preview = Preview.OFF
-        self.traj_ids: List[int] = []
+        self.traj_ids: list[int] = []
 
         # path follower attrs
-        self.model: Optional[phy.ManagedArticulatedObject] = None
-        self.path_data: Optional[PathData] = None
+        self.model: phy.ManagedArticulatedObject | None = None
+        self.path_data: PathData | None = None
 
         # sequence attrs
-        self.order_queue: List[ActionOrder] = []
-        self.staging_queue: List[Tuple] = []
+        self.order_queue: list[ActionOrder] = []
+        self.staging_queue: list[tuple] = []
         self.last_seq_location: mn.Vector3 = mn.Vector3(
             -1.15, 0.0, -3.48
         )  # cupboard under the staircase
-        self.incomplete_order: List[Any] = []
+        self.incomplete_order: list[Any] = []
 
         self.setup_default_metadata()
 
@@ -163,15 +165,15 @@ class FairmotionInterface:
 
         # if default file exists, take it from there
         self.fetch_metadata("default")
-        self.last_metadata_file: Optional[str] = None
+        self.last_metadata_file: str | None = None
 
     def set_data(
         self,
-        urdf_path: Optional[str] = None,
-        amass_path: Optional[str] = None,
-        bm_path: Optional[str] = None,
-        rotation: Optional[mn.Quaternion] = None,
-        translation: Optional[mn.Vector3] = None,
+        urdf_path: str | None = None,
+        amass_path: str | None = None,
+        bm_path: str | None = None,
+        rotation: mn.Quaternion | None = None,
+        translation: mn.Vector3 | None = None,
     ) -> None:
         """
         A method that will take attributes of the model data sets as arguments, filling in
@@ -184,7 +186,7 @@ class FairmotionInterface:
         data["rotation"] = rotation or data["rotation"]
         data["translation"] = translation or data["translation"]
 
-    def metadata_parser(self, metadata_dict: Dict[str, Any], to_file: bool):
+    def metadata_parser(self, metadata_dict: dict[str, Any], to_file: bool):
         """
         Convert metadata dict to and from a form that is json serializable
         """
@@ -257,7 +259,7 @@ class FairmotionInterface:
                 file = filename
                 break
 
-        with open(file, "r") as f:
+        with open(file) as f:
             data = json.load(f)
 
         # set data to what was fetched
@@ -277,8 +279,8 @@ class FairmotionInterface:
 
     def set_transform_offsets(
         self,
-        rotate_offset: Optional[mn.Quaternion] = None,
-        translate_offset: Optional[mn.Vector3] = None,
+        rotate_offset: mn.Quaternion | None = None,
+        translate_offset: mn.Vector3 | None = None,
     ) -> None:
         """
         This method updates the offset of the model with the positional data passed to it.
@@ -379,7 +381,7 @@ class FairmotionInterface:
 
     def convert_CMUamass_single_pose(
         self, pose, model, raw=False
-    ) -> Tuple[List[float], mn.Vector3, mn.Quaternion]:
+    ) -> tuple[list[float], mn.Vector3, mn.Quaternion]:
         """
         This conversion is specific to the datasets from CMU
         """
@@ -522,7 +524,7 @@ class FairmotionInterface:
                 * self.rotation_offset
             )
 
-            def define_preview_points(joint_names: List[str]) -> List[mn.Vector3]:
+            def define_preview_points(joint_names: list[str]) -> list[mn.Vector3]:
                 """
                 Pass in a list containing names of joints as strings and/or lists containing
                 multiple names of joints, where the lists will result in an interpolated
@@ -938,7 +940,7 @@ class FairmotionInterface:
         self.model.joint_positions = pose_data[0]
         self.model.transformation = pose_data[1]
 
-    def interpolate_pose(self, poseA, poseB, t) -> List[mn.Quaternion]:
+    def interpolate_pose(self, poseA, poseB, t) -> list[mn.Quaternion]:
         """
         Pass in two motion pose structs and return them interpolated.
         """
@@ -989,7 +991,7 @@ class FairmotionInterface:
         self.update_pathfollower_sequential(step_size=0)
 
     def update_pathfollower_sequential(
-        self, step_size: int = 1, path_time: Optional[float] = None
+        self, step_size: int = 1, path_time: float | None = None
     ) -> None:
         """
         When this method is called, the path follower model is updated to the next frame
@@ -1053,8 +1055,8 @@ class FairmotionInterface:
         self.model.transformation = full_transform
 
     def point_at_path_t(
-        self, path_points: List[mn.Vector3], t: float
-    ) -> Tuple[mn.Vector3, mn.Vector3]:
+        self, path_points: list[mn.Vector3], t: float
+    ) -> tuple[mn.Vector3, mn.Vector3]:
         """
         Function that give a point on the path at time t.
         """

--- a/examples/fairmotion_interface_utils.py
+++ b/examples/fairmotion_interface_utils.py
@@ -2,10 +2,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union
 
 import magnum as mn
 import numpy as np
@@ -70,9 +71,9 @@ class Motions:
                 self.time_length = self.num_of_frames * (1.0 / motion_.fps)
 
                 # intermediates
-                self.translation_drifts: List[mn.Vector3] = []
-                self.forward_displacements: List[mn.Vector3] = []
-                self.root_orientations: List[mn.Quaternion] = []
+                self.translation_drifts: list[mn.Vector3] = []
+                self.forward_displacements: list[mn.Vector3] = []
+                self.root_orientations: list[mn.Quaternion] = []
 
                 # first and last frame root position vectors
                 f = motion_.poses[0].get_transform(ROOT, local=False)[0:3, 3]
@@ -262,7 +263,7 @@ class PathData:
         self.time = 0.0
 
     # [REFACTOR] I would like to change this to a static method, once I figure out how
-    def calc_path_length(self, path_points: List[mn.Vector3]) -> float:
+    def calc_path_length(self, path_points: list[mn.Vector3]) -> float:
         # get path length
         i, j, summ = 0, 0, 0.0
         while i < len(path_points):
@@ -285,8 +286,8 @@ class ActionOrder:
     def __init__(
         self,
         motion_data: Motions.MotionData,
-        location: Optional[Union[mn.Vector3, np.array]] = None,
-        facing: Optional[Union[mn.Vector3, np.array]] = None,
+        location: mn.Vector3 | np.array | None = None,
+        facing: mn.Vector3 | np.array | None = None,
     ) -> None:
         self.motion_data = motion_data
 

--- a/examples/instance_segmentation/common.py
+++ b/examples/instance_segmentation/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import math
 import random
@@ -8,11 +10,11 @@ import torch
 
 def create_mask_filter(labels, extractor):
     instance_id_to_name = extractor.instance_id_to_name
-    labels_we_care_about = set(
+    labels_we_care_about = {
         instance_id
         for instance_id, name in instance_id_to_name.items()
         if name in labels
-    )
+    }
 
     # Function that filters out instance of objects we do not care about
     return np.vectorize(lambda x: x * int(x in labels_we_care_about))

--- a/examples/instance_segmentation/engine.py
+++ b/examples/instance_segmentation/engine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import math
 import sys
@@ -49,7 +51,7 @@ def train_one_epoch(
     model.train()
     metric_logger = utils.MetricLogger(delimiter="  ")
     metric_logger.add_meter("lr", utils.SmoothedValue(window_size=1, fmt="{value:.6f}"))
-    header = "Epoch: [{}]".format(epoch)
+    header = f"Epoch: [{epoch}]"
     epoch_losses = collections.defaultdict(int)
     total_loss = 0
     num_examples = len(data_loader)
@@ -68,7 +70,7 @@ def train_one_epoch(
             epoch_losses[loss_name] += loss_val
 
         if not math.isfinite(loss_value):
-            print("Loss is {}, stopping training".format(loss_value))
+            print(f"Loss is {loss_value}, stopping training")
             print(loss_dict_reduced)
             sys.exit(1)
 

--- a/examples/motion_viewer.py
+++ b/examples/motion_viewer.py
@@ -2,11 +2,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import ctypes
 import random
 import sys
 import time
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable
 
 import numpy as np
 
@@ -27,7 +29,7 @@ from habitat_sim.logging import logger
 
 class FairmotionSimInteractiveViewer(HabitatSimInteractiveViewer):
     def __init__(
-        self, sim_settings: Dict[str, Any], fm_settings: Dict[str, Any]
+        self, sim_settings: dict[str, Any], fm_settings: dict[str, Any]
     ) -> None:
         super().__init__(sim_settings)
 
@@ -63,7 +65,7 @@ class FairmotionSimInteractiveViewer(HabitatSimInteractiveViewer):
         obj_tmp_mgr.register_template(box_template)
 
         # motion mode attributes
-        self.selected_mocap_char: Optional[FairmotionInterface] = None
+        self.selected_mocap_char: FairmotionInterface | None = None
         self.select_sphere_obj_id: int = -1
         self.select_box_obj_id: int = -1
 
@@ -160,9 +162,9 @@ class FairmotionSimInteractiveViewer(HabitatSimInteractiveViewer):
 
     def draw_event(
         self,
-        simulation_call: Optional[Callable] = None,
-        global_call: Optional[Callable] = None,
-        active_agent_id_and_sensor_name: Tuple[int, str] = (0, "color_sensor"),
+        simulation_call: Callable | None = None,
+        global_call: Callable | None = None,
+        active_agent_id_and_sensor_name: tuple[int, str] = (0, "color_sensor"),
     ) -> None:
         """
         Calls continuously to re-render frames and swap the two frame buffers
@@ -762,12 +764,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Setting up sim_settings
-    sim_settings: Dict[str, Any] = default_sim_settings
+    sim_settings: dict[str, Any] = default_sim_settings
     sim_settings["scene"] = args.scene
     sim_settings["scene_dataset_config_file"] = args.dataset
     sim_settings["enable_physics"] = not args.disable_physics
 
-    fm_settings: Dict[str, Any] = {}
+    fm_settings: dict[str, Any] = {}
     fm_settings["amass_path"] = args.amass_path
     fm_settings["urdf_path"] = args.urdf_path
     fm_settings["bm_path"] = args.bm_path

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import habitat_sim
 import habitat_sim.agent
 

--- a/examples/tutorials/VHACD_tutorial.py
+++ b/examples/tutorials/VHACD_tutorial.py
@@ -1,4 +1,6 @@
 # [setup]
+from __future__ import annotations
+
 import math
 import os
 

--- a/examples/tutorials/async_rendering.py
+++ b/examples/tutorials/async_rendering.py
@@ -32,6 +32,8 @@ Known limitations/issues:
     back to the main thread by calling sim.get_sensor_observations_async_finish() by default.
 """
 
+from __future__ import annotations
+
 import habitat_sim
 
 

--- a/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "lines_to_next_cell": 0
@@ -55,6 +46,8 @@
     "\n",
     "%cd /content/habitat-sim\n",
     "## [setup]\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import math\n",
     "import os\n",
     "import random\n",

--- a/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "<a href=\"https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
@@ -391,7 +402,7 @@
     "# This will display all the properties of an attributes template\n",
     "def show_template_properties(template):\n",
     "    template_dict = build_dict_from_template(template)\n",
-    "    print(\"Template {} has : \".format(template.handle))\n",
+    "    print(f\"Template {template.handle} has : \")\n",
     "    for k, v in template_dict.items():\n",
     "        print(\n",
     "            \"\\tProperty {} has value {} of type {} that is editable : {}\".format(\n",
@@ -1258,9 +1269,7 @@
     "# Get all modified template handles through keyword search\n",
     "mod_template_handles = obj_attr_mgr.get_template_handles(\"_new_\")\n",
     "# Show number of modified templates\n",
-    "print(\n",
-    "    \"Before delete, there are {} modified templates.\".format(len(mod_template_handles))\n",
-    ")\n",
+    "print(f\"Before delete, there are {len(mod_template_handles)} modified templates.\")\n",
     "# Display modified template handles\n",
     "print(*mod_template_handles, sep=\"\\n\")\n",
     "# Remove modified templates\n",
@@ -1544,7 +1553,7 @@
     "            )\n",
     "    else:\n",
     "        dict_of_handles[handle_key] = prim_attr_mgr.get_template_handles(handle_key)[0]\n",
-    "        print(\"Default Primitive Template used at key {}.\".format(handle_key))\n",
+    "        print(f\"Default Primitive Template used at key {handle_key}.\")\n",
     "\n",
     "\n",
     "# Build a dictionary of templates to use to construct objects\n",
@@ -1973,7 +1982,7 @@
     "    # Create object template with passed handle\n",
     "    obj_template = obj_attr_mgr.create_template(solidHandle)\n",
     "    # Create object from object template handle\n",
-    "    print(\"Solid Object being made using handle :{}\".format(solidHandle))\n",
+    "    print(f\"Solid Object being made using handle :{solidHandle}\")\n",
     "    obj_solid = rigid_obj_mgr.add_object_by_template_handle(solidHandle)\n",
     "    objs_to_sim.append(obj_solid)\n",
     "    # Place object in scene relative to agent\n",
@@ -1987,7 +1996,7 @@
     "    # Create object template with passed handle\n",
     "    obj_template = obj_attr_mgr.create_template(wireframeHandle)\n",
     "    # Create object from object template handle\n",
-    "    print(\"Wireframe Object being made using handle :{}\".format(wireframeHandle))\n",
+    "    print(f\"Wireframe Object being made using handle :{wireframeHandle}\")\n",
     "    obj_wf = rigid_obj_mgr.add_object_by_template_handle(wireframeHandle)\n",
     "    objs_to_sim.append(obj_wf)\n",
     "    # Place object in scene relative to agent\n",

--- a/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "lines_to_next_cell": 0
@@ -58,6 +49,8 @@
     "\n",
     "%cd /content/habitat-sim\n",
     "## [setup]\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import math\n",
     "import os\n",
     "import random\n",

--- a/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "<a href=\"https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]

--- a/examples/tutorials/colabs/ECCV_2020_Navigation.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Navigation.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "#Habitat-sim Basics for Navigation\n",
     "\n",

--- a/examples/tutorials/colabs/ECCV_2020_Navigation.ipynb
+++ b/examples/tutorials/colabs/ECCV_2020_Navigation.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "lines_to_next_cell": 0
@@ -52,6 +43,7 @@
    "source": [
     "# @title Colab Setup and Imports { display-mode: \"form\" }\n",
     "# @markdown (double click to see the code)\n",
+    "from __future__ import annotations\n",
     "\n",
     "import math\n",
     "import os\n",

--- a/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb
+++ b/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "lines_to_next_cell": 0
@@ -52,6 +43,8 @@
     "\n",
     "%cd /content/habitat-sim\n",
     "## [setup]\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import os\n",
     "import sys\n",
     "\n",

--- a/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb
+++ b/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "<a href=\"https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
@@ -204,7 +215,7 @@
     "# @markdown (double click to show code)\n",
     "def simulate(sim, dt=1.0, get_frames=True):\n",
     "    # simulate dt seconds at 60Hz to the nearest fixed timestep\n",
-    "    print(\"Simulating {:.3f} world seconds.\".format(dt))\n",
+    "    print(f\"Simulating {dt:.3f} world seconds.\")\n",
     "    observations = []\n",
     "    start_time = sim.get_world_time()\n",
     "    while sim.get_world_time() < start_time + dt:\n",

--- a/examples/tutorials/colabs/asset_viewer.ipynb
+++ b/examples/tutorials/colabs/asset_viewer.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "lines_to_next_cell": 0
@@ -52,6 +43,8 @@
     "\n",
     "%cd /content/habitat-sim\n",
     "## [setup]\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import math\n",
     "import os\n",
     "import sys\n",

--- a/examples/tutorials/colabs/asset_viewer.ipynb
+++ b/examples/tutorials/colabs/asset_viewer.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "<a href=\"https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/asset_viewer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
@@ -551,7 +562,7 @@
     "# This will display all the properties of an attributes template\n",
     "def show_template_properties(template):\n",
     "    template_dict = build_dict_from_template(template)\n",
-    "    print(\"Template {} has : \".format(template.handle))\n",
+    "    print(f\"Template {template.handle} has : \")\n",
     "    for k, v in template_dict.items():\n",
     "        print(\n",
     "            \"\\tProperty {} has value {} of type {} that is editable : {}\".format(\n",
@@ -566,7 +577,7 @@
     "# @markdown - simulate\n",
     "def simulate(sim, dt=1.0, get_frames=True):\n",
     "    # simulate dt seconds at 60Hz to the nearest fixed timestep\n",
-    "    print(\"Simulating {:.3f} world seconds.\".format(dt))\n",
+    "    print(f\"Simulating {dt:.3f} world seconds.\")\n",
     "    observations = []\n",
     "    start_time = sim.get_world_time()\n",
     "    while sim.get_world_time() < start_time + dt:\n",

--- a/examples/tutorials/colabs/managed_rigid_object_tutorial.ipynb
+++ b/examples/tutorials/colabs/managed_rigid_object_tutorial.ipynb
@@ -8,8 +8,6 @@
    },
    "outputs": [],
    "source": [
-    "from __future__ import annotations\n",
-    "\n",
     "!curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s"
    ]
   },
@@ -21,6 +19,8 @@
    "source": [
     "%cd /content/habitat-sim\n",
     "## [setup]\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import os\n",
     "import random\n",
     "import sys\n",

--- a/examples/tutorials/colabs/managed_rigid_object_tutorial.ipynb
+++ b/examples/tutorials/colabs/managed_rigid_object_tutorial.ipynb
@@ -3,9 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "outputs": [],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "!curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s"
    ]
   },
@@ -521,7 +525,7 @@
     "    rigid_obj_mgr.remove_object_by_id(locobot.object_id, delete_object_node=False)\n",
     "\n",
     "    # demonstrate that the locobot object does not now exist'\n",
-    "    print(\"Locobot is still alive : {}\".format(locobot.is_alive))\n",
+    "    print(f\"Locobot is still alive : {locobot.is_alive}\")\n",
     "\n",
     "    # video rendering with embedded 1st person view\n",
     "    if make_video:\n",

--- a/examples/tutorials/colabs/replay_tutorial.ipynb
+++ b/examples/tutorials/colabs/replay_tutorial.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
    "source": [
     "#Gfx Replay Tutorial\n",
     "\n",

--- a/examples/tutorials/lighting_tutorial.py
+++ b/examples/tutorials/lighting_tutorial.py
@@ -1,4 +1,6 @@
 # [setup]
+from __future__ import annotations
+
 import math
 import os
 

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -24,9 +24,6 @@
 #     name: python3
 # ---
 
-# %%
-from __future__ import annotations
-
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 # %% [markdown]
@@ -51,6 +48,8 @@ from __future__ import annotations
 
 # %cd /content/habitat-sim
 ## [setup]
+from __future__ import annotations
+
 import math
 import os
 import random

--- a/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Advanced_Features.py
@@ -24,9 +24,11 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Advanced_Features.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
 # %% [markdown]
 # #Habitat-sim Advanced Features
 #
@@ -389,7 +391,7 @@ def set_template_properties_from_dict(template, template_dict):
 # This will display all the properties of an attributes template
 def show_template_properties(template):
     template_dict = build_dict_from_template(template)
-    print("Template {} has : ".format(template.handle))
+    print(f"Template {template.handle} has : ")
     for k, v in template_dict.items():
         print(
             "\tProperty {} has value {} of type {} that is editable : {}".format(
@@ -1161,9 +1163,7 @@ for i in range(5):
 # Get all modified template handles through keyword search
 mod_template_handles = obj_attr_mgr.get_template_handles("_new_")
 # Show number of modified templates
-print(
-    "Before delete, there are {} modified templates.".format(len(mod_template_handles))
-)
+print(f"Before delete, there are {len(mod_template_handles)} modified templates.")
 # Display modified template handles
 print(*mod_template_handles, sep="\n")
 # Remove modified templates
@@ -1417,7 +1417,7 @@ def register_prim_template_if_valid(
             )
     else:
         dict_of_handles[handle_key] = prim_attr_mgr.get_template_handles(handle_key)[0]
-        print("Default Primitive Template used at key {}.".format(handle_key))
+        print(f"Default Primitive Template used at key {handle_key}.")
 
 
 # Build a dictionary of templates to use to construct objects
@@ -1761,7 +1761,7 @@ for solidHandle in solid_handles_to_use.values():
     # Create object template with passed handle
     obj_template = obj_attr_mgr.create_template(solidHandle)
     # Create object from object template handle
-    print("Solid Object being made using handle :{}".format(solidHandle))
+    print(f"Solid Object being made using handle :{solidHandle}")
     obj_solid = rigid_obj_mgr.add_object_by_template_handle(solidHandle)
     objs_to_sim.append(obj_solid)
     # Place object in scene relative to agent
@@ -1775,7 +1775,7 @@ for wireframeHandle in wireframe_handles_to_use.values():
     # Create object template with passed handle
     obj_template = obj_attr_mgr.create_template(wireframeHandle)
     # Create object from object template handle
-    print("Wireframe Object being made using handle :{}".format(wireframeHandle))
+    print(f"Wireframe Object being made using handle :{wireframeHandle}")
     obj_wf = rigid_obj_mgr.add_object_by_template_handle(wireframeHandle)
     objs_to_sim.append(obj_wf)
     # Place object in scene relative to agent

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -19,9 +19,6 @@
 #     name: python3
 # ---
 
-# %%
-from __future__ import annotations
-
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 # %% [markdown]
@@ -47,6 +44,8 @@ from __future__ import annotations
 
 # %cd /content/habitat-sim
 ## [setup]
+from __future__ import annotations
+
 import math
 import os
 import random

--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -19,9 +19,11 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ECCV_2020_Interactivity.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
 # %% [markdown]
 # #Habitat-sim Interactivity
 #

--- a/examples/tutorials/nb_python/ECCV_2020_Navigation.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Navigation.py
@@ -19,6 +19,9 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # #Habitat-sim Basics for Navigation
 #
@@ -34,7 +37,6 @@
 # - configuration of a Simulator, Sensors, and Agents.
 # - taking actions and retrieving observations
 # - pathfinding and navigation on the NavMesh
-
 # %%
 # @title Installation
 

--- a/examples/tutorials/nb_python/ECCV_2020_Navigation.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Navigation.py
@@ -19,9 +19,6 @@
 #     name: python3
 # ---
 
-# %%
-from __future__ import annotations
-
 # %% [markdown]
 # #Habitat-sim Basics for Navigation
 #
@@ -45,6 +42,7 @@ from __future__ import annotations
 # %%
 # @title Colab Setup and Imports { display-mode: "form" }
 # @markdown (double click to see the code)
+from __future__ import annotations
 
 import math
 import os

--- a/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
+++ b/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
@@ -20,9 +20,11 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
 # %% [markdown]
 # #Habitat-sim ReplicaCAD Quickstart
 #
@@ -192,7 +194,7 @@ def make_simulator_from_settings(sim_settings):
 # @markdown (double click to show code)
 def simulate(sim, dt=1.0, get_frames=True):
     # simulate dt seconds at 60Hz to the nearest fixed timestep
-    print("Simulating {:.3f} world seconds.".format(dt))
+    print(f"Simulating {dt:.3f} world seconds.")
     observations = []
     start_time = sim.get_world_time()
     while sim.get_world_time() < start_time + dt:

--- a/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
+++ b/examples/tutorials/nb_python/ReplicaCAD_quickstart.py
@@ -20,9 +20,6 @@
 #     name: python3
 # ---
 
-# %%
-from __future__ import annotations
-
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/ReplicaCAD_quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 # %% [markdown]
@@ -43,6 +40,8 @@ from __future__ import annotations
 
 # %cd /content/habitat-sim
 ## [setup]
+from __future__ import annotations
+
 import os
 import sys
 

--- a/examples/tutorials/nb_python/asset_viewer.py
+++ b/examples/tutorials/nb_python/asset_viewer.py
@@ -20,9 +20,11 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/asset_viewer.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
 # %% [markdown]
 # #Habitat-sim Asset Viewer
 #
@@ -539,7 +541,7 @@ def set_template_properties_from_dict(template, template_dict):
 # This will display all the properties of an attributes template
 def show_template_properties(template):
     template_dict = build_dict_from_template(template)
-    print("Template {} has : ".format(template.handle))
+    print(f"Template {template.handle} has : ")
     for k, v in template_dict.items():
         print(
             "\tProperty {} has value {} of type {} that is editable : {}".format(
@@ -554,7 +556,7 @@ def show_template_properties(template):
 # @markdown - simulate
 def simulate(sim, dt=1.0, get_frames=True):
     # simulate dt seconds at 60Hz to the nearest fixed timestep
-    print("Simulating {:.3f} world seconds.".format(dt))
+    print(f"Simulating {dt:.3f} world seconds.")
     observations = []
     start_time = sim.get_world_time()
     while sim.get_world_time() < start_time + dt:

--- a/examples/tutorials/nb_python/asset_viewer.py
+++ b/examples/tutorials/nb_python/asset_viewer.py
@@ -20,9 +20,6 @@
 #     name: python3
 # ---
 
-# %%
-from __future__ import annotations
-
 # %% [markdown]
 # <a href="https://colab.research.google.com/github/facebookresearch/habitat-sim/blob/main/examples/tutorials/colabs/asset_viewer.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 # %% [markdown]
@@ -43,6 +40,8 @@ from __future__ import annotations
 
 # %cd /content/habitat-sim
 ## [setup]
+from __future__ import annotations
+
 import math
 import os
 import sys

--- a/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
@@ -19,8 +19,9 @@
 # ---
 
 # %%
-# !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
+from __future__ import annotations
 
+# !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
 # %%
 # %cd /content/habitat-sim
 ## [setup]
@@ -456,7 +457,7 @@ if __name__ == "__main__":
     rigid_obj_mgr.remove_object_by_id(locobot.object_id, delete_object_node=False)
 
     # demonstrate that the locobot object does not now exist'
-    print("Locobot is still alive : {}".format(locobot.is_alive))
+    print(f"Locobot is still alive : {locobot.is_alive}")
 
     # video rendering with embedded 1st person view
     if make_video:

--- a/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
+++ b/examples/tutorials/nb_python/managed_rigid_object_tutorial.py
@@ -19,12 +19,12 @@
 # ---
 
 # %%
-from __future__ import annotations
-
 # !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
 # %%
 # %cd /content/habitat-sim
 ## [setup]
+from __future__ import annotations
+
 import os
 import random
 import sys

--- a/examples/tutorials/nb_python/replay_tutorial.py
+++ b/examples/tutorials/nb_python/replay_tutorial.py
@@ -18,6 +18,9 @@
 #     name: python3
 # ---
 
+# %%
+from __future__ import annotations
+
 # %% [markdown]
 # #Gfx Replay Tutorial
 #
@@ -36,7 +39,6 @@
 # - sim.gfx_replay_manager.read_keyframes_from_file
 # - player.set_keyframe_index
 # - player.get_user_transform
-
 # %%
 # !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
 

--- a/examples/tutorials/new_actions.py
+++ b/examples/tutorials/new_actions.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import attr
 import magnum as mn
 import numpy as np

--- a/examples/tutorials/physics_benchmarking.py
+++ b/examples/tutorials/physics_benchmarking.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 # [setup]
 import os
 import time

--- a/examples/tutorials/semantic_id_tutorial.py
+++ b/examples/tutorials/semantic_id_tutorial.py
@@ -1,4 +1,6 @@
 # [setup]
+from __future__ import annotations
+
 import math
 import os
 

--- a/examples/tutorials/stereo_agent.py
+++ b/examples/tutorials/stereo_agent.py
@@ -3,6 +3,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 import habitat_sim

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -2,13 +2,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import ctypes
 import math
 import os
 import sys
 import time
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable
 
 flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
@@ -23,11 +25,11 @@ from habitat_sim.logging import LoggingContext, logger
 
 
 class HabitatSimInteractiveViewer(Application):
-    def __init__(self, sim_settings: Dict[str, Any]) -> None:
+    def __init__(self, sim_settings: dict[str, Any]) -> None:
         configuration = self.Configuration()
         configuration.title = "Habitat Sim Interactive Viewer"
         Application.__init__(self, configuration)
-        self.sim_settings: Dict[str:Any] = sim_settings
+        self.sim_settings: dict[str:Any] = sim_settings
         self.fps: float = 60.0
         self.debug_bullet_draw = False
         # cache most recently loaded URDF file for quick-reload
@@ -70,7 +72,7 @@ class HabitatSimInteractiveViewer(Application):
 
         # Cycle mouse utilities
         self.mouse_interaction = MouseMode.LOOK
-        self.mouse_grabber: Optional[MouseGrabber] = None
+        self.mouse_grabber: MouseGrabber | None = None
         self.previous_mouse_point = None
 
         # toggle physics simulation on/off
@@ -81,8 +83,8 @@ class HabitatSimInteractiveViewer(Application):
         self.simulate_single_step = False
 
         # configure our simulator
-        self.cfg: Optional[habitat_sim.simulator.Configuration] = None
-        self.sim: Optional[habitat_sim.simulator.Simulator] = None
+        self.cfg: habitat_sim.simulator.Configuration | None = None
+        self.sim: habitat_sim.simulator.Simulator | None = None
         self.reconfigure_sim()
 
         # compute NavMesh if not already loaded by the scene.
@@ -105,9 +107,9 @@ class HabitatSimInteractiveViewer(Application):
 
     def draw_event(
         self,
-        simulation_call: Optional[Callable] = None,
-        global_call: Optional[Callable] = None,
-        active_agent_id_and_sensor_name: Tuple[int, str] = (0, "color_sensor"),
+        simulation_call: Callable | None = None,
+        global_call: Callable | None = None,
+        active_agent_id_and_sensor_name: tuple[int, str] = (0, "color_sensor"),
     ) -> None:
         """
         Calls continuously to re-render frames and swap the two frame buffers
@@ -177,7 +179,7 @@ class HabitatSimInteractiveViewer(Application):
             "move_up",
         ]
 
-        action_space: Dict[str, habitat_sim.agent.ActionSpec] = {}
+        action_space: dict[str, habitat_sim.agent.ActionSpec] = {}
 
         # build our action space map
         for action in action_list:
@@ -187,7 +189,7 @@ class HabitatSimInteractiveViewer(Application):
             )
             action_space[action] = action_spec
 
-        sensor_spec: List[habitat_sim.sensor.SensorSpec] = self.cfg.agents[
+        sensor_spec: list[habitat_sim.sensor.SensorSpec] = self.cfg.agents[
             self.agent_id
         ].sensor_specifications
 
@@ -242,10 +244,10 @@ class HabitatSimInteractiveViewer(Application):
 
         key = Application.KeyEvent.Key
         agent = self.sim.agents[self.agent_id]
-        press: Dict[key.key, bool] = self.pressed
-        act: Dict[key.key, str] = self.key_to_action
+        press: dict[key.key, bool] = self.pressed
+        act: dict[key.key, str] = self.key_to_action
 
-        action_queue: List[str] = [act[k] for k, v in press.items() if v]
+        action_queue: list[str] = [act[k] for k, v in press.items() if v]
 
         for _ in range(int(repetitions)):
             [agent.act(x) for x in action_queue]
@@ -849,7 +851,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Setting up sim_settings
-    sim_settings: Dict[str, Any] = default_sim_settings
+    sim_settings: dict[str, Any] = default_sim_settings
     sim_settings["scene"] = args.scene
     sim_settings["scene_dataset_config_file"] = args.dataset
     sim_settings["enable_physics"] = not args.disable_physics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ exclude = '''
 '''
 
 [tool.isort]
+add_imports = "from __future__ import annotations"
+append_only = true
 skip_glob = ["*/deps/*", "*/build/*", "*/obselete/*"]
 known_first_party = ["habitat_sim"]
 profile = 'black'

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test = pytest
 build_temp = build
 
 [flake8]
-select = A,B,C,F,R,W,SIM
+select = A,B,C,F,FI,R,W,SIM
 exclude =
 	.git,
 	__pycache__,
@@ -16,6 +16,7 @@ exclude =
 	src/deps,
 	tools/run-clang-tidy.py
 max-line-length = 88
+min-version = 3.7
 # A003 prevents class attrs from having builtin name properties
 # C401, and C402 are ignored to make scanning between dict and set easy
 # C408 ignored because we like the dict keyword argument syntax

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@
 Adapted from: http://www.benjack.io/2017/06/12/python-cpp-tests.html
 """
 
+# isort: dont-add-imports
+
 import argparse
 import builtins
 import glob

--- a/src_python/habitat_sim/__init__.py
+++ b/src_python/habitat_sim/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import builtins
 
 __version__ = "0.2.1"

--- a/src_python/habitat_sim/agent/__init__.py
+++ b/src_python/habitat_sim/agent/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from .agent import *  # noqa: F403
 from .controls import *  # noqa: F403
 

--- a/src_python/habitat_sim/agent/agent.py
+++ b/src_python/habitat_sim/agent/agent.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 import attr
 import magnum as mn
@@ -42,10 +44,10 @@ class ActionSpec:
     :property actuation: Arguments that will be passed to the function
     """
     name: str
-    actuation: Optional[ActuationSpec] = None
+    actuation: ActuationSpec | None = None
 
 
-def _default_action_space() -> Dict[str, ActionSpec]:
+def _default_action_space() -> dict[str, ActionSpec]:
     return dict(
         move_forward=ActionSpec("move_forward", ActuationSpec(amount=0.25)),
         turn_left=ActionSpec("turn_left", ActuationSpec(amount=10.0)),
@@ -70,7 +72,7 @@ class SixDOFPose:
     """
 
     position: np.ndarray = attr.ib(factory=_triple_zero, validator=all_is_finite)
-    rotation: Union[qt.quaternion, List] = attr.ib(
+    rotation: qt.quaternion | list = attr.ib(
         factory=_default_quaternion, validator=is_unit_length
     )
 
@@ -78,10 +80,10 @@ class SixDOFPose:
 @attr.s(auto_attribs=True, slots=True)
 class AgentState:
     position: np.ndarray = attr.ib(factory=_triple_zero, validator=all_is_finite)
-    rotation: Union[qt.quaternion, List, np.ndarray] = attr.ib(
+    rotation: qt.quaternion | list | np.ndarray = attr.ib(
         factory=_default_quaternion, validator=is_unit_length
     )
-    sensor_states: Dict[str, SixDOFPose] = attr.ib(
+    sensor_states: dict[str, SixDOFPose] = attr.ib(
         factory=dict,
         validator=attr.validators.deep_mapping(
             key_validator=attr.validators.instance_of(str),
@@ -95,8 +97,8 @@ class AgentState:
 class AgentConfiguration:
     height: float = 1.5
     radius: float = 0.1
-    sensor_specifications: List[hsim.SensorSpec] = attr.Factory(list)
-    action_space: Dict[Any, ActionSpec] = attr.Factory(_default_action_space)
+    sensor_specifications: list[hsim.SensorSpec] = attr.Factory(list)
+    action_space: dict[Any, ActionSpec] = attr.Factory(_default_action_space)
     body_type: str = "cylinder"
 
 
@@ -128,9 +130,9 @@ class Agent:
     def __init__(
         self,
         scene_node: hsim.SceneNode,
-        agent_config: Optional[AgentConfiguration] = None,
-        _sensors: Optional[SensorSuite] = None,
-        controls: Optional[ObjectControls] = None,
+        agent_config: AgentConfiguration | None = None,
+        _sensors: SensorSuite | None = None,
+        controls: ObjectControls | None = None,
     ) -> None:
         self.agent_config = agent_config if agent_config else AgentConfiguration()
         self._sensors = _sensors if _sensors else SensorSuite()
@@ -138,7 +140,7 @@ class Agent:
         self.body = mn.scenegraph.AbstractFeature3D(scene_node)
         scene_node.type = hsim.SceneNodeType.AGENT
         self.reconfigure(self.agent_config)
-        self.initial_state: Optional[AgentState] = None
+        self.initial_state: AgentState | None = None
 
     def reconfigure(
         self, agent_config: AgentConfiguration, reconfigure_sensors: bool = True

--- a/src_python/habitat_sim/agent/controls/__init__.py
+++ b/src_python/habitat_sim/agent/controls/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim.agent.controls.controls import ActuationSpec, SceneNodeControl
 from habitat_sim.agent.controls.default_controls import *  # noqa: F401, F403
 from habitat_sim.agent.controls.object_controls import ObjectControls

--- a/src_python/habitat_sim/agent/controls/controls.py
+++ b/src_python/habitat_sim/agent/controls/controls.py
@@ -4,8 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import abc
-from typing import Optional
 
 import attr
 
@@ -26,7 +27,7 @@ class ActuationSpec:
     """
 
     amount: float
-    constraint: Optional[float] = None
+    constraint: float | None = None
 
 
 @attr.s(auto_attribs=True)

--- a/src_python/habitat_sim/agent/controls/default_controls.py
+++ b/src_python/habitat_sim/agent/controls/default_controls.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional
+from __future__ import annotations
 
 import magnum as mn
 import numpy as np
@@ -14,7 +14,7 @@ from habitat_sim.geo import FRONT
 from habitat_sim.registry import registry
 from habitat_sim.scene import SceneNode
 
-__all__: List[str] = []
+__all__: list[str] = []
 
 
 _X_AXIS = 0
@@ -34,7 +34,7 @@ def _move_along(scene_node: SceneNode, distance: float, axis: int) -> None:
 
 
 def _rotate_local(
-    scene_node: SceneNode, theta: float, axis: int, constraint: Optional[float] = None
+    scene_node: SceneNode, theta: float, axis: int, constraint: float | None = None
 ) -> None:
     if constraint is not None:
         rotation = scene_node.rotation

--- a/src_python/habitat_sim/agent/controls/object_controls.py
+++ b/src_python/habitat_sim/agent/controls/object_controls.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import Callable, Tuple, Union
 
 import attr

--- a/src_python/habitat_sim/agent/controls/pyrobot_noisy_controls.py
+++ b/src_python/habitat_sim/agent/controls/pyrobot_noisy_controls.py
@@ -12,7 +12,9 @@ https://github.com/facebookresearch/pyrobot
 Please cite PyRobot if you use this noise model
 """
 
-from typing import Any, List, Optional, Sequence, Tuple
+from __future__ import annotations
+
+from typing import Any, Sequence
 
 import attr
 import magnum as mn
@@ -43,9 +45,7 @@ class _TruncatedMultivariateGaussian:
 
     def sample(
         self,
-        truncation: Optional[
-            List[Optional[Tuple[Optional[Any], Optional[Any]]]]
-        ] = None,
+        truncation: None | (list[tuple[Any | None, Any | None] | None]) = None,
     ) -> ndarray:
         if truncation is not None:
             assert len(truncation) == len(self.mean)

--- a/src_python/habitat_sim/attributes.py
+++ b/src_python/habitat_sim/attributes.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     CapsulePrimitiveAttributes,
     ConePrimitiveAttributes,

--- a/src_python/habitat_sim/attributes_managers.py
+++ b/src_python/habitat_sim/attributes_managers.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     AssetAttributesManager,
     ObjectAttributesManager,

--- a/src_python/habitat_sim/bindings/__init__.py
+++ b/src_python/habitat_sim/bindings/__init__.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 # TODO: this whole thing needs to get removed, kept just for compatibility
 #   with existing code
-
 from habitat_sim._ext.habitat_sim_bindings import (
     CameraSensor,
     CameraSensorSpec,

--- a/src_python/habitat_sim/errors.py
+++ b/src_python/habitat_sim/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import magnum as mn
 import magnum.scenegraph
 

--- a/src_python/habitat_sim/geo.py
+++ b/src_python/habitat_sim/geo.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import OBB, BBox, Ray
 from habitat_sim._ext.habitat_sim_bindings.geo import (
     BACK,

--- a/src_python/habitat_sim/gfx.py
+++ b/src_python/habitat_sim/gfx.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     DEFAULT_LIGHTING_KEY,
     NO_LIGHT_KEY,

--- a/src_python/habitat_sim/logging.py
+++ b/src_python/habitat_sim/logging.py
@@ -2,6 +2,7 @@ r"""A simple Google-style logging wrapper.
 
 Taken from https://github.com/benley/python-glog and adapted
 """
+from __future__ import annotations
 
 import logging
 from logging import LogRecord
@@ -32,7 +33,7 @@ def format_message(record: LogRecord) -> str:
 
 class HabitatSimFormatter(logging.Formatter):
     def format(self, record: LogRecord) -> str:
-        record_message = "[Sim] %s" % (format_message(record),)
+        record_message = f"[Sim] {format_message(record)}"
         record.getMessage = lambda: record_message  # type:ignore[assignment]
         return logging.Formatter.format(self, record)
 

--- a/src_python/habitat_sim/metadata.py
+++ b/src_python/habitat_sim/metadata.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import MetadataMediator
 
 __all__ = [

--- a/src_python/habitat_sim/nav/__init__.py
+++ b/src_python/habitat_sim/nav/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     GreedyFollowerCodes,
     GreedyGeodesicFollowerImpl,

--- a/src_python/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/src_python/habitat_sim/nav/greedy_geodesic_follower.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional, Tuple
+from __future__ import annotations
+
+from typing import Any
 
 import attr
 import numpy as np
@@ -26,24 +28,24 @@ class GreedyGeodesicFollower:
 
     pathfinder: PathFinder
     agent: Agent
-    goal_radius: Optional[float]
-    action_mapping: Dict[GreedyFollowerCodes, Any]
+    goal_radius: float | None
+    action_mapping: dict[GreedyFollowerCodes, Any]
     impl: GreedyGeodesicFollowerImpl
     forward_spec: ActuationSpec
     left_spec: ActuationSpec
     right_spec: ActuationSpec
-    last_goal: Optional[np.ndarray]
+    last_goal: np.ndarray | None
 
     def __init__(
         self,
         pathfinder: PathFinder,
         agent: Agent,
-        goal_radius: Optional[float] = None,
+        goal_radius: float | None = None,
         *,
-        stop_key: Optional[Any] = None,
-        forward_key: Optional[Any] = None,
-        left_key: Optional[Any] = None,
-        right_key: Optional[Any] = None,
+        stop_key: Any | None = None,
+        forward_key: Any | None = None,
+        left_key: Any | None = None,
+        right_key: Any | None = None,
         fix_thrashing: bool = True,
         thrashing_threshold: int = 16,
     ) -> None:
@@ -118,7 +120,7 @@ class GreedyGeodesicFollower:
             thrashing_threshold,
         )
 
-    def _find_action(self, name: str) -> Tuple[str, ActuationSpec]:
+    def _find_action(self, name: str) -> tuple[str, ActuationSpec]:
         candidates = list(
             filter(
                 lambda kv: kv[1].name == name,
@@ -162,7 +164,7 @@ class GreedyGeodesicFollower:
         else:
             return self.action_mapping[next_act]
 
-    def find_path(self, goal_pos: np.ndarray) -> List[Any]:
+    def find_path(self, goal_pos: np.ndarray) -> list[Any]:
         r"""Finds the sequence actions that greedily follow the geodesic
         shortest path from the agent's current position to get to the goal
 

--- a/src_python/habitat_sim/physics.py
+++ b/src_python/habitat_sim/physics.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     ArticulatedObjectManager,
     CollisionGroupHelper,

--- a/src_python/habitat_sim/registry.py
+++ b/src_python/habitat_sim/registry.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import collections
 import re
-from typing import DefaultDict, Optional, Type
+from typing import DefaultDict
 
 __all__ = ["registry"]
 
@@ -35,10 +37,10 @@ class _Registry:
     @classmethod
     def register_move_fn(
         cls,
-        controller: Optional[Type] = None,
+        controller: type | None = None,
         *,
-        name: Optional[str] = None,
-        body_action: Optional[bool] = None,
+        name: str | None = None,
+        body_action: bool | None = None,
     ):
         r"""Registers a new control with Habitat-Sim. Registered controls can
         then be retrieved via `get_move_fn()`
@@ -62,7 +64,7 @@ class _Registry:
         ), "body_action must be explicitly set to True or False"
         from habitat_sim.agent.controls.controls import SceneNodeControl
 
-        def _wrapper(controller: Type[SceneNodeControl]):
+        def _wrapper(controller: type[SceneNodeControl]):
             assert issubclass(
                 controller, SceneNodeControl
             ), "All controls must inherit from habitat_sim.agent.SceneNodeControl"
@@ -80,7 +82,7 @@ class _Registry:
 
     @classmethod
     def register_noise_model(
-        cls, noise_model: Optional[Type] = None, *, name: Optional[str] = None
+        cls, noise_model: type | None = None, *, name: str | None = None
     ):
         r"""Registers a new sensor noise model with Habitat-Sim
 
@@ -91,7 +93,7 @@ class _Registry:
         """
         from habitat_sim.sensors.noise_models.sensor_noise_model import SensorNoiseModel
 
-        def _wrapper(noise_model: Type[SensorNoiseModel]):
+        def _wrapper(noise_model: type[SensorNoiseModel]):
             assert issubclass(
                 noise_model, SensorNoiseModel
             ), "All noise_models must inherit from habitat_sim.sensor.SensorNoiseModel"
@@ -109,7 +111,7 @@ class _Registry:
 
     @classmethod
     def register_pose_extractor(
-        cls, pose_extractor: Optional[Type] = None, *, name: Optional[str] = None
+        cls, pose_extractor: type | None = None, *, name: str | None = None
     ):
         r"""Registers a new pose extractor model with Habitat-Sim
 
@@ -120,7 +122,7 @@ class _Registry:
         """
         from habitat_sim.utils.data.pose_extractor import PoseExtractor
 
-        def _wrapper(pose_extractor: Type[PoseExtractor]):
+        def _wrapper(pose_extractor: type[PoseExtractor]):
             assert issubclass(
                 pose_extractor, PoseExtractor
             ), "All pose_extractors must inherit from habitat_sim.utils.data.PoseExtractor"

--- a/src_python/habitat_sim/robots/__init__.py
+++ b/src_python/habitat_sim/robots/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim.robots.fetch_robot import FetchRobot, FetchRobotNoWheels
 from habitat_sim.robots.mobile_manipulator import (
     MobileManipulator,

--- a/src_python/habitat_sim/robots/fetch_robot.py
+++ b/src_python/habitat_sim/robots/fetch_robot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import magnum as mn
 import numpy as np
 

--- a/src_python/habitat_sim/robots/mobile_manipulator.py
+++ b/src_python/habitat_sim/robots/mobile_manipulator.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple
 
 import attr
 import magnum as mn
@@ -70,18 +71,18 @@ class MobileManipulatorParams:
     :property base_offset: The offset of the root transform from the center ground point for navmesh kinematic control.
     """
 
-    arm_joints: List[int]
-    gripper_joints: List[int]
-    wheel_joints: Optional[List[int]]
+    arm_joints: list[int]
+    gripper_joints: list[int]
+    wheel_joints: list[int] | None
 
-    arm_init_params: Optional[np.ndarray]
-    gripper_init_params: Optional[np.ndarray]
+    arm_init_params: np.ndarray | None
+    gripper_init_params: np.ndarray | None
 
     ee_offset: mn.Vector3
     ee_link: int
     ee_constraint: np.ndarray
 
-    cameras: Dict[str, RobotCameraParams]
+    cameras: dict[str, RobotCameraParams]
 
     gripper_closed_state: np.ndarray
     gripper_open_state: np.ndarray
@@ -96,7 +97,7 @@ class MobileManipulatorParams:
     wheel_mtr_max_impulse: float
 
     base_offset: mn.Vector3
-    base_link_names: Set[str]
+    base_link_names: set[str]
 
 
 class MobileManipulator(RobotInterface):
@@ -118,7 +119,7 @@ class MobileManipulator(RobotInterface):
         super().__init__()
         self.urdf_path = urdf_path
         self.params = params
-        self._fix_joint_values: Optional[np.ndarray] = None
+        self._fix_joint_values: np.ndarray | None = None
 
         self._sim = sim
         self._limit_robo_joints = limit_robo_joints
@@ -133,12 +134,12 @@ class MobileManipulator(RobotInterface):
 
         # NOTE: the follow members cache static info for improved efficiency over querying the API
         # maps joint ids to motor settings for convenience
-        self.joint_motors: Dict[int, Tuple[int, JointMotorSettings]] = {}
+        self.joint_motors: dict[int, tuple[int, JointMotorSettings]] = {}
         # maps joint ids to position index
-        self.joint_pos_indices: Dict[int, int] = {}
+        self.joint_pos_indices: dict[int, int] = {}
         # maps joint ids to velocity index
-        self.joint_dof_indices: Dict[int, int] = {}
-        self.joint_limits: Tuple[np.ndarray, np.ndarray] = None
+        self.joint_dof_indices: dict[int, int] = {}
+        self.joint_limits: tuple[np.ndarray, np.ndarray] = None
 
         # defaults for optional params
         if self.params.gripper_init_params is None:
@@ -250,7 +251,7 @@ class MobileManipulator(RobotInterface):
     # ARM RELATED
     #############################################
     @property
-    def arm_joint_limits(self) -> Tuple[np.ndarray, np.ndarray]:
+    def arm_joint_limits(self) -> tuple[np.ndarray, np.ndarray]:
         """Get the arm joint limits in radians"""
         arm_pos_indices = list(
             map(lambda x: self.joint_pos_indices[x], self.params.arm_joints)
@@ -314,7 +315,7 @@ class MobileManipulator(RobotInterface):
         )
 
     @gripper_joint_pos.setter
-    def gripper_joint_pos(self, ctrl: List[float]):
+    def gripper_joint_pos(self, ctrl: list[float]):
         """Kinematically sets the gripper joints and sets the motors to target."""
         joint_positions = self.sim_obj.joint_positions
         for i, jidx in enumerate(self.params.gripper_joints):
@@ -374,7 +375,7 @@ class MobileManipulator(RobotInterface):
         )
 
     @arm_joint_pos.setter
-    def arm_joint_pos(self, ctrl: List[float]):
+    def arm_joint_pos(self, ctrl: list[float]):
         """Kinematically sets the arm joints and sets the motors to target."""
         self._validate_arm_ctrl_input(ctrl)
 
@@ -385,7 +386,7 @@ class MobileManipulator(RobotInterface):
             joint_positions[self.joint_pos_indices[jidx]] = ctrl[i]
         self.sim_obj.joint_positions = joint_positions
 
-    def _validate_arm_ctrl_input(self, ctrl: List[float]):
+    def _validate_arm_ctrl_input(self, ctrl: list[float]):
         """
         Raises an exception if the control input is NaN or does not match the
         joint dimensions.
@@ -424,7 +425,7 @@ class MobileManipulator(RobotInterface):
         return motor_targets
 
     @arm_motor_pos.setter
-    def arm_motor_pos(self, ctrl: List[float]) -> None:
+    def arm_motor_pos(self, ctrl: list[float]) -> None:
         """Set the desired target of the arm joint motors."""
         self._validate_arm_ctrl_input(ctrl)
 

--- a/src_python/habitat_sim/robots/robot_interface.py
+++ b/src_python/habitat_sim/robots/robot_interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 from habitat_sim.physics import ManagedBulletArticulatedObject

--- a/src_python/habitat_sim/scene.py
+++ b/src_python/habitat_sim/scene.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     Mp3dObjectCategory,
     Mp3dRegionCategory,

--- a/src_python/habitat_sim/sensor.py
+++ b/src_python/habitat_sim/sensor.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import (
     CameraSensor,
     CameraSensorSpec,

--- a/src_python/habitat_sim/sensors/__init__.py
+++ b/src_python/habitat_sim/sensors/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim.sensors import noise_models
 
 from .sensor_suite import SensorSuite

--- a/src_python/habitat_sim/sensors/noise_models/__init__.py
+++ b/src_python/habitat_sim/sensors/noise_models/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import Any, Dict
 
 from habitat_sim.registry import registry
@@ -20,7 +22,7 @@ from habitat_sim.sensors.noise_models.sensor_noise_model import SensorNoiseModel
 from habitat_sim.sensors.noise_models.speckle_noise_model import SpeckleNoiseModel
 
 
-def make_sensor_noise_model(name: str, kwargs: Dict[str, Any]) -> SensorNoiseModel:
+def make_sensor_noise_model(name: str, kwargs: dict[str, Any]) -> SensorNoiseModel:
     r"""Constructs a noise model using the given name and keyword arguments
 
     :param name: The name of the noise model in the `habitat_sim.registry`
@@ -28,7 +30,7 @@ def make_sensor_noise_model(name: str, kwargs: Dict[str, Any]) -> SensorNoiseMod
     """
 
     model = registry.get_noise_model(name)
-    assert model is not None, "Could not find a noise model for name '{}'".format(name)
+    assert model is not None, f"Could not find a noise model for name '{name}'"
 
     return model(**kwargs)
 

--- a/src_python/habitat_sim/sensors/noise_models/gaussian_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/gaussian_noise_model.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import attr
 import numba
 import numpy as np

--- a/src_python/habitat_sim/sensors/noise_models/no_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/no_noise_model.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Union
+from __future__ import annotations
 
 import attr
 import numpy as np
@@ -27,9 +27,7 @@ class NoSensorNoiseModel(SensorNoiseModel):
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:
         return True
 
-    def apply(
-        self, x: Union[ndarray, "torch.Tensor"]
-    ) -> Union[ndarray, "torch.Tensor"]:
+    def apply(self, x: ndarray | torch.Tensor) -> ndarray | torch.Tensor:
         if isinstance(x, np.ndarray):
             return x.copy()
         elif torch is not None and torch.is_tensor(x):

--- a/src_python/habitat_sim/sensors/noise_models/poisson_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/poisson_noise_model.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import attr
 import numpy as np
 from numpy import ndarray

--- a/src_python/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/redwood_depth_noise_model.py
@@ -4,8 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from os import path as osp
-from typing import Union
 
 import attr
 import numba
@@ -130,7 +131,7 @@ class RedwoodDepthNoiseModel(SensorNoiseModel):
     def is_valid_sensor_type(sensor_type: SensorType) -> bool:
         return sensor_type == SensorType.DEPTH
 
-    def simulate(self, gt_depth: Union[ndarray, "Tensor"]) -> Union[ndarray, "Tensor"]:
+    def simulate(self, gt_depth: ndarray | Tensor) -> ndarray | Tensor:
         if cuda_enabled:
             if isinstance(gt_depth, np.ndarray):
                 return self._impl.simulate_from_cpu(gt_depth)
@@ -144,6 +145,6 @@ class RedwoodDepthNoiseModel(SensorNoiseModel):
         else:
             return self._impl.simulate(gt_depth)
 
-    def apply(self, gt_depth: Union[ndarray, "Tensor"]) -> Union[ndarray, "Tensor"]:
+    def apply(self, gt_depth: ndarray | Tensor) -> ndarray | Tensor:
         r"""Alias of `simulate()` to conform to base-class and expected API"""
         return self.simulate(gt_depth)

--- a/src_python/habitat_sim/sensors/noise_models/salt_and_pepper_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/salt_and_pepper_noise_model.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import attr
 import numpy as np
 from numpy import ndarray

--- a/src_python/habitat_sim/sensors/noise_models/sensor_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/sensor_noise_model.py
@@ -4,8 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import abc
-from typing import Optional, Union
 
 import attr
 from numpy import ndarray
@@ -21,7 +22,7 @@ from habitat_sim.sensor import SensorType
 @attr.s(auto_attribs=True, kw_only=True)
 class SensorNoiseModel(abc.ABC):
     r"""Base class for all sensor noise models"""
-    gpu_device_id: Optional[int] = None
+    gpu_device_id: int | None = None
 
     @staticmethod
     @abc.abstractmethod
@@ -42,8 +43,6 @@ class SensorNoiseModel(abc.ABC):
         :return: The sensor observation with noise applied.
         """
 
-    def __call__(
-        self, sensor_observation: Union[ndarray, "Tensor"]
-    ) -> Union[ndarray, "Tensor"]:
+    def __call__(self, sensor_observation: ndarray | Tensor) -> ndarray | Tensor:
         r"""Alias of `apply()`"""
         return self.apply(sensor_observation)

--- a/src_python/habitat_sim/sensors/noise_models/speckle_noise_model.py
+++ b/src_python/habitat_sim/sensors/noise_models/speckle_noise_model.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import attr
 import numpy as np
 from numpy import ndarray

--- a/src_python/habitat_sim/sensors/sensor_suite.py
+++ b/src_python/habitat_sim/sensors/sensor_suite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 from habitat_sim import bindings as hsim

--- a/src_python/habitat_sim/sim.py
+++ b/src_python/habitat_sim/sim.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim._ext.habitat_sim_bindings import Simulator as SimulatorBackend
 from habitat_sim._ext.habitat_sim_bindings import SimulatorConfiguration
 

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -4,13 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import time
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from os import path as osp
 from typing import Any, Dict, List
 from typing import MutableMapping as MutableMapping_T
-from typing import Optional, Union, cast, overload
+from typing import Union, cast, overload
 
 import attr
 import magnum as mn
@@ -54,9 +56,9 @@ class Configuration:
     """
 
     sim_cfg: SimulatorConfiguration
-    agents: List[AgentConfiguration]
+    agents: list[AgentConfiguration]
     # An existing Metadata Mediator can also be used to construct a SimulatorBackend
-    metadata_mediator: Optional[MetadataMediator] = None
+    metadata_mediator: MetadataMediator | None = None
 
 
 @attr.s(auto_attribs=True)
@@ -71,16 +73,16 @@ class Simulator(SimulatorBackend):
     """
 
     config: Configuration
-    agents: List[Agent] = attr.ib(factory=list, init=False)
+    agents: list[Agent] = attr.ib(factory=list, init=False)
     _num_total_frames: int = attr.ib(default=0, init=False)
     _default_agent_id: int = attr.ib(default=0, init=False)
-    __sensors: List[Dict[str, "Sensor"]] = attr.ib(factory=list, init=False)
+    __sensors: list[dict[str, Sensor]] = attr.ib(factory=list, init=False)
     _initialized: bool = attr.ib(default=False, init=False)
     _previous_step_time: float = attr.ib(
         default=0.0, init=False
     )  # track the compute time of each step
-    _async_draw_agent_ids: Optional[Union[int, List[int]]] = None
-    __last_state: Dict[int, AgentState] = attr.ib(factory=dict, init=False)
+    _async_draw_agent_ids: int | list[int] | None = None
+    __last_state: dict[int, AgentState] = attr.ib(factory=dict, init=False)
 
     @staticmethod
     def _sanitize_config(config: Configuration) -> None:
@@ -155,7 +157,7 @@ class Simulator(SimulatorBackend):
 
         super().close(destroy)
 
-    def __enter__(self) -> "Simulator":
+    def __enter__(self) -> Simulator:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -166,16 +168,16 @@ class Simulator(SimulatorBackend):
         self.pathfinder.seed(new_seed)
 
     @overload
-    def reset(self, agent_ids: List[int]) -> Dict[int, ObservationDict]:
+    def reset(self, agent_ids: list[int]) -> dict[int, ObservationDict]:
         ...
 
     @overload
-    def reset(self, agent_ids: Optional[int] = None) -> ObservationDict:
+    def reset(self, agent_ids: int | None = None) -> ObservationDict:
         ...
 
     def reset(
-        self, agent_ids: Union[Optional[int], List[int]] = None
-    ) -> Union[ObservationDict, Dict[int, ObservationDict],]:
+        self, agent_ids: int | None | list[int] = None
+    ) -> ObservationDict | dict[int, ObservationDict]:
         super().reset()
         for i in range(len(self.agents)):
             self.reset_agent(i)
@@ -267,7 +269,7 @@ class Simulator(SimulatorBackend):
 
         self._default_agent_id = config.sim_cfg.default_agent_id
 
-        self.__sensors: List[Dict[str, Sensor]] = [
+        self.__sensors: list[dict[str, Sensor]] = [
             dict() for i in range(len(config.agents))
         ]
         self.__last_state = dict()
@@ -281,9 +283,7 @@ class Simulator(SimulatorBackend):
             sim=self, agent=self.get_agent(agent_id), sensor_id=uuid
         )
 
-    def add_sensor(
-        self, sensor_spec: SensorSpec, agent_id: Optional[int] = None
-    ) -> None:
+    def add_sensor(self, sensor_spec: SensorSpec, agent_id: int | None = None) -> None:
         if (
             (
                 not self.config.sim_cfg.load_semantic_mesh
@@ -314,7 +314,7 @@ class Simulator(SimulatorBackend):
         return self.agents[agent_id]
 
     def initialize_agent(
-        self, agent_id: int, initial_state: Optional[AgentState] = None
+        self, agent_id: int, initial_state: AgentState | None = None
     ) -> Agent:
         agent = self.get_agent(agent_id=agent_id)
         if initial_state is None:
@@ -330,7 +330,7 @@ class Simulator(SimulatorBackend):
         return agent
 
     def start_async_render_and_step_physics(
-        self, dt: float, agent_ids: Union[int, List[int]] = 0
+        self, dt: float, agent_ids: int | list[int] = 0
     ):
         if self._async_draw_agent_ids is not None:
             raise RuntimeError(
@@ -351,7 +351,7 @@ class Simulator(SimulatorBackend):
         self.renderer.start_draw_jobs()
         self.step_physics(dt)
 
-    def start_async_render(self, agent_ids: Union[int, List[int]] = 0):
+    def start_async_render(self, agent_ids: int | list[int] = 0):
         if self._async_draw_agent_ids is not None:
             raise RuntimeError(
                 "start_async_render_and_step_physics was already called.  "
@@ -372,10 +372,7 @@ class Simulator(SimulatorBackend):
 
     def get_sensor_observations_async_finish(
         self,
-    ) -> Union[
-        Dict[str, Union[ndarray, "Tensor"]],
-        Dict[int, Dict[str, Union[ndarray, "Tensor"]]],
-    ]:
+    ) -> (dict[str, ndarray | Tensor] | dict[int, dict[str, ndarray | Tensor]]):
         if self._async_draw_agent_ids is None:
             raise RuntimeError(
                 "get_sensor_observations_async_finish was called before calling start_async_render_and_step_physics."
@@ -391,9 +388,9 @@ class Simulator(SimulatorBackend):
 
         self.renderer.wait_draw_jobs()
         # As backport. All Dicts are ordered in Python >= 3.7
-        observations: Dict[int, Dict[str, Union[ndarray, "Tensor"]]] = OrderedDict()
+        observations: dict[int, dict[str, ndarray | Tensor]] = OrderedDict()
         for agent_id in agent_ids:
-            agent_observations: Dict[str, Union[ndarray, "Tensor"]] = {}
+            agent_observations: dict[str, ndarray | Tensor] = {}
             for sensor_uuid, sensor in self.__sensors[agent_id].items():
                 agent_observations[sensor_uuid] = sensor._get_observation_async()
 
@@ -408,13 +405,13 @@ class Simulator(SimulatorBackend):
 
     @overload
     def get_sensor_observations(
-        self, agent_ids: List[int]
-    ) -> Dict[int, ObservationDict]:
+        self, agent_ids: list[int]
+    ) -> dict[int, ObservationDict]:
         ...
 
     def get_sensor_observations(
-        self, agent_ids: Union[int, List[int]] = 0
-    ) -> Union[ObservationDict, Dict[int, ObservationDict],]:
+        self, agent_ids: int | list[int] = 0
+    ) -> ObservationDict | dict[int, ObservationDict]:
         if isinstance(agent_ids, int):
             agent_ids = [agent_ids]
             return_single = True
@@ -427,7 +424,7 @@ class Simulator(SimulatorBackend):
                 sensor.draw_observation()
 
         # As backport. All Dicts are ordered in Python >= 3.7
-        observations: Dict[int, ObservationDict] = OrderedDict()
+        observations: dict[int, ObservationDict] = OrderedDict()
         for agent_id in agent_ids:
             agent_observations: ObservationDict = {}
             for sensor_uuid, sensor in self.__sensors[agent_id].items():
@@ -453,37 +450,37 @@ class Simulator(SimulatorBackend):
         self.__last_state[self._default_agent_id] = state
 
     @property
-    def _sensors(self) -> Dict[str, "Sensor"]:
+    def _sensors(self) -> dict[str, Sensor]:
         # TODO Deprecate and remove
         return self.__sensors[self._default_agent_id]
 
-    def last_state(self, agent_id: Optional[int] = None) -> AgentState:
+    def last_state(self, agent_id: int | None = None) -> AgentState:
         if agent_id is None:
             agent_id = self._default_agent_id
         return self.__last_state[agent_id]
 
     @overload
-    def step(self, action: Union[str, int], dt: float = 1.0 / 60.0) -> ObservationDict:
+    def step(self, action: str | int, dt: float = 1.0 / 60.0) -> ObservationDict:
         ...
 
     @overload
     def step(
-        self, action: MutableMapping_T[int, Union[str, int]], dt: float = 1.0 / 60.0
-    ) -> Dict[int, ObservationDict]:
+        self, action: MutableMapping_T[int, str | int], dt: float = 1.0 / 60.0
+    ) -> dict[int, ObservationDict]:
         ...
 
     def step(
         self,
-        action: Union[str, int, MutableMapping_T[int, Union[str, int]]],
+        action: str | int | MutableMapping_T[int, str | int],
         dt: float = 1.0 / 60.0,
-    ) -> Union[ObservationDict, Dict[int, ObservationDict],]:
+    ) -> ObservationDict | dict[int, ObservationDict]:
         self._num_total_frames += 1
         if isinstance(action, MutableMapping):
             return_single = False
         else:
             action = cast(Dict[int, Union[str, int]], {self._default_agent_id: action})
             return_single = True
-        collided_dict: Dict[int, bool] = {}
+        collided_dict: dict[int, bool] = {}
         for agent_id, agent_act in action.items():
             agent = self.get_agent(agent_id)
             collided_dict[agent_id] = agent.act(agent_act)
@@ -503,13 +500,13 @@ class Simulator(SimulatorBackend):
 
     def make_greedy_follower(
         self,
-        agent_id: Optional[int] = None,
+        agent_id: int | None = None,
         goal_radius: float = None,
         *,
-        stop_key: Optional[Any] = None,
-        forward_key: Optional[Any] = None,
-        left_key: Optional[Any] = None,
-        right_key: Optional[Any] = None,
+        stop_key: Any | None = None,
+        forward_key: Any | None = None,
+        left_key: Any | None = None,
+        right_key: Any | None = None,
         fix_thrashing: bool = True,
         thrashing_threshold: int = 16,
     ):
@@ -577,7 +574,7 @@ class Sensor:
 
             resolution = self._spec.resolution
             if self._spec.sensor_type == SensorType.SEMANTIC:
-                self._buffer: Union[np.ndarray, "Tensor"] = torch.empty(
+                self._buffer: np.ndarray | Tensor = torch.empty(
                     resolution[0], resolution[1], dtype=torch.int32, device=device
                 )
             elif self._spec.sensor_type == SensorType.DEPTH:
@@ -698,7 +695,7 @@ class Sensor:
             self._sensor_object, scene, self.view, render_flags
         )
 
-    def get_observation(self) -> Union[ndarray, "Tensor"]:
+    def get_observation(self) -> ndarray | Tensor:
         assert self._sim.renderer is not None
         tgt = self._sensor_object.render_target
 
@@ -724,7 +721,7 @@ class Sensor:
 
         return self._noise_model(obs)
 
-    def _get_observation_async(self) -> Union[ndarray, "Tensor"]:
+    def _get_observation_async(self) -> ndarray | Tensor:
         if self._spec.gpu2gpu_transfer:
             obs = self._buffer.flip(0)  # type: ignore[union-attr]
         else:

--- a/src_python/habitat_sim/utils/__init__.py
+++ b/src_python/habitat_sim/utils/__init__.py
@@ -4,14 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
+from habitat_sim.utils import common, manager_utils, validators, viz_utils
+from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
+
 # quat_from_angle_axis and quat_rotate_vector imports
 # added for backward compatibility with Habitat Lab
 # TODO @maksymets: remove after habitat-lab/examples/new_actions.py will be
 # fixed
 
-
-from habitat_sim.utils import common, manager_utils, validators, viz_utils
-from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
 
 __all__ = [
     "quat_from_angle_axis",

--- a/src_python/habitat_sim/utils/collect_env.py
+++ b/src_python/habitat_sim/utils/collect_env.py
@@ -4,19 +4,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-#
-# A script to capture the running environment information for debugging
-# purposes.
-# Please, run this script and provide it's output when reporting a bug.
-#
-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import locale
 import os
 import platform
 import subprocess
 import sys
+
+#
+# A script to capture the running environment information for debugging
+# purposes.
+# Please, run this script and provide it's output when reporting a bug.
+#
 
 
 def run_command(command: str) -> str:

--- a/src_python/habitat_sim/utils/common.py
+++ b/src_python/habitat_sim/utils/common.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import math
 from io import BytesIO
-from typing import List, Sequence, Tuple, Union
+from typing import Sequence
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -15,7 +17,7 @@ import numpy as np
 import quaternion as qt
 
 
-def quat_from_coeffs(coeffs: Union[Sequence[float], np.ndarray]) -> qt.quaternion:
+def quat_from_coeffs(coeffs: Sequence[float] | np.ndarray) -> qt.quaternion:
     r"""Creates a quaternion from the coeffs returned by the simulator backend
 
     :param coeffs: Coefficients of a quaternion in :py:`[b, c, d, a]` format,
@@ -52,7 +54,7 @@ def quat_from_magnum(quat: mn.Quaternion) -> qt.quaternion:
     return a
 
 
-def quat_to_angle_axis(quat: qt.quaternion) -> Tuple[float, np.ndarray]:
+def quat_to_angle_axis(quat: qt.quaternion) -> tuple[np.floating, np.ndarray]:
     r"""Converts a quaternion to angle axis format
 
     :param quat: The quaternion
@@ -67,7 +69,7 @@ def quat_to_angle_axis(quat: qt.quaternion) -> Tuple[float, np.ndarray]:
     theta = np.linalg.norm(rot_vec)
     if np.abs(theta) < 1e-5:
         w = np.array([1, 0, 0])
-        theta = 0.0
+        theta = 0.0  # type: ignore[assignment]
     else:
         w = rot_vec / theta
 
@@ -228,7 +230,7 @@ d3_40_colors_rgb: np.ndarray = np.array(
 
 
 # [d3_40_colors_hex]
-d3_40_colors_hex: List[str] = [
+d3_40_colors_hex: list[str] = [
     "0x1f77b4",
     "0xaec7e8",
     "0xff7f0e",

--- a/src_python/habitat_sim/utils/compare_profiles.py
+++ b/src_python/habitat_sim/utils/compare_profiles.py
@@ -40,6 +40,8 @@ batch_obs                             1,915         1,915          -144         
 before_step (for optimize)            1,681         1,681           -62           -62
 backward (for surrogate loss)         1,463         1,463           -22           -22
 """
+from __future__ import annotations
+
 import argparse
 import glob
 import os
@@ -47,7 +49,7 @@ import sqlite3
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from sqlite3 import Connection
-from typing import Any, DefaultDict, Dict, List, Optional, Set, Union
+from typing import Any, DefaultDict
 
 import attr
 
@@ -72,10 +74,10 @@ class SummaryItem:
     count: int = 0
 
 
-def get_sqlite_events(conn: Connection) -> List[Event]:
+def get_sqlite_events(conn: Connection) -> list[Event]:
     """Parse an sqlite database containing an NVTX_EVENTS table and return a
     list of Events."""
-    events: List[Event] = []
+    events: list[Event] = []
 
     # check if table exists
     cursor = conn.execute(
@@ -94,7 +96,7 @@ def get_sqlite_events(conn: Connection) -> List[Event]:
     return events
 
 
-def create_summary_from_events(events: List[Event]) -> DefaultDict[str, SummaryItem]:
+def create_summary_from_events(events: list[Event]) -> DefaultDict[str, SummaryItem]:
     """From a list of events, group by name and create summary items. Returns a
     dictionary of items keyed by name."""
     # sort by start time (ascending). For ties, sort by end time (descending). In this way,
@@ -117,11 +119,11 @@ def create_summary_from_events(events: List[Event]) -> DefaultDict[str, SummaryI
         # iterate chronologically through later events. Our accumulated
         #  "exclusive duration" is time during which we aren't inside any
         #  overlapping, same-thread event ("child event").
-        recent_exclusive_start_time: Optional[int] = event.start
-        child_end_times: Set[int] = set()
+        recent_exclusive_start_time: int | None = event.start
+        child_end_times: set[int] = set()
         for j in range(i + 1, len(events) + 1):  # note one extra iteration
 
-            other_event: Optional[Event] = None if j == len(events) else events[j]
+            other_event: Event | None = None if j == len(events) else events[j]
             if other_event:
                 if other_event.thread_id != event.thread_id:
                     continue
@@ -169,9 +171,9 @@ def _display_time_ms(time: int, args: Namespace, show_sign: bool = False) -> str
 
 
 def print_summaries(
-    summaries: Union[List[DefaultDict[str, SummaryItem]], List[DefaultDict[Any, Any]]],
+    summaries: list[DefaultDict[str, SummaryItem]] | list[DefaultDict[Any, Any]],
     args: Namespace,
-    labels: Optional[List[str]] = None,
+    labels: list[str] | None = None,
 ) -> None:
     """Print a dictionary of summaries to stdout. See create_arg_parser for
     formatting options available in the args object. See also
@@ -183,7 +185,7 @@ def print_summaries(
         print("no summaries to print")
         return
 
-    all_names_with_times: Dict[str, int] = {}
+    all_names_with_times: dict[str, int] = {}
     max_name_len = 0
     for summary in summaries:
         for name in summary:

--- a/src_python/habitat_sim/utils/data/__init__.py
+++ b/src_python/habitat_sim/utils/data/__init__.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 from habitat_sim import registry as registry  # noqa: F401
 from habitat_sim.utils.data import data_extractor, data_structures, pose_extractor
 from habitat_sim.utils.data.data_extractor import ImageExtractor

--- a/src_python/habitat_sim/utils/data/data_extractor.py
+++ b/src_python/habitat_sim/utils/data/data_extractor.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Union
+from __future__ import annotations
+
+from typing import Callable
 
 import numpy as np
 
@@ -59,10 +61,10 @@ class ImageExtractor:
 
     def __init__(
         self,
-        scene_filepath: Union[str, List[str]],
-        labels: List[float] = None,
+        scene_filepath: str | list[str],
+        labels: list[float] = None,
         img_size: tuple = (512, 512),
-        output: List[str] = None,
+        output: list[str] = None,
         pose_extractor_name: str = "closest_point_extractor",
         sim=None,
         shuffle: bool = True,
@@ -204,7 +206,7 @@ class ImageExtractor:
 
         self.mode = mymode
 
-    def get_semantic_class_names(self) -> List[str]:
+    def get_semantic_class_names(self) -> list[str]:
         r"""Returns a list of english class names in the scene(s). E.g. ['wall', 'ceiling', 'chair']"""
         class_names = list(set(self.instance_id_to_name.values()))
         return class_names

--- a/src_python/habitat_sim/utils/data/data_structures.py
+++ b/src_python/habitat_sim/utils/data/data_structures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 
 
@@ -9,7 +11,7 @@ class ExtractorLRUCache:
 
     def __getitem__(self, key):
         if not self.__contains__(key):
-            raise KeyError("Key {} not in extractor cache".format(key))
+            raise KeyError(f"Key {key} not in extractor cache")
         else:
             # Accessing the data should move it to front of cache
             k, data = self._order.pop(key)

--- a/src_python/habitat_sim/utils/data/pose_extractor.py
+++ b/src_python/habitat_sim/utils/data/pose_extractor.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import collections
-from typing import List, Tuple, Union
 
 import attr
 import numpy as np
@@ -37,7 +38,7 @@ class PoseExtractor:
 
     def __init__(
         self,
-        topdown_views: List[Tuple[TopdownView, str, Tuple[float32, float32, float32]]],
+        topdown_views: list[tuple[TopdownView, str, tuple[float32, float32, float32]]],
         meters_per_pixel: float = 0.1,
     ) -> None:
         self.tdv_fp_ref_triples = topdown_views
@@ -60,7 +61,7 @@ class PoseExtractor:
 
     def extract_poses(
         self, view: np.ndarray, fp: str
-    ) -> List[Tuple[Tuple[int, int], Tuple[int, int], str]]:
+    ) -> list[tuple[tuple[int, int], tuple[int, int], str]]:
         r"""Extracts poses according to a programatic rule.
 
         :property view: 2D numpy array representing the topdown view of the scene.
@@ -72,8 +73,8 @@ class PoseExtractor:
         return view[row][col] == 1.0
 
     def _is_point_of_interest(
-        self, point: Tuple[int, int], labels: List[float], view: ndarray
-    ) -> Tuple[bool, float64]:
+        self, point: tuple[int, int], labels: list[float], view: ndarray
+    ) -> tuple[bool, float64]:
         r, c = point
         is_interesting = False
         if view[r][c] in labels:
@@ -87,9 +88,9 @@ class PoseExtractor:
 
     def _convert_to_scene_coordinate_system(
         self,
-        poses: List[Tuple[Tuple[int, int], Tuple[int, int], str]],
-        ref_point: Tuple[float32, float32, float32],
-    ) -> List[Tuple[Tuple[int, int], quaternion, str]]:
+        poses: list[tuple[tuple[int, int], tuple[int, int], str]],
+        ref_point: tuple[float32, float32, float32],
+    ) -> list[tuple[tuple[int, int], quaternion, str]]:
         # Convert from topdown map coordinate system to that of the scene
         startw, starty, starth = ref_point
         for i, pose in enumerate(poses):
@@ -112,7 +113,7 @@ class PoseExtractor:
             )
             cam_normal = new_cpi - new_pos
             new_rot = self._compute_quat(cam_normal)
-            new_pos_t: Tuple[int, int] = tuple(new_pos)  # type: ignore[assignment]
+            new_pos_t: tuple[int, int] = tuple(new_pos)  # type: ignore[assignment]
             poses[i] = (new_pos_t, new_rot, filepath)
 
         return poses
@@ -122,14 +123,14 @@ class PoseExtractor:
 class ClosestPointExtractor(PoseExtractor):
     def __init__(
         self,
-        topdown_views: List[Tuple[TopdownView, str, Tuple[float32, float32, float32]]],
+        topdown_views: list[tuple[TopdownView, str, tuple[float32, float32, float32]]],
         meters_per_pixel: float = 0.1,
     ) -> None:
         super().__init__(topdown_views, meters_per_pixel)
 
     def extract_poses(
         self, view: ndarray, fp: str
-    ) -> List[Tuple[Tuple[int, int], Tuple[int, int], str]]:
+    ) -> list[tuple[tuple[int, int], tuple[int, int], str]]:
         # Determine the physical spacing between each camera position
         height, width = view.shape
         dist = min(height, width) // 10  # We can modify this to be user-defined later
@@ -161,8 +162,8 @@ class ClosestPointExtractor(PoseExtractor):
         return poses
 
     def _bfs(
-        self, point: Tuple[int, int], labels: List[float], view: ndarray, dist: int
-    ) -> Union[Tuple[Tuple[int, int], float64], Tuple[None, None]]:
+        self, point: tuple[int, int], labels: list[float], view: ndarray, dist: int
+    ) -> tuple[tuple[int, int], float64] | tuple[None, None]:
         step = 3  # making this larger really speeds up BFS
 
         def get_neighbors(p):
@@ -216,14 +217,14 @@ class ClosestPointExtractor(PoseExtractor):
 class PanoramaExtractor(PoseExtractor):
     def __init__(
         self,
-        topdown_views: List[Tuple[TopdownView, str, Tuple[float32, float32, float32]]],
+        topdown_views: list[tuple[TopdownView, str, tuple[float32, float32, float32]]],
         meters_per_pixel: float = 0.1,
     ) -> None:
         super().__init__(topdown_views, meters_per_pixel)
 
     def extract_poses(
         self, view: ndarray, fp: str
-    ) -> List[Tuple[Tuple[int, int], Tuple[int, int], str]]:
+    ) -> list[tuple[tuple[int, int], tuple[int, int], str]]:
         # Determine the physical spacing between each camera position
         height, width = view.shape
         dist = min(height, width) // 10  # We can modify this to be user-defined later
@@ -252,8 +253,8 @@ class PanoramaExtractor(PoseExtractor):
         return poses
 
     def _panorama_extraction(
-        self, point: Tuple[int, int], view: ndarray, dist: int
-    ) -> List[Tuple[Tuple[int, int], float]]:
+        self, point: tuple[int, int], view: ndarray, dist: int
+    ) -> list[tuple[tuple[int, int], float]]:
         in_bounds_of_topdown_view = lambda row, col: 0 <= row < len(
             view
         ) and 0 <= col < len(view[0])

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import argparse
 import gzip
 import itertools
@@ -17,13 +19,12 @@ import sys
 import tarfile
 import traceback
 import zipfile
-from typing import List, Optional
 
 data_sources = {}
 data_groups = {}
 
 
-def hm3d_train_configs_post(extract_dir: str) -> List[str]:
+def hm3d_train_configs_post(extract_dir: str) -> list[str]:
     all_scene_dataset_cfg = os.path.join(
         extract_dir, "hm3d_basis.scene_dataset_config.json"
     )
@@ -316,9 +317,9 @@ def clean_data(uid, data_path):
 def download_and_place(
     uid,
     data_path,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-    replace: Optional[bool] = None,
+    username: str | None = None,
+    password: str | None = None,
+    replace: bool | None = None,
 ):
     r"""Data-source download function. Validates uid, handles existing data version, downloads data, unpacks, writes version, cleans up."""
     if not data_sources.get(uid):

--- a/src_python/habitat_sim/utils/gfx_replay_utils.py
+++ b/src_python/habitat_sim/utils/gfx_replay_utils.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import magnum as mn
 
 import habitat_sim

--- a/src_python/habitat_sim/utils/manager_utils.py
+++ b/src_python/habitat_sim/utils/manager_utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import csv
 
 

--- a/src_python/habitat_sim/utils/profiling_utils.py
+++ b/src_python/habitat_sim/utils/profiling_utils.py
@@ -53,6 +53,8 @@ path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=cuda,nvtx
 "habitat_capture_range" --output=my_profile python my_program.py
 # look for my_profile.qdrep in working directory
 """
+from __future__ import annotations
+
 import os
 from contextlib import ContextDecorator
 
@@ -63,7 +65,7 @@ from habitat_sim.logging import logger
 _env_var = os.environ.get("HABITAT_PROFILING", "0")
 _enable_profiling = _env_var != "0"
 if _enable_profiling:
-    logger.info("HABITAT_PROFILING={}".format(_env_var))
+    logger.info(f"HABITAT_PROFILING={_env_var}")
     logger.info("profiling_utils.py range_push/range_pop annotation is enabled")
     from torch.cuda import nvtx
 
@@ -168,7 +170,7 @@ class RangeContext(ContextDecorator):
     def __init__(self, msg: str) -> None:
         self._msg = msg
 
-    def __enter__(self) -> "RangeContext":
+    def __enter__(self) -> RangeContext:
         range_push(self._msg)
         return self
 

--- a/src_python/habitat_sim/utils/validators.py
+++ b/src_python/habitat_sim/utils/validators.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 # contains validators for attrs
 from contextlib import ContextDecorator
-from typing import Optional
 
 import attr
 import magnum as mn
@@ -19,9 +20,9 @@ class NoAttrValidationContext(ContextDecorator):
     r"""Ensures validators are not run within this context.
     Useful for function where we generate an attr validated object.
     """
-    original_state: Optional[bool] = None
+    original_state: bool | None = None
 
-    def __enter__(self) -> "NoAttrValidationContext":
+    def __enter__(self) -> NoAttrValidationContext:
         self.original_state = attr.get_run_validators()
         attr.set_run_validators(False)
         return self

--- a/src_python/habitat_sim/utils/viz_utils.py
+++ b/src_python/habitat_sim/utils/viz_utils.py
@@ -2,8 +2,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import base64
-import io
 import os
 import subprocess
 import sys
@@ -12,7 +13,7 @@ from functools import partial
 if "google.colab" in sys.modules:
     os.environ["IMAGEIO_FFMPEG_EXE"] = "/usr/bin/ffmpeg"
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import imageio
 import numpy as np
@@ -87,7 +88,8 @@ def display_video(video_file: str, height: int = 400):
         from IPython.display import HTML
 
         ext = os.path.splitext(video_file)[-1][1:]
-        video = io.open(video_file, "r+b").read()
+        with open(video_file, "r+b") as f:
+            video = f.read()
         ipythondisplay.display(
             HTML(
                 data="""<video alt="test" autoplay
@@ -109,7 +111,7 @@ def display_video(video_file: str, height: int = 400):
 def observation_to_image(
     observation_image: np.ndarray,
     observation_type: str,
-    depth_clip: Optional[float] = 10.0,
+    depth_clip: float | None = 10.0,
 ):
     """Generate an rgb image from a sensor observation. Supported types are: "color", "depth", "semantic"
 
@@ -204,15 +206,15 @@ def make_video_frame(
 
 
 def make_video(
-    observations: List[np.ndarray],
+    observations: list[np.ndarray],
     primary_obs: str,
     primary_obs_type: str,
     video_file: str,
     fps: int = 60,
     open_vid: bool = True,
-    video_dims: Optional[Tuple[int]] = None,
-    overlay_settings: Optional[List[Dict[str, Any]]] = None,
-    depth_clip: Optional[float] = 10.0,
+    video_dims: tuple[int] | None = None,
+    overlay_settings: list[dict[str, Any]] | None = None,
+    depth_clip: float | None = 10.0,
     observation_to_image=observation_to_image,
 ):
     """Build a video from a passed observations array, with some images optionally overlayed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from os import path as osp

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import multiprocessing
 import runpy
 import sys

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import quaternion  # noqa: F401

--- a/tests/test_attributes_managers.py
+++ b/tests/test_attributes_managers.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import magnum as mn
 
 import examples.settings

--- a/tests/test_compare_profiles.py
+++ b/tests/test_compare_profiles.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import sqlite3
 from io import StringIO
 from unittest.mock import patch

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import magnum as mn
 import numpy as np
 

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import attr
 import hypothesis
 import magnum as mn

--- a/tests/test_data_extraction.py
+++ b/tests/test_data_extraction.py
@@ -1,6 +1,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -19,7 +21,7 @@ from habitat_sim.utils.data.pose_extractor import TopdownView
 
 class TrivialNet(nn.Module):
     def __init__(self):
-        super(TrivialNet, self).__init__()
+        super().__init__()
 
     def forward(self, x):
         x = F.relu(x)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from os import path as osp
 

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from os import path as osp
 
 import magnum as mn

--- a/tests/test_greedy_follower.py
+++ b/tests/test_greedy_follower.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 from os import path as osp
 
@@ -155,7 +157,7 @@ def test_greedy_follower(test_navmesh, move_filter_fn, action_noise, pbar):
 
             agent.act(next_action)
 
-            agent_distance += np.linalg.norm(last_xyz - agent.state.position)
+            agent_distance += np.linalg.norm(last_xyz - agent.state.position)  # type: ignore[assignment]
             last_xyz = agent.state.position
 
             num_acts += 1

--- a/tests/test_light_setup.py
+++ b/tests/test_light_setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import habitat_sim
 from examples.settings import make_cfg
 from habitat_sim.gfx import (

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from os import path as osp
 

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from os import path as osp
 
 import numpy as np

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import math
 import random
 from os import path as osp

--- a/tests/test_physics_benchmarking.py
+++ b/tests/test_physics_benchmarking.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import pytest
 
 import examples.settings

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import importlib
 import os
 from io import StringIO
@@ -121,7 +123,7 @@ def test_configure_and_on_start_step():
         profiling_utils.configure(capture_start_step=2, num_steps_to_capture=5)
         for step in range(8):
             profiling_utils.on_start_step()  # Mark start of train step
-            print("step {}".format(step))
+            print(f"step {step}")
 
         # Expect the capture range to span steps 2 through 6.
         expected_out = "step 0\nstep 1\nrange_push habitat_capture_range\nstep 2\nstep 3\nstep 4\nstep 5\nstep 6\nrange_pop\nstep 7\n"

--- a/tests/test_pyrobot_noisy_controls.py
+++ b/tests/test_pyrobot_noisy_controls.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import quaternion as qt

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import examples.settings
 import habitat_sim
 

--- a/tests/test_robot_wrapper.py
+++ b/tests/test_robot_wrapper.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from os import path as osp
 
 import numpy as np

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from os import path as osp
 
 import pytest
@@ -32,7 +34,7 @@ _test_scenes = [
 @pytest.mark.parametrize("scene", _test_scenes)
 def test_semantic_scene(scene, make_cfg_settings):
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
 
     make_cfg_settings = {k: v for k, v in make_cfg_settings.items()}
     make_cfg_settings["semantic_sensor"] = False

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,11 +3,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
 import importlib.util
 import itertools
 import json
 from os import path as osp
-from typing import Any, Dict
+from typing import Any
 
 import magnum as mn
 import numpy as np
@@ -28,10 +30,10 @@ def _render_scene(sim, scene, sensor_type, gpu2gpu):
         osp.join(
             osp.dirname(__file__),
             "gt_data",
-            "{}-state.json".format(osp.basename(osp.splitext(scene)[0])),
+            f"{osp.basename(osp.splitext(scene)[0])}-state.json",
         )
     )
-    with open(gt_data_pose_file, "r") as f:
+    with open(gt_data_pose_file) as f:
         render_state = json.load(f)
         state = habitat_sim.AgentState()
         state.position = render_state["pos"]
@@ -69,7 +71,7 @@ def _render_and_load_gt(sim, scene, sensor_type, gpu2gpu):
         osp.join(
             osp.dirname(__file__),
             "gt_data",
-            "{}-{}.npy".format(osp.basename(osp.splitext(scene)[0]), sensor_type),
+            f"{osp.basename(osp.splitext(scene)[0])}-{sensor_type}.npy",
         )
     )
     # if not osp.exists(gt_obs_file):
@@ -182,7 +184,7 @@ def test_sensors(
 ):
     scene = scene_and_dataset[0]
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
     if gpu2gpu and (not habitat_sim.cuda_enabled or not _HAS_TORCH):
         pytest.skip("Skipping GPU->GPU test")
     scene_dataset_config = scene_and_dataset[1]
@@ -213,7 +215,7 @@ def test_sensors(
 
     with habitat_sim.Simulator(cfg) as sim:
         if add_sensor_lazy:
-            obs: Dict[str, Any] = sim.reset()
+            obs: dict[str, Any] = sim.reset()
             assert len(obs) == 1, "Other sensors were not removed"
             for sensor_spec in additional_sensors:
                 sim.add_sensor(sensor_spec)
@@ -241,7 +243,7 @@ def test_reconfigure_render(
 ):
     scene = scene_and_dataset[0]
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
 
     for sens in all_base_sensor_types:
         make_cfg_settings[sens] = False
@@ -297,7 +299,7 @@ def test_smoke_no_sensors(make_cfg_settings):
 def test_smoke_redwood_noise(scene_and_dataset, gpu2gpu, make_cfg_settings):
     scene = scene_and_dataset[0]
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
     if gpu2gpu and (not habitat_sim.cuda_enabled or not _HAS_TORCH):
         pytest.skip("Skipping GPU->GPU test")
     scene_dataset_config = scene_and_dataset[1]
@@ -327,7 +329,7 @@ def test_smoke_redwood_noise(scene_and_dataset, gpu2gpu, make_cfg_settings):
 def test_initial_hfov(scene_and_dataset, sensor_type, make_cfg_settings):
     scene = scene_and_dataset[0]
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
     make_cfg_settings["hfov"] = 70
     with habitat_sim.Simulator(make_cfg(make_cfg_settings)) as sim:
         assert sim.agents[0]._sensors[sensor_type].hfov == mn.Deg(
@@ -349,7 +351,7 @@ def test_initial_hfov(scene_and_dataset, sensor_type, make_cfg_settings):
 def test_rgba_noise(scene_and_dataset, model_name, make_cfg_settings):
     scene = scene_and_dataset[0]
     if not osp.exists(scene):
-        pytest.skip("Skipping {}".format(scene))
+        pytest.skip(f"Skipping {scene}")
     scene_dataset_config = scene_and_dataset[1]
     make_cfg_settings["depth_sensor"] = False
     make_cfg_settings["color_sensor"] = True

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from copy import copy
 from os import path as osp

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import hypothesis
@@ -35,4 +37,4 @@ def test_snap_point(nudge, test_data):
     proj_pt = pf.snap_point(pt)
     hypothesis.assume(not math.isnan(proj_pt[0]))
 
-    assert pf.is_navigable(proj_pt), "{} -> {} not navigable!".format(pt, proj_pt)
+    assert pf.is_navigable(proj_pt), f"{pt} -> {proj_pt} not navigable!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from habitat_sim.utils.collect_env import main as collect_env
 
 

--- a/tools/create_basis_compressed_glbs.py
+++ b/tools/create_basis_compressed_glbs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import glob
 import itertools
@@ -8,7 +10,7 @@ import os.path as osp
 import shlex
 import shutil
 import subprocess
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable
 
 import tqdm
 
@@ -24,7 +26,7 @@ IMAGE_CONVERTER_DEFAULT = "build/utils/imageconverter/magnum-imageconverter"
 
 
 def build_parser(
-    parser: Optional[argparse.ArgumentParser] = None,
+    parser: argparse.ArgumentParser | None = None,
 ) -> argparse.ArgumentParser:
     if parser is None:
         parser = argparse.ArgumentParser(
@@ -102,7 +104,7 @@ def img_name_to_basis(img: str) -> str:
     return osp.splitext(img)[0] + ".basis"
 
 
-def convert_image_to_basis(args: Tuple[str, str, int]) -> None:
+def convert_image_to_basis(args: tuple[str, str, int]) -> None:
     img, imageconverter, compression_level = args
     basis_img = img_name_to_basis(img)
 
@@ -117,7 +119,7 @@ def convert_image_to_basis(args: Tuple[str, str, int]) -> None:
 
 def _gltf2unlit(gltf_name: str):
     assert osp.exists(gltf_name)
-    with open(gltf_name, "r") as f:
+    with open(gltf_name) as f:
         json_data = json.load(f)
     # add references to the KHR_materials_unlit extension in
     # gltf root-level tags
@@ -154,7 +156,7 @@ def _gltf2unlit(gltf_name: str):
         f.write(json.dumps(json_data, indent=2).encode("utf-8"))
 
 
-def package_meshes(args: Tuple[str, bool]) -> None:
+def package_meshes(args: tuple[str, bool]) -> None:
     mesh_name, convert_to_unlit = args
     output_dir = osp.splitext(mesh_name)[0] + "_hab_basis_tool"
     base_mesh_name = osp.splitext(osp.basename(mesh_name))[0]
@@ -192,13 +194,13 @@ def finalize(output_folder: str, rename_basis: bool) -> None:
             shutil.move(basis_mesh, mesh_name)
 
 
-def _map_all_and_wait(pool: multiprocessing.Pool, func: Callable, inputs: List[Any]):
+def _map_all_and_wait(pool: multiprocessing.Pool, func: Callable, inputs: list[Any]):
     with tqdm.tqdm(total=len(inputs)) as pbar:
         for _ in pool.imap_unordered(func, inputs):
             pbar.update()
 
 
-def _clean(lst: List[str]) -> None:
+def _clean(lst: list[str]) -> None:
     if len(lst) > 0:
         print("Cleaning...")
 

--- a/tools/npz2ids.py
+++ b/tools/npz2ids.py
@@ -3,6 +3,8 @@
 # npz2ids - tool for extracting object_ids from 3dscenegraph dataset
 #           (https://3dscenegraph.stanford.edu/)
 
+from __future__ import annotations
+
 import argparse
 
 import numpy as np

--- a/tools/npz2scn.py
+++ b/tools/npz2scn.py
@@ -3,15 +3,17 @@
 # npz2scn - tool for extracting semantic scene information from 3dscenegraph
 #           dataset (https://3dscenegraph.stanford.edu/)
 
+from __future__ import annotations
+
 import argparse
 import json
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
 
 # Convert ndarrays to python lists so that we can serialize.
-def listify(entry: Dict[str, Any]) -> None:
+def listify(entry: dict[str, Any]) -> None:
     for key in entry.keys():
         if type(entry[key]) is np.ndarray:
             entry[key] = entry[key].tolist()

--- a/tools/run-clang-tidy.py
+++ b/tools/run-clang-tidy.py
@@ -33,7 +33,7 @@ Compilation database setup:
 http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
 """
 
-from __future__ import print_function
+from __future__ import annotations
 
 import argparse
 import glob
@@ -123,7 +123,7 @@ def merge_replacement_files(tmpdir, mergefile):
     mergekey = "Diagnostics"
     merged = []
     for replacefile in glob.iglob(os.path.join(tmpdir, "*.yaml")):
-        content = yaml.safe_load(open(replacefile, "r"))
+        content = yaml.safe_load(open(replacefile))
         if not content:
             continue  # Skip empty files.
         merged.extend(content.get(mergekey, []))


### PR DESCRIPTION
## Motivation and Context
* This upgrades our type annotation to modern Python syntax. It's a lot more succinct and removes a lot of typing imports which may potentially allow faster startups. This may break some old runtime type checkers, but we don't use TypeGuard at all anymore and mypy has full support. 
* For instance '|' can now replace Union[] and Optional etc.
* This enables a future flag which will be the default in 3.11 anyhow so might as well get the code written
* This also adds a pre-commit hook called pyupgrade which ensures we are using the latest syntax available for 3.7 and other best practices. 
* I also added an isort config which adds the __future__ import for annotations to all python files which do at least one import.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* locally with pre-commit and pytest
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
