### PR TITLE
Update m.css to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ jobs:
               while [ ! -f ~/miniconda/pytorch_installed ]; do sleep 2; done # wait for Pytorch
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
-              conda install -y -c conda-forge doxygen==1.8.16
+              conda install -y -c conda-forge doxygen
               conda install -y  jinja2 pygments docutils
               while [ ! -f ~/cuda_installed ]; do sleep 2; done # wait for CUDA
               sudo apt install --allow-change-held-packages \
@@ -443,7 +443,7 @@ jobs:
               python setup.py develop --all
 
               cd docs
-              conda install -y -c conda-forge doxygen==1.8.16
+              conda install -y -c conda-forge doxygen
               conda install -y  jinja2 pygments docutils
               ./build-public.sh
       - save_cache:


### PR DESCRIPTION
## Motivation and Context

This should make it work with latest docutils, Pelican, Doxygen etc., not being so painful to install and use anymore; plus also various fixes to adapt to new pybind11 changes. A corresponding PR is being opened on the website repo as well: https://github.com/facebookmicrosites/habitat-website/pull/114

## How Has This Been Tested

With two weeks of labour-intensive work, getting all dependencies to work again like they used to. Yay.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
