### PR TITLE
Make NavMesh recomputation for non-default agent params optional

### DIFF
--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+#include <Corrade/Containers/OptionalPythonBindings.h>
 #include <Magnum/Math/Vector3.h>
 
 #include "esp/assets/MeshData.h"
@@ -69,7 +70,9 @@ void initShortestPathBindings(py::module& m) {
       .def_readwrite("filter_ledge_spans", &NavMeshSettings::filterLedgeSpans)
       .def_readwrite("filter_walkable_low_height_spans",
                      &NavMeshSettings::filterWalkableLowHeightSpans)
-      .def("set_defaults", &NavMeshSettings::setDefaults);
+      .def("set_defaults", &NavMeshSettings::setDefaults)
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 
   py::class_<PathFinder, PathFinder::ptr>(m, "PathFinder")
       .def(py::init(&PathFinder::create<>))
@@ -117,7 +120,10 @@ void initShortestPathBindings(py::module& m) {
            "pt"_a, "max_search_radius"_a = 2.0)
       .def("is_navigable", &PathFinder::isNavigable,
            R"(Checks to see if the agent can stand at the specified point.)",
-           "pt"_a, "max_y_delta"_a = 0.5);
+           "pt"_a, "max_y_delta"_a = 0.5)
+      .def_property_readonly("nav_mesh_settings",
+                             &PathFinder::getNavMeshSettings,
+                             R"(The settings for the current nav mesh)");
 
   // this enum is used by GreedyGeodesicFollowerImpl so it needs to be defined
   // before it

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -38,20 +38,33 @@ void initSimBindings(py::module& m) {
           "scene_id", &SimulatorConfiguration::activeSceneName,
           R"(Either the name of a stage asset or configuration file, or else the name of a scene
           instance configuration, used to initialize the simulator world.)")
-      .def_readwrite("random_seed", &SimulatorConfiguration::randomSeed)
-      .def_readwrite("default_agent_id",
-                     &SimulatorConfiguration::defaultAgentId)
-      .def_readwrite("default_camera_uuid",
-                     &SimulatorConfiguration::defaultCameraUuid)
-      .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId)
-      .def_readwrite("allow_sliding", &SimulatorConfiguration::allowSliding)
-      .def_readwrite("create_renderer", &SimulatorConfiguration::createRenderer)
+      .def_readwrite(
+          "random_seed", &SimulatorConfiguration::randomSeed,
+          R"(The Simulator and Pathfinder random seed. Set during scene initialization.)")
+      .def_readwrite(
+          "default_agent_id", &SimulatorConfiguration::defaultAgentId,
+          R"(The default agent id used during initialization and functionally whenever alternative agent ids are not provided.)")
+      .def_readwrite("gpu_device_id", &SimulatorConfiguration::gpuDeviceId,
+                     R"(The system GPU device to use for rendering.)")
+      .def_readwrite(
+          "allow_sliding", &SimulatorConfiguration::allowSliding,
+          R"(Whether or not the agent can slide on NavMesh collisions.)")
+      .def_readwrite(
+          "recompute_navmesh_on_agent_params",
+          &SimulatorConfiguration::recomputeNavMeshOnAgentParams,
+          R"(If true(default), changing default agent radius or height will trigger automatic NavMesh recomputation in python reconfigure.)")
+      .def_readwrite(
+          "create_renderer", &SimulatorConfiguration::createRenderer,
+          R"(Optimisation for non-visual simulation. If false, no renderer will be created and no materials or textures loaded.)")
       .def_readwrite(
           "leave_context_with_background_renderer",
           &SimulatorConfiguration::leaveContextWithBackgroundRenderer,
           R"(See tutorials/async_rendering.py)")
-      .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling)
-      .def_readwrite("enable_physics", &SimulatorConfiguration::enablePhysics)
+      .def_readwrite("frustum_culling", &SimulatorConfiguration::frustumCulling,
+                     R"(Enable or disable the frustum culling optimisation.)")
+      .def_readwrite(
+          "enable_physics", &SimulatorConfiguration::enablePhysics,
+          R"(Specifies whether or not dynamics is supported by the simulation if a suitable library (i.e. Bullet) has been installed. Install with --bullet to enable.)")
       .def_readwrite(
           "use_semantic_textures",
           &SimulatorConfiguration::useSemanticTexturesIfFound,
@@ -62,22 +75,26 @@ void initSimBindings(py::module& m) {
           &SimulatorConfiguration::enableGfxReplaySave,
           R"(Enable replay recording. See sim.gfx_replay.save_keyframe.)")
       .def_readwrite("physics_config_file",
-                     &SimulatorConfiguration::physicsConfigFile)
+                     &SimulatorConfiguration::physicsConfigFile,
+                     R"(Path to the physics parameter config file.)")
       .def_readwrite(
           "override_scene_light_defaults",
           &SimulatorConfiguration::overrideSceneLightDefaults,
           R"(Override scene lighting setup to use with value specified below.)")
       .def_readwrite("scene_light_setup",
-                     &SimulatorConfiguration::sceneLightSetupKey)
+                     &SimulatorConfiguration::sceneLightSetupKey,
+                     R"(Light setup key for the scene.)")
       .def_readwrite("load_semantic_mesh",
-                     &SimulatorConfiguration::loadSemanticMesh)
+                     &SimulatorConfiguration::loadSemanticMesh,
+                     R"(Whether or not to load the semantic mesh.)")
       .def_readwrite(
           "force_separate_semantic_scene_graph",
           &SimulatorConfiguration::forceSeparateSemanticSceneGraph,
           R"(Required to support playback of any gfx replay that includes a
           stage with a semantic mesh. Set to false otherwise.)")
-      .def_readwrite("requires_textures",
-                     &SimulatorConfiguration::requiresTextures)
+      .def_readwrite(
+          "requires_textures", &SimulatorConfiguration::requiresTextures,
+          R"(Whether or not to load textures for the meshes. This MUST be true for RGB rendering.)")
       .def(py::self == py::self)
       .def(py::self != py::self);
 

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -50,10 +50,6 @@ void initSimBindings(py::module& m) {
           "allow_sliding", &SimulatorConfiguration::allowSliding,
           R"(Whether or not the agent can slide on NavMesh collisions.)")
       .def_readwrite(
-          "recompute_navmesh_on_agent_params",
-          &SimulatorConfiguration::recomputeNavMeshOnAgentParams,
-          R"(If true(default), changing default agent radius or height will trigger automatic NavMesh recomputation in python reconfigure.)")
-      .def_readwrite(
           "create_renderer", &SimulatorConfiguration::createRenderer,
           R"(Optimisation for non-visual simulation. If false, no renderer will be created and no materials or textures loaded.)")
       .def_readwrite(

--- a/src/esp/bindings_js/bindings_js.cpp
+++ b/src/esp/bindings_js/bindings_js.cpp
@@ -377,9 +377,7 @@ EMSCRIPTEN_BINDINGS(habitat_sim_bindings_js) {
       .property("sceneDatasetConfigFile",
                 &SimulatorConfiguration::sceneDatasetConfigFile)
       .property("defaultAgentId", &SimulatorConfiguration::defaultAgentId)
-      .property("defaultCameraUuid", &SimulatorConfiguration::defaultCameraUuid)
       .property("gpuDeviceId", &SimulatorConfiguration::gpuDeviceId)
-      .property("compressTextures", &SimulatorConfiguration::compressTextures)
       .property("enablePhysics", &SimulatorConfiguration::enablePhysics)
       .property("physicsConfigFile", &SimulatorConfiguration::physicsConfigFile)
       .property("createRenderer", &SimulatorConfiguration::createRenderer)

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -848,6 +848,9 @@ bool PathFinder::Impl::loadNavMesh(const std::string& path) {
   navMeshSettings_ = {NavMeshSettings{}};
   if (header.version >= 2) {
     fread(&(*navMeshSettings_), sizeof(NavMeshSettings), 1, fp);
+  } else {
+    ESP_DEBUG()
+        << "NavMeshSettings aren't present, guessing that they are the default";
   }
 
   vec3f bmin, bmax;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -38,7 +38,7 @@ namespace esp {
 namespace nav {
 
 bool operator==(const NavMeshSettings& a, const NavMeshSettings& b) {
-#define CLOSE(name) ((a.name - b.name) < 1e-5)
+#define CLOSE(name) (std::abs(a.name - b.name) < 1e-5)
 #define EQ(name) (a.name == b.name)
 
   return CLOSE(cellSize) && CLOSE(cellHeight) && CLOSE(agentHeight) &&

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -5,6 +5,7 @@
 #ifndef ESP_NAV_PATHFINDER_H_
 #define ESP_NAV_PATHFINDER_H_
 
+#include <Corrade/Containers/Optional.h>
 #include <string>
 #include <vector>
 
@@ -126,9 +127,6 @@ struct NavMeshSettings {
   float detailSampleDist{};
   //! Detail sample max error in voxel heights.
   float detailSampleMaxError{};
-  //! Bounds of the area to mesh
-  vec3f navMeshBMin;
-  vec3f navMeshBMax;
 
   bool filterLowHangingObstacles{};
   bool filterLedgeSpans{};
@@ -157,6 +155,9 @@ struct NavMeshSettings {
 
   ESP_SMART_POINTERS(NavMeshSettings)
 };
+
+bool operator==(const NavMeshSettings& a, const NavMeshSettings& b);
+bool operator!=(const NavMeshSettings& a, const NavMeshSettings& b);
 
 /** Loads and/or builds a navigation mesh and then performs path
  * finding and collision queries on that navmesh
@@ -353,6 +354,11 @@ class PathFinder {
    * @return The object containing triangulated NavMesh polys.
    */
   std::shared_ptr<assets::MeshData> getNavMeshData();
+
+  /**
+   * @brief Return the settings for the current NavMesh.
+   */
+  Corrade::Containers::Optional<NavMeshSettings> getNavMeshSettings() const;
 
   ESP_SMART_POINTERS_WITH_UNIQUE_PIMPL(PathFinder)
 };

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -808,12 +808,11 @@ double Simulator::getPhysicsTimeStep() {
 bool Simulator::recomputeNavMesh(nav::PathFinder& pathfinder,
                                  const nav::NavMeshSettings& navMeshSettings,
                                  bool includeStaticObjects) {
-  CORRADE_ASSERT(config_.createRenderer,
-                 "::recomputeNavMesh: "
-                 "SimulatorConfiguration::createRenderer is false. Scene "
-                 "geometry is required to recompute navmesh. No geometry is "
-                 "loaded without renderer initialization.",
-                 false);
+  ESP_CHECK(config_.createRenderer,
+            "::recomputeNavMesh: "
+            "SimulatorConfiguration::createRenderer is false. Scene "
+            "geometry is required to recompute navmesh. No geometry is "
+            "loaded without renderer initialization.");
 
   assets::MeshData::uptr joinedMesh = assets::MeshData::create_unique();
   auto stageInitAttrs = physicsManager_->getStageInitAttributes();

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -11,10 +11,9 @@ bool operator==(const SimulatorConfiguration& a,
   return a.activeSceneName == b.activeSceneName &&
          a.defaultAgentId == b.defaultAgentId &&
          a.gpuDeviceId == b.gpuDeviceId && a.randomSeed == b.randomSeed &&
-         a.defaultCameraUuid == b.defaultCameraUuid &&
-         a.compressTextures == b.compressTextures &&
          a.createRenderer == b.createRenderer &&
          a.allowSliding == b.allowSliding &&
+         a.recomputeNavMeshOnAgentParams == b.recomputeNavMeshOnAgentParams &&
          a.frustumCulling == b.frustumCulling &&
          a.enablePhysics == b.enablePhysics &&
          a.enableGfxReplaySave == b.enableGfxReplaySave &&

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -13,7 +13,6 @@ bool operator==(const SimulatorConfiguration& a,
          a.gpuDeviceId == b.gpuDeviceId && a.randomSeed == b.randomSeed &&
          a.createRenderer == b.createRenderer &&
          a.allowSliding == b.allowSliding &&
-         a.recomputeNavMeshOnAgentParams == b.recomputeNavMeshOnAgentParams &&
          a.frustumCulling == b.frustumCulling &&
          a.enablePhysics == b.enablePhysics &&
          a.enableGfxReplaySave == b.enableGfxReplaySave &&

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -14,19 +14,24 @@ namespace esp {
 
 namespace sim {
 struct SimulatorConfiguration {
-  /**
-   * @brief Name of scene or stage config or asset to load
-   */
+  //! Name of scene or stage config or asset to load
   std::string activeSceneName;
+  //! The default agent id used during initialization and functionally whenever
+  //! alternative agent ids are not provided.
   int defaultAgentId = 0;
+  //! The system GPU device to use for rendering.
   int gpuDeviceId = 0;
+  //! The Simulator and Pathfinder random seed. Set during scene initialization.
   unsigned int randomSeed = 0;
-  std::string defaultCameraUuid = "rgba_camera";
-  bool compressTextures = false;
+  //! Optimisation for non-visual simulation. If false, no renderer will be
+  //! created and no materials or textures loaded.
   bool createRenderer = true;
-  // Whether or not the agent can slide on collisions
+  //! Whether or not the agent can slide on NavMesh collisions.
   bool allowSliding = true;
-  // enable or disable the frustum culling
+  //! If true, changing default agent radius or height will trigger automatic
+  //! NavMesh recomputation in python reconfigure
+  bool recomputeNavMeshOnAgentParams = true;
+  //! Enable or disable the frustum culling optimisation
   bool frustumCulling = true;
   /**
    * @brief This flags specifies whether or not dynamics is supported by the
@@ -42,9 +47,9 @@ struct SimulatorConfiguration {
    */
   bool loadSemanticMesh = true;
   /**
-   * Force creation of a separate semantic scene graph, even when no semantic
-   * mesh is loaded for the stage. Required to support playback of any replay
-   * that includes a semantic-only render asset instance. Set to false
+   * @brief Force creation of a separate semantic scene graph, even when no
+   * semantic mesh is loaded for the stage. Required to support playback of any
+   * replay that includes a semantic-only render asset instance. Set to false
    * otherwise.
    */
   bool forceSeparateSemanticSceneGraph = false;
@@ -62,6 +67,7 @@ struct SimulatorConfiguration {
    */
   bool leaveContextWithBackgroundRenderer = false;
 
+  //! Path to the physics parameter config file.
   std::string physicsConfigFile = ESP_DEFAULT_PHYSICS_CONFIG_REL_PATH;
 
   /**
@@ -70,7 +76,7 @@ struct SimulatorConfiguration {
   std::string sceneDatasetConfigFile = "default";
 
   /**
-   * @brief allows for overriding any scene lighting setup specified in a scene
+   * @brief Allows for overriding any scene lighting setup specified in a scene
    * instance file with the value specified below.
    */
   bool overrideSceneLightDefaults = false;
@@ -79,11 +85,11 @@ struct SimulatorConfiguration {
   std::string sceneLightSetupKey = esp::NO_LIGHT_KEY;
 
   /**
-   * @brief setup the image based lighting for pbr rendering
+   * @brief Setup the image based lighting for pbr rendering
    */
   bool pbrImageBasedLighting = false;
   /**
-   * @brief use texture-based semantics if the specified asset/dataset support
+   * @brief Use texture-based semantics if the specified asset/dataset support
    * them.
    */
   bool useSemanticTexturesIfFound = true;

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -28,9 +28,6 @@ struct SimulatorConfiguration {
   bool createRenderer = true;
   //! Whether or not the agent can slide on NavMesh collisions.
   bool allowSliding = true;
-  //! If true, changing default agent radius or height will trigger automatic
-  //! NavMesh recomputation in python reconfigure
-  bool recomputeNavMeshOnAgentParams = true;
   //! Enable or disable the frustum culling optimisation
   bool frustumCulling = true;
   /**

--- a/src/tests/PathFinderTest.cpp
+++ b/src/tests/PathFinderTest.cpp
@@ -42,6 +42,8 @@ struct PathFinderTest : Cr::TestSuite::Tester {
   void benchmarkMultiGoal();
 
   void testCaching();
+
+  esp::logging::LoggingContext loggingContext;
 };
 
 PathFinderTest::PathFinderTest() {

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -234,7 +234,7 @@ class Simulator(SimulatorBackend):
         needed_settings.agent_height = default_agent_config.height
         if (
             self.pathfinder.nav_mesh_settings != needed_settings
-            and config.sim_cfg.scene_id != "NONE"
+            and config.sim_cfg.scene_id.lower() != "none"
         ):
             logger.info(
                 f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -227,20 +227,26 @@ class Simulator(SimulatorBackend):
             self.pathfinder.load_nav_mesh(navmesh_filenname)
             logger.info(f"Loaded navmesh {navmesh_filenname}")
 
-        agent_legacy_config = AgentConfiguration()
-        default_agent_config = config.agents[config.sim_cfg.default_agent_id]
-        if not np.isclose(
-            agent_legacy_config.radius, default_agent_config.radius
-        ) or not np.isclose(agent_legacy_config.height, default_agent_config.height):
-            logger.info(
-                f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
-                f" {default_agent_config.radius}."
-            )
-            navmesh_settings = NavMeshSettings()
-            navmesh_settings.set_defaults()
-            navmesh_settings.agent_radius = default_agent_config.radius
-            navmesh_settings.agent_height = default_agent_config.height
-            self.recompute_navmesh(self.pathfinder, navmesh_settings)
+        if config.sim_cfg.recompute_navmesh_on_agent_params:
+            # Typically, Habitat provided NavMesh assets are built with default agent parameters.
+            # If the default_agent_config has been modified, recompute the NavMesh with the new parameters.
+            # NOTE: this recomputed NavMesh does not include STATIC objects.
+            agent_legacy_config = AgentConfiguration()
+            default_agent_config = config.agents[config.sim_cfg.default_agent_id]
+            if not np.isclose(
+                agent_legacy_config.radius, default_agent_config.radius
+            ) or not np.isclose(
+                agent_legacy_config.height, default_agent_config.height
+            ):
+                logger.info(
+                    f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
+                    f" {default_agent_config.radius}."
+                )
+                navmesh_settings = NavMeshSettings()
+                navmesh_settings.set_defaults()
+                navmesh_settings.agent_radius = default_agent_config.radius
+                navmesh_settings.agent_height = default_agent_config.height
+                self.recompute_navmesh(self.pathfinder, navmesh_settings)
 
         self.pathfinder.seed(config.sim_cfg.random_seed)
 

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -232,7 +232,10 @@ class Simulator(SimulatorBackend):
         default_agent_config = config.agents[config.sim_cfg.default_agent_id]
         needed_settings.agent_radius = default_agent_config.radius
         needed_settings.agent_height = default_agent_config.height
-        if self.pathfinder.nav_mesh_settings != needed_settings:
+        if (
+            self.pathfinder.nav_mesh_settings != needed_settings
+            and config.sim_cfg.scene_id != "NONE"
+        ):
             logger.info(
                 f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
                 f" {default_agent_config.radius}."

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -227,26 +227,17 @@ class Simulator(SimulatorBackend):
             self.pathfinder.load_nav_mesh(navmesh_filenname)
             logger.info(f"Loaded navmesh {navmesh_filenname}")
 
-        if config.sim_cfg.recompute_navmesh_on_agent_params:
-            # Typically, Habitat provided NavMesh assets are built with default agent parameters.
-            # If the default_agent_config has been modified, recompute the NavMesh with the new parameters.
-            # NOTE: this recomputed NavMesh does not include STATIC objects.
-            agent_legacy_config = AgentConfiguration()
-            default_agent_config = config.agents[config.sim_cfg.default_agent_id]
-            if not np.isclose(
-                agent_legacy_config.radius, default_agent_config.radius
-            ) or not np.isclose(
-                agent_legacy_config.height, default_agent_config.height
-            ):
-                logger.info(
-                    f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
-                    f" {default_agent_config.radius}."
-                )
-                navmesh_settings = NavMeshSettings()
-                navmesh_settings.set_defaults()
-                navmesh_settings.agent_radius = default_agent_config.radius
-                navmesh_settings.agent_height = default_agent_config.height
-                self.recompute_navmesh(self.pathfinder, navmesh_settings)
+        # NOTE: this recomputed NavMesh does not include STATIC objects.
+        needed_settings = NavMeshSettings()
+        default_agent_config = config.agents[config.sim_cfg.default_agent_id]
+        needed_settings.agent_radius = default_agent_config.radius
+        needed_settings.agent_height = default_agent_config.height
+        if self.pathfinder.nav_mesh_settings != needed_settings:
+            logger.info(
+                f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
+                f" {default_agent_config.radius}."
+            )
+            self.recompute_navmesh(self.pathfinder, needed_settings)
 
         self.pathfinder.seed(config.sim_cfg.random_seed)
 


### PR DESCRIPTION
## Motivation and Context

`simulator.py` `reconfigure()` automatically recomputes the NavMesh if `default_agent` has non-default parameters. Generally this makes sense because most of our saved NavMeshes are generated for the default agent. However, users may want to skip this if they've generated their own custom NavMeshes as in ReplicaCAD dataset for Hab2.0 rearrangement tasks.

~This PR primarily adds a new config option `recompute_navmesh_on_agent_params` which defaults to previous behavior, but if toggled off allows skipping automatic recomputation.~
Edit: This PR adds cache, query, and serialization of navmesh settings accompanying any programmatically computed or loaded NavMesh. Existing NavMeshes computed before this PR are assumed to use default settings. If agent params are different from cached settings for the currently loaded NavMesh, it will be recomputed to match current agent settings. 

In addition, I cleaned up documentation for SimulatorConfiguration and removed two unused legacy fields:
 - `defaultCameraUuid`
 - `compressTextures`

## How Has This Been Tested

CI passes, new tests for NavMesh settings cache and comparators. Built the docs locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
