### PR TITLE
Assorted fixes for more robust handling of asset corner cases

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -169,7 +169,7 @@ void ResourceManager::initDefaultPrimAttributes() {
     return;
   }
 
-  ConfigureImporterManagerGLExtensions();
+  configureImporterManagerGLExtensions();
   // by this point, we should have a GL::Context so load the bb primitive.
   // TODO: replace this completely with standard mesh (i.e. treat the bb
   // wireframe cube no differently than other primitive-based rendered
@@ -1523,7 +1523,7 @@ bool ResourceManager::loadRenderAssetSemantic(const AssetInfo& info) {
   const std::string& filename = info.filepath;
 
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
-  ConfigureImporterManagerGLExtensions();
+  configureImporterManagerGLExtensions();
 
   /* Open the file. On error the importer already prints a diagnostic message,
      so no need to do that here. The importer implicitly converts per-face
@@ -1632,13 +1632,16 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceVertSemantic(
   return instanceRoot;
 }  // ResourceManager::createRenderAssetInstanceVertSemantic
 
-void ResourceManager::ConfigureImporterManagerGLExtensions() {
+void ResourceManager::configureImporterManagerGLExtensions() {
   if (!getCreateRenderer()) {
     return;
   }
 
   Cr::PluginManager::PluginMetadata* const metadata =
       importerManager_.metadata("BasisImporter");
+  if (!metadata)
+    return;
+
   Mn::GL::Context& context = Mn::GL::Context::current();
 #ifdef MAGNUM_TARGET_WEBGL
   if (context.isExtensionSupported<
@@ -1709,7 +1712,7 @@ void ResourceManager::ConfigureImporterManagerGLExtensions() {
   }
 #endif
 
-}  // ResourceManager::ConfigureImporterManagerGLExtensions
+}  // ResourceManager::configureImporterManagerGLExtensions
 
 namespace {
 
@@ -1738,7 +1741,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
 
   const std::string& filename = info.filepath;
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
-  ConfigureImporterManagerGLExtensions();
+  configureImporterManagerGLExtensions();
 
   ESP_CHECK(
       (fileImporter_->openFile(filename) && (fileImporter_->meshCount() > 0u)),

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1758,9 +1758,9 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   auto inserted = resourceDict_.emplace(filename, std::move(loadedAssetData));
   MeshMetaData& meshMetaData = inserted.first->second.meshMetaData;
 
-  // no default scene --- standalone OBJ/PLY files, for example
+  // no scenes --- standalone OBJ/PLY files, for example
   // take a wild guess and load the first mesh with the first material
-  if (fileImporter_->defaultScene() == -1) {
+  if (!fileImporter_->sceneCount()) {
     if ((fileImporter_->meshCount() != 0u) &&
         meshes_.at(meshMetaData.meshIndex.first)) {
       meshMetaData.root.children.emplace_back();
@@ -1772,9 +1772,11 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
     }
   }
 
-  /* Load the scene */
+  /* Load the scene. If no default scene is specified, use the first one. */
   Cr::Containers::Optional<Mn::Trade::SceneData> scene;
-  if (!(scene = fileImporter_->scene(fileImporter_->defaultScene())) ||
+  if (!(scene = fileImporter_->scene(fileImporter_->defaultScene() == -1
+                                         ? 0
+                                         : fileImporter_->defaultScene())) ||
       !scene->is3D() || !scene->hasField(Mn::Trade::SceneField::Parent)) {
     ESP_ERROR() << "Cannot load scene, exiting";
     return false;

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -762,7 +762,7 @@ class ResourceManager {
    * compilation flags, before any general assets are imported.  This should
    * only occur if a gl context exists.
    */
-  void ConfigureImporterManagerGLExtensions();
+  void configureImporterManagerGLExtensions();
 
  protected:
   // ======== Structs and Types only used locally ========

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -29,7 +29,15 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
       materialData_{
           shaderManager.get<MaterialData, PhongMaterialData>(materialDataKey)} {
   flags_ = Mn::Shaders::PhongGL::Flag::ObjectId;
-  if (materialData_->textureMatrix != Mn::Matrix3{}) {
+
+  /* If texture transformation is specified, enable it only if the material is
+     actually textured -- it's an error otherwise */
+  if (materialData_->textureMatrix != Mn::Matrix3{} &&
+     (materialData_->ambientTexture ||
+      materialData_->diffuseTexture ||
+      materialData_->specularTexture ||
+      materialData_->specularTexture ||
+      materialData_->textureObjectId)) {
     flags_ |= Mn::Shaders::PhongGL::Flag::TextureTransformation;
   }
   if (materialData_->ambientTexture) {

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -33,11 +33,9 @@ GenericDrawable::GenericDrawable(scene::SceneNode& node,
   /* If texture transformation is specified, enable it only if the material is
      actually textured -- it's an error otherwise */
   if (materialData_->textureMatrix != Mn::Matrix3{} &&
-     (materialData_->ambientTexture ||
-      materialData_->diffuseTexture ||
-      materialData_->specularTexture ||
-      materialData_->specularTexture ||
-      materialData_->textureObjectId)) {
+      (materialData_->ambientTexture || materialData_->diffuseTexture ||
+       materialData_->specularTexture || materialData_->specularTexture ||
+       materialData_->textureObjectId)) {
     flags_ |= Mn::Shaders::PhongGL::Flag::TextureTransformation;
   }
   if (materialData_->ambientTexture) {


### PR DESCRIPTION
## Motivation and Context

- Enables shader texture transform only if it's actually textured. If it's not (for example if a texture failed to load or if the material data are strange in some way), then the shader construction would assert with
    
      Shaders::PhongGL: texture transformation enabled but the shader is not textured

  This change *doesn't* fix any root causes of a texture missing or failing to load, it only makes it not abort anymore. ~~Also removed a now-irrelevant TODO and a branch in flat material data setup -- that check should have been done in the shader setup code in the first place anyway, which is how it's done now.~~ The TODO was about a different thing, reverted that back.
- Fixed a crash if the `BasisImporter` plugin wouldn't be present for whatever reason. (I disabled it in order to be able to test the above assert, and discovered this crash.)
- And fixed a case where files without a default scene would be treated as having no scene at all. This is the case for example with glTF files produced by `gltfpack`.

## How Has This Been Tested

With the `BasisImporter` plugin disabled, loading gltfpack-produced files shared by @mukulkhanna no longer dies with the above shader assertion.

Originally the assertion was a consequence of this error:

```
Trade::AnyImageImporter::openData(): cannot load the KtxImporter plugin
```

... which as far as I can tell isn't reproducible on current `main` anymore. It was fixed by https://github.com/mosra/magnum/commit/569ae5a195f768ecaec4b827f5f66be28e6ee899 (which delegates to `BasisImporter` if `KtxImporter` isn't found), which was merged into Habitat with https://github.com/facebookresearch/habitat-sim/pull/1853.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)