### PR TITLE
--Add ConfigValue support for Mn::Matrix3 (3x3 matrices of floats)

### DIFF
--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -26,6 +26,8 @@ py::object getObjectForConfigValue(const ConfigValue& value) {
       return py::cast(value.get<std::string>());
     case ConfigStoredType::MagnumVec3:
       return py::cast(value.get<Mn::Vector3>());
+    case ConfigStoredType::MagnumMat3:
+      return py::cast(value.get<Mn::Matrix3>());
     case ConfigStoredType::MagnumQuat:
       return py::cast(value.get<Mn::Quaternion>());
     case ConfigStoredType::MagnumRad:
@@ -42,6 +44,7 @@ void initConfigBindings(py::module& m) {
       .value("Float", ConfigStoredType::Double)
       .value("String", ConfigStoredType::String)
       .value("MagnumVec3", ConfigStoredType::MagnumVec3)
+      .value("MagnumMat3", ConfigStoredType::MagnumMat3)
       .value("MagnumQuat", ConfigStoredType::MagnumQuat)
       .value("MagnumRad", ConfigStoredType::MagnumRad);
 
@@ -101,7 +104,12 @@ void initConfigBindings(py::module& m) {
              const Magnum::Vector3& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Vector3 value)",
           "key"_a, "value"_a)
-
+      .def(
+          "set",
+          [](Configuration& self, const std::string& key,
+             const Magnum::Matrix3& val) { self.set(key, val); },
+          R"(Set the value specified by given string key to be specified Magnum::Matrix3 value)",
+          "key"_a, "value"_a)
       .def(
           "get_type", &Configuration::getType,
           R"(Retrieves the ConfigStoredType of the value referred to by the passed key.)")

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -191,7 +191,7 @@ std::string ConfigValue::getAsString() const {
           Cr::Utility::formatString("[[{} {} {}]", v.x(), v.y(), v.z());
       for (int i = 1; i < m.Size; ++i) {
         v = m.row(i);
-        Cr::Utility::formatInto(res, res.length(), ", [{} {} {}]", v.x(), v.y(),
+        Cr::Utility::formatInto(res, res.length(), "[{} {} {}]", v.x(), v.y(),
                                 v.z());
       }
       Cr::Utility::formatInto(res, res.length(), "]");

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -186,11 +186,9 @@ std::string ConfigValue::getAsString() const {
     }
     case ConfigStoredType::MagnumMat3: {
       auto m = get<Mn::Matrix3>();
-      auto v = m.row(0);
-      std::string res =
-          Cr::Utility::formatString("[[{} {} {}]", v.x(), v.y(), v.z());
-      for (int i = 1; i < m.Size; ++i) {
-        v = m.row(i);
+      std::string res = "[";
+      for (int i = 0; i < m.Size; ++i) {
+        auto v = m.row(i);
         Cr::Utility::formatInto(res, res.length(), "[{} {} {}]", v.x(), v.y(),
                                 v.z());
       }

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -36,6 +36,7 @@ const std::unordered_map<ConfigStoredType, std::string, ConfigStoredTypeHash>
                           {ConfigStoredType::Integer, "int"},
                           {ConfigStoredType::Double, "double"},
                           {ConfigStoredType::MagnumVec3, "Magnum::Vector3"},
+                          {ConfigStoredType::MagnumMat3, "Magnum::Matrix3"},
                           {ConfigStoredType::MagnumQuat, "Magnum::Quaternion"},
                           {ConfigStoredType::MagnumRad, "Magnum::Rad"},
                           {ConfigStoredType::String, "std::string"}};
@@ -86,7 +87,7 @@ constexpr NonTrivialTypeHandler nonTrivialTypeHandlers[]{
     NonTrivialTypeHandler::make<std::string>()};
 
 NonTrivialTypeHandler nonTrivialConfigStoredTypeHandlerFor(
-    ConfigStoredType type) {  // eugh, long name
+    ConfigStoredType type) {
   const std::size_t i = int(type) - int(ConfigStoredType::_nonTrivialTypes);
   CORRADE_INTERNAL_ASSERT(i <
                           Cr::Containers::arraySize(nonTrivialTypeHandlers));
@@ -183,6 +184,19 @@ std::string ConfigValue::getAsString() const {
       auto v = get<Mn::Vector3>();
       return Cr::Utility::formatString("[{} {} {}]", v.x(), v.y(), v.z());
     }
+    case ConfigStoredType::MagnumMat3: {
+      auto m = get<Mn::Matrix3>();
+      auto v = m.row(0);
+      std::string res =
+          Cr::Utility::formatString("[[{} {} {}]", v.x(), v.y(), v.z());
+      for (int i = 1; i < m.Size; ++i) {
+        v = m.row(i);
+        Cr::Utility::formatInto(res, res.length(), ", [{} {} {}]", v.x(), v.y(),
+                                v.z());
+      }
+      Cr::Utility::formatInto(res, res.length(), "]");
+      return res;
+    }
     case ConfigStoredType::MagnumQuat: {
       auto q = get<Mn::Quaternion>();
       auto qv = q.vector();
@@ -203,26 +217,29 @@ io::JsonGenericValue ConfigValue::writeToJsonObject(
     io::JsonAllocator& allocator) const {
   // unknown is checked before this function is called, so does not need support
   switch (getType()) {
-    case core::config::ConfigStoredType::Boolean: {
+    case ConfigStoredType::Boolean: {
       return io::toJsonValue(get<bool>(), allocator);
     }
-    case core::config::ConfigStoredType::Integer: {
+    case ConfigStoredType::Integer: {
       return io::toJsonValue(get<int>(), allocator);
     }
-    case core::config::ConfigStoredType::Double: {
+    case ConfigStoredType::Double: {
       return io::toJsonValue(get<double>(), allocator);
     }
-    case core::config::ConfigStoredType::MagnumVec3: {
+    case ConfigStoredType::MagnumVec3: {
       return io::toJsonValue(get<Magnum::Vector3>(), allocator);
     }
-    case core::config::ConfigStoredType::MagnumQuat: {
+    case ConfigStoredType::MagnumMat3: {
+      return io::toJsonValue(get<Magnum::Matrix3>(), allocator);
+    }
+    case ConfigStoredType::MagnumQuat: {
       return io::toJsonValue(get<Magnum::Quaternion>(), allocator);
     }
-    case core::config::ConfigStoredType::MagnumRad: {
+    case ConfigStoredType::MagnumRad: {
       auto r = get<Magnum::Rad>();
       return io::toJsonValue((r.operator float()), allocator);
     }
-    case core::config::ConfigStoredType::String: {
+    case ConfigStoredType::String: {
       return io::toJsonValue(get<std::string>(), allocator);
     }
     default:
@@ -247,6 +264,8 @@ bool ConfigValue::putValueInConfigGroup(
       return cfg.setValue(key, get<std::string>());
     case ConfigStoredType::MagnumVec3:
       return cfg.setValue(key, get<Mn::Vector3>());
+    case ConfigStoredType::MagnumMat3:
+      return cfg.setValue(key, get<Mn::Matrix3>());
     case ConfigStoredType::MagnumQuat:
       return cfg.setValue(key, get<Mn::Quaternion>());
     case ConfigStoredType::MagnumRad:
@@ -287,18 +306,35 @@ int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
       set(key, obj.GetString());
     } else if (obj.IsBool()) {
       set(key, obj.GetBool());
-    } else if (obj.IsArray() && obj.Size() > 0 && obj[0].IsNumber()) {
-      // numeric vector or quaternion
-      if (obj.Size() == 3) {
-        Magnum::Vector3 val{};
-        if (io::fromJsonValue(obj, val)) {
-          set(key, val);
+    } else if (obj.IsArray() && obj.Size() > 0) {
+      // non-empty array
+      if (obj[0].IsNumber()) {
+        // numeric vector or quaternion
+        if (obj.Size() == 3) {
+          Magnum::Vector3 val{};
+          if (io::fromJsonValue(obj, val)) {
+            set(key, val);
+          }
+        } else if (obj.Size() == 4) {
+          // assume is quaternion
+          Magnum::Quaternion val{};
+          if (io::fromJsonValue(obj, val)) {
+            set(key, val);
+          }
+        } else {
+          // decrement count for key:obj due to not being handled vector
+          --numConfigSettings;
+          // TODO support numeric array in JSON
+          ESP_WARNING()
+              << "Config cell in JSON document contains key" << key
+              << "referencing an unsupported numeric array of length :"
+              << obj.Size() << "so skipping.";
         }
-      } else if (obj.Size() == 4) {
-        // assume is quaternion
-        Magnum::Quaternion val{};
-        if (io::fromJsonValue(obj, val)) {
-          set(key, val);
+      } else if (obj.Size() == 3 && obj[0].IsArray() && obj[0][0].IsNumber()) {
+        // 3x3 matrix
+        Magnum::Matrix3 mat{};
+        if (io::fromJsonValue(obj, mat)) {
+          set(key, mat);
         }
       } else {
         // decrement count for key:obj due to not being handled vector
@@ -327,7 +363,7 @@ int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
     }
   }
   return numConfigSettings;
-}  // Configuration::loadFromJson
+}  // namespace config
 
 void Configuration::writeValueToJson(const char* key,
                                      const char* jsonName,

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -129,7 +129,7 @@ class ConfigValue {
    * _type is 4 bytes, 4 bytes of padding (on 64 bit machines) and 48 bytes for
    * data.
    */
-  alignas(sizeof(void*)) char _data[6 * 8] = {0};
+  alignas(8) char _data[6 * 8] = {0};
 
   /**
    * @brief Copy the passed @p val into this ConfigValue.  If this @ref

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -36,6 +36,7 @@ enum class ConfigStoredType {
   Integer,
   Double,
   MagnumVec3,
+  MagnumMat3,
   MagnumQuat,
   MagnumRad,
 
@@ -92,6 +93,10 @@ constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {
   return ConfigStoredType::MagnumVec3;
 }
 template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Matrix3>() {
+  return ConfigStoredType::MagnumMat3;
+}
+template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Quaternion>() {
   return ConfigStoredType::MagnumQuat;
 }
@@ -118,10 +123,13 @@ class ConfigValue {
   ConfigStoredType _type{ConfigStoredType::Unknown};
 
   /**
-   * @brief The data this ConfigValue holds - four doubles at most (strings
-   * require 32 bytes), doubles and 64bit pointers need 8-byte alignment
+   * @brief The data this ConfigValue holds.
+   * Aligns to individual 8-byte bounds. The pair the Configuration map holds
+   * consists of a std::string key (sizeof:24 bytes) and a ConfigValue. The
+   * _type is 4 bytes, 4 bytes of padding (on 64 bit machines) and 48 bytes for
+   * data.
    */
-  alignas(sizeof(void*) * 2) char _data[4 * 8] = {0};
+  alignas(sizeof(void*)) char _data[6 * 8] = {0};
 
   /**
    * @brief Copy the passed @p val into this ConfigValue.  If this @ref
@@ -164,25 +172,27 @@ class ConfigValue {
 
   template <class T>
   void set(const T& value) {
-    // this never fails
     deleteCurrentValue();
-    // this will blow up at compile time if given type is not supported
+    // This will blow up at compile time if given type is not supported
     _type = configStoredTypeFor<T>();
-    // these asserts are checking the integrity of the support for T's type, and
-    // will fire if...
+    // These asserts are checking the integrity of the support for T's type, and
+    // will fire if conditions are not met.
 
-    // ...we added a new type into @ref ConfigStoredType enum improperly
-    // (trivial type added after entry ConfigStoredType::_nonTrivialTypes, or
-    // vice-versa)
+    // This fails if we added a new type into @ref ConfigStoredType enum
+    // improperly (trivial type added after entry
+    // ConfigStoredType::_nonTrivialTypes, or vice-versa)
     static_assert(isConfigStoredTypeNonTrivial(configStoredTypeFor<T>()) !=
                       std::is_trivially_copyable<T>::value,
                   "Something's incorrect about enum placement for added type!");
-    // ...we added a new type that is too large for internal storage
-    static_assert(sizeof(T) <= sizeof(_data), "internal storage too small");
-    // ...we added a new type whose alignment does not match internal storage
-    // alignment
-    static_assert(alignof(T) <= alignof(ConfigValue),
-                  "internal storage too unaligned");
+    // This fails if a new type was added that is too large for internal storage
+    static_assert(
+        sizeof(T) <= sizeof(_data),
+        "ConfigValue's internal storage is too small for added type!");
+    // This fails if a new type was added whose alignment does not match
+    // internal storage alignment
+    static_assert(
+        alignof(T) <= alignof(ConfigValue),
+        "ConfigValue's internal storage improperly aligned for added type!");
 
     //_data should be destructed at this point, construct a new value
     new (_data) T{value};

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -8,6 +8,40 @@
 namespace esp {
 namespace io {
 
+JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
+                             JsonAllocator& allocator) {
+  JsonGenericValue arr(rapidjson::kArrayType);
+  // save matrix as array of per-row arrays, for readability in json.
+  for (int i = 0; i < mat.Size; ++i) {
+    // per row vector as sub-array
+    arr.PushBack(toJsonValue(mat.row(i), allocator), allocator);
+  }
+  return arr;
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val) {
+  if (obj.IsArray() && obj.Size() == 3) {
+    for (rapidjson::SizeType i = 0; i < 3; ++i) {
+      if (obj[i].IsArray() && obj.Size() == 3) {
+        Mn::Vector3 rowVec{};
+        bool success = fromJsonValue(obj[i], rowVec);
+        if (success) {
+          val.setRow(i, rowVec);
+        } else {
+          // error in per-array-to-vector read already reported.
+          return false;
+        }
+      } else {
+        ESP_ERROR() << "Invalid row value specified in JSON Matrix3, index :"
+                    << i;
+        return false;
+      }
+    }  // for each matrix row
+    return true;
+  }
+  return false;
+}
+
 JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
                              JsonAllocator& allocator) {
   JsonGenericValue arr(rapidjson::kArrayType);

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -10,33 +10,20 @@ namespace io {
 
 JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
                              JsonAllocator& allocator) {
-  JsonGenericValue arr(rapidjson::kArrayType);
-  // save matrix as array of per-row arrays, for readability in json.
-  for (int i = 0; i < mat.Size; ++i) {
-    // per row vector as sub-array
-    arr.PushBack(toJsonValue(mat.row(i), allocator), allocator);
-  }
-  return arr;
+  return toJsonArrayHelper(mat.data(), 9, allocator);
 }
 
-bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val) {
-  if (obj.IsArray() && obj.Size() == 3) {
-    for (rapidjson::SizeType i = 0; i < 3; ++i) {
-      if (obj[i].IsArray() && obj.Size() == 3) {
-        Mn::Vector3 rowVec{};
-        bool success = fromJsonValue(obj[i], rowVec);
-        if (success) {
-          val.setRow(i, rowVec);
-        } else {
-          // error in per-array-to-vector read already reported.
-          return false;
-        }
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& mat) {
+  if (obj.IsArray() && obj.Size() == 9) {
+    for (rapidjson::SizeType i = 0; i < 9; ++i) {
+      if (obj[i].IsNumber()) {
+        mat.data()[i] = obj[i].GetFloat();
       } else {
-        ESP_ERROR() << "Invalid row value specified in JSON Matrix3, index :"
-                    << i;
+        ESP_ERROR()
+            << "Invalid numeric value specified in JSON Matrix3, index :" << i;
         return false;
       }
-    }  // for each matrix row
+    }
     return true;
   }
   return false;

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -22,6 +22,19 @@
 namespace esp {
 namespace io {
 
+JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
+                             JsonAllocator& allocator);
+/**
+ * @brief Specialization to handle Magnum::Matrix3 values. Populate passed @p
+ * val with value. Returns whether successfully populated, or not. Logs an error
+ * if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val);
+
 inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
                                     JsonAllocator& allocator) {
   return toJsonArrayHelper(vec.data(), 3, allocator);

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -25,10 +25,15 @@ CoreTest::CoreTest() {
 void CoreTest::TestConfiguration() {
   Configuration cfg;
   cfg.set("myInt", 10);
+  cfg.set("myMat3", Mn::Matrix3(Mn::Math::IdentityInit));
   cfg.set("myString", "test");
   CORRADE_VERIFY(cfg.hasValue("myInt"));
+  CORRADE_VERIFY(cfg.hasValue("myMat3"));
   CORRADE_VERIFY(cfg.hasValue("myString"));
   CORRADE_COMPARE(cfg.get<int>("myInt"), 10);
+  for (int i = 0; i < 3; ++i) {
+    CORRADE_COMPARE(cfg.get<Mn::Matrix3>("myMat3").row(i)[i], 1);
+  }
   CORRADE_COMPARE(cfg.get<std::string>("myString"), "test");
 }
 

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -25,15 +25,15 @@ CoreTest::CoreTest() {
 void CoreTest::TestConfiguration() {
   Configuration cfg;
   cfg.set("myInt", 10);
-  cfg.set("myDouble", 1.2);
+  cfg.set("myFloatToDouble", 1.2f);
   cfg.set("myMat3", Mn::Matrix3(Mn::Math::IdentityInit));
   cfg.set("myString", "test");
   CORRADE_VERIFY(cfg.hasValue("myInt"));
-  CORRADE_VERIFY(cfg.hasValue("myDouble"));
+  CORRADE_VERIFY(cfg.hasValue("myFloatToDouble"));
   CORRADE_VERIFY(cfg.hasValue("myMat3"));
   CORRADE_VERIFY(cfg.hasValue("myString"));
   CORRADE_COMPARE(cfg.get<int>("myInt"), 10);
-  CORRADE_COMPARE(cfg.get<double>("myDouble"), 1.2);
+  CORRADE_COMPARE(cfg.get<double>("myFloatToDouble"), 1.2f);
   for (int i = 0; i < 3; ++i) {
     CORRADE_COMPARE(cfg.get<Mn::Matrix3>("myMat3").row(i)[i], 1);
   }

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -25,12 +25,15 @@ CoreTest::CoreTest() {
 void CoreTest::TestConfiguration() {
   Configuration cfg;
   cfg.set("myInt", 10);
+  cfg.set("myDouble", 1.2);
   cfg.set("myMat3", Mn::Matrix3(Mn::Math::IdentityInit));
   cfg.set("myString", "test");
   CORRADE_VERIFY(cfg.hasValue("myInt"));
+  CORRADE_VERIFY(cfg.hasValue("myDouble"));
   CORRADE_VERIFY(cfg.hasValue("myMat3"));
   CORRADE_VERIFY(cfg.hasValue("myString"));
   CORRADE_COMPARE(cfg.get<int>("myInt"), 10);
+  CORRADE_COMPARE(cfg.get<double>("myDouble"), 1.2);
   for (int i = 0; i < 3; ++i) {
     CORRADE_COMPARE(cfg.get<Mn::Matrix3>("myMat3").row(i)[i], 1);
   }

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -41,6 +41,11 @@ def test_core_configuration():
     config.set("vec3", my_vec3)
     assert config.get("vec3") == my_vec3
 
+    # Magnum::Matrix3 (3x3)
+    my_mat3x3 = mn.Matrix3((1.1, 2.2, -3.3), (4.4, 5.0, -6.6), (7.7, 8.0, -9.9))
+    config.set("mat3x3", my_mat3x3)
+    assert config.get("mat3x3")
+
     # Magnum::Quaternion (float)
     my_quat = mn.Quaternion(((1.12345, 2.0, -3.0), 4.0))
     config.set("quat", my_quat)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -44,7 +44,7 @@ def test_core_configuration():
     # Magnum::Matrix3 (3x3)
     my_mat3x3 = mn.Matrix3((1.1, 2.2, -3.3), (4.4, 5.0, -6.6), (7.7, 8.0, -9.9))
     config.set("mat3x3", my_mat3x3)
-    assert config.get("mat3x3")
+    assert config.get("mat3x3") == my_mat3x3
 
     # Magnum::Quaternion (float)
     my_quat = mn.Quaternion(((1.12345, 2.0, -3.0), 4.0))


### PR DESCRIPTION
## Motivation and Context
This PR adds support for 3x3 float Magnum Matrices to the ConfigValue/Configuration subsystem.  This includes writing/reading json values, as well internally storing the data within a ConfigValue structure.

IOTest has also been streamlined somewhat, to make adding tests to validate json read/write for new types easier.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.  CoreTest and IOTest have been modified to test appropriate functionality.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
