### PR TITLE
Franka Panda Download without a Wrapping Directory

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -127,8 +127,8 @@ def initialize_test_data_sources(data_path):
             "version": "1.2",
         },
         "franka_panda": {
-            "source": "https://dl.fbaipublicfiles.com/polymetis/franka_panda.zip",
-            "package_name": "franka_panda.zip",
+            "source": "https://dl.fbaipublicfiles.com/polymetis/franka_panda_no_dir.zip",
+            "package_name": "franka_panda_no_dir.zip",
             "link": data_path + "robots/franka_panda",
             "version": "1.0",
         },


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The franka panda model is required by features in Habitat Lab. The [previously merged downloader](https://github.com/facebookresearch/habitat-sim/pull/1837) fails since the linked file represents a zipped directory rather than the files themselves zipped together (os.unlink raises an OSError for a directory). A new download link was created rather than replacing the file at the existing link following the guidance of the [FAIR AWS documentation](https://www.internalfb.com/intern/wiki/FAIR/Platforms/Clusters/FAIRClusters/S3Storage/#public-file-hosting-dl-f:~:text=We%20recommend%20that%20you%20do%20not%20overwrite%20file%20contents%20(i.e.%20please%20use%20a%20different%20file%20name%20for%20each%20new%20file))

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

I copied the changes into the datasets_download.py file installed in my conda environment and was able to run the download successfully. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
