### PR TITLE
[WIP] refactor CI audio testing to use a standard example test process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,6 +563,7 @@ jobs:
                 --build-datatool \
                 --run-tests \
                 --no-lto \
+                --audio \
                 --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
 
               PYTHONPATH=src_python pytest -n 4 --durations=10 --cov-report=xml --cov=./
@@ -580,18 +581,6 @@ jobs:
               . ~/emsdk/emsdk_env.sh
               # Generate JS CodeConv
               npm run test_with_coverage
-      -  run:
-          name: Build, install habitat-sim with audio and run audio_agent script
-          no_output_timeout: 10m
-          command: |
-              export PATH=$HOME/miniconda/bin:$PATH
-              . activate habitat;
-              cd habitat-sim
-              pip install -r requirements.txt --progress-bar off
-              pip install imageio imageio-ffmpeg
-              git submodule update --init --recursive --jobs 8
-              python -u setup.py install --build-type "Release" --lto --headless --audio
-              python examples/tutorials/audio_agent.py
       - save_cache:
           key: ccache-{{ arch }}-{{ .Branch }}-{{ .BuildNum }}
           background: true

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -94,6 +94,22 @@ def test_replica_cad_quickstart(args):
     run_main_subproc(args)
 
 
+@pytest.mark.skipif(
+    not habitat_sim.audio_enabled,
+    reason="Requires Habitat-sim to be built with RLR-audio-propogation support (--audio)",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/mp3d_example/17DRP5sb8fy/17DRP5sb8fy.glb"),
+    reason="Requires the MP3D test scene for semantic annotations.",
+)
+@pytest.mark.parametrize(
+    "args",
+    [("examples/tutorials/audio_agent.py")],
+)
+def test_audio_example(args):
+    run_main_subproc(args)
+
+
 @pytest.mark.gfxtest
 @pytest.mark.skipif(
     not osp.exists("data/scene_datasets/habitat-test-scenes/skokloster-castle.glb"),


### PR DESCRIPTION
## Motivation and Context

On CI `--audio` is currently built separately and tested only on its example file. This is non-standard and requires extra build time. We'll try to refactor to normalize the testing process.

## How Has This Been Tested

Testing the python script through test_examples.py

Currently this is breaking the pytest w/ code cov run. Not sure why.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
