### PR TITLE
Updated semantic annotations in habitat-lab

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -112,18 +112,39 @@ habitat-viewer --dataset '<PATH TO HM3D>/hm3d_annotated_basis.scene_dataset_conf
 
 To load semantic annotations in habitat-lab:
 
-* Add the semantic sensor to the list of agent sensors:
+* Update your config by adding the semantic sensor to the list of agent sensors:
 
-    ```
-    SIMULATOR.AGENT_0.SENSORS = ["RGB_SENSOR", "SEMANTIC_SENSOR"]
-    ```
-* Set the `SIMULATOR.SCENE_DATASET` configuration variable:
+    ```yaml
+    # @package _global_
 
+    defaults:
+      - /habitat: habitat_config_base
+      - /habitat/simulator/agents@habitat.simulator.agents.<agent_name>: agent_base
+      # add semantic sensor:
+      - /habitat/simulator/sim_sensors@habitat.simulator.agents.<agent_name>.sim_sensors.semantic_sensor: semantic_sensor
+      - /habitat/task/rearrange: <task>
+      - /habitat/dataset/rearrangement: <dataset>
+      - _self_
+    
+    habitat:
+      simulator:
+        agents:
+          <agent_name>:
+            sim_sensors:
+              # configure semantic sensor:
+              semantic_sensor:
+                height: 256
+                width: 256
     ```
-    SIMULATOR.SCENE_DATASET = "<PATH TO HM3D>/hm3d_annotated_basis.scene_dataset_config.json"
+* Set the `habitat.simulator.scene_dataset` configuration variable:
+
+    ```yaml
+    habitat:
+      simulator:
+        scene_dataset: "<PATH TO HM3D>/hm3d_annotated_basis.scene_dataset_config.json"
     ```
 
-Note that if you are using the RL environment from habitat-lab, `SIMULATOR.SCENE_DATASET` is overridden by the episode dataset (see [here](https://github.com/facebookresearch/habitat-lab/blob/e934b15c35233457cc3cb9c90ba0e207610dbd19/habitat/core/env.py#L94-L96)). Each episode in the episode dataset must point to the annotation config file (as done in the HM3D ObjectNav dataset [here](https://github.com/facebookresearch/habitat-lab)).
+Note that if you are using the RL environment from habitat-lab, `habitat.simulator.scene_dataset` is overridden by the episode dataset (see [here](https://github.com/facebookresearch/habitat-lab/blob/b1f2d4791a0065d0791001b72a6c96748a5f9ae0/habitat-lab/habitat/core/env.py#L104-L108)). Each episode in the episode dataset must point to the annotation config file (as done in the HM3D ObjectNav dataset [here](https://github.com/facebookresearch/habitat-lab/blob/b1f2d4791a0065d0791001b72a6c96748a5f9ae0/DATASETS.md)).
 
 
 ## Matterport3D (MP3D) dataset


### PR DESCRIPTION
## Motivation and Context

I'm not sure if loading semantic annotations in habitat-lab should be part of habitat-sim README.md, but if so, then it has to be updated to Hydra style.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Docs change / refactoring / dependency upgrade

