### PR TITLE
--Semantic texture support

### DIFF
--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -33,6 +33,7 @@ AssetInfo AssetInfo::fromPath(const std::string& path) {
 bool operator==(const AssetInfo& a, const AssetInfo& b) {
   return a.type == b.type && a.filepath == b.filepath && a.frame == b.frame &&
          a.shaderTypeToUse == b.shaderTypeToUse &&
+         a.isSemanticRGB == b.isSemanticRGB &&
          a.virtualUnitToMeters == b.virtualUnitToMeters &&
          a.forceFlatShading == b.forceFlatShading;
 }

--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -33,7 +33,7 @@ AssetInfo AssetInfo::fromPath(const std::string& path) {
 bool operator==(const AssetInfo& a, const AssetInfo& b) {
   return a.type == b.type && a.filepath == b.filepath && a.frame == b.frame &&
          a.shaderTypeToUse == b.shaderTypeToUse &&
-         a.isSemanticRGB == b.isSemanticRGB &&
+         a.hasSemanticTextures == b.hasSemanticTextures &&
          a.virtualUnitToMeters == b.virtualUnitToMeters &&
          a.forceFlatShading == b.forceFlatShading;
 }

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -62,8 +62,8 @@ struct AssetInfo {
       metadata::attributes::ObjectInstanceShaderType::Unspecified;
 
   /**
-   * @brief Asset will be used for semantic information using semantically
-   * annotated textures with a flat shader.
+   * @brief Asset is a semantic mesh that uses textures (instead of vertices)
+   * for annotation information.
    */
   bool isSemanticRGB = false;
 

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -61,6 +61,12 @@ struct AssetInfo {
   metadata::attributes::ObjectInstanceShaderType shaderTypeToUse =
       metadata::attributes::ObjectInstanceShaderType::Unspecified;
 
+  /**
+   * @brief Asset will be used for semantic information using semantically
+   * annotated textures with a flat shader.
+   */
+  bool isSemanticRGB = false;
+
   //! Populates a preset AssetInfo by matching against known filepaths
   static AssetInfo fromPath(const std::string& filepath);
 

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -65,7 +65,7 @@ struct AssetInfo {
    * @brief Asset is a semantic mesh that uses textures (instead of vertices)
    * for annotation information.
    */
-  bool isSemanticRGB = false;
+  bool hasSemanticTextures = false;
 
   //! Populates a preset AssetInfo by matching against known filepaths
   static AssetInfo fromPath(const std::string& filepath);

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -157,9 +157,8 @@ void BaseMesh::buildSemanticOBBs(
     const std::string debugStr = Cr::Utility::formatString(
         "{} Semantic ID : {} : color : {} tag : {} present in {} "
         "verts | ",
-        msgPrefix, semanticID,
-        getColorAsString(static_cast<Mn::Color3ub>(ssdObj.getColor())),
-        ssdObj.id(), vertCounts[semanticID]);
+        msgPrefix, semanticID, ssdObj.getColorAsInt(), ssdObj.id(),
+        vertCounts[semanticID]);
     if (vertCounts[semanticID] == 0) {
       ESP_DEBUG() << Cr::Utility::formatString(
           "{}No verts have specified Semantic ID.", debugStr);

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -54,6 +54,7 @@ void BaseMesh::buildColorMapToUse(
     const Cr::Containers::Array<Mn::Color3ub>& vertColors,
     bool useVertexColors,
     std::vector<Mn::Vector3ub>& colorMapToUse) const {
+  colorMapToUse.clear();
   if (useVertexColors) {
     // removeDuplicates returns array of unique idxs for ids, to
     // be used on meshColors to provide mappings for colorMapToUse

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -154,24 +154,13 @@ GenericSemanticMeshData::buildSemanticMeshData(
       // build maps of color ints to semantic IDs and color ints to
       // region ids in SSD find max regions present, so we can have an
       // "unassigned"/"unknown" region to move all verts whose region is
-
       int maxRegion = -1;
-      // build the color map with first maxSemanticID elements in proper order
-      // to match provided semantic IDs (so that ID is IDX of semantic color in
-      // map) and any overflow colors uniquely map 1-to-1 to an unmapped
-      // semantic ID as their index.
-      colorMapToUse.resize(numSSDObjs);
       for (int i = 0; i < numSSDObjs; ++i) {
         const auto& ssdObj = ssdObjs[i];
-        const Mn::Vector3ub ssdColor = ssdObj->getColor();
-        const uint32_t colorInt = colorAsInt(ssdColor);
+        const uint32_t colorInt = colorAsInt(ssdObj->getColor());
         int semanticID = ssdObj->semanticID();
         int regionIDX = ssdObj->region()->getIndex();
         tmpColorMapToSSDidAndRegionIndex[colorInt] = {semanticID, regionIDX};
-        if (colorMapToUse.size() <= semanticID) {
-          colorMapToUse.resize(semanticID + 1);
-        }
-        colorMapToUse[semanticID] = ssdColor;
         maxRegion = Mn::Math::max(regionIDX, maxRegion);
       }
       // largest possible known semanticID will be size of colorMapToUse at this

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -25,11 +25,10 @@ namespace Mn = Magnum;
 namespace esp {
 namespace assets {
 
-std::vector<std::unique_ptr<GenericSemanticMeshData>>
+std::unique_ptr<GenericSemanticMeshData>
 GenericSemanticMeshData::buildSemanticMeshData(
     const Mn::Trade::MeshData& srcMeshData,
     const std::string& semanticFilename,
-    const bool splitMesh,
     std::vector<Mn::Vector3ub>& colorMapToUse,
     bool convertToSRGB,
     const std::shared_ptr<scene::SemanticScene>& semanticScene) {
@@ -48,36 +47,36 @@ GenericSemanticMeshData::buildSemanticMeshData(
      The importer always provides an indexed mesh with positions, so no need
      for extra error checking. */
 
-  auto semanticData = GenericSemanticMeshData::create_unique();
+  auto semanticMeshData = GenericSemanticMeshData::create_unique();
   const auto numVerts = srcMeshData.vertexCount();
 
-  semanticData->cpu_ibo_.resize(srcMeshData.indexCount());
-  semanticData->cpu_vbo_.resize(numVerts);
-  semanticData->cpu_cbo_.resize(numVerts);
-  semanticData->objectIds_.resize(numVerts);
+  semanticMeshData->cpu_ibo_.resize(srcMeshData.indexCount());
+  semanticMeshData->cpu_vbo_.resize(numVerts);
+  semanticMeshData->cpu_cbo_.resize(numVerts);
+  semanticMeshData->objectIds_.resize(numVerts);
 
   srcMeshData.positions3DInto(Cr::Containers::arrayCast<Mn::Vector3>(
-      Cr::Containers::arrayView(semanticData->cpu_vbo_)));
+      Cr::Containers::arrayView(semanticMeshData->cpu_vbo_)));
 
   if (semanticFilename.find(".ply") != std::string::npos) {
     // Generic Semantic PLY meshes have -Z gravity
     const auto T_esp_scene =
         Mn::Quaternion{quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY)}
             .toMatrix();
-    for (auto& xyz : semanticData->cpu_vbo_) {
+    for (auto& xyz : semanticMeshData->cpu_vbo_) {
       xyz = T_esp_scene * xyz;
     }
   }
 
-  srcMeshData.indicesInto(semanticData->cpu_ibo_);
+  srcMeshData.indicesInto(semanticMeshData->cpu_ibo_);
 
   // initialize per-vertex color array
   Cr::Containers::Array<Mn::Color3ub> meshColors{Mn::NoInit, numVerts};
   // build color array from colors present in mesh
-  semanticData->convertMeshColors(srcMeshData, convertToSRGB, meshColors);
+  semanticMeshData->convertMeshColors(srcMeshData, convertToSRGB, meshColors);
 
   Cr::Utility::copy(meshColors,
-                    Cr::Containers::arrayView(semanticData->cpu_cbo_));
+                    Cr::Containers::arrayView(semanticMeshData->cpu_cbo_));
 
   // Check we actually have object IDs before copying them, and that those are
   // in a range we expect them to be
@@ -86,22 +85,18 @@ GenericSemanticMeshData::buildSemanticMeshData(
   // Whether or not the objectIds were provided by the source file. If so then
   // we assume they can be used to provide islands to split the semantic mesh
   // for better frustum culling.
-  bool objIdsFromFile = false;
+  bool objIdsFromSrcMesh = false;
 
   // Whether or not region partitions are provided in the SSD file. If so then
   // we assume they can be used to provide islands to split the semantic mesh
   // for better frustum culling.
-  bool objPartitionsFromSSD = false;
-
-  // This is used to map every vertex to a particular partition, for culling.
-  std::vector<uint16_t> partitionIds;
+  semanticMeshData->meshHasSeparatePartitionIDs = false;
 
   if (srcMeshData.hasAttribute(Mn::Trade::MeshAttribute::ObjectId)) {
     // Per-mesh vertex semantic object ids are provided - this will override any
     // vertex colors provided in file
     objectIds = srcMeshData.objectIdsAsArray();
-    objIdsFromFile = true;
-    objPartitionsFromSSD = false;
+    objIdsFromSrcMesh = true;
     const int maxVal = Mn::Math::max(objectIds);
     ESP_CHECK(maxVal <= 65535, Cr::Utility::formatString(
                                    "{}Object IDs can't be stored into 16 bits "
@@ -112,8 +107,8 @@ GenericSemanticMeshData::buildSemanticMeshData(
     // provided vertex colors (NOTE : There must be 1-to-1 map between ID and
     // vert colors - if unsure do not use these) or a magnum color map
 
-    semanticData->buildColorMapToUse(objectIds, meshColors, false,
-                                     colorMapToUse);
+    semanticMeshData->buildColorMapToUse(objectIds, meshColors, false,
+                                         colorMapToUse);
   } else {
     // No Object IDs defined - assign them based on colors at verts, if they
     // exist
@@ -123,15 +118,15 @@ GenericSemanticMeshData::buildSemanticMeshData(
     // These ids should probably not be used to split the mesh into submeshes
     // for culling purposes, since there may be very many different vertex
     // colors.
-    objIdsFromFile = false;
+    objIdsFromSrcMesh = false;
 
     // If a vertex color array and array of semantic ids are provided via a
     // semantic scene descriptor, use these to replace the idxs found in using
     // the removeDuplicatesInPlace process and their color mappings
-    if ((semanticScene != nullptr) && semanticScene->hasVertColorsDefined()) {
+    if (semanticScene && semanticScene->hasVertColorsDefined()) {
       // built partion IDs from SSD regions, to split mesh for culling, instead
       // of objectIDs
-      objPartitionsFromSSD = true;
+      semanticMeshData->meshHasSeparatePartitionIDs = true;
 
       // from SSD's objects_ array - this is the number of defined semantic
       // descriptors corresponding to object instances.
@@ -165,10 +160,10 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
       // map regionIDs to affected verts using semantic color provided in
       // SemanticScene, as specified in SSD file.
-      partitionIds.resize(numVerts);
+      semanticMeshData->partitionIds_.resize(numVerts);
       // map semantic IDs corresponding to colors from SSD file to appropriate
       // verts (via index)
-      semanticData->objectIds_.resize(numVerts);
+      semanticMeshData->objectIds_.resize(numVerts);
       // temporary holding structure to hold any non-SSD vert colors, so that
       // the nonSSDObjID for new colors can be incremented appropriately
       // not using set to avoid extra include. Key is color, value is semantic
@@ -228,15 +223,11 @@ GenericSemanticMeshData::buildSemanticMeshData(
         }
 
         // assign semantic ID for vertex
-        semanticData->objectIds_[vertIdx] = semanticID;
+        semanticMeshData->objectIds_[vertIdx] = semanticID;
         // partition Ids for each vertex, for multi-mesh construction.
-        partitionIds[vertIdx] = regionID;
+        semanticMeshData->partitionIds_[vertIdx] = regionID;
       }  // for each vertex
-      // FOR VERT-BASED OBB CALC
-      // build semantic OBBs here
-      semanticData->buildSemanticOBBs(semanticData->cpu_vbo_,
-                                      semanticData->objectIds_, ssdObjs,
-                                      dbgMsgPrefix);
+
       // colors found on vertices not found in semantic lexicon :
       if (nonSSDVertColorIDs.empty()) {
         ESP_DEBUG() << dbgMsgPrefix
@@ -252,11 +243,12 @@ GenericSemanticMeshData::buildSemanticMeshData(
               << dbgMsgPrefix
               << Cr::Utility::formatString(
                      "\t\tColor {} | # verts {} | applied Semantic ID {}.",
-                     semanticData->getColorAsString(
+                     semanticMeshData->getColorAsString(
                          static_cast<Mn::Color3ub>(colorMapToUse[elem.second])),
                      nonSSDVertColorCounts.at(elem.first), elem.second);
         }
       }
+
     } else {
       // Per vertex colors provided, but no semantic scene provided to provide
       // color->id mapping, so build a mapping based on colors at vertices -
@@ -277,64 +269,68 @@ GenericSemanticMeshData::buildSemanticMeshData(
       objectIds = std::move(out.first);
       auto clrMapView = colorsThatBecomeTheColorMap.prefix(out.second);
       colorMapToUse.assign(clrMapView.begin(), clrMapView.end());
-
-      objPartitionsFromSSD = false;
     }
   }
-  if (!objPartitionsFromSSD) {
-    // if objPartitionsFromSSD then semanticData->objectIds were
-    // populated directly
+  if (!semanticMeshData->meshHasSeparatePartitionIDs) {
+    // if objPartitionsFromSSD then semanticMeshData->objectIds were
+    // populated directly while partition IDs were derived
     Mn::Math::castInto(
         Cr::Containers::arrayCast<2, Mn::UnsignedInt>(
             Cr::Containers::stridedArrayView(objectIds)),
         Cr::Containers::arrayCast<2, Mn::UnsignedShort>(
-            Cr::Containers::stridedArrayView(semanticData->objectIds_)));
+            Cr::Containers::stridedArrayView(semanticMeshData->objectIds_)));
   }
 
+  semanticMeshData->meshHasPartitionIDXs =
+      (objIdsFromSrcMesh || semanticMeshData->meshHasSeparatePartitionIDs);
+
+  semanticMeshData->collisionMeshData_.primitive = Mn::MeshPrimitive::Triangles;
+  semanticMeshData->updateCollisionMeshData();
+
+  if (semanticScene && (semanticScene->buildBBoxFromVertColors())) {
+    // FOR VERT-BASED OBB CALC build semantic (actually AABBs currently)
+    semanticMeshData->buildSemanticOBBs(semanticMeshData->cpu_vbo_,
+                                        semanticMeshData->objectIds_,
+                                        semanticScene->objects(), dbgMsgPrefix);
+  }
+
+  ////
+  return semanticMeshData;
+}
+
+std::vector<std::unique_ptr<GenericSemanticMeshData>>
+GenericSemanticMeshData::partitionSemanticMeshData(
+    std::unique_ptr<GenericSemanticMeshData>& semanticMeshData) {
   // build output vector of meshdata unique pointers
   std::vector<GenericSemanticMeshData::uptr> splitMeshData;
-  if (splitMesh && (objIdsFromFile || objPartitionsFromSSD)) {
-    // use these ids to identify partitions that any particular vert should
-    // belong to
-    std::vector<uint16_t>& meshPartitionIds =
-        objIdsFromFile ? semanticData->objectIds_ : partitionIds;
-
-    std::unordered_map<uint16_t, PerPartitionIdMeshBuilder>
-        partitionIdToObjectData;
-
-    for (size_t i = 0; i < semanticData->cpu_ibo_.size(); ++i) {
-      const uint32_t globalIndex = semanticData->cpu_ibo_[i];
-      const uint16_t objectId = semanticData->objectIds_[globalIndex];
-      const uint16_t partitionId = meshPartitionIds[globalIndex];
-      // if not found in map to data create new mesh
-      if (partitionIdToObjectData.find(partitionId) ==
-          partitionIdToObjectData.end()) {
-        auto instanceMesh = GenericSemanticMeshData::create_unique();
-        partitionIdToObjectData.emplace(
-            partitionId, PerPartitionIdMeshBuilder{*instanceMesh, partitionId});
-        splitMeshData.emplace_back(std::move(instanceMesh));
-      }
-      partitionIdToObjectData.at(partitionId)
-          .addVertex(globalIndex, semanticData->cpu_vbo_[globalIndex],
-                     semanticData->cpu_cbo_[globalIndex], objectId);
+  std::unordered_map<uint16_t, PerPartitionIdMeshBuilder>
+      partitionIdToObjectData;
+  const std::vector<uint16_t>& meshPartitionIds =
+      semanticMeshData->getPartitionIDs();
+  for (size_t i = 0; i < semanticMeshData->cpu_ibo_.size(); ++i) {
+    const uint32_t globalIndex = semanticMeshData->cpu_ibo_[i];
+    const uint16_t objectId = semanticMeshData->objectIds_[globalIndex];
+    const uint16_t partitionId = meshPartitionIds[globalIndex];
+    // if not found in map to data create new mesh
+    if (partitionIdToObjectData.find(partitionId) ==
+        partitionIdToObjectData.end()) {
+      auto instanceMesh = GenericSemanticMeshData::create_unique();
+      partitionIdToObjectData.emplace(
+          partitionId, PerPartitionIdMeshBuilder{*instanceMesh, partitionId});
+      splitMeshData.emplace_back(std::move(instanceMesh));
     }
-    // Update collision mesh data for each mesh
-    for (size_t i = 0; i < splitMeshData.size(); ++i) {
-      splitMeshData[i]->updateCollisionMeshData();
-    }
-  } else {
-    // mesh should not be split - ids were synthesized
-
-    // Store indices, facd_ids in Magnum MeshData3D format such that
-    // later they can be accessed.
-    // Note that normal and texture data are not stored
-    semanticData->collisionMeshData_.primitive = Mn::MeshPrimitive::Triangles;
-    semanticData->updateCollisionMeshData();
-    splitMeshData.emplace_back(std::move(semanticData));
+    partitionIdToObjectData.at(partitionId)
+        .addVertex(globalIndex, semanticMeshData->cpu_vbo_[globalIndex],
+                   semanticMeshData->cpu_cbo_[globalIndex], objectId);
   }
+  // Update collision mesh data for each mesh
+  for (size_t i = 0; i < splitMeshData.size(); ++i) {
+    splitMeshData[i]->updateCollisionMeshData();
+  }
+
   return splitMeshData;
 
-}  // GenericSemanticMeshData::buildSemanticMeshData
+}  // GenericSemanticMeshData::partitionSemanticMeshData
 
 void GenericSemanticMeshData::uploadBuffersToGPU(bool forceReload) {
   if (forceReload) {

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -300,7 +300,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
 std::vector<std::unique_ptr<GenericSemanticMeshData>>
 GenericSemanticMeshData::partitionSemanticMeshData(
-    std::unique_ptr<GenericSemanticMeshData>& semanticMeshData) {
+    const std::unique_ptr<GenericSemanticMeshData>& semanticMeshData) {
   // build output vector of meshdata unique pointers
   std::vector<GenericSemanticMeshData::uptr> splitMeshData;
   std::unordered_map<uint16_t, PerPartitionIdMeshBuilder>

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -82,7 +82,7 @@ class GenericSemanticMeshData : public BaseMesh {
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>>
   partitionSemanticMeshData(
-      std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
+      const std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -47,6 +47,28 @@ class GenericSemanticMeshData : public BaseMesh {
    * do so.
    * @param meshData The imported meshData.
    * @param semanticFilename Path-less Filename of source mesh.
+   * @param [out] colorMapToUse An array holding the semantic colors to use for
+   * visualization or matching to semantic IDs.
+   * @param convertToSRGB Whether the source vertex colors from the @p meshData
+   * should be converted to SRGB
+   * @param semanticScene The SSD for the instance mesh being loaded.
+   * @return vector holding one or more mesh results from the semantic asset
+   * file.
+   */
+  static std::unique_ptr<GenericSemanticMeshData> buildSemanticMeshData(
+      const Magnum::Trade::MeshData& meshData,
+      const std::string& semanticFilename,
+      std::vector<Magnum::Vector3ub>& colorMapToUse,
+      bool convertToSRGB,
+      const std::shared_ptr<scene::SemanticScene>& semanticScene = nullptr);
+
+  /**
+   * @brief Build one ore more @ref GenericSemanticMeshData based on the
+   * contents of the passed @p meshData, splitting the result into multiples if
+   * specified and if the source file's objectIds are compatibly configured to
+   * do so.
+   * @param meshData The imported meshData.
+   * @param semanticFilename Path-less Filename of source mesh.
    * @param splitMesh Whether or not the resultant mesh should be split into
    * multiple components based on objectIds, for frustum culling.
    * @param [out] colorMapToUse An array holding the semantic colors to use for
@@ -59,13 +81,8 @@ class GenericSemanticMeshData : public BaseMesh {
    */
 
   static std::vector<std::unique_ptr<GenericSemanticMeshData>>
-  buildSemanticMeshData(
-      const Magnum::Trade::MeshData& meshData,
-      const std::string& semanticFilename,
-      bool splitMesh,
-      std::vector<Magnum::Vector3ub>& colorMapToUse,
-      bool convertToSRGB,
-      const std::shared_ptr<scene::SemanticScene>& semanticScene = nullptr);
+  partitionSemanticMeshData(
+      std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;
@@ -88,7 +105,39 @@ class GenericSemanticMeshData : public BaseMesh {
     return objectIds_;
   }
 
+  /**
+   * @brief Either return separate partition IDs or objectIDs, depending on
+   * which were available when mesh was initially configured.  These are used to
+   * partition mesh for culling.
+   */
+  const std::vector<uint16_t>& getPartitionIDs() const {
+    if (meshHasSeparatePartitionIDs) {
+      return partitionIds_;
+    }
+    return objectIds_;
+  }
+  /**
+   * @brief This mesh can be partitioned - either object IDs were found in
+   * vertices or per-vert region partition values were found from semantic
+   * descriptor file.
+   */
+  bool meshCanBePartitioned() const { return meshHasPartitionIDXs; }
+
  protected:
+  /**
+   * @brief Whether or not this mesh can be partitioned - either object IDs were
+   * found in vertices or per-vert region partition values were found from
+   * semantic descriptor file.
+   */
+  bool meshHasPartitionIDXs = false;
+
+  /**
+   * @brief This mesh has separate partition IDs. If false, uses the objectIDs
+   * for the partitioning, if true means region IDs were provided in semantic
+   * scene descriptor.
+   */
+  bool meshHasSeparatePartitionIDs = false;
+
   class PerPartitionIdMeshBuilder {
    public:
     PerPartitionIdMeshBuilder(GenericSemanticMeshData& data,
@@ -114,6 +163,8 @@ class GenericSemanticMeshData : public BaseMesh {
   std::vector<Mn::Color3ub> cpu_cbo_;
   std::vector<uint32_t> cpu_ibo_;
   std::vector<uint16_t> objectIds_;
+  // only for mesh paritioning - either points to objectIds_ or to new data
+  std::vector<uint16_t> partitionIds_{};
 
   ESP_SMART_POINTERS(GenericSemanticMeshData)
 };

--- a/src/esp/assets/RenderAssetInstanceCreationInfo.h
+++ b/src/esp/assets/RenderAssetInstanceCreationInfo.h
@@ -22,7 +22,9 @@ struct RenderAssetInstanceCreationInfo {
   enum class Flag : unsigned int {
     IsStatic = 1 << 0,  // inform the renderer that this instance won't be moved
     IsRGBD = 1 << 1,    // use in RGB and depth observations
-    IsSemantic = 1 << 2  // use in semantic observations
+    IsSemantic = 1 << 2,             // use in semantic observations
+    IsTextureBasedSemantic = 1 << 3  // semantic asset using annotated textures
+                                     // (as opposed to vertex annotations)
   };
   typedef Corrade::Containers::EnumSet<Flag> Flags;
 
@@ -37,6 +39,9 @@ struct RenderAssetInstanceCreationInfo {
   bool isStatic() const { return bool(flags & Flag::IsStatic); }
   bool isRGBD() const { return bool(flags & Flag::IsRGBD); }
   bool isSemantic() const { return bool(flags & Flag::IsSemantic); }
+  bool isTextureBasedSemantic() const {
+    return bool(flags & Flag::IsTextureBasedSemantic);
+  }
 
   std::string filepath;  // see also AssetInfo::filepath
   Corrade::Containers::Optional<Magnum::Vector3> scale;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2333,17 +2333,13 @@ Mn::Image2D ResourceManager::convertRGBToSemanticId(
     Cr::Containers::StridedArrayView1D<const Mn::Color3ub> inputRow = input[y];
     Cr::Containers::StridedArrayView1D<Mn::UnsignedShort> outputRow = output[y];
     for (std::size_t x = 0; x != size.x(); ++x) {
-      /* Fugly. Sorry. Needs better API on Magnum side. */
       const Mn::Color3ub color = inputRow[x];
-
+      /* Fugly. Sorry. Needs better API on Magnum side. */
       const Mn::UnsignedInt colorInt =
           color.r() << 16 | color.g() << 8 | color.b();
       outputRow[x] = clrToSemanticId[colorInt];
     }
   }
-  // upload the `integer` image to an integer Texture2D and then use as
-  // a semantic texture in the shader
-
   return resImage;
 }  // ResourceManager::convertRGBToSemanticId
 void ResourceManager::loadTextures(Importer& importer,
@@ -2356,15 +2352,12 @@ void ResourceManager::loadTextures(Importer& importer,
     // build semantic BBoxes and semanticColorMapBeingUsed_ if semanticScene_
     flattenImportedMeshAndBuildSemantic(importer, loadedAssetData.assetInfo);
 
-    // // build semanticColorMapBeingUsed_ if semanticScene_ is not nullptr
-    // if (semanticScene_) {
-    //   buildSemanticColorMap();
-    // }
-
-    // assuming that the only textures that exist are the RGB
-    // build table of colors
-    // Object IDs for ALL POSSIBLE COLORS IN EXISTENCE. Unknown entries have
-    // semantic id 0xffff .
+    // We are assuming that the only textures that exist are the semantic
+    // textures. We build table of all possible colors holding ushorts
+    // representing semantic IDs for those colors. We then assign known semantic
+    // IDs to table entries corresponding the ID's specified color. Unknown
+    // entries have semantic id 0xffff.
+    //
     Cr::Containers::Array<Mn::UnsignedShort> clrToSemanticId{
         Mn::DirectInit, 256 * 256 * 256, Mn::UnsignedShort(0xffff)};
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2356,13 +2356,14 @@ void ResourceManager::loadTextures(Importer& importer,
     // textures. We build table of all possible colors holding ushorts
     // representing semantic IDs for those colors. We then assign known semantic
     // IDs to table entries corresponding the ID's specified color. Unknown
-    // entries have semantic id 0xffff.
+    // entries have semantic id 0x0 (corresponding to Unknown object in semantic
+    // scene).
     //
     Cr::Containers::Array<Mn::UnsignedShort> clrToSemanticId{
-        Mn::DirectInit, 256 * 256 * 256, Mn::UnsignedShort(0xffff)};
+        Mn::DirectInit, 256 * 256 * 256, Mn::UnsignedShort(0x0)};
 
     for (std::size_t i = 0; i < semanticColorAsInt_.size(); ++i) {
-      // skip '0x0' (black) color.
+      // skip '0x0' (black) color - already mapped 0
       if (semanticColorAsInt_[i] == 0) {
         continue;
       }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -580,7 +580,10 @@ ResourceManager::createStageAssetInfosFromAttributes(
         stageAttributes->getFrustumCulling()  // splitInstanceMesh
     };
     // specify whether the semantic asset has semantically annotated textures.
-    semanticInfo.isSemanticRGB = stageAttributes->getHasSemanticTextures();
+    // this is only true if the assets are available (as specified in the
+    // dataset config) and if the  user has requested them (via
+    // SimulatorConfiguration::useSemanticTexturesIfFound)
+    semanticInfo.isSemanticRGB = stageAttributes->useSemanticTextures();
 
     Cr::Utility::formatInto(
         debugStr, debugStr.size(),

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -723,7 +723,7 @@ std::string ResourceManager::createModifiedAssetName(const AssetInfo& info,
       // based on this color and values specified in info
       materialId = createColorMaterial(*info.overridePhongMaterial);
     }
-    modifiedAssetName += "?" + materialId;
+    modifiedAssetName += '?' + materialId;
   }
   // construct name with materialId specification and desired shader type
   return modifiedAssetName;
@@ -1325,10 +1325,9 @@ bool ResourceManager::loadSemanticRenderAsset(const AssetInfo& info) {
   if (info.hasSemanticTextures) {
     // use loadRenderAssetGeneral for texture-based semantics
     return loadRenderAssetGeneral(info);
-  } else {
-    // special handling for vertex-based semantics
-    return loadRenderAssetIMesh(info);
   }
+  // special handling for vertex-based semantics
+  return loadRenderAssetIMesh(info);
 }  // ResourceManager::loadSemanticRenderAsset
 
 scene::SceneNode* ResourceManager::createSemanticRenderAssetInstance(
@@ -1339,10 +1338,10 @@ scene::SceneNode* ResourceManager::createSemanticRenderAssetInstance(
     // Treat texture-based semantic meshes as General/Primitves.
     return createRenderAssetInstanceGeneralPrimitive(creation, parent,
                                                      drawables, nullptr);
-  } else {
-    // Special handling for vertex-based semantics
-    return createRenderAssetInstanceIMesh(creation, parent, drawables);
   }
+  // Special handling for vertex-based semantics
+  return createRenderAssetInstanceIMesh(creation, parent, drawables);
+
 }  // ResourceManager::createSemanticRenderAssetInstance
 
 GenericSemanticMeshData::uptr

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -352,6 +352,10 @@ bool ResourceManager::loadStage(
         // only treat as static if doing culling
         flags |= RenderAssetInstanceCreationInfo::Flag::IsStatic;
       }
+      // if texture-based semantic mesh specify in creation
+      if (semanticInfo.isSemanticRGB) {
+        flags |= RenderAssetInstanceCreationInfo::Flag::IsTextureBasedSemantic;
+      }
       RenderAssetInstanceCreationInfo creation(
           semanticStageFilename, Cr::Containers::NullOpt, flags, NO_LIGHT_KEY);
 
@@ -1414,6 +1418,13 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceIMesh(
   instanceRoot->MagnumObject::setTransformation(
       meshMetaData.root.transformFromLocalToParent);
 
+  Mn::ResourceKey materialKey;
+  if (creation.isTextureBasedSemantic()) {
+    materialKey = TEXTURE_OBJECT_ID_MATERIAL_KEY;
+  } else {
+    materialKey = PER_VERTEX_OBJECT_ID_MATERIAL_KEY;
+  }
+
   for (int iMesh = start; iMesh <= end; ++iMesh) {
     scene::SceneNode& node = instanceRoot->createChild();
 
@@ -1428,11 +1439,11 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceIMesh(
     // meshes_.at(iMesh)->getMeshData()->hasAttribute(Mn::Trade::MeshAttribute::Tangent)
     // It will SEGFAULT!
     createDrawable(meshes_.at(iMesh)->getMagnumGLMesh(),  // render mesh
-                   meshAttributeFlags,                 // mesh attribute flags
-                   node,                               // scene node
-                   creation.lightSetupKey,             // lightSetup key
-                   PER_VERTEX_OBJECT_ID_MATERIAL_KEY,  // material key
-                   drawables);                         // drawable group
+                   meshAttributeFlags,      // mesh attribute flags
+                   node,                    // scene node
+                   creation.lightSetupKey,  // lightSetup key
+                   materialKey,             // material key
+                   drawables);              // drawable group
 
     if (computeAbsoluteAABBs) {
       staticDrawableInfo.emplace_back(StaticDrawableInfo{node, iMesh});

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -369,7 +369,7 @@ bool ResourceManager::loadStage(
         flags |= RenderAssetInstanceCreationInfo::Flag::IsStatic;
       }
       // if texture-based semantic mesh specify in creation
-      if (semanticInfo.isSemanticRGB) {
+      if (semanticInfo.hasSemanticTextures) {
         flags |= RenderAssetInstanceCreationInfo::Flag::IsTextureBasedSemantic;
       }
       RenderAssetInstanceCreationInfo creation(
@@ -425,7 +425,7 @@ bool ResourceManager::loadStage(
   // if texture-based semantic mesh specify in creation
   // TODO: Currently do not support single mesh texture-based semantic and
   // render stages
-  // if (renderInfo.isSemanticRGB) {
+  // if (renderInfo.hasSemanticTextures) {
   //   flags |= RenderAssetInstanceCreationInfo::Flag::IsTextureBasedSemantic;
   // }
   RenderAssetInstanceCreationInfo renderCreation(
@@ -497,7 +497,7 @@ bool ResourceManager::buildMeshGroups(
   if (collisionMeshGroups_.count(info.filepath) == 0) {
     //! Collect collision mesh group
     bool colMeshGroupSuccess = false;
-    if ((info.type == AssetType::INSTANCE_MESH) && !info.isSemanticRGB) {
+    if ((info.type == AssetType::INSTANCE_MESH) && !info.hasSemanticTextures) {
       // PLY Semantic mesh
       colMeshGroupSuccess =
           buildStageCollisionMeshGroup<GenericSemanticMeshData>(info.filepath,
@@ -505,7 +505,7 @@ bool ResourceManager::buildMeshGroups(
     } else if ((info.type == AssetType::MP3D_MESH ||
                 info.type == AssetType::UNKNOWN) ||
                ((info.type == AssetType::INSTANCE_MESH) &&
-                info.isSemanticRGB)) {
+                info.hasSemanticTextures)) {
       // GLB Mesh
       colMeshGroupSuccess = buildStageCollisionMeshGroup<GenericMeshData>(
           info.filepath, meshGroup);
@@ -598,7 +598,7 @@ ResourceManager::createStageAssetInfosFromAttributes(
     // this is only true if the assets are available (as specified in the
     // dataset config) and if the  user has requested them (via
     // SimulatorConfiguration::useSemanticTexturesIfFound)
-    semanticInfo.isSemanticRGB = stageAttributes->useSemanticTextures();
+    semanticInfo.hasSemanticTextures = stageAttributes->useSemanticTextures();
 
     Cr::Utility::formatInto(
         debugStr, debugStr.size(),
@@ -606,7 +606,7 @@ ResourceManager::createStageAssetInfosFromAttributes(
         "Txtrs : {}",
         frame.toString(), semanticInfo.filepath,
         esp::metadata::attributes::getMeshTypeName(semanticInfo.type),
-        (semanticInfo.isSemanticRGB ? "True" : "False"));
+        (semanticInfo.hasSemanticTextures ? "True" : "False"));
     resMap["semantic"] = semanticInfo;
   } else {
     Cr::Utility::formatInto(debugStr, debugStr.size(),
@@ -1322,7 +1322,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstancePTex(
 }  // ResourceManager::createRenderAssetInstancePTex
 
 bool ResourceManager::loadSemanticRenderAsset(const AssetInfo& info) {
-  if (info.isSemanticRGB) {
+  if (info.hasSemanticTextures) {
     // use loadRenderAssetGeneral for texture-based semantics
     return loadRenderAssetGeneral(info);
   } else {
@@ -1631,7 +1631,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   // w/texture annotations
   CORRADE_INTERNAL_ASSERT(
       isRenderAssetGeneral(info.type) ||
-      ((info.type == AssetType::INSTANCE_MESH) && info.isSemanticRGB));
+      ((info.type == AssetType::INSTANCE_MESH) && info.hasSemanticTextures));
 
   const std::string& filename = info.filepath;
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
@@ -1994,7 +1994,7 @@ void ResourceManager::loadMaterials(Importer& importer,
       << "Building " << numMaterials << " materials for asset named '"
       << assetName << "' : ";
 
-  if (loadedAssetData.assetInfo.isSemanticRGB) {
+  if (loadedAssetData.assetInfo.hasSemanticTextures) {
     int textureBaseIndex = loadedAssetData.meshMetaData.textureIndex.first;
     // TODO: Verify this is correct process for building individual materials
     // for each semantic int texture.
@@ -2353,7 +2353,7 @@ void ResourceManager::loadTextures(Importer& importer,
   int textureEnd = textureStart + importer.textureCount() - 1;
   nextTextureID_ = textureEnd + 1;
   loadedAssetData.meshMetaData.setTextureIndices(textureStart, textureEnd);
-  if (loadedAssetData.assetInfo.isSemanticRGB) {
+  if (loadedAssetData.assetInfo.hasSemanticTextures) {
     // build semantic BBoxes and semanticColorMapBeingUsed_ if semanticScene_
     flattenImportedMeshAndBuildSemantic(importer, loadedAssetData.assetInfo);
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -490,13 +490,15 @@ bool ResourceManager::buildMeshGroups(
   if (collisionMeshGroups_.count(info.filepath) == 0) {
     //! Collect collision mesh group
     bool colMeshGroupSuccess = false;
-    if (info.type == AssetType::INSTANCE_MESH) {
+    if ((info.type == AssetType::INSTANCE_MESH) && !info.isSemanticRGB) {
       // PLY Semantic mesh
       colMeshGroupSuccess =
           buildStageCollisionMeshGroup<GenericSemanticMeshData>(info.filepath,
                                                                 meshGroup);
-    } else if (info.type == AssetType::MP3D_MESH ||
-               info.type == AssetType::UNKNOWN) {
+    } else if ((info.type == AssetType::MP3D_MESH ||
+                info.type == AssetType::UNKNOWN) ||
+               ((info.type == AssetType::INSTANCE_MESH) &&
+                info.isSemanticRGB)) {
       // GLB Mesh
       colMeshGroupSuccess = buildStageCollisionMeshGroup<GenericMeshData>(
           info.filepath, meshGroup);

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2551,6 +2551,14 @@ void ResourceManager::initDefaultMaterials() {
   perVertexObjectId->ambientColor = Mn::Color4{1.0};
   shaderManager_.set<gfx::MaterialData>(PER_VERTEX_OBJECT_ID_MATERIAL_KEY,
                                         perVertexObjectId);
+
+  // build default material for texture-based annotations
+  auto* textureObjectId = new gfx::PhongMaterialData();
+  // has texture-based semantic annotations
+  textureObjectId->textureObjectId = true;
+  textureObjectId->ambientColor = Mn::Color4{1.0};
+  shaderManager_.set<gfx::MaterialData>(TEXTURE_OBJECT_ID_MATERIAL_KEY,
+                                        textureObjectId);
   shaderManager_.setFallback<gfx::MaterialData>(new gfx::PhongMaterialData{});
 }
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -548,6 +548,8 @@ ResourceManager::createStageAssetInfosFromAttributes(
         // only split semantic mesh if doing frustum culling
         stageAttributes->getFrustumCulling()  // splitInstanceMesh
     };
+    // specify whether the semantic asset has semantically annotated textures.
+    semanticInfo.isSemanticRGB = stageAttributes->getHasSemanticTextures();
 
     Cr::Utility::formatInto(
         debugStr, debugStr.size(),

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -192,6 +192,14 @@ class ResourceManager {
    */
   void buildSemanticColorMap();
 
+  /**
+   * @brief Remap a semantic annotation texture to have the semantic IDs per
+   * pxl.
+   * @param srcImage The source texture with the semantic colors.
+   * @return An image of the semantic IDs, with the ID mapped
+   */
+  Mn::Image2D convertRGBToSemanticId(const Mn::ImageView2D& srcImage);
+
   /** @brief check if the @ref esp::scene::SemanticScene exists.*/
   bool semanticSceneExists() const { return (semanticScene_ != nullptr); }
 
@@ -1175,6 +1183,7 @@ class ResourceManager {
    * @brief Colormap to use for visualizing currently loaded semantic scene.
    */
   std::vector<Mn::Vector3ub> semanticColorMapBeingUsed_{};
+  std::vector<uint32_t> semanticColorAsInt_{};
 
   // ======== Physical parameter data ========
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -30,6 +30,7 @@
 #include "BaseMesh.h"
 #include "CollisionMeshData.h"
 #include "GenericMeshData.h"
+#include "GenericSemanticMeshData.h"
 #include "MeshData.h"
 #include "MeshMetaData.h"
 #include "RenderAssetInstanceCreationInfo.h"
@@ -983,6 +984,19 @@ class ResourceManager {
    * @brief PTex Mesh backend for loadRenderAsset
    */
   bool loadRenderAssetPTex(const AssetInfo& info);
+
+  /**
+   * @brief Build @ref GenericSemanticMeshData from a single, flattened Magnum
+   * Meshdata, built from the meshes provided by the importer, preserving all
+   * transformations.  This building process will also synthesize bounding boxes
+   * if requested from the @ref semanticScene_ .
+   * @param fileImporter Importer used to load the scene.
+   * @param info AssetInfo describing asset.
+   * @return The GenericSemanticMeshData being built.
+   */
+  GenericSemanticMeshData::uptr flattenImportedMeshAndBuildSemantic(
+      Importer& fileImporter,
+      const AssetInfo& info);
 
   /**
    * @brief Semantic Mesh backend for loadRenderAsset.  Either use

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -196,9 +196,13 @@ class ResourceManager {
    * @brief Remap a semantic annotation texture to have the semantic IDs per
    * pxl.
    * @param srcImage The source texture with the semantic colors.
+   * @param clrToSemanticId Large table of all possible colors to their semantic
+   * IDs. initialized to 0xffff
    * @return An image of the semantic IDs, with the ID mapped
    */
-  Mn::Image2D convertRGBToSemanticId(const Mn::ImageView2D& srcImage);
+  Mn::Image2D convertRGBToSemanticId(
+      const Mn::ImageView2D& srcImage,
+      Cr::Containers::Array<Mn::UnsignedShort>& clrToSemanticId);
 
   /** @brief check if the @ref esp::scene::SemanticScene exists.*/
   bool semanticSceneExists() const { return (semanticScene_ != nullptr); }

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1002,7 +1002,7 @@ class ResourceManager {
    * @brief Semantic Mesh backend for loadRenderAsset.  Either use
    * loadRenderAssetIMesh if semantic mesh has vertex annotations only, or
    * loadRenderAssetGeneral if semantic mesh has texture-based annotations. This
-   * choice is governed by info.isSemanticRGB.
+   * choice is governed by info.hasSemanticTextures.
    */
   bool loadSemanticRenderAsset(const AssetInfo& info);
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -985,7 +985,15 @@ class ResourceManager {
   bool loadRenderAssetPTex(const AssetInfo& info);
 
   /**
-   * @brief Instance Mesh backend for loadRenderAsset
+   * @brief Semantic Mesh backend for loadRenderAsset.  Either use
+   * loadRenderAssetIMesh if semantic mesh has vertex annotations only, or
+   * loadRenderAssetGeneral if semantic mesh has texture-based annotations. This
+   * choice is governed by info.isSemanticRGB.
+   */
+  bool loadSemanticRenderAsset(const AssetInfo& info);
+
+  /**
+   * @brief Semantic (vertex-annotated) Mesh backend for loadRenderAsset
    */
   bool loadRenderAssetIMesh(const AssetInfo& info);
 
@@ -1020,7 +1028,20 @@ class ResourceManager {
       DrawableGroup* drawables);
 
   /**
-   * @brief Instance Mesh backend for createRenderAssetInstance
+   * @brief Semantic Mesh backend for create Either use
+   * createRenderAssetInstanceIMesh if semantic mesh has vertex annotations
+   * only, or createRenderAssetInstanceGeneralPrimitive if semantic mesh has
+   * texture-based annotations. This choice is governed by
+   * creation.isTextureBasedSemantic().
+   */
+  scene::SceneNode* createSemanticRenderAssetInstance(
+      const RenderAssetInstanceCreationInfo& creation,
+      scene::SceneNode* parent,
+      DrawableGroup* drawables);
+
+  /**
+   * @brief Semantic Mesh (vertex-annotated) backend for
+   * createRenderAssetInstance
    */
   scene::SceneNode* createRenderAssetInstanceIMesh(
       const RenderAssetInstanceCreationInfo& creation,

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -186,6 +186,12 @@ class ResourceManager {
     return semanticColorMapBeingUsed_;
   }
 
+  /**
+   * @brief Build the color map from a semantic scene descriptor, by iterating
+   * through the objects and mapping their color values to their semantic ids.
+   */
+  void buildSemanticColorMap();
+
   /** @brief check if the @ref esp::scene::SemanticScene exists.*/
   bool semanticSceneExists() const { return (semanticScene_ != nullptr); }
 
@@ -1168,7 +1174,7 @@ class ResourceManager {
   /**
    * @brief Colormap to use for visualizing currently loaded semantic scene.
    */
-  std::vector<Magnum::Vector3ub> semanticColorMapBeingUsed_{};
+  std::vector<Mn::Vector3ub> semanticColorMapBeingUsed_{};
 
   // ======== Physical parameter data ========
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -187,10 +187,20 @@ class ResourceManager {
   }
 
   /**
-   * @brief Build the color map from a semantic scene descriptor, by iterating
-   * through the objects and mapping their color values to their semantic ids.
+   * @brief Build @ref semanticColorMapBeingUsed_ holding the semantic colors
+   * defined from a semantic scene descriptor, by iterating through the objects
+   * and mapping their color values to their semantic ids.
    */
   void buildSemanticColorMap();
+
+  /**
+   * @brief Build @ref semanticColorAsInt_ (array of colors as integers) from
+   * the current @ref semanticColorMapBeingUsed_ map. The @ref
+   * semanticColorAsInt_ is used when building the color matrix for conversion
+   * of colors found in semantic textures to their semantic IDs. When semantic
+   * textures are preprocessed, this will not need to be performed.
+   */
+  void buildSemanticColorAsIntMap();
 
   /**
    * @brief Remap a semantic annotation texture to have the semantic IDs per

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -56,7 +56,7 @@ void initSimBindings(py::module& m) {
           "use_semantic_textures",
           &SimulatorConfiguration::useSemanticTexturesIfFound,
           R"(If the loaded scene/dataset supports semantically annotated textures, use these for
-      semantic rendering.)")
+      semantic rendering. Defaults to True)")
       .def_readwrite(
           "enable_gfx_replay_save",
           &SimulatorConfiguration::enableGfxReplaySave,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -53,6 +53,11 @@ void initSimBindings(py::module& m) {
       .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling)
       .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
       .def_readwrite(
+          "use_semantic_textures",
+          &SimulatorConfiguration::useSemanticTexturesIfFound,
+          R"(If the loaded scene/dataset supports semantically annotated textures, use these for
+      semantic rendering.)")
+      .def_readwrite(
           "enable_gfx_replay_save",
           &SimulatorConfiguration::enableGfxReplaySave,
           R"(Enable replay recording. See sim.gfx_replay.save_keyframe.)")

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -236,12 +236,6 @@ constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
  */
 constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] = "per_vertex_object_id";
 
-/**
- *@brief The @ref ShaderManager key for @ref MaterialInfo with texture
- * object ID
- */
-constexpr char TEXTURE_OBJECT_ID_MATERIAL_KEY[] = "texture_object_id";
-
 template <typename T>
 inline bool equal(const std::vector<std::shared_ptr<T>>& a,
                   const std::vector<std::shared_ptr<T>>& b) {

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -236,6 +236,12 @@ constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
  */
 constexpr char PER_VERTEX_OBJECT_ID_MATERIAL_KEY[] = "per_vertex_object_id";
 
+/**
+ *@brief The @ref ShaderManager key for @ref MaterialInfo with texture
+ * object ID
+ */
+constexpr char TEXTURE_OBJECT_ID_MATERIAL_KEY[] = "texture_object_id";
+
 template <typename T>
 inline bool equal(const std::vector<std::shared_ptr<T>>& a,
                   const std::vector<std::shared_ptr<T>>& b) {

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -41,6 +41,7 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
   if (materialData_->specularTexture) {
     flags_ |= Mn::Shaders::PhongGL::Flag::SpecularTexture;
   }
+
   if (materialData_->normalTexture) {
     if (meshAttributeFlags & Drawable::Flag::HasTangent) {
       flags_ |= Mn::Shaders::PhongGL::Flag::NormalTexture;
@@ -130,9 +131,10 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // uploaded to GPU so simply pass 0 to the uniform "objectId" in the
       // fragment shader
       .setObjectId(
-          static_cast<RenderCamera&>(camera).useDrawableIds()
-              ? drawableId_
-              : (materialData_->perVertexObjectId ? 0 : node_.getSemanticId()))
+          static_cast<RenderCamera&>(camera).useDrawableIds() ? drawableId_
+          : (materialData_->perVertexObjectId || materialData_->textureObjectId)
+              ? 0
+              : node_.getSemanticId())
       .setTransformationMatrix(transformationMatrix)
       .setProjectionMatrix(camera.projectionMatrix())
       .setNormalMatrix(transformationMatrix.normalMatrix());
@@ -153,6 +155,9 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
   }
   if (flags_ & Mn::Shaders::PhongGL::Flag::NormalTexture) {
     shader_->bindNormalTexture(*(materialData_->normalTexture));
+  }
+  if (flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture) {
+    shader_->bindObjectIdTexture(*(materialData_->objectIdTexture));
   }
 
   shader_->draw(getMesh());

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -156,7 +156,8 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
   if (flags_ & Mn::Shaders::PhongGL::Flag::NormalTexture) {
     shader_->bindNormalTexture(*(materialData_->normalTexture));
   }
-  if (flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture) {
+  if ((flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture) ==
+      Mn::Shaders::PhongGL::Flag::ObjectIdTexture) {
     shader_->bindObjectIdTexture(*(materialData_->objectIdTexture));
   }
 

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -55,6 +55,9 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
   if (materialData_->perVertexObjectId) {
     flags_ |= Mn::Shaders::PhongGL::Flag::InstancedObjectId;
   }
+  if (materialData_->textureObjectId) {
+    flags_ |= Mn::Shaders::PhongGL::Flag::ObjectIdTexture;
+  }
   if (meshAttributeFlags & Drawable::Flag::HasVertexColor) {
     flags_ |= Mn::Shaders::PhongGL::Flag::VertexColor;
   }

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -156,8 +156,7 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
   if (flags_ & Mn::Shaders::PhongGL::Flag::NormalTexture) {
     shader_->bindNormalTexture(*(materialData_->normalTexture));
   }
-  if ((flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture) ==
-      Mn::Shaders::PhongGL::Flag::ObjectIdTexture) {
+  if (flags_ >= Mn::Shaders::PhongGL::Flag::ObjectIdTexture) {
     shader_->bindObjectIdTexture(*(materialData_->objectIdTexture));
   }
 

--- a/src/esp/gfx/MaterialData.h
+++ b/src/esp/gfx/MaterialData.h
@@ -32,6 +32,12 @@ struct MaterialData {
 
   bool perVertexObjectId = false;
 
+  // This denotes a material with texture-based annotations
+  bool textureObjectId = false;
+
+  // This references the texture of ObjectID values
+  Magnum::GL::Texture2D* objectIdTexture = nullptr;
+
   // construct it using the default constructor. NO initial values, such as
   // identity matrix
   Magnum::Matrix3 textureMatrix;
@@ -44,9 +50,6 @@ struct MaterialData {
 
 struct PhongMaterialData : public MaterialData {
   PhongMaterialData() : MaterialData(MaterialDataType::Phong){};
-
-  // This denotes a material with texture-based annotations
-  bool textureObjectId = false;
   Magnum::Float shininess = 80.f;
   Magnum::Color4 ambientColor{0.1};
   // NOTE: This multiplication is a hack to roughly balance the Phong and PBR

--- a/src/esp/gfx/MaterialData.h
+++ b/src/esp/gfx/MaterialData.h
@@ -45,6 +45,8 @@ struct MaterialData {
 struct PhongMaterialData : public MaterialData {
   PhongMaterialData() : MaterialData(MaterialDataType::Phong){};
 
+  // This denotes a material with texture-based annotations
+  bool textureObjectId = false;
   Magnum::Float shininess = 80.f;
   Magnum::Color4 ambientColor{0.1};
   // NOTE: This multiplication is a hack to roughly balance the Phong and PBR

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -147,6 +147,7 @@ inline JsonGenericValue toJsonValue(
   addMember(obj, "isStatic", x.isStatic(), allocator);
   addMember(obj, "isRGBD", x.isRGBD(), allocator);
   addMember(obj, "isSemantic", x.isSemantic(), allocator);
+  addMember(obj, "isTextureSemantic", x.isTextureBasedSemantic(), allocator);
   addMember(obj, "lightSetupKey", x.lightSetupKey, allocator);
   return obj;
 }
@@ -161,6 +162,8 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
   readMember(obj, "isRGBD", isRGBD);
   bool isSemantic = false;
   readMember(obj, "isSemantic", isSemantic);
+  bool isTextureSemantic = false;
+  readMember(obj, "isTextureSemantic", isTextureSemantic);
   if (isStatic) {
     x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsStatic;
   }
@@ -170,6 +173,11 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
   if (isSemantic) {
     x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
   }
+  if (isTextureSemantic) {
+    x.flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::
+        IsTextureBasedSemantic;
+  }
+
   readMember(obj, "lightSetupKey", x.lightSetupKey);
   return true;
 }

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -92,6 +92,7 @@ inline JsonGenericValue toJsonValue(const esp::assets::AssetInfo& x,
   addMember(obj, "splitInstanceMesh", x.splitInstanceMesh, allocator);
   addMember(obj, "shaderTypeToUse", x.shaderTypeToUse, allocator);
   addMember(obj, "overridePhongMaterial", x.overridePhongMaterial, allocator);
+  addMember(obj, "isSemanticRGB", x.isSemanticRGB, allocator);
 
   return obj;
 }
@@ -106,6 +107,7 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
   readMember(obj, "splitInstanceMesh", x.splitInstanceMesh);
   readMember(obj, "shaderTypeToUse", x.shaderTypeToUse);
   readMember(obj, "overridePhongMaterial", x.overridePhongMaterial);
+  readMember(obj, "isSemanticRGB", x.isSemanticRGB);
   return true;
 }
 

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -92,7 +92,7 @@ inline JsonGenericValue toJsonValue(const esp::assets::AssetInfo& x,
   addMember(obj, "splitInstanceMesh", x.splitInstanceMesh, allocator);
   addMember(obj, "shaderTypeToUse", x.shaderTypeToUse, allocator);
   addMember(obj, "overridePhongMaterial", x.overridePhongMaterial, allocator);
-  addMember(obj, "isSemanticRGB", x.isSemanticRGB, allocator);
+  addMember(obj, "hasSemanticTextures", x.hasSemanticTextures, allocator);
 
   return obj;
 }
@@ -107,7 +107,7 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
   readMember(obj, "splitInstanceMesh", x.splitInstanceMesh);
   readMember(obj, "shaderTypeToUse", x.shaderTypeToUse);
   readMember(obj, "overridePhongMaterial", x.overridePhongMaterial);
-  readMember(obj, "isSemanticRGB", x.isSemanticRGB);
+  readMember(obj, "hasSemanticTextures", x.hasSemanticTextures);
   return true;
 }
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -484,6 +484,25 @@ class StageAttributes : public AbstractObjectAttributes {
     return get<bool>("has_semantic_textures");
   }
 
+  /**
+   * @brief Only set internally if we should use semantic textures for semantic
+   * asset loading/rendering. Should only be true if "has_semantic_textures" is
+   * true and user has specified to use semantic textures via
+   * SimulatorConfiguration.
+   */
+  bool useSemanticTextures() const {
+    return get<bool>("use_textures_for_semantic_rendering");
+  }
+
+  /**
+   * @brief Only should be called when simulator::reconfigure is called, based
+   * on setting
+   */
+  void setUseSemanticTextures(bool useSemanticTextures) {
+    set("use_textures_for_semantic_rendering",
+        (useSemanticTextures && getHasSemanticTextures()));
+  }
+
   // Currently not supported
   void setLoadSemanticMesh(bool loadSemanticMesh) {
     set("loadSemanticMesh", loadSemanticMesh);

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -211,7 +211,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     }
     scene.semanticColorMapBeingUsed_[idx] = objPtr->getColor();
     scene.semanticColorToIdAndRegion_.insert(
-        std::make_pair<uint32_t, std::pair<int, int>>(
+        std::pair<uint32_t, std::pair<int, int>>(
             objPtr->getColorAsInt(),
             {objPtr->semanticID(), objPtr->region()->getIndex()}));
   }

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -211,7 +211,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     }
     scene.semanticColorMapBeingUsed_[idx] = objPtr->getColor();
     scene.semanticColorToIdAndRegion_.insert(
-        std::pair<uint32_t, std::pair<int, int>>(
+        std::make_pair<uint32_t, std::pair<int, int>>(
             objPtr->getColorAsInt(),
             {objPtr->semanticID(), objPtr->region()->getIndex()}));
   }

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -180,8 +180,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   // build all object instances
   // object instances
   scene.objects_.clear();
-  scene.objects_.reserve(objInstance.size() + 1);
-
+  scene.objects_.reserve(objInstance.size());
   for (auto& item : objInstance) {
     TempHM3DObject obj = item.second;
     auto objPtr = std::make_shared<HM3DObjectInstance>(HM3DObjectInstance(
@@ -194,6 +193,21 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     scene.objects_.emplace_back(objPtr);
   }
   scene.hasVertColors_ = true;
+
+  // build colormap from colors defined in ssd
+  scene.semanticColorMapBeingUsed_.clear();
+  scene.semanticColorMapBeingUsed_.reserve(objInstance.size());
+  // build the color map with first maxSemanticID elements in proper order
+  // to match provided semantic IDs (so that ID is IDX of semantic color in
+  // map).  Any overflow colors will be uniquely mapped 1-to-1 to unmapped
+  // semantic IDs as their index.
+  for (const auto& objPtr : scene.objects_) {
+    int idx = objPtr->semanticID();
+    if (scene.semanticColorMapBeingUsed_.size() <= idx) {
+      scene.semanticColorMapBeingUsed_.resize(idx + 1);
+    }
+    scene.semanticColorMapBeingUsed_[idx] = objPtr->getColor();
+  }
 
   scene.levels_.clear();  // Not used for Hm3d currently
 

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -47,7 +47,7 @@ struct TempHM3DObject {
   int objCatID;
   std::string categoryName;
   std::string objInstanceName;
-  Mn::Vector3ub color;
+  unsigned colorInt;
   std::shared_ptr<SemanticRegion> region;
 };
 
@@ -65,7 +65,7 @@ struct TempHM3DCategory {
 
 void buildInstanceRegionCategory(
     int instanceID,
-    const Mn::Vector3ub colorVec,
+    const unsigned colorInt,
     const std::string& objCategoryName,
     int regionID,
     std::map<int, TempHM3DObject>& objInstance,
@@ -75,7 +75,7 @@ void buildInstanceRegionCategory(
   TempHM3DObject obj{
       instanceID, 0, objCategoryName,
       Cr::Utility::formatString("{}_{}", objCategoryName, instanceID),
-      colorVec};
+      colorInt};
   objInstance[instanceID] = obj;
   // find category, build if dne
   TempHM3DCategory tmpCat{
@@ -93,20 +93,13 @@ void buildInstanceRegionCategory(
 bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
                                    SemanticScene& scene,
                                    const quatf& /*rotation*/) {
-  // convert a hex string containing 3 bytes to a vector3ub (represents a color)
-  auto getVec3ub = [](const std::string& hexValStr) -> Mn::Vector3ub {
-    const unsigned val = std::stoul(hexValStr, nullptr, 16);
-    return {uint8_t((val >> 16) & 0xff), uint8_t((val >> 8) & 0xff),
-            uint8_t(val & 0xff)};
-  };
-
   // temp constructs
   std::map<int, TempHM3DObject> objInstance;
   std::map<int, TempHM3DRegion> regions;
   std::unordered_map<std::string, TempHM3DCategory> categories;
   // build an unknown object
-  buildInstanceRegionCategory(0, Mn::Vector3ub{}, "Unknown", -1, objInstance,
-                              regions, categories);
+  buildInstanceRegionCategory(0, 0, "Unknown", -1, objInstance, regions,
+                              categories);
 
   std::string line;
   while (std::getline(ifs, line)) {
@@ -132,14 +125,20 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     // ID is integer
     int instanceID = std::stoi(Cr::Utility::String::trim(subtokens[0]));
     // semantic color is 2nd token, as hex string
-    auto colorVec = getVec3ub(Cr::Utility::String::trim(subtokens[1]));
+    const unsigned colorInt =
+        std::stoul(Cr::Utility::String::trim(subtokens[1]), nullptr, 16);
+    // convert a hex string containing 3 bytes to a vector3ub (represents a
+    // color)
+    Mn::Vector3ub colorVec = {uint8_t((colorInt >> 16) & 0xff),
+                              uint8_t((colorInt >> 8) & 0xff),
+                              uint8_t(colorInt & 0xff)};
     // object category will possibly have commas
     const std::string objCategoryName = tokens[1];
     // room/region is always last token - get rid of first comma
     int regionID =
         std::stoi(Cr::Utility::String::trim(tokens[tokens.size() - 1], " ,"));
 
-    buildInstanceRegionCategory(instanceID, colorVec, objCategoryName, regionID,
+    buildInstanceRegionCategory(instanceID, colorInt, objCategoryName, regionID,
                                 objInstance, regions, categories);
 
   }  // while
@@ -184,7 +183,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   for (auto& item : objInstance) {
     TempHM3DObject obj = item.second;
     auto objPtr = std::make_shared<HM3DObjectInstance>(HM3DObjectInstance(
-        obj.objInstanceID, obj.objCatID, obj.objInstanceName, obj.color));
+        obj.objInstanceID, obj.objCatID, obj.objInstanceName, obj.colorInt));
     objPtr->category_ = categories[obj.categoryName].category_;
     // set region
     objPtr->parentIndex_ = obj.region->index_;
@@ -197,6 +196,8 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   // build colormap from colors defined in ssd
   scene.semanticColorMapBeingUsed_.clear();
   scene.semanticColorMapBeingUsed_.reserve(objInstance.size());
+  scene.semanticColorToIdAndRegion_.clear();
+  scene.semanticColorToIdAndRegion_.reserve(objInstance.size());
   // build the color map with first maxSemanticID elements in proper order
   // to match provided semantic IDs (so that ID is IDX of semantic color in
   // map).  Any overflow colors will be uniquely mapped 1-to-1 to unmapped
@@ -204,11 +205,18 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   for (const auto& objPtr : scene.objects_) {
     int idx = objPtr->semanticID();
     if (scene.semanticColorMapBeingUsed_.size() <= idx) {
+      // both are same size, so resize both at same time
       scene.semanticColorMapBeingUsed_.resize(idx + 1);
+      scene.semanticColorToIdAndRegion_.reserve(idx + 1);
     }
     scene.semanticColorMapBeingUsed_[idx] = objPtr->getColor();
+    scene.semanticColorToIdAndRegion_.insert(
+        std::make_pair<uint32_t, std::pair<int, int>>(
+            objPtr->getColorAsInt(),
+            {objPtr->semanticID(), objPtr->region()->getIndex()}));
   }
-
+  // we need to build the bbox on load for each semantic annotation
+  scene.needBBoxFromVertColors = true;
   scene.levels_.clear();  // Not used for Hm3d currently
 
   return true;

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -36,10 +36,11 @@ class HM3DObjectInstance : public SemanticObject {
   HM3DObjectInstance(int objInstanceID,
                      int objCatID,
                      const std::string& name,
-                     const Mn::Vector3ub& clr)
+                     const unsigned colorInt)
       : SemanticObject(), objCatID_(objCatID), name_(name) {
     index_ = objInstanceID;
-    color_ = clr;
+    // sets both colorAsInt_ and updates color_ vector to match
+    setColorAsInt(colorInt);
   }
 
   std::string id() const override { return name_; }

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -163,9 +163,30 @@ class SemanticScene {
    */
   bool hasVertColorsDefined() const { return hasVertColors_; }
 
+  /**
+   * @brief return a read-only reference to the semantic color map, where value
+   * is annotation color and index corresponds to id for that color. (HM3D only
+   * currently)
+   */
   const std::vector<Mn::Vector3ub>& getSemanticColorMap() const {
     return semanticColorMapBeingUsed_;
   }
+
+  /**
+   * @brief return a read-only reference to a mapping of semantic
+   * color-as-integer to id and region id.(HM3D only currently)
+   */
+  const std::unordered_map<uint32_t, std::pair<int, int>>&
+  getSemanticColorToIdAndRegionMap() const {
+    return semanticColorToIdAndRegion_;
+  }
+
+  /**
+   * @Brief whether or not we should build bounding boxes around vertex
+   * annotations on semantic asset load. Currently used for HM3D.
+   */
+
+  bool buildBBoxFromVertColors() const { return needBBoxFromVertColors; }
 
  protected:
   /**
@@ -250,6 +271,12 @@ class SemanticScene {
 
   // Currently only supported by HM3D semantic files.
   bool hasVertColors_ = false;
+
+  /**
+   * @Brief whether or not we should build bounding boxes around vertex
+   * annotations on semantic asset load. Currently used for HM3D.
+   */
+  bool needBBoxFromVertColors = false;
   std::string name_;
   std::string label_;
   box3f bbox_;
@@ -265,6 +292,12 @@ class SemanticScene {
    * Index/semantic ID (HM3D only currently)
    */
   std::vector<Mn::Vector3ub> semanticColorMapBeingUsed_{};
+  /**
+   * @brief Map of integer color to segment and region ids. Used for
+   * transforming provided vertex colors. (HM3D only currently)
+   */
+  std::unordered_map<uint32_t, std::pair<int, int>>
+      semanticColorToIdAndRegion_{};
 
   ESP_SMART_POINTERS(SemanticScene)
 };
@@ -364,7 +397,22 @@ class SemanticObject {
   }
 
   Mn::Vector3ub getColor() const { return color_; }
-  void setColor(Mn::Vector3ub _color) { color_ = _color; }
+
+  void setColor(Mn::Vector3ub _color) {
+    color_ = _color;
+    // update colorAsInt_
+    colorAsInt_ = (unsigned(color_[0]) << 16) | (unsigned(color_[1]) << 8) |
+                  unsigned(color_[2]);
+  }
+
+  unsigned getColorAsInt() const { return colorAsInt_; }
+
+  void setColorAsInt(const unsigned _colorAsInt) {
+    colorAsInt_ = _colorAsInt;
+    // update color_ vector
+    color_ = {uint8_t((colorAsInt_ >> 16) & 0xff),
+              uint8_t((colorAsInt_ >> 8) & 0xff), uint8_t(colorAsInt_ & 0xff)};
+  }
 
  protected:
   /**
@@ -373,6 +421,8 @@ class SemanticObject {
   int index_{};
   // specified color for this object instance.
   Mn::Vector3ub color_{};
+  // specified color as unsigned int
+  unsigned colorAsInt_{};
 
   /**
    * @brief References the parent region for this object

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -163,6 +163,10 @@ class SemanticScene {
    */
   bool hasVertColorsDefined() const { return hasVertColors_; }
 
+  const std::vector<Mn::Vector3ub>& getSemanticColorMap() const {
+    return semanticColorMapBeingUsed_;
+  }
+
  protected:
   /**
    * @brief Verify a requested file exists.
@@ -256,6 +260,11 @@ class SemanticScene {
   std::vector<std::shared_ptr<SemanticObject>> objects_;
   //! map from combined region-segment id to objectIndex for semantic mesh
   std::unordered_map<int, int> segmentToObjectIndex_;
+  /**
+   * @brief List of mapped vertex colors, where index corresponds to object
+   * Index/semantic ID (HM3D only currently)
+   */
+  std::vector<Mn::Vector3ub> semanticColorMapBeingUsed_{};
 
   ESP_SMART_POINTERS(SemanticScene)
 };

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -384,7 +384,9 @@ bool Simulator::instanceStageForSceneAttributes(
   // set scaling values for this instance of stage attributes
   stageAttributes->setScale(stageAttributes->getScale() *
                             stageInstanceAttributes->getUniformScale());
-
+  // this will only be true if semantic textures have been set to be available
+  // from the dataset config
+  stageAttributes->setUseSemanticTextures(config_.useSemanticTexturesIfFound);
   // set stage's ref to ssd file
   stageAttributes->setSemanticDescriptorFilename(
       metadataMediator_->getSemanticSceneDescriptorPathByHandle(

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -24,6 +24,7 @@ bool operator==(const SimulatorConfiguration& a,
          a.requiresTextures == b.requiresTextures &&
          a.leaveContextWithBackgroundRenderer ==
              b.leaveContextWithBackgroundRenderer &&
+         a.useSemanticTexturesIfFound == b.useSemanticTexturesIfFound &&
          a.sceneDatasetConfigFile == b.sceneDatasetConfigFile &&
          a.physicsConfigFile == b.physicsConfigFile &&
          a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -82,6 +82,11 @@ struct SimulatorConfiguration {
    * @brief setup the image based lighting for pbr rendering
    */
   bool pbrImageBasedLighting = false;
+  /**
+   * @brief use texture-based semantics if the specified asset/dataset support
+   * them.
+   */
+  bool useSemanticTexturesIfFound = false;
 
   ESP_SMART_POINTERS(SimulatorConfiguration)
 };

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -86,7 +86,7 @@ struct SimulatorConfiguration {
    * @brief use texture-based semantics if the specified asset/dataset support
    * them.
    */
-  bool useSemanticTexturesIfFound = false;
+  bool useSemanticTexturesIfFound = true;
 
   ESP_SMART_POINTERS(SimulatorConfiguration)
 };

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -85,17 +85,15 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
       Cr::Utility::formatString("Error loading instance mesh data from file {}",
                                 semanticFilename));
 
-  static std::vector<std::unique_ptr<GenericSemanticMeshData>> meshVec =
+  static std::unique_ptr<GenericSemanticMeshData> semanticMesh =
       GenericSemanticMeshData::buildSemanticMeshData(
-          *meshData, semanticFilename, false, dummyColormap, false);
-  // verify result vector holds a mesh
-  CORRADE_VERIFY(!meshVec.empty());
+          *meshData, semanticFilename, dummyColormap, false);
   // verify first entry exists
-  CORRADE_VERIFY(meshVec[0]);
+  CORRADE_VERIFY(semanticMesh);
 
-  const auto& vbo = meshVec[0]->getVertexBufferObjectCPU();
-  const auto& objectIds = meshVec[0]->getObjectIdsBufferObjectCPU();
-  const auto& ibo = meshVec[0]->getIndexBufferObjectCPU();
+  const auto& vbo = semanticMesh->getVertexBufferObjectCPU();
+  const auto& objectIds = semanticMesh->getObjectIdsBufferObjectCPU();
+  const auto& ibo = semanticMesh->getIndexBufferObjectCPU();
 
   for (const auto& obj : scene.objects()) {
     if (obj == nullptr)

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -57,13 +57,13 @@ MeshData SceneLoader::load(const AssetInfo& info) {
         Cr::Utility::formatString(
             "Error loading instance mesh data from file {}", info.filepath));
 
-    std::vector<GenericSemanticMeshData::uptr> instanceMeshData =
-        GenericSemanticMeshData::buildSemanticMeshData(
-            *meshData, info.filepath, false, dummyColormap, false);
+    GenericSemanticMeshData::uptr instanceMeshData =
+        GenericSemanticMeshData::buildSemanticMeshData(*meshData, info.filepath,
+                                                       dummyColormap, false);
 
-    const auto& vbo = instanceMeshData[0]->getVertexBufferObjectCPU();
-    const auto& cbo = instanceMeshData[0]->getColorBufferObjectCPU();
-    const auto& ibo = instanceMeshData[0]->getIndexBufferObjectCPU();
+    const auto& vbo = instanceMeshData->getVertexBufferObjectCPU();
+    const auto& cbo = instanceMeshData->getColorBufferObjectCPU();
+    const auto& ibo = instanceMeshData->getIndexBufferObjectCPU();
 
     mesh.vbo.resize(vbo.size());
     Cr::Utility::copy(vbo, Cr::Containers::arrayCast<Mn::Vector3>(

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -771,9 +771,10 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("object-dir",
                "Provide a directory to search for object config files "
                "(relative to habitat-sim directory).")
-      .addBooleanOption("orthographic")
-      .setHelp("orthographic",
-               "If specified, use orthographic camera to view scene.")
+      .addBooleanOption("semanticTextures")
+      .setHelp("semanticTextures",
+               "If specified, use texture-based semantic annotations if the "
+               "scene/dataset support them.")
       .addBooleanOption("disable-navmesh")
       .setHelp("disable-navmesh",
                "Disable the navmesh, disabling agent navigation constraints.")
@@ -817,7 +818,6 @@ Viewer::Viewer(const Arguments& arguments)
     debugBullet_ = true;
   }
 
-  isOrtho_ = args.isSet("orthographic");
   agentTransformLoadPath_ = args.value("agent-transform-filepath");
   gfxReplayRecordFilepath_ = args.value("gfx-replay-record-filepath");
 
@@ -875,6 +875,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig_.frustumCulling = true;
   simConfig_.requiresTextures = true;
   simConfig_.enableGfxReplaySave = !gfxReplayRecordFilepath_.empty();
+  simConfig_.useSemanticTexturesIfFound = args.isSet("semanticTextures");
   if (args.isSet("stage-requires-lighting")) {
     ESP_DEBUG() << "Stage using DEFAULT_LIGHTING_KEY";
     simConfig_.sceneLightSetupKey = esp::DEFAULT_LIGHTING_KEY;

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1517,16 +1517,20 @@ void Viewer::drawEvent() {
   } else {
     // Depth Or Semantic, or Non-pinhole RGBA
     simulator_->drawObservation(defaultAgentId_, sensorVisID_);
+
     esp::gfx::RenderTarget* sensorRenderTarget =
         simulator_->getRenderTarget(defaultAgentId_, sensorVisID_);
     CORRADE_ASSERT(sensorRenderTarget,
                    "Error in Viewer::drawEvent: sensor's rendering target "
                    "cannot be nullptr.", );
+
     if (visualizeMode_ == VisualizeMode::Depth) {
       simulator_->visualizeObservation(defaultAgentId_, sensorVisID_,
                                        1.0f / 512.0f,  // colorMapOffset
                                        1.0f / 12.0f);  // colorMapScale
     } else if (visualizeMode_ == VisualizeMode::Semantic) {
+      Mn::GL::defaultFramebuffer.clear(Mn::GL::FramebufferClear::Color |
+                                       Mn::GL::FramebufferClear::Depth);
       simulator_->visualizeObservation(defaultAgentId_, sensorVisID_);
     }
     sensorRenderTarget->blitRgbaToDefault();

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -771,10 +771,10 @@ Viewer::Viewer(const Arguments& arguments)
       .setHelp("object-dir",
                "Provide a directory to search for object config files "
                "(relative to habitat-sim directory).")
-      .addBooleanOption("semanticTextures")
-      .setHelp("semanticTextures",
-               "If specified, use texture-based semantic annotations if the "
-               "scene/dataset support them.")
+      .addBooleanOption("no-semantic-textures")
+      .setHelp("no-semantic-textures",
+               "If specified, force vertex semantic annotations even if the "
+               "scene/dataset support texture-based.")
       .addBooleanOption("disable-navmesh")
       .setHelp("disable-navmesh",
                "Disable the navmesh, disabling agent navigation constraints.")
@@ -875,7 +875,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig_.frustumCulling = true;
   simConfig_.requiresTextures = true;
   simConfig_.enableGfxReplaySave = !gfxReplayRecordFilepath_.empty();
-  simConfig_.useSemanticTexturesIfFound = args.isSet("semanticTextures");
+  simConfig_.useSemanticTexturesIfFound = !args.isSet("no-semantic-textures");
   if (args.isSet("stage-requires-lighting")) {
     ESP_DEBUG() << "Stage using DEFAULT_LIGHTING_KEY";
     simConfig_.sceneLightSetupKey = esp::DEFAULT_LIGHTING_KEY;


### PR DESCRIPTION
## Motivation and Context
This PR provides support for semantically annotated textures on meshes. Bounding boxes are still calculated using vertex annotations, but the actual semantic annotations are derived from textures.

To enable texture-based semantics both of the following settings must be set to true
 - The dataset used must support texture semantic annotations (currently only HM3D) - the scene dataset config or stage config must have the field ` "has_semantic_textures": true`
 - SimulatorConfiguration /sim_config has a field "use_semantic_textures" (in python) that needs to be set to true.
 
 Loading of texture-based semantics is currently approx. 15-20% slower than loading the same scene for vertex annotation.  This primarily caused by the online conversion from semantic color textures to integer semantic id textures. These will eventually be precomputed.

TODO : test case to verify integrity of annotation.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
