### PR TITLE
chore: Add a few missing std::move to shared_ptr. 

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -106,10 +106,10 @@ using Mn::Trade::MaterialAttribute;
 namespace assets {
 
 ResourceManager::ResourceManager(
-    metadata::MetadataMediator::ptr& _metadataMediator,
+    metadata::MetadataMediator::ptr _metadataMediator,
     Flags _flags)
     : flags_(_flags),
-      metadataMediator_(_metadataMediator)
+      metadataMediator_(std::move(_metadataMediator))
 #ifdef MAGNUM_BUILD_STATIC
       ,
       // avoid using plugins that might depend on different library versions

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -616,9 +616,8 @@ class ResourceManager {
    * @brief Set a replay recorder so that ResourceManager can notify it about
    * render assets.
    */
-  void setRecorder(
-      const std::shared_ptr<gfx::replay::Recorder>& gfxReplayRecorder) {
-    gfxReplayRecorder_ = gfxReplayRecorder;
+  void setRecorder(std::shared_ptr<gfx::replay::Recorder> gfxReplayRecorder) {
+    gfxReplayRecorder_ = std::move(gfxReplayRecorder);
   }
 
   /**

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -139,7 +139,7 @@ class ResourceManager {
 
   /** @brief Constructor */
   explicit ResourceManager(
-      std::shared_ptr<metadata::MetadataMediator>& _metadataMediator,
+      std::shared_ptr<metadata::MetadataMediator> _metadataMediator,
       Flags flags = {});
 
   /** @brief Destructor */

--- a/src/esp/gfx/replay/ReplayManager.h
+++ b/src/esp/gfx/replay/ReplayManager.h
@@ -24,8 +24,8 @@ class ReplayManager {
    * @brief Optionally make a Recorder instance available to python, or pass
    * nullptr.
    */
-  void setRecorder(const std::shared_ptr<Recorder>& writer) {
-    recorder_ = writer;
+  void setRecorder(std::shared_ptr<Recorder> writer) {
+    recorder_ = std::move(writer);
   }
 
   /**

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -32,9 +32,7 @@ class AbstractManagedPhysicsObject
     AbstractManagedPhysicsObject::setClassKey(classKey);
   }
 
-  void setObjectRef(std::shared_ptr<T> objRef) {
-    weakObjRef_ = std::move(objRef);
-  }
+  void setObjectRef(const std::shared_ptr<T>& objRef) { weakObjRef_ = objRef; }
 
   ~AbstractManagedPhysicsObject() override = default;
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -32,7 +32,9 @@ class AbstractManagedPhysicsObject
     AbstractManagedPhysicsObject::setClassKey(classKey);
   }
 
-  void setObjectRef(const std::shared_ptr<T>& objRef) { weakObjRef_ = objRef; }
+  void setObjectRef(std::shared_ptr<T> objRef) {
+    weakObjRef_ = std::move(objRef);
+  }
 
   ~AbstractManagedPhysicsObject() override = default;
 


### PR DESCRIPTION
## Motivation and Context
* This prevents some unnecessary atomic increments and decrements of a shared pointer. We only ever appear to pass the shared pointer by value anyway so this should be more efficient. The previous version of the code always performed a copy.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
