### PR TITLE
[bugfix] - moveUp moveDown

### DIFF
--- a/src/esp/scene/ObjectControls.cpp
+++ b/src/esp/scene/ObjectControls.cpp
@@ -28,7 +28,9 @@ SceneNode& moveLeft(SceneNode& object, float distance) {
 
 SceneNode& moveUp(SceneNode& object, float distance) {
   // TODO: this assumes no scale is applied
-  object.translateLocal(object.transformation().up() * distance);
+  // Note: this is not a body action and is applied to the sensor rather than
+  // the Agent, so it will move the sensor in Agent's +Y (up) direction
+  object.translate(Magnum::Vector3(0, 1, 0) * distance);
   return object;
 }
 


### PR DESCRIPTION
## Motivation and Context

`moveUp` and `moveDown` actions (in C++) are used exclusively in the viewer application to raise and lower the agent camera. Current implementation uses camera local "up" translation. When the camera is pitched this results in moving the camera node off-axis, changing the axis of rotation. 

This PR changes moveUp and moveDown action to apply parent coordinate system +Y translation instead of local "up" so the camera always stays constrained to the agent's "up" axis.

If moving the camera off-axis is desirable it should be implemented as a separate action.

## How Has This Been Tested

Local in viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
