### PR TITLE
HM3D Semantics v0.1 fixes

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -26,7 +26,7 @@ Now, you are ready to download. For example, to download the minival split, use:
 python -m habitat_sim.utils.datasets_download --username <api-token-id> --password <api-token-secret> --uids hm3d_minival
 ```
 
-By default, downloading the data for train/val/example scenes also pulls in the semantic annotations for [HM3D-Semantics v0.1](https://aihabitat.org/datasets/hm3d-semantics/). To download only the semantic annotations for these splits, use the uid `hm3d_<split>_semantics_0.1`.
+By default, downloading the data for train/val/example scenes also pulls in the semantic annotations and configs for [HM3D-Semantics v0.1](https://aihabitat.org/datasets/hm3d-semantics/). To download only the semantic files for these splits, use the uid `hm3d_semantics`.
 
 
 By default the download script will only download what is needed for habitat-sim.  You can add `_full` to the uid to download the raw glbs and the obj+mtl's in addition to what is needed for use with habitat-sim.

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -35,6 +35,18 @@ def hm3d_train_configs_post(extract_dir: str) -> List[str]:
     return [link_name]
 
 
+def hm3d_semantic_train_configs_post(extract_dir: str) -> List[str]:
+    all_scene_dataset_cfg = os.path.join(
+        extract_dir, "hm3d_annotated_basis.scene_dataset_config.json"
+    )
+    assert os.path.exists(all_scene_dataset_cfg)
+
+    link_name = os.path.join(extract_dir, "..", "hm3d_annotated_basis.scene_dataset_config.json")
+    os.symlink(all_scene_dataset_cfg, link_name)
+
+    return [link_name]
+
+
 def initialize_test_data_sources(data_path):
     global data_sources
     global data_groups
@@ -193,38 +205,54 @@ def initialize_test_data_sources(data_path):
 
     data_sources.update(
         {
-            f"hm3d_{split}_semantics_v0.1": {
-                "source": "https://api.matterport.com/resources/habitat/hm3d-{split}-semantic-annots-v0.1.tar.gz".format(
+            f"hm3d_{split}_semantic_{data_format}_v0.1": {
+                "source": "https://api.matterport.com/resources/habitat/hm3d-{split}-semantic-{data_format}-v0.1.tar{ext}".format(
+                    ext=".gz" if data_format == "annots" else "",
                     split=split,
+                    data_format=data_format,
                 ),
                 "download_pre_args": "--location",
-                "package_name": "hm3d-{split}-semantic-annots-v0.1.tar.gz".format(
+                "package_name": "hm3d-{split}-semantic-{data_format}-v0.1.tar{ext}".format(
+                    ext=".gz" if data_format == "annots" else "",
                     split=split,
+                    data_format=data_format,
                 ),
                 "link": data_path + "scene_datasets/hm3d",
                 "version": "1.0",
                 "version_dir": "hm3d-{version}/hm3d",
                 "extract_postfix": f"{split}",
-                "downloaded_file_list": f"hm3d-{{version}}/{split}-semantic-annot-files.json.gz",
+                "downloaded_file_list": f"hm3d-{{version}}/{split}-semantic-{data_format}-files.json.gz",
                 "requires_auth": True,
                 "use_curl": True,
-                "post_extract_fn": None,
+                "post_extract_fn": hm3d_semantic_train_configs_post
+                if split == "train" and data_format == "configs"
+                else None,
             }
-            for split in ["train", "val"]
+            for split, data_format in itertools.product(
+                ["minival", "train", "val"],
+                ["annots", "configs"],
+            )
         }
     )
 
     data_sources.update(
         {
-            "hm3d_example_semantics_v0.1": {
-                "source": "https://github.com/matterport/habitat-matterport-3dresearch/raw/main/example/hm3d-example-semantic-annots-v0.1.tar.gz",
-                "package_name": "hm3d-example-semantic-annots-v0.1.tar.gz",
+            f"hm3d_example_semantic_{data_format}_v0.1": {
+                "source": "https://github.com/matterport/habitat-matterport-3dresearch/raw/main/example/hm3d-example-semantic-{data_format}-v0.1.tar{ext}".format(
+                    ext=".gz" if data_format == "annots" else "",
+                    data_format=data_format,
+                ),
+                "package_name": "hm3d-example-semantic-{data_format}-v0.1.tar{ext}".format(
+                    ext=".gz" if data_format == "annots" else "",
+                    data_format=data_format,
+                ),
                 "link": data_path + "scene_datasets/hm3d",
                 "version": "1.0",
                 "version_dir": "hm3d-{version}/hm3d",
                 "extract_postfix": "example",
-                "downloaded_file_list": "hm3d-{version}/example-semantic-annot-files.json.gz",
+                "downloaded_file_list": f"hm3d-{{version}}/example-semantic-{data_format}-files.json.gz",
             }
+            for data_format in ["annots", "configs"]
         }
     )
 
@@ -250,19 +278,36 @@ def initialize_test_data_sources(data_path):
         "hm3d_example": [
             "hm3d_example_habitat",
             "hm3d_example_configs",
-            "hm3d_example_semantics_v0.1",
+            "hm3d_example_semantic_annots_v0.1",
+            "hm3d_example_semantic_configs_v0.1",
         ],
-        "hm3d_val": ["hm3d_val_habitat", "hm3d_val_configs", "hm3d_val_semantics_v0.1"],
+        "hm3d_val": [
+            "hm3d_val_habitat",
+            "hm3d_val_configs",
+            "hm3d_val_semantic_annots_v0.1",
+            "hm3d_val_semantic_configs_v0.1",
+        ],
         "hm3d_train": [
             "hm3d_train_habitat",
             "hm3d_train_configs",
-            "hm3d_train_semantics_v0.1",
+            "hm3d_train_semantic_annots_v0.1",
+            "hm3d_train_semantic_configs_v0.1",
         ],
-        "hm3d_minival": ["hm3d_minival_habitat", "hm3d_minival_configs"],
+        "hm3d_minival": [
+            "hm3d_minival_habitat",
+            "hm3d_minival_configs",
+            "hm3d_minival_semantic_annots_v0.1",
+            "hm3d_minival_semantic_configs_v0.1",
+        ],
         "hm3d_semantics": [
-            "hm3d_train_semantics_v0.1",
-            "hm3d_val_semantics_v0.1",
-            "hm3d_example_semantics_v0.1",
+            "hm3d_example_semantic_annots_v0.1",
+            "hm3d_example_semantic_configs_v0.1",
+            "hm3d_val_semantic_annots_v0.1",
+            "hm3d_val_semantic_configs_v0.1",
+            "hm3d_train_semantic_annots_v0.1",
+            "hm3d_train_semantic_configs_v0.1",
+            "hm3d_minival_semantic_annots_v0.1",
+            "hm3d_minival_semantic_configs_v0.1",
         ],
         "hm3d_full": list(filter(lambda k: k.startswith("hm3d_"), data_sources.keys())),
     }

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -41,10 +41,10 @@ def hm3d_semantic_configs_post(extract_dir: str) -> List[str]:
     )
     assert os.path.exists(all_scene_dataset_cfg)
 
-    link_name = os.path.join(extract_dir, "..", "hm3d_annotated_basis.scene_dataset_config.json")
-    os.symlink(all_scene_dataset_cfg, link_name)
+    dst_name = os.path.join(extract_dir, "..", "hm3d_annotated_basis.scene_dataset_config.json")
+    os.replace(all_scene_dataset_cfg, dst_name)
 
-    return [link_name]
+    return [dst_name]
 
 
 def initialize_test_data_sources(data_path):

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -35,7 +35,7 @@ def hm3d_train_configs_post(extract_dir: str) -> List[str]:
     return [link_name]
 
 
-def hm3d_semantic_train_configs_post(extract_dir: str) -> List[str]:
+def hm3d_semantic_configs_post(extract_dir: str) -> List[str]:
     all_scene_dataset_cfg = os.path.join(
         extract_dir, "hm3d_annotated_basis.scene_dataset_config.json"
     )
@@ -224,9 +224,8 @@ def initialize_test_data_sources(data_path):
                 "downloaded_file_list": f"hm3d-{{version}}/{split}-semantic-{data_format}-files.json.gz",
                 "requires_auth": True,
                 "use_curl": True,
-                "post_extract_fn": hm3d_semantic_train_configs_post
-                if split == "train" and data_format == "configs"
-                else None,
+                "post_extract_fn": hm3d_semantic_configs_post
+                if  data_format == "configs" else None,
             }
             for split, data_format in itertools.product(
                 ["minival", "train", "val"],

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -41,7 +41,9 @@ def hm3d_semantic_configs_post(extract_dir: str) -> List[str]:
     )
     assert os.path.exists(all_scene_dataset_cfg)
 
-    dst_name = os.path.join(extract_dir, "..", "hm3d_annotated_basis.scene_dataset_config.json")
+    dst_name = os.path.join(
+        extract_dir, "..", "hm3d_annotated_basis.scene_dataset_config.json"
+    )
     os.replace(all_scene_dataset_cfg, dst_name)
 
     return [dst_name]
@@ -225,7 +227,8 @@ def initialize_test_data_sources(data_path):
                 "requires_auth": True,
                 "use_curl": True,
                 "post_extract_fn": hm3d_semantic_configs_post
-                if  data_format == "configs" else None,
+                if data_format == "configs"
+                else None,
             }
             for split, data_format in itertools.product(
                 ["minival", "train", "val"],


### PR DESCRIPTION
## Motivation and Context

This PR updates the dataset download script to use HM3D semantics files with corrected directory structure. It also ensures that the HM3D semantics files are smoothly merged with the original HM3D files for ease of use. 

Note: The tests will not pass until the Matterport repo PR containing the new example files is merged into main. 

## How Has This Been Tested

Tested locally

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
