### PR TITLE
[bugfix] minor fix to viewer text string creation for semantic labels

### DIFF
--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -1817,7 +1817,7 @@ void Viewer::drawEvent() {
                             mouseModeNames.at(mouseInteractionMode));
 
     if (!semanticTag_.empty()) {
-      Cr::Utility::formatInto(text, text.size(), "Semantic %s\n", semanticTag_);
+      Cr::Utility::formatInto(text, text.size(), "Semantic {}\n", semanticTag_);
     }
 
     fontText_->render(text);


### PR DESCRIPTION
## Motivation and Context

#1853 converted viewer.cpp to use Magnum text instead of imgui. Syntax for referencing variables in strings changed and one refactor was missed.

## How Has This Been Tested

locally with viewer.cpp

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
