### PR TITLE
[BUGFIX]--Address mem leak in ConfigValue destructor for strings.

### DIFF
--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -142,10 +142,10 @@ void ConfigValue::moveValueFrom(ConfigValue&& otr) {
 }
 
 void ConfigValue::deleteCurrentValue() {
-  _type = ConfigStoredType::Unknown;
   if (isConfigStoredTypeNonTrivial(_type)) {
     nonTrivialConfigStoredTypeHandlerFor(_type).destructor(_data);
   }
+  _type = ConfigStoredType::Unknown;
 }
 
 ConfigValue& ConfigValue::operator=(const ConfigValue& otr) {


### PR DESCRIPTION
## Motivation and Context
This addresses a memory leak in the ConfigValues where non-trivially constructible objects (like strings) were never getting properly disposed of.

Valgrind output before fix : 
`==22314== LEAK SUMMARY:
==22314==    definitely lost: 418,522 bytes in 4,963 blocks`

after fix : 
`==28380== LEAK SUMMARY:
==28380==    definitely lost: 13,544 bytes in 42 blocks`


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass, valgrind's mood definitely improved.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
