### PR TITLE
[CI] - fix nightly conda preserve_egg_dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,7 +733,11 @@ workflows:
       - install_and_test_ubuntu
       - pre-commit
       - build_conda_binaries:
-          CI_TEST: true
+          AIHABITAT_CONDA_CHN: aihabitat-nightly
+          AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
+          NIGHTLY_FLAG: "--nightly"
+          requires:
+            - install_and_test_ubuntu
       - clang_tidy
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,11 +733,7 @@ workflows:
       - install_and_test_ubuntu
       - pre-commit
       - build_conda_binaries:
-          AIHABITAT_CONDA_CHN: aihabitat-nightly
-          AIHABITAT_CONDA_CHN_PWD_VAR: AIHABITAT_NIGHTLY_CONDA_PWD
-          NIGHTLY_FLAG: "--nightly"
-          requires:
-            - install_and_test_ubuntu
+          CI_TEST: true
       - clang_tidy
   nightly:
     triggers:

--- a/conda-build/habitat-sim/meta.yaml
+++ b/conda-build/habitat-sim/meta.yaml
@@ -90,6 +90,7 @@ build:
   number: {{ build_number }}
   binary_relocation: True
   detect_binary_files_with_prefix: False
+  preserve_egg_dir: True
   script_env:
     - HEADLESS
     - WITH_CUDA


### PR DESCRIPTION
## Motivation and Context

Nightly conda failing due to conflicting files during merge. Implement suggested change setting `preserve_egg_dir = True` seems to fix it.

## How Has This Been Tested

Built and uploaded nightly CI from this PR branch.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
