### PR TITLE
[mypy] - ignore erroneous type warning in new imageio version.

### DIFF
--- a/src_python/habitat_sim/utils/viz_utils.py
+++ b/src_python/habitat_sim/utils/viz_utils.py
@@ -49,7 +49,7 @@ def get_fast_video_writer(video_file: str, fps: int = 60):
             codec="h264_nvenc",
             mode="I",
             bitrate="1000k",
-            format="FFMPEG",
+            format="FFMPEG",  # type: ignore[arg-type]
             ffmpeg_log_level="info",
             output_params=["-minrate", "500k", "-maxrate", "5000k"],
         )


### PR DESCRIPTION
## Motivation and Context

New imageio version may have conflicting API. mypy asserts that `format` should be `Format` type, but should actually be string as written.

## How Has This Been Tested

CI SSH and local

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
