### PR TITLE
Update Magnum to latest and adapt to API deprecation

### DIFF
--- a/src/esp/assets/BaseMesh.cpp
+++ b/src/esp/assets/BaseMesh.cpp
@@ -42,7 +42,7 @@ void BaseMesh::convertMeshColors(
   } else {
     Mn::Math::packInto(
         Cr::Containers::arrayCast<2, float>(stridedArrayView(colors))
-            .except({0, 1}),
+            .exceptSuffix({0, 1}),
         Cr::Containers::arrayCast<2, Mn::UnsignedByte>(
             stridedArrayView(meshColors)));
   }

--- a/src/esp/assets/PTexMeshData.cpp
+++ b/src/esp/assets/PTexMeshData.cpp
@@ -16,7 +16,7 @@
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/GL/BufferTextureFormat.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/ImageView.h>
@@ -37,18 +37,18 @@ namespace assets {
 
 void PTexMeshData::load(const std::string& meshFile,
                         const std::string& atlasFolder) {
-  if (!Cr::Utility::Directory::exists(meshFile)) {
+  if (!Cr::Utility::Path::exists(meshFile)) {
     Cr::Utility::Fatal{-1} << "PTexMeshData::load: Mesh file" << meshFile
                            << "does not exist.";
   }
-  if (!Cr::Utility::Directory::exists(atlasFolder)) {
+  if (!Cr::Utility::Path::exists(atlasFolder)) {
     Cr::Utility::Fatal{-1} << "PTexMeshData::load: The atlasFolder"
                            << atlasFolder << "does not exist.";
   }
 
   // Parse parameters
   const auto& paramsFile = atlasFolder + "/parameters.json";
-  if (!Cr::Utility::Directory::exists(paramsFile)) {
+  if (!Cr::Utility::Path::exists(paramsFile)) {
     Cr::Utility::Fatal{-1} << "PTexMeshData::load: The parameter file"
                            << paramsFile << "does not exist.";
   }
@@ -490,7 +490,7 @@ void PTexMeshData::loadMeshData(const std::string& meshFile) {
     // splitMesh(...)
 
     // See detailed comments in front of the splitMesh(...)
-    std::string subMeshesFilename = Corrade::Utility::Directory::join(
+    std::string subMeshesFilename = Corrade::Utility::Path::join(
         atlasFolder_, "../habitat/sorted_faces.bin");
     submeshes_ = loadSubMeshes(originalMesh, subMeshesFilename);
 
@@ -756,10 +756,10 @@ void PTexMeshData::parsePLY(const std::string& filename,
 
   file.close();
 
-  Cr::Containers::Array<const char, Cr::Utility::Directory::MapDeleter>
-      mmappedData = Cr::Utility::Directory::mapRead(filename);
+  Cr::Containers::Array<const char, Cr::Utility::Path::MapDeleter> mmappedData =
+      *Cr::Utility::Path::mapRead(filename);
 
-  const size_t fileSize = *Cr::Utility::Directory::fileSize(filename);
+  const size_t fileSize = *Cr::Utility::Path::size(filename);
 
   // Parse each vertex packet and unpack
   const char* bytes = mmappedData + postHeader;
@@ -903,18 +903,18 @@ void PTexMeshData::uploadBuffersToGPU(bool forceReload) {
   // load atlas data and upload them to GPU
   ESP_DEBUG() << "loading atlas textures:";
   for (size_t iMesh = 0; iMesh < renderingBuffers_.size(); ++iMesh) {
-    const std::string hdrFile = Cr::Utility::Directory::join(
+    const std::string hdrFile = Cr::Utility::Path::join(
         atlasFolder_, std::to_string(iMesh) + "-color-ptex.hdr");
 
-    CORRADE_ASSERT(Cr::Utility::Directory::exists(hdrFile),
+    CORRADE_ASSERT(Cr::Utility::Path::exists(hdrFile),
                    "PTexMeshData::uploadBuffersToGPU: Cannot find the .hdr file"
                        << hdrFile, );
 
     ESP_DEBUG() << "Loading atlas" << iMesh + 1 << "/"
                 << renderingBuffers_.size() << "from" << hdrFile << ".";
 
-    Cr::Containers::Array<const char, Cr::Utility::Directory::MapDeleter> data =
-        Cr::Utility::Directory::mapRead(hdrFile);
+    Cr::Containers::Array<const char, Cr::Utility::Path::MapDeleter> data =
+        *Cr::Utility::Path::mapRead(hdrFile);
     // divided by 6, since there are 3 channels, R, G, B, each of which takes
     // 1 half_float (2 bytes)
     const int dim = static_cast<int>(std::sqrt(data.size() / 6));  // square

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -121,7 +121,7 @@ void declareBaseAttributesManager(py::module& m,
       .def(
           "is_valid_filename",
           [](CORRADE_UNUSED MgrClass& self, const std::string& filename) {
-            return Corrade::Utility::Directory::exists(filename);
+            return Corrade::Utility::Path::exists(filename);
           },
           R"(Returns whether the passed handle is a valid, existing file.)",
           "handle"_a)

--- a/src/esp/core/Logging.cpp
+++ b/src/esp/core/Logging.cpp
@@ -10,12 +10,13 @@
 #include <cstdlib>
 
 #include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Containers/StaticArray.h>
 #include <Corrade/Containers/String.h>
 #include <Corrade/Containers/StringStl.h>
-#include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/Format.h>
 #include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Path.h>
 
 namespace Cr = Corrade;
 using Cr::Containers::Literals::operator""_s;
@@ -132,7 +133,7 @@ Cr::Containers::String buildMessagePrefix(Subsystem subsystem,
                                           const std::string& filename,
                                           const std::string& function,
                                           int line) {
-  auto baseFileName = Cr::Utility::Directory::filename(filename);
+  auto baseFileName = Cr::Utility::Path::split(filename).second();
 
   const auto timePassed =
       std::chrono::high_resolution_clock::now().time_since_epoch();

--- a/src/esp/core/managedContainers/AbstractFileBasedManagedObject.h
+++ b/src/esp/core/managedContainers/AbstractFileBasedManagedObject.h
@@ -5,7 +5,9 @@
 #ifndef ESP_CORE_ABSTRACTFILEBASEDMANAGEDOBJECT_H_
 #define ESP_CORE_ABSTRACTFILEBASEDMANAGEDOBJECT_H_
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Containers/Pair.h>
+#include <Corrade/Utility/Path.h>
+#include <string>
 #include "AbstractManagedObject.h"
 #include "esp/io/Json.h"
 
@@ -31,11 +33,11 @@ class AbstractFileBasedManagedObject : public AbstractManagedObject {
    */
   virtual std::string getSimplifiedHandle() const {
     // first parse for file name, and then get rid of extension(s).
-    return Corrade::Utility::Directory::splitExtension(
-               Corrade::Utility::Directory::splitExtension(
-                   Corrade::Utility::Directory::filename(getHandle()))
-                   .first)
-        .first;
+    return Corrade::Utility::Path::splitExtension(
+               Corrade::Utility::Path::splitExtension(
+                   Corrade::Utility::Path::split(getHandle()).second())
+                   .first())
+        .first();
   }
 
   /**

--- a/src/esp/geo/VoxelGrid.h
+++ b/src/esp/geo/VoxelGrid.h
@@ -9,7 +9,7 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Containers/StridedArrayView.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/GL/PixelFormat.h>
 #include <Magnum/Image.h>
 #include <Magnum/Math/Color.h>

--- a/src/esp/gfx/DebugLineRender.cpp
+++ b/src/esp/gfx/DebugLineRender.cpp
@@ -95,7 +95,7 @@ void DebugLineRender::flushLines(const Magnum::Matrix4& camMatrix,
                  "DebugLineRender::flushLines: no GL resources; see "
                  "also releaseGLResources", );
 
-  if (_verts.empty()) {
+  if (_verts.isEmpty()) {
     return;
   }
 

--- a/src/esp/gfx/DepthUnprojection.cpp
+++ b/src/esp/gfx/DepthUnprojection.cpp
@@ -51,8 +51,8 @@ DepthShader::DepthShader(Flags flags) : flags_{flags} {
   if (flags & Flag::NoFarPlanePatching)
     frag.addSource("#define NO_FAR_PLANE_PATCHING\n");
 
-  vert.addSource(rs.get("depth.vert"));
-  frag.addSource(rs.get("depth.frag"));
+  vert.addSource(rs.getString("depth.vert"));
+  frag.addSource(rs.getString("depth.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/DoubleSphereCameraShader.cpp
+++ b/src/esp/gfx/DoubleSphereCameraShader.cpp
@@ -46,7 +46,7 @@ DoubleSphereCameraShader::DoubleSphereCameraShader(
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
   // Add macros
-  vert.addSource(rs.get("bigTriangle.vert"));
+  vert.addSource(rs.getString("bigTriangle.vert"));
 
   std::stringstream outputAttributeLocationsStream;
 
@@ -69,7 +69,7 @@ DoubleSphereCameraShader::DoubleSphereCameraShader(
       .addSource(flags_ & CubeMapShaderBase::Flag::ObjectIdTexture
                      ? "#define OBJECT_ID_TEXTURE\n"
                      : "")
-      .addSource(rs.get("doubleSphereCamera.frag"));
+      .addSource(rs.getString("doubleSphereCamera.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/EquirectangularShader.cpp
+++ b/src/esp/gfx/EquirectangularShader.cpp
@@ -51,7 +51,7 @@ EquirectangularShader::EquirectangularShader(Flags flags)
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
   // Add macros
-  vert.addSource(rs.get("bigTriangle.vert"));
+  vert.addSource(rs.getString("bigTriangle.vert"));
 
   std::stringstream outputAttributeLocationsStream;
 
@@ -74,7 +74,7 @@ EquirectangularShader::EquirectangularShader(Flags flags)
       .addSource(flags_ & CubeMapShaderBase::Flag::ObjectIdTexture
                      ? "#define OBJECT_ID_TEXTURE\n"
                      : "")
-      .addSource(rs.get("equirectangular.frag"));
+      .addSource(rs.getString("equirectangular.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/GaussianFilterShader.cpp
+++ b/src/esp/gfx/GaussianFilterShader.cpp
@@ -44,12 +44,13 @@ GaussianFilterShader::GaussianFilterShader() {
   Mn::GL::Shader vert{glVersion, Mn::GL::Shader::Type::Vertex};
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
-  vert.addSource("#define OUTPUT_UV\n").addSource(rs.get("bigTriangle.vert"));
+  vert.addSource("#define OUTPUT_UV\n")
+      .addSource(rs.getString("bigTriangle.vert"));
 
   frag.addSource("#define EXPLICIT_ATTRIB_LOCATION\n")
       .addSource(Cr::Utility::formatString(
           "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput))
-      .addSource(rs.get("gaussianFilter.frag"));
+      .addSource(rs.getString("gaussianFilter.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/PTexMeshShader.cpp
+++ b/src/esp/gfx/PTexMeshShader.cpp
@@ -51,12 +51,12 @@ PTexMeshShader::PTexMeshShader() {
   Mn::GL::Shader geom{Mn::GL::Version::GL410, Mn::GL::Shader::Type::Geometry};
   Mn::GL::Shader frag{Mn::GL::Version::GL410, Mn::GL::Shader::Type::Fragment};
 
-  vert.addSource(rs.get("ptex-default-gl410.vert"));
-  geom.addSource(rs.get("ptex-default-gl410.geom"));
+  vert.addSource(rs.getString("ptex-default-gl410.vert"));
+  geom.addSource(rs.getString("ptex-default-gl410.geom"));
 #ifdef CORRADE_TARGET_APPLE
   frag.addSource("#define CORRADE_TARGET_APPLE\n");
 #endif
-  frag.addSource(rs.get("ptex-default-gl410.frag"));
+  frag.addSource(rs.getString("ptex-default-gl410.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, geom, frag}));
 

--- a/src/esp/gfx/PbrEquiRectangularToCubeMapShader.cpp
+++ b/src/esp/gfx/PbrEquiRectangularToCubeMapShader.cpp
@@ -51,12 +51,13 @@ PbrEquiRectangularToCubeMapShader::PbrEquiRectangularToCubeMapShader() {
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
   // Add macros
-  vert.addSource("#define OUTPUT_UV\n").addSource(rs.get("bigTriangle.vert"));
+  vert.addSource("#define OUTPUT_UV\n")
+      .addSource(rs.getString("bigTriangle.vert"));
 
   frag
       .addSource(Cr::Utility::formatString(
           "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput))
-      .addSource(rs.get("equirectangularToCubeMap.frag"));
+      .addSource(rs.getString("equirectangularToCubeMap.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -62,17 +62,17 @@ PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
   vert
       .addSource(Cr::Utility::formatString(
           "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location))
-      .addSource(rs.get("pbrPrecomputedMap.vert"));
+      .addSource(rs.getString("pbrPrecomputedMap.vert"));
 
   frag
       .addSource(Cr::Utility::formatString(
           "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput))
-      .addSource(rs.get("pbrCommon.glsl") + "\n");
+      .addSource(rs.getString("pbrCommon.glsl") + "\n");
 
   if (flags & Flag::IrradianceMap) {
-    frag.addSource(rs.get("pbrIrradianceMap.frag"));
+    frag.addSource(rs.getString("pbrIrradianceMap.frag"));
   } else if (flags & Flag::PrefilteredMap) {
-    frag.addSource(rs.get("pbrPrefilteredMap.frag"));
+    frag.addSource(rs.getString("pbrPrefilteredMap.frag"));
   }
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -96,7 +96,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
       .addSource(flags_ & Flag::TextureTransformation
                      ? "#define TEXTURE_TRANSFORMATION\n"
                      : "")
-      .addSource(rs.get("pbr.vert"));
+      .addSource(rs.getString("pbr.vert"));
 
   std::stringstream outputAttributeLocationsStream;
   outputAttributeLocationsStream << Cr::Utility::formatString(
@@ -131,10 +131,11 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
                                              : "")
       .addSource(
           Cr::Utility::formatString("#define LIGHT_COUNT {}\n", lightCount_))
-      .addSource(flags_ & Flag::ShadowsVSM ? rs.get("shadowsVSM.glsl") + "\n"
-                                           : "")
-      .addSource(rs.get("pbrCommon.glsl") + "\n")
-      .addSource(rs.get("pbr.frag"));
+      .addSource(flags_ & Flag::ShadowsVSM
+                     ? rs.getString("shadowsVSM.glsl") + "\n"
+                     : "")
+      .addSource(rs.getString("pbrCommon.glsl") + "\n")
+      .addSource(rs.getString("pbr.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/TextureVisualizerShader.cpp
+++ b/src/esp/gfx/TextureVisualizerShader.cpp
@@ -57,7 +57,8 @@ TextureVisualizerShader::TextureVisualizerShader(Flags flags) : flags_(flags) {
   Mn::GL::Shader vert{glVersion, Mn::GL::Shader::Type::Vertex};
   Mn::GL::Shader frag{glVersion, Mn::GL::Shader::Type::Fragment};
 
-  vert.addSource("#define OUTPUT_UV\n").addSource(rs.get("bigTriangle.vert"));
+  vert.addSource("#define OUTPUT_UV\n")
+      .addSource(rs.getString("bigTriangle.vert"));
 
   frag.addSource("#define EXPLICIT_ATTRIB_LOCATION\n")
       .addSource(Cr::Utility::formatString(
@@ -65,7 +66,7 @@ TextureVisualizerShader::TextureVisualizerShader(Flags flags) : flags_(flags) {
       .addSource(flags_ & Flag::DepthTexture ? "#define DEPTH_TEXTURE\n" : "")
       .addSource(flags_ & Flag::ObjectIdTexture ? "#define OBJECT_ID_TEXTURE\n"
                                                 : "")
-      .addSource(rs.get("textureVisualizer.frag"));
+      .addSource(rs.getString("textureVisualizer.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/VarianceShadowMapShader.cpp
+++ b/src/esp/gfx/VarianceShadowMapShader.cpp
@@ -55,12 +55,12 @@ VarianceShadowMapShader::VarianceShadowMapShader() {
   vert
       .addSource(Cr::Utility::formatString(
           "#define ATTRIBUTE_LOCATION_POSITION {}\n", Position::Location))
-      .addSource(rs.get("varianceShadowMap.vert"));
+      .addSource(rs.getString("varianceShadowMap.vert"));
 
   frag
       .addSource(Cr::Utility::formatString(
           "#define OUTPUT_ATTRIBUTE_LOCATION_COLOR {}\n", ColorOutput))
-      .addSource(rs.get("varianceShadowMap.frag"));
+      .addSource(rs.getString("varianceShadowMap.frag"));
 
   CORRADE_INTERNAL_ASSERT_OUTPUT(Mn::GL::Shader::compile({vert, frag}));
 

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -33,7 +33,7 @@ Player::Player(const LoadAndCreateRenderAssetInstanceCallback& callback)
 void Player::readKeyframesFromFile(const std::string& filepath) {
   close();
 
-  if (!Corrade::Utility::Directory::exists(filepath)) {
+  if (!Corrade::Utility::Path::exists(filepath)) {
     ESP_ERROR() << "File" << filepath << "not found.";
     return;
   }

--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -3,8 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "Io.h"
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Containers/Pair.h>
+#include <Corrade/Containers/StringStl.h>
 #include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Path.h>
 #include <Corrade/Utility/String.h>
 #include <glob.h>
 
@@ -14,8 +16,8 @@ namespace io {
 
 std::string changeExtension(const std::string& filename,
                             const std::string& ext) {
-  const std::string filenameBase =
-      Cr::Utility::Directory::splitExtension(filename).first;
+  const Cr::Containers::StringView filenameBase =
+      Cr::Utility::Path::splitExtension(filename).first();
   return Cr::Utility::formatString(
       ext.empty() || ext[0] == '.' ? "{}{}" : "{}.{}", filenameBase, ext);
 

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -4,8 +4,9 @@
 
 // Code adapted from Bullet3/examples/Importers/ImportURDFDemo ...
 
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Corrade/Utility/String.h>
 #include <Magnum/Math/Quaternion.h>
 #include <iostream>
@@ -104,11 +105,11 @@ void Model::setMassScaling(float massScaling) {
 bool Model::loadJsonAttributes(const std::string& filename) {
   namespace CrUt = Corrade::Utility;
   const std::string jsonName = CrUt::formatString(
-      "{}.ao_config.json", CrUt::Directory::splitExtension(
-                               CrUt::Directory::splitExtension(filename).first)
-                               .first);
+      "{}.ao_config.json",
+      CrUt::Path::splitExtension(CrUt::Path::splitExtension(filename).first())
+          .first());
 
-  if (!CrUt::Directory::exists(jsonName)) {
+  if (!CrUt::Path::exists(jsonName)) {
     // file does not exists, so no Json configuration defined for this Model.
     return false;
   }
@@ -164,7 +165,7 @@ bool Parser::parseURDF(std::shared_ptr<Model>& urdfModel,
   sourceFilePath_ = filename;
   urdfModel->m_sourceFile = filename;
 
-  std::string xmlString = Corrade::Utility::Directory::readString(filename);
+  std::string xmlString = *Corrade::Utility::Path::readString(filename);
 
   XMLDocument xml_doc;
   xml_doc.Parse(xmlString.c_str());
@@ -881,11 +882,11 @@ bool Parser::validateMeshFile(std::string& meshFilename) {
       sourceFilePath_.substr(0, sourceFilePath_.find_last_of('/'));
 
   std::string meshFilePath =
-      Corrade::Utility::Directory::join(urdfDirectory, meshFilename);
+      Corrade::Utility::Path::join(urdfDirectory, meshFilename);
 
   bool meshSuccess = false;
   // defer asset loading to instancing time. Check asset file existence here.
-  meshSuccess = Corrade::Utility::Directory::exists(meshFilePath);
+  meshSuccess = Corrade::Utility::Path::exists(meshFilePath);
 
   if (meshSuccess) {
     // modify the meshFilename to full filepath to enable access into

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -256,7 +256,7 @@ MetadataMediator::getSceneInstanceAttributesByName(
     const std::string sceneFilenameCandidate =
         dsSceneAttrMgr->getFormattedJSONFileName(sceneName);
 
-    if (Cr::Utility::Directory::exists(sceneFilenameCandidate)) {
+    if (Cr::Utility::Path::exists(sceneFilenameCandidate)) {
       // 2.  Existing, valid SceneInstanceAttributes file on disk, but not in
       // dataset.
       //    If this is the case, then the SceneInstanceAttributes should be

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
 #define ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <deque>
 #include "AttributesEnumMaps.h"
 #include "esp/core/Configuration.h"

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -383,8 +383,7 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
                                          meshTypeSetter);
     } else {
       // is not valid primitive, assume valid file name
-      assetName =
-          Cr::Utility::Directory::join(propertiesFileDirectory, assetName);
+      assetName = Cr::Utility::Path::join(propertiesFileDirectory, assetName);
       if ((typeVal == -1) && (oldFName != assetName)) {
         // if file name is different, and type val has not been specified,
         // perform name-specific mesh type config do not override orientation
@@ -415,15 +414,14 @@ bool AbstractObjectAttributesManager<T, Access>::setHandleFromDefaultTag(
     // not.
     tempStr.replace(loc, strlen(CONFIG_NAME_AS_ASSET_FILENAME),
                     attributes->getSimplifiedHandle());
-    if (Cr::Utility::Directory::exists(tempStr)) {
+    if (Cr::Utility::Path::exists(tempStr)) {
       // replace the component of the string containing the tag with the base
       // filename/handle, and verify it exists. Otherwise, clear it.
       filenameSetter(tempStr);
       return true;
     }
-    tempStr =
-        Cr::Utility::Directory::join(attributes->getFileDirectory(), tempStr);
-    if (Cr::Utility::Directory::exists(tempStr)) {
+    tempStr = Cr::Utility::Path::join(attributes->getFileDirectory(), tempStr);
+    if (Cr::Utility::Path::exists(tempStr)) {
       // replace the component of the string containing the tag with the base
       // filename/handle, and verify it exists. Otherwise, clear it.
       filenameSetter(tempStr);
@@ -434,7 +432,7 @@ bool AbstractObjectAttributesManager<T, Access>::setHandleFromDefaultTag(
     filenameSetter("");
   }
   // no tag found - check if existing non-empty field exists.
-  return Cr::Utility::Directory::exists(srcAssetFilename);
+  return Cr::Utility::Path::exists(srcAssetFilename);
 }  // AbstractObjectAttributesManager<T, Access>::setHandleFromDefaultTag
 
 }  // namespace managers

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -191,9 +191,9 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::buildObjectFromJSONDoc(
     const io::JsonGenericValue& jsonDoc) {
   // find type of attributes - file name should contain handle
   const std::string primAttrHandle =
-      Cr::Utility::Directory::splitExtension(
-          Cr::Utility::Directory::filename(filename))
-          .first;
+      Cr::Utility::Path::splitExtension(
+          Cr::Utility::Path::split(filename).second())
+          .first();
 
   std::string primClassName =
       Cr::Utility::String::partition(primAttrHandle, '_')[0];

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -233,14 +233,14 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
     bool saveAsDefaults) {
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
   if (paths.size() > 0) {
-    std::string dir = Cr::Utility::Directory::path(paths[0]);
+    std::string dir = Cr::Utility::Path::split(paths[0]).first();
     ESP_DEBUG() << "Loading" << paths.size() << "" << this->objectType_
                 << "templates found in" << dir;
     for (int i = 0; i < paths.size(); ++i) {
       auto attributesFilename = paths[i];
-      ESP_VERY_VERBOSE() << "Load" << this->objectType_ << "template:"
-                         << Cr::Utility::Directory::filename(
-                                attributesFilename);
+      ESP_VERY_VERBOSE()
+          << "Load" << this->objectType_ << "template:"
+          << Cr::Utility::Path::split(attributesFilename).second();
       auto tmplt = this->createObject(attributesFilename, true);
       // If failed to load, do not attempt to modify further
       if (tmplt == nullptr) {
@@ -265,7 +265,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     const std::string& path,
     const std::string& extType,
     bool saveAsDefaults) {
-  namespace Dir = Cr::Utility::Directory;
+  namespace Dir = Cr::Utility::Path;
   std::vector<std::string> paths;
   std::vector<int> templateIndices;
 
@@ -275,7 +275,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     ESP_DEBUG(Mn::Debug::Flag::NoSpace)
         << "Parsing " << this->objectType_
         << " library directory: " + path + " for \'" + extType + "\' files";
-    for (auto& file : Dir::list(path, Dir::Flag::SortAscending)) {
+    for (auto& file : *Dir::list(path, Dir::ListFlag::SortAscending)) {
       std::string absoluteSubfilePath = Dir::join(path, file);
       if (Cr::Utility::String::endsWith(absoluteSubfilePath, extType)) {
         paths.push_back(absoluteSubfilePath);
@@ -316,7 +316,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
       continue;
     }
     std::string absolutePath =
-        Cr::Utility::Directory::join(configDir, filePaths[i].GetString());
+        Cr::Utility::Path::join(configDir, filePaths[i].GetString());
     std::vector<std::string> globPaths = io::globDirs(absolutePath);
     if (globPaths.size() > 0) {
       for (const auto& globPath : globPaths) {
@@ -348,7 +348,7 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
            : this->getFormattedJSONFileName(filename));
   // Check if this configuration file exists and if so use it to build
   // attributes
-  bool jsonFileExists = Cr::Utility::Directory::exists(jsonAttrFileName);
+  bool jsonFileExists = Cr::Utility::Path::exists(jsonAttrFileName);
   ESP_DEBUG(Mn::Debug::Flag::NoSpace)
       << "<" << this->objectType_
       << ">: Proposing JSON name : " << jsonAttrFileName
@@ -364,7 +364,7 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     // default attributes.
     attrs = this->createDefaultObject(filename, registerObj);
     // check if original filename is an actual object
-    bool fileExists = Cr::Utility::Directory::exists(filename);
+    bool fileExists = Cr::Utility::Path::exists(filename);
     // if filename passed is name of some kind of asset, or if it was not
     // found
     if (fileExists) {

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -23,7 +23,7 @@ LightLayoutAttributes::ptr LightLayoutAttributesManager::createObject(
   bool doRegister = registerTemplate;
   // File based attributes are automatically registered.
   std::string jsonAttrFileName = getFormattedJSONFileName(lightConfigName);
-  bool jsonFileExists = (Cr::Utility::Directory::exists(jsonAttrFileName));
+  bool jsonFileExists = (Cr::Utility::Path::exists(jsonAttrFileName));
   if (jsonFileExists) {
     // if exists, force registration to be true.
     doRegister = true;
@@ -46,13 +46,13 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
   // this will parse jsonConfig for the description of each light, and build an
   // attributes for each.
   // set file directory here, based on layout name
-  std::string dirname = Cr::Utility::Directory::path(layoutNameAndPath);
-  std::string filenameExt = Cr::Utility::Directory::filename(layoutNameAndPath);
+  std::string filenameExt =
+      Cr::Utility::Path::split(layoutNameAndPath).second();
   // remove ".lighting_config.json" from name
   std::string layoutName =
-      Cr::Utility::Directory::splitExtension(
-          Cr::Utility::Directory::splitExtension(filenameExt).first)
-          .first;
+      Cr::Utility::Path::splitExtension(
+          Cr::Utility::Path::splitExtension(filenameExt).first())
+          .first();
   LightInstanceAttributes::ptr lightInstanceAttribs = nullptr;
 
   // check if positive scaling is set

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -231,7 +231,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     // physicsSynthObjTmpltLibByID_
     objectTemplate->setRenderAssetIsPrimitive(true);
     mapToUse = &physicsSynthObjTmpltLibByID_;
-  } else if (Cr::Utility::Directory::exists(renderAssetHandle)) {
+  } else if (Cr::Utility::Path::exists(renderAssetHandle)) {
     // Check if renderAssetHandle is valid file name and is found in file system
     // - if so then setRenderAssetIsPrimitive to false and set map of IDs->Names
     // to physicsFileObjTmpltLibByID_ - verify file  exists
@@ -261,7 +261,7 @@ int ObjectAttributesManager::registerObjectFinalize(
     // If collisionAssetHandle corresponds to valid/existing primitive
     // attributes then setCollisionAssetIsPrimitive to true
     objectTemplate->setCollisionAssetIsPrimitive(true);
-  } else if (Cr::Utility::Directory::exists(collisionAssetHandle)) {
+  } else if (Cr::Utility::Path::exists(collisionAssetHandle)) {
     // Check if collisionAssetHandle is valid file name and is found in file
     // system - if so then setCollisionAssetIsPrimitive to false
     objectTemplate->setCollisionAssetIsPrimitive(false);

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -76,7 +76,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
   // All of the below will be replaced by readDatasetJSONCell call
   const char* tag = "articulated_objects";
   if (jsonConfig.HasMember(tag)) {
-    namespace Dir = Cr::Utility::Directory;
+    namespace Dir = Cr::Utility::Path;
     if (!jsonConfig[tag].IsObject()) {
       ESP_WARNING()
           << "\"" << tag
@@ -138,7 +138,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                              "Parsing articulated object library directory: " +
                                  globPath;
                       for (auto& file :
-                           Dir::list(globPath, Dir::Flag::SortAscending)) {
+                           *Dir::list(globPath, Dir::ListFlag::SortAscending)) {
                         std::string absoluteSubfilePath =
                             Dir::join(globPath, file);
                         if (Cr::Utility::String::endsWith(absoluteSubfilePath,
@@ -163,7 +163,7 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
                   // check if any exist, may be more than 1 since may have
                   // traversing a subdirectory
                   if (aoFilePaths.size() > 0) {
-                    std::string ao_dir = Dir::path(aoFilePaths[0]);
+                    std::string ao_dir = Dir::split(aoFilePaths[0]).first();
                     ESP_DEBUG() << "(Articulated Object) : Loading"
                                 << aoFilePaths.size() << "" << this->objectType_
                                 << "templates found in" << ao_dir;
@@ -175,12 +175,12 @@ void SceneDatasetAttributesManager::setValsFromJSONDoc(
 
                       // set k-v pairs here.
                       auto key =
-                          Corrade::Utility::Directory::splitExtension(
-                              Corrade::Utility::Directory::splitExtension(
-                                  Corrade::Utility::Directory::filename(
-                                      aoModelFileName))
-                                  .first)
-                              .first;
+                          Corrade::Utility::Path::splitExtension(
+                              Corrade::Utility::Path::splitExtension(
+                                  Corrade::Utility::Path::split(aoModelFileName)
+                                      .second())
+                                  .first())
+                              .first();
 
                       dsAttribs->setArticulatedObjectModelFilename(
                           key, aoModelFileName);
@@ -255,9 +255,9 @@ void SceneDatasetAttributesManager::loadAndValidateMap(
   // dsDir-prepended entry
   for (std::pair<const std::string, std::string>& entry : map) {
     const std::string loc = entry.second;
-    if (!Cr::Utility::Directory::exists(loc)) {
-      std::string newLoc = Cr::Utility::Directory::join(dsDir, loc);
-      if (!Cr::Utility::Directory::exists(newLoc)) {
+    if (!Cr::Utility::Path::exists(loc)) {
+      std::string newLoc = Cr::Utility::Path::join(dsDir, loc);
+      if (!Cr::Utility::Path::exists(newLoc)) {
         ESP_WARNING() << jsonTag << "Value :" << loc
                       << "not found on disk as absolute path or relative to"
                       << dsDir;

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -65,7 +65,7 @@ int StageAttributesManager::registerObjectFinalize(
     // then setRenderAssetIsPrimitive to true and set map of IDs->Names to
     // physicsSynthObjTmpltLibByID_
     stageAttributes->setRenderAssetIsPrimitive(true);
-  } else if (Cr::Utility::Directory::exists(renderAssetHandle)) {
+  } else if (Cr::Utility::Path::exists(renderAssetHandle)) {
     // Check if renderAssetHandle is valid file name and is found in file
     // system
     // - if so then setRenderAssetIsPrimitive to false and set map of
@@ -96,7 +96,7 @@ int StageAttributesManager::registerObjectFinalize(
     // If collisionAssetHandle corresponds to valid/existing primitive
     // attributes then setCollisionAssetIsPrimitive to true
     stageAttributes->setCollisionAssetIsPrimitive(true);
-  } else if (Cr::Utility::Directory::exists(collisionAssetHandle)) {
+  } else if (Cr::Utility::Path::exists(collisionAssetHandle)) {
     // Check if collisionAssetHandle is valid file name and is found in file
     // system - if so then setCollisionAssetIsPrimitive to false
     stageAttributes->setCollisionAssetIsPrimitive(false);
@@ -255,13 +255,13 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
         if (ssdFileName.empty()) {
           if (attributesHandle.find("/replica_dataset") != std::string::npos) {
             // replica hack until dataset gets appropriate configuration support
-            ssdFileName = Cr::Utility::Directory::join(
+            ssdFileName = Cr::Utility::Path::join(
                 newAttributes->getFileDirectory(), "info_semantic.json");
           } else {
             // hack to support back-compat until configs are implemented for all
             // datasets
             ssdFileName =
-                Cr::Utility::Directory::splitExtension(attributesHandle).first +
+                Cr::Utility::Path::splitExtension(attributesHandle).first() +
                 ".scn";
           }
         }
@@ -429,9 +429,8 @@ void StageAttributesManager::setValsFromJSONDoc(
     // if "nav mesh" is specified in stage json set value (override default).
     // navmesh filename might already be fully qualified; if not, might just be
     // file name
-    if (!Corrade::Utility::Directory::exists(navmeshFName)) {
-      navmeshFName =
-          Cr::Utility::Directory::join(stageLocFileDir, navmeshFName);
+    if (!Corrade::Utility::Path::exists(navmeshFName)) {
+      navmeshFName = Cr::Utility::Path::join(stageLocFileDir, navmeshFName);
     }
     stageAttributes->setNavmeshAssetHandle(navmeshFName);
   }
@@ -442,9 +441,9 @@ void StageAttributesManager::setValsFromJSONDoc(
     // (override default).
     // semanticSceneDescriptor filename might already be fully qualified; if
     // not, might just be file name
-    if (!Corrade::Utility::Directory::exists(semanticSceneDescriptor)) {
-      semanticSceneDescriptor = Cr::Utility::Directory::join(
-          stageLocFileDir, semanticSceneDescriptor);
+    if (!Corrade::Utility::Path::exists(semanticSceneDescriptor)) {
+      semanticSceneDescriptor =
+          Cr::Utility::Path::join(stageLocFileDir, semanticSceneDescriptor);
     }
     stageAttributes->setSemanticDescriptorFilename(semanticSceneDescriptor);
   }

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include "URDFImporter.h"
 
 namespace Mn = Magnum;
@@ -22,8 +22,8 @@ bool URDFImporter::loadURDF(const std::string& filename,
   auto modelCacheIter = modelCache_.find(filename);
   // if map not found or forcing reload
   if ((modelCacheIter == modelCache_.end()) || forceReload) {
-    if (!Corrade::Utility::Directory::exists(filename) ||
-        Corrade::Utility::Directory::isDirectory(filename)) {
+    if (!Corrade::Utility::Path::exists(filename) ||
+        Corrade::Utility::Path::isDirectory(filename)) {
       ESP_DEBUG() << "File does not exist:" << filename
                   << ". Aborting URDF parse/load.";
       return false;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -199,11 +199,11 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
 
   // get a simplified name of the handle for the object
   std::string simpleArtObjHandle =
-      Corrade::Utility::Directory::splitExtension(
-          Corrade::Utility::Directory::splitExtension(
-              Corrade::Utility::Directory::filename(filepath))
-              .first)
-          .first;
+      Corrade::Utility::Path::splitExtension(
+          Corrade::Utility::Path::splitExtension(
+              Corrade::Utility::Path::split(filepath).second())
+              .first())
+          .first();
 
   std::string newArtObjectHandle =
       articulatedObjectManager_->getUniqueHandleFromCandidate(

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/BulletIntegration/Integration.h>
 #include "BulletCollision/CollisionShapes/btCompoundShape.h"
 #include "BulletCollisionHelper.h"

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -7,6 +7,7 @@
 #include "Mp3dSemanticScene.h"
 #include "ReplicaSemanticScene.h"
 
+#include <Corrade/Containers/Pair.h>
 #include <Corrade/Utility/FormatStl.h>
 
 #include <fstream>
@@ -74,11 +75,11 @@ bool SemanticScene::
     }
   }
   // should only reach here if not successfully loaded
-  namespace FileUtil = Cr::Utility::Directory;
+  namespace FileUtil = Cr::Utility::Path;
   // check if constructed replica file exists in directory of passed
   // ssdFileName
-  const std::string tmpFName =
-      FileUtil::join(FileUtil::path(ssdFileName), "info_semantic.json");
+  const std::string tmpFName = FileUtil::join(
+      FileUtil::split(ssdFileName).first(), "info_semantic.json");
   if (FileUtil::exists(tmpFName)) {
     success = scene::SemanticScene::loadReplicaHouse(tmpFName, scene);
   }

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -5,7 +5,7 @@
 #ifndef ESP_SCENE_SEMANTICSCENE_H_
 #define ESP_SCENE_SEMANTICSCENE_H_
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -284,7 +284,7 @@ class SemanticScene {
    */
   static bool checkFileExists(const std::string& filename,
                               const std::string& srcFunc) {
-    if (!Cr::Utility::Directory::exists(filename)) {
+    if (!Cr::Utility::Path::exists(filename)) {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "::" << srcFunc << ": File" << filename
           << "does not exist.  Aborting load.";

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -8,7 +8,8 @@
 #include <string>
 #include <utility>
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Containers/Pair.h>
+#include <Corrade/Utility/Path.h>
 #include <Corrade/Utility/String.h>
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/GL/Context.h>
@@ -237,7 +238,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // Get name of navmesh and use to create pathfinder and load navmesh
   // create pathfinder and load navmesh if available
   pathfinder_ = nav::PathFinder::create();
-  if (Cr::Utility::Directory::exists(navmeshFileLoc)) {
+  if (Cr::Utility::Path::exists(navmeshFileLoc)) {
     ESP_DEBUG() << "Loading navmesh from" << navmeshFileLoc;
     bool pfSuccess = pathfinder_->loadNavMesh(navmeshFileLoc);
     ESP_DEBUG() << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
@@ -423,7 +424,7 @@ bool Simulator::instanceStageForSceneAttributes(
   // sending semantic colormap to shader for visualizations.
   // This map may have color mappings specified in supported semantic screen
   // descriptor text files with vertex mappings to ids on semantic scene mesh.
-  if (renderer_ && !colorMap.empty()) {
+  if (renderer_ && !colorMap.isEmpty()) {
     // send colormap to TextureVisualizeShader via renderer.
     renderer_->setSemanticVisualizerColormap(colorMap);
   }
@@ -989,7 +990,7 @@ std::string Simulator::convexHullDecomposition(
 
   // generate a unique filename
   std::string chdFilename =
-      Cr::Utility::Directory::splitExtension(filename).first + ".chd";
+      Cr::Utility::Path::splitExtension(filename).first() + ".chd";
   if (resourceManager_->isAssetDataRegistered(chdFilename)) {
     int nameAttempt = 1;
     chdFilename += "_";

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -38,7 +38,7 @@ namespace {
 
 // base directory to save test attributes
 const std::string testAttrSaveDir =
-    Cr::Utility::Directory::join(DATA_DIR, "test_assets");
+    Cr::Utility::Path::join(DATA_DIR, "test_assets");
 
 /**
  * @brief Test attributes/configuration functionality via setting values from
@@ -325,7 +325,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
   ESP_DEBUG() << "Tested physMgrAttr";
 
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Path::remove(newAttrName);
 
 }  // AttributesManagers_PhysicsJSONLoadTest
 
@@ -463,7 +463,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
   ESP_DEBUG() << "About to test lightLayoutAttr2";
 
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Path::remove(newAttrName);
 
 }  // AttributesManagers_LightJSONLoadTest
 
@@ -740,7 +740,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
   testSceneInstanceAttrVals(sceneAttr2);
   ESP_DEBUG() << "Tested saved sceneAttr2 :";
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Path::remove(newAttrName);
 
 }  // AttributesManagers_SceneInstanceJSONLoadTest
 
@@ -837,7 +837,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
   // now need to change the render and collision assets to make sure they are
   // legal so test can proceed (needs to be actual existing file)
   const std::string stageAssetFile =
-      Cr::Utility::Directory::join(testAttrSaveDir, "scenes/plane.glb");
+      Cr::Utility::Path::join(testAttrSaveDir, "scenes/plane.glb");
 
   stageAttr->setRenderAssetHandle(stageAssetFile);
   stageAttr->setCollisionAssetHandle(stageAssetFile);
@@ -875,7 +875,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
   ESP_DEBUG() << "Tested saved stageAttr2 :";
 
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Path::remove(newAttrName);
 
 }  // AttributesManagers_StageJSONLoadTest
 
@@ -955,7 +955,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
   // now need to change the render and collision assets to make sure they are
   // legal so test can proceed (needs to be actual existing file)
   const std::string objAssetFile =
-      Cr::Utility::Directory::join(testAttrSaveDir, "objects/donut.glb");
+      Cr::Utility::Path::join(testAttrSaveDir, "objects/donut.glb");
 
   objAttr->setRenderAssetHandle(objAssetFile);
   objAttr->setCollisionAssetHandle(objAssetFile);
@@ -992,7 +992,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
   ESP_DEBUG() << "Tested saved stageAttr2 :";
 
   // delete file-based config
-  Cr::Utility::Directory::rm(newAttrName);
+  Cr::Utility::Path::remove(newAttrName);
 }  // AttributesConfigsTest::testObjectJSONLoadTest
 
 }  // namespace

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -40,8 +40,8 @@ using Attrs::UVSpherePrimitiveAttributes;
 
 namespace {
 const std::string physicsConfigFile =
-    Cr::Utility::Directory::join(DATA_DIR,
-                                 "test_assets/testing.physics_config.json");
+    Cr::Utility::Path::join(DATA_DIR,
+                            "test_assets/testing.physics_config.json");
 
 /**
  * @brief Test attributesManagers' functionality via loading, creating, copying
@@ -567,8 +567,8 @@ void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
 }  // AttributesManagersTest::PhysicsAttributesManagersCreate
 
 void AttributesManagersTest::testStageAttributesManagersCreate() {
-  std::string stageConfigFile = Cr::Utility::Directory::join(
-      DATA_DIR, "test_assets/scenes/simple_room.glb");
+  std::string stageConfigFile =
+      Cr::Utility::Path::join(DATA_DIR, "test_assets/scenes/simple_room.glb");
 
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
@@ -584,7 +584,7 @@ void AttributesManagersTest::testStageAttributesManagersCreate() {
 }  // AttributesManagersTest::StageAttributesManagersCreate
 
 void AttributesManagersTest::testObjectAttributesManagersCreate() {
-  std::string objectConfigFile = Cr::Utility::Directory::join(
+  std::string objectConfigFile = Cr::Utility::Path::join(
       DATA_DIR, "test_assets/objects/chair.object_config.json");
 
   CORRADE_INFO(
@@ -625,7 +625,7 @@ void AttributesManagersTest::testObjectAttributesManagersCreate() {
 }  // AttributesManagersTest::ObjectAttributesManagersCreate test
 
 void AttributesManagersTest::testLightLayoutAttributesManager() {
-  std::string lightConfigFile = Cr::Utility::Directory::join(
+  std::string lightConfigFile = Cr::Utility::Path::join(
       DATA_DIR, "test_assets/lights/test_lights.lighting_config.json");
 
   CORRADE_INFO(

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -5,7 +5,7 @@
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/GL/SampleQuery.h>
 #include <Magnum/Math/Frustum.h>
@@ -75,7 +75,7 @@ int CullingTest::setupTests() {
   }
   auto stageAttributesMgr = MM->getStageAttributesManager();
   std::string stageFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/5boxes.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/5boxes.glb");
   // create scene attributes file
   auto stageAttributes = stageAttributesMgr->createObject(stageFile, true);
   int sceneID = sceneManager_->initSceneGraph();

--- a/src/tests/DrawableTest.cpp
+++ b/src/tests/DrawableTest.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/MeshTools/Compile.h>
 #include <Magnum/Primitives/Cube.h>
@@ -57,7 +57,7 @@ DrawableTest::DrawableTest() {
   //clang-format on
   auto stageAttributesMgr = MM->getStageAttributesManager();
   std::string stageFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/5boxes.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/5boxes.glb");
   auto stageAttributes = stageAttributesMgr->createObject(stageFile, true);
 
   sceneID_ = sceneManager_.initSceneGraph();

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -7,7 +7,7 @@
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Math/Range.h>
 
@@ -86,7 +86,7 @@ void GfxReplayTest::testRecorder() {
   ResourceManager resourceManager(MM);
   SceneManager sceneManager_;
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
 
   int sceneID = sceneManager_.initSceneGraph();
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
@@ -195,7 +195,7 @@ void GfxReplayTest::testPlayer() {
   ResourceManager resourceManager(MM);
   SceneManager sceneManager_;
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
 
   int sceneID = sceneManager_.initSceneGraph();
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
@@ -355,7 +355,7 @@ void GfxReplayTest::testPlayerReadMissingFile() {
 void GfxReplayTest::testPlayerReadInvalidFile() {
   esp::logging::LoggingContext loggingContext;
   auto testFilepath =
-      Corrade::Utility::Directory::join(DATA_DIR, "./gfx_replay_test.json");
+      Corrade::Utility::Path::join(DATA_DIR, "./gfx_replay_test.json");
 
   std::ofstream out(testFilepath);
   out << "{invalid json";
@@ -372,7 +372,7 @@ void GfxReplayTest::testPlayerReadInvalidFile() {
   CORRADE_COMPARE(player.getNumKeyframes(), 0);
 
   // remove bogus file created for this test
-  bool success = Corrade::Utility::Directory::rm(testFilepath);
+  bool success = Corrade::Utility::Path::remove(testFilepath);
   if (!success) {
     ESP_WARNING() << "Unable to remove temporary test JSON file"
                   << testFilepath;
@@ -382,9 +382,9 @@ void GfxReplayTest::testPlayerReadInvalidFile() {
 // test recording and playback through the simulator interface
 void GfxReplayTest::testSimulatorIntegration() {
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
   auto testFilepath =
-      Corrade::Utility::Directory::join(DATA_DIR, "./gfx_replay_test.json");
+      Corrade::Utility::Path::join(DATA_DIR, "./gfx_replay_test.json");
 
   SimulatorConfiguration simConfig{};
   simConfig.activeSceneName = boxFile;
@@ -394,7 +394,7 @@ void GfxReplayTest::testSimulatorIntegration() {
   auto sim = Simulator::create_unique(simConfig);
   auto objAttrMgr = sim->getObjectAttributesManager();
   objAttrMgr->loadAllJSONConfigsFromPath(
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/nested_box"), true);
 
   auto handles = objAttrMgr->getObjectHandlesBySubstring("nested_box");
   CORRADE_VERIFY(!handles.empty());
@@ -442,7 +442,7 @@ void GfxReplayTest::testSimulatorIntegration() {
                   prevNumberOfChildrenOfRoot);
 
   // remove file created for this test
-  bool success = Corrade::Utility::Directory::rm(testFilepath);
+  bool success = Corrade::Utility::Path::remove(testFilepath);
   if (!success) {
     ESP_WARNING() << "Unable to remove temporary test JSON file"
                   << testFilepath;

--- a/src/tests/GibsonSceneTest.cpp
+++ b/src/tests/GibsonSceneTest.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <string>
 #include "esp/io/Io.h"
 #include "esp/scene/SemanticScene.h"
@@ -18,12 +18,12 @@ using esp::sim::SimulatorConfiguration;
 
 namespace {
 
-const std::string houseFilename = Cr::Utility::Directory::join(
+const std::string houseFilename = Cr::Utility::Path::join(
     DATA_DIR,
     "test_assets/dataset_tests/GibsonSceneTest/GibsonTestScene.scn");
 
 const std::string gibsonSemanticFilename =
-    Cr::Utility::Directory::join(SCENE_DATASETS, "gibson/Allensville.scn");
+    Cr::Utility::Path::join(SCENE_DATASETS, "gibson/Allensville.scn");
 
 struct GibsonSceneTest : Cr::TestSuite::Tester {
   explicit GibsonSceneTest();
@@ -61,7 +61,7 @@ void GibsonSceneTest::testGibsonScene() {
 
 void GibsonSceneTest::testGibsonSemanticScene() {
   esp::logging::LoggingContext loggingContext;
-  if (!Cr::Utility::Directory::exists(gibsonSemanticFilename)) {
+  if (!Cr::Utility::Path::exists(gibsonSemanticFilename)) {
     std::string skip_message = "Gibson's semantic scene file \"" +
                                gibsonSemanticFilename + "\" wasn't found.";
     CORRADE_SKIP(skip_message.c_str());

--- a/src/tests/HM3DSceneTest.cpp
+++ b/src/tests/HM3DSceneTest.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <string>
 
 #include "esp/scene/SemanticScene.h"
@@ -20,7 +20,7 @@ namespace {
 // Scene dataset config directly references test scene locations, along with
 // providing default values for stage configuration, obviating the need for
 // per-scene/per-stage configs.
-const std::string HM3DTestConfigLoc = Cr::Utility::Directory::join(
+const std::string HM3DTestConfigLoc = Cr::Utility::Path::join(
     SCENE_DATASETS,
     "habitat-test-scenes/hm3d_habitat_annotated_testdata/"
     "hm3d_annotated_testdata.scene_dataset_config.json");
@@ -80,7 +80,7 @@ HM3DSceneTest::HM3DSceneTest() {
 
 void HM3DSceneTest::testHM3DScene() {
   // If scene dataset does not exist, skip test for now
-  if (!Cr::Utility::Directory::exists(HM3DTestConfigLoc)) {
+  if (!Cr::Utility::Path::exists(HM3DTestConfigLoc)) {
     CORRADE_SKIP("HM3D dataset not found.");
   }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];
@@ -91,7 +91,7 @@ void HM3DSceneTest::testHM3DScene() {
 
 void HM3DSceneTest::testHM3DSemanticScene() {
   // If scene dataset does not exist, skip test for now
-  if (!Cr::Utility::Directory::exists(HM3DTestConfigLoc)) {
+  if (!Cr::Utility::Path::exists(HM3DTestConfigLoc)) {
     CORRADE_SKIP("HM3D dataset not found.");
   }
   auto&& testData = TestHM3DScenes[testCaseInstanceId()];

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -4,7 +4,7 @@
 
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/core/Esp.h"
@@ -22,8 +22,7 @@ using esp::metadata::attributes::AbstractObjectAttributes;
 using esp::metadata::attributes::ObjectAttributes;
 
 namespace {
-const std::string dataDir =
-    Corrade::Utility::Directory::join(SCENE_DATASETS, "../");
+const std::string dataDir = Corrade::Utility::Path::join(SCENE_DATASETS, "../");
 
 struct IOTest : Cr::TestSuite::Tester {
   explicit IOTest();
@@ -90,7 +89,7 @@ void IOTest::fileReplaceExtTest() {
 }
 
 void IOTest::parseURDF() {
-  const std::string iiwaURDF = Cr::Utility::Directory::join(
+  const std::string iiwaURDF = Cr::Utility::Path::join(
       TEST_ASSETS, "urdf/kuka_iiwa/model_free_base.urdf");
 
   esp::io::URDF::Parser parser;
@@ -156,11 +155,11 @@ void IOTest::testJson() {
 
   // test io
   auto testFilepath =
-      Corrade::Utility::Directory::join(dataDir, "../io_test_json.json");
+      Corrade::Utility::Path::join(dataDir, "../io_test_json.json");
   CORRADE_VERIFY(esp::io::writeJsonToFile(json, testFilepath));
   const auto& loadedJson = esp::io::parseJsonFile(testFilepath);
   CORRADE_COMPARE(esp::io::jsonToString(loadedJson), s);
-  Corrade::Utility::Directory::rm(testFilepath);
+  Corrade::Utility::Path::remove(testFilepath);
 
   // test basic attributes populating
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -20,19 +20,19 @@ using esp::metadata::MetadataMediator;
 namespace {
 
 const std::string physicsConfigFile =
-    Cr::Utility::Directory::join(DATA_DIR,
-                                 "test_assets/testing.physics_config.json");
+    Cr::Utility::Path::join(DATA_DIR,
+                            "test_assets/testing.physics_config.json");
 
 const std::string datasetTestDirs =
-    Cr::Utility::Directory::join(DATA_DIR, "test_assets/dataset_tests/");
+    Cr::Utility::Path::join(DATA_DIR, "test_assets/dataset_tests/");
 
-const std::string sceneDatasetConfigFile_0 = Cr::Utility::Directory::join(
+const std::string sceneDatasetConfigFile_0 = Cr::Utility::Path::join(
     datasetTestDirs,
     "dataset_0/test_dataset_0.scene_dataset_config.json");
 
 // test dataset contains glob wildcards in scene config, and articulated object
 // refs
-const std::string sceneDatasetConfigFile_1 = Cr::Utility::Directory::join(
+const std::string sceneDatasetConfigFile_1 = Cr::Utility::Path::join(
     datasetTestDirs,
     "dataset_1/test_dataset_1.scene_dataset_config.json");
 
@@ -488,7 +488,7 @@ void MetadataMediatorTest::testDataset1() {
 
   ESP_WARNING() << "Starting test LoadArticulatedObjects";
 
-  namespace Dir = Cr::Utility::Directory;
+  namespace Dir = Cr::Utility::Path;
   // verify # of urdf filepaths loaded - should be 6;
   const std::map<std::string, std::string>& urdfTestFilenames =
       MM_->getArticulatedObjectModelFilenames();
@@ -502,14 +502,14 @@ void MetadataMediatorTest::testDataset1() {
     // instances proper key synth methods.
     const std::string shortHandle =
         Dir::splitExtension(
-            Dir::splitExtension(Dir::filename(iter->second)).first)
-            .first;
+            Dir::splitExtension(Dir::split(iter->second).second()).first())
+            .first();
     // test that map key constructed as shortened handle.
     CORRADE_COMPARE(shortHandle, iter->first);
     // test that file name ends in ".urdf"
-    CORRADE_COMPARE(Dir::splitExtension(Dir::filename(iter->second))
-                        .second.compare(".urdf"),
-                    0);
+    CORRADE_COMPARE(
+        Dir::splitExtension(Dir::split(iter->second).second()).second(),
+        ".urdf");
     // test that file actually exists
     const std::string filename = iter->second;
     CORRADE_VERIFY(Dir::exists(filename));

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -4,7 +4,7 @@
 
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 
 #include "esp/scene/SemanticScene.h"
 
@@ -27,9 +27,9 @@ Mp3dTest::Mp3dTest() {
 }  // Mp3dTest ctor
 
 void Mp3dTest::testLoad() {
-  const std::string filename = Cr::Utility::Directory::join(
+  const std::string filename = Cr::Utility::Path::join(
       SCENE_DATASETS, "mp3d/17DRP5sb8fy/17DRP5sb8fy.house");
-  if (!Cr::Utility::Directory::exists(filename)) {
+  if (!Cr::Utility::Path::exists(filename)) {
     CORRADE_SKIP("MP3D dataset not found.");
   }
 

--- a/src/tests/NavTest.cpp
+++ b/src/tests/NavTest.cpp
@@ -4,7 +4,7 @@
 
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 
 #include "esp/assets/MeshData.h"
 #include "esp/core/Esp.h"
@@ -45,7 +45,7 @@ NavTest::NavTest() {
 
 void NavTest::PathFinderLoadTest() {
   esp::nav::PathFinder pf;
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
   for (int i = 0; i < 100000; ++i) {
     esp::nav::ShortestPath path;
@@ -103,7 +103,7 @@ void printRandomizedPathSet(esp::nav::PathFinder& pf) {
 
 void NavTest::PathFinderTestCases() {
   esp::nav::PathFinder pf;
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
   esp::nav::ShortestPath testPath;
   testPath.requestedStart = esp::vec3f(-6.493, 0.072, -3.292);
@@ -128,7 +128,7 @@ void NavTest::PathFinderTestCases() {
 
 void NavTest::PathFinderTestNonNavigable() {
   esp::nav::PathFinder pf;
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
 
   const esp::vec3f nonNavigablePoint{1e2, 1e2, 1e2};
@@ -141,7 +141,7 @@ void NavTest::PathFinderTestNonNavigable() {
 
 void NavTest::PathFinderTestSeed() {
   esp::nav::PathFinder pf;
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
 
   // The same seed should produce the same point
@@ -169,7 +169,7 @@ void NavTest::PathFinderTestSeed() {
 
 void NavTest::PathFinderTestMeshData() {
   esp::nav::PathFinder pf;
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.navmesh"));
 
   esp::assets::MeshData::ptr meshData = pf.getNavMeshData();
@@ -178,7 +178,7 @@ void NavTest::PathFinderTestMeshData() {
   CORRADE_COMPARE(meshData->vbo.size(), 1155);
   CORRADE_COMPARE(meshData->ibo.size(), 1155);
 
-  pf.loadNavMesh(Cr::Utility::Directory::join(
+  pf.loadNavMesh(Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/van-gogh-room.navmesh"));
 
   meshData = pf.getNavMeshData();

--- a/src/tests/PathFinderTest.cpp
+++ b/src/tests/PathFinderTest.cpp
@@ -8,7 +8,7 @@
 
 #include <esp/nav/PathFinder.h>
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Swizzle.h>
@@ -21,9 +21,9 @@ namespace Mn = Magnum;
 
 namespace {
 
-const std::string skokloster = Cr::Utility::Directory::join(
-    SCENE_DATASETS,
-    "habitat-test-scenes/skokloster-castle.navmesh");
+const std::string skokloster =
+    Cr::Utility::Path::join(SCENE_DATASETS,
+                            "habitat-test-scenes/skokloster-castle.navmesh");
 
 constexpr struct {
   const char* name;

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -4,7 +4,7 @@
 
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <string>
 
 #include "esp/sim/Simulator.h"
@@ -32,10 +32,9 @@ using esp::metadata::attributes::ObjectAttributes;
 using esp::physics::PhysicsManager;
 using esp::scene::SceneManager;
 
-const std::string dataDir = Cr::Utility::Directory::join(SCENE_DATASETS, "../");
+const std::string dataDir = Cr::Utility::Path::join(SCENE_DATASETS, "../");
 const std::string physicsConfigFile =
-    Cr::Utility::Directory::join(SCENE_DATASETS,
-                                 "../default.physics_config.json");
+    Cr::Utility::Path::join(SCENE_DATASETS, "../default.physics_config.json");
 
 namespace {
 struct PhysicsTest : Cr::TestSuite::Tester {
@@ -187,10 +186,10 @@ PhysicsTest::PhysicsTest() {
 }
 
 void PhysicsTest::testJoinCompound() {
-  std::string stageFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/scenes/simple_room.glb");
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/nested_box.glb");
+  std::string stageFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/simple_room.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/nested_box.glb");
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
@@ -263,9 +262,9 @@ void PhysicsTest::testJoinCompound() {
 #ifdef ESP_BUILD_WITH_BULLET
 void PhysicsTest::testCollisionBoundingBox() {
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
   std::string objectFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/objects/sphere.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/sphere.glb");
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
@@ -342,9 +341,9 @@ void PhysicsTest::testCollisionBoundingBox() {
 
 void PhysicsTest::testDiscreteContactTest() {
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
   initStage(stageFile);
@@ -426,8 +425,8 @@ void PhysicsTest::testBulletCompoundShapeMargins() {
   // test that all different construction methods for a simple shape result in
   // the same Aabb for the given margin
 
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
   initStage(objectFile);
@@ -495,10 +494,10 @@ void PhysicsTest::testConfigurableScaling() {
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
 
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   initStage(stageFile);
 
@@ -563,11 +562,11 @@ void PhysicsTest::testVelocityControl() {
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
 
   initStage(stageFile);
 
@@ -711,11 +710,11 @@ void PhysicsTest::testSceneNodeAttachment() {
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
 
   initStage(stageFile);
 
@@ -769,11 +768,11 @@ void PhysicsTest::testMotionTypes() {
 
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-  std::string objectFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/objects/transform_box.glb");
+  std::string objectFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/objects/transform_box.glb");
 
   std::string stageFile =
-      Cr::Utility::Directory::join(dataDir, "test_assets/scenes/plane.glb");
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/plane.glb");
 
   initStage(stageFile);
 
@@ -887,8 +886,8 @@ void PhysicsTest::testMotionTypes() {
 void PhysicsTest::testNumActiveContactPoints() {
   resetCreateRendererFlag(RendererEnabledData[testCaseInstanceId()].enabled);
 
-  std::string stageFile = Cr::Utility::Directory::join(
-      dataDir, "test_assets/scenes/simple_room.glb");
+  std::string stageFile =
+      Cr::Utility::Path::join(dataDir, "test_assets/scenes/simple_room.glb");
 
   initStage(stageFile);
   auto& drawables = sceneManager_->getSceneGraph(sceneID_).getDrawables();

--- a/src/tests/ReplicaSceneTest.cpp
+++ b/src/tests/ReplicaSceneTest.cpp
@@ -5,7 +5,7 @@
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/EigenIntegration/GeometryIntegration.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Magnum.h>
@@ -26,10 +26,9 @@ using esp::assets::GenericSemanticMeshData;
 namespace {
 
 const std::string replicaRoom0 =
-    Cr::Utility::Directory::join(SCENE_DATASETS,
-                                 "replica_dataset/room_0/habitat");
+    Cr::Utility::Path::join(SCENE_DATASETS, "replica_dataset/room_0/habitat");
 const std::string replicaCAD =
-    Cr::Utility::Directory::join(SCENE_DATASETS, "replicaCAD");
+    Cr::Utility::Path::join(SCENE_DATASETS, "replicaCAD");
 
 struct ReplicaSceneTest : Cr::TestSuite::Tester {
   explicit ReplicaSceneTest();
@@ -50,14 +49,14 @@ ReplicaSceneTest::ReplicaSceneTest() {
 }
 
 void ReplicaSceneTest::testSemanticSceneOBB() {
-  if (!Cr::Utility::Directory::exists(replicaRoom0)) {
+  if (!Cr::Utility::Path::exists(replicaRoom0)) {
     CORRADE_SKIP("Replica dataset not found at '" + replicaRoom0 +
                  "'\nSkipping test");
   }
 
   esp::scene::SemanticScene scene;
   CORRADE_VERIFY(esp::scene::SemanticScene::loadReplicaHouse(
-      Cr::Utility::Directory::join(replicaRoom0, "info_semantic.json"), scene));
+      Cr::Utility::Path::join(replicaRoom0, "info_semantic.json"), scene));
 
 #ifndef MAGNUM_BUILD_STATIC
   Cr::PluginManager::Manager<Mn::Trade::AbstractImporter> manager;
@@ -75,7 +74,7 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
   // dummy colormap
   std::vector<Magnum::Vector3ub> dummyColormap;
   const std::string semanticFilename =
-      Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply");
+      Cr::Utility::Path::join(replicaRoom0, "mesh_semantic.ply");
   /* Open the file. On error the importer already prints a diagnostic message,
      so no need to do that here. The importer implicitly converts per-face
      attributes to per-vertex, so nothing extra needs to be done. */
@@ -120,14 +119,14 @@ void ReplicaSceneTest::testSemanticSceneOBB() {
 }  // ReplicaSceneTest::testSemanticSceneOBB()
 
 void ReplicaSceneTest::testSemanticSceneLoading() {
-  if (!Cr::Utility::Directory::exists(replicaRoom0)) {
+  if (!Cr::Utility::Path::exists(replicaRoom0)) {
     CORRADE_SKIP("Replica dataset not found at '" + replicaRoom0 +
                  "'\nSkipping test");
   }
 
   esp::sim::SimulatorConfiguration cfg;
   cfg.activeSceneName =
-      Cr::Utility::Directory::join(replicaRoom0, "mesh_semantic.ply");
+      Cr::Utility::Path::join(replicaRoom0, "mesh_semantic.ply");
 
   esp::sim::Simulator sim{cfg};
 
@@ -160,12 +159,12 @@ void ReplicaSceneTest::testSemanticSceneLoading() {
 }
 
 void ReplicaSceneTest::testSemanticSceneDescriptorReplicaCAD() {
-  if (!Cr::Utility::Directory::exists(replicaCAD)) {
+  if (!Cr::Utility::Path::exists(replicaCAD)) {
     CORRADE_SKIP("ReplicaCAD dataset not found at '" + replicaCAD +
                  "'\nSkipping test");
   }
   esp::sim::SimulatorConfiguration cfg;
-  cfg.sceneDatasetConfigFile = Cr::Utility::Directory::join(
+  cfg.sceneDatasetConfigFile = Cr::Utility::Path::join(
       replicaCAD, "replicaCAD.scene_dataset_config.json");
 
   cfg.activeSceneName = "apt_0.scene_instance";

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -7,7 +7,7 @@
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/TestSuite/Compare/Container.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/Math/Range.h>
 #include <string>
@@ -72,7 +72,7 @@ void ResourceManagerTest::createJoinedCollisionMesh() {
   SceneManager sceneManager_;
   auto stageAttributesMgr = MM->getStageAttributesManager();
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
 
   // create stage attributes file
   auto stageAttributes = stageAttributesMgr->createObject(boxFile, true);
@@ -136,9 +136,9 @@ void ResourceManagerTest::VHACDUsageTest() {
   SceneManager sceneManager_;
   auto stageAttributesMgr = MM->getStageAttributesManager();
   std::string donutFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/donut.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/donut.glb");
   std::string CHdonutFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/CHdonut.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/CHdonut.glb");
 
   // create stage attributes file
   auto stageAttributes = stageAttributesMgr->createObject(donutFile, true);
@@ -178,7 +178,7 @@ void ResourceManagerTest::loadAndCreateRenderAssetInstance() {
   ResourceManager resourceManager(MM);
   SceneManager sceneManager_;
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
 
   int sceneID = sceneManager_.initSceneGraph();
   auto& sceneGraph = sceneManager_.getSceneGraph(sceneID);
@@ -267,7 +267,7 @@ void ResourceManagerTest::testShaderTypeSpecification() {
   // must declare these in this order due to avoid deallocation errors
   auto MM = MetadataMediator::create();
   std::string boxFile =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
   // bogus test for corrade
   CORRADE_VERIFY(true);
 

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -5,7 +5,7 @@
 #include <Corrade/Containers/StridedArrayView.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/DebugTools/CompareImage.h>
 #include <Magnum/EigenIntegration/Integration.h>
 #include <Magnum/ImageView.h>
@@ -47,17 +47,17 @@ namespace {
 using namespace Magnum::Math::Literals;
 
 const std::string vangogh =
-    Cr::Utility::Directory::join(SCENE_DATASETS,
-                                 "habitat-test-scenes/van-gogh-room.glb");
+    Cr::Utility::Path::join(SCENE_DATASETS,
+                            "habitat-test-scenes/van-gogh-room.glb");
 const std::string skokloster =
-    Cr::Utility::Directory::join(SCENE_DATASETS,
-                                 "habitat-test-scenes/skokloster-castle.glb");
+    Cr::Utility::Path::join(SCENE_DATASETS,
+                            "habitat-test-scenes/skokloster-castle.glb");
 const std::string planeStage =
-    Cr::Utility::Directory::join(TEST_ASSETS, "scenes/plane.glb");
+    Cr::Utility::Path::join(TEST_ASSETS, "scenes/plane.glb");
 const std::string physicsConfigFile =
-    Cr::Utility::Directory::join(TEST_ASSETS, "testing.physics_config.json");
+    Cr::Utility::Path::join(TEST_ASSETS, "testing.physics_config.json");
 const std::string screenshotDir =
-    Cr::Utility::Directory::join(TEST_ASSETS, "screenshots/");
+    Cr::Utility::Path::join(TEST_ASSETS, "screenshots/");
 
 struct SimTest : Cr::TestSuite::Tester {
   explicit SimTest();
@@ -77,7 +77,7 @@ struct SimTest : Cr::TestSuite::Tester {
     auto sim = Simulator::create_unique(simConfig);
     auto objAttrMgr = sim->getObjectAttributesManager();
     objAttrMgr->loadAllJSONConfigsFromPath(
-        Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+        Cr::Utility::Path::join(TEST_ASSETS, "objects/nested_box"), true);
 
     sim->setLightSetup(self.lightSetup1, "custom_lighting_1");
     sim->setLightSetup(self.lightSetup2, "custom_lighting_2");
@@ -100,7 +100,7 @@ struct SimTest : Cr::TestSuite::Tester {
     auto sim = Simulator::create_unique(simConfig, MM);
     auto objAttrMgr = sim->getObjectAttributesManager();
     objAttrMgr->loadAllJSONConfigsFromPath(
-        Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+        Cr::Utility::Path::join(TEST_ASSETS, "objects/nested_box"), true);
 
     sim->setLightSetup(self.lightSetup1, "custom_lighting_1");
     sim->setLightSetup(self.lightSetup2, "custom_lighting_2");
@@ -262,7 +262,7 @@ void SimTest::checkPinholeCameraRGBAObservation(
           Mn::PixelFormat::RGBA8Unorm,
           {pinholeCameraSpec->resolution[0], pinholeCameraSpec->resolution[1]},
           observation.buffer->data}),
-      Cr::Utility::Directory::join(screenshotDir, groundTruthImageFile),
+      Cr::Utility::Path::join(screenshotDir, groundTruthImageFile),
       (Mn::DebugTools::CompareImageToFile{maxThreshold, meanThreshold}));
 }
 
@@ -499,7 +499,7 @@ void SimTest::loadingObjectTemplates() {
   // test directory of templates
   std::vector<int> templateIndices =
       objectAttribsMgr->loadAllJSONConfigsFromPath(
-          Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
+          Cr::Utility::Path::join(TEST_ASSETS, "objects"));
   CORRADE_VERIFY(!templateIndices.empty());
   for (auto index : templateIndices) {
     CORRADE_VERIFY(index != esp::ID_UNDEFINED);
@@ -508,7 +508,7 @@ void SimTest::loadingObjectTemplates() {
   // reload again and ensure that old loaded indices are returned
   std::vector<int> templateIndices2 =
       objectAttribsMgr->loadAllJSONConfigsFromPath(
-          Cr::Utility::Directory::join(TEST_ASSETS, "objects"));
+          Cr::Utility::Path::join(TEST_ASSETS, "objects"));
   CORRADE_COMPARE(templateIndices2, templateIndices);
 
   // test the loaded assets and accessing them by name
@@ -535,14 +535,14 @@ void SimTest::loadingObjectTemplates() {
   ObjectAttributes::ptr newTemplate =
       objectAttribsMgr->createObject("new template", false);
   std::string boxPath =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/transform_box.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/transform_box.glb");
   newTemplate->setRenderAssetHandle(boxPath);
   int templateIndex = objectAttribsMgr->registerObject(newTemplate, boxPath);
 
   CORRADE_VERIFY(templateIndex != esp::ID_UNDEFINED);
   // change render asset for object template named boxPath
   std::string chairPath =
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/chair.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/chair.glb");
   newTemplate->setRenderAssetHandle(chairPath);
   int templateIndex2 = objectAttribsMgr->registerObject(newTemplate, boxPath);
 
@@ -718,7 +718,7 @@ void SimTest::addObjectByHandle() {
   CORRADE_COMPARE(obj, nullptr);
 
   // pass valid object_config.json filepath as handle to addObjectByHandle
-  const auto validHandle = Cr::Utility::Directory::join(
+  const auto validHandle = Cr::Utility::Path::join(
       TEST_ASSETS, "objects/nested_box.object_config.json");
   obj = rigidObjMgr->addObjectByHandle(validHandle);
   CORRADE_VERIFY(obj->isAlive());
@@ -783,7 +783,7 @@ void SimTest::addSensorToObject() {
       (Mn::ImageView2D{Mn::PixelFormat::RGBA8Unorm,
                        {defaultResolution[0], defaultResolution[1]},
                        observation.buffer->data}),
-      Cr::Utility::Directory::join(screenshotDir, "SimTestExpectedScene.png"),
+      Cr::Utility::Path::join(screenshotDir, "SimTestExpectedScene.png"),
       (Mn::DebugTools::CompareImageToFile{maxThreshold, 0.75f}));
 }
 
@@ -804,7 +804,7 @@ void SimTest::createMagnumRenderingOff() {
   auto objectAttribsMgr = simulator->getObjectAttributesManager();
   auto rigidObjMgr = simulator->getRigidObjectManager();
   objectAttribsMgr->loadAllJSONConfigsFromPath(
-      Cr::Utility::Directory::join(TEST_ASSETS, "objects/nested_box"), true);
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/nested_box"), true);
 
   // check that we can load a glb file
   auto objs = objectAttribsMgr->getObjectHandlesBySubstring("nested_box");

--- a/src/tests/VoxelGridTest.cpp
+++ b/src/tests/VoxelGridTest.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 #include <Corrade/TestSuite/Tester.h>
-#include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/Path.h>
 #include <Magnum/Magnum.h>
 
 #include "esp/geo/VoxelUtils.h"
@@ -34,7 +34,7 @@ VoxelGridTest::VoxelGridTest() {
 void VoxelGridTest::testVoxelGridWithVHACD() {
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
-  simConfig.activeSceneName = Cr::Utility::Directory::join(
+  simConfig.activeSceneName = Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.glb");
   simConfig.enablePhysics = true;
   simConfig.frustumCulling = true;
@@ -115,7 +115,7 @@ void VoxelGridTest::testVoxelGridWithVHACD() {
 void VoxelGridTest::testVoxelUtilityFunctions() {
   // configure and intialize Simulator
   auto simConfig = esp::sim::SimulatorConfiguration();
-  simConfig.activeSceneName = Cr::Utility::Directory::join(
+  simConfig.activeSceneName = Cr::Utility::Path::join(
       SCENE_DATASETS, "habitat-test-scenes/skokloster-castle.glb");
   simConfig.enablePhysics = true;
   simConfig.frustumCulling = true;

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -10,8 +10,8 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Corrade/Utility/Algorithms.h>
-#include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Path.h>
 #include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"
@@ -39,7 +39,7 @@ SceneLoader::SceneLoader()
 
 MeshData SceneLoader::load(const AssetInfo& info) {
   MeshData mesh;
-  if (!Cr::Utility::Directory::exists(info.filepath)) {
+  if (!Cr::Utility::Path::exists(info.filepath)) {
     ESP_ERROR() << "Could not find file" << info.filepath;
     return mesh;
   }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -38,8 +38,8 @@
 #include <Corrade/Utility/Assert.h>
 #include <Corrade/Utility/Debug.h>
 #include <Corrade/Utility/DebugStl.h>
-#include <Corrade/Utility/Directory.h>
 #include <Corrade/Utility/FormatStl.h>
+#include <Corrade/Utility/Path.h>
 #include <Corrade/Utility/String.h>
 #include <Magnum/DebugTools/FrameProfiler.h>
 #include <Magnum/DebugTools/Screenshot.h>
@@ -904,9 +904,10 @@ Viewer::Viewer(const Arguments& arguments)
   }
 
   // setup the PhysicsManager config file
-  std::string physicsConfig = Cr::Utility::Directory::join(
-      Corrade::Utility::Directory::current(), args.value("physics-config"));
-  if (Cr::Utility::Directory::exists(physicsConfig)) {
+  std::string physicsConfig =
+      Cr::Utility::Path::join(*Corrade::Utility::Path::currentDirectory(),
+                              args.value("physics-config"));
+  if (Cr::Utility::Path::exists(physicsConfig)) {
     ESP_DEBUG() << "Using PhysicsManager config:" << physicsConfig;
     simConfig_.physicsConfigFile = physicsConfig;
   }
@@ -1036,9 +1037,9 @@ void Viewer::initSimPostReconfigure() {
     simulator_->recomputeNavMesh(*simulator_->getPathFinder().get(),
                                  navMeshSettings, true);
   } else if (!navmeshFilename_.empty()) {
-    std::string navmeshFile = Cr::Utility::Directory::join(
-        Corrade::Utility::Directory::current(), navmeshFilename_);
-    if (Cr::Utility::Directory::exists(navmeshFile)) {
+    std::string navmeshFile = Cr::Utility::Path::join(
+        *Corrade::Utility::Path::currentDirectory(), navmeshFilename_);
+    if (Cr::Utility::Path::exists(navmeshFile)) {
       simulator_->getPathFinder()->loadNavMesh(navmeshFile);
     }
   }
@@ -1106,8 +1107,8 @@ void saveTransformToFile(const std::string& filename,
 }
 void Viewer::saveAgentAndSensorTransformToFile() {
   const char* saved_transformations_directory = "saved_transformations/";
-  if (!Cr::Utility::Directory::exists(saved_transformations_directory)) {
-    Cr::Utility::Directory::mkpath(saved_transformations_directory);
+  if (!Cr::Utility::Path::exists(saved_transformations_directory)) {
+    Cr::Utility::Path::make(saved_transformations_directory);
   }
 
   // update temporary save
@@ -1177,19 +1178,19 @@ bool Viewer::generateAndSaveVertColorMapReports() {
   if (results.empty()) {
     return false;
   }
-  const std::string fileDir = Cr::Utility::Directory::join(
-      {Cr::Utility::Directory::path(MM_->getActiveSceneDatasetName()),
-       "Vertex_Color_Reports"});
+  const std::string fileDir = Cr::Utility::Path::join(
+      Cr::Utility::Path::split(MM_->getActiveSceneDatasetName()).first(),
+      "Vertex_Color_Reports");
 
-  Cr::Utility::Directory::mkpath(fileDir);
+  Cr::Utility::Path::make(fileDir);
 
-  const std::string filename = Cr::Utility::Directory::join(
+  const std::string filename = Cr::Utility::Path::join(
       fileDir,
       Cr::Utility::formatString(
           "{}_vert_color_report.txt",
-          Cr::Utility::Directory::splitExtension(
-              Cr::Utility::Directory::filename(simConfig_.activeSceneName))
-              .first));
+          Cr::Utility::Path::splitExtension(
+              Cr::Utility::Path::split(simConfig_.activeSceneName).second())
+              .first()));
   ESP_DEBUG() << "Fully qualified destination file name :" << filename;
   std::ofstream file(filename);
   if (!file.good()) {
@@ -1224,19 +1225,19 @@ bool Viewer::generateAndSaveSemanticCCReport() {
   if (results.empty()) {
     return false;
   }
-  const std::string fileDir = Cr::Utility::Directory::join(
-      {Cr::Utility::Directory::path(MM_->getActiveSceneDatasetName()),
-       "Semantic_CC_Reports"});
+  const std::string fileDir = Cr::Utility::Path::join(
+      Cr::Utility::Path::split(MM_->getActiveSceneDatasetName()).first(),
+      "Semantic_CC_Reports");
 
-  Cr::Utility::Directory::mkpath(fileDir);
+  Cr::Utility::Path::make(fileDir);
 
-  const std::string filename = Cr::Utility::Directory::join(
+  const std::string filename = Cr::Utility::Path::join(
       fileDir,
       Cr::Utility::formatString(
           "{}_CC_report.csv",
-          Cr::Utility::Directory::splitExtension(
-              Cr::Utility::Directory::filename(simConfig_.activeSceneName))
-              .first));
+          Cr::Utility::Path::splitExtension(
+              Cr::Utility::Path::split(simConfig_.activeSceneName).second())
+              .first()));
   ESP_DEBUG() << "Fully qualified destination file name :" << filename;
   auto semanticScene = simulator_->getSemanticScene();
 
@@ -2394,7 +2395,7 @@ void Viewer::keyPressEvent(KeyEvent& event) {
       } else if (!Cr::Utility::String::endsWith(urdfFilepath, ".urdf") &&
                  !Cr::Utility::String::endsWith(urdfFilepath, ".URDF")) {
         ESP_DEBUG() << "... input is not a URDF. Aborting.";
-      } else if (Cr::Utility::Directory::exists(urdfFilepath)) {
+      } else if (Cr::Utility::Path::exists(urdfFilepath)) {
         // cache the file for quick-reload with SHIFT-T
         cachedURDF_ = urdfFilepath;
         auto aom = simulator_->getArticulatedObjectManager();
@@ -2463,8 +2464,8 @@ int savedFrames = 0;
 void Viewer::screenshot() {
   std::string screenshot_directory =
       "screenshots/" + viewerStartTimeString + "/";
-  if (!Cr::Utility::Directory::exists(screenshot_directory)) {
-    Cr::Utility::Directory::mkpath(screenshot_directory);
+  if (!Cr::Utility::Path::exists(screenshot_directory)) {
+    Cr::Utility::Path::make(screenshot_directory);
   }
   Mn::DebugTools::screenshot(
       Mn::GL::defaultFramebuffer,


### PR DESCRIPTION
## Motivation and Context

Updates Corrade & Magnum to latest and adapts to breaking changes that happened over the last four (or more?) months:

- `Utility::Directory` is deprecated in favor of [Utility::Path](https://doc.magnum.graphics/corrade/namespaceCorrade_1_1Utility_1_1Path.html). It's shorter to type, but the main reason for a name change was that it would be impossible to preserve backwards compatibility due to all changes that had to be made:
    - `read()`, `map()`, `list()` and others now return `Optional<Array>` instead of `Array` to clearly distinguish a failure from an empty file or directory
    - all functions calling into OS APIs now properly report failures including the OS-specific error code / message
    - `read()` is now up to 2x faster thanks to the output memory not being unnecessarily zero-initialized anymore
    - `readString()` is up to 3x faster thanks to the output memory no longer being zero-initialized and *then copied* to a `std::string`, the memory ownership is now instead *transferred* from an `Array` to a `String` without a copy
    - All functions now take string views instead of allocated strings, meaning a lot less temporary string copies and allocations needs to be made. Functions operating on paths such as `split()` and `splitExtension()` now also *return* string views, meaning you can perform complex path decomposing operations with no temporary allocations. (But watch out for dangling views, of course.)
    - APIs with silly Unix-like names such as `rm()` or `mkpath()` dating back to 2008 were changed to clearer names
- Array, array view, string and string view slicing APIs were cleaned up for more consistency, deprecating functions with ambiguous naming
- `TestSuite`, `PluginManager`, `Utility::Resource` and `Trade` APIs were ported to use string views, removing many cases of unnecessary temporary std::string allocations
- All function taking or returning strings and string views now also work with C++17 `std::string_view` (but Corrade's string views [are better, of course](https://doc.magnum.graphics/corrade/classCorrade_1_1Containers_1_1BasicStringView.html) :trollface:)
- New [TestSuite::Compare::StringContains](https://doc.magnum.graphics/corrade/classCorrade_1_1TestSuite_1_1Compare_1_1StringContains.html) and other comparators for advanced string comparisons with detailed failure diagnostics
- As a side-product of the glTF exporter that I'm working on, Corrade now has a streaming [Utility::JsonWriter](https://doc.magnum.graphics/corrade/classCorrade_1_1Utility_1_1JsonWriter.html) as well as a minimalistic read-only [Utility::Json](https://doc.magnum.graphics/corrade/classCorrade_1_1Utility_1_1Json.html) tokenizer & parser. Because, after suffering through various limitations and annoyances with 3rd party glTF parsers and writers, this turned out to be the most straightforward option. The parser took about two days to write and has speed and memory use comparable to rapidjson (i.e., there's still a lot of room for improvement).
- A new set of [CORRADE_*_DEBUG_ASSERT()](https://doc.magnum.graphics/corrade/DebugAssert_8h.html) macros that get compiled out on release builds, for use in tight loops or element accessors where a regular `CORRADE_ASSERT()` would make things too slow. These aren't used in any Magnum code yet, but I'll be gradually adding them to various `operator[]` accessors that didn't have any bounds checks exactly because it would have too much overhead in release builds.
- A new [MeshTools::boundingSphereBouncingBubble()](https://doc.magnum.graphics/magnum/namespaceMagnum_1_1MeshTools.html#a4345353fda33aa694181c42067a7ecd7) algorithm for calculating a tight bounding sphere of an arbitrary mesh. Compared to AABB it's rotation invariant and collisions are cheaper to calculate when doing frustum culling. [Sphere/frustum collision algorithms are already there](https://doc.magnum.graphics/magnum/namespaceMagnum_1_1Math_1_1Intersection.html#aa7c4b8af19c89fa58368e6e1bb04da5a) for quite some time. (@erikwijmans, FYI)
- Building blocks for batch-friendly glTF assets:
    - Custom property and extension import for glTF materials in [CgltfImporter](https://doc.magnum.graphics/magnum/classMagnum_1_1Trade_1_1CgltfImporter.html#Trade-CgltfImporter-behavior-materials). Custom property import for glTF scenes is being worked on, and together these features will be used to describe mesh ranges and texture layers to submit to a multi-draw call.
    - 2D array image conversion in [BasisImageConverter](https://doc.magnum.graphics/magnum/classMagnum_1_1Trade_1_1BasisImageConverter.html), together with related plumbing in `AnyImageConverter` and `magnum-imageconverter`

The thousands of changed files in the PR diff are only because of copyright years being updated, the real changes don't amount to *that* much ;)

## How Has This Been Tested

I demand the CI to pass already :green_circle:
