### PR TITLE
(bugfix): Remove an extra tmp copy of lightsetup in Simulator.cpp

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -308,7 +308,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
           metadataMediator_->getLightLayoutAttributesManager()
               ->createLightSetupFromAttributes(lightSetupKey);
       // set lightsetup in resource manager
-      resourceManager_->setLightSetup(lightingSetup,
+      resourceManager_->setLightSetup(std::move(lightingSetup),
                                       Mn::ResourceKey{lightSetupKey});
     }
   }


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Tiny performance bug in simulator.cpp relating to lighting setup. This removes an unnecessary extra copy.

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
