### PR TITLE
gfx-replay: Record scene graph deletions.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1428,7 +1428,7 @@ scene::SceneNode* ResourceManager::createSemanticRenderAssetInstance(
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
   if (creation.isTextureBasedSemantic()) {
-    // Treat texture-based semantic meshes as General/Primitves.
+    // Treat texture-based semantic meshes as General/Primitives.
     return createRenderAssetInstanceGeneralPrimitive(creation, parent,
                                                      drawables, nullptr);
   }
@@ -1820,7 +1820,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
 
     // If meshIDLocal != -1 then we have multiple meshes assigned to the same
     // MeshTransformNode.  We make subsequent meshes children of the first mesh
-    // we've seen, and give them identity trasnforms.
+    // we've seen, and give them identity transforms.
     // TODO: either drop MeshTransformNode in favor of SceneData or use
     // Mn::SceneTools::convertToSingleFunctionObjects() when it's exposed.
     esp::assets::MeshTransformNode* tmpNode = &*node;
@@ -2065,7 +2065,7 @@ namespace {
  * @param typeToCheck The type of shader being specified.
  * @param materialData The imported material to check for type
  * @return Whether the imported material's supported types include one
- * congruient with the specified shader type.
+ * congruent with the specified shader type.
  */
 bool compareShaderTypeToMnMatType(const ObjectInstanceShaderType typeToCheck,
                                   const Mn::Trade::MaterialData& materialData) {

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1428,7 +1428,7 @@ scene::SceneNode* ResourceManager::createSemanticRenderAssetInstance(
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
   if (creation.isTextureBasedSemantic()) {
-    // Treat texture-based semantic meshes as General/Primitives.
+    // Treat texture-based semantic meshes as General/Primitves.
     return createRenderAssetInstanceGeneralPrimitive(creation, parent,
                                                      drawables, nullptr);
   }

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -161,6 +161,18 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     assetInfos_[assetInfo.filepath] = assetInfo;
   }
 
+  for (const auto& deletionInstanceKey : keyframe.deletions) {
+    const auto& it = createdInstances_.find(deletionInstanceKey);
+    if (it == createdInstances_.end()) {
+      // missing instance for this key, probably due to a failed instance
+      // creation
+      continue;
+    }
+
+    implementation_->deleteAssetInstance(it->second);
+    createdInstances_.erase(deletionInstanceKey);
+  }
+
   for (const auto& pair : keyframe.creations) {
     const auto& creation = pair.second;
     if (assetInfos_.count(creation.filepath) == 0u) {
@@ -186,18 +198,6 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     const auto& instanceKey = pair.first;
     CORRADE_INTERNAL_ASSERT(createdInstances_.count(instanceKey) == 0);
     createdInstances_[instanceKey] = node;
-  }
-
-  for (const auto& deletionInstanceKey : keyframe.deletions) {
-    const auto& it = createdInstances_.find(deletionInstanceKey);
-    if (it == createdInstances_.end()) {
-      // missing instance for this key, probably due to a failed instance
-      // creation
-      continue;
-    }
-
-    implementation_->deleteAssetInstance(it->second);
-    createdInstances_.erase(deletionInstanceKey);
   }
 
   for (const auto& pair : keyframe.stateUpdates) {

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -161,18 +161,6 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     assetInfos_[assetInfo.filepath] = assetInfo;
   }
 
-  for (const auto& deletionInstanceKey : keyframe.deletions) {
-    const auto& it = createdInstances_.find(deletionInstanceKey);
-    if (it == createdInstances_.end()) {
-      // missing instance for this key, probably due to a failed instance
-      // creation
-      continue;
-    }
-
-    implementation_->deleteAssetInstance(it->second);
-    createdInstances_.erase(deletionInstanceKey);
-  }
-
   for (const auto& pair : keyframe.creations) {
     const auto& creation = pair.second;
     if (assetInfos_.count(creation.filepath) == 0u) {
@@ -198,6 +186,18 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
     const auto& instanceKey = pair.first;
     CORRADE_INTERNAL_ASSERT(createdInstances_.count(instanceKey) == 0);
     createdInstances_[instanceKey] = node;
+  }
+
+  for (const auto& deletionInstanceKey : keyframe.deletions) {
+    const auto& it = createdInstances_.find(deletionInstanceKey);
+    if (it == createdInstances_.end()) {
+      // missing instance for this key, probably due to a failed instance
+      // creation
+      continue;
+    }
+
+    implementation_->deleteAssetInstance(it->second);
+    createdInstances_.erase(deletionInstanceKey);
   }
 
   for (const auto& pair : keyframe.stateUpdates) {

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -78,7 +78,7 @@ void Recorder::onCreateRenderAssetInstance(
       node, instanceKey, Corrade::Containers::NullOpt, deletionHelper});
 }
 
-void Recorder::onRemoveSceneGraph(const esp::scene::SceneGraph& sceneGraph) {
+void Recorder::onDeleteSceneGraph(const esp::scene::SceneGraph& sceneGraph) {
   auto& root = sceneGraph.getRootNode();
   scene::preOrderTraversalWithCallback(root,
                                        [this](const scene::SceneNode& node) {
@@ -158,12 +158,13 @@ void Recorder::checkAndAddDeletion(Keyframe* keyframe,
 
 void Recorder::onDeleteRenderAssetInstance(const scene::SceneNode* node) {
   int index = findInstance(node);
+  CORRADE_INTERNAL_ASSERT(index != ID_UNDEFINED);
 
-  if (index != ID_UNDEFINED) {
-    auto instanceKey = instanceRecords_[index].instanceKey;
-    checkAndAddDeletion(&getKeyframe(), instanceKey);
-    instanceRecords_.erase(instanceRecords_.begin() + index);
-  }
+  auto instanceKey = instanceRecords_[index].instanceKey;
+
+  checkAndAddDeletion(&getKeyframe(), instanceKey);
+
+  instanceRecords_.erase(instanceRecords_.begin() + index);
 }
 
 Keyframe& Recorder::getKeyframe() {

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -80,13 +80,13 @@ void Recorder::onCreateRenderAssetInstance(
 
 void Recorder::onDeleteSceneGraph(const esp::scene::SceneGraph& sceneGraph) {
   auto& root = sceneGraph.getRootNode();
-  scene::preOrderTraversalWithCallback(root,
-                                       [this](const scene::SceneNode& node) {
-                                         int index = findInstance(&node);
-                                         if (index != ID_UNDEFINED) {
-                                           onDeleteRenderAssetInstance(&node);
-                                         }
-                                       });
+  scene::preOrderTraversalWithCallback(
+      root, [this](const scene::SceneNode& node) {
+        int index = findInstance(&node);
+        if (index != ID_UNDEFINED) {
+          delete instanceRecords_[index].deletionHelper;
+        }
+      });
 }
 
 void Recorder::saveKeyframe() {

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -78,8 +78,8 @@ void Recorder::onCreateRenderAssetInstance(
       node, instanceKey, Corrade::Containers::NullOpt, deletionHelper});
 }
 
-void Recorder::onDeleteSceneGraph(const esp::scene::SceneGraph& sceneGraph) {
-  auto& root = sceneGraph.getRootNode();
+void Recorder::onHideSceneGraph(const esp::scene::SceneGraph& sceneGraph) {
+  const auto& root = sceneGraph.getRootNode();
   scene::preOrderTraversalWithCallback(
       root, [this](const scene::SceneNode& node) {
         int index = findInstance(&node);

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -18,7 +18,8 @@ struct RenderAssetInstanceCreationInfo;
 }  // namespace assets
 namespace scene {
 class SceneNode;
-}
+class SceneGraph;
+}  // namespace scene
 namespace gfx {
 namespace replay {
 
@@ -56,6 +57,15 @@ class Recorder {
    * @param assetInfo The asset that was loaded.
    */
   void onLoadRenderAsset(const esp::assets::AssetInfo& assetInfo);
+
+  /**
+   * @brief Remove all graph nodes from the current keyframe.
+   * Because scene graphs are currently leaked when scenes changes, we cannot
+   * rely on node deletion to issue deletion entries. This function allows to
+   * circumvent this issue.
+   * @param sceneGraph The scene graph from which deletion entries are issued.
+   */
+  void onRemoveSceneGraph(const esp::scene::SceneGraph& sceneGraph);
 
   /**
    * @brief Save/capture a render keyframe (a visual snapshot of the scene).

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -59,13 +59,13 @@ class Recorder {
   void onLoadRenderAsset(const esp::assets::AssetInfo& assetInfo);
 
   /**
-   * @brief Remove all graph nodes from the current keyframe.
-   * Because scene graphs are currently leaked when scenes changes, we cannot
-   * rely on node deletion to issue deletion entries. This function allows to
-   * circumvent this issue.
-   * @param sceneGraph The scene graph from which deletion entries are issued.
+   * @brief Record deletion of all render instances in a scene graph.
+   * Because scene graphs are currently leaked when the active scene changes, we
+   * cannot rely on node deletion to issue gfx-replay deletion entries. This
+   * function allows to circumvent this issue.
+   * @param sceneGraph The scene graph to delete.
    */
-  void onRemoveSceneGraph(const esp::scene::SceneGraph& sceneGraph);
+  void onDeleteSceneGraph(const esp::scene::SceneGraph& sceneGraph);
 
   /**
    * @brief Save/capture a render keyframe (a visual snapshot of the scene).

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -63,9 +63,10 @@ class Recorder {
    * Because scene graphs are currently leaked when the active scene changes, we
    * cannot rely on node deletion to issue gfx-replay deletion entries. This
    * function allows to circumvent this issue.
-   * @param sceneGraph The scene graph to delete.
+   * The scene graph leak occurs in createSceneInstance(), in Simulator.cpp.
+   * @param sceneGraph The scene graph being hidden.
    */
-  void onDeleteSceneGraph(const esp::scene::SceneGraph& sceneGraph);
+  void onHideSceneGraph(const esp::scene::SceneGraph& sceneGraph);
 
   /**
    * @brief Save/capture a render keyframe (a visual snapshot of the scene).

--- a/src/esp/scene/SceneManager.h
+++ b/src/esp/scene/SceneManager.h
@@ -28,7 +28,7 @@ class SceneManager {
   const SceneGraph& getSceneGraph(int sceneID) const;
 
   // Returns the count of registered scene graphs
-  inline int getSceneGraphCount() { return sceneGraphs_.size(); }
+  inline size_t getSceneGraphCount() const { return sceneGraphs_.size(); }
 
  protected:
   // Each item within is a base node, parent of all in that scene, for easy

--- a/src/esp/scene/SceneManager.h
+++ b/src/esp/scene/SceneManager.h
@@ -11,13 +11,10 @@
 #include "esp/core/Esp.h"
 
 #include "SceneGraph.h"
-#include "SceneNode.h"
 
 namespace esp {
 namespace scene {
 
-// TODO:
-// make SceneManager a singleton class
 class SceneManager {
  public:
   SceneManager() = default;
@@ -29,6 +26,9 @@ class SceneManager {
   // returns the scene graph
   SceneGraph& getSceneGraph(int sceneID);
   const SceneGraph& getSceneGraph(int sceneID) const;
+
+  // Returns the count of registered scene graphs
+  inline int getSceneGraphCount() { return sceneGraphs_.size(); }
 
  protected:
   // Each item within is a base node, parent of all in that scene, for easy

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -249,6 +249,15 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // before anything else.
   seed(config_.randomSeed);
 
+  // This code removes the previously loaded scene from gfx-replay. Because of
+  // the issue below, scene graphs are leaked, so we cannot rely on node
+  // deletion to issue gfx-replay deletion entries.
+  auto recorder = gfxReplayMgr_->getRecorder();
+  if (recorder && activeSceneID_ >= 0 &&
+      activeSceneID_ < sceneManager_->getSceneGraphCount()) {
+    recorder->onRemoveSceneGraph(sceneManager_->getSceneGraph(activeSceneID_));
+  }
+
   // initialize scene graph CAREFUL! previous scene graph is not deleted!
   // TODO:
   // We need to make a design decision here:
@@ -319,7 +328,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
 
   // 8. Load stage specified by Scene Instance Attributes
   bool success = instanceStageForSceneAttributes(curSceneInstanceAttributes_);
-  // 9. Load object instances as spceified by Scene Instance Attributes.
+  // 9. Load object instances as specified by Scene Instance Attributes.
   if (success) {
     success = instanceObjectsForSceneAttributes(curSceneInstanceAttributes_);
     if (success) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -255,7 +255,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   auto recorder = gfxReplayMgr_->getRecorder();
   if (recorder && activeSceneID_ >= 0 &&
       activeSceneID_ < sceneManager_->getSceneGraphCount()) {
-    recorder->onDeleteSceneGraph(sceneManager_->getSceneGraph(activeSceneID_));
+    recorder->onHideSceneGraph(sceneManager_->getSceneGraph(activeSceneID_));
   }
 
   // initialize scene graph CAREFUL! previous scene graph is not deleted!

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -249,13 +249,13 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // before anything else.
   seed(config_.randomSeed);
 
-  // This code removes the previously loaded scene from gfx-replay. Because of
-  // the issue below, scene graphs are leaked, so we cannot rely on node
-  // deletion to issue gfx-replay deletion entries.
+  // This code deletes the instances in the previously loaded scene from
+  // gfx-replay. Because of the issue below, scene graphs are leaked, so we
+  // cannot rely on node deletion to issue gfx-replay deletion entries.
   auto recorder = gfxReplayMgr_->getRecorder();
   if (recorder && activeSceneID_ >= 0 &&
       activeSceneID_ < sceneManager_->getSceneGraphCount()) {
-    recorder->onRemoveSceneGraph(sceneManager_->getSceneGraph(activeSceneID_));
+    recorder->onDeleteSceneGraph(sceneManager_->getSceneGraph(activeSceneID_));
   }
 
   // initialize scene graph CAREFUL! previous scene graph is not deleted!


### PR DESCRIPTION
## Motivation and Context

When the simulator changes scene, the previous scene graph is not deleted. Because `Recorder` relies on scene node deletion to issue deletion entries to gfx-replay, the previous scene is not cleared from the replay renderer.

This changeset adds a method to delete all gfx-replay nodes within a scene graph so that the replay renderer can correctly render process scene changes.

## How Has This Been Tested

Tested through Python viewer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
