### PR TITLE
[Bugfix]--verify directory is not empty before using it to save attributes

### DIFF
--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -478,7 +478,7 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
   // first strip object's file directory from objectHandle
   std::size_t pos = objectHandle.find(fileDirectory);
   std::string fileNameRaw;
-  if (pos == std::string::npos) {
+  if ((fileDirectory.empty()) || (pos == std::string::npos)) {
     // directory not found, construct filename from simplified object handle
     fileNameRaw = FileUtil::filename(objectHandle);
   } else {


### PR DESCRIPTION
## Motivation and Context
A minor bugfix for when the scene directory is empty, should not consider the file name found.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All local c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
