### PR TITLE
Assorted updates to the batch renderer

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -180,22 +180,22 @@ struct RenderTarget::Impl {
 
   void renderExit() {}
 
-  void blitRgbaToDefault() {
+  void blitRgbaTo(Mn::GL::AbstractFramebuffer& target,
+                  const Mn::Range2Di& targetRectangle) {
     CORRADE_ASSERT(
         flags_ & Flag::RgbaAttachment,
         "RenderTarget::Impl::blitRgbaToDefault(): this render target "
         "was not created with rgba render buffer enabled.", );
     CORRADE_ASSERT(
-        framebuffer_.viewport() == Mn::GL::defaultFramebuffer.viewport(),
-        "RenderTarget::Impl::blitRgbaToDefault(): the viewport size does not "
-        "match "
-        "between the internal frame buffer and the default frame buffer", );
+        framebuffer_.viewport().size() == targetRectangle.size(),
+        "RenderTarget::Impl::blitRgbaTo(): target framebuffer has a size of"
+            << targetRectangle.size() << "but expected"
+            << framebuffer_.viewport().size(), );
 
     framebuffer_.mapForRead(RgbaBufferAttachment);
     Mn::GL::AbstractFramebuffer::blit(
-        framebuffer_, Mn::GL::defaultFramebuffer, framebuffer_.viewport(),
-        Mn::GL::defaultFramebuffer.viewport(), Mn::GL::FramebufferBlit::Color,
-        Mn::GL::FramebufferBlitFilter::Nearest);
+        framebuffer_, target, framebuffer_.viewport(), targetRectangle,
+        Mn::GL::FramebufferBlit::Color, Mn::GL::FramebufferBlitFilter::Nearest);
   }
 
   void readFrameRgba(const Mn::MutableImageView2D& view) {
@@ -404,8 +404,14 @@ void RenderTarget::readFrameObjectId(const Mn::MutableImageView2D& view) {
   pimpl_->readFrameObjectId(view);
 }
 
+void RenderTarget::blitRgbaTo(Mn::GL::AbstractFramebuffer& target,
+                              const Mn::Range2Di& targetRectangle) {
+  pimpl_->blitRgbaTo(target, targetRectangle);
+}
+
 void RenderTarget::blitRgbaToDefault() {
-  pimpl_->blitRgbaToDefault();
+  pimpl_->blitRgbaTo(Mn::GL::defaultFramebuffer,
+                     Mn::GL::defaultFramebuffer.viewport());
 }
 
 Mn::Vector2i RenderTarget::framebufferSize() const {

--- a/src/esp/gfx/RenderTarget.h
+++ b/src/esp/gfx/RenderTarget.h
@@ -146,6 +146,13 @@ class RenderTarget {
   void readFrameObjectId(const Magnum::MutableImageView2D& view);
 
   /**
+   * @brief Blits the rgba buffer from internal FBO to given framebuffer
+   * rectangle
+   */
+  void blitRgbaTo(Magnum::GL::AbstractFramebuffer& target,
+                  const Magnum::Range2Di& targetRectangle);
+
+  /**
    * @brief Blits the rgba buffer from internal FBO to default frame buffer
    * which in case of EmscriptenApplication will be a canvas element.
    */

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -379,7 +379,7 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
             importer->image3DLevelCount(textureData->image());
         Cr::Containers::Optional<Mn::Trade::ImageData3D> image =
             importer->image3D(textureData->image());
-        if (!textureData) {
+        if (!image) {
           Mn::Error{} << "Renderer::addFile(): can't import 3D image"
                       << textureData->image() << "of" << filename;
           return {};
@@ -415,7 +415,7 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
             importer->image2DLevelCount(textureData->image());
         Cr::Containers::Optional<Mn::Trade::ImageData2D> image =
             importer->image2D(textureData->image());
-        if (!textureData) {
+        if (!image) {
           Mn::Error{} << "Renderer::addFile(): can't import 2D image"
                       << textureData->image() << "of" << filename;
           return {};

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -756,7 +756,7 @@ bool Renderer::hasMeshHierarchy(const Cr::Containers::StringView name) const {
 
 std::size_t Renderer::addMeshHierarchy(const Mn::UnsignedInt sceneId,
                                        const Cr::Containers::StringView name,
-                                       const Mn::Matrix4& transformation) {
+                                       const Mn::Matrix4& bakeTransformation) {
   CORRADE_ASSERT(sceneId < state_->scenes.size(),
                  "Renderer::add(): index" << sceneId << "out of range for"
                                           << state_->scenes.size() << "scenes",
@@ -789,7 +789,7 @@ std::size_t Renderer::addMeshHierarchy(const Mn::UnsignedInt sceneId,
   /* Add a top-level object with no attached mesh */
   const std::size_t topLevelId = scene.transformations.size();
   arrayAppend(scene.parents, -1);
-  arrayAppend(scene.transformations, transformation);
+  arrayAppend(scene.transformations, Cr::InPlaceInit);
 
   /* Add the whole hierarchy under this name, with a mesh for each */
   // TODO the hierarchy can eventually also have meshless "grouping nodes" or
@@ -801,7 +801,7 @@ std::size_t Renderer::addMeshHierarchy(const Mn::UnsignedInt sceneId,
        transformation */
     const std::size_t id = scene.transformations.size();
     arrayAppend(scene.parents, topLevelId);
-    arrayAppend(scene.transformations, meshView.transformation);
+    arrayAppend(scene.transformations, bakeTransformation*meshView.transformation);
 
     /* Get a batch ID for given shader/mesh/texture combination */
     const Mn::UnsignedInt batchId = drawBatchId(

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -388,8 +388,12 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
         /* Generate a full mipmap if there's just one level and if the image is
            not compressed. It's opt-in to force people to learn how to make
            assets Vulkan-ready. */
-        const bool generateMipmap = levelCount == 1 && (flags & RendererFileFlag::GenerateMipmap) && !image->isCompressed();
-        const Mn::UnsignedInt desiredLevelCount = generateMipmap ? Mn::Math::log2(image->size().xy().min()) + 1 : levelCount;
+        const bool generateMipmap =
+            levelCount == 1 && (flags & RendererFileFlag::GenerateMipmap) &&
+            !image->isCompressed();
+        const Mn::UnsignedInt desiredLevelCount =
+            generateMipmap ? Mn::Math::log2(image->size().xy().min()) + 1
+                           : levelCount;
 
         texture
             .setMinificationFilter(textureData->minificationFilter(),
@@ -412,11 +416,11 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
           }
         } else {
           texture
-              .setStorage(desiredLevelCount, Mn::GL::textureFormat(image->format()),
-                          image->size())
+              .setStorage(desiredLevelCount,
+                          Mn::GL::textureFormat(image->format()), image->size())
               .setSubImage(0, {}, *image);
-          if(generateMipmap)
-              texture.generateMipmap();
+          if (generateMipmap)
+            texture.generateMipmap();
         }
       } else if (textureData->type() == Mn::Trade::TextureType::Texture2D) {
         const Mn::UnsignedInt levelCount =
@@ -432,8 +436,12 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
         /* Generate a full mipmap if there's just one level and if the image is
            not compressed. It's opt-in to force people to learn how to make
            assets Vulkan-ready. */
-        const bool generateMipmap = levelCount == 1 && (flags & RendererFileFlag::GenerateMipmap) && !image->isCompressed();
-        const Mn::UnsignedInt desiredLevelCount = generateMipmap ? Mn::Math::log2(image->size().min()) + 1 : levelCount;
+        const bool generateMipmap =
+            levelCount == 1 && (flags & RendererFileFlag::GenerateMipmap) &&
+            !image->isCompressed();
+        const Mn::UnsignedInt desiredLevelCount =
+            generateMipmap ? Mn::Math::log2(image->size().min()) + 1
+                           : levelCount;
 
         texture
             .setMinificationFilter(textureData->minificationFilter(),
@@ -457,11 +465,12 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
           }
         } else {
           texture
-              .setStorage(desiredLevelCount, Mn::GL::textureFormat(image->format()),
+              .setStorage(desiredLevelCount,
+                          Mn::GL::textureFormat(image->format()),
                           {image->size(), 1})
               .setSubImage(0, {}, Mn::ImageView2D{*image});
-          if(generateMipmap)
-              texture.generateMipmap();
+          if (generateMipmap)
+            texture.generateMipmap();
         }
       } else
         CORRADE_INTERNAL_ASSERT_UNREACHABLE(); /* LCOV_EXCL_LINE */
@@ -817,7 +826,8 @@ std::size_t Renderer::addMeshHierarchy(const Mn::UnsignedInt sceneId,
        transformation */
     const std::size_t id = scene.transformations.size();
     arrayAppend(scene.parents, topLevelId);
-    arrayAppend(scene.transformations, bakeTransformation*meshView.transformation);
+    arrayAppend(scene.transformations,
+                bakeTransformation * meshView.transformation);
 
     /* Get a batch ID for given shader/mesh/texture combination */
     const Mn::UnsignedInt batchId = drawBatchId(
@@ -884,9 +894,10 @@ Mn::Matrix4& Renderer::camera(const Mn::UnsignedInt scene) {
 Cr::Containers::StridedArrayView1D<Mn::Matrix4> Renderer::transformations(
     const Mn::UnsignedInt sceneId) {
   CORRADE_ASSERT(sceneId < state_->scenes.size(),
-                 "Renderer::transformations(): index" << sceneId << "out of range for"
-                                            << state_->scenes.size()
-                                            << "scenes", {});
+                 "Renderer::transformations(): index"
+                     << sceneId << "out of range for" << state_->scenes.size()
+                     << "scenes",
+                 {});
 
   return state_->scenes[sceneId].transformations;
 }

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -882,8 +882,13 @@ Mn::Matrix4& Renderer::camera(const Mn::UnsignedInt scene) {
 }
 
 Cr::Containers::StridedArrayView1D<Mn::Matrix4> Renderer::transformations(
-    const Mn::UnsignedInt scene) {
-  return state_->scenes[scene].transformations;
+    const Mn::UnsignedInt sceneId) {
+  CORRADE_ASSERT(sceneId < state_->scenes.size(),
+                 "Renderer::transformations(): index" << sceneId << "out of range for"
+                                            << state_->scenes.size()
+                                            << "scenes", {});
+
+  return state_->scenes[sceneId].transformations;
 }
 
 void Renderer::draw(Mn::GL::AbstractFramebuffer& framebuffer) {

--- a/src/esp/gfx_batch/Renderer.h
+++ b/src/esp/gfx_batch/Renderer.h
@@ -511,22 +511,27 @@ class Renderer {
    *    @ref sceneCount()
    * @param name            *Mesh hierarchy template* name, added with
    *    @ref addFile() earlier
-   * @param transformation  Initial transformation of the hierarchy
+   * @param bakeTransformation Transformation to bake into the hierarchy
+   * @return ID of the newly added node
    *
-   * Returns an ID of the newly added node, which can be subsequently used to
-   * update transformations via @ref transformations(). The returned IDs are
-   * *not* contiguous, the gaps correspond to number of child nodes in the
-   * hierarchy.
+   * The returned ID can be subsequently used to update transformations via
+   * @ref transformations(). The returned IDs are *not* contiguous, the gaps
+   * correspond to number of child nodes in the hierarchy.
+   *
+   * The @p bakeTransformation is baked into the added hierarchy, i.e.
+   * @ref transformations() at the returned ID is kept as an identity transform
+   * and writing to it will not overwrite the baked transformation. This
+   * parameter is useful for correcting orientation/scale of the imported mesh.
    * @see @ref hasMeshHierarchy()
    */
   std::size_t addMeshHierarchy(Magnum::UnsignedInt sceneId,
                                Corrade::Containers::StringView name,
-                               const Magnum::Matrix4& transformation = {});
+                               const Magnum::Matrix4& bakeTransformation = {});
 #else
   /* To avoid having to include Matrix4 in the header */
   std::size_t addMeshHierarchy(Magnum::UnsignedInt sceneId,
                                Corrade::Containers::StringView name,
-                               const Magnum::Matrix4& transformation);
+                               const Magnum::Matrix4& bakeTransformation);
   std::size_t addMeshHierarchy(Magnum::UnsignedInt sceneId,
                                Corrade::Containers::StringView name);
 #endif

--- a/src/esp/gfx_batch/Renderer.h
+++ b/src/esp/gfx_batch/Renderer.h
@@ -109,7 +109,23 @@ enum class RendererFileFlag {
    *    This flag is required to be set when importing scene-less files such as
    *    STL or PLY.
    */
-  Whole = 1 << 0
+  Whole = 1 << 0,
+
+  /**
+   * Generate a mipmap out of single-level uncompressed textures.
+   *
+   * By default, no renderer-side processing of imported textures is done ---
+   * if the image contains multiple levels, they're imported as well, otherwise
+   * just a single level is uploaded, regardless of whether the texture has a
+   * filtering across mip levels set up.
+   *
+   * With this option enabled, if the input image is uncompressed and there's
+   * just a single level, the texture is created with a full mip pyramid and
+   * the lower levels get generated on the fly, leading to a smoother look with
+   * large textures. On-the-fly mip level generation is impossible for
+   * compressed formats, there this option is ignored.
+   */
+  GenerateMipmap = 1 << 1
 };
 
 /**

--- a/src/esp/gfx_batch/RendererStandalone.h
+++ b/src/esp/gfx_batch/RendererStandalone.h
@@ -178,6 +178,17 @@ class RendererStandalone : public Renderer {
   Magnum::Image2D colorImage();
 
   /**
+   * @brief Retrieve the rendered color output into a pre-allocated location
+   *
+   * Expects that @p rectangle is contained in a size defined
+   * by @ref tileSize() multiplied by @ref tileCount(), that @p image
+   * size corresponds to @p rectangle size and that its format is compatible
+   * with @ref colorFramebufferFormat().
+   */
+  void colorImageInto(const Magnum::Range2Di& rectangle,
+                      const Magnum::MutableImageView2D& image);
+
+  /**
    * @brief Retrieve the rendered depth output
    *
    * Stalls the CPU until the GPU finishes the last @ref draw() and then
@@ -185,6 +196,17 @@ class RendererStandalone : public Renderer {
    * @ref tileSize() multiplied by @ref tileCount().
    */
   Magnum::Image2D depthImage();
+
+  /**
+   * @brief Retrieve the rendered depth output into a pre-allocated location
+   *
+   * Expects that @p rectangle is contained in a size defined
+   * by @ref tileSize() multiplied by @ref tileCount(), that @p image
+   * size corresponds to @p rectangle size and that its format is compatible
+   * with @ref depthFramebufferFormat().
+   */
+  void depthImageInto(const Magnum::Range2Di& rectangle,
+                      const Magnum::MutableImageView2D& image);
 
 #if defined(ESP_BUILD_WITH_CUDA) || defined(DOXYGEN_GENERATING_OUTPUT)
   /**

--- a/src/esp/gfx_batch/RendererStandalone.h
+++ b/src/esp/gfx_batch/RendererStandalone.h
@@ -143,8 +143,7 @@ class RendererStandalone : public Renderer {
    *
    * Format in which @ref colorImage() and @ref colorCudaBufferDevicePointer()
    * is returned. At the moment @ref Magnum::PixelFormat::RGBA8Unorm.
-   * Framebuffer size is given by the @ref Magnum::Math::Vector::product() "product()"
-   * of @ref tileSize() and @ref tileCount().
+   * Framebuffer size is @ref tileSize() multiplied by @ref tileCount().
    * @see @ref Magnum::pixelFormatSize(), @ref Magnum::pixelFormatChannelCount()
    */
   Magnum::PixelFormat colorFramebufferFormat() const;
@@ -153,9 +152,8 @@ class RendererStandalone : public Renderer {
    * @brief Depth framebuffer format
    *
    * Format in which @ref depthImage() and @ref colorCudaBufferDevicePointer()
-   * is returned. At the moment @ref Magnum::PixelFormat::Depth32F.
-   * Framebuffer size is given by the @ref Magnum::Math::Vector::product() "product()"
-   * of @ref tileSize() and @ref tileCount().
+   * is returned. At the moment @ref Magnum::PixelFormat::Depth32F. Framebuffer
+   * size is @ref tileSize() multiplied by @ref tileCount().
    * @see @ref Magnum::pixelFormatSize()
    */
   Magnum::PixelFormat depthFramebufferFormat() const;
@@ -174,9 +172,8 @@ class RendererStandalone : public Renderer {
    * @brief Retrieve the rendered color output
    *
    * Stalls the CPU until the GPU finishes the last @ref draw() and then
-   * returns an image in @ref colorFramebufferFormat() and with size given by
-   * the @ref Magnum::Math::Vector::product() "product()" of @ref tileSize()
-   * and @ref tileCount().
+   * returns an image in @ref colorFramebufferFormat() and with size being
+   * @ref tileSize() multiplied by @ref tileCount().
    */
   Magnum::Image2D colorImage();
 
@@ -184,9 +181,8 @@ class RendererStandalone : public Renderer {
    * @brief Retrieve the rendered depth output
    *
    * Stalls the CPU until the GPU finishes the last @ref draw() and then
-   * returns an image in @ref depthFramebufferFormat() and with size given by
-   * the @ref Magnum::Math::Vector::product() "product()" of @ref tileSize()
-   * and @ref tileCount().
+   * returns an image in @ref depthFramebufferFormat() and with size being
+   * @ref tileSize() multiplied by @ref tileCount().
    */
   Magnum::Image2D depthImage();
 

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -41,19 +41,26 @@ namespace {
 
 /* Needs to be an internal utility because CameraSensor uses everything except
    hFoV from the CameraSensorSpec */
-Mn::Matrix4 projectionMatrixInternal(const CameraSensorSpec& spec, Mn::Rad hfov) {
-  const Mn::Vector2 nearPlaneSize{1.0f, Mn::Vector2{Mn::Vector2i{spec.resolution}}.aspectRatio()};
+Mn::Matrix4 projectionMatrixInternal(const CameraSensorSpec& spec,
+                                     Mn::Rad hfov) {
+  const Mn::Vector2 nearPlaneSize{
+      1.0f, Mn::Vector2{Mn::Vector2i{spec.resolution}}.aspectRatio()};
   if (spec.sensorSubType == SensorSubType::Orthographic) {
-    return Mn::Matrix4::orthographicProjection(nearPlaneSize/spec.orthoScale, spec.near, spec.far);
-  } else if(spec.sensorSubType == SensorSubType::Pinhole) {
+    return Mn::Matrix4::orthographicProjection(nearPlaneSize / spec.orthoScale,
+                                               spec.near, spec.far);
+  } else if (spec.sensorSubType == SensorSubType::Pinhole) {
     const float scale = 1.0f / (2.0f * spec.near * Mn::Math::tan(0.5f * hfov));
-    return Mn::Matrix4::perspectiveProjection(nearPlaneSize/scale, spec.near, spec.far);
-  } else CORRADE_ASSERT_UNREACHABLE("CameraSensorSpec::projectionMatrix(): sensorSpec does not have "
-      "SensorSubType "
-      "Pinhole or Orthographic", {});
+    return Mn::Matrix4::perspectiveProjection(nearPlaneSize / scale, spec.near,
+                                              spec.far);
+  } else
+    CORRADE_ASSERT_UNREACHABLE(
+        "CameraSensorSpec::projectionMatrix(): sensorSpec does not have "
+        "SensorSubType "
+        "Pinhole or Orthographic",
+        {});
 }
 
-}
+}  // namespace
 
 Mn::Matrix4 CameraSensorSpec::projectionMatrix() const {
   return projectionMatrixInternal(*this, hfov);

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -37,6 +37,28 @@ bool CameraSensorSpec::operator==(const CameraSensorSpec& a) const {
   return VisualSensorSpec::operator==(a) && orthoScale == a.orthoScale;
 }
 
+namespace {
+
+/* Needs to be an internal utility because CameraSensor uses everything except
+   hFoV from the CameraSensorSpec */
+Mn::Matrix4 projectionMatrixInternal(const CameraSensorSpec& spec, Mn::Rad hfov) {
+  const Mn::Vector2 nearPlaneSize{1.0f, Mn::Vector2{Mn::Vector2i{spec.resolution}}.aspectRatio()};
+  if (spec.sensorSubType == SensorSubType::Orthographic) {
+    return Mn::Matrix4::orthographicProjection(nearPlaneSize/spec.orthoScale, spec.near, spec.far);
+  } else if(spec.sensorSubType == SensorSubType::Pinhole) {
+    const float scale = 1.0f / (2.0f * spec.near * Mn::Math::tan(0.5f * hfov));
+    return Mn::Matrix4::perspectiveProjection(nearPlaneSize/scale, spec.near, spec.far);
+  } else CORRADE_ASSERT_UNREACHABLE("CameraSensorSpec::projectionMatrix(): sensorSpec does not have "
+      "SensorSubType "
+      "Pinhole or Orthographic", {});
+}
+
+}
+
+Mn::Matrix4 CameraSensorSpec::projectionMatrix() const {
+  return projectionMatrixInternal(*this, hfov);
+}
+
 CameraSensor::CameraSensor(scene::SceneNode& cameraNode,
                            const CameraSensorSpec::ptr& spec)
     : VisualSensor(cameraNode, spec),
@@ -77,28 +99,7 @@ void CameraSensor::recomputeProjectionMatrix() {
 
 void CameraSensor::recomputeBaseProjectionMatrix() {
   // refresh size after relevant parameters have changed
-  CORRADE_ASSERT(
-      cameraSensorSpec_->sensorSubType == SensorSubType::Pinhole ||
-          cameraSensorSpec_->sensorSubType == SensorSubType::Orthographic,
-      "CameraSensor::recomputeBaseProjectionMatrix(): sensorSpec does not have "
-      "SensorSubType "
-      "Pinhole or Orthographic", );
-  Mn::Vector2 nearPlaneSize_ =
-      Mn::Vector2{1.0f, static_cast<float>(cameraSensorSpec_->resolution[0]) /
-                            cameraSensorSpec_->resolution[1]};
-  if (cameraSensorSpec_->sensorSubType == SensorSubType::Orthographic) {
-    nearPlaneSize_ /= cameraSensorSpec_->orthoScale;
-    baseProjMatrix_ = Mn::Matrix4::orthographicProjection(
-        nearPlaneSize_, cameraSensorSpec_->near, cameraSensorSpec_->far);
-  } else {
-    // cameraSensorSpec_ is subtype Pinhole
-    Magnum::Deg halfHFovRad{Magnum::Deg(.5 * hfov_)};
-    float scale = 1.0f / (2.0f * cameraSensorSpec_->near *
-                          Magnum::Math::tan(halfHFovRad));
-    nearPlaneSize_ /= scale;
-    baseProjMatrix_ = Mn::Matrix4::perspectiveProjection(
-        nearPlaneSize_, cameraSensorSpec_->near, cameraSensorSpec_->far);
-  }
+  baseProjMatrix_ = projectionMatrixInternal(*cameraSensorSpec_, hfov_);
   // build projection matrix
   recomputeProjectionMatrix();
 }  // CameraSensor::recomputeNearPlaneSize

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -18,6 +18,7 @@ struct CameraSensorSpec : public VisualSensorSpec {
   CameraSensorSpec();
   void sanityCheck() const override;
   bool operator==(const CameraSensorSpec& a) const;
+  Magnum::Matrix4 projectionMatrix() const;
   ESP_SMART_POINTERS(CameraSensorSpec)
 };
 

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -1422,7 +1422,10 @@ void GfxBatchRendererTest::singleMesh() {
   CORRADE_VERIFY(renderer.hasMeshHierarchy("square"));
   CORRADE_VERIFY(!renderer.hasMeshHierarchy("squares"));
   CORRADE_VERIFY(!renderer.hasMeshHierarchy(""));
-  CORRADE_COMPARE(renderer.addMeshHierarchy(0, "square"), 0);
+  CORRADE_COMPARE(renderer.addMeshHierarchy(0, "square",
+    /* Initial baked-in transformation, combined with what's set in
+       transformations() below */
+    Mn::Matrix4::scaling(Mn::Vector3{0.4f})), 0);
 
   /* Stats will show two nodes now -- it adds one transformation for the
      top-level object and then one nested for the mesh, corresponding to the
@@ -1433,7 +1436,10 @@ void GfxBatchRendererTest::singleMesh() {
   CORRADE_COMPARE(stats.drawBatchCount, 1);
 
   CORRADE_COMPARE(renderer.transformations(0).size(), 2);
-  renderer.transformations(0)[0] = Mn::Matrix4::scaling(Mn::Vector3{0.8f});
+  /* The initial baked-in transformation shouldn't appear here (that's why it's
+     baked), combine it so it's a 0.8 scale in total */
+  CORRADE_COMPARE(renderer.transformations(0)[0], Mn::Matrix4{});
+  renderer.transformations(0)[0] = Mn::Matrix4::scaling(Mn::Vector3{2.0f});
 
   renderer.draw();
   Mn::Image2D color = renderer.colorImage();

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -1444,10 +1444,12 @@ void GfxBatchRendererTest::singleMesh() {
   CORRADE_VERIFY(renderer.hasMeshHierarchy("square"));
   CORRADE_VERIFY(!renderer.hasMeshHierarchy("squares"));
   CORRADE_VERIFY(!renderer.hasMeshHierarchy(""));
-  CORRADE_COMPARE(renderer.addMeshHierarchy(0, "square",
-    /* Initial baked-in transformation, combined with what's set in
-       transformations() below */
-    Mn::Matrix4::scaling(Mn::Vector3{0.4f})), 0);
+  CORRADE_COMPARE(
+      renderer.addMeshHierarchy(0, "square",
+                                /* Initial baked-in transformation, combined
+                                   with what's set in transformations() below */
+                                Mn::Matrix4::scaling(Mn::Vector3{0.4f})),
+      0);
 
   /* Stats will show two nodes now -- it adds one transformation for the
      top-level object and then one nested for the mesh, corresponding to the

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -1485,6 +1485,13 @@ void GfxBatchRendererTest::singleMesh() {
     CORRADE_COMPARE(color.pixels<Mn::Color4ub>()[75][35], 0xcccccc_rgb);
     CORRADE_COMPARE(color.pixels<Mn::Color4ub>()[20][38], 0x990000_rgb);
   }
+
+  /* Depth should have *some* data also */
+  Mn::Image2D depth = renderer.depthImage();
+  MAGNUM_VERIFY_NO_GL_ERROR();
+  CORRADE_COMPARE(depth.pixels<Mn::Float>()[0][0], 1.0f);
+  CORRADE_COMPARE(depth.pixels<Mn::Float>()[95][127], 1.0f);
+  CORRADE_COMPARE(depth.pixels<Mn::Float>()[64][48], 0.0909091f);
 }
 
 void GfxBatchRendererTest::meshHierarchy() {

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -97,6 +97,13 @@ const struct {
     1,
     {1, 1, 0, 1},
     0.0f, 0.0f},
+  /* Doesn't really verify that the right level count is generated, but at
+     least checks that things don't crash */
+  {"generate mipmap", {Cr::InPlaceInit, {
+    {"batch.gltf", esp::gfx_batch::RendererFileFlag::GenerateMipmap, nullptr}}},
+    1,
+    {1, 1, 0, 1},
+    0.0f, 0.0f},
   {"multiple meshes", {Cr::InPlaceInit, {
     {"batch-multiple-meshes.gltf", {}, nullptr}}},
     /* Each has a separate mesh */
@@ -105,6 +112,14 @@ const struct {
     0.0f, 0.0f},
   {"multiple textures", {Cr::InPlaceInit, {
     {"batch-multiple-textures.gltf", {}, nullptr}}},
+    /* Each has a separate texture */
+    3,
+    {4, 2, 0, 1},
+    0.0f, 0.0f},
+  /* Doesn't really verify that the right level count is generated, but at
+     least checks that things don't crash */
+  {"multiple textures, generate mipmap", {Cr::InPlaceInit, {
+    {"batch-multiple-textures.gltf", esp::gfx_batch::RendererFileFlag::GenerateMipmap, nullptr}}},
     /* Each has a separate texture */
     3,
     {4, 2, 0, 1},
@@ -125,6 +140,13 @@ const struct {
     2,
     {4, 2, 0, 1},
     /* DXT-compressed images have minor compression errors */
+    1.5f, 0.5f},
+  /* Mip level generation should do nothing for compressed textures */
+  {"multiple files, compressed textures, generate mipmap", {Cr::InPlaceInit, {
+    {"batch-square-circle-triangle-compressed.gltf", esp::gfx_batch::RendererFileFlag::GenerateMipmap, nullptr},
+    {"batch-four-squares-compressed.gltf", esp::gfx_batch::RendererFileFlag::GenerateMipmap, nullptr}}},
+    2,
+    {4, 2, 0, 1},
     1.5f, 0.5f},
   {"multiple files, some whole-file", {Cr::InPlaceInit, {
     {"batch-square-circle-triangle.gltf", {}, nullptr},


### PR DESCRIPTION
## Motivation and Context

Contains various minor updates and fixes that *don't* depend on changes from #1947, thus hopefully possible to be reviewed & merged in isolation:

- Ability to bake-in an initial transformation for added hierarchy (i.e., without it being overwritten next time the hierarchy transform is updated). Will be used for specifying initial scale and coordinate frame correction and should fix 99.7% of nasty transformation bugs I had in the initial gfx-replay demo screenshots in September.
- Opt-in flag to generate texture mipmaps. This is something that Vulkan will not give us for free in the driver (and so the assets will need to contain full mip pyramids themselves), so it's not enabled by default, but it's currently used to have a pixel-perfect match with the classic renderer.
- Adds a more efficient way to retrieve rendered images -- instead of putting them into a newly-allocated memory, it reads them to a pre-allocated view. 
- **Extracted projection matrix calculation out of `CameraSensor`** to a utility function on the `CameraSensorSpec` so I can use it even in scenegraph-less contexts. I felt like redoing all that calculation from scratch on my side would be too error prone, so I did it like this, and simplified the code slightly in the process. I hope it doesn't conflict with the upcoming/ongoing sensor refactor. The new API entrypoint isn't used anywhere at the moment, but it'll be in the `ReplayBatchRenderer` that depends on #1947.
- Adds `gfx::RenderTarget::blitRgbaTo()` which is like `blitRgbaToDefault()` but with an ability to choose an arbitrary rectangle of an arbitrary framebuffer, which I need for feature parity in the batch renderer replay GUI. The `blitRgbaToDefault()` is now built on top of this new API.

## How Has This Been Tested

The first two parts have a corresponding update in `GfxBatchRendererTest`. 

The projection matrix is I assume tested somewhere already. I tried to exactly match the original behavior, including taking the `hfov` override from `CameraSensor` instead of `CameraSensorSpec`, please let me know if something feels off.
