### PR TITLE
[bugfix] Support habitat-lab requirements.txt after split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
                 # For whatever reason we have to install pytorch first. If it isn't
                 # it installs the 1.4 cpuonly version. Which is no good.
                 conda install -q -y pytorch torchvision cudatoolkit=11.3 -c pytorch
-                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
+                conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis pytest-mock
                 pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython mock
               fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
                 # it installs the 1.4 cpuonly version. Which is no good.
                 conda install -q -y pytorch torchvision cudatoolkit=11.3 -c pytorch
                 conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-                pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython
+                pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython mock
               fi
       - run:
           name: Install emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,7 +439,7 @@ jobs:
                 git clone -q --depth 1 https://github.com/facebookresearch/habitat-lab.git
               fi
               cd habitat-lab
-              pip install -r requirements.txt --progress-bar off
+              pip install -r habitat-lab/requirements.txt --progress-bar off
               ln -s ../habitat-sim/data data
               touch ~/miniconda/pip_deps_installed
       - run:
@@ -461,7 +461,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-lab
               # Install requirments first to avoid errors related to gym
-              pip install -r requirements.txt --progress-bar off
+              pip install -r habitat-lab/requirements.txt --progress-bar off
               python setup.py develop --all
 
               cd docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,8 +448,11 @@ jobs:
           command: |
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat; cd habitat-lab
-              python -u setup.py develop --all
-              python -u setup.py test
+              pip install -e habitat-lab
+              pip install -e habitat-baselines
+              export PYTHONPATH=.:$PYTHONPATH
+              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
+              python -m pytest
       - save_cache:
           key: habitat-lab-{{ checksum "./hablab_sha" }}
           background: true
@@ -462,7 +465,7 @@ jobs:
               . activate habitat; cd habitat-lab
               # Install requirments first to avoid errors related to gym
               pip install -r habitat-lab/requirements.txt --progress-bar off
-              python setup.py develop --all
+              pip install -e habitat-lab
 
               cd docs
               conda install -y -c conda-forge doxygen

--- a/examples/colab_utils/colab_install.sh
+++ b/examples/colab_utils/colab_install.sh
@@ -47,8 +47,7 @@ pip install -r ./habitat-lab/requirements.txt
 reqs=(./habitat_baselines/**/requirements.txt)
 pip install "${reqs[@]/#/-r}"
 set -e
-python setup.py develop --all
-pip install . #Reinstall to trigger sys.path update
+pip install -e habitat-lab
 cd /content/habitat-sim/
 
 #Download Assets

--- a/examples/colab_utils/colab_install.sh
+++ b/examples/colab_utils/colab_install.sh
@@ -43,7 +43,7 @@ git clone https://github.com/facebookresearch/habitat-sim --depth 1
 #Install Requirements.
 cd /content/habitat-lab/
 set +e
-pip install -r ./requirements.txt
+pip install -r ./habitat-lab/requirements.txt
 reqs=(./habitat_baselines/**/requirements.txt)
 pip install "${reqs[@]/#/-r}"
 set -e


### PR DESCRIPTION
## Motivation and Context

With the baselines/lab split from [PR 922](https://github.com/facebookresearch/habitat-lab/pull/922), requirements.txt was moved. This PR updates install paths for sim testing and colab install pipelines.

Addresses #1884 and should fix broken lab test.

## How Has This Been Tested

Here

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
