### PR TITLE
(bugfix): Prevent unnecessary copies with more std::move and emplace

### DIFF
--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -748,7 +748,7 @@ class Configuration {
    */
   std::shared_ptr<Configuration> addSubgroup(const std::string& name) {
     // Attempt to insert an empty pointer
-    auto result = configMap_.insert({name, std::shared_ptr<Configuration>{}});
+    auto result = configMap_.emplace(name, std::shared_ptr<Configuration>{});
     // If name not already present (insert succeeded) then add new
     // configuration
     if (result.second) {

--- a/src/esp/geo/VoxelGrid.cpp
+++ b/src/esp/geo/VoxelGrid.cpp
@@ -288,8 +288,8 @@ void VoxelGrid::generateMeshDataAndMeshGL(
   if (meshGLDict_.find(gridName) != meshGLDict_.end()) {
     meshGLDict_[gridName] = Mn::MeshTools::compile(*meshDataDict_[gridName]);
   } else {
-    meshGLDict_.insert(std::make_pair(
-        gridName, Mn::MeshTools::compile(*meshDataDict_[gridName])));
+    meshGLDict_.emplace(gridName,
+                        Mn::MeshTools::compile(*meshDataDict_[gridName]));
   }
 }
 

--- a/src/esp/geo/VoxelGrid.h
+++ b/src/esp/geo/VoxelGrid.h
@@ -130,7 +130,7 @@ class VoxelGrid {
 
     new_grid.view = view;
     new_grid.type = type;
-    grids_.insert(std::make_pair(gridName, std::move(new_grid)));
+    grids_.emplace(gridName, std::move(new_grid));
   }
 
   /**

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -104,7 +104,7 @@ AssetAttributesManager::AssetAttributesManager()
     auto tmplt = AssetAttributesManager::createObject(elem.second, true);
     std::string tmpltHandle = tmplt->getHandle();
     defaultPrimAttributeHandles_[elem.second] = tmpltHandle;
-    this->undeletableObjectNames_.insert(tmpltHandle);
+    this->undeletableObjectNames_.insert(std::move(tmpltHandle));
   }
 
   ESP_DEBUG() << "Built default primitive asset templates :"

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -277,7 +277,7 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
       // save handles in list of defaults, so they are not removed, if desired.
       if (saveAsDefaults) {
         std::string tmpltHandle = tmplt->getHandle();
-        this->undeletableObjectNames_.insert(tmpltHandle);
+        this->undeletableObjectNames_.insert(std::move(tmpltHandle));
       }
       templateIndices[i] = tmplt->getID();
     }

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -66,7 +66,7 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
     auto tmplt = createPrimBasedAttributesTemplate(elem, true);
     // save handles in list of defaults, so they are not removed
     std::string tmpltHandle = tmplt->getHandle();
-    this->undeletableObjectNames_.insert(tmpltHandle);
+    this->undeletableObjectNames_.insert(std::move(tmpltHandle));
   }
 }  // ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -41,7 +41,7 @@ StageAttributesManager::StageAttributesManager(
   auto tmplt = this->postCreateRegister(
       StageAttributesManager::initNewObjectInternal("NONE", false), true);
   std::string tmpltHandle = tmplt->getHandle();
-  this->undeletableObjectNames_.insert(tmpltHandle);
+  this->undeletableObjectNames_.insert(std::move(tmpltHandle));
 }  // StageAttributesManager::ctor
 
 int StageAttributesManager::registerObjectFinalize(

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -210,10 +210,11 @@ bool SemanticScene::buildHM3DHouse(std::ifstream& ifs,
       scene.semanticColorToIdAndRegion_.reserve(idx + 1);
     }
     scene.semanticColorMapBeingUsed_[idx] = objPtr->getColor();
-    scene.semanticColorToIdAndRegion_.insert(
-        std::make_pair<uint32_t, std::pair<int, int>>(
-            objPtr->getColorAsInt(),
-            {objPtr->semanticID(), objPtr->region()->getIndex()}));
+    scene.semanticColorToIdAndRegion_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(objPtr->getColorAsInt()),
+        std::forward_as_tuple(objPtr->semanticID(),
+                              objPtr->region()->getIndex()));
   }
   // we need to build the bbox on load for each semantic annotation
   // TODO: eventually BBoxes will be pre-generated and stored in semantic text

--- a/src/esp/scene/HM3DSemanticScene.cpp
+++ b/src/esp/scene/HM3DSemanticScene.cpp
@@ -76,15 +76,15 @@ void buildInstanceRegionCategory(
       instanceID, 0, objCategoryName,
       Cr::Utility::formatString("{}_{}", objCategoryName, instanceID),
       colorInt};
-  objInstance[instanceID] = obj;
+  objInstance[instanceID] = std::move(obj);
   // find category, build if dne
   TempHM3DCategory tmpCat{
       static_cast<int>(categories.size()), objCategoryName, {}};
-  auto categoryIter = categories.emplace(objCategoryName, tmpCat);
+  auto categoryIter = categories.emplace(objCategoryName, std::move(tmpCat));
   categoryIter.first->second.objInstances.push_back(&objInstance[instanceID]);
   // find region, build if dne
   TempHM3DRegion tmpRegion{regionID, {}};
-  auto regionIter = regions.emplace(regionID, tmpRegion);
+  auto regionIter = regions.emplace(regionID, std::move(tmpRegion));
   regionIter.first->second.objInstances.push_back(&objInstance[instanceID]);
 }  // buildInstanceRegionCategory
 

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -182,7 +182,7 @@ SemanticScene::buildCCBasedSemanticObjs(
   std::unordered_map<uint32_t, uint32_t> mapColorIntsToSemanticObjIDXs;
   mapColorIntsToSemanticObjIDXs.reserve(semanticObjs.size());
   for (uint32_t i = 0; i < semanticObjs.size(); ++i) {
-    mapColorIntsToSemanticObjIDXs.insert({semanticObjs[i]->getColorAsInt(), i});
+    mapColorIntsToSemanticObjIDXs.emplace(semanticObjs[i]->getColorAsInt(), i);
   }
   // build map with key being semanticObject IDX in semantic Objects array
   std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>


### PR DESCRIPTION
## Motivation and Context

* When I was reviewing @jturner65's PR, I noticed a series of strings that were being copied into their std::set. This explicitly moves them when inserting them into the set instead which should prevent an unnecessary copy.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
