### PR TITLE
Pin toml-sort version to fix pre-commit issue on CI.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,8 @@ repos:
         args: [--autofix]
     -   id: pretty-format-toml
         args: [--autofix]
+        additional_dependencies:
+         - toml-sort==0.21.0
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0  # Use the ref you want to point at


### PR DESCRIPTION
## Motivation and Context

This pins `toml-sort` to a specific version to fix a pre-commit CI issue.
The same fix was applied to lab here: https://github.com/facebookresearch/habitat-lab/pull/1063

## How Has This Been Tested

Tested on CI.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
