### PR TITLE
[bugfix] - viewer.py navmesh recompute skip for "none" scene

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -91,7 +91,10 @@ class HabitatSimInteractiveViewer(Application):
         self.reconfigure_sim()
 
         # compute NavMesh if not already loaded by the scene.
-        if not self.sim.pathfinder.is_loaded and self.cfg.sim_cfg.scene_id != "NONE":
+        if (
+            not self.sim.pathfinder.is_loaded
+            and self.cfg.sim_cfg.scene_id.lower() != "none"
+        ):
             self.navmesh_config_and_recompute()
 
         self.time_since_last_simulation = 0.0


### PR DESCRIPTION
## Motivation and Context

When choosing to skip navmesh recompute for none scene, need to handle cases where the "NONE" scene is not all upper case.

## How Has This Been Tested

locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
