### PR TITLE
[Bugfix]--Verify that semantic scenes exist before reporting

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -220,6 +220,12 @@ void ResourceManager::initPhysicsManager(
 std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
 ResourceManager::buildSemanticCCObjects(
     const StageAttributes::ptr& stageAttributes) {
+  if (!metadataMediator_->getSimulatorConfiguration().loadSemanticMesh) {
+    ESP_WARNING() << "Unable to create semantic CC Objects due to no semantic "
+                     "scene being loaded/existing.";
+    return {};
+  }
+
   std::map<std::string, AssetInfo> assetInfoMap =
       createStageAssetInfosFromAttributes(stageAttributes, false, true);
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -99,6 +99,7 @@ void Simulator::close(const bool destroy) {
 
   activeSceneID_ = ID_UNDEFINED;
   activeSemanticSceneID_ = ID_UNDEFINED;
+  semanticSceneMeshLoaded_ = false;
   config_ = SimulatorConfiguration{};
 
   frustumCulling_ = true;
@@ -442,6 +443,9 @@ bool Simulator::instanceStageForSceneAttributes(
   // the semantic scene mesh is loaded.
 
   if (activeSemanticSceneID_ != tempIDs[1]) {
+    // check if semantic scene mesh has been loaded
+    // assume it has if tempIDs[1] is different
+    semanticSceneMeshLoaded_ = true;
     // id has changed so act - if ID has not changed, do nothing
     activeSemanticSceneID_ = tempIDs[1];
     if ((activeSemanticSceneID_ != ID_UNDEFINED) &&
@@ -454,10 +458,12 @@ bool Simulator::instanceStageForSceneAttributes(
       // empty scene has none to worry about
       if (!(stageType == assets::AssetType::INSTANCE_MESH ||
             stageAttributesHandle == assets::EMPTY_SCENE)) {
+        semanticSceneMeshLoaded_ = false;
         // TODO: programmatic generation of semantic meshes when no
         // annotations are provided.
         ESP_WARNING() << "\n---\nThe active scene does not contain semantic "
-                         "annotations. \n---";
+                         "annotations : activeSemanticSceneID_ ="
+                      << activeSemanticSceneID_ << " \n---";
       }
     }
   }  // if ID has changed - needs to be reset

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -209,7 +209,7 @@ class Simulator {
   const esp::physics::PhysicsManager::PhysicsSimulationLibrary&
   getPhysicsSimulationLibrary() const {
     return physicsManager_->getPhysicsSimulationLibrary();
-  };
+  }
 
   /** @brief Render any debugging visualizations provided by the underlying
    * physics simulator implementation. By default does nothing. See @ref
@@ -219,7 +219,7 @@ class Simulator {
    */
   void physicsDebugDraw(const Magnum::Matrix4& projTrans) const {
     physicsManager_->debugDraw(projTrans);
-  };
+  }
 
   /**
    * @brief Get a copy of a stage's template when the stage was instanced.
@@ -241,8 +241,13 @@ class Simulator {
   std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
   buildSemanticCCObjects() const {
     // build report with current stage attributes
-    return resourceManager_->buildSemanticCCObjects(
-        physicsManager_->getStageInitAttributes());
+    if (semanticSceneMeshLoaded_) {
+      return resourceManager_->buildSemanticCCObjects(
+          physicsManager_->getStageInitAttributes());
+    }
+    ESP_WARNING()
+        << "Unable to build semantic CC objects since no semantic mesh exists.";
+    return {};
   }
 
   /**
@@ -251,8 +256,13 @@ class Simulator {
    * any semantic object colors are not present in the mesh.
    */
   std::vector<std::string> buildVertexColorMapReport() const {
-    return resourceManager_->buildVertexColorMapReport(
-        physicsManager_->getStageInitAttributes());
+    if (semanticSceneMeshLoaded_) {
+      return resourceManager_->buildVertexColorMapReport(
+          physicsManager_->getStageInitAttributes());
+    }
+    ESP_WARNING() << "Unable to build vertex-to-color mapping report since no "
+                     "semantic mesh exists.";
+    return {};
   }
 
   /**
@@ -1123,6 +1133,12 @@ class Simulator {
 
   int activeSceneID_ = ID_UNDEFINED;
   int activeSemanticSceneID_ = ID_UNDEFINED;
+
+  /**
+   * @brief Whether or not the loaded scene has a semantic scene mesh loaded.
+   */
+  bool semanticSceneMeshLoaded_ = false;
+
   std::vector<int> sceneID_;
 
   std::shared_ptr<physics::PhysicsManager> physicsManager_ = nullptr;


### PR DESCRIPTION
## Motivation and Context
This will prevent viewer or bindings from calling the reporting and semantic CC calculation functionality if no semantic scene mesh exists.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
