### PR TITLE
orthonormalize the rotationShear() part of transforms

### DIFF
--- a/src/esp/bindings/CoreBindings.cpp
+++ b/src/esp/bindings/CoreBindings.cpp
@@ -4,6 +4,7 @@
 
 #include "esp/bindings/Bindings.h"
 #include "esp/core/Random.h"
+#include "esp/core/Utility.h"
 
 namespace py = pybind11;
 using py::literals::operator""_a;
@@ -48,6 +49,11 @@ void initCoreBindings(py::module& m) {
                logging::LoggingLevel::Debug;
       });
   core.attr("_logging_context") = new LoggingContext{};
+
+  core.def("orthonormalize_rotation_shear",
+           &orthonormalizeRotationShear<float>);
+  core.def("orthonormalize_rotation_shear",
+           &orthonormalizeRotationShear<double>);
 }
 }  // namespace core
 

--- a/src/esp/core/Utility.h
+++ b/src/esp/core/Utility.h
@@ -8,6 +8,8 @@
 /** @file */
 
 #include <Magnum/Magnum.h>
+#include <Magnum/Math/Algorithms/GramSchmidt.h>
+#include <Magnum/Math/Matrix4.h>
 #include <Magnum/Math/Quaternion.h>
 #include <Magnum/Math/Vector3.h>
 #include <cmath>
@@ -20,7 +22,7 @@ namespace core {
  *
  * @return a unit quternion
  */
-Magnum::Quaternion randomRotation() {
+inline Magnum::Quaternion randomRotation() {
   // generate random rotation using:
   // http://planning.cs.uiuc.edu/node198.html
   double u1 = (rand() % 1000) / 1000.0;
@@ -32,6 +34,17 @@ Magnum::Quaternion randomRotation() {
                         sqrt(u1) * cos(2 * M_PI * u3));
 
   return Magnum::Quaternion(qAxis, sqrt(1 - u1) * sin(2 * M_PI * u2));
+}
+
+template <typename T>
+Magnum::Math::Matrix4<T> orthonormalizeRotationShear(
+    const Magnum::Math::Matrix4<T>& transformation) {
+  Magnum::Math::Matrix3<T> rotation = transformation.rotationShear();
+  Magnum::Math::Algorithms::gramSchmidtOrthonormalizeInPlace(rotation);
+
+  return Magnum::Math::Matrix4<T>::from(rotation,
+                                        transformation.translation()) *
+         Magnum::Math::Matrix4<T>::scaling(transformation.scaling());
 }
 }  // namespace core
 }  // namespace esp

--- a/src/esp/sensor/VisualSensor.cpp
+++ b/src/esp/sensor/VisualSensor.cpp
@@ -9,6 +9,7 @@
 
 #include <utility>
 
+#include "esp/core/Utility.h"
 #include "esp/gfx/RenderTarget.h"
 #include "esp/sim/Simulator.h"
 
@@ -173,8 +174,10 @@ VisualSensor::MoveSemanticSensorNodeHelper::MoveSemanticSensorNodeHelper(
   CORRADE_INTERNAL_ASSERT(relativeTransformBackup_ == Cr::Containers::NullOpt);
 
   // back up the data
-  relativeTransformBackup_ = node.transformation();
-  Mn::Matrix4 absTransform = node.absoluteTransformation();
+  relativeTransformBackup_ =
+      core::orthonormalizeRotationShear(node.transformation());
+  Mn::Matrix4 absTransform =
+      core::orthonormalizeRotationShear(node.absoluteTransformation());
   semanticSensorParentNodeBackup_ =
       static_cast<scene::SceneNode*>(node.parent());
 

--- a/src_python/habitat_sim/robots/mobile_manipulator.py
+++ b/src_python/habitat_sim/robots/mobile_manipulator.py
@@ -8,6 +8,7 @@ import numpy as np
 from habitat_sim.physics import JointMotorSettings
 from habitat_sim.robots.robot_interface import RobotInterface
 from habitat_sim.simulator import Simulator
+from habitat_sim.utils.common import orthonormalize_rotation_shear
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -245,7 +246,9 @@ class MobileManipulator(RobotInterface):
                 cam_transform = link_trans @ cam_transform @ cam_info.relative_transform
                 cam_transform = inv_T @ cam_transform
 
-                sens_obj.node.transformation = cam_transform
+                sens_obj.node.transformation = orthonormalize_rotation_shear(
+                    cam_transform
+                )
         if self._fix_joint_values is not None:
             self.arm_joint_pos = self._fix_joint_values
 

--- a/src_python/habitat_sim/utils/common.py
+++ b/src_python/habitat_sim/utils/common.py
@@ -14,6 +14,10 @@ import magnum as mn
 import numpy as np
 import quaternion as qt
 
+from habitat_sim._ext.habitat_sim_bindings.core import (  # noqa: F401
+    orthonormalize_rotation_shear,
+)
+
 
 def quat_from_coeffs(coeffs: Union[Sequence[float], np.ndarray]) -> qt.quaternion:
     r"""Creates a quaternion from the coeffs returned by the simulator backend


### PR DESCRIPTION
## Motivation and Context

When setting scene graph transformations, we need to explicitly normalize the rotation component to be orthonormal as sometimes floating point errors accumulate.

I also preemptively added an orthornomalize call when updating the camera positions for a robot as that seems like it'll be prone to this issue.

## How Has This Been Tested

This was discovered in https://github.com/facebookresearch/habitat-lab/issues/697, so I used the repro script there.

## Types of changes

Bug fix (non-breaking change which fixes an issue)



