### PR TITLE
python - Add settings module to utils init

### DIFF
--- a/src_python/habitat_sim/utils/__init__.py
+++ b/src_python/habitat_sim/utils/__init__.py
@@ -10,7 +10,7 @@
 # fixed
 
 
-from habitat_sim.utils import common, manager_utils, validators, viz_utils
+from habitat_sim.utils import common, manager_utils, settings, validators, viz_utils
 from habitat_sim.utils.common import quat_from_angle_axis, quat_rotate_vector
 
 __all__ = [
@@ -19,4 +19,5 @@ __all__ = [
     "common",
     "viz_utils",
     "validators",
+    "settings",
 ]


### PR DESCRIPTION
## Motivation and Context

When importing from outside of habitat-sim, settings module was not available from utils.

## How Has This Been Tested



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
