### PR TITLE
normalizing the actions so that -1 and 1 become the limits

### DIFF
--- a/src/esp/batched_sim/BatchedSimulator.cpp
+++ b/src/esp/batched_sim/BatchedSimulator.cpp
@@ -1937,10 +1937,10 @@ void BatchedSimulator::substepPhysics() {
       robotInstance.doAttemptDrop_ = graspReleaseAction < graspReleaseSetup.thresholds[0];
     }
 
-    const float clampedBaseYawAction = Mn::Math::clamp(baseRotateAction, baseRotateSetup.stepMin, baseRotateSetup.stepMax);
+    const float clampedBaseYawAction = Mn::Math::clamp(baseRotateAction * (baseRotateSetup.stepMax - baseRotateSetup.stepMin) + baseRotateSetup.stepMin, baseRotateSetup.stepMin, baseRotateSetup.stepMax);
     yaws[b] = prevYaws[b] + clampedBaseYawAction; // todo: wrap angle to 360 degrees
 
-    float clampedBaseMovementAction = Mn::Math::clamp(baseMoveAction, baseMoveSetup.stepMin, baseMoveSetup.stepMax);
+    float clampedBaseMovementAction = Mn::Math::clamp(baseMoveAction * (baseMoveSetup.stepMax - baseMoveSetup.stepMin) + baseMoveSetup.stepMin, baseMoveSetup.stepMin, baseMoveSetup.stepMax);
     positions[b] =
         prevPositions[b] + 
         Mn::Vector2(Mn::Math::cos(Mn::Math::Rad(yaws[b])), -Mn::Math::sin(Mn::Math::Rad(yaws[b]))) 
@@ -1961,7 +1961,7 @@ void BatchedSimulator::substepPhysics() {
       BATCHED_SIM_ASSERT(j >= 0 && j < robot_.numPosVars);
       auto& pos = jointPositions[baseJointIndex + j];
       const auto& prevPos = prevJointPositions[baseJointIndex + j];
-      const float clampedJointMovementAction = Mn::Math::clamp(jointMovementAction, 
+      const float clampedJointMovementAction = Mn::Math::clamp(jointMovementAction * (actionSetup.stepMax - actionSetup.stepMin) + actionSetup.stepMin, 
         actionSetup.stepMin, actionSetup.stepMax);
       pos = prevPos + clampedJointMovementAction;
       pos = Mn::Math::clamp(pos, robot_.jointPositionLimits.first[j],


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Right now the actions are not normalized. This can cause issues: for example, the rotate action value needs to be between                -0.0873 and 0.0873 because of clamping. It is easier for the network to output values in the range [-1,1] and makes entropy easier to tune.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
