### PR TITLE
Avoid loading textures in simulator when batch rendering.

### DIFF
--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -103,7 +103,7 @@ class Simulator(SimulatorBackend):
             )
         )
 
-        config.sim_cfg.requires_textures = any(
+        config.sim_cfg.requires_textures = not config.enable_batch_renderer and any(
             (
                 any(
                     sens_spec.sensor_type == SensorType.COLOR


### PR DESCRIPTION
## Motivation and Context

This fixes an issue where textures would load even if batch rendering is enabled.

## How Has This Been Tested

Tested locally on Habitat-Lab batch renderer integration prototype.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
