### PR TITLE
[bugfix] - skip non-triangle mesh primitives in mesh join for navmesh recomputation

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2971,12 +2971,17 @@ void ResourceManager::joinHierarchy(
         meshes_.at(node.meshIDLocal + metaData.meshIndex.first)
             ->getCollisionMeshData();
     int lastIndex = mesh.vbo.size();
-    for (const auto& pos : meshData.positions) {
-      mesh.vbo.push_back(Mn::EigenIntegration::cast<vec3f>(
-          transformFromLocalToWorld.transformPoint(pos)));
-    }
-    for (const auto& index : meshData.indices) {
-      mesh.ibo.push_back(index + lastIndex);
+    if (meshData.primitive != Mn::MeshPrimitive::Triangles) {
+      ESP_WARNING() << "Unsupported mesh primitive in join: "
+                    << meshData.primitive << Mn::Debug::nospace << ", skipping";
+    } else {
+      for (const auto& pos : meshData.positions) {
+        mesh.vbo.push_back(Mn::EigenIntegration::cast<vec3f>(
+            transformFromLocalToWorld.transformPoint(pos)));
+      }
+      for (const auto& index : meshData.indices) {
+        mesh.ibo.push_back(index + lastIndex);
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation and Context

@mosra fixed a bug with non-triangle primitive support in #1888. This worked for physics, but was not being applied to navmesh recomputation resulting in artifacts for affected scenes. See [comments ](https://github.com/facebookresearch/habitat-sim/pull/1888#issuecomment-1312803701)for details. 

## How Has This Been Tested

Locally with FP scene 102816627.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
