### PR TITLE
Python Sensor debug_draw

### DIFF
--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -425,6 +425,7 @@ class Simulator(SimulatorBackend):
             agent_sensorsuite = self.__sensors[agent_id]
             for _sensor_uuid, sensor in agent_sensorsuite.items():
                 sensor.draw_observation()
+                self.debug_draw()
 
         # As backport. All Dicts are ordered in Python >= 3.7
         observations: Dict[int, ObservationDict] = OrderedDict()
@@ -436,6 +437,9 @@ class Simulator(SimulatorBackend):
         if return_single:
             return next(iter(observations.values()))
         return observations
+
+    def debug_draw(self):
+        pass
 
     @property
     def _default_agent(self) -> Agent:

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -425,7 +425,7 @@ class Simulator(SimulatorBackend):
             agent_sensorsuite = self.__sensors[agent_id]
             for _sensor_uuid, sensor in agent_sensorsuite.items():
                 sensor.draw_observation()
-                self.debug_draw()
+                self.debug_draw(_sensor_uuid)
 
         # As backport. All Dicts are ordered in Python >= 3.7
         observations: Dict[int, ObservationDict] = OrderedDict()
@@ -438,8 +438,12 @@ class Simulator(SimulatorBackend):
             return next(iter(observations.values()))
         return observations
 
-    def debug_draw(self):
-        pass
+    def debug_draw(self, sensor_uuid: Optional[str] = None) -> None:
+        r"""Override this method in derived Simulator class to add optional, application specific debug line drawing commands to the sensor output.
+        See Simulator.get_debug_line_render().
+
+        :param sensor_uuid: The uuid of the sensor being rendered to optionally limit debug drawing to specific visualizations (e.g. a third person eval camera)
+        """
 
     @property
     def _default_agent(self) -> Agent:


### PR DESCRIPTION
## Motivation and Context

It can be useful to define custom debug drawing methods with a derived Simulator class (e.g. in Habitat-lab). This PR adds a hook to a `debug_draw()` function stub which is called in `simulator.get_sensor_observations()` and can be overridden for application specific debugging visualizations.

For example, 

## How Has This Been Tested

Overrode this in a Habitat-lab task and added [DebugLineRender](https://aihabitat.org/docs/habitat-sim/habitat_sim.gfx.DebugLineRender.html) commands for an evaluation camera sensor.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
