### PR TITLE
Constrain numpy version for compatibility with numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imageio
 imageio-ffmpeg
 matplotlib
 numba
-numpy
+numpy<=1.22
 numpy-quaternion
 pillow
 scipy>=1.3.0


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

New NumPy versions (>1.22) are incompatible with [Numba](https://numba.readthedocs.io/en/stable/user/installing.html). This constraint ensures that the NumPy version is compatible with Numba.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

Launched example client using polymetis, tested against polymetis automated tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
