### PR TITLE
viewer.py - agent state re-sampling with ALT+'n'

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -13,8 +13,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
-import numpy as np
 import magnum as mn
+import numpy as np
 from magnum.platform.glfw import Application
 
 import habitat_sim
@@ -277,7 +277,7 @@ class HabitatSimInteractiveViewer(Application):
 
         shift_pressed = bool(event.modifiers & mod.SHIFT)
         alt_pressed = bool(event.modifiers & mod.ALT)
-        #warning: ctrl doesn't always pass through with other key-presses
+        # warning: ctrl doesn't always pass through with other key-presses
 
         if key == pressed.ESC:
             event.accepted = True
@@ -377,15 +377,18 @@ class HabitatSimInteractiveViewer(Application):
                 logger.info("Command: resample agent state from navmesh")
                 if self.sim.pathfinder.is_loaded:
                     new_agent_state = habitat_sim.AgentState()
-                    new_agent_state.position = self.sim.pathfinder.get_random_navigable_point()
+                    new_agent_state.position = (
+                        self.sim.pathfinder.get_random_navigable_point()
+                    )
                     new_agent_state.rotation = quat_from_angle_axis(
-                        self.sim.random.uniform_float(0, 2.0 * np.pi), np.array([0, 1, 0])
+                        self.sim.random.uniform_float(0, 2.0 * np.pi),
+                        np.array([0, 1, 0]),
                     )
                     self.default_agent.set_state(new_agent_state)
                 else:
                     logger.warning(
-                            f"NavMesh is not initialized. Cannot sample new agent state."
-                        )
+                        "NavMesh is not initialized. Cannot sample new agent state."
+                    )
             elif shift_pressed:
                 logger.info("Command: recompute navmesh")
                 self.navmesh_config_and_recompute()


### PR DESCRIPTION
## Motivation and Context

Needed a way to escape NavMesh islands in disconnected scenes.
Added a keypress `ALT`+`'n'` to resample position from the NavMesh and randomize orientation.

## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
