### PR TITLE
Don't give up when encountering lines/points/... in collision mesh data

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -566,7 +566,7 @@ bool ResourceManager::loadStage(
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
     bool sceneSuccess = _physicsManager->addStage(
-        stageAttributes, stageInstanceAttributes, meshGroup);
+        stageAttributes, stageInstanceAttributes);
     if (!sceneSuccess) {
       ESP_ERROR() << "Adding Stage" << stageAttributes->getHandle()
                   << "to PhysicsManager failed. Aborting stage initialization.";

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -565,8 +565,8 @@ bool ResourceManager::loadStage(
     // Either add with pre-built meshGroup if collision assets are loaded
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
-    bool sceneSuccess = _physicsManager->addStage(
-        stageAttributes, stageInstanceAttributes);
+    bool sceneSuccess =
+        _physicsManager->addStage(stageAttributes, stageInstanceAttributes);
     if (!sceneSuccess) {
       ESP_ERROR() << "Adding Stage" << stageAttributes->getHandle()
                   << "to PhysicsManager failed. Aborting stage initialization.";

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -57,15 +57,7 @@ PhysicsManager::~PhysicsManager() {
 bool PhysicsManager::addStage(
     const metadata::attributes::StageAttributes::ptr& initAttributes,
     const metadata::attributes::SceneObjectInstanceAttributes::cptr&
-        stageInstanceAttributes,
-    const std::vector<assets::CollisionMeshData>& meshGroup) {
-  // Test Mesh primitive is valid
-  for (const assets::CollisionMeshData& meshData : meshGroup) {
-    if (!isMeshPrimitiveValid(meshData)) {
-      return false;
-    }
-  }
-
+        stageInstanceAttributes) {
   //! Initialize stage
   bool sceneSuccess = addStageFinalize(initAttributes);
   if (sceneSuccess) {
@@ -533,11 +525,6 @@ bool PhysicsManager::makeAndAddRigidObject(
     existingObjects_.emplace(newObjectID, std::move(ptr));
   }
   return objSuccess;
-}
-
-//! Base physics manager has no requirement for mesh primitive
-bool PhysicsManager::isMeshPrimitiveValid(const assets::CollisionMeshData&) {
-  return true;
 }
 
 // TODO: this function should do any engine specific setting which is

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -274,14 +274,12 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * Attributes Manager.
    * @param stageInstanceAttributes The stage instance attributes that was used
    * to create this stage. Might be empty.
-   * @param meshGroup collision meshs for the scene.
    * @return true if successful and false otherwise
    */
   bool addStage(
       const metadata::attributes::StageAttributes::ptr& initAttributes,
       const metadata::attributes::SceneObjectInstanceAttributes::cptr&
-          stageInstanceAttributes,
-      const std::vector<assets::CollisionMeshData>& meshGroup);
+          stageInstanceAttributes);
 
   /**
    * @brief Instance and place a physics object from a @ref
@@ -1072,15 +1070,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
     CORRADE_INTERNAL_ASSERT(aObjIter != existingArticulatedObjects_.end());
     return aObjIter;
   }
-
-  /** @brief Check if a particular mesh can be used as a collision mesh for
-   * a particular physics implemenation. Always True for base @ref
-   * PhysicsManager class, since the mesh has already been successfully
-   * loaded by @ref esp::assets::ResourceManager.
-   * @param meshData The mesh to validate.
-   * @return true if valid, false otherwise.
-   */
-  virtual bool isMeshPrimitiveValid(const assets::CollisionMeshData& meshData);
 
   /** @brief Acquire a new ObjectID by recycling the ID of an object removed
    * with @ref removeObject or by incrementing @ref nextObjectID_. See @ref

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -244,40 +244,6 @@ BulletPhysicsManager::getArticulatedObjectWrapper() {
       "ManagedBulletArticulatedObject");
 }
 
-//! Check if mesh primitive is compatible with physics
-bool BulletPhysicsManager::isMeshPrimitiveValid(
-    const assets::CollisionMeshData& meshData) {
-  if (meshData.primitive == Magnum::MeshPrimitive::Triangles) {
-    //! Only triangle mesh works
-    return true;
-  } else {
-    switch (meshData.primitive) {
-      case Magnum::MeshPrimitive::Lines:
-        ESP_ERROR() << "Invalid primitive: Lines";
-        break;
-      case Magnum::MeshPrimitive::Points:
-        ESP_ERROR() << "Invalid primitive: Points";
-        break;
-      case Magnum::MeshPrimitive::LineLoop:
-        ESP_ERROR() << "Invalid primitive Line loop";
-        break;
-      case Magnum::MeshPrimitive::LineStrip:
-        ESP_ERROR() << "Invalid primitive Line Strip";
-        break;
-      case Magnum::MeshPrimitive::TriangleStrip:
-        ESP_ERROR() << "Invalid primitive Triangle Strip";
-        break;
-      case Magnum::MeshPrimitive::TriangleFan:
-        ESP_ERROR() << "Invalid primitive Triangle Fan";
-        break;
-      default:
-        ESP_ERROR() << "Invalid primitive" << int(meshData.primitive);
-    }
-    ESP_ERROR() << "Cannot load collision mesh, skipping";
-    return false;
-  }
-}
-
 bool BulletPhysicsManager::attachLinkGeometry(
     ArticulatedLink* linkObject,
     const std::shared_ptr<io::URDF::Link>& link,

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -431,15 +431,6 @@ class BulletPhysicsManager : public PhysicsManager {
   int recentNumSubStepsTaken_ = -1;
 
  private:
-  /** @brief Check if a particular mesh can be used as a collision mesh for
-   * Bullet.
-   * @param meshData The mesh to validate. Only a triangle mesh is valid. Checks
-   * that the only #ref Magnum::MeshPrimitive are @ref
-   * Magnum::MeshPrimitive::Triangles.
-   * @return true if valid, false otherwise.
-   */
-  bool isMeshPrimitiveValid(const assets::CollisionMeshData& meshData) override;
-
   /**
    * @brief Helper function for getting object and link unique ids from
    * btCollisionObject cache

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -432,7 +432,7 @@ void BulletRigidObject::activateCollisionIsland() {
   // bitset template argument specifies reasonable allocation size at compile
   // time - it is not expected that we would require more than 65536 different
   // islands; if we do, this number should be increased.
-  Magnum::Math::BoolVector<65536> overlappingSimIslands;
+  Magnum::Math::BitVector<65536> overlappingSimIslands;
   // each index represents an island tag present - default in bullet is -1, so
   // add one.
   overlappingSimIslands.set(thisColObj->getIslandTag() + 1, true);

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -101,14 +101,22 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
     const assets::MeshTransformNode& node) {
   Magnum::Matrix4 transformFromLocalToWorld =
       transformFromParentToWorld * node.transformFromLocalToParent;
-  if (node.meshIDLocal != ID_UNDEFINED) {
-    const assets::CollisionMeshData& mesh = meshGroup[node.meshIDLocal];
 
+  const assets::CollisionMeshData* mesh = nullptr;
+  if (node.meshIDLocal != ID_UNDEFINED)
+    mesh = &meshGroup[node.meshIDLocal];
+  // TODO TriangleStrip and TriangleFan would work
+  if(mesh && mesh->primitive != Mn::MeshPrimitive::Triangles) {
+    ESP_WARNING() << "Unsupported collision mesh primitive" << mesh->primitive << Mn::Debug::nospace << ", skipping";
+    mesh = nullptr;
+  }
+
+  if(mesh) {
     // SCENE: create a concave static mesh
     btIndexedMesh bulletMesh;
 
-    Corrade::Containers::ArrayView<Magnum::Vector3> v_data = mesh.positions;
-    Corrade::Containers::ArrayView<Magnum::UnsignedInt> ui_data = mesh.indices;
+    Corrade::Containers::ArrayView<Magnum::Vector3> v_data = mesh->positions;
+    Corrade::Containers::ArrayView<Magnum::UnsignedInt> ui_data = mesh->indices;
 
     //! Configure Bullet Mesh
     //! This part is very likely to cause segfault, if done incorrectly

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -106,12 +106,13 @@ void BulletRigidStage::constructBulletSceneFromMeshes(
   if (node.meshIDLocal != ID_UNDEFINED)
     mesh = &meshGroup[node.meshIDLocal];
   // TODO TriangleStrip and TriangleFan would work
-  if(mesh && mesh->primitive != Mn::MeshPrimitive::Triangles) {
-    ESP_WARNING() << "Unsupported collision mesh primitive" << mesh->primitive << Mn::Debug::nospace << ", skipping";
+  if (mesh && mesh->primitive != Mn::MeshPrimitive::Triangles) {
+    ESP_WARNING() << "Unsupported collision mesh primitive" << mesh->primitive
+                  << Mn::Debug::nospace << ", skipping";
     mesh = nullptr;
   }
 
-  if(mesh) {
+  if (mesh) {
     // SCENE: create a concave static mesh
     btIndexedMesh bulletMesh;
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -849,6 +849,7 @@ Viewer::Viewer(const Arguments& arguments)
       .addOption("dataset", "default")
       .setHelp("dataset", "dataset configuration file to use")
       .addBooleanOption("enable-physics")
+      .setHelp("enable-physics", "Enable Bullet physics.")
       .addBooleanOption("stage-requires-lighting")
       .setHelp("stage-requires-lighting",
                "Stage asset should be lit with Phong shading.")


### PR DESCRIPTION
## Motivation and Context

Instead just skipping them. See [this Slack thread](https://cvmlp.slack.com/archives/CFN5TAUSD/p1663176292006099) for background info.

As this makes the `isMeshPrimitiveValid()` check obsolete, I removed the whole implementation of it (which, after all, was just a very verbose way to print the mesh primitive name originating back in the days when Habitat used glog and thus couldn't just call [Magnum's builtin output operator for MeshPrimitive](https://doc.magnum.graphics/magnum/namespaceMagnum_1_1Vk.html#a7a3593c8ac0af192feba9eae70e2d62d)). Furthermore, a call to this function was also the only reason why `addStage()` too the collision mesh group parameter, so I removed it from there as well. Which is a documentation TODO: 

- [ ] The `addStage()` docs probably need to be updated as they mention collision data that are no longer passed there. I don't know what should be said there, tho.

The check is now moved to inside `constructBulletSceneFromMeshes()`, where it just skips unsupported primitives with a warning. If the code could access the originating Magnum `Trade::MeshData` instead of
`CollisionMeshData`, it could be easily extended to support also triangle fans and triangle strips (since there's a [MeshTools utility for converting them to triangle lists](https://doc.magnum.graphics/magnum/namespaceMagnum_1_1MeshTools.html#a8b0d9114105a36fbd2147ee129e2017d)), but right now it skips those as well.

Also contains a drive-by fix for viewer `--help` output and use of a deprecated Magnum API.

## How Has This Been Tested

:warning: **I have no idea what am I doing!** The viewer doesn't assert for me anymore, but I don't know anything about the physics code, how it should / should not behave, and how to verify if the collision mesh is indeed generated correctly. So please test and give feedback. Making the PR as a draft due to that reason (and due to the doc TODO above).
