### PR TITLE
--AttributesManagers : Move abstract method to obj mgrs; simplify Object/Stage Manager creation;

### DIFF
--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -16,12 +16,12 @@ SceneDatasetAttributes::SceneDatasetAttributes(
   assetAttributesManager_ = managers::AssetAttributesManager::create();
   lightLayoutAttributesManager_ =
       managers::LightLayoutAttributesManager::create();
-  objectAttributesManager_ = managers::ObjectAttributesManager::create();
-  objectAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
+  objectAttributesManager_ =
+      managers::ObjectAttributesManager::create(assetAttributesManager_);
   sceneInstanceAttributesManager_ =
       managers::SceneInstanceAttributesManager::create();
   stageAttributesManager_ = managers::StageAttributesManager::create(
-      objectAttributesManager_, physAttrMgr);
+      assetAttributesManager_, physAttrMgr);
 }  // ctor
 
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -12,8 +12,9 @@
 
 #include "esp/metadata/attributes/ObjectAttributes.h"
 
+#include "AssetAttributesManager.h"
+#include "AttributesManagerBase.h"
 #include "esp/metadata/MetadataUtils.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
 
 namespace Cr = Corrade;
 
@@ -37,11 +38,14 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
 
   typedef std::shared_ptr<T> AbsObjAttrPtr;
 
-  AbstractObjectAttributesManager(const std::string& attrType,
-                                  const std::string& JSONTypeExt)
+  AbstractObjectAttributesManager(
+      const std::string& attrType,
+      const std::string& JSONTypeExt,
+      AssetAttributesManager::cptr assetAttributesMgr)
       : AttributesManager<T, Access>::AttributesManager(
             (attrType + " Template"),
-            JSONTypeExt) {}
+            JSONTypeExt),
+        assetAttributesMgr_(std::move(assetAttributesMgr)) {}
   ~AbstractObjectAttributesManager() override = default;
 
   /**
@@ -86,6 +90,29 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
       bool registerTemplate = true) = 0;
 
  protected:
+  /**
+   * @brief Check if currently configured primitive asset template library has
+   * passed handle.
+   * @param handle String name of primitive asset attributes desired
+   * @return whether handle exists or not in asset attributes library
+   */
+  bool isValidPrimitiveAttributes(const std::string& handle) {
+    return assetAttributesMgr_->getObjectLibHasHandle(handle);
+  }
+
+  /**
+   * @brief Create and save default primitive asset-based object templates,
+   * saving their handles as non-deletable default handles.
+   * This needs to be called from the constructor of the specialization class.
+   */
+  virtual void createDefaultPrimTemplatesForObjType() = 0;
+
+  /**
+   * @brief Reference to AssetAttributesManager to give access to primitive
+   * attributes for object construction
+   */
+  AssetAttributesManager::cptr assetAttributesMgr_ = nullptr;
+
   //======== Common JSON import functions ========
 
   /**

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -420,16 +420,6 @@ class AssetAttributesManager
 
  protected:
   /**
-   * @brief Check if currently configured primitive asset template library has
-   * passed handle.
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
-   */
-  bool isValidPrimitiveAttributes(const std::string& handle) override {
-    return this->getObjectLibHasHandle(handle);
-  }
-
-  /**
    * @brief This method will perform any necessary updating that is
    * attributesManager-specific upon template removal, such as removing a
    * specific template handle from the list of file-based template handles in

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -154,14 +154,6 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
                                         const io::JsonGenericValue& jsonPaths);
 
   /**
-   * @brief Check if currently configured primitive asset template library has
-   * passed handle.
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
-   */
-  virtual bool isValidPrimitiveAttributes(const std::string& handle) = 0;
-
-  /**
    * @brief Parse passed JSON Document for @ref
    * esp::metadata::attributes::AbstractAttributes. It always returns a
    * valid @ref esp::metadata::attributes::AbstractAttributes shared

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -134,16 +134,6 @@ class LightLayoutAttributesManager
    */
   void resetFinalize() override {}
 
-  /**
-   * @brief Light Attributes has no reason to check this value
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
-   */
-  bool isValidPrimitiveAttributes(
-      CORRADE_UNUSED const std::string& handle) override {
-    return false;
-  }
-
  public:
   ESP_SMART_POINTERS(LightLayoutAttributesManager)
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -22,6 +22,20 @@ using attributes::AbstractObjectAttributes;
 using attributes::ObjectAttributes;
 namespace managers {
 
+ObjectAttributesManager::ObjectAttributesManager(
+    AssetAttributesManager::cptr assetAttributesMgr)
+    : AbstractObjectAttributesManager<attributes::ObjectAttributes,
+                                      ManagedObjectAccess::Copy>::
+          AbstractObjectAttributesManager("Object",
+                                          "object_config.json",
+                                          assetAttributesMgr) {
+  // build this manager's copy constructor map
+  this->copyConstructorMap_["ObjectAttributes"] =
+      &ObjectAttributesManager::createObjectCopy<attributes::ObjectAttributes>;
+  // call this to instantiate default prim object templates
+  this->createDefaultPrimTemplatesForObjType();
+}
+
 ObjectAttributes::ptr
 ObjectAttributesManager::createPrimBasedAttributesTemplate(
     const std::string& primAttrTemplateHandle,
@@ -56,7 +70,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   return this->postCreateRegister(primObjectAttributes, registerTemplate);
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
-void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
+void ObjectAttributesManager::createDefaultPrimTemplatesForObjType() {
   this->undeletableObjectNames_.clear();
   // build default primtive object templates corresponding to given default
   // asset templates
@@ -68,7 +82,7 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
     std::string tmpltHandle = tmplt->getHandle();
     this->undeletableObjectNames_.insert(tmpltHandle);
   }
-}  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
+}  // ObjectAttributesManager::createDefaultPrimTemplatesForObjType
 
 void ObjectAttributesManager::setValsFromJSONDoc(
     attributes::ObjectAttributes::ptr objAttributes,

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -28,12 +28,12 @@ ObjectAttributesManager::ObjectAttributesManager(
                                       ManagedObjectAccess::Copy>::
           AbstractObjectAttributesManager("Object",
                                           "object_config.json",
-                                          assetAttributesMgr) {
+                                          std::move(assetAttributesMgr)) {
   // build this manager's copy constructor map
   this->copyConstructorMap_["ObjectAttributes"] =
       &ObjectAttributesManager::createObjectCopy<attributes::ObjectAttributes>;
   // call this to instantiate default prim object templates
-  this->createDefaultPrimTemplatesForObjType();
+  ObjectAttributesManager::createDefaultPrimTemplatesForObjType();
 }
 
 ObjectAttributes::ptr

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "AbstractObjectAttributesManagerBase.h"
-#include "AssetAttributesManager.h"
 
 namespace esp {
 namespace metadata {
@@ -25,23 +24,8 @@ class ObjectAttributesManager
     : public AbstractObjectAttributesManager<attributes::ObjectAttributes,
                                              ManagedObjectAccess::Copy> {
  public:
-  ObjectAttributesManager()
-      : AbstractObjectAttributesManager<attributes::ObjectAttributes,
-                                        ManagedObjectAccess::Copy>::
-            AbstractObjectAttributesManager("Object", "object_config.json") {
-    // build this manager's copy constructor map
-    this->copyConstructorMap_["ObjectAttributes"] =
-        &ObjectAttributesManager::createObjectCopy<
-            attributes::ObjectAttributes>;
-  }
-
-  void setAssetAttributesManager(
-      AssetAttributesManager::cptr assetAttributesMgr) {
-    assetAttributesMgr_ = std::move(assetAttributesMgr);
-    // Create default primitive-based object attributess
-    createDefaultPrimBasedAttributesTemplates();
-  }
-
+  explicit ObjectAttributesManager(
+      AssetAttributesManager::cptr assetAttributesMgr);
   /**
    * @brief Creates an instance of an object template described by passed
    * string, which should be a reference to an existing primitive asset template
@@ -67,16 +51,6 @@ class ObjectAttributesManager
    */
   void setValsFromJSONDoc(attributes::ObjectAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
-
-  /**
-   * @brief Check if currently configured primitive asset template library has
-   * passed handle.
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
-   */
-  bool isValidPrimitiveAttributes(const std::string& handle) override {
-    return assetAttributesMgr_->getObjectLibHasHandle(handle);
-  }
 
   // ======== File-based and primitive-based partition functions ========
 
@@ -171,7 +145,7 @@ class ObjectAttributesManager
    * @brief Create and save default primitive asset-based object templates,
    * saving their handles as non-deletable default handles.
    */
-  void createDefaultPrimBasedAttributesTemplates();
+  void createDefaultPrimTemplatesForObjType() override;
 
   /**
    * @brief Perform file-name-based attributes initialization. This is to
@@ -254,12 +228,6 @@ class ObjectAttributesManager
   }
 
   // ======== Typedefs and Instance Variables ========
-
-  /**
-   * @brief Reference to AssetAttributesManager to give access to primitive
-   * attributes for object construction
-   */
-  AssetAttributesManager::cptr assetAttributesMgr_ = nullptr;
 
   /**
    * @brief Maps loaded object template IDs to the appropriate template

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -67,16 +67,6 @@ class PhysicsAttributesManager
 
  protected:
   /**
-   * @brief Physics Manager Attributes has no reason to check this value
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
-   */
-  bool isValidPrimitiveAttributes(
-      CORRADE_UNUSED const std::string& handle) override {
-    return false;
-  }
-
-  /**
    * @brief Used Internally.  Create and configure newly-created attributes with
    * any default values, before any specific values are set.
    *

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -179,16 +179,6 @@ class SceneDatasetAttributesManager
       CORRADE_UNUSED bool forceRegistration) override;
 
   /**
-   * @brief This function is meaningless for this manager's ManagedObjects.
-   * @param handle Ignored.
-   * @return false
-   */
-  bool isValidPrimitiveAttributes(
-      CORRADE_UNUSED const std::string& handle) override {
-    return false;
-  }
-
-  /**
    * @brief Name of currently used physicsManagerAttributes
    */
   std::string physicsManagerAttributesHandle_ = "";

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.h
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.h
@@ -178,16 +178,6 @@ class SceneInstanceAttributesManager
       const std::string& sceneInstanceAttributesHandle,
       CORRADE_UNUSED bool forceRegistration) override;
 
-  /**
-   * @brief This function is meaningless for this manager's ManagedObjects.
-   * @param handle Ignored.
-   * @return false
-   */
-  bool isValidPrimitiveAttributes(
-      CORRADE_UNUSED const std::string& handle) override {
-    return false;
-  }
-
  public:
   ESP_SMART_POINTERS(SceneInstanceAttributesManager)
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -25,24 +25,31 @@ using attributes::StageAttributes;
 namespace managers {
 
 StageAttributesManager::StageAttributesManager(
-    ObjectAttributesManager::ptr objectAttributesMgr,
-    PhysicsAttributesManager::ptr physicsAttributesManager)
+    AssetAttributesManager::cptr assetAttributesMgr,
+    PhysicsAttributesManager::cptr physicsAttributesManager)
     : AbstractObjectAttributesManager<StageAttributes,
                                       ManagedObjectAccess::Copy>::
-          AbstractObjectAttributesManager("Stage", "stage_config.json"),
-      objectAttributesMgr_(std::move(objectAttributesMgr)),
+          AbstractObjectAttributesManager("Stage",
+                                          "stage_config.json",
+                                          assetAttributesMgr),
       physicsAttributesManager_(std::move(physicsAttributesManager)),
       cfgLightSetup_(NO_LIGHT_KEY) {
   // build this manager's copy constructor map
   this->copyConstructorMap_["StageAttributes"] =
       &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
+  // call this to instantiate default prim object templates
+  this->createDefaultPrimTemplatesForObjType();
+
+}  // StageAttributesManager::ctor
+
+void StageAttributesManager::createDefaultPrimTemplatesForObjType() {
   // create none-type stage attributes and set as undeletable
   // based on default
   auto tmplt = this->postCreateRegister(
       StageAttributesManager::initNewObjectInternal("NONE", false), true);
   std::string tmpltHandle = tmplt->getHandle();
   this->undeletableObjectNames_.insert(tmpltHandle);
-}  // StageAttributesManager::ctor
+}  // StageAttributesManager::createDefaultPrimTemplatesForObjType
 
 int StageAttributesManager::registerObjectFinalize(
     StageAttributes::ptr stageAttributes,

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -31,14 +31,14 @@ StageAttributesManager::StageAttributesManager(
                                       ManagedObjectAccess::Copy>::
           AbstractObjectAttributesManager("Stage",
                                           "stage_config.json",
-                                          assetAttributesMgr),
+                                          std::move(assetAttributesMgr)),
       physicsAttributesManager_(std::move(physicsAttributesManager)),
       cfgLightSetup_(NO_LIGHT_KEY) {
   // build this manager's copy constructor map
   this->copyConstructorMap_["StageAttributes"] =
       &StageAttributesManager::createObjectCopy<attributes::StageAttributes>;
   // call this to instantiate default prim object templates
-  this->createDefaultPrimTemplatesForObjType();
+  StageAttributesManager::createDefaultPrimTemplatesForObjType();
 
 }  // StageAttributesManager::ctor
 

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -85,8 +85,7 @@ class StageAttributesManager
  protected:
   /**
    * @brief Create and save default primitive asset-based object templates,
-   * saving their handles as non-deletable default handles.  TODO : possibly
-   * extend this to actually build default stage templates for certain prims.
+   * saving their handles as non-deletable default handles.  Builds NONE stage.
    * See @ref ObjectAttributesManager::createDefaultPrimTemplatesForObjType() .
    */
   void createDefaultPrimTemplatesForObjType() override;

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -6,8 +6,6 @@
 #define ESP_METADATA_MANAGERS_STAGEATTRIBUTEMANAGER_H_
 
 #include "AbstractObjectAttributesManagerBase.h"
-
-#include "ObjectAttributesManager.h"
 #include "PhysicsAttributesManager.h"
 
 namespace esp {
@@ -22,9 +20,9 @@ class StageAttributesManager
     : public AbstractObjectAttributesManager<attributes::StageAttributes,
                                              ManagedObjectAccess::Copy> {
  public:
-  StageAttributesManager(
-      ObjectAttributesManager::ptr objectAttributesMgr,
-      PhysicsAttributesManager::ptr physicsAttributesManager);
+  explicit StageAttributesManager(
+      AssetAttributesManager::cptr assetAttributesMgr,
+      PhysicsAttributesManager::cptr physicsAttributesManager);
 
   /**
    * @brief This will set the current physics manager attributes that is
@@ -86,14 +84,13 @@ class StageAttributesManager
 
  protected:
   /**
-   * @brief Check if currently configured primitive asset template library has
-   * passed handle.
-   * @param handle String name of primitive asset attributes desired
-   * @return whether handle exists or not in asset attributes library
+   * @brief Create and save default primitive asset-based object templates,
+   * saving their handles as non-deletable default handles.  TODO : possibly
+   * extend this to actually build default stage templates for certain prims.
+   * See @ref ObjectAttributesManager::createDefaultPrimTemplatesForObjType() .
    */
-  bool isValidPrimitiveAttributes(const std::string& handle) override {
-    return objectAttributesMgr_->getObjectLibHasHandle(handle);
-  }
+  void createDefaultPrimTemplatesForObjType() override;
+
   /**
    * @brief Perform file-name-based attributes initialization. This is to
    * take the place of the AssetInfo::fromPath functionality, and is only
@@ -170,17 +167,11 @@ class StageAttributesManager
   // instance vars
 
   /**
-   * @brief Reference to ObjectAttributesManager to give access to setting
-   * object template library using paths specified in
-   * esp::metadata::attributes::StageAttributes json
-   */
-  ObjectAttributesManager::ptr objectAttributesMgr_ = nullptr;
-  /**
    * @brief Reference to PhysicsAttributesManager to give access to default
    * physics manager attributes settings when
    * esp::metadata::attributes::StageAttributes are created.
    */
-  PhysicsAttributesManager::ptr physicsAttributesManager_ = nullptr;
+  PhysicsAttributesManager::cptr physicsAttributesManager_ = nullptr;
 
   /**
    * @brief Current lighting default value based on current @ref


### PR DESCRIPTION
## Motivation and Context
This small PR simplifes the AttributesManagers architecture somewhat, moving an abstract method out of the base class template into the derived class template where it is used and appropriate.  Previously inappropriate AttributeManagers had access to this

The instantiation of the Object and Stage attributes managers has also been simplified and no longer requires a separate post-constructor init call.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests all pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
