### PR TITLE
--Minor fix to remove file being written by test

### DIFF
--- a/src/tests/PathFinderTest.cpp
+++ b/src/tests/PathFinderTest.cpp
@@ -241,16 +241,22 @@ void PathFinderTest::navMeshSettingsTestJSON() {
 
   // check saving settings
   esp::nav::NavMeshSettings defaultSettings;
-
+  const auto testFilepath =
+      Cr::Utility::Path::join(TEST_ASSETS, "test_navmeshsettings_reload.json");
   // save defaults to a file
-  defaultSettings.writeToJSON(
-      Cr::Utility::Path::join(TEST_ASSETS, "test_navmeshsettings_reload.json"));
+  defaultSettings.writeToJSON(testFilepath);
 
   // reload and check against original
-  navmeshSettings.readFromJSON(
-      Cr::Utility::Path::join(TEST_ASSETS, "test_navmeshsettings_reload.json"));
+  navmeshSettings.readFromJSON(testFilepath);
 
   CORRADE_VERIFY(defaultSettings == navmeshSettings);
+
+  // remove file created for this test
+  bool success = Corrade::Utility::Path::remove(testFilepath);
+  if (!success) {
+    ESP_WARNING() << "Unable to remove temporary test JSON file"
+                  << testFilepath;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Motivation and Context
The current PathfinderTest.cpp is writing a test file to disk to validate file read ability. This PR removes that file after the test is complete.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
