### PR TITLE
Port stage_requires_lighting arg to python viewer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
               pip install -U --prefer-binary \
                 black \
                 flake8 \
-                flake8-bugbear \
+                flake8-bugbear==22.6.22 \
                 flake8-builtins \
                 flake8-comprehensions \
                 flake8-return \

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -252,6 +252,11 @@ class HabitatSimInteractiveViewer(Application):
         self.agent_id: int = self.sim_settings["default_agent"]
         self.cfg.agents[self.agent_id] = self.default_agent_config()
 
+        if self.sim_settings["stage_requires_lighting"]:
+            logger.info("Setting synthetic lighting override for stage.")
+            self.cfg.sim_cfg.override_scene_light_defaults = True
+            self.cfg.sim_cfg.scene_light_setup = habitat_sim.gfx.DEFAULT_LIGHTING_KEY
+
         if self.sim is None:
             self.sim = habitat_sim.Simulator(self.cfg)
 
@@ -924,6 +929,11 @@ if __name__ == "__main__":
         action="store_true",
         help="disable physics simulation (default: False)",
     )
+    parser.add_argument(
+        "--stage_requires_lighting",
+        action="store_true",
+        help="Override configured lighting to use synthetic lighting for the stage.",
+    )
 
     args = parser.parse_args()
 
@@ -932,5 +942,6 @@ if __name__ == "__main__":
     sim_settings["scene"] = args.scene
     sim_settings["scene_dataset_config_file"] = args.dataset
     sim_settings["enable_physics"] = not args.disable_physics
+    sim_settings["stage_requires_lighting"] = args.stage_requires_lighting
 
     HabitatSimInteractiveViewer(sim_settings).exec()


### PR DESCRIPTION
## Motivation and Context

This argument allows terminal override of stage lighting defaults to enable synthetic lighting for scenes which require it but may not be configured to use it automatically.

## How Has This Been Tested

Locally with stage assets which crash when rendered with flat shader.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
