### PR TITLE
Properly use texture transformation matrix for flat materials as well.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2224,6 +2224,14 @@ gfx::PhongMaterialData::uptr ResourceManager::buildFlatShadedMaterialData(
   // flat materials
   auto finalMaterial = gfx::PhongMaterialData::create_unique();
 
+  // texture transform, if the material has a texture; if there's none the
+  // matrix is an identity
+  // TODO this check shouldn't be needed, remove when this no longer asserts
+  // in magnum for untextured materials
+  if (material.hasTexture()) {
+    finalMaterial->textureMatrix = material.textureMatrix();
+  }
+
   finalMaterial->ambientColor = material.color();
   if (material.hasTexture()) {
     finalMaterial->ambientTexture =


### PR DESCRIPTION
## Motivation and Context

Fixes texture transformation with flat materials. Was done for Phong but not for flat.

Once we port away from these custom structures and use Magnum's `MaterialData` everywhere, this kind of bugs will become *much* less likely.

## How Has This Been Tested

Trust Me :tm:

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
