### PR TITLE
Temporarily work around lost code coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,24 +583,7 @@ jobs:
               . ~/emsdk/emsdk_env.sh
               # Generate JS CodeConv
               npm run test_with_coverage
-      -  run:
-          name: Build, install habitat-sim with audio and run audio_agent script
-          no_output_timeout: 10m
-          command: |
-              export PATH=$HOME/miniconda/bin:$PATH
-              . activate habitat;
-              cd habitat-sim
-              pip install -r requirements.txt --progress-bar off
-              pip install imageio imageio-ffmpeg
-              git submodule update --init --recursive --jobs 8
-              python -u setup.py install --build-type "Release" --lto --headless --audio
-              python examples/tutorials/audio_agent.py
-      - save_cache:
-          key: ccache-{{ arch }}-{{ .Branch }}-{{ .BuildNum }}
-          background: true
-          paths:
-            - /home/circleci/.ccache
-      - run:
+      - run: &upload_coverage
           name: Upload test coverage
           command: |
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
@@ -623,6 +606,27 @@ jobs:
               #lcov --remove coverage.info "*/test/*" --output-file coverage.info > /dev/null
               #lcov --remove coverage.info "*/tests/*" --output-file coverage.info > /dev/null
               ./codecov -f coverage.info -cF CPP
+      -  run:
+          name: Build, install habitat-sim with audio and run audio_agent script
+          no_output_timeout: 10m
+          command: |
+              export PATH=$HOME/miniconda/bin:$PATH
+              . activate habitat;
+              cd habitat-sim
+              pip install -r requirements.txt --progress-bar off
+              pip install imageio imageio-ffmpeg
+              git submodule update --init --recursive --jobs 8
+              python -u setup.py install --build-type "Release" --lto --headless --audio
+              python examples/tutorials/audio_agent.py
+      - save_cache:
+          key: ccache-{{ arch }}-{{ .Branch }}-{{ .BuildNum }}
+          background: true
+          paths:
+            - /home/circleci/.ccache
+      # Uploading test coverage again for code changed by the above rebuild.
+      # TODO: https://github.com/facebookresearch/habitat-sim/pull/1860 fixes
+      # this better, remove once it's merged
+      - run: *upload_coverage
 
 
 


### PR DESCRIPTION
## Motivation and Context

Builds on `main` are getting a lot of these errors due to the coverage being collected after the Audio build (originating from https://github.com/facebookresearch/habitat-sim/pull/1646), losing the coverage collected earlier:

> libgcov profiling error:/home/circleci/project/habitat-sim/build/esp/bindings/CMakeFiles/habitat_sim_bindings.dir/Bindings.cpp.gcda:overwriting an existing profile data with a different timestamp

With this change the coverage is back at 60% (from 40%), and still includes also everything from the Audio build.

The better long-term solution, however, would be like something in https://github.com/facebookresearch/habitat-sim/pull/1860 -- this unnecessarily duplicates a lot of the CI setup code. (@Skylion007 or anybody else who knows YAML or CircleCI, do you know if there is a possibility to reuse / deduplicate the markup somehow?)

## How Has This Been Tested

Comparing these two reports gives a ~20% increase in code coverage:

- https://app.codecov.io/gh/facebookresearch/habitat-sim/tree/main/src/esp
- https://app.codecov.io/gh/facebookresearch/habitat-sim/tree/codecov-gimme-back-those-20-percent/src/esp

As far as I checked, the Audio build coverage (such as `src/esp/sensor/AudioSensor.cpp`) seems to stay the same, so the second coverage upload gets merged with the first one. That's only from a cursory look though, if you see anything suspicious in the new reports, let me know.
