### PR TITLE
[viewer.py] unloaded stage cycling

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -781,6 +781,9 @@ Key Commands:
     esc:        Exit the application.
     'h':        Display this help message.
     'm':        Cycle mouse interaction modes.
+    'TAB':      Cycle scenes within the SceneDataset
+                (+ALT) Reconfigure the Simulator without cycling scenes
+                (+SHIFT) Cycle through unloaded stage assets with no corresponding SceneInstance.
 
     Agent Controls:
     'wasd':     Move the agent's body forward/backward and left/right.


### PR DESCRIPTION
## Motivation and Context

Add feature to viewer.py for cycling through unloaded stages in a SceneDataset via `SHIFT-TAB` keypress. 

Currently, scenes will not be created for stage files without separate configs unless explicitly set as the `scene_id`. viewer.py scene cycling with `TAB` cycles registered scene instances, so unregistered stages will never be loaded. This feature adds a way to force new stages to be loaded with cycling to make investigation of SceneDatasets such as gibson and MP3D a bit easier.

## How Has This Been Tested

Locally w/ gibson

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
