### PR TITLE
[BUGFIX]--fix flake8 complaints; refactor a few expensive self-accesses in loops

### DIFF
--- a/src_python/habitat_sim/nav/greedy_geodesic_follower.py
+++ b/src_python/habitat_sim/nav/greedy_geodesic_follower.py
@@ -188,7 +188,8 @@ class GreedyGeodesicFollower:
         if len(path) == 0:
             raise errors.GreedyFollowerError()
 
-        path = list(map(lambda v: self.action_mapping[v], path))
+        # path = list(map(lambda v: self.action_mapping[v], path))
+        path = [self.action_mapping[v] for v in path]
 
         return path
 

--- a/src_python/habitat_sim/robots/mobile_manipulator.py
+++ b/src_python/habitat_sim/robots/mobile_manipulator.py
@@ -274,15 +274,17 @@ class MobileManipulator(RobotInterface):
     @property
     def arm_joint_limits(self) -> Tuple[np.ndarray, np.ndarray]:
         """Get the arm joint limits in radians"""
-        arm_pos_indices = list(
-            map(lambda x: self.joint_pos_indices[x], self.params.arm_joints)
-        )
 
+        # deref self vars to cut access in half
+        joint_pos_indices = self.joint_pos_indices
+        joint_limits = self.joint_limits
+        arm_joints = self.params.arm_joints
+        arm_pos_indices = [joint_pos_indices[x] for x in arm_joints]
         lower_lims = np.array(
-            [self.joint_limits[0][i] for i in arm_pos_indices], dtype=np.float32
+            [joint_limits[0][i] for i in arm_pos_indices], dtype=np.float32
         )
         upper_lims = np.array(
-            [self.joint_limits[1][i] for i in arm_pos_indices], dtype=np.float32
+            [joint_limits[1][i] for i in arm_pos_indices], dtype=np.float32
         )
         return lower_lims, upper_lims
 
@@ -327,11 +329,17 @@ class MobileManipulator(RobotInterface):
     @property
     def gripper_joint_pos(self) -> np.ndarray:
         """Get the current gripper joint positions."""
-        gripper_pos_indices = map(
-            lambda x: self.joint_pos_indices[x], self.params.gripper_joints
-        )
+
+        # deref self vars to cut access in half
+        joint_pos_indices = self.joint_pos_indices
+        gripper_joints = self.params.gripper_joints
+        sim_obj_joint_pos = self.sim_obj.joint_positions
+        # gripper_pos_indices = map(
+        #     lambda x: self.joint_pos_indices[x], self.params.gripper_joints
+        # )
+        gripper_pos_indices = (joint_pos_indices[x] for x in gripper_joints)
         return np.array(
-            [self.sim_obj.joint_positions[i] for i in gripper_pos_indices],
+            [sim_obj_joint_pos[i] for i in gripper_pos_indices],
             dtype=np.float32,
         )
 
@@ -388,11 +396,18 @@ class MobileManipulator(RobotInterface):
     @property
     def arm_joint_pos(self) -> np.ndarray:
         """Get the current arm joint positions."""
-        arm_pos_indices = map(
-            lambda x: self.joint_pos_indices[x], self.params.arm_joints
-        )
+        # arm_pos_indices = map(
+        #     lambda x: self.joint_pos_indices[x], self.params.arm_joints
+        # )
+
+        # deref self vars to cut access in half
+        joint_pos_indices = self.joint_pos_indices
+        arm_joints = self.params.arm_joints
+        sim_obj_joint_pos = self.sim_obj.joint_positions
+
+        arm_pos_indices = [joint_pos_indices[x] for x in arm_joints]
         return np.array(
-            [self.sim_obj.joint_positions[i] for i in arm_pos_indices], dtype=np.float32
+            [sim_obj_joint_pos[i] for i in arm_pos_indices], dtype=np.float32
         )
 
     @arm_joint_pos.setter
@@ -429,11 +444,19 @@ class MobileManipulator(RobotInterface):
     @property
     def arm_velocity(self) -> np.ndarray:
         """Get the velocity of the arm joints."""
-        arm_dof_indices = map(
-            lambda x: self.joint_dof_indices[x], self.params.arm_joints
-        )
+
+        # deref self vars to cut access in half
+        joint_dof_indices = self.joint_dof_indices
+        arm_joints = self.params.arm_joints
+        sim_obj_joint_vel = self.sim_obj.joint_velocities
+
+        # arm_dof_indices = map(
+        #     lambda x: self.joint_dof_indices[x], self.params.arm_joints
+        # )
+
+        arm_dof_indices = [joint_dof_indices[x] for x in arm_joints]
         return np.array(
-            [self.sim_obj.joint_velocities[i] for i in arm_dof_indices],
+            [sim_obj_joint_vel[i] for i in arm_dof_indices],
             dtype=np.float32,
         )
 

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -90,30 +90,45 @@ class Simulator(SimulatorBackend):
             )
 
         config.sim_cfg.create_renderer = any(
-            map(lambda cfg: len(cfg.sensor_specifications) > 0, config.agents)
+            (len(cfg.sensor_specifications) > 0 for cfg in config.agents)
+            # map(lambda cfg: len(cfg.sensor_specifications) > 0, config.agents)
         )
         config.sim_cfg.load_semantic_mesh = any(
-            map(
-                lambda cfg: any(
-                    map(
-                        lambda sens_spec: sens_spec.sensor_type == SensorType.SEMANTIC,
-                        cfg.sensor_specifications,
-                    )
-                ),
-                config.agents,
+            (
+                any(
+                    sens_spec.sensor_type == SensorType.SEMANTIC
+                    for sens_spec in cfg.sensor_specifications
+                )
+                for cfg in config.agents
             )
+            # map(
+            #     lambda cfg: any(
+            #         map(
+            #             lambda sens_spec: sens_spec.sensor_type == SensorType.SEMANTIC,
+            #             cfg.sensor_specifications,
+            #         )
+            #     ),
+            #     config.agents,
+            # )
         )
 
         config.sim_cfg.requires_textures = any(
-            map(
-                lambda cfg: any(
-                    map(
-                        lambda sens_spec: sens_spec.sensor_type == SensorType.COLOR,
-                        cfg.sensor_specifications,
-                    )
-                ),
-                config.agents,
+            (
+                any(
+                    sens_spec.sensor_type == SensorType.COLOR
+                    for sens_spec in cfg.sensor_specifications
+                )
+                for cfg in config.agents
             )
+            # map(
+            #     lambda cfg: any(
+            #         map(
+            #             lambda sens_spec: sens_spec.sensor_type == SensorType.COLOR,
+            #             cfg.sensor_specifications,
+            #         )
+            #     ),
+            #     config.agents,
+            # )
         )
 
     def __attrs_post_init__(self) -> None:


### PR DESCRIPTION
## Motivation and Context
This should fix the issues that the new update to flake8-comprehension is complaining about, using generators and comprehensions instead of maps in a few of the python files.

I also derefed a few member variable dicts/lists to locals before loops, to speed up access.  Afaik, Python is still not smart enough to cache that access, and this results in 2 accesses (one to self, the other into the container) instead of just one per iteration.  

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
