### PR TITLE
[ci] - Don't cache habitat-lab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,9 +157,9 @@ commands:
                 npm install
                 touch ~/npm_deps_installed
               fi
-      - restore_cache:
-          keys:
-            - habitat-lab-{{ checksum "./hablab_sha" }}
+      #- restore_cache:
+      #    keys:
+      #      - habitat-lab-{{ checksum "./hablab_sha" }}
       - restore_cache: &ccache_cache
           keys:
             - ccache-{{ arch }}-{{ .Branch }}-{{ .BuildNum }}

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -298,6 +298,7 @@ def initialize_test_data_sources(data_path):
             "coda_scene",
             "replica_cad_dataset",
             "hab_fetch",
+            "hab_stretch",
         ],
         "rearrange_task_assets": [
             "replica_cad_dataset",


### PR DESCRIPTION
## Motivation and Context

For some reason habitat-lab caching was broken resulting in a stale commit failing tests. For now we'll not cache while we figure out the issue.

Note: also adds hab_stretch to ci_test_assets as required by new lab tests.

## How Has This Been Tested

CI is passing again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
