### PR TITLE
Add replay renderer bindings to get CUDA device pointers.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -410,8 +410,9 @@ void initSimBindings(py::module& m) {
             self.preloadFile(filePath);
           },
           R"(Load a composite file that the renderer will use in-place of simulation assets to improve memory usage and performance.)")
-      .def("environment_count", &AbstractReplayRenderer::environmentCount,
-           "Get the batch size.")
+      .def_property_readonly("environment_count",
+                             &AbstractReplayRenderer::environmentCount,
+                             "Get the batch size.")
       .def("sensor_size", &AbstractReplayRenderer::sensorSize,
            "Get the resolution of a sensor.")
       .def("clear_environment", &AbstractReplayRenderer::clearEnvironment,
@@ -430,17 +431,17 @@ void initSimBindings(py::module& m) {
       .def("set_environment_keyframe",
            &AbstractReplayRenderer::setEnvironmentKeyframe,
            R"(Set the keyframe for a specific environment.)")
-      .def_static(
+      .def_property_readonly(
           "environment_grid_size", &AbstractReplayRenderer::environmentGridSize,
           R"(Get the dimensions (tile counts) of the environment grid.)")
       .def(
-          "get_cuda_color_buffer_device_pointer",
+          "cuda_color_buffer_device_pointer",
           [](AbstractReplayRenderer& self) {
             return py::capsule(self.getCudaColorBufferDevicePointer());
           },
           R"(Retrieve the color buffer as a CUDA device pointer.)")
       .def(
-          "get_cuda_depth_buffer_device_pointer",
+          "cuda_depth_buffer_device_pointer",
           [](AbstractReplayRenderer& self) {
             return py::capsule(self.getCudaColorBufferDevicePointer());
           },

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -432,7 +432,19 @@ void initSimBindings(py::module& m) {
            R"(Set the keyframe for a specific environment.)")
       .def_static("environment_grid_size",
                   &AbstractReplayRenderer::environmentGridSize,
-                  R"(Dimensions of the environment grid.)");
+                  R"(Dimensions of the environment grid.)")
+      .def(
+          "get_cuda_color_buffer_device_pointer",
+          [](AbstractReplayRenderer& self) {
+            return py::capsule(self.getCudaColorBufferDevicePointer());
+          },
+          R"(Retrieve the color buffer as a CUDA device pointer.)")
+      .def(
+          "get_cuda_depth_buffer_device_pointer",
+          [](AbstractReplayRenderer& self) {
+            return py::capsule(self.getCudaColorBufferDevicePointer());
+          },
+          R"(Retrieve the depth buffer as a CUDA device pointer.)");
 }
 
 }  // namespace sim

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -431,7 +431,7 @@ void initSimBindings(py::module& m) {
       .def("set_environment_keyframe",
            &AbstractReplayRenderer::setEnvironmentKeyframe,
            R"(Set the keyframe for a specific environment.)")
-      .def_property_readonly(
+      .def_static(
           "environment_grid_size", &AbstractReplayRenderer::environmentGridSize,
           R"(Get the dimensions (tile counts) of the environment grid.)")
       .def(

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -409,7 +409,7 @@ void initSimBindings(py::module& m) {
           [](AbstractReplayRenderer& self, const std::string& filePath) {
             self.preloadFile(filePath);
           },
-          R"(Load an composite file that the renderer will use in-place of simulation assets to improve memory usage and performance.)")
+          R"(Load a composite file that the renderer will use in-place of simulation assets to improve memory usage and performance.)")
       .def("environment_count", &AbstractReplayRenderer::environmentCount,
            "Get the batch size.")
       .def("sensor_size", &AbstractReplayRenderer::sensorSize,
@@ -420,7 +420,7 @@ void initSimBindings(py::module& m) {
            static_cast<void (AbstractReplayRenderer::*)(
                Magnum::GL::AbstractFramebuffer&)>(
                &AbstractReplayRenderer::render),
-           R"(Render all sensors onto the main framebuffer.)")
+           R"(Render all sensors onto the specified framebuffer.)")
       .def(
           "set_sensor_transforms_from_keyframe",
           &AbstractReplayRenderer::setSensorTransformsFromKeyframe,
@@ -430,9 +430,9 @@ void initSimBindings(py::module& m) {
       .def("set_environment_keyframe",
            &AbstractReplayRenderer::setEnvironmentKeyframe,
            R"(Set the keyframe for a specific environment.)")
-      .def_static("environment_grid_size",
-                  &AbstractReplayRenderer::environmentGridSize,
-                  R"(Dimensions of the environment grid.)")
+      .def_static(
+          "environment_grid_size", &AbstractReplayRenderer::environmentGridSize,
+          R"(Get the dimensions (tile counts) of the environment grid.)")
       .def(
           "get_cuda_color_buffer_device_pointer",
           [](AbstractReplayRenderer& self) {

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -104,5 +104,15 @@ void AbstractReplayRenderer::render(
   return doRender(framebuffer);
 }
 
+const void* AbstractReplayRenderer::getCudaColorBufferDevicePointer() {
+  ESP_ERROR() << "CUDA device pointer only available with the batch renderer.";
+  return nullptr;
+}
+
+const void* AbstractReplayRenderer::getCudaDepthBufferDevicePointer() {
+  ESP_ERROR() << "CUDA device pointer only available with the batch renderer.";
+  return nullptr;
+}
+
 }  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -102,6 +102,12 @@ class AbstractReplayRenderer {
   // Assumes the framebuffer color & depth is cleared
   void render(Magnum::GL::AbstractFramebuffer& framebuffer);
 
+  // Retrieve the color buffer as a CUDA device pointer. */
+  virtual const void* getCudaColorBufferDevicePointer();
+
+  // Retrieve the depth buffer as a CUDA device pointer. */
+  virtual const void* getCudaDepthBufferDevicePointer();
+
  private:
   /* Implementation of all public API is in the private do*() functions,
      similarly to how e.g. Magnum plugin interfaces work. The public API does

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -244,8 +244,8 @@ void BatchReplayRenderer::doRender(
   renderer_->draw(framebuffer);
 }
 
-#ifdef ESP_BUILD_WITH_CUDA
 const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {
+#ifdef ESP_BUILD_WITH_CUDA
   CORRADE_ASSERT(standalone_,
                  "ReplayBatchRenderer::colorCudaBufferDevicePointer(): can use "
                  "this function only "
@@ -253,9 +253,15 @@ const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {
                  nullptr);
   return static_cast<gfx_batch::RendererStandalone&>(*renderer_)
       .colorCudaBufferDevicePointer();
+#else
+  ESP_ERROR() << "Failed to retrieve device pointer because CUDA is not "
+                 "available in this build.";
+  return nullptr;
+#endif
 }
 
 const void* BatchReplayRenderer::getCudaDepthBufferDevicePointer() {
+#ifdef ESP_BUILD_WITH_CUDA
   CORRADE_ASSERT(standalone_,
                  "ReplayBatchRenderer::getCudaDepthBufferDevicePointer(): can "
                  "use this function only "
@@ -263,19 +269,11 @@ const void* BatchReplayRenderer::getCudaDepthBufferDevicePointer() {
                  nullptr);
   return static_cast<gfx_batch::RendererStandalone&>(*renderer_)
       .depthCudaBufferDevicePointer();
-}
 #else
-const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {
   ESP_ERROR() << "Failed to retrieve device pointer because CUDA is not "
                  "available in this build.";
   return nullptr;
-}
-
-const void* BatchReplayRenderer::getCudaDepthBufferDevicePointer() {
-  ESP_ERROR() << "Failed to retrieve device pointer because CUDA is not "
-                 "available in this build.";
-  return nullptr;
-}
 #endif
+}
 }  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -244,5 +244,38 @@ void BatchReplayRenderer::doRender(
   renderer_->draw(framebuffer);
 }
 
+#ifdef ESP_BUILD_WITH_CUDA
+const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {
+  CORRADE_ASSERT(standalone_,
+                 "ReplayBatchRenderer::colorCudaBufferDevicePointer(): can use "
+                 "this function only "
+                 "with a standalone renderer",
+                 nullptr);
+  return static_cast<gfx_batch::RendererStandalone&>(*renderer_)
+      .colorCudaBufferDevicePointer();
+}
+
+const void* BatchReplayRenderer::getCudaDepthBufferDevicePointer() {
+  CORRADE_ASSERT(standalone_,
+                 "ReplayBatchRenderer::getCudaDepthBufferDevicePointer(): can "
+                 "use this function only "
+                 "with a standalone renderer",
+                 nullptr);
+  return static_cast<gfx_batch::RendererStandalone&>(*renderer_)
+      .depthCudaBufferDevicePointer();
+}
+#else
+const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {
+  ESP_ERROR() << "Failed to retrieve device pointer because CUDA is not "
+                 "available in this build.";
+  return nullptr;
+}
+
+const void* BatchReplayRenderer::getCudaDepthBufferDevicePointer() {
+  ESP_ERROR() << "Failed to retrieve device pointer because CUDA is not "
+                 "available in this build.";
+  return nullptr;
+}
+#endif
 }  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -24,6 +24,10 @@ class BatchReplayRenderer : public AbstractReplayRenderer {
 
   ~BatchReplayRenderer() override;
 
+  const void* getCudaColorBufferDevicePointer() override;
+
+  const void* getCudaDepthBufferDevicePointer() override;
+
  private:
   void doPreloadFile(Corrade::Containers::StringView filename) override;
 

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/esp/sim/ClassicReplayRenderer.h
+++ b/src/esp/sim/ClassicReplayRenderer.h
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/tests/BatchReplayRendererTest.cpp
+++ b/src/tests/BatchReplayRendererTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 

--- a/src/tests/BatchReplayRendererTest.cpp
+++ b/src/tests/BatchReplayRendererTest.cpp
@@ -2,6 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include "Corrade/Utility/Assert.h"
 #include "Magnum/DebugTools/Screenshot.h"
 #include "Magnum/Magnum.h"
 #include "Magnum/Trade/AbstractImageConverter.h"
@@ -13,6 +14,7 @@
 #include "esp/physics/objectManagers/RigidObjectManager.h"
 #include "esp/sensor/CameraSensor.h"
 #include "esp/sensor/Sensor.h"
+#include "esp/sim/AbstractReplayRenderer.h"
 #include "esp/sim/BatchReplayRenderer.h"
 #include "esp/sim/ClassicReplayRenderer.h"
 #include "esp/sim/Simulator.h"
@@ -186,6 +188,24 @@ void BatchReplayRendererTest::testIntegration() {
         Cr::Utility::Path::join(screenshotDir, groundTruthImageFile),
         (Mn::DebugTools::CompareImageToFile{maxThreshold, meanThreshold}));
   }
+
+  const auto colorPtr = renderer->getCudaColorBufferDevicePointer();
+  const auto depthPtr = renderer->getCudaDepthBufferDevicePointer();
+  bool isBatchRenderer =
+      dynamic_cast<esp::sim::BatchReplayRenderer*>(renderer.get());
+#ifdef ESP_BUILD_WITH_CUDA
+  if (isBatchRenderer) {
+    CORRADE_VERIFY(colorPtr);
+    CORRADE_VERIFY(depthPtr);
+  } else {
+    // Not implemented in ClassicReplayRenderer
+    CORRADE_VERIFY(!colorPtr);
+    CORRADE_VERIFY(!depthPtr);
+  }
+#else
+  CORRADE_VERIFY(!colorPtr);
+  CORRADE_VERIFY(!depthPtr);
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
## Motivation and Context

This adds replay renderer bindings to get CUDA device pointers from Python.

## How Has This Been Tested

Device pointers are tested in `BatchReplayRendererTest`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
