### PR TITLE
[HM3D]--Connected Components Utility; CC-based Semantic BBox generation; Mesh connectivity reporting

### DIFF
--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -81,21 +81,6 @@ void BaseMesh::buildColorMapToUse(
 
 }  // BaseMesh::buildColorMapToUse
 
-namespace {
-// TODO remove when/if Magnum ever supports this function for Color3ub
-constexpr const char Hex[]{"0123456789abcdef"};
-}  // namespace
-std::string BaseMesh::getColorAsString(Magnum::Color3ub color) const {
-  char out[] = "#______";
-  out[1] = Hex[(color.r() >> 4) & 0xf];
-  out[2] = Hex[(color.r() >> 0) & 0xf];
-  out[3] = Hex[(color.g() >> 4) & 0xf];
-  out[4] = Hex[(color.g() >> 0) & 0xf];
-  out[5] = Hex[(color.b() >> 4) & 0xf];
-  out[6] = Hex[(color.b() >> 0) & 0xf];
-  return std::string(out);
-}
-
 void BaseMesh::buildSemanticOBBs(
     const std::vector<Mn::Vector3>& vertices,
     const std::vector<uint16_t>& vertSemanticIDs,
@@ -154,20 +139,21 @@ void BaseMesh::buildSemanticOBBs(
     Mn::Vector3 center{};
     Mn::Vector3 dims{};
 
-    const std::string debugStr = Cr::Utility::formatString(
-        "{} Semantic ID : {} : color : {} tag : {} present in {} "
-        "verts | ",
-        msgPrefix, semanticID, getColorAsString(ssdObj.getColor()), ssdObj.id(),
-        vertCounts[semanticID]);
     if (vertCounts[semanticID] == 0) {
       ESP_DEBUG() << Cr::Utility::formatString(
-          "{}No verts have specified Semantic ID.", debugStr);
+          "{} Semantic ID : {} : color : {} tag : {} present in {} "
+          "verts | No verts have specified Semantic ID.",
+          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
+          ssdObj.id(), vertCounts[semanticID]);
     } else {
       center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
       dims = vertMax[semanticID] - vertMin[semanticID];
       ESP_DEBUG() << Cr::Utility::formatString(
-          "{}BB Center [{} {} {}] Dims [{} {} {}]", debugStr, center.x(),
-          center.y(), center.z(), dims.x(), dims.y(), dims.z());
+          "{} Semantic ID : {} : color : {} tag : {} present in {} verts | BB "
+          "Center [{} {} {}] Dims [{} {} {}]",
+          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
+          ssdObj.id(), vertCounts[semanticID], center.x(), center.y(),
+          center.z(), dims.x(), dims.y(), dims.z());
     }
     ssdObj.setObb(Mn::EigenIntegration::cast<esp::vec3f>(center),
                   Mn::EigenIntegration::cast<esp::vec3f>(dims));

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -157,7 +157,7 @@ void BaseMesh::buildSemanticOBBs(
     const std::string debugStr = Cr::Utility::formatString(
         "{} Semantic ID : {} : color : {} tag : {} present in {} "
         "verts | ",
-        msgPrefix, semanticID, ssdObj.getColorAsInt(), ssdObj.id(),
+        msgPrefix, semanticID, getColorAsString(ssdObj.getColor()), ssdObj.id(),
         vertCounts[semanticID]);
     if (vertCounts[semanticID] == 0) {
       ESP_DEBUG() << Cr::Utility::formatString(

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -166,7 +166,7 @@ void BaseMesh::buildSemanticOBBs(
       center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
       dims = vertMax[semanticID] - vertMin[semanticID];
       ESP_DEBUG() << Cr::Utility::formatString(
-          "{}BB Center [{},{},{}] Dims [{},{},{}]", debugStr, center.x(),
+          "{}BB Center [{} {} {}] Dims [{} {} {}]", debugStr, center.x(),
           center.y(), center.z(), dims.x(), dims.y(), dims.z());
     }
     ssdObj.setObb(Mn::EigenIntegration::cast<esp::vec3f>(center),

--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -11,7 +11,6 @@
 #include <Magnum/Math/PackingBatch.h>
 #include <Magnum/MeshTools/Compile.h>
 #include <Magnum/MeshTools/RemoveDuplicates.h>
-#include "esp/scene/SemanticScene.h"
 
 namespace Cr = Corrade;
 namespace Mn = Magnum;
@@ -80,85 +79,6 @@ void BaseMesh::buildColorMapToUse(
   }
 
 }  // BaseMesh::buildColorMapToUse
-
-void BaseMesh::buildSemanticOBBs(
-    const std::vector<Mn::Vector3>& vertices,
-    const std::vector<uint16_t>& vertSemanticIDs,
-    const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
-    const std::string& msgPrefix) const {
-  // build per-SSD object vector of known semantic IDs
-  std::size_t numSSDObjs = ssdObjs.size();
-  std::vector<int> semanticIDToSSOBJidx(numSSDObjs, -1);
-  for (int i = 0; i < numSSDObjs; ++i) {
-    const auto& ssdObj = *ssdObjs[i];
-    int semanticID = ssdObj.semanticID();
-    // should not happen unless semantic ids are not sequential
-    if (semanticIDToSSOBJidx.size() <= semanticID) {
-      semanticIDToSSOBJidx.resize(semanticID + 1);
-    }
-    semanticIDToSSOBJidx[semanticID] = i;
-  }
-
-  // aggegates of per-semantic ID mins and maxes
-  std::vector<Mn::Vector3> vertMax(
-      semanticIDToSSOBJidx.size(),
-      {-Mn::Constants::inf(), -Mn::Constants::inf(), -Mn::Constants::inf()});
-  std::vector<Mn::Vector3> vertMin(
-      semanticIDToSSOBJidx.size(),
-      {Mn::Constants::inf(), Mn::Constants::inf(), Mn::Constants::inf()});
-  std::vector<int> vertCounts(semanticIDToSSOBJidx.size());
-
-  // for each vertex, map vert min and max for each known semantic ID
-  // Known semantic IDs are expected to be contiguous, and correspond to the
-  // number of unique ssdObjs mappings.
-
-  for (int vertIdx = 0; vertIdx < vertSemanticIDs.size(); ++vertIdx) {
-    // semantic ID on vertex - valid values are 1->semanticIDToSSOBJidx.size().
-    // Invalid/unknown semantic ids are > semanticIDToSSOBJidx.size()
-    const auto semanticID = vertSemanticIDs[vertIdx];
-    if ((semanticID >= 0) && (semanticID < semanticIDToSSOBJidx.size())) {
-      const auto vert = vertices[vertIdx];
-      // FOR VERT-BASED OBB CALC
-      // only support bbs for known colors that map to semantic objects
-      vertMax[semanticID] = Mn::Math::max(vertMax[semanticID], vert);
-      vertMin[semanticID] = Mn::Math::min(vertMin[semanticID], vert);
-      vertCounts[semanticID] += 1;
-    }
-  }
-
-  // with mins/maxs per ID, map to objs
-  // give each ssdObj the values to build its OBB
-  for (int semanticID = 0; semanticID < semanticIDToSSOBJidx.size();
-       ++semanticID) {
-    int objIdx = semanticIDToSSOBJidx[semanticID];
-    if (objIdx == -1) {
-      continue;
-    }
-    // get object with given semantic ID
-    auto& ssdObj = *ssdObjs[objIdx];
-    Mn::Vector3 center{};
-    Mn::Vector3 dims{};
-
-    if (vertCounts[semanticID] == 0) {
-      ESP_DEBUG() << Cr::Utility::formatString(
-          "{} Semantic ID : {} : color : {} tag : {} present in {} "
-          "verts | No verts have specified Semantic ID.",
-          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
-          ssdObj.id(), vertCounts[semanticID]);
-    } else {
-      center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
-      dims = vertMax[semanticID] - vertMin[semanticID];
-      ESP_DEBUG() << Cr::Utility::formatString(
-          "{} Semantic ID : {} : color : {} tag : {} present in {} verts | BB "
-          "Center [{} {} {}] Dims [{} {} {}]",
-          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
-          ssdObj.id(), vertCounts[semanticID], center.x(), center.y(),
-          center.z(), dims.x(), dims.y(), dims.z());
-    }
-    ssdObj.setObb(Mn::EigenIntegration::cast<esp::vec3f>(center),
-                  Mn::EigenIntegration::cast<esp::vec3f>(dims));
-  }
-}  // BaseMesh::buildSemanticOBBs
 
 }  // namespace assets
 }  // namespace esp

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -150,8 +150,6 @@ class BaseMesh {
   Magnum::Range3D BB;
 
  protected:
-  std::string getColorAsString(Magnum::Color3ub color) const;
-
   /**
    * @brief Build a colormap to use either from mapping given list of per-vertex
    * object IDs to per-vertex Colors, or through a mapping of a Magnum-provided

--- a/src/esp/assets/BaseMesh.h
+++ b/src/esp/assets/BaseMesh.h
@@ -179,21 +179,6 @@ class BaseMesh {
                          Cr::Containers::Array<Mn::Color3ub>& destColors) const;
 
   /**
-   * @brief Build semantic OBBs based on presence of semantic IDs on vertices.
-   * @param vertices Ref to vertex array
-   * @param vertSemanticIDs Ref to per-vertex semantic IDs persent on source
-   * mesh, both known in semantic scene descriptor, and unknown.  Known IDs are
-   * expected to start at 1 and be contiguous, followed by unknown semantic IDs
-   * @param ssdObjs The known semantic scene descriptor objects for the mesh
-   * @param msgPrefix Debug message prefix, referencing caller.
-   */
-  void buildSemanticOBBs(
-      const std::vector<Mn::Vector3>& vertices,
-      const std::vector<uint16_t>& vertSemanticIDs,
-      const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
-      const std::string& msgPrefix) const;
-
-  /**
    * @brief Identifies the derived type of this object and the format of the
    * asset.
    */

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -293,11 +293,6 @@ GenericSemanticMeshData::buildSemanticMeshData(
   if (semanticScene && (semanticScene->buildBBoxFromVertColors())) {
     float fractionOfMaxBBoxSize = semanticScene->CCFractionToUseForBBox();
     if (fractionOfMaxBBoxSize > 0.0f) {
-      // temp
-      scene::SemanticScene::buildSemanticOBBs(
-          semanticMeshData->cpu_vbo_, semanticMeshData->objectIds_,
-          semanticScene->objects(), dbgMsgPrefix);
-
       // build adj list
       std::vector<std::set<uint32_t>> adjList = geo::buildAdjList(
           semanticMeshData->cpu_vbo_.size(), semanticMeshData->cpu_ibo_);
@@ -308,6 +303,7 @@ GenericSemanticMeshData::buildSemanticMeshData(
 
       // FOR VERT-BASED OBB CALC build semantic (actually AABBs currently)
       // only use CCs that have some fraction of largest CC's bbox volume.
+      // Currently uses only max volume CC bbox for disjoint semantic regions.
       scene::SemanticScene::buildSemanticOBBsFromCCs(
           semanticMeshData->cpu_vbo_, clrsToComponents, semanticScene,
           dbgMsgPrefix);

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -412,7 +412,7 @@ GenericSemanticMeshData::findConnectedComponentsByColor() {
         // not found already
         findIter = clrsToComponents.insert({colorKey, {}}).first;
       }
-      findIter->second.push_back(setOfVerts);
+      findIter->second.push_back(std::move(setOfVerts));
     }
   }
 
@@ -432,10 +432,13 @@ GenericSemanticMeshData::buildSemanticCCReportData() {
     auto findIter = results.find(colorKey);
     if (findIter == results.end()) {
       // not found already
-      findIter = results.insert({colorKey, {}}).first;
+      findIter =
+          results
+              .emplace(colorKey, std::vector<std::pair<int, esp::geo::OBB>>{})
+              .first;
     }
     for (const std::set<uint32_t>& vertSet : vectorOfSets) {
-      findIter->second.push_back(
+      findIter->second.emplace_back(
           buildOBBAndCountForSetOfVerts(cpu_vbo_, vertSet));
     }
   }

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -16,6 +16,7 @@
 
 #include "BaseMesh.h"
 #include "esp/core/Esp.h"
+#include "esp/geo/OBB.h"
 
 namespace esp {
 namespace scene {
@@ -87,11 +88,19 @@ class GenericSemanticMeshData : public BaseMesh {
 
   /**
    * @brief Calculate mesh connectivity based color.
-   * @return unordered multi-map of connected components, keyed by color.
+   * @return unordered map of vectors of connected component vert idxs, keyed by
+   * color.
    */
 
-  std::unordered_multimap<std::string, std::set<uint32_t>>
+  std::unordered_map<std::string, std::vector<std::set<uint32_t>>>
   findConnectedComponentsByColor();
+
+  /**
+   * @build a per-color map of all bounding boxes for each CC found in the mesh,
+   * and the count of verts responsible for each.
+   */
+  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  buildSemanticCCReportData();
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -87,20 +87,11 @@ class GenericSemanticMeshData : public BaseMesh {
       const std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
 
   /**
-   * @brief Calculate mesh connectivity based color.
-   * @return unordered map of vectors of connected component vert idxs, keyed by
-   * color.
-   */
-
-  std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
-  findConnectedComponentsByColor();
-
-  /**
    * @build a per-color map of all bounding boxes for each CC found in the mesh,
    * and the count of verts responsible for each.
    */
   std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
-  buildSemanticCCReportData();
+  buildCCBasedSemanticBBoxes();
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -92,14 +92,14 @@ class GenericSemanticMeshData : public BaseMesh {
    * color.
    */
 
-  std::unordered_map<std::string, std::vector<std::set<uint32_t>>>
+  std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
   findConnectedComponentsByColor();
 
   /**
    * @build a per-color map of all bounding boxes for each CC found in the mesh,
    * and the count of verts responsible for each.
    */
-  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
   buildSemanticCCReportData();
 
   // ==== rendering ====

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -16,7 +16,7 @@
 
 #include "BaseMesh.h"
 #include "esp/core/Esp.h"
-#include "esp/geo/OBB.h"
+#include "esp/scene/SemanticScene.h"
 
 namespace esp {
 namespace scene {
@@ -53,7 +53,7 @@ class GenericSemanticMeshData : public BaseMesh {
    * visualization or matching to semantic IDs.
    * @param convertToSRGB Whether the source vertex colors from the @p meshData
    * should be converted to SRGB
-   * @param semanticScene The SSD for the instance mesh being loaded.
+   * @param semanticScene The SSD for the semantic mesh being loaded.
    * @return vector holding one or more mesh results from the semantic asset
    * file.
    */
@@ -77,7 +77,7 @@ class GenericSemanticMeshData : public BaseMesh {
    * visualization or matching to semantic IDs.
    * @param convertToSRGB Whether the source vertex colors from the @p meshData
    * should be converted to SRGB
-   * @param semanticScene The SSD for the instance mesh being loaded.
+   * @param semanticScene The SSD for the semantic mesh being loaded.
    * @return vector holding one or more mesh results from the semantic asset
    * file.
    */
@@ -87,11 +87,16 @@ class GenericSemanticMeshData : public BaseMesh {
       const std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
 
   /**
-   * @build a per-color map of all bounding boxes for each CC found in the mesh,
-   * and the count of verts responsible for each.
+   * @build a per-color/per-semantic ID map of all bounding boxes for each CC
+   * found in the mesh, and the count of verts responsible for each.
+   * @param semanticScene The SSD for the current semantic mesh.  Used to query
+   * semantic objs. If nullptr, this function returns hex-color-keyed map,
+   * otherwise returns SemanticID-keyed map.
    */
-  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
-  buildCCBasedSemanticBBoxes();
+  std::unordered_map<uint32_t,
+                     std::vector<std::shared_ptr<scene::CCSemanticObject>>>
+  buildCCBasedSemanticObjs(
+      const std::shared_ptr<scene::SemanticScene>& semanticScene);
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -9,6 +9,7 @@
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -83,6 +84,14 @@ class GenericSemanticMeshData : public BaseMesh {
   static std::vector<std::unique_ptr<GenericSemanticMeshData>>
   partitionSemanticMeshData(
       const std::unique_ptr<GenericSemanticMeshData>& semanticMeshData);
+
+  /**
+   * @brief Calculate mesh connectivity based color.
+   * @return unordered multi-map of connected components, keyed by color.
+   */
+
+  std::unordered_multimap<std::string, std::set<uint32_t>>
+  findConnectedComponentsByColor();
 
   // ==== rendering ====
   void uploadBuffersToGPU(bool forceReload = false) override;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -217,7 +217,7 @@ void ResourceManager::initPhysicsManager(
   physicsManager->initPhysics(parent);
 }  // ResourceManager::initPhysicsManager
 
-std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
+std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
 ResourceManager::buildSemanticCCReport(
     const StageAttributes::ptr& stageAttributes) {
   std::map<std::string, AssetInfo> assetInfoMap =
@@ -239,32 +239,10 @@ ResourceManager::buildSemanticCCReport(
   GenericSemanticMeshData::uptr semanticMeshData =
       flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
 
-  // return connectivity query results - per color map of vectors of pairs of
-  // vert counts and OBBs
-  auto semanticRes = semanticMeshData->buildCCBasedSemanticBBoxes();
-  // build temp map of colors to SemanticObject IDs
-  const auto& semanticObjs = semanticScene_->objects();
-
-  std::unordered_map<uint32_t, uint32_t> mapColorIntsToSemanticObjIDXs;
-  mapColorIntsToSemanticObjIDXs.reserve(mapColorIntsToSemanticObjIDXs.size());
-  for (uint32_t i = 0; i < semanticObjs.size(); ++i) {
-    const auto obj = semanticObjs[i];
-    mapColorIntsToSemanticObjIDXs.insert({obj->getColorAsInt(), i});
-  }
-  // build map with key being semanticObject IDX in semantic Objects array
-  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
-      results;
-  for (auto& elem : mapColorIntsToSemanticObjIDXs) {
-    const auto objID = elem.second;
-    const auto colorAsInt = elem.first;
-    auto mapEntry = semanticRes.find(colorAsInt);
-    if (mapEntry != semanticRes.end()) {
-      results.emplace(objID, std::move(mapEntry->second));
-    }
-  }
-  return results;
-
-}  // namespace assets
+  // return connectivity query results - per color map of vectors of CC-based
+  // Semantic objects.
+  return semanticMeshData->buildCCBasedSemanticObjs(semanticScene_);
+}  // ResourceManager::buildSemanticCCReport
 
 bool ResourceManager::loadSemanticSceneDescriptor(
     const std::string& ssdFilename,

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -246,6 +246,7 @@ ResourceManager::buildSemanticCCReport(
   const auto& semanticObjs = semanticScene_->objects();
 
   std::unordered_map<uint32_t, uint32_t> mapColorIntsToSemanticObjIDXs;
+  mapColorIntsToSemanticObjIDXs.reserve(mapColorIntsToSemanticObjIDXs.size());
   for (uint32_t i = 0; i < semanticObjs.size(); ++i) {
     const auto obj = semanticObjs[i];
     mapColorIntsToSemanticObjIDXs.insert({obj->getColorAsInt(), i});
@@ -258,7 +259,7 @@ ResourceManager::buildSemanticCCReport(
     const auto colorAsInt = elem.first;
     auto mapEntry = semanticRes.find(colorAsInt);
     if (mapEntry != semanticRes.end()) {
-      results.insert({objID, std::move(mapEntry->second)});
+      results.emplace(objID, std::move(mapEntry->second));
     }
   }
   return results;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -217,7 +217,8 @@ void ResourceManager::initPhysicsManager(
   physicsManager->initPhysics(parent);
 }  // ResourceManager::initPhysicsManager
 
-void ResourceManager::buildSemanticCCReport(
+std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+ResourceManager::buildSemanticCCReport(
     const StageAttributes::ptr& stageAttributes) {
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, false, true);
@@ -238,9 +239,9 @@ void ResourceManager::buildSemanticCCReport(
   GenericSemanticMeshData::uptr semanticMeshData =
       flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
 
-  // return connectivity query results - per color multi-map of vert idxs in
-  // semanticMeshData
-  auto ccCalcRes = semanticMeshData->findConnectedComponentsByColor();
+  // return connectivity query results - per color map of vectors of pairs of
+  // vert counts and OBBs
+  return semanticMeshData->buildSemanticCCReportData();
 
 }  // ResourceManager::buildSemanticCCReport
 
@@ -1450,10 +1451,6 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
   if (semanticScene_) {
     buildSemanticColorAsIntMap();
   }
-
-  // return connectivity query results - per color multi-map of vert idxs in
-  // semanticMeshData
-  auto ccCalcRes = semanticMeshData->findConnectedComponentsByColor();
   return semanticMeshData;
 }  // ResourceManager::loadAndFlattenImportedMeshData
 

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -321,7 +321,7 @@ void ResourceManager::buildSemanticColorMap() {
   semanticColorMapBeingUsed_.clear();
   semanticColorAsInt_.clear();
   const auto& ssdClrMap = semanticScene_->getSemanticColorMap();
-  if (ssdClrMap.size() == 0) {
+  if (ssdClrMap.empty()) {
     return;
   }
 
@@ -336,7 +336,7 @@ void ResourceManager::buildSemanticColorMap() {
 
 void ResourceManager::buildSemanticColorAsIntMap() {
   semanticColorAsInt_.clear();
-  if (semanticColorMapBeingUsed_.size() == 0) {
+  if (semanticColorMapBeingUsed_.empty()) {
     return;
   }
   semanticColorAsInt_.reserve(semanticColorMapBeingUsed_.size());

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -217,7 +217,7 @@ void ResourceManager::initPhysicsManager(
   physicsManager->initPhysics(parent);
 }  // ResourceManager::initPhysicsManager
 
-std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
 ResourceManager::buildSemanticCCReport(
     const StageAttributes::ptr& stageAttributes) {
   std::map<std::string, AssetInfo> assetInfoMap =
@@ -241,9 +241,29 @@ ResourceManager::buildSemanticCCReport(
 
   // return connectivity query results - per color map of vectors of pairs of
   // vert counts and OBBs
-  return semanticMeshData->buildSemanticCCReportData();
+  auto semanticRes = semanticMeshData->buildSemanticCCReportData();
+  // build temp map of colors to SemanticObject IDs
+  const auto& semanticObjs = semanticScene_->objects();
 
-}  // ResourceManager::buildSemanticCCReport
+  std::unordered_map<uint32_t, uint32_t> mapColorIntsToSemanticObjIDXs;
+  for (uint32_t i = 0; i < semanticObjs.size(); ++i) {
+    const auto obj = semanticObjs[i];
+    mapColorIntsToSemanticObjIDXs.insert({obj->getColorAsInt(), i});
+  }
+  // build map with key being semanticObject IDX in semantic Objects array
+  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
+      results;
+  for (auto& elem : mapColorIntsToSemanticObjIDXs) {
+    const auto objID = elem.second;
+    const auto colorAsInt = elem.first;
+    auto mapEntry = semanticRes.find(colorAsInt);
+    if (mapEntry != semanticRes.end()) {
+      results.insert({objID, std::move(mapEntry->second)});
+    }
+  }
+  return results;
+
+}  // namespace assets
 
 bool ResourceManager::loadSemanticSceneDescriptor(
     const std::string& ssdFilename,

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -241,7 +241,7 @@ ResourceManager::buildSemanticCCReport(
 
   // return connectivity query results - per color map of vectors of pairs of
   // vert counts and OBBs
-  auto semanticRes = semanticMeshData->buildSemanticCCReportData();
+  auto semanticRes = semanticMeshData->buildCCBasedSemanticBBoxes();
   // build temp map of colors to SemanticObject IDs
   const auto& semanticObjs = semanticScene_->objects();
 
@@ -362,13 +362,13 @@ void ResourceManager::buildSemanticColorAsIntMap() {
     return;
   }
   semanticColorAsInt_.reserve(semanticColorMapBeingUsed_.size());
+
   // build listing of colors as ints, with idx being semantic ID
   std::transform(semanticColorMapBeingUsed_.cbegin(),
                  semanticColorMapBeingUsed_.cend(),
                  std::back_inserter(semanticColorAsInt_),
                  [](const Mn::Color3ub& color) -> uint32_t {
-                   return (unsigned(color[0]) << 16) |
-                          (unsigned(color[1]) << 8) | unsigned(color[2]);
+                   return geo::getValueAsUInt(color);
                  });
 }
 
@@ -2403,8 +2403,7 @@ Mn::Image2D ResourceManager::convertRGBToSemanticId(
     for (std::size_t x = 0; x != size.x(); ++x) {
       const Mn::Color3ub color = inputRow[x];
       /* Fugly. Sorry. Needs better API on Magnum side. */
-      const Mn::UnsignedInt colorInt =
-          color.r() << 16 | color.g() << 8 | color.b();
+      const Mn::UnsignedInt colorInt = geo::getValueAsUInt(color);
       outputRow[x] = clrToSemanticId[colorInt];
     }
   }

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -712,7 +712,8 @@ class ResourceManager {
    * @brief Build data for a report for semantic mesh connected components based
    * on color/id.
    */
-  void buildSemanticCCReport(
+  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  buildSemanticCCReport(
       const metadata::attributes::StageAttributes::ptr& stageAttributes);
 
  private:

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -710,9 +710,10 @@ class ResourceManager {
 
   /**
    * @brief Build data for a report for semantic mesh connected components based
-   * on color/id.
+   * on color/id.  Returns map of data keyed by SemanticObject index in
+   * SemanticObjs array.
    */
-  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
   buildSemanticCCReport(
       const metadata::attributes::StageAttributes::ptr& stageAttributes);
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -708,6 +708,13 @@ class ResourceManager {
   static constexpr const char* SHADOW_MAP_KEY_TEMPLATE =
       "scene_id={}-light_id={}";
 
+  /**
+   * @brief Build data for a report for semantic mesh connected components based
+   * on color/id.
+   */
+  void buildSemanticCCReport(
+      const metadata::attributes::StageAttributes::ptr& stageAttributes);
+
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
@@ -717,8 +724,8 @@ class ResourceManager {
    * @param objectAttributes the object attributes owning
    * this mesh.
    * @param assetType either "render" or "collision" (for error log output)
-   * @param forceFlatShading whether to force this asset to be rendered via flat
-   * shading.
+   * @param forceFlatShading whether to force this asset to be rendered via
+   * flat shading.
    * @return whether or not the mesh was loaded successfully
    */
   bool loadObjectMeshDataFromFile(

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1009,7 +1009,7 @@ class ResourceManager {
 
   /**
    * @brief Semantic Mesh backend for loadRenderAsset.  Either use
-   * loadRenderAssetIMesh if semantic mesh has vertex annotations only, or
+   * loadRenderAssetSemantic if semantic mesh has vertex annotations only, or
    * loadRenderAssetGeneral if semantic mesh has texture-based annotations. This
    * choice is governed by info.hasSemanticTextures.
    */
@@ -1018,7 +1018,7 @@ class ResourceManager {
   /**
    * @brief Semantic (vertex-annotated) Mesh backend for loadRenderAsset
    */
-  bool loadRenderAssetIMesh(const AssetInfo& info);
+  bool loadRenderAssetSemantic(const AssetInfo& info);
 
   /**
    * @brief General Mesh backend for loadRenderAsset
@@ -1051,10 +1051,10 @@ class ResourceManager {
       DrawableGroup* drawables);
 
   /**
-   * @brief Semantic Mesh backend for create Either use
-   * createRenderAssetInstanceIMesh if semantic mesh has vertex annotations
-   * only, or createRenderAssetInstanceGeneralPrimitive if semantic mesh has
-   * texture-based annotations. This choice is governed by
+   * @brief Semantic Mesh backend creation. Either use
+   * createRenderAssetInstanceVertSemantic if semantic mesh has vertex
+   * annotations only, or createRenderAssetInstanceGeneralPrimitive if semantic
+   * mesh has texture-based annotations. This choice is governed by
    * creation.isTextureBasedSemantic().
    */
   scene::SceneNode* createSemanticRenderAssetInstance(
@@ -1066,7 +1066,7 @@ class ResourceManager {
    * @brief Semantic Mesh (vertex-annotated) backend for
    * createRenderAssetInstance
    */
-  scene::SceneNode* createRenderAssetInstanceIMesh(
+  scene::SceneNode* createRenderAssetInstanceVertSemantic(
       const RenderAssetInstanceCreationInfo& creation,
       scene::SceneNode* parent,
       DrawableGroup* drawables);

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -713,7 +713,8 @@ class ResourceManager {
    * on color/id.  Returns map of data keyed by SemanticObject index in
    * SemanticObjs array.
    */
-  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
+  std::unordered_map<uint32_t,
+                     std::vector<std::shared_ptr<scene::CCSemanticObject>>>
   buildSemanticCCReport(
       const metadata::attributes::StageAttributes::ptr& stageAttributes);
 

--- a/src/esp/bindings/GeoBindings.cpp
+++ b/src/esp/bindings/GeoBindings.cpp
@@ -44,6 +44,7 @@ void initGeoBindings(py::module& m) {
            })
       .def_property_readonly("center", &OBB::center)
       .def_property_readonly("sizes", &OBB::sizes)
+      .def_property_readonly("volume", &OBB::volume)
       .def_property_readonly("half_extents", &OBB::halfExtents)
       .def_property_readonly(
           "rotation", [](const OBB& self) { return self.rotation().coeffs(); })

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -183,6 +183,13 @@ void initSimBindings(py::module& m) {
           &Simulator::getStageInitializationTemplate, "scene_id"_a = 0,
           R"(Get a copy of the StageAttributes template used to instance a scene's stage or None if it does not exist.)")
 
+      .def("build_semantic_CC_report", &Simulator::buildSemanticCCReport,
+           R"(Get a report on the current semantic scene's connected
+          components based on color. Returns a dictionary keyed by
+          color where each value is a list of tuples, where the
+          first element is the number of verts in the CC and the
+          second is the AABB)")
+
       /* --- Kinematics and dynamics --- */
       .def(
           "step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0,

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -133,6 +133,8 @@ typedef Eigen::Vector4ul vec4ul;
 typedef Eigen::VectorXi vecXi;
 typedef Eigen::AlignedBox3f box3f;
 
+typedef Eigen::Transform<float, 3, Eigen::Affine, Eigen::DontAlign> Transform;
+
 //! Write box3f into ostream in JSON string format
 inline std::ostream& operator<<(std::ostream& os, const box3f& bbox) {
   return os << "{min:" << bbox.min() << ",max:" << bbox.max() << "}";

--- a/src/esp/geo/Geo.cpp
+++ b/src/esp/geo/Geo.cpp
@@ -504,7 +504,7 @@ Mn::Trade::MeshData buildTrajectoryTubeSolid(
       static_cast<Mn::UnsignedInt>(positions.size())};
 
   return meshData;
-}  // ResourceManager::trajectoryTubeSolid
+}  // buildTrajectoryTubeSolid
 
 }  // namespace geo
 }  // namespace esp

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -10,7 +10,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "OBB.h"
 #include "esp/core/Esp.h"
 
 #include <Magnum/Math/CubicHermite.h>
@@ -290,27 +289,6 @@ findCCsByGivenColor(const std::vector<std::set<uint32_t>>& adjList,
   }
   return clrsToComponents;
 }  // findCCsByGivenColor
-
-/**
- * @brief Builds a mapping of connected component-driven bounding boxes, keyed
- * by criteria used to decide connectivity (the per-vertex attribute suche as
- * color).
- * @param verts the vertex buffer holding all vertex positions in the mesh.
- * @param clrsToComponents an unordered map, keyed by tag/color value encoded as
- * uint, where the value is a vector of all sets of CCs consisting of verts with
- * specified tag/"color". (see @ref findCCsByGivenColor).
- * @return A map keyed by a representattion of the per-vertex "color" where each
- * entry contains a vector of values for all the CCs of verts having the "color"
- * attribute specified by the key.  Each element in the vector is a pair, with
- * the first entry being the size of the CC and the 2nd entry being an AABB
- * built from the CC.
- */
-
-std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
-buildCCBasedBBoxes(
-    const std::vector<Mn::Vector3>& verts,
-    const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
-        clrsToComponents);
 
 template <typename T>
 T clamp(const T& n, const T& low, const T& high) {

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -6,8 +6,11 @@
 #define ESP_GEO_GEO_H_
 
 #include <set>
+#include <typeinfo>
+#include <unordered_map>
 #include <vector>
 
+#include "OBB.h"
 #include "esp/core/Esp.h"
 
 #include <Magnum/Math/CubicHermite.h>
@@ -18,6 +21,7 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace geo {
+class OBB;
 
 /**
  * @brief This enum describes the various colorspaces that colors in Habitat can
@@ -49,8 +53,6 @@ static const vec3f ESP_GRAVITY = -ESP_UP;
 static const vec3f ESP_FRONT = -vec3f::UnitZ();
 //! global/world back direction
 static const vec3f ESP_BACK = -ESP_FRONT;
-
-typedef Eigen::Transform<float, 3, Eigen::Affine, Eigen::DontAlign> Transform;
 
 // compute convex hull of 2D points and return as vector of vertices
 std::vector<vec2f> convexHull2D(const std::vector<vec2f>& points);
@@ -156,20 +158,70 @@ Mn::Trade::MeshData buildTrajectoryTubeSolid(
     ColorSpace clrSpace = ColorSpace::HSV);
 
 /**
+ * @brief Returns a nicely formatted hex string representation of @p color.
+ * @param color Color to build string from.
+ */
+std::string getColorAsString(const Magnum::Color3ub& color);
+
+/**
+ * @brief Return an unsigned int encoding of passed @p color value
+ */
+template <class T>
+uint32_t getValueAsUInt(T color) {
+  ESP_ERROR() << "Unsupported type for conversion to uint32_t :"
+              << typeid(color).name() << "Aborting.";
+  // returning max value for unsupported types
+  return ~uint32_t(0);
+}
+
+/**
+ * @brief Return an unsigned int encoding of passed @p color for type
+ * Mn::Color3ub.
+ */
+uint32_t getValueAsUInt(const Mn::Color3ub& color);
+
+/**
+ * @brief Return an unsigned int encoding of passed @p color for type
+ * Mn::Color4ub.
+ */
+uint32_t getValueAsUInt(const Mn::Color4ub& color);
+
+/**
+ * @brief Return an unsigned int encoding of passed @p color for type
+ * int - provided to support vector of per-vertex IDs .
+ */
+uint32_t getValueAsUInt(int color);
+
+/**
+ * @brief Build an adjacency list using the passed index buffer.  Assumes each
+ * sequence of 3 indices describesd a poly.
+ * @param numVerts Number of verts found in mesh.
+ * @param indices Index buffer.
+ * @return vector of sets, where each set's index corresponds to the src vert in
+ * the vertex buffer, and each element is a set containing the indices of the
+ * adjacent verts.
+ */
+
+std::vector<std::set<uint32_t>> buildAdjList(
+    int numVerts,
+    const std::vector<uint32_t>& indexBuffer);
+
+/**
  * @brief Build a connected component recursively on an unconnected graph
  * (i.e. mesh vertices), building from passed @p vIDX from adjecent verts
- * that match the passed @p clr value.
+ * that match the passed @p clr value, which can be any per-vertex identifier
+ * or tag.
  *
  * @tparam The type of the conditioning variable.
  * @param adjList A reference to the mesh's adjacency list.  IDX of list is
  * src vert index in owning vert list, value is dest vert index in vert
  * list.
  * @param clrVec A reference to the per-vertex identifiers used to condition
- * the CC.
+ * the CC (not necessarily a color).
  * @param vIDX The index of the src vertex of this part of the CC.
  * @param visited Per-vertex visitation record.
- * @param clr The CC's identifying "color", to be matched by adjacent verts
- * for membership.
+ * @param clr The CC's identifying "color"/tag, to be matched by adjacent
+ * verts for membership in CC.
  * @param setOfVerts Aggregation of verts in the CC.
  */
 template <class T>
@@ -189,6 +241,76 @@ void conditionalDFS(const std::vector<std::set<uint32_t>>& adjList,
     }
   }
 }  // conditionalDFS
+
+/**
+ * @brief Find and return all connected components in a graph (represented by
+ * the @p adjList ), that match some specified per-vertex tag/"color".
+ * @tparam The type of the CC conditioning variable.
+ * @param adjList A reference to the mesh's per-vertex adjacency list.  IDX of
+ * list is src vert index in owning vert list, value is dest vert index in
+ * vert list.
+ * @param clrVec A reference to the per-vertex identifiers used to condition
+ * the CC (not necessarily a color).
+ * @return an unordered map, keyed by tag/color value encoded as int, where
+ * the value is a vector of all sets of CCs consisting of verts with specified
+ * tag/"color".
+ */
+template <class T>
+std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
+findCCsByGivenColor(const std::vector<std::set<uint32_t>>& adjList,
+                    const std::vector<T>& clrVec) {
+  // standard dfs implementation of CC builder, with added conditioning on
+  // some per-vert characteristic (in this case, vertex color)
+  int numVerts = adjList.size();
+  std::vector<bool> visited(numVerts, false);
+  std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
+      clrsToComponents(numVerts);
+  for (uint32_t vIDX = 0; vIDX < numVerts; ++vIDX) {
+    if (!visited[vIDX]) {
+      // initialize CC's set of member verts
+      std::set<uint32_t> setOfVerts{};
+      // vert's color for membership in CC
+      const auto vertColor = clrVec[vIDX];
+      // build CC of connected verts that share vertColor
+      conditionalDFS(adjList, clrVec, vIDX, visited, vertColor, setOfVerts);
+      // convert color/tag to key for map
+      const uint32_t colorKey = getValueAsUInt(vertColor);
+      if (colorKey == ~uint32_t(0)) {
+        return {};
+      }
+      // find or build map entry keyed by color of vert set for CC
+      auto findIter = clrsToComponents.find(colorKey);
+      if (findIter == clrsToComponents.end()) {
+        // not found already, so add new entry
+        findIter = clrsToComponents.insert({colorKey, {}}).first;
+      }
+      // move set to map entry of CC sets with specified color
+      findIter->second.push_back(std::move(setOfVerts));
+    }
+  }
+  return clrsToComponents;
+}  // findCCsByGivenColor
+
+/**
+ * @brief Builds a mapping of connected component-driven bounding boxes, keyed
+ * by criteria used to decide connectivity (the per-vertex attribute suche as
+ * color).
+ * @param verts the vertex buffer holding all vertex positions in the mesh.
+ * @param clrsToComponents an unordered map, keyed by tag/color value encoded as
+ * uint, where the value is a vector of all sets of CCs consisting of verts with
+ * specified tag/"color". (see @ref findCCsByGivenColor).
+ * @return A map keyed by a representattion of the per-vertex "color" where each
+ * entry contains a vector of values for all the CCs of verts having the "color"
+ * attribute specified by the key.  Each element in the vector is a pair, with
+ * the first entry being the size of the CC and the 2nd entry being an AABB
+ * built from the CC.
+ */
+
+std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
+buildCCBasedBBoxes(
+    const std::vector<Mn::Vector3>& verts,
+    const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
+        clrsToComponents);
 
 template <typename T>
 T clamp(const T& n, const T& low, const T& high) {

--- a/src/esp/geo/Geo.h
+++ b/src/esp/geo/Geo.h
@@ -261,7 +261,7 @@ findCCsByGivenColor(const std::vector<std::set<uint32_t>>& adjList,
                     const std::vector<T>& clrVec) {
   // standard dfs implementation of CC builder, with added conditioning on
   // some per-vert characteristic (in this case, vertex color)
-  int numVerts = adjList.size();
+  auto numVerts = adjList.size();
   std::vector<bool> visited(numVerts, false);
   std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
       clrsToComponents(numVerts);

--- a/src/esp/geo/OBB.cpp
+++ b/src/esp/geo/OBB.cpp
@@ -16,7 +16,6 @@ OBB::OBB() {
   center_.setZero();
   halfExtents_.setZero();
   rotation_.setIdentity();
-  box3f box;
 }
 
 OBB::OBB(const vec3f& center, const vec3f& dimensions, const quatf& rotation)

--- a/src/esp/geo/OBB.h
+++ b/src/esp/geo/OBB.h
@@ -26,6 +26,13 @@ class OBB {
   //! Returns the dimensions of this OBB in its own frame of reference
   vec3f sizes() const { return halfExtents_ * 2; }
 
+  /**
+   * @brief Return the volume of this bbox
+   */
+  float volume() const {
+    return halfExtents_.x() * halfExtents_.y() * halfExtents_.z() * 8.0f;
+  }
+
   //! Returns half-extents of this OBB (dimensions)
   vec3f halfExtents() const { return halfExtents_; }
 

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -102,6 +102,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
                               categories);
 
   std::string line;
+  int oldInstanceID = 0;
   while (std::getline(ifs, line)) {
     if (line.empty()) {
       continue;
@@ -141,6 +142,13 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     buildInstanceRegionCategory(instanceID, colorInt, objCategoryName, regionID,
                                 objInstance, regions, categories);
 
+    ESP_CHECK(
+        oldInstanceID == instanceID - 1,
+        Cr::Utility::formatString("\nError loading semantic mesh data - "
+                                  "oldInstanceID : {} new instance ID : {}\n",
+                                  oldInstanceID, instanceID));
+
+    oldInstanceID = instanceID;
   }  // while
 
   // construct object instance names for each object instance, by setting the
@@ -219,6 +227,8 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   // TODO eventually BBoxes will be pre-generated and stored in semantic text
   // file.
   scene.needBBoxFromVertColors_ = true;
+  // use only largest volume bbox
+  scene.ccLargestVolToUseForBBox_ = 1.0f;
   scene.levels_.clear();  // Not used for Hm3d currently
 
   return true;

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -102,7 +102,6 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
                               categories);
 
   std::string line;
-  int oldInstanceID = 0;
   while (std::getline(ifs, line)) {
     if (line.empty()) {
       continue;
@@ -142,13 +141,6 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     buildInstanceRegionCategory(instanceID, colorInt, objCategoryName, regionID,
                                 objInstance, regions, categories);
 
-    // ESP_CHECK(
-    //     oldInstanceID == instanceID - 1,
-    //     Cr::Utility::formatString("\nError loading semantic mesh data - "
-    //                               "oldInstanceID : {} new instance ID :
-    //                               {}\n", oldInstanceID, instanceID));
-
-    oldInstanceID = instanceID;
   }  // while
 
   // construct object instance names for each object instance, by setting the
@@ -224,10 +216,11 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
             {objPtr->semanticID(), objPtr->region()->getIndex()}));
   }
   // we need to build the bbox on load for each semantic annotation
-  // TODO eventually BBoxes will be pre-generated and stored in semantic text
+  // TODO: eventually BBoxes will be pre-generated and stored in semantic text
   // file.
   scene.needBBoxFromVertColors_ = true;
   // use only largest volume bbox
+  // TODO: eventually drive this via customizable config value.
   scene.ccLargestVolToUseForBBox_ = 1.0f;
   scene.levels_.clear();  // Not used for Hm3d currently
 

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -216,7 +216,9 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
             {objPtr->semanticID(), objPtr->region()->getIndex()}));
   }
   // we need to build the bbox on load for each semantic annotation
-  scene.needBBoxFromVertColors = true;
+  // TODO eventually BBoxes will be pre-generated and stored in semantic text
+  // file.
+  scene.needBBoxFromVertColors_ = true;
   scene.levels_.clear();  // Not used for Hm3d currently
 
   return true;

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -142,11 +142,11 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
     buildInstanceRegionCategory(instanceID, colorInt, objCategoryName, regionID,
                                 objInstance, regions, categories);
 
-    ESP_CHECK(
-        oldInstanceID == instanceID - 1,
-        Cr::Utility::formatString("\nError loading semantic mesh data - "
-                                  "oldInstanceID : {} new instance ID : {}\n",
-                                  oldInstanceID, instanceID));
+    // ESP_CHECK(
+    //     oldInstanceID == instanceID - 1,
+    //     Cr::Utility::formatString("\nError loading semantic mesh data - "
+    //                               "oldInstanceID : {} new instance ID :
+    //                               {}\n", oldInstanceID, instanceID));
 
     oldInstanceID = instanceID;
   }  // while

--- a/src/esp/scene/HM3DSemanticScene.h
+++ b/src/esp/scene/HM3DSemanticScene.h
@@ -36,7 +36,7 @@ class HM3DObjectInstance : public SemanticObject {
   HM3DObjectInstance(int objInstanceID,
                      int objCatID,
                      const std::string& name,
-                     const unsigned colorInt)
+                     uint32_t colorInt)
       : SemanticObject(), objCatID_(objCatID), name_(name) {
     index_ = objInstanceID;
     // sets both colorAsInt_ and updates color_ vector to match

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -7,7 +7,8 @@
 #include "Mp3dSemanticScene.h"
 #include "ReplicaSemanticScene.h"
 
-#include <algorithm>
+#include <Corrade/Utility/FormatStl.h>
+
 #include <fstream>
 #include <map>
 #include <sstream>
@@ -84,6 +85,226 @@ bool SemanticScene::
   return success;
 
 }  // SemanticScene::loadSemanticSceneDescriptor
+
+namespace {
+/**
+ * @brief Build an AABB for a given set of vertex indices in @p verts list, and
+ * return in a std::pair, along with the count of verts used to build the AABB.
+ * @param colorInt Semantic Color of object
+ * @param verts The mesh's vertex buffer.
+ * @param setOfIDXs set of vertex IDXs in the vertex buffer being used to build
+ * the resultant AABB.
+ */
+CCSemanticObject::ptr buildCCSemanticObjForSetOfVerts(
+    uint32_t colorInt,
+    const std::vector<Mn::Vector3>& verts,
+    const std::set<uint32_t>& setOfIDXs) {
+  Mn::Vector3 vertMax{-Mn::Constants::inf(), -Mn::Constants::inf(),
+                      -Mn::Constants::inf()};
+  Mn::Vector3 vertMin{Mn::Constants::inf(), Mn::Constants::inf(),
+                      Mn::Constants::inf()};
+
+  for (uint32_t idx : setOfIDXs) {
+    Mn::Vector3 vert = verts[idx];
+    vertMax = Mn::Math::max(vertMax, vert);
+    vertMin = Mn::Math::min(vertMin, vert);
+  }
+
+  Mn::Vector3 center = .5f * (vertMax + vertMin);
+  Mn::Vector3 dims = vertMax - vertMin;
+
+  auto obj = std::make_shared<CCSemanticObject>(
+      CCSemanticObject(setOfIDXs.size(), colorInt));
+  // set obj's bounding box
+  obj->setObb(Mn::EigenIntegration::cast<esp::vec3f>(center),
+              Mn::EigenIntegration::cast<esp::vec3f>(dims), quatf::Identity());
+  return obj;
+}  // buildCCSemanticObjForSetOfVerts
+
+}  // namespace
+
+std::unordered_map<uint32_t, std::vector<CCSemanticObject::ptr>>
+SemanticScene::buildCCBasedSemanticObjs(
+    const std::vector<Mn::Vector3>& verts,
+    const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
+        clrsToComponents,
+    const std::shared_ptr<SemanticScene>& semanticScene) {
+  // build color-keyed map of lists of pairs of vert-count/bboxes
+  std::unordered_map<uint32_t, std::vector<CCSemanticObject::ptr>>
+      semanticCCObjsByVertTag(clrsToComponents.size());
+  for (const auto& elem : clrsToComponents) {
+    const uint32_t colorKey = elem.first;
+    const std::vector<std::set<uint32_t>>& vectorOfSets = elem.second;
+    auto findIter = semanticCCObjsByVertTag.find(colorKey);
+    if (findIter == semanticCCObjsByVertTag.end()) {
+      // not found already - initialize new entry
+      findIter = semanticCCObjsByVertTag
+                     .emplace(colorKey, std::vector<CCSemanticObject::ptr>{})
+                     .first;
+    }
+    for (const std::set<uint32_t>& vertSet : vectorOfSets) {
+      findIter->second.emplace_back(
+          buildCCSemanticObjForSetOfVerts(colorKey, verts, vertSet));
+    }
+  }
+
+  // only map to semantic ID if semanticScene exists, otherwise return map with
+  // objects keyed by hex color
+  if (!semanticScene) {
+    return semanticCCObjsByVertTag;
+  }
+  // if semanticScene is provided, assume vert color was tag used to determine
+  // CC membership
+  const auto& semanticObjs = semanticScene->objects();
+  // build temp map of colors to SemanticObject IDs
+  std::unordered_map<uint32_t, uint32_t> mapColorIntsToSemanticObjIDXs;
+  mapColorIntsToSemanticObjIDXs.reserve(semanticObjs.size());
+  for (uint32_t i = 0; i < semanticObjs.size(); ++i) {
+    mapColorIntsToSemanticObjIDXs.insert({semanticObjs[i]->getColorAsInt(), i});
+  }
+  // build map with key being semanticObject IDX in semantic Objects array
+  std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
+      results;
+  for (auto& elem : mapColorIntsToSemanticObjIDXs) {
+    const auto objID = elem.second;
+    const auto colorAsInt = elem.first;
+    auto mapEntry = semanticCCObjsByVertTag.find(colorAsInt);
+    if (mapEntry != semanticCCObjsByVertTag.end()) {
+      results.emplace(objID, std::move(mapEntry->second));
+    }
+  }
+  return results;
+}  // SemanticScene::buildCCBasedBBoxes
+
+void SemanticScene::buildSemanticOBBsFromCCs(
+    const std::vector<Mn::Vector3>& verts,
+    const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
+        clrsToComponents,
+    const std::shared_ptr<SemanticScene>& semanticScene,
+    const std::string& msgPrefix) {
+  // get map of semantic ID to vector of CCSemanticObjs.
+  const auto perIDMapOfCCSemanticObjs =
+      buildCCBasedSemanticObjs(verts, clrsToComponents, semanticScene);
+
+  // get all semantic objects
+  const auto& ssdObjs = semanticScene->objects();
+  std::multimap<float, std::shared_ptr<CCSemanticObject>> perSemanticObjCCs;
+  for (const auto& ccObj : perIDMapOfCCSemanticObjs) {
+    // get vector of CCSemanticObjs
+    const auto& vecOfCCSemanticObjs = ccObj.second;
+    // if only one element, skip
+    if (vecOfCCSemanticObjs.size() == 1) {
+      continue;
+    }
+    uint32_t objIdx = ccObj.first;
+    // do not process Unknown
+    if (objIdx == 0) {
+      continue;
+    }
+    // get object with given semantic ID
+    auto& ssdObj = *ssdObjs[objIdx];
+    // build temp multimap keyed by volume
+    perSemanticObjCCs.clear();
+    for (const auto& CCObj : vecOfCCSemanticObjs) {
+      perSemanticObjCCs.emplace(CCObj->obb().volume(), CCObj);
+    }
+    // after all are emplaced, reverse order will be in order of decreasing
+    // volume
+    ESP_DEBUG() << Cr::Utility::formatString(
+        "\nmap size {} : vec size {} Displaying elements in decreasing order "
+        "for objIDX : {} | name : {} | vol : {}",
+        perSemanticObjCCs.size(), vecOfCCSemanticObjs.size(), objIdx,
+        ssdObj.id(), ssdObj.obb().volume());
+    for (auto elem = perSemanticObjCCs.crbegin();
+         elem != perSemanticObjCCs.crend(); ++elem) {
+      ESP_DEBUG() << Cr::Utility::formatString(
+          "\tvol:{} : #pts {}", elem->first, elem->second->getNumSrcVerts());
+    }
+    // Set Largest volume element as new OBB
+    ssdObj.setObb(perSemanticObjCCs.crbegin()->second->obb());
+  }
+
+}  // SemanticScene::buildSemanticOBBsFromCCs
+
+void SemanticScene::buildSemanticOBBs(
+    const std::vector<Mn::Vector3>& vertices,
+    const std::vector<uint16_t>& vertSemanticIDs,
+    const std::vector<std::shared_ptr<esp::scene::SemanticObject>>& ssdObjs,
+    const std::string& msgPrefix) {
+  // build per-SSD object vector of known semantic IDs
+  // doing this in case semanticIDs are not contiguous.
+  std::size_t numSSDObjs = ssdObjs.size();
+  std::vector<int> semanticIDToSSOBJidx(numSSDObjs, -1);
+  for (int i = 0; i < numSSDObjs; ++i) {
+    const auto& ssdObj = *ssdObjs[i];
+    int semanticID = ssdObj.semanticID();
+    // should not happen unless semantic ids are not sequential
+    if (semanticIDToSSOBJidx.size() <= semanticID) {
+      semanticIDToSSOBJidx.resize(semanticID + 1);
+    }
+    semanticIDToSSOBJidx[semanticID] = i;
+  }
+
+  // aggegates of per-semantic ID mins and maxes
+  std::vector<Mn::Vector3> vertMax(
+      semanticIDToSSOBJidx.size(),
+      {-Mn::Constants::inf(), -Mn::Constants::inf(), -Mn::Constants::inf()});
+  std::vector<Mn::Vector3> vertMin(
+      semanticIDToSSOBJidx.size(),
+      {Mn::Constants::inf(), Mn::Constants::inf(), Mn::Constants::inf()});
+  std::vector<int> vertCounts(semanticIDToSSOBJidx.size());
+
+  // for each vertex, map vert min and max for each known semantic ID
+  // Known semantic IDs are expected to be contiguous, and correspond to the
+  // number of unique ssdObjs mappings.
+
+  for (int vertIdx = 0; vertIdx < vertSemanticIDs.size(); ++vertIdx) {
+    // semantic ID on vertex - valid values are 1->semanticIDToSSOBJidx.size().
+    // Invalid/unknown semantic ids are > semanticIDToSSOBJidx.size()
+    const auto semanticID = vertSemanticIDs[vertIdx];
+    if ((semanticID >= 0) && (semanticID < semanticIDToSSOBJidx.size())) {
+      const auto vert = vertices[vertIdx];
+      // FOR VERT-BASED OBB CALC
+      // only support bbs for known colors that map to semantic objects
+      vertMax[semanticID] = Mn::Math::max(vertMax[semanticID], vert);
+      vertMin[semanticID] = Mn::Math::min(vertMin[semanticID], vert);
+      vertCounts[semanticID] += 1;
+    }
+  }
+
+  // with mins/maxs per ID, map to objs
+  // give each ssdObj the values to build its OBB
+  for (int semanticID = 0; semanticID < semanticIDToSSOBJidx.size();
+       ++semanticID) {
+    int objIdx = semanticIDToSSOBJidx[semanticID];
+    if (objIdx == -1) {
+      continue;
+    }
+    // get object with given semantic ID
+    auto& ssdObj = *ssdObjs[objIdx];
+    Mn::Vector3 center{};
+    Mn::Vector3 dims{};
+
+    if (vertCounts[semanticID] == 0) {
+      ESP_DEBUG() << Cr::Utility::formatString(
+          "{} Semantic ID : {} : color : {} tag : {} present in {} "
+          "verts | No verts have specified Semantic ID.",
+          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
+          ssdObj.id(), vertCounts[semanticID]);
+    } else {
+      center = .5f * (vertMax[semanticID] + vertMin[semanticID]);
+      dims = vertMax[semanticID] - vertMin[semanticID];
+      ESP_DEBUG() << Cr::Utility::formatString(
+          "{} Semantic ID : {} : color : {} tag : {} present in {} verts | BB "
+          "Center [{} {} {}] Dims [{} {} {}]",
+          msgPrefix, semanticID, geo::getColorAsString(ssdObj.getColor()),
+          ssdObj.id(), vertCounts[semanticID], center.x(), center.y(),
+          center.z(), dims.x(), dims.y(), dims.z());
+    }
+    ssdObj.setObb(Mn::EigenIntegration::cast<esp::vec3f>(center),
+                  Mn::EigenIntegration::cast<esp::vec3f>(dims));
+  }
+}  // SemanticScene::buildSemanticOBBs
 
 }  // namespace scene
 }  // namespace esp

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -235,7 +235,7 @@ void SemanticScene::buildSemanticOBBsFromCCs(
         semanticCCsPerID = perIDMapOfCCSemanticObjs.find(objIdx);
 
     if ((semanticCCsPerID == perIDMapOfCCSemanticObjs.end()) ||
-        (semanticCCsPerID->second.size() == 0)) {
+        (semanticCCsPerID->second.empty())) {
       ESP_DEBUG() << msgPrefix << "\n!!!!!!Note : ID :" << objIdx
                   << "has no corresponding CC; therefore, this semantic object "
                      "will have no BBox since its color is not present in the "

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -539,7 +539,7 @@ class CCSemanticObject : public SemanticObject {
   }
 
   void setIndex(int _index) { index_ = _index; }
-  uint32_t getNumSrcVerts() { return numSrcVerts_; }
+  uint32_t getNumSrcVerts() const { return numSrcVerts_; }
 
  protected:
   /**

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -401,8 +401,7 @@ class SemanticObject {
   void setColor(Mn::Vector3ub _color) {
     color_ = _color;
     // update colorAsInt_
-    colorAsInt_ = (unsigned(color_[0]) << 16) | (unsigned(color_[1]) << 8) |
-                  unsigned(color_[2]);
+    colorAsInt_ = geo::getValueAsUInt(color_);
   }
 
   unsigned getColorAsInt() const { return colorAsInt_; }

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -182,11 +182,11 @@ class SemanticScene {
   }
 
   /**
-   * @Brief whether or not we should build bounding boxes around vertex
+   * @brief whether or not we should build bounding boxes around vertex
    * annotations on semantic asset load. Currently used for HM3D.
    */
 
-  bool buildBBoxFromVertColors() const { return needBBoxFromVertColors; }
+  bool buildBBoxFromVertColors() const { return needBBoxFromVertColors_; }
 
  protected:
   /**
@@ -276,7 +276,7 @@ class SemanticScene {
    * @Brief whether or not we should build bounding boxes around vertex
    * annotations on semantic asset load. Currently used for HM3D.
    */
-  bool needBBoxFromVertColors = false;
+  bool needBBoxFromVertColors_ = false;
   std::string name_;
   std::string label_;
   box3f bbox_;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -238,9 +238,10 @@ class Simulator {
    * @brief Build a connectivity report for current stage's semantic scene
    * vertex annotation regions.
    */
-  void buildSemanticCCReport() {
+  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  buildSemanticCCReport() {
     // build report with current stage attributes
-    resourceManager_->buildSemanticCCReport(
+    return resourceManager_->buildSemanticCCReport(
         physicsManager_->getStageInitAttributes());
   }
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -238,7 +238,7 @@ class Simulator {
    * @brief Build a connectivity report for current stage's semantic scene
    * vertex annotation regions.
    */
-  std::unordered_map<std::string, std::vector<std::pair<int, esp::geo::OBB>>>
+  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
   buildSemanticCCReport() {
     // build report with current stage attributes
     return resourceManager_->buildSemanticCCReport(

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -238,7 +238,7 @@ class Simulator {
    * @brief Build a connectivity report for current stage's semantic scene
    * vertex annotation regions.
    */
-  std::unordered_map<uint32_t, std::vector<std::pair<int, esp::geo::OBB>>>
+  std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
   buildSemanticCCReport() {
     // build report with current stage attributes
     return resourceManager_->buildSemanticCCReport(

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -235,6 +235,16 @@ class Simulator {
   }
 
   /**
+   * @brief Build a connectivity report for current stage's semantic scene
+   * vertex annotation regions.
+   */
+  void buildSemanticCCReport() {
+    // build report with current stage attributes
+    resourceManager_->buildSemanticCCReport(
+        physicsManager_->getStageInitAttributes());
+  }
+
+  /**
    * @brief Builds a @ref esp::metadata::SceneInstanceAttributes describing the
    * current scene configuration, and saves it to a JSON file, using @p
    * saveFileName .

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1183,16 +1183,19 @@ void Viewer::generateAndSaveSemanticCCReport() {
 
   for (const auto& elem : results) {
     const uint32_t objIDX = elem.first;
-    const std::vector<std::pair<int, esp::geo::OBB>>& listOfObbs = elem.second;
+    const std::vector<std::shared_ptr<esp::scene::CCSemanticObject>>&
+        listOfObbs = elem.second;
     const auto baseObj = semanticObjs[objIDX];
-    const auto clr = baseObj->getColor();
-    for (const std::pair<int, esp::geo::OBB>& elem : listOfObbs) {
-      const auto& obb = elem.second;
+    for (const std::shared_ptr<esp::scene::CCSemanticObject>& ccObj :
+         listOfObbs) {
+      const auto obb = ccObj->obb();
+      const auto clr = ccObj->getColor();
+      const auto ctr = obb.center();
+      const auto sizes = obb.sizes();
       const std::string dataString = Cr::Utility::formatString(
           "{},{},{} {} {},{},{} {} {}, {} {} {},{}", objIDX, baseObj->id(),
-          clr.r(), clr.g(), clr.b(), elem.first, obb.center().x(),
-          obb.center().y(), obb.center().z(), obb.sizes().x(), obb.sizes().y(),
-          obb.sizes().z(), obb.volume());
+          clr.r(), clr.g(), clr.b(), ccObj->getNumSrcVerts(), ctr.x(), ctr.y(),
+          ctr.z(), sizes.x(), sizes.y(), sizes.z(), obb.volume());
       ESP_DEBUG() << dataString;
       file << dataString << '\n';
     }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1179,7 +1179,7 @@ void Viewer::generateAndSaveSemanticCCReport() {
   }
 
   file << "Obj IDX, Object ID, Color RGB, # Verts in partition, BBOX "
-          "Center XYZ, BBOX Dims XYZ\n";
+          "Center XYZ, BBOX Dims XYZ, BBOX Vol\n";
 
   for (const auto& elem : results) {
     const uint32_t objIDX = elem.first;
@@ -1189,10 +1189,10 @@ void Viewer::generateAndSaveSemanticCCReport() {
     for (const std::pair<int, esp::geo::OBB>& elem : listOfObbs) {
       const auto& obb = elem.second;
       const std::string dataString = Cr::Utility::formatString(
-          "{},{},{} {} {},{},{} {} {}, {} {} {}", objIDX, baseObj->id(),
+          "{},{},{} {} {},{},{} {} {}, {} {} {},{}", objIDX, baseObj->id(),
           clr.r(), clr.g(), clr.b(), elem.first, obb.center().x(),
           obb.center().y(), obb.center().z(), obb.sizes().x(), obb.sizes().y(),
-          obb.sizes().z());
+          obb.sizes().z(), obb.volume());
       ESP_DEBUG() << dataString;
       file << dataString << '\n';
     }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1194,7 +1194,7 @@ void Viewer::generateAndSaveSemanticCCReport() {
           obb.center().y(), obb.center().z(), obb.sizes().x(), obb.sizes().y(),
           obb.sizes().z());
       ESP_DEBUG() << dataString;
-      file << dataString << "\n";
+      file << dataString << '\n';
     }
   }
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1167,7 +1167,7 @@ void Viewer::generateAndSaveSemanticCCReport() {
           Cr::Utility::Directory::splitExtension(
               Cr::Utility::Directory::filename(simConfig_.activeSceneName))
               .first));
-  ESP_DEBUG() << "Full Path File name :" << filename;
+  ESP_DEBUG() << "Fully qualified destination file name :" << filename;
   auto semanticScene = simulator_->getSemanticScene();
 
   const auto& semanticObjs = semanticScene->objects();
@@ -1196,7 +1196,7 @@ void Viewer::generateAndSaveSemanticCCReport() {
           "{},{},{} {} {},{},{} {} {}, {} {} {},{}", objIDX, baseObj->id(),
           clr.r(), clr.g(), clr.b(), ccObj->getNumSrcVerts(), ctr.x(), ctr.y(),
           ctr.z(), sizes.x(), sizes.y(), sizes.z(), obb.volume());
-      ESP_DEBUG() << dataString;
+      ESP_VERY_VERBOSE() << dataString;
       file << dataString << '\n';
     }
   }


### PR DESCRIPTION
## Motivation and Context
This PR adds the following functionality : 
- Derive connected components on a set of vertices conditioned on some vertex attribute, such as color.  It finds all cc's that share the same vertex attribute value, finds the AABB of the resultant vertex cloud, and aggregates the results into a map keyed by semantic object IDX.

- Semantic BBoxes are being generated when needed (currently only in HM3D dataset) using CC with largest BBox (by volume) for a particular semantic annotation.

 - Reporting tools are provided through viewer, including the ability to go through all the scenes in a dataset to derive and save the report to csv file.  A python binding is also provided to give access to this data.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing local c++ and python tests pass. 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
