### PR TITLE
MultiGoalShortestPath improvements

### DIFF
--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -70,7 +70,7 @@ void initShortestPathBindings(py::module& m) {
       .def_readwrite(
           "closest_end_point_index",
           &MultiGoalShortestPath::closestEndPointIndex,
-          R"(he index of the closest end point corresponding to end of the shortest path. Will be -1 if no path exists.)");
+          R"(The index of the closest end point corresponding to end of the shortest path. Will be -1 if no path exists.)");
 
   py::class_<NavMeshSettings, NavMeshSettings::ptr>(
       m, "NavMeshSettings",

--- a/src/esp/bindings/ShortestPathBindings.cpp
+++ b/src/esp/bindings/ShortestPathBindings.cpp
@@ -66,7 +66,11 @@ void initShortestPathBindings(py::module& m) {
           R"(A list of points that specify the shortest path on the navigation mesh between requestedStart and the closest (by geodesic distance) point in requestedEnds. Will be empty if no path exists.)")
       .def_readwrite(
           "geodesic_distance", &MultiGoalShortestPath::geodesicDistance,
-          R"(The total geodesic distance of the path. Will be inf if no path exists.)");
+          R"(The total geodesic distance of the path. Will be inf if no path exists.)")
+      .def_readwrite(
+          "closest_end_point_index",
+          &MultiGoalShortestPath::closestEndPointIndex,
+          R"(he index of the closest end point corresponding to end of the shortest path. Will be -1 if no path exists.)");
 
   py::class_<NavMeshSettings, NavMeshSettings::ptr>(
       m, "NavMeshSettings",

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1335,6 +1335,7 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
                                      dtPolyRef& startRef,
                                      vec3f& pathStart) {
   path.geodesicDistance = std::numeric_limits<float>::infinity();
+  path.closestEndPointIndex = -1;
   path.points.clear();
 
   // find nearest polys and path
@@ -1423,6 +1424,7 @@ bool PathFinder::Impl::findPath(MultiGoalShortestPath& path) {
       path.pimpl_->minTheoreticalDist[i] = std::get<0>(*findResult);
       path.geodesicDistance = std::get<0>(*findResult);
       path.points = std::get<1>(*findResult);
+      path.closestEndPointIndex = i;
     }
   }
 

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1349,6 +1349,7 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
   if (!path.pimpl_->endRefs.empty())
     return true;
 
+  int numValidPoints = 0;
   for (const auto& rqEnd : path.getRequestedEnds()) {
     dtPolyRef endRef = 0;
     vec3f pathEnd;
@@ -1356,11 +1357,18 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
         projectToPoly(rqEnd, navQuery_.get(), filter_.get());
 
     if (status != DT_SUCCESS || endRef == 0) {
-      return false;
+      ESP_DEBUG() << "Can't project end-point to navmesh, skipping: " << rqEnd;
+    } else {
+      numValidPoints++;
     }
 
     path.pimpl_->endRefs.emplace_back(endRef);
     path.pimpl_->pathEnds.emplace_back(pathEnd);
+
+    if (numValidPoints == 0) {
+      ESP_DEBUG() << "Early abort, can't project any points to navmesh.";
+      return false;
+    }
   }
 
   return true;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -1365,11 +1365,10 @@ bool PathFinder::Impl::findPathSetup(MultiGoalShortestPath& path,
 
     path.pimpl_->endRefs.emplace_back(endRef);
     path.pimpl_->pathEnds.emplace_back(pathEnd);
-
-    if (numValidPoints == 0) {
-      ESP_DEBUG() << "Early abort, can't project any points to navmesh.";
-      return false;
-    }
+  }
+  if (numValidPoints == 0) {
+    ESP_DEBUG() << "Early abort, can't project any points to navmesh.";
+    return false;
   }
 
   return true;

--- a/src/esp/nav/PathFinder.h
+++ b/src/esp/nav/PathFinder.h
@@ -105,6 +105,14 @@ struct MultiGoalShortestPath {
    */
   float geodesicDistance{};
 
+  /**
+   * @brief The index of the closest end point corresponding to end of the
+   * shortest path.
+   *
+   * Will be -1 if no path exists.
+   */
+  int closestEndPointIndex{};
+
   friend class PathFinder;
 
   ESP_SMART_POINTERS_WITH_UNIQUE_PIMPL(MultiGoalShortestPath)


### PR DESCRIPTION
## Motivation and Context

Currently, if any of the requested_end points don't snap to the navmesh, `MultiGoalShortestPath` will early abort and return `inf` distance.
Expected behavior: if *any* of the points in `requested_ends` are valid, the shortest path should be computed accurately.

Additional feature: adds `closest_end_point_index` to `MultiGoalShortestPath` struct API. Makes it easier to know which point form the input set was actually selected as closets. Corresponds to the end of the `path`.

## How Has This Been Tested

TODO:
May need to update tests to check these edge cases:
- all points off navmesh
- some points off navmesh
- all points on other island
- all point son other island or off navmesh

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
