### PR TITLE
Allow the batch renderer to draw empty scenes.

### DIFF
--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -1076,6 +1076,10 @@ Cr::Containers::StridedArrayView1D<Mn::Float> Renderer::lightRanges(
 }
 
 void Renderer::draw(Mn::GL::AbstractFramebuffer& framebuffer) {
+  if (state_->shaders.empty()) {
+    return;
+  }
+
   /* Process scenes that are marked as dirty */
   // TODO this could be a separate step to allow the user to control when it
   //  runs

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -1076,10 +1076,6 @@ Cr::Containers::StridedArrayView1D<Mn::Float> Renderer::lightRanges(
 }
 
 void Renderer::draw(Mn::GL::AbstractFramebuffer& framebuffer) {
-  // TODO allow this (currently addFile() sets up shader limits)
-  CORRADE_ASSERT(!state_->meshes.isEmpty(),
-                 "Renderer::draw(): no file was added", );
-
   /* Process scenes that are marked as dirty */
   // TODO this could be a separate step to allow the user to control when it
   //  runs

--- a/src/esp/gfx_batch/Renderer.cpp
+++ b/src/esp/gfx_batch/Renderer.cpp
@@ -1076,7 +1076,10 @@ Cr::Containers::StridedArrayView1D<Mn::Float> Renderer::lightRanges(
 }
 
 void Renderer::draw(Mn::GL::AbstractFramebuffer& framebuffer) {
+  /* If addFile() was not called, we don't have the shaders set up yet. In that
+     case there should be no meshes to render from either, so nothing to do. */
   if (state_->shaders.empty()) {
+    CORRADE_INTERNAL_ASSERT(state_->meshes.isEmpty());
     return;
   }
 

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -63,7 +63,7 @@ struct GfxBatchRendererTest : Cr::TestSuite::Tester {
   void meshHierarchy();
   void multipleMeshes();
 
-  void emptyScene();
+  void renderNoFileAdded();
   void multipleScenes();
   void clearScene();
 
@@ -285,7 +285,7 @@ GfxBatchRendererTest::GfxBatchRendererTest() {
   addInstancedTests({&GfxBatchRendererTest::meshHierarchy},
       Cr::Containers::arraySize(MeshHierarchyData));
 
-  addTests({&GfxBatchRendererTest::emptyScene});
+  addTests({&GfxBatchRendererTest::renderNoFileAdded});
 
   addInstancedTests({&GfxBatchRendererTest::multipleMeshes,
                      &GfxBatchRendererTest::multipleScenes,
@@ -1713,7 +1713,7 @@ void GfxBatchRendererTest::multipleMeshes() {
   CORRADE_COMPARE(color.pixels<Mn::Color4ub>()[24][88], 0xcc00cc_rgb);
 }
 
-void GfxBatchRendererTest::emptyScene() {
+void GfxBatchRendererTest::renderNoFileAdded() {
   // clang-format off
   esp::gfx_batch::RendererStandalone renderer{
       esp::gfx_batch::RendererConfiguration{}
@@ -1722,13 +1722,6 @@ void GfxBatchRendererTest::emptyScene() {
           .setFlags(esp::gfx_batch::RendererStandaloneFlag::QuietLog)
   };
   // clang-format on
-
-  for (int i = 0; i < 4; ++i) {
-    esp::gfx_batch::SceneStats stats = renderer.sceneStats(i);
-    CORRADE_COMPARE(stats.nodeCount, 0);
-    CORRADE_COMPARE(stats.drawCount, 0);
-    CORRADE_COMPARE(stats.drawBatchCount, 0);
-  }
 
   renderer.draw();
   MAGNUM_VERIFY_NO_GL_ERROR();

--- a/src/tests/GfxBatchRendererTest.cpp
+++ b/src/tests/GfxBatchRendererTest.cpp
@@ -63,6 +63,7 @@ struct GfxBatchRendererTest : Cr::TestSuite::Tester {
   void meshHierarchy();
   void multipleMeshes();
 
+  void emptyScene();
   void multipleScenes();
   void clearScene();
 
@@ -283,6 +284,8 @@ GfxBatchRendererTest::GfxBatchRendererTest() {
 
   addInstancedTests({&GfxBatchRendererTest::meshHierarchy},
       Cr::Containers::arraySize(MeshHierarchyData));
+
+  addTests({&GfxBatchRendererTest::emptyScene});
 
   addInstancedTests({&GfxBatchRendererTest::multipleMeshes,
                      &GfxBatchRendererTest::multipleScenes,
@@ -1708,6 +1711,27 @@ void GfxBatchRendererTest::multipleMeshes() {
   CORRADE_COMPARE(color.format(), Mn::PixelFormat::RGBA8Unorm);
   CORRADE_COMPARE(color.pixels<Mn::Color4ub>()[18][44], 0x00cccc_rgb);
   CORRADE_COMPARE(color.pixels<Mn::Color4ub>()[24][88], 0xcc00cc_rgb);
+}
+
+void GfxBatchRendererTest::emptyScene() {
+  // clang-format off
+  esp::gfx_batch::RendererStandalone renderer{
+      esp::gfx_batch::RendererConfiguration{}
+          .setTileSizeCount({64, 48}, {2, 2}),
+      esp::gfx_batch::RendererStandaloneConfiguration{}
+          .setFlags(esp::gfx_batch::RendererStandaloneFlag::QuietLog)
+  };
+  // clang-format on
+
+  for (int i = 0; i < 4; ++i) {
+    esp::gfx_batch::SceneStats stats = renderer.sceneStats(i);
+    CORRADE_COMPARE(stats.nodeCount, 0);
+    CORRADE_COMPARE(stats.drawCount, 0);
+    CORRADE_COMPARE(stats.drawBatchCount, 0);
+  }
+
+  renderer.draw();
+  MAGNUM_VERIFY_NO_GL_ERROR();
 }
 
 void GfxBatchRendererTest::multipleScenes() {


### PR DESCRIPTION
## Motivation and Context

This replaces an assertion that prevents drawing empty scenes by an early-out.

## How Has This Been Tested

Tested locally and via unit test.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
