### PR TITLE
[bugfix] - viewer toggle lighting override with --stage-requires-lighting

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -900,6 +900,7 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig_.useSemanticTexturesIfFound = !args.isSet("no-semantic-textures");
   if (args.isSet("stage-requires-lighting")) {
     ESP_DEBUG() << "Stage using DEFAULT_LIGHTING_KEY";
+    simConfig_.overrideSceneLightDefaults = true;
     simConfig_.sceneLightSetupKey = esp::DEFAULT_LIGHTING_KEY;
   }
 


### PR DESCRIPTION
## Motivation and Context

Override light setups with `SimulatorConfiguration` requires `overrideSceneLightDefaults==true`. Viewer `--stage-requires-lighting` argument should therefore set both `overrideSceneLightDefaults` and `sceneLightSetupKey` to function.

## How Has This Been Tested

locally w/ viewer and test assets.
`./build/viewer --recompute-navmesh --stage-requires-lighting -- data/test_assets/scenes/simple_room.glb`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
