### PR TITLE
don't default to joined collision objects

### DIFF
--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -91,7 +91,7 @@ ObjectAttributes::ObjectAttributes(const std::string& handle)
   setComputeCOMFromShape(true);
 
   setBoundingBoxCollisions(false);
-  setJoinCollisionMeshes(true);
+  setJoinCollisionMeshes(false);
   // default to use material-derived shader unless otherwise specified in config
   // or instance config
   setShaderType(getShaderTypeName(ObjectInstanceShaderType::Material));


### PR DESCRIPTION
## Motivation and Context

Current default is to join all collision shapes into a single convex unless explicitly configured otherwise. This is an outdated stability consideration from a buggier time and should no longer be the default.

## How Has This Been Tested

locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
