### PR TITLE
[bugfix] - ray distance scaling

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -491,8 +491,7 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
     hit.normal = Magnum::Vector3{allResults.m_hitNormalWorld[i]};
     hit.point = Magnum::Vector3{allResults.m_hitPointWorld[i]};
     hit.rayDistance =
-        (static_cast<double>(allResults.m_hitFractions[i]) * maxDistance) /
-        rayLength;
+        (static_cast<double>(allResults.m_hitFractions[i]) * maxDistance);
     // default to -1 for "scene collision" if we don't know which object was
     // involved
     hit.objectId = -1;

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -568,6 +568,20 @@ def test_raycast():
             sim.set_stage_is_collidable(False)
             raycast_results = sim.cast_ray(test_ray_1)
             assert not raycast_results.has_hits()
+            sim.set_stage_is_collidable(True)
+
+            # test non-unit ray direction
+            test_ray_1.direction = mn.Vector3(0.5, 0, 0)
+            raycast_results = sim.cast_ray(test_ray_1)
+            assert raycast_results.has_hits()
+            assert len(raycast_results.hits) == 3
+            assert (
+                raycast_results.hits[0].point
+                - (
+                    test_ray_1.origin
+                    + test_ray_1.direction * raycast_results.hits[0].ray_distance
+                )
+            ).length() < 0.001
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Motivation and Context

`RayHitInfo.rayDistance` should be in units of ray length. In other words, `rayDistance==1` indicates a world distance of `length(ray.direction)`. The hit fraction from Bullet is already scaled this way, so additional scaling is not necessary, but was being done erroneously.

Because no tests or downstream code had the audacity to use non-unit ray directions, this bug was not caught until now.

## How Has This Been Tested

Added a test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
