### PR TITLE
Add batch renderer API for rendering standalone applications.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -418,10 +418,15 @@ void initSimBindings(py::module& m) {
       .def("clear_environment", &AbstractReplayRenderer::clearEnvironment,
            "Clear all instances and resets memory of an environment.")
       .def("render",
-           static_cast<void (AbstractReplayRenderer::*)(
-               Magnum::GL::AbstractFramebuffer&)>(
+           static_cast<void (AbstractReplayRenderer::*)()>(
                &AbstractReplayRenderer::render),
-           R"(Render all sensors onto the specified framebuffer.)")
+           R"(Render all sensors onto the main framebuffer.)")
+      .def(
+          "render",
+          static_cast<void (AbstractReplayRenderer::*)(
+              Magnum::GL::AbstractFramebuffer&)>(
+              &AbstractReplayRenderer::render),
+          R"(Render all sensors onto an external framebuffer. For standalone applications, use the parameterless overload.)")
       .def(
           "set_sensor_transforms_from_keyframe",
           &AbstractReplayRenderer::setSensorTransformsFromKeyframe,

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -737,7 +737,7 @@ bool Renderer::addFile(const Cr::Containers::StringView filename,
        "named templates" to be referenced from addNodeHierarchy(). */
     if (!(flags & RendererFileFlag::Whole)) {
       /* Transformations of all objects in the scene. Objects that don't have
-         this field default to an indentity transform. */
+         this field default to an identity transform. */
       Cr::Containers::Array<Mn::Matrix4> transformations{
           std::size_t(scene->mappingBound())};
       for (Cr::Containers::Pair<Mn::UnsignedInt, Mn::Matrix4> transformation :

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -20,6 +20,7 @@
 #include <Corrade/Utility/Path.h>
 #include <Magnum/GL/AbstractFramebuffer.h>
 #include <Magnum/GL/Buffer.h>
+#include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Renderer.h>
 #include <Magnum/GL/TextureArray.h>
@@ -1073,6 +1074,10 @@ Cr::Containers::StridedArrayView1D<Mn::Float> Renderer::lightRanges(
                  {});
 
   return stridedArrayView(state_->scenes[sceneId].lights).slice(&Light::range);
+}
+
+void Renderer::draw() {
+  draw(Mn::GL::defaultFramebuffer);
 }
 
 void Renderer::draw(Mn::GL::AbstractFramebuffer& framebuffer) {

--- a/src/esp/gfx_batch/Renderer.h
+++ b/src/esp/gfx_batch/Renderer.h
@@ -696,6 +696,11 @@ class Renderer {
       Magnum::UnsignedInt sceneId);
 
   /**
+   * @brief Draw all scenes in the default framebuffer.
+   */
+  virtual void draw();
+
+  /**
    * @brief Draw all scenes into provided framebuffer
    *
    * The @p framebuffer is expected to have a size at least as larger as the

--- a/src/esp/gfx_batch/Renderer.h
+++ b/src/esp/gfx_batch/Renderer.h
@@ -485,7 +485,7 @@ class Renderer {
   /**
    * @brief Max light count
    *
-   * By default there's zero lights, i.e. flat-shaded renderering.
+   * By default there's zero lights, i.e. flat-shaded rendering.
    * @see @ref RendererConfiguration::setMaxLightCount()
    */
   Magnum::UnsignedInt maxLightCount() const;

--- a/src/esp/gfx_batch/RendererStandalone.h
+++ b/src/esp/gfx_batch/RendererStandalone.h
@@ -29,7 +29,7 @@ enum class RendererStandaloneFlag {
    * @m_class{m-note m-warning}
    *
    * @par
-   *    **Not recommmended** to be enabled in end-user applications, as the log
+   *    **Not recommended** to be enabled in end-user applications, as the log
    *    contains vital information for debugging platform-specific issues.
    */
   QuietLog = 1 << 0
@@ -166,7 +166,7 @@ class RendererStandalone : public Renderer {
    * @ref depthImage() or @ref colorCudaBufferDevicePointer() /
    * @ref depthCudaBufferDevicePointer() to retrieve the output.
    */
-  void draw();
+  void draw() override;
 
   /**
    * @brief Retrieve the rendered color output

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -90,6 +90,10 @@ void AbstractReplayRenderer::setSensorTransformsFromKeyframe(
   return doSetSensorTransformsFromKeyframe(envIndex, prefix);
 }
 
+void AbstractReplayRenderer::render() {
+  doRender();
+}
+
 void AbstractReplayRenderer::render(
     Cr::Containers::ArrayView<const Mn::MutableImageView2D> imageViews) {
   CORRADE_ASSERT(imageViews.size() == doEnvironmentCount(),

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -95,11 +95,15 @@ class AbstractReplayRenderer {
   void setSensorTransformsFromKeyframe(unsigned envIndex,
                                        const std::string& prefix);
 
-  // Renders and waits for the render to finish
+  // Render into the default framebuffer. Assumes the framebuffer color & depth
+  // is cleared.
+  void render();
+
+  // Renders and waits for the render to finish.
   void render(Corrade::Containers::ArrayView<const Magnum::MutableImageView2D>
                   imageViews);
 
-  // Assumes the framebuffer color & depth is cleared
+  // Assumes the framebuffer color & depth is cleared.
   void render(Magnum::GL::AbstractFramebuffer& framebuffer);
 
   // Retrieve the color buffer as a CUDA device pointer. */
@@ -136,6 +140,8 @@ class AbstractReplayRenderer {
   /* envIndex is guaranteed to be in bounds */
   virtual void doSetSensorTransformsFromKeyframe(unsigned envIndex,
                                                  const std::string& prefix) = 0;
+
+  virtual void doRender() = 0;
 
   /* imageViews.size() is guaranteed to be same as doEnvironmentCount() */
   virtual void doRender(

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -103,7 +103,8 @@ class AbstractReplayRenderer {
   void render(Corrade::Containers::ArrayView<const Magnum::MutableImageView2D>
                   imageViews);
 
-  // Assumes the framebuffer color & depth is cleared.
+  // Renders into an external framebuffer. Assumes the framebuffer color & depth
+  // is cleared.
   void render(Magnum::GL::AbstractFramebuffer& framebuffer);
 
   // Retrieve the color buffer as a CUDA device pointer. */

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -217,6 +217,10 @@ void BatchReplayRenderer::doSetSensorTransformsFromKeyframe(
       Mn::Matrix4::from(rotation.toMatrix(), translation).inverted();
 }
 
+void BatchReplayRenderer::doRender() {
+  renderer_->draw();
+}
+
 void BatchReplayRenderer::doRender(
     Cr::Containers::ArrayView<const Mn::MutableImageView2D> imageViews) {
   CORRADE_ASSERT(standalone_,

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -44,6 +44,8 @@ class BatchReplayRenderer : public AbstractReplayRenderer {
   void doSetSensorTransformsFromKeyframe(unsigned envIndex,
                                          const std::string& prefix) override;
 
+  void doRender() override;
+
   void doRender(Corrade::Containers::ArrayView<const Magnum::MutableImageView2D>
                     imageViews) override;
 

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -12,6 +12,7 @@
 #include "esp/sim/SimulatorConfiguration.h"
 
 #include <Magnum/GL/Context.h>
+#include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/ImageView.h>
 
 namespace esp {
@@ -183,6 +184,10 @@ void ClassicReplayRenderer::doSetSensorTransformsFromKeyframe(
     sensor.node().setRotation(rotation);
     sensor.node().setTranslation(translation);
   }
+}
+
+void ClassicReplayRenderer::doRender() {
+  doRender(Mn::GL::defaultFramebuffer);
 }
 
 void ClassicReplayRenderer::doRender(

--- a/src/esp/sim/ClassicReplayRenderer.h
+++ b/src/esp/sim/ClassicReplayRenderer.h
@@ -70,6 +70,8 @@ class ClassicReplayRenderer : public AbstractReplayRenderer {
   void doSetSensorTransformsFromKeyframe(unsigned envIndex,
                                          const std::string& prefix) override;
 
+  void doRender() override;
+
   void doRender(Corrade::Containers::ArrayView<const Magnum::MutableImageView2D>
                     imageViews) override;
 


### PR DESCRIPTION
## Motivation and Context

This changeset adds a general `render()` method to replay renderer to render into default framebuffer.
This is used by standalone applications, i.e. applications that don't create their own context, like Habitat-lab.

## How Has This Been Tested

Tested locally on Habitat-lab integration prototype.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
