### PR TITLE
(perf): Improve codebase by adding std::move on last use of object

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -48,6 +48,7 @@
 #include <Magnum/VertexFormat.h>
 
 #include <memory>
+#include <utility>
 
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/CollisionMeshData.h"
@@ -1295,7 +1296,7 @@ void ResourceManager::buildPrimitiveAssetData(
   // set the root rotation to world frame upon load
   meshMetaData.setRootFrameOrientation(info.frame);
   // make LoadedAssetData corresponding to this asset
-  LoadedAssetData loadedAssetData{info, meshMetaData};
+  LoadedAssetData loadedAssetData{std::move(info), std::move(meshMetaData)};
   auto inserted =
       resourceDict_.emplace(primAssetHandle, std::move(loadedAssetData));
 
@@ -1979,7 +1980,7 @@ bool ResourceManager::buildTrajectoryVisualization(
   meshMetaData.setRootFrameOrientation(info.frame);
 
   // make LoadedAssetData corresponding to this asset
-  LoadedAssetData loadedAssetData{info, meshMetaData};
+  LoadedAssetData loadedAssetData{std::move(info), std::move(meshMetaData)};
   // TODO : need to free render assets associated with this object if
   // collision occurs, otherwise leak! (Currently unsupported).
   // if (resourceDict_.count(trajVisName) != 0) {

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -107,7 +107,7 @@ class ManagedContainer : public ManagedContainerBase {
     if (nullptr == object) {
       return nullptr;
     }
-    return this->postCreateRegister(object, registerObject);
+    return this->postCreateRegister(std::move(object), registerObject);
   }  // ManagedContainer::createDefault
 
   /**
@@ -135,7 +135,7 @@ class ManagedContainer : public ManagedContainerBase {
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
-      return registerObjectFinalize(managedObject, objectHandle,
+      return registerObjectFinalize(std::move(managedObject), objectHandle,
                                     forceRegistration);
     }
     std::string handleToSet = managedObject->getHandle();
@@ -146,7 +146,7 @@ class ManagedContainer : public ManagedContainerBase {
           << this->objectType_ << " managed object. Aborting.";
       return ID_UNDEFINED;
     }
-    return registerObjectFinalize(managedObject, handleToSet,
+    return registerObjectFinalize(std::move(managedObject), handleToSet,
                                   forceRegistration);
   }  // ManagedContainer::registerObject
 

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -77,7 +77,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     // convert doc to const value
     const io::JsonGenericValue config = docConfig->GetObject();
     ManagedFileIOPtr attr = this->buildManagedObjectFromDoc(filename, config);
-    return this->postCreateRegister(attr, registerObject);
+    return this->postCreateRegister(std::move(attr), registerObject);
   }  // ManagedFileBasedContainer::createObjectFromJSONFile
 
   /**

--- a/src/esp/io/Json.h
+++ b/src/esp/io/Json.h
@@ -72,7 +72,7 @@ bool jsonIntoSetter(const JsonGenericValue& d,
                     std::function<void(T)> setter) {
   T val;
   if (readMember(d, tag, val)) {
-    setter(val);
+    setter(std::move(val));
     return true;
   }
   return false;

--- a/src/esp/metadata/attributes/LightLayoutAttributes.cpp
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.cpp
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "LightLayoutAttributes.h"
+
+#include <utility>
 using Magnum::Math::Literals::operator""_radf;
 using Magnum::Math::Literals::operator""_degf;
 
@@ -82,8 +84,7 @@ LightLayoutAttributes& LightLayoutAttributes::operator=(
     LightLayoutAttributes&& otr) noexcept {
   // point to our own light instance config and available ids
   availableLightIDs_ = std::move(otr.availableLightIDs_);
-  this->AbstractAttributes::operator=(
-      std::move(static_cast<AbstractAttributes>(otr)));
+  this->AbstractAttributes::operator=(static_cast<AbstractAttributes&&>(otr));
   lightInstConfig_ = editSubconfig<Configuration>("lights");
   return *this;
 }

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "SceneInstanceAttributes.h"
+
+#include <utility>
 #include "esp/physics/RigidBase.h"
 namespace esp {
 namespace metadata {
@@ -315,8 +317,7 @@ SceneInstanceAttributes& SceneInstanceAttributes::operator=(
     SceneInstanceAttributes&& otr) noexcept {
   availableObjInstIDs_ = std::move(otr.availableObjInstIDs_);
   availableArtObjInstIDs_ = std::move(otr.availableArtObjInstIDs_);
-  this->AbstractAttributes::operator=(
-      std::move(static_cast<AbstractAttributes>(otr)));
+  this->AbstractAttributes::operator=(static_cast<AbstractAttributes&&>(otr));
 
   objInstConfig_ = editSubconfig<Configuration>("object_instances");
   artObjInstConfig_ =

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -367,8 +367,8 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
         (oldFName != assetName)) {
       // if mesh name is specified and different than old value,
       // perform name-specific mesh-type config.
-      setDefaultAssetNameBasedAttributes(attributes, false, assetName,
-                                         meshTypeSetter);
+      setDefaultAssetNameBasedAttributes(std::move(attributes), false,
+                                         assetName, meshTypeSetter);
     } else {
       // is not valid primitive, assume valid file name
       assetName = Cr::Utility::Path::join(propertiesFileDirectory, assetName);
@@ -376,8 +376,8 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
         // if file name is different, and type val has not been specified,
         // perform name-specific mesh type config do not override orientation
         // - should be specified in json.
-        setDefaultAssetNameBasedAttributes(attributes, false, assetName,
-                                           meshTypeSetter);
+        setDefaultAssetNameBasedAttributes(std::move(attributes), false,
+                                           assetName, meshTypeSetter);
       }
     }  // value is valid prim and exists, else value is valid file and exists
     return assetName;

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -5,6 +5,8 @@
 #include <Corrade/Containers/StaticArray.h>
 #include <Corrade/Utility/String.h>
 
+#include <utility>
+
 #include "AssetAttributesManager.h"
 #include "AttributesManagerBase.h"
 
@@ -123,7 +125,8 @@ AbstractPrimitiveAttributes::ptr AssetAttributesManager::createObject(
       << primAssetAttributes->getHandle() << ") created"
       << (registerTemplate ? " and registered." : ".");
 
-  return this->postCreateRegister(primAssetAttributes, registerTemplate);
+  return this->postCreateRegister(std::move(primAssetAttributes),
+                                  registerTemplate);
 }  // AssetAttributesManager::createObject
 
 attributes::AbstractPrimitiveAttributes::ptr
@@ -161,7 +164,8 @@ AssetAttributesManager::createTemplateFromHandle(
                     << primAssetAttributes->getHandle() << ".";
     }
   }
-  return this->postCreateRegister(primAssetAttributes, registerTemplate);
+  return this->postCreateRegister(std::move(primAssetAttributes),
+                                  registerTemplate);
 }  // AssetAttributesManager::createTemplateFromHandle
 
 int AssetAttributesManager::registerObjectFinalize(
@@ -181,8 +185,8 @@ int AssetAttributesManager::registerObjectFinalize(
 
   // return either the ID of the existing template referenced by
   // primAttributesHandle, or the next available ID if not found.
-  int primTemplateID =
-      this->addObjectToLibrary(primAttributesTemplate, primAttributesHandle);
+  int primTemplateID = this->addObjectToLibrary(
+      std::move(primAttributesTemplate), primAttributesHandle);
   return primTemplateID;
 }  // AssetAttributesManager::registerObjectFinalize
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -7,6 +7,8 @@
 
 #include <Corrade/Utility/String.h>
 
+#include <utility>
+
 #include "esp/assets/Asset.h"
 #include "esp/io/Json.h"
 
@@ -53,7 +55,8 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   // collision primitive mesh needs to be configured and set in MeshMetaData
   // and CollisionMesh
 
-  return this->postCreateRegister(primObjectAttributes, registerTemplate);
+  return this->postCreateRegister(std::move(primObjectAttributes),
+                                  registerTemplate);
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
 void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
@@ -284,7 +287,7 @@ int ObjectAttributesManager::registerObjectFinalize(
 
   // Add object template to template library
   int objectTemplateID =
-      this->addObjectToLibrary(objectTemplate, objectTemplateHandle);
+      this->addObjectToLibrary(std::move(objectTemplate), objectTemplateHandle);
 
   if (mapToUse != nullptr) {
     mapToUse->emplace(objectTemplateID, objectTemplateHandle);

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -5,6 +5,8 @@
 #ifndef ESP_METADATA_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
 #define ESP_METADATA_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
 
+#include <utility>
+
 #include "AttributesManagerBase.h"
 
 #include "ObjectAttributesManager.h"
@@ -133,8 +135,8 @@ class PhysicsAttributesManager
     // adds template to library, and returns either the ID of the existing
     // template referenced by physicsAttributesHandle, or the next available ID
     // if not found.
-    int physicsTemplateID = this->addObjectToLibrary(physicsAttributesTemplate,
-                                                     physicsAttributesHandle);
+    int physicsTemplateID = this->addObjectToLibrary(
+        std::move(physicsAttributesTemplate), physicsAttributesHandle);
     return physicsTemplateID;
   }  // PhysicsAttributesManager::registerObjectFinalize
 

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -4,6 +4,8 @@
 
 #include "SceneDatasetAttributesManager.h"
 
+#include <utility>
+
 #include "esp/io/Json.h"
 
 namespace esp {
@@ -491,7 +493,7 @@ int SceneDatasetAttributesManager::registerObjectFinalize(
   // template referenced by SceneDatasetAttributesHandle, or the next
   // available ID if not found.
   int datasetTemplateID = this->addObjectToLibrary(
-      SceneDatasetAttributes, SceneDatasetAttributesHandle);
+      std::move(SceneDatasetAttributes), SceneDatasetAttributesHandle);
   return datasetTemplateID;
 }  // SceneDatasetAttributesManager::registerObjectFinalize
 

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -462,7 +462,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // object is available now. Modify it using json tag data
     attrMgr->setValsFromJSONDoc(attr, jCell["attributes"]);
     // register object
-    attrMgr->registerObject(attr, regHandle);
+    attrMgr->registerObject(std::move(attr), regHandle);
   } else {  // orig file name not specified, create a new object
     // create a default object
     auto attr = attrMgr->createDefaultObject(newTemplateHandle, false);
@@ -481,7 +481,7 @@ void SceneDatasetAttributesManager::readDatasetConfigsJSONCell(
     // default object is available now. Modify it using json tag data
     attrMgr->setValsFromJSONDoc(attr, jCell["attributes"]);
     // register object
-    attrMgr->registerObject(attr, regHandle);
+    attrMgr->registerObject(std::move(attr), regHandle);
   }  // if original filename was specified else
 }  // SceneDatasetAttributesManager::readDatasetConfigsJSONCell
 

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -5,6 +5,8 @@
 #include "SceneInstanceAttributesManager.h"
 
 #include <Corrade/Utility/FormatStl.h>
+
+#include <utility>
 #include "esp/metadata/MetadataUtils.h"
 #include "esp/physics/RigidBase.h"
 
@@ -334,7 +336,7 @@ int SceneInstanceAttributesManager::registerObjectFinalize(
   // template referenced by sceneInstanceAttributesHandle, or the next available
   // ID if not found.
   int datasetTemplateID = this->addObjectToLibrary(
-      sceneInstanceAttributes, sceneInstanceAttributesHandle);
+      std::move(sceneInstanceAttributes), sceneInstanceAttributesHandle);
   return datasetTemplateID;
 }  // SceneInstanceAttributesManager::registerObjectFinalize
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -124,8 +124,8 @@ int StageAttributesManager::registerObjectFinalize(
   // adds template to library, and returns either the ID of the existing
   // template referenced by stageAttributesHandle, or the next available ID
   // if not found.
-  int stageTemplateID =
-      this->addObjectToLibrary(stageAttributes, stageAttributesHandle);
+  int stageTemplateID = this->addObjectToLibrary(std::move(stageAttributes),
+                                                 stageAttributesHandle);
   return stageTemplateID;
 }  // StageAttributesManager::registerAttributesTemplate
 
@@ -156,7 +156,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
   // collision primitive mesh needs to be configured and set in MeshMetaData
   // and CollisionMesh
 
-  return this->postCreateRegister(stageAttributes, registerTemplate);
+  return this->postCreateRegister(std::move(stageAttributes), registerTemplate);
 }  // StageAttributesManager::createPrimBasedAttributesTemplate
 
 StageAttributes::ptr StageAttributesManager::initNewObjectInternal(

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -22,6 +22,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>
+#include <utility>
 
 #include "esp/assets/MeshData.h"
 #include "esp/core/Esp.h"
@@ -1583,7 +1584,7 @@ HitRecord PathFinder::Impl::closestObstacleSurfacePoint(
   navQuery_->findDistanceToWall(ptRef, polyPt.data(), maxSearchRadius,
                                 filter_.get(), &hitDist, hitPos.data(),
                                 hitNormal.data());
-  return {hitPos, hitNormal, hitDist};
+  return {std::move(hitPos), std::move(hitNormal), hitDist};
 }
 
 bool PathFinder::Impl::isNavigable(const vec3f& pt,

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1494,7 +1494,7 @@ T PathFinder::Impl::tryStep(const T& start, const T& end, bool allowSliding) {
     endPoint = endPoint + nudgeDistance * nudgeDir;
   }
 
-  return T{endPoint};
+  return T{std::move(endPoint)};
 }
 
 template <typename T>
@@ -1527,7 +1527,7 @@ T PathFinder::Impl::snapPoint(const T& pt, int islandIndex /*=ID_UNDEFINED*/) {
   }
 
   if (dtStatusSucceed(status)) {
-    return T{projectedPt};
+    return T{std::move(projectedPt)};
   }
   return {Mn::Constants::nan(), Mn::Constants::nan(), Mn::Constants::nan()};
 }

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -4,6 +4,8 @@
 
 #include "PhysicsManager.h"
 #include <Magnum/Math/Range.h>
+
+#include <utility>
 #include "esp/assets/CollisionMeshData.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
@@ -296,7 +298,7 @@ int PhysicsManager::addObject(
   objWrapper->setObjectRef(existingObjects_.at(nextObjectID_));
 
   // 4.0 register wrapper in manager
-  rigidObjectManager_->registerObject(objWrapper, newObjectHandle);
+  rigidObjectManager_->registerObject(std::move(objWrapper), newObjectHandle);
 
   return nextObjectID_;
 }  // PhysicsManager::addObject

--- a/src/esp/physics/bullet/BulletCollisionHelper.cpp
+++ b/src/esp/physics/bullet/BulletCollisionHelper.cpp
@@ -7,6 +7,7 @@
 #include "BulletCollisionHelper.h"
 
 #include <sstream>
+#include <utility>
 
 namespace esp {
 namespace physics {
@@ -93,7 +94,7 @@ std::string BulletCollisionHelper::getDebugStringForCollisionObject(
     result += ", no broadphase handle";
   }
 #else
-  std::string result = name;
+  std::string result = std::move(name);
 #endif
   return result;
 }

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -6,6 +6,8 @@
 //#include "BulletCollision/Gimpact/btGImpactShape.h"
 
 #include "BulletPhysicsManager.h"
+
+#include <utility>
 #include "BulletArticulatedObject.h"
 #include "BulletDynamics/Featherstone/btMultiBodyLinkCollider.h"
 #include "BulletRigidObject.h"
@@ -223,7 +225,8 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
       existingArticulatedObjects_.at(articulatedObjectID));
 
   // 4.0 register wrapper in manager
-  articulatedObjectManager_->registerObject(AObjWrapper, newArtObjectHandle);
+  articulatedObjectManager_->registerObject(std::move(AObjWrapper),
+                                            newArtObjectHandle);
 
   return articulatedObjectID;
 }  // BulletPhysicsManager::addArticulatedObjectFromURDF

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -128,7 +128,7 @@ class PhysicsObjectBaseManager
                              const std::string& objectHandle,
                              CORRADE_UNUSED bool forceRegistration) override {
     // Add wrapper to template library
-    return this->addObjectToLibrary(object, objectHandle);
+    return this->addObjectToLibrary(std::move(object), objectHandle);
   }  // PhysicsObjectBaseManager::registerObjectFinalize
 
   /**

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1179,7 +1179,7 @@ agent::Agent::ptr Simulator::addAgent(
         return pathfinder_->tryStepNoSliding(start, end);
       };
     }
-    ag->getControls()->setMoveFilterFunction(moveFilterFunction);
+    ag->getControls()->setMoveFilterFunction(std::move(moveFilterFunction));
   }
 
   return ag;


### PR DESCRIPTION
## Motivation and Context
* I found a new clang-tidy check in that is being proposed and decided to give it an early try. I went through all the fixes manually and removed any false positives. This should get rid of of most of the unnecessary copies left in the codebase.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and with Clang-Tidy
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
