### PR TITLE
[doc] - Simulator.PhysicsDebugDraw binding update

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -101,7 +101,7 @@ class HabitatSimInteractiveViewer(Application):
         if self.debug_bullet_draw:
             render_cam = self.render_camera.render_camera
             proj_mat = render_cam.projection_matrix.__matmul__(render_cam.camera_matrix)
-            self.sim.debug_draw(proj_mat)
+            self.sim.physics_debug_draw(proj_mat)
 
     def draw_event(
         self,

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -110,7 +110,9 @@ void initSimBindings(py::module& m) {
       .def(
           "close", &Simulator::close, "destroy"_a = true,
           R"(Free all loaded assets and GPU contexts. Use destroy=true except where noted in tutorials/async_rendering.py.)")
-      .def("debug_draw", &Simulator::physicsDebugDraw, "projMat"_a)
+      .def(
+          "physics_debug_draw", &Simulator::physicsDebugDraw, "projMat"_a,
+          R"(Render any debugging visualizations provided by the underlying physics simulator implementation given the composed projection and transformation matrix for the render camera.)")
       .def_property("pathfinder", &Simulator::getPathFinder,
                     &Simulator::setPathFinder)
       .def_property(


### PR DESCRIPTION
## Motivation and Context

Add missing docstring and more descriptive name for physics debug draw function (e.g. Bullet debug lines integration).

User note: Any previous uses of `Simulator.debug_draw()` should be changed to `Simulator.physics_debug_draw()`, though low risk because I don't think anything but our python viewer should be using this currently.

## How Has This Been Tested

NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
