### PR TITLE
[bugfix] - compute navmesh visualization node AABB

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2034,6 +2034,8 @@ int ResourceManager::loadNavMeshVisualization(esp::nav::PathFinder& pathFinder,
       navMeshPrimitiveID != ID_UNDEFINED) {
     // create the drawable
     addPrimitiveToDrawables(navMeshPrimitiveID, *parent, drawables);
+    parent->setMeshBB(Mn::Math::minmax(positions));
+    parent->computeCumulativeBB();
   }
 
   return navMeshPrimitiveID;


### PR DESCRIPTION
## Motivation and Context

Set the SceneNode bounding box for navmesh visualization nodes upon creation. Fixes incorrect culling on navmesh visualization causing navmesh wireframes to disappear for some camera positions.

## How Has This Been Tested

locally in viewer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
