### PR TITLE
[CI] - Updating docs should wait until lab-build is complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,6 +748,7 @@ workflows:
       - update_docs:
           requires:
             - install_and_test_ubuntu
+            - lab_build_habitat
           filters:
             branches:
               only: main


### PR DESCRIPTION
## Motivation and Context

Public sim docs are built during the lab-build job, so updating the docs should wait until this phase is complete. This is already the case for version builds.

## How Has This Been Tested

Re-running the failed update-doc job after everything else completed works. Failure was inability to find and copy the built doc directory.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
