### PR TITLE
Chore: Remove unnecessary casts from SensorSpec bindings

### DIFF
--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -82,15 +82,15 @@ void initSensorBindings(py::module& m) {
       .def_readwrite("noise_model", &SensorSpec::noiseModel)
       .def_property(
           "noise_model_kwargs",
-          [](SensorSpec& self) -> py::dict {
-            py::handle handle = py::cast(self);
-            if (!py::hasattr(handle, "__noise_model_kwargs")) {
-              py::setattr(handle, "__noise_model_kwargs", py::dict());
+          // Note: self remains a python object handle
+          [](py::handle self) -> py::dict {
+            if (!py::hasattr(self, "__noise_model_kwargs")) {
+              py::setattr(self, "__noise_model_kwargs", py::dict());
             }
-            return py::getattr(handle, "__noise_model_kwargs");
+            return py::getattr(self, "__noise_model_kwargs");
           },
-          [](SensorSpec& self, py::dict v) {
-            py::setattr(py::cast(self), "__noise_model_kwargs", std::move(v));
+          [](py::handle self, py::dict v) {
+            py::setattr(self, "__noise_model_kwargs", std::move(v));
           })
       .def("is_visual_sensor_spec", &SensorSpec::isVisualSensorSpec)
       .def("__eq__", &SensorSpec::operator==)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
While reviewing #1849 I noticed that we are doing some very inefficent things for modifying the attributes on the Python object. Mainly we are casting to a C++ object and then back again. Since we know the first argument will be an injected "self" argument, that it will be non-null, and it will manage it's own ownership we can just use a lightweight handle pointing to the underlying py::object. This means we don't have to do any casting and can just call the relevant C++ python API directly. 
## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Locally by running the test_sensors tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
