### PR TITLE
ReplicaCAD v1.4

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -109,16 +109,16 @@ def initialize_test_data_sources(data_path):
             "version": "1.0",
         },
         "replica_cad_dataset": {
-            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_dataset_v1.3.zip",
-            "package_name": "ReplicaCAD_dataset_v1.3.zip",
+            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_dataset_v1.4.zip",
+            "package_name": "ReplicaCAD_dataset_v1.4.zip",
             "link": data_path + "replica_cad",
-            "version": "1.3",
+            "version": "1.4",
         },
         "replica_cad_baked_lighting": {
-            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_baked_lighting_v1.3.zip",
-            "package_name": "ReplicaCAD_baked_lighting_v1.3.zip",
+            "source": "https://dl.fbaipublicfiles.com/habitat/ReplicaCAD/ReplicaCAD_baked_lighting_v1.4.zip",
+            "package_name": "ReplicaCAD_baked_lighting_v1.4.zip",
             "link": data_path + "replica_cad_baked_lighting",
-            "version": "1.3",
+            "version": "1.4",
         },
         "ycb": {
             "source": "https://dl.fbaipublicfiles.com/habitat/ycb/hab_ycb_v1.1.zip",


### PR DESCRIPTION
## Motivation and Context

Updates the default downloader version for ReplicaCAD to v1.4.

Changes with v1.4:
- NavMeshes recomputed for agent radius 0.3m (from default 0.1m) corresponding to Fetch robot base as used in Habitat 2.0 (default navmeshes also included in a separate folder for optional use)
- Minor furniture layout modifications to the following scenes in order to better accommodate robot access to the full set of receptacles for rearrange tasks:
  - sc1_staging_02
  - sc1_staging_05
  - sc1_staging_12
  - sc1_staging_03
  - sc1_staging_06
  - sc1_staging_09
  - sc1_staging_10
  - sc1_staging_13
  - sc1_staging_16
  - sc2_staging_00
  - sc2_staging_07
  - sc2_staging_09
  - sc3_staging_03
  - sc3_staging_05
  - sc3_staging_11
  - sc4_staging_08
- Fixed layout error with Fridge intersecting tv_stand in sc2_staging_20
- Minor furniture layout modifications to the following scenes in order to move furniture blocking kitchen drawers from fully opening:
  - sc1_staging_03
  - sc1_staging_05
  - sc1_staging_09
  - sc1_staging_10
  - sc1_staging_14
  - sc1_staging_15
  - sc2_staging_03
  - sc2_staging_06
  - sc2_staging_09
  - sc2_staging_13
- Added visual geometry to `frl_apartment_shoebox_01.glb` which didn't have a bottom.

## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
