### PR TITLE
--Rigid Object Instance Non-uniform scaling

### DIFF
--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -161,14 +161,35 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Get or set the uniform scaling of the instanced object.  Want this
+   * @brief Get the uniform scaling of the instanced object.  Want this
    * to be a float for consumption in instance creation
    */
   float getUniformScale() const {
     return static_cast<float>(get<double>("uniform_scale"));
   }
+
+  /**
+   * @brief Set the uniform scaling of the instanced object.  Want this
+   * to be a float for consumption in instance creation
+   */
   void setUniformScale(double uniform_scale) {
     set("uniform_scale", uniform_scale);
+  }
+
+  /**
+   * @brief Get the non-uniform scale vector of the described stage/object
+   * instance.
+   */
+  Magnum::Vector3 getNonUniformScale() const {
+    return get<Magnum::Vector3>("non_uniform_scale");
+  }
+
+  /**
+   * @brief Set the non-uniform scale vector of the described stage/object
+   * instance.
+   */
+  void setNonUniformScale(const Magnum::Vector3& non_uniform_scale) {
+    set("non_uniform_scale", non_uniform_scale);
   }
 
   /**

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -280,6 +280,14 @@ void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
                              [instanceAttrs](double uniform_scale) {
                                instanceAttrs->setUniformScale(uniform_scale);
                              });
+
+  // non-uniform scaling for instance
+  io::jsonIntoConstSetter<Magnum::Vector3>(
+      jCell, "non_uniform_scale",
+      [instanceAttrs](const Magnum::Vector3& non_uniform_scale) {
+        instanceAttrs->setNonUniformScale(non_uniform_scale);
+      });
+
   // mass scaling for instance
   io::jsonIntoSetter<double>(jCell, "mass_scale",
                              [instanceAttrs](double mass_scale) {

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -117,6 +117,17 @@ int PhysicsManager::addObjectInstance(
       metadata::attributes::ObjectInstanceShaderType::Unspecified) {
     objAttributes->setShaderType(getShaderTypeName(objShaderType));
   }
+
+  // set scaling values for this instance of stage attributes - first uniform
+  // scaling
+  objAttributes->setScale(objAttributes->getScale() *
+                          objInstAttributes->getUniformScale());
+  // set scaling values for this instance of stage attributes - next non-uniform
+  // scaling
+  objAttributes->setScale(objAttributes->getScale() *
+                          objInstAttributes->getNonUniformScale());
+
+  // adding object using provided object attributes
   int objID =
       addObjectQueryDrawables(objAttributes, attachmentNode, lightSetup);
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -383,9 +383,15 @@ bool Simulator::instanceStageForSceneAttributes(
   stageAttributes->setLightSetupKey(config_.sceneLightSetupKey);
   // set frustum culling from simulator config
   stageAttributes->setFrustumCulling(frustumCulling_);
-  // set scaling values for this instance of stage attributes
+  // set scaling values for this instance of stage attributes - first uniform
+  // scaling
   stageAttributes->setScale(stageAttributes->getScale() *
                             stageInstanceAttributes->getUniformScale());
+  // set scaling values for this instance of stage attributes - next non-uniform
+  // scaling
+  stageAttributes->setScale(stageAttributes->getScale() *
+                            stageInstanceAttributes->getNonUniformScale());
+
   // this will only be true if semantic textures have been set to be available
   // from the dataset config
   stageAttributes->setUseSemanticTextures(config_.useSemanticTexturesIfFound);

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -498,6 +498,9 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Magnum::Quaternion({0.3f, 0.4f, 0.5f}, 0.2f));
   CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
                   static_cast<int>(esp::physics::MotionType::KINEMATIC));
+  CORRADE_COMPARE(objInstance->getUniformScale(), 1.1f);
+  CORRADE_COMPARE(objInstance->getNonUniformScale(),
+                  Magnum::Vector3(1.1f, 2.2f, 3.3f));
 
   // test object 0 instance attributes-level user config vals
   testUserDefinedConfigVals(objInstance->getUserConfiguration(),
@@ -512,8 +515,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Magnum::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f));
   CORRADE_COMPARE(static_cast<int>(objInstance->getMotionType()),
                   static_cast<int>(esp::physics::MotionType::DYNAMIC));
+  CORRADE_COMPARE(objInstance->getUniformScale(), 2.1f);
+  CORRADE_COMPARE(objInstance->getNonUniformScale(),
+                  Magnum::Vector3(2.1f, 3.2f, 4.3f));
 
-  // test object 0 instance attributes-level user config vals
+  // test object 1 instance attributes-level user config vals
   testUserDefinedConfigVals(objInstance->getUserConfiguration(),
                             "obj1 instance defined string", false, 1, 1.1,
                             Magnum::Vector3(10.3, 30.5, -5.07),
@@ -591,6 +597,9 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // make sure that is not default value "flat"
   CORRADE_COMPARE(static_cast<int>(stageInstance->getShaderType()),
                   static_cast<int>(Attrs::ObjectInstanceShaderType::PBR));
+  CORRADE_COMPARE(stageInstance->getUniformScale(), 1.9f);
+  CORRADE_COMPARE(stageInstance->getNonUniformScale(),
+                  Magnum::Vector3(1.5f, 2.5f, 3.5f));
 
   // test stage instance attributes-level user config vals
   testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
@@ -612,6 +621,8 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
       "translation": [1,2,3],
       "rotation": [0.1, 0.2, 0.3, 0.4],
       "shader_type" : "pbr",
+      "uniform_scale" : 1.9,
+      "non_uniform_scale" : [1.5,2.5,3.5],
       "user_defined" : {
           "user_string" : "stage instance defined string",
           "user_bool" : true,
@@ -628,6 +639,8 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "translation": [0,1,2],
           "rotation": [0.2, 0.3, 0.4, 0.5],
           "motion_type": "KINEMATIC",
+          "uniform_scale" : 1.1,
+          "non_uniform_scale" : [1.1,2.2,3.3],
           "user_defined" : {
               "user_string" : "obj0 instance defined string",
               "user_bool" : false,
@@ -642,6 +655,8 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "translation": [0,-1,-2],
           "rotation": [0.5, 0.6, 0.7, 0.8],
           "motion_type": "DYNAMIC",
+          "uniform_scale" : 2.1,
+          "non_uniform_scale" : [2.1,3.2,4.3],
           "user_defined" : {
               "user_string" : "obj1 instance defined string",
               "user_bool" : false,


### PR DESCRIPTION
## Motivation and Context
This PR adds SceneObjectInstance support of non-uniform scaling.  Coupled with the existing online support of modifying scale via setting stage or object config attributes, non-uniform scaling capabilities can be provided to the user.  Note : this scaling is only available before instantiation - once an object is instantiated, the scale is set and unmodifiable (as is the existing paradigm for scale).

Please also see [this PR for an alternative, online approach to nonuniform scaling.](https://github.com/facebookresearch/habitat-sim/pull/1740)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing c++ and python tests pass.  C++ tests added to verify appropriate load from json and save to json file for new fields.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
