### PR TITLE
[Bugfix]--add missing fields to AssetInfo comparator;

### DIFF
--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -35,10 +35,21 @@ bool operator==(const AssetInfo& a, const AssetInfo& b) {
          a.shaderTypeToUse == b.shaderTypeToUse &&
          a.hasSemanticTextures == b.hasSemanticTextures &&
          a.virtualUnitToMeters == b.virtualUnitToMeters &&
+         a.splitInstanceMesh == b.splitInstanceMesh &&
+         a.overridePhongMaterial == b.overridePhongMaterial &&
          a.forceFlatShading == b.forceFlatShading;
 }
 
 bool operator!=(const AssetInfo& a, const AssetInfo& b) {
+  return !(a == b);
+}
+
+bool operator==(const PhongMaterialColor& a, const PhongMaterialColor& b) {
+  return a.ambientColor == b.ambientColor && a.diffuseColor == b.diffuseColor &&
+         a.specularColor == b.specularColor;
+}
+
+bool operator!=(const PhongMaterialColor& a, const PhongMaterialColor& b) {
   return !(a == b);
 }
 

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -38,6 +38,9 @@ struct PhongMaterialColor {
   Magnum::Color4 specularColor{0.2};
 };
 
+bool operator==(const PhongMaterialColor& a, const PhongMaterialColor& b);
+bool operator!=(const PhongMaterialColor& a, const PhongMaterialColor& b);
+
 //! AssetInfo stores information necessary to identify and load an Asset
 struct AssetInfo {
   AssetType type = AssetType::UNKNOWN;


### PR DESCRIPTION
## Motivation and Context
This PR adds missing fields in operator==() for AssetInfo.  Also added is a comparison operator for the esp::assets::PhongMaterialColor struct.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
