### PR TITLE
(bugfix): remove direct usage of hsim_bindings for audio and fix missing reexports

### DIFF
--- a/examples/tutorials/audio_agent.py
+++ b/examples/tutorials/audio_agent.py
@@ -9,7 +9,6 @@ import quaternion  # noqa: F401
 from numpy import ndarray  # noqa: F401
 
 import habitat_sim
-import habitat_sim._ext.habitat_sim_bindings as hsim_bindings
 import habitat_sim.sensor
 import habitat_sim.sim
 
@@ -36,13 +35,13 @@ def main():
     with habitat_sim.Simulator(cfg) as sim:
 
         # create the acoustic configs
-        acoustics_config = hsim_bindings.RLRAudioPropagationConfiguration()
+        acoustics_config = habitat_sim.sensor.RLRAudioPropagationConfiguration()
         acoustics_config.enableMaterials = True
 
         # create channel layout
-        channel_layout = hsim_bindings.RLRAudioPropagationChannelLayout()
+        channel_layout = habitat_sim.sensor.RLRAudioPropagationChannelLayout()
         channel_layout.channelType = (
-            hsim_bindings.RLRAudioPropagationChannelLayoutType.Binaural
+            habitat_sim.sensor.RLRAudioPropagationChannelLayoutType.Binaural
         )
         channel_layout.channelCount = 2
 

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -412,6 +412,7 @@ void initSensorBindings(py::module& m) {
   py::class_<AudioEmptyStubChannelLayoutClass>(
       m, "RLRAudioPropagationChannelLayout")
       .def(py::init<>());
+  m.attr("RLRAudioPropagationChannelLayoutType") = py::none();
 #endif  // ESP_BUILD_WITH_AUDIO
 
 #ifdef ESP_BUILD_WITH_AUDIO

--- a/src_python/habitat_sim/__init__.py
+++ b/src_python/habitat_sim/__init__.py
@@ -86,6 +86,7 @@ if not getattr(builtins, "__HSIM_SETUP__", False):
         FisheyeSensorModelType,
         FisheyeSensorSpec,
         RLRAudioPropagationChannelLayout,
+        RLRAudioPropagationChannelLayoutType,
         RLRAudioPropagationConfiguration,
         Sensor,
         SensorFactory,

--- a/src_python/habitat_sim/bindings/__init__.py
+++ b/src_python/habitat_sim/bindings/__init__.py
@@ -28,6 +28,7 @@ from habitat_sim._ext.habitat_sim_bindings import (
     PathFinder,
     RigidState,
     RLRAudioPropagationChannelLayout,
+    RLRAudioPropagationChannelLayoutType,
     RLRAudioPropagationConfiguration,
     SceneGraph,
     SceneNode,

--- a/src_python/habitat_sim/sensor.py
+++ b/src_python/habitat_sim/sensor.py
@@ -17,6 +17,7 @@ from habitat_sim._ext.habitat_sim_bindings import (
     FisheyeSensorSpec,
     Observation,
     RLRAudioPropagationChannelLayout,
+    RLRAudioPropagationChannelLayoutType,
     RLRAudioPropagationConfiguration,
     Sensor,
     SensorFactory,
@@ -49,5 +50,6 @@ __all__ = [
     "AudioSensorSpec",
     "AudioSensor",
     "RLRAudioPropagationChannelLayout",
+    "RLRAudioPropagationChannelLayoutType",
     "RLRAudioPropagationConfiguration",
 ]


### PR DESCRIPTION
## Motivation and Context
* hsim_bindings is supposed to be a private API as indicated by the underscore. I guess it was used since one of the bindings wasn't properly exported under habitat_sim.sensor. I went ahead and added the missing exports and changed the tutorial accordingly. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
