### PR TITLE
--Semantic Vertex-Color-Semantic object mapping report capabilities.

### DIFF
--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -293,11 +293,14 @@ GenericSemanticMeshData::buildSemanticMeshData(
   if (semanticScene && (semanticScene->buildBBoxFromVertColors())) {
     float fractionOfMaxBBoxSize = semanticScene->CCFractionToUseForBBox();
     if (fractionOfMaxBBoxSize > 0.0f) {
-      // build adj list
-      std::vector<std::set<uint32_t>> adjList = geo::buildAdjList(
+      // build adj list to use to derive CCs
+      // Assumes that index buffer defines triangle polys in sequential groups
+      // of 3 vert idxs
+      const std::vector<std::set<uint32_t>> adjList = geo::buildAdjList(
           semanticMeshData->cpu_vbo_.size(), semanticMeshData->cpu_ibo_);
-      // find all connected components based on vertex color.
-      std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
+
+      // find all connected components based on adj list and vertex color.
+      const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>
           clrsToComponents =
               geo::findCCsByGivenColor(adjList, semanticMeshData->cpu_cbo_);
 

--- a/src/esp/assets/GenericSemanticMeshData.cpp
+++ b/src/esp/assets/GenericSemanticMeshData.cpp
@@ -368,7 +368,7 @@ std::vector<std::string> GenericSemanticMeshData::getVertColorSSDReport(
   results.emplace_back(Cr::Utility::formatString(
       "{} : Colors from semantic objects not found on any mesh verts : ",
       semanticFilename));
-  if (unMappedObjectIDXs.size() == 0) {
+  if (unMappedObjectIDXs.empty()) {
     results.emplace_back("All semantic object colors are found on mesh.");
     return results;
   }

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -125,7 +125,7 @@ class GenericSemanticMeshData : public BaseMesh {
    * partition mesh for culling.
    */
   const std::vector<uint16_t>& getPartitionIDs() const {
-    if (meshHasSeparatePartitionIDs) {
+    if (meshUsesSSDPartitionIDs) {
       return partitionIds_;
     }
     return objectIds_;
@@ -146,11 +146,11 @@ class GenericSemanticMeshData : public BaseMesh {
   bool meshHasPartitionIDXs = false;
 
   /**
-   * @brief This mesh has separate partition IDs. If false, uses the objectIDs
-   * for the partitioning, if true means region IDs were provided in semantic
-   * scene descriptor.
+   * @brief This mesh has separate partition IDs, provided by Semantic Scene
+   * Descriptor file. If false, uses the objectIDs for the partitioning, if true
+   * means region IDs were provided in semantic scene descriptor.
    */
-  bool meshHasSeparatePartitionIDs = false;
+  bool meshUsesSSDPartitionIDs = false;
 
   class PerPartitionIdMeshBuilder {
    public:

--- a/src/esp/assets/GenericSemanticMeshData.h
+++ b/src/esp/assets/GenericSemanticMeshData.h
@@ -137,7 +137,27 @@ class GenericSemanticMeshData : public BaseMesh {
    */
   bool meshCanBePartitioned() const { return meshHasPartitionIDXs; }
 
+  /**
+   * @brief build a string array holding mapping information for colors found on
+   * verts and colors found in semantic scene descriptor aggregated during load.
+   */
+
+  std::vector<std::string> getVertColorSSDReport(
+      const std::string& semanticFilename,
+      const std::vector<Mn::Vector3ub>& colorMapToUse,
+      const std::shared_ptr<scene::SemanticScene>& semanticScene);
+
  protected:
+  // temporary holding structures to hold any non-SSD vert colors, so that
+  // the nonSSDObjID for new colors can be incremented appropriately
+  // not using set to avoid extra include. Key is color, value is semantic
+  // ID assigned for unknown color
+  std::unordered_map<uint32_t, int> nonSSDVertColorIDs{};
+  std::unordered_map<uint32_t, int> nonSSDVertColorCounts{};
+
+  // record of semantic object IDXs with no presence in any verts
+  std::vector<uint32_t> unMappedObjectIDXs{};
+
   /**
    * @brief Whether or not this mesh can be partitioned - either object IDs were
    * found in vertices or per-vert region partition values were found from

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1397,7 +1397,7 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
   if (sceneID == -1) {
     // no default scene --- standalone OBJ/PLY files, for example
     // already verified at least one mesh exists, this means only one mesh,
-    // treat as before
+    // so no need to merge/flatten anything
     meshData =
         Mn::MeshTools::transform3D(*fileImporter.mesh(0), reframeTransform);
   } else {
@@ -1428,7 +1428,8 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
     }
     // build concatenated meshData from container of meshes.
     meshData = Mn::MeshTools::concatenate(meshView);
-    // filter out texture coords and remove duplicate verts
+    // filter out all unnecessary attributes (i.e. texture coords) in order to
+    // remove duplicate verts
     meshData =
         Mn::MeshTools::removeDuplicates(Mn::MeshTools::filterOnlyAttributes(
             *meshData, {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -218,7 +218,7 @@ void ResourceManager::initPhysicsManager(
 }  // ResourceManager::initPhysicsManager
 
 std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
-ResourceManager::buildSemanticCCReport(
+ResourceManager::buildSemanticCCObjects(
     const StageAttributes::ptr& stageAttributes) {
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, false, true);
@@ -226,46 +226,56 @@ ResourceManager::buildSemanticCCReport(
   AssetInfo semanticInfo = assetInfoMap.at("semantic");
 
   const std::string& filename = semanticInfo.filepath;
-  /* Open the file. On error the importer already prints a diagnostic message,
-     so no need to do that here. The importer implicitly converts per-face
-     attributes to per-vertex, so nothing extra needs to be done. */
-  ESP_CHECK(
-      (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0u)),
-      Cr::Utility::formatString("Error loading semantic mesh data from file {}",
-                                filename));
+  if (!infoSemanticMeshData_) {
+    /* Open the file. On error the importer already prints a diagnostic message,
+   so no need to do that here. The importer implicitly converts per-face
+   attributes to per-vertex, so nothing extra needs to be done. */
+    ESP_CHECK((fileImporter_->openFile(filename) &&
+               (fileImporter_->meshCount() > 0u)),
+              Cr::Utility::formatString(
+                  "Error loading semantic mesh data from file {}", filename));
 
-  // flatten source meshes, preserving transforms, build semanticMeshData and
-  // construct vertex-based semantic bboxes, if requested for dataset.
-  GenericSemanticMeshData::uptr semanticMeshData =
-      flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
+    // flatten source meshes, preserving transforms, build semanticMeshData and
+    // construct vertex-based semantic bboxes, if requested for dataset.
+    infoSemanticMeshData_ =
+        flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
+  }
 
   // return connectivity query results - per color map of vectors of CC-based
   // Semantic objects.
-  return semanticMeshData->buildCCBasedSemanticObjs(semanticScene_);
-}  // ResourceManager::buildSemanticCCReport
+  return infoSemanticMeshData_->buildCCBasedSemanticObjs(semanticScene_);
+}  // ResourceManager::buildSemanticCCObjects
 
 std::vector<std::string> ResourceManager::buildVertexColorMapReport(
     const metadata::attributes::StageAttributes::ptr& stageAttributes) {
+  if (!semanticScene_) {
+    // must have a semantic scene for this report to make sense.
+    return {
+        "Unable to evaluate vertex-to-semantic object color mapping due to "
+        "semantic scene being null."};
+  }
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, false, true);
 
   AssetInfo semanticInfo = assetInfoMap.at("semantic");
 
   const std::string& filename = semanticInfo.filepath;
-  /* Open the file. On error the importer already prints a diagnostic message,
-     so no need to do that here. The importer implicitly converts per-face
-     attributes to per-vertex, so nothing extra needs to be done. */
-  ESP_CHECK(
-      (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0u)),
-      Cr::Utility::formatString("Error loading semantic mesh data from file {}",
-                                filename));
+  if (!infoSemanticMeshData_) {
+    /* Open the file. On error the importer already prints a diagnostic message,
+       so no need to do that here. The importer implicitly converts per-face
+       attributes to per-vertex, so nothing extra needs to be done. */
+    ESP_CHECK((fileImporter_->openFile(filename) &&
+               (fileImporter_->meshCount() > 0u)),
+              Cr::Utility::formatString(
+                  "Error loading semantic mesh data from file {}", filename));
 
-  // flatten source meshes, preserving transforms, build semanticMeshData and
-  // construct vertex-based semantic bboxes, if requested for dataset.
-  GenericSemanticMeshData::uptr semanticMeshData =
-      flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
+    // flatten source meshes, preserving transforms, build semanticMeshData and
+    // construct vertex-based semantic bboxes, if requested for dataset.
+    infoSemanticMeshData_ =
+        flattenImportedMeshAndBuildSemantic(*fileImporter_, semanticInfo);
+  }
 
-  return semanticMeshData->getVertColorSSDReport(
+  return infoSemanticMeshData_->getVertColorSSDReport(
       Cr::Utility::Directory::filename(filename), semanticColorMapBeingUsed_,
       semanticScene_);
 }  // ResourceManager::buildVertexColorMapReport
@@ -2422,7 +2432,10 @@ void ResourceManager::loadTextures(Importer& importer,
   loadedAssetData.meshMetaData.setTextureIndices(textureStart, textureEnd);
   if (loadedAssetData.assetInfo.hasSemanticTextures) {
     // build semantic BBoxes and semanticColorMapBeingUsed_ if semanticScene_
-    flattenImportedMeshAndBuildSemantic(importer, loadedAssetData.assetInfo);
+    // and save results to informational SemanticMeshData, to facilitate future
+    // reporting
+    infoSemanticMeshData_ = flattenImportedMeshAndBuildSemantic(
+        importer, loadedAssetData.assetInfo);
 
     // We are assuming that the only textures that exist are the semantic
     // textures. We build table of all possible colors holding ushorts

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -718,6 +718,15 @@ class ResourceManager {
   buildSemanticCCReport(
       const metadata::attributes::StageAttributes::ptr& stageAttributes);
 
+  /**
+   * @brief Build data for a report for vertex color mapping to semantic scene
+   * objects - this list of strings will disclose which colors are found in
+   * vertices but not in semantic scene descirptors, and which semantic objects
+   * do not have their colors mapped in mesh verts.
+   */
+  std::vector<std::string> buildVertexColorMapReport(
+      const metadata::attributes::StageAttributes::ptr& stageAttributes);
+
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -715,7 +715,7 @@ class ResourceManager {
    */
   std::unordered_map<uint32_t,
                      std::vector<std::shared_ptr<scene::CCSemanticObject>>>
-  buildSemanticCCReport(
+  buildSemanticCCObjects(
       const metadata::attributes::StageAttributes::ptr& stageAttributes);
 
   /**
@@ -1229,6 +1229,17 @@ class ResourceManager {
    * to load asset data
    */
   Corrade::PluginManager::Manager<Importer> importerManager_;
+
+  /**
+   * @brief This @ref GenericSemanticMeshData unique pointer is not used to
+   * actually create a mesh, but rather for reporting and color annotations (for
+   * texture-based semantics processing). We retain this so we do not need to
+   * re-load from scratch for future reporting functionality.
+   * NOTE : We must not use this to retain a semantic mesh that is actually
+   * being rendered, since that mesh will have its components moved into actual
+   * render mesh constructs.
+   */
+  GenericSemanticMeshData::uptr infoSemanticMeshData_{};
 
   /**
    * @brief Importer used to synthesize Magnum Primitives (PrimitiveImporter).

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -183,12 +183,10 @@ void initSimBindings(py::module& m) {
           &Simulator::getStageInitializationTemplate, "scene_id"_a = 0,
           R"(Get a copy of the StageAttributes template used to instance a scene's stage or None if it does not exist.)")
 
-      .def("build_semantic_CC_report", &Simulator::buildSemanticCCReport,
-           R"(Get a report on the current semantic scene's connected
-          components based on color. Returns a dictionary keyed by
-          color where each value is a list of tuples, where the
-          first element is the number of verts in the CC and the
-          second is the AABB)")
+      .def("build_semantic_CC_objects", &Simulator::buildSemanticCCObjects,
+           R"(Get a dictionary of the current semantic scene's connected
+          components keyed by color or id, where each value is a list of Semantic Objects
+          corresponding to an individual connected component.")
       .def(
           "build_vertex_color_map_report",
           &Simulator::buildVertexColorMapReport,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -189,6 +189,13 @@ void initSimBindings(py::module& m) {
           color where each value is a list of tuples, where the
           first element is the number of verts in the CC and the
           second is the AABB)")
+      .def(
+          "build_vertex_color_map_report",
+          &Simulator::buildVertexColorMapReport,
+          R"(Get a list of strings describing first each color found on vertices in the
+          semantic mesh that is not present in the loaded semantic scene descriptor file,
+          and then a list of each semantic object whose specified color is not found on
+          any vertex in the mesh.)")
 
       /* --- Kinematics and dynamics --- */
       .def(

--- a/src/esp/geo/OBB.cpp
+++ b/src/esp/geo/OBB.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <vector>
 
+#include "esp/core/Check.h"
 #include "esp/geo/Geo.h"
 
 namespace esp {
@@ -41,9 +42,13 @@ box3f OBB::toAABB() const {
 }
 
 void OBB::recomputeTransforms() {
-  CORRADE_INTERNAL_ASSERT(center_.allFinite());
-  CORRADE_INTERNAL_ASSERT(halfExtents_.allFinite());
-  CORRADE_INTERNAL_ASSERT(rotation_.coeffs().allFinite());
+  ESP_CHECK(center_.allFinite(),
+            "Illegal center for OBB. Cannot recompute transformations.");
+  ESP_CHECK(halfExtents_.allFinite(),
+            "Illegal size values for OBB. Cannot recompute transformations.");
+  ESP_CHECK(
+      rotation_.coeffs().allFinite(),
+      "Illegal rotation quaternion for OBB. Cannot recompute transformations.");
 
   // TODO(MS): these can be composed more efficiently and directly
   const mat3f R = rotation_.matrix();

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -195,7 +195,7 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
 
   // build colormap from colors defined in ssd
   scene.semanticColorMapBeingUsed_.clear();
-  scene.semanticColorMapBeingUsed_.reserve(objInstance.size());
+  scene.semanticColorMapBeingUsed_.resize(objInstance.size());
   scene.semanticColorToIdAndRegion_.clear();
   scene.semanticColorToIdAndRegion_.reserve(objInstance.size());
   // build the color map with first maxSemanticID elements in proper order
@@ -219,11 +219,21 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
   // TODO: eventually BBoxes will be pre-generated and stored in semantic text
   // file.
   scene.needBBoxFromVertColors_ = true;
-  // use only largest volume bbox
-  // TODO: eventually drive this via customizable config value.
-  scene.ccLargestVolToUseForBBox_ = 1.0f;
-  scene.levels_.clear();  // Not used for Hm3d currently
 
+  // TODO: eventually set this via customizable config value.
+  // TODO: Using float to potentially allow for this value to include multiple
+  // CC's verts via their BBox volume, where float value denotes fraction of
+  // largest bbox's volume to include in final BBox.
+
+  // Currently, if this value is > 0.0f, semantic BBox is
+  // an AABB in world space built by largest CC vertset by volume sharing
+  // semantic color annotation; if 0.0, it uses all verts assigned specific
+  // color annotations. Using a float value to
+  //
+  scene.ccLargestVolToUseForBBox_ = 1.0f;
+
+  // Not used for Hm3d currently
+  scene.levels_.clear();
   return true;
 
 }  // SemanticScene::buildHM3DHouse

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -202,7 +202,7 @@ std::vector<uint32_t> SemanticScene::buildSemanticOBBsFromCCs(
     const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
         clrsToComponents,
     const std::shared_ptr<SemanticScene>& semanticScene,
-    const float maxVolFraction,
+    float maxVolFraction,
     const std::string& msgPrefix) {
   // Semantic scene is required to map color annotations to semantic objects
   if (!semanticScene) {

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -230,7 +230,7 @@ class SemanticScene {
       const std::unordered_map<uint32_t, std::vector<std::set<uint32_t>>>&
           clrsToComponents,
       const std::shared_ptr<SemanticScene>& semanticScene,
-      const float maxVolFraction,
+      float maxVolFraction,
       const std::string& msgPrefix);
 
   /**

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -235,13 +235,13 @@ class Simulator {
   }
 
   /**
-   * @brief Build a connectivity report for current stage's semantic scene
-   * vertex annotation regions.
+   * @brief Build a map keyed by semantic color/id referencing a vector
+   * connected component-based Semantic objects.
    */
   std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
-  buildSemanticCCReport() const {
+  buildSemanticCCObjects() const {
     // build report with current stage attributes
-    return resourceManager_->buildSemanticCCReport(
+    return resourceManager_->buildSemanticCCObjects(
         physicsManager_->getStageInitAttributes());
   }
 

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -239,9 +239,19 @@ class Simulator {
    * vertex annotation regions.
    */
   std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
-  buildSemanticCCReport() {
+  buildSemanticCCReport() const {
     // build report with current stage attributes
     return resourceManager_->buildSemanticCCReport(
+        physicsManager_->getStageInitAttributes());
+  }
+
+  /**
+   * @brief Build a report on vertex color mappings to semantic scene descriptor
+   * object colors, to show whether any verts have unknown colors and whether
+   * any semantic object colors are not present in the mesh.
+   */
+  std::vector<std::string> buildVertexColorMapReport() const {
+    return resourceManager_->buildVertexColorMapReport(
         physicsManager_->getStageInitAttributes());
   }
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1161,6 +1161,7 @@ void Viewer::generateAndSaveAllVertColorMapReports() {
     setSceneInstanceFromListAndShow(idx);
     generateAndSaveVertColorMapReports();
   }
+  ESP_DEBUG() << "All reports done!";
 }
 
 /**
@@ -1203,6 +1204,7 @@ void Viewer::generateAndSaveAllSemanticCCReports() {
     setSceneInstanceFromListAndShow(idx);
     generateAndSaveSemanticCCReport();
   }
+  ESP_DEBUG() << "All reports done!";
 }
 
 void Viewer::generateAndSaveSemanticCCReport() {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1208,7 +1208,7 @@ void Viewer::generateAndSaveAllSemanticCCReports() {
 }
 
 void Viewer::generateAndSaveSemanticCCReport() {
-  const auto results = simulator_->buildSemanticCCReport();
+  const auto results = simulator_->buildSemanticCCObjects();
   const std::string fileDir = Cr::Utility::Directory::join(
       {Cr::Utility::Directory::path(MM_->getActiveSceneDatasetName()),
        "Semantic_CC_Reports"});


### PR DESCRIPTION
## Motivation and Context
This PR will provide a reporting tool usable on semantic scenes (currently only HM3D) that have vertex-annotated colors and semantic scene descriptor file color-to-id mappings.  This report will list all the verts that have colors assigned in the mesh that are not present in the semantic scene descriptor, and all the semantic objects that have colors that are not found on the mesh.

This report can be synthesized via a viewer key bind and also using the python binding `sim.build_vertex_color_map_report()` after the scene is loaded.  This returns a list of strings containing the pertinent report data.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally via c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
