### PR TITLE
--Move wildcard filename handling to AttributesManagerBase

### DIFF
--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -153,33 +153,6 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
       const std::string& assetName,
       const std::function<void(int)>& meshTypeSetter) = 0;
 
-  /**
-   * @brief Set a filename attribute to hold the appropriate data if the
-   * existing attribute's given path contains the sentinel tag value defined at
-   * @ref esp::metadata::CONFIG_NAME_AS_ASSET_FILENAME.  This will be used in
-   * the Scene Dataset configuration file in the "default_attributes" tag for
-   * stage or object attributes to specify that the name specified as the
-   * instanced attributes should also be used to build the name of the specified
-   * asset.  The tag value will be replaced by the attributes object's
-   * simplified handle.
-   *
-   * This will only be called from the specified manager's initNewObjectInternal
-   * function, where the attributes is initially built from a default attributes
-   * (if such an attributes exists).
-   * @param attributers The AbstractObjectAttributes being worked with.
-   * @param srcAssetFilename The given asset's stored filename to be queried for
-   * the specified tag.  If the tag exists, replace it to build the  with the
-   * simplified handle given by the attributes (hence copy).  If this DNE on
-   * disk, add file directory.
-   * @param filenameSetter The function to set the filename appropriately for
-   * the given asset.
-   * @return Whether or not the final value residing within the attribute's
-   * asset filename exists or not.
-   */
-  bool setHandleFromDefaultTag(
-      AbsObjAttrPtr attributes,
-      const std::string& srcAssetFilename,
-      const std::function<void(const std::string&)>& filenameSetter);
   // ======== Typedefs and Instance Variables ========
 
  public:
@@ -397,43 +370,6 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
   // handle value is not present in JSON or is specified but does not change
   return oldFName;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::setJSONAssetHandleAndType
-
-template <class T, ManagedObjectAccess Access>
-bool AbstractObjectAttributesManager<T, Access>::setHandleFromDefaultTag(
-    AbsObjAttrPtr attributes,
-    const std::string& srcAssetFilename,
-    const std::function<void(const std::string&)>& filenameSetter) {
-  if (srcAssetFilename.empty()) {
-    return false;
-  }
-  std::string tempStr(srcAssetFilename);
-  const auto loc = srcAssetFilename.find(CONFIG_NAME_AS_ASSET_FILENAME);
-  if (loc != std::string::npos) {
-    // sentinel tag is found - replace tag with simplified handle of
-    // attributes and use filenameSetter and return whether this file exists or
-    // not.
-    tempStr.replace(loc, strlen(CONFIG_NAME_AS_ASSET_FILENAME),
-                    attributes->getSimplifiedHandle());
-    if (Cr::Utility::Path::exists(tempStr)) {
-      // replace the component of the string containing the tag with the base
-      // filename/handle, and verify it exists. Otherwise, clear it.
-      filenameSetter(tempStr);
-      return true;
-    }
-    tempStr = Cr::Utility::Path::join(attributes->getFileDirectory(), tempStr);
-    if (Cr::Utility::Path::exists(tempStr)) {
-      // replace the component of the string containing the tag with the base
-      // filename/handle, and verify it exists. Otherwise, clear it.
-      filenameSetter(tempStr);
-      return true;
-    }
-    // out of options, clear out the wild-card default so that init-based
-    // default is derived and used.
-    filenameSetter("");
-  }
-  // no tag found - check if existing non-empty field exists.
-  return Cr::Utility::Path::exists(srcAssetFilename);
-}  // AbstractObjectAttributesManager<T, Access>::setHandleFromDefaultTag
 
 }  // namespace managers
 }  // namespace metadata

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -223,20 +223,20 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
   /**
    * @brief Set a filename attribute to hold the appropriate data if the
    * existing attribute's given path contains the sentinel tag value defined at
-   * @ref esp::metadata::CONFIG_NAME_AS_ASSET_FILENAME.  This will be used in
+   * @ref esp::metadata::CONFIG_NAME_AS_ASSET_FILENAME. This will be used in
    * the Scene Dataset configuration file in the "default_attributes" tag for
-   * stage or object attributes to specify that the name specified as the
-   * instanced attributes should also be used to build the name of the specified
-   * asset.  The tag value will be replaced by the attributes object's
+   * any attributes which consume file names to specify that the name specified
+   * as the instanced attributes should also be used to build the name of the
+   * specified asset. The tag value will be replaced by the attributes object's
    * simplified handle.
    *
    * This will only be called from the specified manager's initNewObjectInternal
    * function, where the attributes is initially built from a default attributes
    * (if such an attributes exists).
-   * @param attributers The AbstractObjectAttributes being worked with.
+   * @param attributers The AbstractAttributes being worked with.
    * @param srcAssetFilename The given asset's stored filename to be queried for
-   * the specified tag.  If the tag exists, replace it to build the  with the
-   * simplified handle given by the attributes (hence copy).  If this DNE on
+   * the specified tag. If the tag exists, replace it to build the  with the
+   * simplified handle given by the attributes (hence copy). If this DNE on
    * disk, add file directory.
    * @param filenameSetter The function to set the filename appropriately for
    * the given asset.
@@ -244,7 +244,7 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
    * asset filename exists or not.
    */
   bool setHandleFromDefaultTag(
-      attributes::AbstractAttributes::ptr attributes,
+      const attributes::AbstractAttributes::ptr& attributes,
       const std::string& srcAssetFilename,
       const std::function<void(const std::string&)>& filenameSetter);
 
@@ -441,7 +441,7 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
 
 template <class T, ManagedObjectAccess Access>
 bool AttributesManager<T, Access>::setHandleFromDefaultTag(
-    attributes::AbstractAttributes::ptr attributes,
+    const attributes::AbstractAttributes::ptr& attributes,
     const std::string& srcAssetFilename,
     const std::function<void(const std::string&)>& filenameSetter) {
   if (srcAssetFilename.empty()) {


### PR DESCRIPTION
This PR promotes functionality for filename and wildcard handling to AttributesManagerBase from AbstractObjectAttributesManagerBase to open it up to non-object-related managers and the configs they manage.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
