### PR TITLE
Better colors for "info" and "success" notes in the documentation and website

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -261,11 +261,7 @@ TAB_SIZE               = 4
 # commands \{ and \} for these it is advised to use the version @{ and @} or use
 # a double escape (\\{ and \\})
 
-ALIASES                = \
-    "cb{1}=@code{\1}" \
-    "cpp=@code{.cpp}" \
-    "cmake=@code{.cmake}" \
-    "ce=@endcode"
+ALIASES                =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -2137,7 +2133,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = CORRADE_UNUSED=
+PREDEFINED             = DOXYGEN_GENERATING_OUTPUT \
+    CORRADE_UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/Doxyfile-mcss
+++ b/docs/Doxyfile-mcss
@@ -40,6 +40,7 @@ ALIASES                = \
     "cpp=@code{.cpp}" \
     "glsl=@code{.glsl}" \
     "cmake=@code{.cmake}" \
+    "relativeref{2}=@ref \1::\2 \"\2\"" \
     "ce=@endcode" \
     "m_div{1}=@xmlonly<mcss:div xmlns:mcss=\"http://mcss.mosra.cz/doxygen/\" mcss:class=\"\1\">@endxmlonly" \
     "m_enddiv=@xmlonly</mcss:div>@endxmlonly" \

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,3 +71,18 @@ nano Doxyfile # modify it to have GENERATE_TAGFILE = bullet.tag
 doxygen # it'll complain about some CHM file, ignore that
 cp bullet.tag ../habitat-sim/docs/
 ```
+
+### Updating the CSS theme, refreshing the compiled version of it
+
+Make your changes to `theme.css`. Easiest is to experiment in a browser
+inspector and then copy the updated colors over to the theme file. Note that
+the color variables are shared by multiple places, so for example changing
+colors of the warning note will also affect labels and table backgrounds.
+
+Then, run `./build.sh` (which regenerates `theme-compiled.css`, which is
+deliberately *not* tracked in Git) and verify the generated output in the
+browser again.
+
+The `theme.css` should then get synced with the `habitat-lab` and
+`habitat-website` repositories so it's always possible to play with the colors
+in context of one repository and sync it to the others.

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -97,10 +97,10 @@
 
   --success-color: #3bd267;
   --success-link-active-color: #acecbe;
-  --success-filled-color: #acecbe;
-  --success-filled-background-color: #2a703f;
-  --success-filled-link-color: #3bd267;
-  --success-filled-link-active-color: #acecbe;
+  --success-filled-color: #2a703f;
+  --success-filled-background-color: #d9efdf;
+  --success-filled-link-color: #00cf3c;
+  --success-filled-link-active-color: #53e97d;
 
   --warning-color: #6d7207;
   --warning-link-active-color: #e9ecae;
@@ -118,8 +118,8 @@
 
   --info-color: #2f83cc;
   --info-link-active-color: #5297d7;
-  --info-filled-color: #a5caeb;
-  --info-filled-background-color: #2a4f70;
+  --info-filled-color: #2a4f70;
+  --info-filled-background-color: #d7ebfe;
   --info-filled-link-color: #5297d7;
   --info-filled-link-active-color: #a5caeb;
 


### PR DESCRIPTION
## Motivation and Context

Sorry for opening too many PRs lately :D I was in the process of writing high-level docs for the batch renderer in #1874, submitted #1889 for doc updates already, but then wanted to put some note blocks into the doc copy, realized they look kinda awful, and had to fix those too. Before:

<img src="https://user-images.githubusercontent.com/344828/194379598-bf389928-31df-47f0-9246-883d36f3fc65.png" width="400">

After:

<img src="https://user-images.githubusercontent.com/344828/194379633-18ce1c3f-0402-417a-9a48-4b3feda55700.png" width="400">

The "warning" note was good enough already, but apparently those two were never used so far so they still had the dark theme colors. I didn't spend time updating the remaining color styles for "primary" and "danger" as I don't need them at the moment, and this was enough of a detour already :sweat_smile: Same for #1812, originally I wanted to merge those changes with mine, but the font and spacing changes felt like a lot more time investment would be needed to get things look consistent again, so I didn't either. The two PRs don't conflict with each other, at least.

Also updated the m.css submodule to latest, because why not, and added a note into the documentation README about updating CSS colors. Reverting a change from #1889 that added a few new Doxygen aliases, as those were present in `Doxyfile-mcss` already; added a new alias for relative references that look shorter in the output, and added a predefined `DOXYGEN_GENERATING_OUTPUT` macro for hiding internal and nasty-looking code from Doxygen.

Once merged, I'll transfer the CSS changes to the lab and website repos.

## How Has This Been Tested

See screenshots above.
