### PR TITLE
[Bugfix] Fix python bindings for OBB

### DIFF
--- a/src/esp/bindings/GeoBindings.cpp
+++ b/src/esp/bindings/GeoBindings.cpp
@@ -2,10 +2,13 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include "Magnum/Magnum.h"
 #include "esp/bindings/Bindings.h"
 
 #include "esp/geo/Geo.h"
 #include "esp/geo/OBB.h"
+
+#include <Magnum/EigenIntegration/GeometryIntegration.h>
 
 namespace py = pybind11;
 using py::literals::operator""_a;
@@ -25,7 +28,11 @@ void initGeoBindings(py::module& m) {
 
   // ==== OBB ====
   py::class_<OBB>(m, "OBB")
-      .def(py::init<const vec3f&, const vec3f&, const quatf&>())
+      .def(py::init([](const vec3f& center, const vec3f& dimensions,
+                       const Magnum::Quaternion& rotation) {
+        return OBB(center, dimensions,
+                   Magnum::EigenIntegration::cast<quatf>(rotation));
+      }))
       .def(py::init<box3f&>())
       .def("contains", &OBB::contains)
       .def("closest_point", &OBB::closestPoint)

--- a/src/esp/bindings/GeoBindings.cpp
+++ b/src/esp/bindings/GeoBindings.cpp
@@ -2,7 +2,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <Magnum/Magnum.h>
 #include "esp/bindings/Bindings.h"
 
 #include "esp/geo/Geo.h"
@@ -10,6 +9,7 @@
 
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 
+namespace Mn = Magnum;
 namespace py = pybind11;
 using py::literals::operator""_a;
 
@@ -29,9 +29,9 @@ void initGeoBindings(py::module& m) {
   // ==== OBB ====
   py::class_<OBB>(m, "OBB")
       .def(py::init([](const vec3f& center, const vec3f& dimensions,
-                       const Magnum::Quaternion& rotation) {
+                       const Mn::Quaternion& rotation) {
         return OBB(center, dimensions,
-                   Magnum::EigenIntegration::cast<quatf>(rotation));
+                   Mn::EigenIntegration::cast<quatf>(rotation));
       }))
       .def(py::init<box3f&>())
       .def("contains", &OBB::contains)

--- a/src/esp/bindings/GeoBindings.cpp
+++ b/src/esp/bindings/GeoBindings.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "Magnum/Magnum.h"
+#include <Magnum/Magnum.h>
 #include "esp/bindings/Bindings.h"
 
 #include "esp/geo/Geo.h"


### PR DESCRIPTION
## Motivation and Context
* The constructor for OBB now takes a Magnum Quaternion. We don't have any casters from numpy-quaternion to Eigen::Quaternion. Therefore, the previous constructor could never be called. Now the user can pass a Magnum::Quaternion instead which we will cast to an Eigen equivalent.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
