### PR TITLE
--Update Bullet to Bullet 3.22b

### DIFF
--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -168,6 +168,14 @@ if(BUILD_WITH_BULLET AND NOT USE_SYSTEM_BULLET)
     # shared libs)
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
   endif()
+  ## Bullet Optimisation Bug
+  # We need to define this macro for bullet to bypass an early-out optimisation that
+  # was added to bullet via this PR https://github.com/bulletphysics/bullet3/pull/4190 ,
+  # specifically here :
+  #      https://github.com/erwincoumans/bullet3/blob/28b951c128b53e1dcf26271dd47b88776148a940/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp#L106
+  # that causes rigid objects to never come to rest.
+  # This needs to be further examined on bullet side
+  add_definitions(-DBT_DISABLE_CONVEX_CONCAVE_EARLY_OUT=1)
   add_subdirectory(${DEPS_DIR}/bullet3 EXCLUDE_FROM_ALL)
   set(CMAKE_CXX_FLAGS ${_PREV_CMAKE_CXX_FLAGS})
 endif()


### PR DESCRIPTION
## Motivation and Context
This PR updates our bullet dependency to version 3.22.  This opens up access to [bug fixes, expanded deformable support (including cloth), multibody functionality](https://github.com/bulletphysics/bullet3/compare/2.89...3.22#files_bucket), etc [added to support various paper-based implementations.](https://github.com/bulletphysics/bullet3/releases)

One interesting issue I ran during the process of updating was that [this Bullet PR introduced an optimisation that causes erroneous rigid body behavior in our code.](https://github.com/bulletphysics/bullet3/pull/4190), specifically [this calculation here](https://github.com/erwincoumans/bullet3/blob/28b951c128b53e1dcf26271dd47b88776148a940/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp#L106).  The changes to our dependencies.cmake file allow for this optimisation to be bypassed.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass locally.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
