### PR TITLE
[Bugfix]--Add "unknown" object corresponding to semantic ID 0 for HM3D; Refactors for Texture Semantics

### DIFF
--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -102,8 +102,7 @@ void BaseMesh::buildSemanticOBBs(
     const std::string& msgPrefix) const {
   // build per-SSD object vector of known semantic IDs
   std::size_t numSSDObjs = ssdObjs.size();
-  // no semantic ID 0 so add 1 to size
-  std::vector<int> semanticIDToSSOBJidx(numSSDObjs + 1);
+  std::vector<int> semanticIDToSSOBJidx(numSSDObjs, -1);
   for (int i = 0; i < numSSDObjs; ++i) {
     const auto& ssdObj = *ssdObjs[i];
     int semanticID = ssdObj.semanticID();
@@ -131,7 +130,7 @@ void BaseMesh::buildSemanticOBBs(
     // semantic ID on vertex - valid values are 1->semanticIDToSSOBJidx.size().
     // Invalid/unknown semantic ids are > semanticIDToSSOBJidx.size()
     const auto semanticID = vertSemanticIDs[vertIdx];
-    if ((semanticID > 0) && (semanticID < semanticIDToSSOBJidx.size())) {
+    if ((semanticID >= 0) && (semanticID < semanticIDToSSOBJidx.size())) {
       const auto vert = vertices[vertIdx];
       // FOR VERT-BASED OBB CALC
       // only support bbs for known colors that map to semantic objects
@@ -143,10 +142,14 @@ void BaseMesh::buildSemanticOBBs(
 
   // with mins/maxs per ID, map to objs
   // give each ssdObj the values to build its OBB
-  for (int semanticID = 1; semanticID < semanticIDToSSOBJidx.size();
+  for (int semanticID = 0; semanticID < semanticIDToSSOBJidx.size();
        ++semanticID) {
+    int objIdx = semanticIDToSSOBJidx[semanticID];
+    if (objIdx == -1) {
+      continue;
+    }
     // get object with given semantic ID
-    auto& ssdObj = *ssdObjs[semanticIDToSSOBJidx[semanticID]];
+    auto& ssdObj = *ssdObjs[objIdx];
     Mn::Vector3 center{};
     Mn::Vector3 dims{};
 

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -174,7 +174,7 @@ class BaseMesh {
    * @param msgPrefix Debug message prefix, referencing caller.
    */
   void buildSemanticOBBs(
-      const std::vector<vec3f>& vertices,
+      const std::vector<Mn::Vector3>& vertices,
       const std::vector<uint16_t>& vertSemanticIDs,
       const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
       const std::string& msgPrefix) const;

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -153,6 +153,22 @@ class BaseMesh {
   std::string getColorAsString(Magnum::Color3ub color) const;
 
   /**
+   * @brief Build a colormap to use either from mapping given list of per-vertex
+   * object IDs to per-vertex Colors, or through a mapping of a Magnum-provided
+   * color map depending on value of @p useVertexColors .
+   * @param vertIDs Per-vertex ids from mesh
+   * @param vertColors Per-vertex colors from mesh
+   * @param useVertexColors Whether or not to use vertex colors in mesh for
+   * color map
+   * @param [out] colorMapToUse The mapping of semantic ID to color
+   */
+  void buildColorMapToUse(
+      Corrade::Containers::Array<Magnum::UnsignedInt>& vertIDs,
+      const Cr::Containers::Array<Mn::Color3ub>& vertColors,
+      bool useVertexColors,
+      std::vector<Mn::Vector3ub>& colorMapToUse) const;
+
+  /**
    * @brief Populate an array of colors of the correct type from the given
    * @p srcColors. Generally used for semantic processing/rendering.
    * @param srcColors The source colors

--- a/src/esp/assets/CMakeLists.txt
+++ b/src/esp/assets/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(
   GL
   MeshTools
   SceneGraph
+  SceneTools
   Shaders
   Trade
   Primitives

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -61,11 +61,11 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
   if (semanticFilename.find(".ply") != std::string::npos) {
     // Generic Semantic PLY meshes have -Z gravity
-    const quatf T_esp_scene =
-        quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY);
+    const Mn::Quaternion T_esp_scene = Mn::Quaternion{
+        quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY)};
 
     for (auto& xyz : semanticData->cpu_vbo_) {
-      xyz = T_esp_scene * xyz;
+      xyz = T_esp_scene.toMatrix() * xyz;
     }
   }
 
@@ -77,8 +77,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
   semanticData->convertMeshColors(srcMeshData, convertToSRGB, meshColors);
 
   Cr::Utility::copy(meshColors,
-                    Cr::Containers::arrayCast<Mn::Color3ub>(
-                        Cr::Containers::arrayView(semanticData->cpu_cbo_)));
+                    Cr::Containers::arrayView(semanticData->cpu_cbo_));
 
   // Check we actually have object IDs before copying them, and that those are
   // in a range we expect them to be
@@ -392,16 +391,14 @@ Mn::GL::Mesh* GenericSemanticMeshData::getMagnumGLMesh() {
 }
 
 void GenericSemanticMeshData::updateCollisionMeshData() {
-  collisionMeshData_.positions = Cr::Containers::arrayCast<Mn::Vector3>(
-      Cr::Containers::arrayView(cpu_vbo_));
-  collisionMeshData_.indices = Cr::Containers::arrayCast<Mn::UnsignedInt>(
-      Cr::Containers::arrayView(cpu_ibo_));
+  collisionMeshData_.positions = Cr::Containers::arrayView(cpu_vbo_);
+  collisionMeshData_.indices = Cr::Containers::arrayView(cpu_ibo_);
 }
 
 void GenericSemanticMeshData::PerPartitionIdMeshBuilder::addVertex(
     uint32_t vertexId,
-    const vec3f& position,
-    const vec3uc& color,
+    const Mn::Vector3& position,
+    const Mn::Color3ub& color,
     int objectId) {
   // if we haven't seen this vertex, add it to the local vertex/color buffer
   auto result = vertexIdToVertexIndex_.emplace(vertexId, data_.cpu_vbo_.size());

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -61,11 +61,11 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
   if (semanticFilename.find(".ply") != std::string::npos) {
     // Generic Semantic PLY meshes have -Z gravity
-    const Mn::Quaternion T_esp_scene = Mn::Quaternion{
-        quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY)};
-
+    const auto T_esp_scene =
+        Mn::Quaternion{quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY)}
+            .toMatrix();
     for (auto& xyz : semanticData->cpu_vbo_) {
-      xyz = T_esp_scene.toMatrix() * xyz;
+      xyz = T_esp_scene * xyz;
     }
   }
 

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -73,10 +73,10 @@ class GenericSemanticMeshData : public BaseMesh {
 
   Magnum::GL::Mesh* getMagnumGLMesh() override;
 
-  const std::vector<vec3f>& getVertexBufferObjectCPU() const {
+  const std::vector<Mn::Vector3>& getVertexBufferObjectCPU() const {
     return cpu_vbo_;
   }
-  const std::vector<vec3uc>& getColorBufferObjectCPU() const {
+  const std::vector<Mn::Color3ub>& getColorBufferObjectCPU() const {
     return cpu_cbo_;
   }
 
@@ -96,8 +96,8 @@ class GenericSemanticMeshData : public BaseMesh {
         : data_{data}, partitionId{partitionId} {}
 
     void addVertex(uint32_t vertexId,
-                   const vec3f& vertex,
-                   const vec3uc& color,
+                   const Mn::Vector3& vertex,
+                   const Mn::Color3ub& color,
                    int objectId);
 
    private:
@@ -110,8 +110,8 @@ class GenericSemanticMeshData : public BaseMesh {
 
   // ==== rendering ====
   std::unique_ptr<RenderingBuffer> renderingBuffer_ = nullptr;
-  std::vector<vec3f> cpu_vbo_;
-  std::vector<vec3uc> cpu_cbo_;
+  std::vector<Mn::Vector3> cpu_vbo_;
+  std::vector<Mn::Color3ub> cpu_cbo_;
   std::vector<uint32_t> cpu_ibo_;
   std::vector<uint16_t> objectIds_;
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2150,6 +2150,7 @@ void ResourceManager::loadMeshes(Importer& importer,
   int meshEnd = meshStart + importer.meshCount() - 1;
   nextMeshID_ = meshEnd + 1;
   loadedAssetData.meshMetaData.setMeshIndices(meshStart, meshEnd);
+
   for (int iMesh = 0; iMesh < importer.meshCount(); ++iMesh) {
     // don't need normals if we aren't using lighting
     auto gltfMeshData = std::make_unique<GenericMeshData>(

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1026,13 +1026,6 @@ void ResourceManager::computeInstanceMeshAbsoluteAABBs(
   for (size_t iEntry = 0; iEntry < absTransforms.size(); ++iEntry) {
     const int meshID = staticDrawableInfo[iEntry].meshID;
 
-    // convert std::vector<vec3f> to std::vector<Mn::Vector3>
-    // const std::vector<vec3f>& vertexPositions =
-    //     dynamic_cast<GenericSemanticMeshData&>(*meshes_.at(meshID))
-    //         .getVertexBufferObjectCPU();
-    // std::vector<Mn::Vector3> transformedPositions{vertexPositions.begin(),
-    //                                               vertexPositions.end()};
-
     std::vector<Mn::Vector3> transformedPositions =
         dynamic_cast<GenericSemanticMeshData&>(*meshes_.at(meshID))
             .getVertexBufferObjectCPU();

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1027,11 +1027,15 @@ void ResourceManager::computeInstanceMeshAbsoluteAABBs(
     const int meshID = staticDrawableInfo[iEntry].meshID;
 
     // convert std::vector<vec3f> to std::vector<Mn::Vector3>
-    const std::vector<vec3f>& vertexPositions =
+    // const std::vector<vec3f>& vertexPositions =
+    //     dynamic_cast<GenericSemanticMeshData&>(*meshes_.at(meshID))
+    //         .getVertexBufferObjectCPU();
+    // std::vector<Mn::Vector3> transformedPositions{vertexPositions.begin(),
+    //                                               vertexPositions.end()};
+
+    std::vector<Mn::Vector3> transformedPositions =
         dynamic_cast<GenericSemanticMeshData&>(*meshes_.at(meshID))
             .getVertexBufferObjectCPU();
-    std::vector<Mn::Vector3> transformedPositions{vertexPositions.begin(),
-                                                  vertexPositions.end()};
 
     Mn::MeshTools::transformPointsInPlace(absTransforms[iEntry],
                                           transformedPositions);

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -126,6 +126,9 @@ StageAttributes::StageAttributes(const std::string& handle)
   // setting defaults for semantic frame will have changed this to false. change
   // to true so that only used if actually changed.
   setUseFrameForAllOrientation(true);
+  // setting default for semantic assets having semantically painted textures to
+  // false
+  setHasSemanticTextures(false);
   // default to use material-derived shader unless otherwise specified in config
   // or instance config
   setShaderType(getShaderTypeName(ObjectInstanceShaderType::Material));
@@ -152,11 +155,42 @@ void StageAttributes::writeValuesToJsonInternal(
     writeValueToJson("semantic_orient_front", "semantic_front", jsonObj,
                      allocator);
   }
+  writeValueToJson("has_semantic_textures", jsonObj, allocator);
   writeValueToJson("semantic_asset", jsonObj, allocator);
   writeValueToJson("nav_asset", jsonObj, allocator);
   writeValueToJson("semantic_descriptor_filename", jsonObj, allocator);
 
 }  // StageAttributes::writeValuesToJsonInternal
+
+std::string StageAttributes::getAbstractObjectInfoHeaderInternal() const {
+  std::string res = "Gravity XYZ,Origin XYZ,";
+  if (!getUseFrameForAllOrientation()) {
+    Cr::Utility::formatInto(res, res.length(), "{}",
+                            "Semantic Up XYZ,Semantic Front XYZ");
+  }
+
+  Cr::Utility::formatInto(
+      res, res.length(), "{}",
+      "Has Semantic Texture,Navmesh Handle,Semantic Asset Handle,Semantic "
+      "Descriptor Filename,Light Setup,");
+  return res;
+}
+
+std::string StageAttributes::getAbstractObjectInfoInternal() const {
+  std::string res = Cr::Utility::formatString("{},{},", getAsString("gravity"),
+                                              getAsString("origin"));
+
+  if (!getUseFrameForAllOrientation()) {
+    Cr::Utility::formatInto(res, res.length(), "{},{}",
+                            getAsString("semantic_orient_up"),
+                            getAsString("semantic_orient_front"));
+  }
+  Cr::Utility::formatInto(res, res.length(), "{},{},{},{},{}",
+                          getAsString("has_semantic_textures"),
+                          getNavmeshAssetHandle(), getSemanticAssetHandle(),
+                          getSemanticDescriptorFilename(), getLightSetupKey());
+  return res;
+}
 
 }  // namespace attributes
 }  // namespace metadata

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -44,7 +44,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
   bool getIsCollidable() const { return get<bool>("is_collidable"); }
 
   /**
-   * @brief set default up orientation for object/stage mesh
+   * @brief Set default up orientation for object/stage mesh
    */
   void setOrientUp(const Magnum::Vector3& orientUp) {
     set("orient_up", orientUp);
@@ -56,7 +56,7 @@ class AbstractObjectAttributes : public AbstractAttributes {
     return get<Magnum::Vector3>("orient_up");
   }
   /**
-   * @brief set default forward orientation for object/stage mesh
+   * @brief Set default forward orientation for object/stage mesh
    */
   void setOrientFront(const Magnum::Vector3& orientFront) {
     set("orient_front", orientFront);
@@ -397,7 +397,7 @@ class StageAttributes : public AbstractObjectAttributes {
   Magnum::Vector3 getGravity() const { return get<Magnum::Vector3>("gravity"); }
 
   /**
-   * @brief set default up orientation for semantic mesh. This is to support
+   * @brief Set default up orientation for semantic mesh. This is to support
    * stage aligning semantic meshes that have different orientations than the
    * stage render mesh.
    */
@@ -420,7 +420,7 @@ class StageAttributes : public AbstractObjectAttributes {
   }
 
   /**
-   * @brief set default forward orientation for semantic mesh. This is to
+   * @brief Set default forward orientation for semantic mesh. This is to
    * support stage aligning semantic meshes that have different orientations
    * than the stage render mesh.
    */
@@ -470,7 +470,19 @@ class StageAttributes : public AbstractObjectAttributes {
   void setSemanticAssetType(int semanticAssetType) {
     set("semantic_asset_type", semanticAssetType);
   }
-  int getSemanticAssetType() { return get<int>("semantic_asset_type"); }
+  int getSemanticAssetType() const { return get<int>("semantic_asset_type"); }
+
+  /**
+   * @brief Set whether or not the semantic asset for this stage supports
+   * texture semantics.
+   */
+  void setHasSemanticTextures(bool hasSemanticTextures) {
+    set("has_semantic_textures", hasSemanticTextures);
+  }
+
+  bool getHasSemanticTextures() const {
+    return get<bool>("has_semantic_textures");
+  }
 
   // Currently not supported
   void setLoadSemanticMesh(bool loadSemanticMesh) {
@@ -489,7 +501,7 @@ class StageAttributes : public AbstractObjectAttributes {
   }
 
   /**
-   * @brief set lighting setup for stage.  Default value comes from
+   * @brief Set lighting setup for stage.  Default value comes from
    * @ref esp::sim::SimulatorConfiguration, is overridden by any value set in
    * json, if exists.
    */
@@ -502,7 +514,7 @@ class StageAttributes : public AbstractObjectAttributes {
   }
 
   /**
-   * @brief set frustum culling for stage.  Default value comes from
+   * @brief Set frustum culling for stage.  Default value comes from
    * @ref esp::sim::SimulatorConfiguration, is overridden by any value set in
    * json, if exists.
    * Currently only set from SimulatorConfiguration
@@ -523,18 +535,12 @@ class StageAttributes : public AbstractObjectAttributes {
   /**
    * @brief get AbstractObject specific info header
    */
-  std::string getAbstractObjectInfoHeaderInternal() const override {
-    return "Navmesh Handle,Gravity XYZ,Origin XYZ,Light Setup,";
-  }
+  std::string getAbstractObjectInfoHeaderInternal() const override;
 
   /**
    * @brief get AbstractObject specific info for csv string
    */
-  std::string getAbstractObjectInfoInternal() const override {
-    return Cr::Utility::formatString("{},{},{},{}", getNavmeshAssetHandle(),
-                                     getAsString("gravity"),
-                                     getAsString("origin"), getLightSetupKey());
-  }
+  std::string getAbstractObjectInfoInternal() const override;
 
  public:
   ESP_SMART_POINTERS(StageAttributes)

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -395,6 +395,14 @@ void StageAttributesManager::setValsFromJSONDoc(
         stageAttributes->setSemanticOrientFront(front);
       });
 
+  // load whether the semantic asset for this stage has semantically annotated
+  // textures
+  io::jsonIntoSetter<bool>(
+      jsonConfig, "has_semantic_textures",
+      [stageAttributes](bool has_semantic_textures) {
+        stageAttributes->setHasSemanticTextures(has_semantic_textures);
+      });
+
   // populate specified semantic file name if specified in json - defaults
   // are overridden only if specified in json.
 

--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -121,7 +121,7 @@ bool SemanticScene::buildReplicaHouse(const io::JsonDocument& jsonDoc,
 
     scene.objects_[id] = std::move(object);
   }
-
+  scene.hasVertColors_ = true;
   return true;
 }
 

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -769,11 +769,13 @@ void AttributesConfigsTest::testStageAttrVals(
   CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(), assetPath);
   CORRADE_VERIFY(!stageAttr->getIsCollidable());
   // stage-specific attributes
+  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
   CORRADE_COMPARE(stageAttr->getGravity(), Magnum::Vector3(9, 8, 7));
+  CORRADE_VERIFY(stageAttr->getHasSemanticTextures());
+
   // make sure that is not default value "flat"
   CORRADE_COMPARE(static_cast<int>(stageAttr->getShaderType()),
                   static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
-  CORRADE_COMPARE(stageAttr->getOrigin(), Magnum::Vector3(1, 2, 3));
   CORRADE_COMPARE(stageAttr->getSemanticAssetHandle(), assetPath);
   CORRADE_COMPARE(stageAttr->getNavmeshAssetHandle(), assetPath);
   // test stage attributes-level user config vals
@@ -798,6 +800,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
         "units_to_meters": 1.1,
         "up":[2.1, 0, 0],
         "front":[0, 2.1, 0],
+        "has_semantic_textures":true,
         "render_asset": "testJSONRenderAsset.glb",
         "collision_asset": "testJSONCollisionAsset.glb",
         "is_collidable": false,

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -108,8 +108,9 @@ void HM3DSceneTest::testHM3DSemanticScene() {
   CORRADE_VERIFY(semanticScene);
   auto semanticObjects = semanticScene->objects();
   // verify there are at least as many colors defined as there are
-  // semanticObjects, plus one more for colorList's idx 0.
-  CORRADE_VERIFY(semanticObjects.size() < colorList.size());
+  // semanticObjects. There may be more if there are unmapped colors in the
+  // source scene
+  CORRADE_VERIFY(semanticObjects.size() <= colorList.size());
   // verify all colors in colormap correspond to expected colors in semantic
   // scene descriptor objects
   for (int i = 0; i < semanticObjects.size(); ++i) {

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -108,13 +108,14 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
     for (uint64_t fid = 0; fid < ibo.size(); fid += 6) {
       CORRADE_ITERATION(fid);
       if (objectIds[ibo[fid]] == id) {
-        esp::vec3f quadCenter = esp::vec3f::Zero();
+        Mn::Vector3 quadCenter{};
         // Mesh was converted from quads to tris
         for (int i = 0; i < 6; ++i) {
           quadCenter += vbo[ibo[fid + i]] / 6;
         }
 
-        CORRADE_VERIFY(obj->obb().contains(quadCenter, 5e-2));
+        CORRADE_VERIFY(
+            obj->obb().contains(esp::vec3f{quadCenter.data()}, 5e-2));
       }
     }
   }

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include <Corrade/Containers/ArrayViewStl.h>
+#include <Corrade/Utility/Algorithms.h>
 #include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/FormatStl.h>
 #include "esp/assets/GenericSemanticMeshData.h"
@@ -18,6 +20,8 @@
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
 
+#include <Magnum/EigenIntegration/GeometryIntegration.h>
+#include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Trade/AbstractImporter.h>
 
 namespace Cr = Corrade;
@@ -60,10 +64,14 @@ MeshData SceneLoader::load(const AssetInfo& info) {
     const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();
     const auto& cbo = instanceMeshData[0]->getColorBufferObjectCPU();
     const auto& ibo = instanceMeshData[0]->getIndexBufferObjectCPU();
-    mesh.vbo = vbo;
+
+    mesh.vbo.resize(vbo.size());
+    Cr::Utility::copy(vbo, Cr::Containers::arrayCast<Mn::Vector3>(
+                               Cr::Containers::arrayView(mesh.vbo)));
     mesh.ibo = ibo;
     for (const auto& c : cbo) {
-      mesh.cbo.emplace_back(c.cast<float>() / 255.0f);
+      auto clr = Mn::EigenIntegration::cast<esp::vec3uc>(c);
+      mesh.cbo.emplace_back(clr.cast<float>() / 255.0f);
     }
   } else {
     const aiScene* scene;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1841,7 +1841,6 @@ void Viewer::mousePressEvent(MouseEvent& event) {
         if ((semanticScene) && (semanticScene->hasVertColorsDefined())) {
           auto semanticObjects = semanticScene->objects();
           std::string sensorId = "semantic_camera";
-          simulator_->drawObservation(defaultAgentId_, sensorId);
           esp::sensor::Observation observation;
           simulator_->getAgentObservation(defaultAgentId_, sensorId,
                                           observation);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1837,7 +1837,7 @@ void Viewer::mousePressEvent(MouseEvent& event) {
 
         // get semantic scene
         auto semanticScene = simulator_->getSemanticScene();
-        // only enable for HM3D for now
+        // only enable for HM3D, MP3D and Replica for now
         if ((semanticScene) && (semanticScene->hasVertColorsDefined())) {
           auto semanticObjects = semanticScene->objects();
           std::string sensorId = "semantic_camera";

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1857,7 +1857,7 @@ void Viewer::mousePressEvent(MouseEvent& event) {
           // observation.buffer->pixels<uint32_t>().flipped<0>()[viewportPoint[1]][viewportPoint[0]];
 
           // subtract 1 to align with semanticObject array
-          --objIdx;
+          //--objIdx;
           std::string tmpStr = "Unknown";
 
           if ((objIdx >= 0) && (objIdx < semanticObjects.size())) {
@@ -1865,12 +1865,11 @@ void Viewer::mousePressEvent(MouseEvent& event) {
             tmpStr = semanticObj->id();
             const auto obb = semanticObj->obb();
             // get center and scale of bb and use to build visualization reps
-            buildSemanticPrims((objIdx + 1), tmpStr, Mn::Vector3{obb.center()},
+            buildSemanticPrims(objIdx, tmpStr, Mn::Vector3{obb.center()},
                                Mn::Vector3{obb.sizes()},
                                Mn::Quaternion{obb.rotation()});
           }
-          semanticTag_ =
-              Cr::Utility::formatString("id:{}:{}", (objIdx + 1), tmpStr);
+          semanticTag_ = Cr::Utility::formatString("id:{}:{}", objIdx, tmpStr);
         }
       }
     }


### PR DESCRIPTION
## Motivation and Context
This PR fixes a bug/oversight in the creation of the Semantic Scene for HM3D dataset, where semantic ID 0 should have corresponded to an "Unknown" Object with black color.

This PR also lays some essential groundwork for the ongoing texture-based semantics effort by making GenericSemanticMeshData use Magnum vectors instead of Eigen and moving some essential color and id-based functionality to BaseMesh that might be shared amongst Semantic and Render mesh loading.  Also adds a stage attributes field denoting the semantic asset has annotated textures.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
