### PR TITLE
[Bugfix]-- Fix semantic color map binds (arrayView -> const ref)

### DIFF
--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -49,10 +49,13 @@ class GenericSemanticMeshData : public BaseMesh {
    * @param semanticFilename Path-less Filename of source mesh.
    * @param splitMesh Whether or not the resultant mesh should be split into
    * multiple components based on objectIds, for frustum culling.
+   * @param [out] colorMapToUse An array holding the semantic colors to use for
+   * visualization or matching to semantic IDs.
    * @param convertToSRGB Whether the source vertex colors from the @p meshData
    * should be converted to SRGB
    * @param semanticScene The SSD for the instance mesh being loaded.
-   * @return vector holding one or more mesh results from the .ply file.
+   * @return vector holding one or more mesh results from the semantic asset
+   * file.
    */
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>>

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -182,8 +182,7 @@ class ResourceManager {
   /**
    * @brief Return a view of the currently set Semantic scene colormap.
    */
-  Cr::Containers::ArrayView<const Mn::Vector3ub> getSemanticSceneColormap()
-      const {
+  const std::vector<Mn::Vector3ub>& getSemanticSceneColormap() const {
     return semanticColorMapBeingUsed_;
   }
 

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -72,7 +72,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   auto getVec3ub = [](const std::string& hexValStr) -> Mn::Vector3ub {
     const unsigned val = std::stoul(hexValStr, nullptr, 16);
     return {uint8_t((val >> 16) & 0xff), uint8_t((val >> 8) & 0xff),
-            uint8_t((val >> 0) & 0xff)};
+            uint8_t(val & 0xff)};
   };
 
   // temp constructs

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -84,8 +84,7 @@ class Simulator {
   /**
    * @brief Return a view of the currently set Semantic scene colormap.
    */
-  Cr::Containers::ArrayView<const Mn::Vector3ub> getSemanticSceneColormap()
-      const {
+  const std::vector<Mn::Vector3ub>& getSemanticSceneColormap() const {
     return resourceManager_->getSemanticSceneColormap();
   }
 

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -40,7 +40,8 @@ def test_semantic_scene(scene, make_cfg_settings):
     cfg = make_cfg(make_cfg_settings)
     cfg.agents[0].sensor_specifications = []
     sim = habitat_sim.Simulator(cfg)
-
+    # verify color map access
+    sim.semantic_color_map
     scene = sim.semantic_scene
     for obj in scene.objects:
         obj.aabb


### PR DESCRIPTION
## Motivation and Context
Minor bugfix to address bindings to colormap query not working properly.  Added python test to verify colormap is accessible through bindings.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
