### PR TITLE
[WIP] Handle zero scaling mesh transforms

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1783,10 +1783,21 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   // Set transformations. Objects that are not part of the hierarchy are
   // ignored, nodes that have no transformation entry retain an identity
   // transformation.
-  for (const Cr::Containers::Pair<unsigned, Mn::Matrix4>& transformation :
+  for (Cr::Containers::Pair<unsigned, Mn::Matrix4>& transformation :
        scene->transformations3DAsArray()) {
     if (Cr::Containers::Optional<esp::assets::MeshTransformNode>& node =
             nodes[transformation.first()]) {
+      if (transformation.second().scaling().product() == 0) {
+        ESP_ERROR() << "0 value in scaling vector for mesh transform. "
+                       "Indicates an issue with source asset. Overriding to "
+                       "small nonzero and continuing.";
+        ESP_ERROR() << transformation.second();
+        for (auto ix = 0; ix < 3; ++ix) {
+          if (transformation.second()[ix][ix] == 0) {
+            transformation.second()[ix][ix] = 1e-7;
+          }
+        }
+      }
       node->transformFromLocalToParent = transformation.second();
     }
   }


### PR DESCRIPTION
## Motivation and Context

Some mesh transforms contain zeros in the scaling component of the transform. Likely this is erroneous, but currently this will crash the simulator during import. This patch isolates the issue and adds a check with an error message and corrective measure applied automatically to prevent crashing.

We should think about the correct handling here.

## How Has This Been Tested

Locally with a crashing asset. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
