### PR TITLE
[HM3D] - update hm3d importer to expect another entry after region id

### DIFF
--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -134,9 +134,9 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
                               uint8_t(colorInt & 0xff)};
     // object category will possibly have commas
     const std::string objCategoryName = tokens[1];
-    // room/region is always last token - get rid of first comma
-    int regionID =
-        std::stoi(Cr::Utility::String::trim(tokens[tokens.size() - 1], " ,"));
+
+    // region id comes after instace category raw text
+    int regionID = std::stoi(Cr::Utility::String::trim(tokens[2], " ,"));
 
     buildInstanceRegionCategory(instanceID, colorInt, objCategoryName, regionID,
                                 objInstance, regions, categories);


### PR DESCRIPTION
## Motivation and Context

New semantic txt files will include a region string after the id. This violates an assumption that region id will be the last token in each line.

TODO:
- we should parse the region name

## How Has This Been Tested

locally with new semantic txt file

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
