### PR TITLE
--Configuration support for Magnum Vector2, Vector4, Color3 and Color4, UserDefinedAttr support of str Lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ examples/web_apps/webxr_hand_demo/js/hsim_bindings.wasm
 data/fairmotion/
 
 pre-commit-deps.txt
+
+tools/qa_scenes/qa_scenes_output/

--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -52,17 +52,17 @@ Configuring Child Attributes
 Stages, Objects, Lights, and Scenes can be linked from .json, created directly from assets (e.g. .glb) or configured directly in this file's configuration nodes via the syntax below:
 
 "stages" \| "objects" \| "articulated_objects" \| "light_setups" \| "scene_instances"
-    - json object
+    - JSON object
     - Configuration pertaining to the specified attribute type.
 
     - "default_attributes"
-        - json object
-        - Set default attributes for all like objects in the dataset. Individual objects can override these values. See StageAttributes, ObjectAttributes, etc... below.
+        - JSON object
+        - Set default attributes for all like objects in the dataset. Individual JSON instances can override these values. See StageAttributes, ObjectAttributes, etc... below.
     - "paths"
-        - json object
+        - JSON object
         - keyed by file extension to search for. Value is a list of paths relative to this file to search for the designated filetype.
     - "configs"
-        - list of json objects
+        - list of JSON objects
         - Define modified copies or completely new Attributes objects directly in the SceneDatasetAttributes. See StageAttributes, ObjectAttributes, etc... below.
             - "original_file"
                 - string
@@ -71,11 +71,11 @@ Stages, Objects, Lights, and Scenes can be linked from .json, created directly f
                 - string
                 - Handle/name for the new *Attributes*. Used to reference it withing its *AttributesManager*.
             -  "attributes"
-                - json object
+                - JSON object
                 - Attribute configuration to override defaults or copied values.
 
 "semantic_scene_descriptor_instances" \| "navmesh_instances"
-    - json object
+    - JSON object
     - key\|value pairs link handles to relative filepaths for all Semantic Scene Descriptor (SSD) and NavMesh files. These can then be referenced by name within `SceneInstanceAttributes`.
 
 `SceneInstanceAttributes`_
@@ -142,7 +142,7 @@ Stage Instance
 --------------
 
 "stage_instance"
-    - json object
+    - JSON object
     - Each scene can support one stage instance.
         - "template_name"
             - string
@@ -169,7 +169,7 @@ Object Instances
 All rigid and articulated objects instanced in the scene during initialization should be listed and configured here.
 
 "object_instances"
-    - list of json objects
+    - list of JSON objects
     - List all rigid object instances within the scene.
         - "template_name"
             - string
@@ -194,7 +194,7 @@ All rigid and articulated objects instanced in the scene during initialization s
             - One of ('COM', 'asset_local'). Defines whether the translation provided for this object instance is applied in render asset local space or center of mass (COM) aligned space. All rigid object translations within Habitat-sim are in COM space, but external translations (e.g. exported from Blender) may not be.
 
 "articulated_object_instances"
-    - list of json objects
+    - list of JSON objects
     - List of all articulated object instances within the scene.
         - "template_name"
             - string
@@ -227,10 +227,10 @@ All rigid and articulated objects instanced in the scene during initialization s
             - string
             - One of ('COM', 'asset_local'). Defines whether the translation provided for this object instance is applied in render asset local space or center of mass (COM) aligned space.
         - "initial_joint_pose"
-            - json object or list
+            - JSON object or list
             - The initial joint state of the articulated object. If a list, should be the full set of joint positions as floats. If an object, key\|value pairs map individual joint names to positions.
         - "initial_joint_velocities"
-            - json object or list
+            - JSON object or list
             - The initial joint velocity state of the articulated object. If a list, should be the full set of joint velocities as floats. If an object, key\|value pairs map individual joint names to velocities.
 
 Other Features
@@ -493,8 +493,9 @@ Below are the supported JSON tags for Physics Manager Attributes templates, and 
 `User Defined Attributes`_
 ==========================
 
-For all Attributes objects, the "user_defined" tag is reserved for a json configuration node which can be filled with user data. There are no limitations on the depth of this subtree (i.e., you can stack JSON objects to arbitrary depth) and Habitat-sim functionality will not depend on any specific metadata under this tag.
-You can use this tag to cache object information for your specific use cases or track simulation properties over time in user code.
+For all Attributes objects and their source JSON files, the "user_defined" tag is reserved for a JSON configuration node which can be filled with user data. Objects bearing this tag can be placed
+anywhere in a JSON configuration file; there are no limitations on the depth of this subtree (i.e., you can stack JSON objects to arbitrary depth) and Habitat-sim functionality will neither depend on
+nor process any specific metadata under this tag. You can use this tag to cache object information for your specific use cases or track simulation properties over time in user code.
 
 For example, :ref:`ObjectAttributes.get_user_config` returns the configuration object containing all metadata from this tag within a *.object_config.json* file:
 
@@ -525,12 +526,19 @@ User-Defined JSON Field type mappings
 JSON field data example Habitat-Sim internal type   Notes
 ======================= =========================== ===================
 10.0                    double
+7                       integer
+"can grip"              string
 false                   boolean
-[0,1]                   Magnum Vector2
+[0,1]                   Magnum Vector2 (float)
+[0,1,2]                 Magnum Vector3 (float)
+[0,1,3,4]               Magnum Vector4 (float)      1
+[0,1,2,3]               Magnum Quaternion (float)   1
+[1,2,3,4,5,6,7,8,9]     Magnum Matrix3 (float)      2
+
 ======================= =========================== ===================
 
-
-
+1 - If a length-4 numeric vector's tag contains as a substring 'quat', 'orient' or 'rotat', case-insensitive, the object will be loaded and processed as a Magnum::Quaternion (w,x,y,z) by the parser. Otherwise, it will be loaded as a Magnum::Vector4.
+2 - A length-9 numeric vector will be mapped into a Magnum Matrix3 in column-major order.
 
 Object Instance User Data
 -------------------------

--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -525,14 +525,9 @@ User-Defined JSON Field type mappings
 JSON field data example Habitat-Sim internal type   Notes
 ======================= =========================== ===================
 10.0                    double
-(false, true)           boolean
-"false"
+false                   boolean
+[0,1]                   Magnum Vector2
 ======================= =========================== ===================
-
-
-
-
-
 
 
 

--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -538,6 +538,7 @@ false                   boolean
 ======================= =========================== ===================
 
 1 - If a length-4 numeric vector's tag contains as a substring 'quat', 'orient' or 'rotat', case-insensitive, the object will be loaded and processed as a Magnum::Quaternion (w,x,y,z) by the parser. Otherwise, it will be loaded as a Magnum::Vector4.
+
 2 - A length-9 numeric vector will be mapped into a Magnum Matrix3 in column-major order.
 
 Object Instance User Data

--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -25,13 +25,13 @@ All necessary configuration can be done as a pre-process via the JSON configurat
 .. figure:: images/scenedataset_documentation_diagram.svg
     :width: 100em
 
-    A *SceneDataset* system diagram illustrating the correspondance between JSON configs and programmatic structures. Note that the *Simulator* controls instatiation of objects by accessing data cached within its internal *MetadataMediator*.
+    A *SceneDataset* system diagram illustrating the correspondence between JSON configs and programmatic structures. Note that the *Simulator* controls instantiation of objects by accessing data cached within its internal *MetadataMediator*.
 
 Programmatically, a *SceneDataset* consists of sets of *Attributes* objects detailing the configuration of individual objects, stages, scenes etc... which can be modified via C++ and python APIs (:ref:`habitat_sim.attributes`) and managed by *AttributeManager* APIs (:ref:`habitat_sim.attributes_managers`).
 
-These *Attributes* objects are improted from their corresponding .json files. See `ReplicaCAD <https://aihabitat.org/datasets/replica_cad/index.html>`_ for an example of a complete SceneDataset JSON config structure.
+These *Attributes* objects are imported from their corresponding .json files. See `ReplicaCAD <https://aihabitat.org/datasets/replica_cad/index.html>`_ for an example of a complete SceneDataset JSON config structure.
 
-The :ref:`MetadataMediator` aggregates all *AttributesManagers* and provides an API for swapping the active *SceneDataset*. It can exist independant of a :ref:`Simulator` object for programmatic metadata management and can be passed into the constructor via the :ref:`SimulatorConfiguration`.
+The :ref:`MetadataMediator` aggregates all *AttributesManagers* and provides an API for swapping the active *SceneDataset*. It can exist independent of a :ref:`Simulator` object for programmatic metadata management and can be passed into the constructor via the :ref:`SimulatorConfiguration`.
 
 The remaining documentation on this page details the *SceneDataset* JSON configuration options available at this time.
 
@@ -318,6 +318,9 @@ Below are stage-specific physical and object-related quantities.  These values w
 "is_collidable"
     - boolean
     - Whether the stage should be added to the collision and physics simulation world upon instancing.
+"force_flat_shading"
+    - boolean
+    - Whether the stage should be rendered with a flat shader. If this is set to true, it will override any shader_type specifications.
 "shader_type"
     - string (one of "material", "flat", "phong", "pbr")
     - The shader to be used to render the stage. 'material' uses the render asset's specified material, other values force specified shader regardless of asset specification.
@@ -399,6 +402,9 @@ Below are object-specific physical quantities.  These values will override simil
 "units_to_meters"
     - double
     - The conversion of given units to meters.
+"force_flat_shading"
+    - boolean
+    - Whether the object should be rendered with a flat shader. If this is set to true, it will override any shader_type specifications.
 "shader_type"
     - string (one of "material", "flat", "phong", "pbr")
     - The shader to be used to render the object. 'material' uses the render asset's specified material, other values force specified shader regardless of asset specification.
@@ -487,7 +493,7 @@ Below are the supported JSON tags for Physics Manager Attributes templates, and 
 `User Defined Attributes`_
 ==========================
 
-For all Attributes objects, the "user_defined" tag is reserved for a json configuration node which can be filled with user data. There are no limitations on the depth of this subtree (i.e., you can stack JSON objects to arbitrary depth) and Habitat-sim functioanlity will not depend on any specific metadata under this tag.
+For all Attributes objects, the "user_defined" tag is reserved for a json configuration node which can be filled with user data. There are no limitations on the depth of this subtree (i.e., you can stack JSON objects to arbitrary depth) and Habitat-sim functionality will not depend on any specific metadata under this tag.
 You can use this tag to cache object information for your specific use cases or track simulation properties over time in user code.
 
 For example, :ref:`ObjectAttributes.get_user_config` returns the configuration object containing all metadata from this tag within a *.object_config.json* file:
@@ -502,11 +508,34 @@ For example, :ref:`ObjectAttributes.get_user_config` returns the configuration o
                 "can open"
             ],
             "custom_object_properties":{
-                "is_gripped": "false",
+                "is_gripped": false,
                 "temperature": 10.0,
             },
         }
     }
+
+The attributes parser interprets the type of the data in the user-defined json fields based on each field's data and layout, with a few exceptions, as illustrated below:
+
+User-Defined JSON Field type mappings
+-------------------------------------
+
+.. class:: m-table m-fullwidth
+
+======================= =========================== ===================
+JSON field data example Habitat-Sim internal type   Notes
+======================= =========================== ===================
+10.0                    double
+(false, true)           boolean
+"false"
+======================= =========================== ===================
+
+
+
+
+
+
+
+
 
 Object Instance User Data
 -------------------------
@@ -516,4 +545,4 @@ User data can also be tied to specific instances of an object. When an object is
 ArticulatedObject User Data
 ---------------------------
 
-While *ArticulatedObjects* are completely defined by their URDF files and parsing parameters. However, Habitat-sim does support importing of additional user metadata via an accompanying *<urdf_name>.ao_config.json* file. See `ReplicaCAD <https://aihabitat.org/datasets/replica_cad/index.html>`_ for an example.
+While *ArticulatedObjects* are completely defined by their URDF files and parsing parameters, Habitat-sim does support importing additional user metadata via an accompanying *<urdf_name>.ao_config.json* file. See `ReplicaCAD <https://aihabitat.org/datasets/replica_cad/index.html>`_ for an example.

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -24,6 +24,8 @@ py::object getObjectForConfigValue(const ConfigValue& value) {
       return py::cast(value.get<double>());
     case ConfigStoredType::String:
       return py::cast(value.get<std::string>());
+    case ConfigStoredType::MagnumVec2:
+      return py::cast(value.get<Mn::Vector2>());
     case ConfigStoredType::MagnumVec3:
       return py::cast(value.get<Mn::Vector3>());
     case ConfigStoredType::MagnumVec4:
@@ -45,6 +47,7 @@ void initConfigBindings(py::module& m) {
       .value("Integer", ConfigStoredType::Integer)
       .value("Float", ConfigStoredType::Double)
       .value("String", ConfigStoredType::String)
+      .value("MagnumVec2", ConfigStoredType::MagnumVec2)
       .value("MagnumVec3", ConfigStoredType::MagnumVec3)
       .value("MagnumVec4", ConfigStoredType::MagnumVec4)
       .value("MagnumMat3", ConfigStoredType::MagnumMat3)
@@ -100,6 +103,12 @@ void initConfigBindings(py::module& m) {
           [](Configuration& self, const std::string& key,
              const Magnum::Quaternion& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Quaternion value)",
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](Configuration& self, const std::string& key,
+             const Magnum::Vector2& val) { self.set(key, val); },
+          R"(Set the value specified by given string key to be specified Magnum::Vector2 value)",
           "key"_a, "value"_a)
       .def(
           "set",

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -24,14 +24,10 @@ py::object getObjectForConfigValue(const ConfigValue& value) {
       return py::cast(value.get<double>());
     case ConfigStoredType::String:
       return py::cast(value.get<std::string>());
-    case ConfigStoredType::MagnumColor3:
-      return py::cast(value.get<Mn::Color3>());
     case ConfigStoredType::MagnumVec3:
       return py::cast(value.get<Mn::Vector3>());
     case ConfigStoredType::MagnumVec4:
       return py::cast(value.get<Mn::Vector4>());
-    case ConfigStoredType::MagnumColor4:
-      return py::cast(value.get<Mn::Color4>());
     case ConfigStoredType::MagnumMat3:
       return py::cast(value.get<Mn::Matrix3>());
     case ConfigStoredType::MagnumQuat:
@@ -49,11 +45,9 @@ void initConfigBindings(py::module& m) {
       .value("Integer", ConfigStoredType::Integer)
       .value("Float", ConfigStoredType::Double)
       .value("String", ConfigStoredType::String)
-      .value("MagnumColor3", ConfigStoredType::MagnumColor3)
       .value("MagnumVec3", ConfigStoredType::MagnumVec3)
       .value("MagnumVec4", ConfigStoredType::MagnumVec4)
       .value("MagnumMat3", ConfigStoredType::MagnumMat3)
-      .value("MagnumColor4", ConfigStoredType::MagnumColor4)
       .value("MagnumQuat", ConfigStoredType::MagnumQuat)
       .value("MagnumRad", ConfigStoredType::MagnumRad);
 
@@ -110,12 +104,6 @@ void initConfigBindings(py::module& m) {
       .def(
           "set",
           [](Configuration& self, const std::string& key,
-             const Magnum::Color3& val) { self.set(key, val); },
-          R"(Set the value specified by given string key to be specified Magnum::Color3 value)",
-          "key"_a, "value"_a)
-      .def(
-          "set",
-          [](Configuration& self, const std::string& key,
              const Magnum::Vector3& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Vector3 value)",
           "key"_a, "value"_a)
@@ -124,12 +112,6 @@ void initConfigBindings(py::module& m) {
           [](Configuration& self, const std::string& key,
              const Magnum::Vector4& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Vector4 value)",
-          "key"_a, "value"_a)
-      .def(
-          "set",
-          [](Configuration& self, const std::string& key,
-             const Magnum::Color4& val) { self.set(key, val); },
-          R"(Set the value specified by given string key to be specified Magnum::Color4 value)",
           "key"_a, "value"_a)
       .def(
           "set",

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -24,6 +24,8 @@ py::object getObjectForConfigValue(const ConfigValue& value) {
       return py::cast(value.get<double>());
     case ConfigStoredType::String:
       return py::cast(value.get<std::string>());
+    case ConfigStoredType::MagnumColor3:
+      return py::cast(value.get<Mn::Color3>());
     case ConfigStoredType::MagnumVec3:
       return py::cast(value.get<Mn::Vector3>());
     case ConfigStoredType::MagnumVec4:
@@ -47,6 +49,7 @@ void initConfigBindings(py::module& m) {
       .value("Integer", ConfigStoredType::Integer)
       .value("Float", ConfigStoredType::Double)
       .value("String", ConfigStoredType::String)
+      .value("MagnumColor3", ConfigStoredType::MagnumColor3)
       .value("MagnumVec3", ConfigStoredType::MagnumVec3)
       .value("MagnumVec4", ConfigStoredType::MagnumVec4)
       .value("MagnumMat3", ConfigStoredType::MagnumMat3)
@@ -103,6 +106,12 @@ void initConfigBindings(py::module& m) {
           [](Configuration& self, const std::string& key,
              const Magnum::Quaternion& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Quaternion value)",
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](Configuration& self, const std::string& key,
+             const Magnum::Color3& val) { self.set(key, val); },
+          R"(Set the value specified by given string key to be specified Magnum::Color3 value)",
           "key"_a, "value"_a)
       .def(
           "set",

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -26,6 +26,10 @@ py::object getObjectForConfigValue(const ConfigValue& value) {
       return py::cast(value.get<std::string>());
     case ConfigStoredType::MagnumVec3:
       return py::cast(value.get<Mn::Vector3>());
+    case ConfigStoredType::MagnumVec4:
+      return py::cast(value.get<Mn::Vector4>());
+    case ConfigStoredType::MagnumColor4:
+      return py::cast(value.get<Mn::Color4>());
     case ConfigStoredType::MagnumMat3:
       return py::cast(value.get<Mn::Matrix3>());
     case ConfigStoredType::MagnumQuat:
@@ -44,7 +48,9 @@ void initConfigBindings(py::module& m) {
       .value("Float", ConfigStoredType::Double)
       .value("String", ConfigStoredType::String)
       .value("MagnumVec3", ConfigStoredType::MagnumVec3)
+      .value("MagnumVec4", ConfigStoredType::MagnumVec4)
       .value("MagnumMat3", ConfigStoredType::MagnumMat3)
+      .value("MagnumColor4", ConfigStoredType::MagnumColor4)
       .value("MagnumQuat", ConfigStoredType::MagnumQuat)
       .value("MagnumRad", ConfigStoredType::MagnumRad);
 
@@ -103,6 +109,18 @@ void initConfigBindings(py::module& m) {
           [](Configuration& self, const std::string& key,
              const Magnum::Vector3& val) { self.set(key, val); },
           R"(Set the value specified by given string key to be specified Magnum::Vector3 value)",
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](Configuration& self, const std::string& key,
+             const Magnum::Vector4& val) { self.set(key, val); },
+          R"(Set the value specified by given string key to be specified Magnum::Vector4 value)",
+          "key"_a, "value"_a)
+      .def(
+          "set",
+          [](Configuration& self, const std::string& key,
+             const Magnum::Color4& val) { self.set(key, val); },
+          R"(Set the value specified by given string key to be specified Magnum::Color4 value)",
           "key"_a, "value"_a)
       .def(
           "set",

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -375,8 +375,7 @@ int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
               ESP_WARNING()
                   << "Config cell in JSON document contains key" << key
                   << "referencing an existing configuration element of size "
-                     "4 "
-                     "of unknown type:"
+                     "4 of unknown type:"
                   << getNameForStoredType(valType) << "so skipping.";
             }
           } else {
@@ -454,7 +453,9 @@ void Configuration::writeValueToJson(const char* key,
                                      const char* jsonName,
                                      io::JsonGenericValue& jsonObj,
                                      io::JsonAllocator& allocator) const {
-  rapidjson::GenericStringRef<char> name{jsonName};
+  // Create Generic value for key, using allocator, to make sure its a copy
+  // and lives long enough
+  io::JsonGenericValue name{jsonName, allocator};
   auto jsonVal = get(key).writeToJsonObject(allocator);
   jsonObj.AddMember(name, jsonVal, allocator);
 }
@@ -469,8 +470,9 @@ void Configuration::writeValuesToJson(io::JsonGenericValue& jsonObj,
   for (auto& valIter = valIterPair.first; valIter != valIterPair.second;
        ++valIter) {
     if (valIter->second.isValid()) {
-      // make sure value is legal
-      rapidjson::GenericStringRef<char> name{valIter->first.c_str()};
+      // Create Generic value for key, using allocator, to make sure its a copy
+      // and lives long enough
+      io::JsonGenericValue name{valIter->first.c_str(), allocator};
       auto jsonVal = valIter->second.writeToJsonObject(allocator);
       jsonObj.AddMember(name, jsonVal, allocator);
     } else {
@@ -491,7 +493,9 @@ void Configuration::writeSubconfigsToJson(io::JsonGenericValue& jsonObj,
        ++cfgIter) {
     // only save if subconfig has entries
     if (cfgIter->second->getNumEntries() > 0) {
-      rapidjson::GenericStringRef<char> name{cfgIter->first.c_str()};
+      // Create Generic value for key, using allocator, to make sure its a copy
+      // and lives long enough
+      io::JsonGenericValue name{cfgIter->first.c_str(), allocator};
       io::JsonGenericValue subObj =
           cfgIter->second->writeToJsonObject(allocator);
       jsonObj.AddMember(name, subObj, allocator);

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -36,9 +36,7 @@ enum class ConfigStoredType {
   Integer,
   Double,
   MagnumVec3,
-  MagnumColor3,
   MagnumVec4,
-  MagnumColor4,
   MagnumMat3,
   MagnumQuat,
   MagnumRad,
@@ -94,14 +92,6 @@ constexpr ConfigStoredType configStoredTypeFor<std::string>() {
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {
   return ConfigStoredType::MagnumVec3;
-}
-template <>
-constexpr ConfigStoredType configStoredTypeFor<Mn::Color3>() {
-  return ConfigStoredType::MagnumColor3;
-}
-template <>
-constexpr ConfigStoredType configStoredTypeFor<Mn::Color4>() {
-  return ConfigStoredType::MagnumColor4;
 }
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector4>() {

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -36,6 +36,8 @@ enum class ConfigStoredType {
   Integer,
   Double,
   MagnumVec3,
+  MagnumVec4,
+  MagnumColor4,
   MagnumMat3,
   MagnumQuat,
   MagnumRad,
@@ -91,6 +93,14 @@ constexpr ConfigStoredType configStoredTypeFor<std::string>() {
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {
   return ConfigStoredType::MagnumVec3;
+}
+template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Color4>() {
+  return ConfigStoredType::MagnumColor4;
+}
+template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Vector4>() {
+  return ConfigStoredType::MagnumVec4;
 }
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Matrix3>() {

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -36,6 +36,7 @@ enum class ConfigStoredType {
   Integer,
   Double,
   MagnumVec3,
+  MagnumColor3,
   MagnumVec4,
   MagnumColor4,
   MagnumMat3,
@@ -93,6 +94,10 @@ constexpr ConfigStoredType configStoredTypeFor<std::string>() {
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {
   return ConfigStoredType::MagnumVec3;
+}
+template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Color3>() {
+  return ConfigStoredType::MagnumColor3;
 }
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Color4>() {

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -94,7 +94,15 @@ constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {
   return ConfigStoredType::MagnumVec3;
 }
 template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Color3>() {
+  return ConfigStoredType::MagnumVec3;
+}
+template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector4>() {
+  return ConfigStoredType::MagnumVec4;
+}
+template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Color4>() {
   return ConfigStoredType::MagnumVec4;
 }
 template <>

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -35,6 +35,7 @@ enum class ConfigStoredType {
   Boolean,
   Integer,
   Double,
+  MagnumVec2,
   MagnumVec3,
   MagnumVec4,
   MagnumMat3,
@@ -88,6 +89,10 @@ constexpr ConfigStoredType configStoredTypeFor<double>() {
 template <>
 constexpr ConfigStoredType configStoredTypeFor<std::string>() {
   return ConfigStoredType::String;
+}
+template <>
+constexpr ConfigStoredType configStoredTypeFor<Mn::Vector2>() {
+  return ConfigStoredType::MagnumVec2;
 }
 template <>
 constexpr ConfigStoredType configStoredTypeFor<Mn::Vector3>() {

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -8,13 +8,59 @@
 namespace esp {
 namespace io {
 
+JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(mat.data(), (mat.Size * mat.Size), allocator);
+}
+
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& mat) {
   int numElems = mat.Size * mat.Size;
   if (obj.IsArray() && obj.Size() == numElems) {
     for (rapidjson::SizeType i = 0; i < numElems; ++i) {
       if (!fromJsonValue(obj[i], mat.data()[i])) {
-        ESP_ERROR()
-            << "Invalid numeric value specified in JSON Matrix3, index :" << i;
+        ESP_ERROR() << "Invalid numeric value specified in JSON "
+                       "Magnum::Matrix3, index :"
+                    << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(vec.data(), vec.Size, allocator);
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
+        ESP_ERROR() << "Invalid numeric value specified in JSON "
+                       "Magnum::Vector3, index :"
+                    << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(vec.data(), vec.Size, allocator);
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val) {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
+        ESP_ERROR() << "Invalid numeric value specified in JSON "
+                       "Magnum::Vector4, index :"
+                    << i;
         return false;
       }
     }
@@ -38,14 +84,34 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Quaternion& val) {
   if (obj.IsArray() && obj.Size() == 4) {
     if (!fromJsonValue(obj[0], val.scalar())) {
       ESP_ERROR() << "Invalid numeric scalar value specified in JSON "
-                     "Quaternion, index : 0";
+                     "Magnum::Quaternion, index : 0";
       return false;
     }
     for (rapidjson::SizeType i = 1; i < 4; ++i) {
       if (!fromJsonValue(obj[i], val.vector()[i - 1])) {
         ESP_ERROR() << "Invalid numeric vector value specified in JSON "
-                       "Quaternion, index :"
+                       "Magnum::Quaternion, index :"
                     << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+JsonGenericValue toJsonValue(const Magnum::Color4& color,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(color.data(), color.Size, allocator);
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
+        ESP_ERROR()
+            << "Invalid numeric value specified in JSON Magnum::Color4, index :"
+            << i;
         return false;
       }
     }

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -49,6 +49,26 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
   return false;
 }
 
+JsonGenericValue toJsonValue(const Magnum::Color3& color,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(color.data(), color.Size, allocator);
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color3& color) {
+  if (obj.IsArray() && obj.Size() == color.Size) {
+    for (rapidjson::SizeType i = 0; i < color.Size; ++i) {
+      if (!fromJsonValue(obj[i], color.data()[i])) {
+        ESP_ERROR() << "Invalid numeric value specified in JSON "
+                       "Magnum::Color3, index :"
+                    << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
                              JsonAllocator& allocator) {
   return toJsonArrayHelper(vec.data(), vec.Size, allocator);

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -8,17 +8,11 @@
 namespace esp {
 namespace io {
 
-JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
-                             JsonAllocator& allocator) {
-  return toJsonArrayHelper(mat.data(), 9, allocator);
-}
-
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& mat) {
-  if (obj.IsArray() && obj.Size() == 9) {
-    for (rapidjson::SizeType i = 0; i < 9; ++i) {
-      if (obj[i].IsNumber()) {
-        mat.data()[i] = obj[i].GetFloat();
-      } else {
+  int numElems = mat.Size * mat.Size;
+  if (obj.IsArray() && obj.Size() == numElems) {
+    for (rapidjson::SizeType i = 0; i < numElems; ++i) {
+      if (!fromJsonValue(obj[i], mat.data()[i])) {
         ESP_ERROR()
             << "Invalid numeric value specified in JSON Matrix3, index :" << i;
         return false;
@@ -42,17 +36,16 @@ JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
 
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Quaternion& val) {
   if (obj.IsArray() && obj.Size() == 4) {
-    for (rapidjson::SizeType i = 0; i < 4; ++i) {
-      if (obj[i].IsNumber()) {
-        if (i == 0) {
-          val.scalar() = obj[0].GetFloat();
-        } else {
-          val.vector()[i - 1] = obj[i].GetFloat();
-        }
-      } else {
-        ESP_ERROR()
-            << "Invalid numeric value specified in JSON Quaternion, index :"
-            << i;
+    if (!fromJsonValue(obj[0], val.scalar())) {
+      ESP_ERROR() << "Invalid numeric scalar value specified in JSON "
+                     "Quaternion, index : 0";
+      return false;
+    }
+    for (rapidjson::SizeType i = 1; i < 4; ++i) {
+      if (!fromJsonValue(obj[i], val.vector()[i - 1])) {
+        ESP_ERROR() << "Invalid numeric vector value specified in JSON "
+                       "Quaternion, index :"
+                    << i;
         return false;
       }
     }

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -49,26 +49,6 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
   return false;
 }
 
-JsonGenericValue toJsonValue(const Magnum::Color3& color,
-                             JsonAllocator& allocator) {
-  return toJsonArrayHelper(color.data(), color.Size, allocator);
-}
-
-bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color3& color) {
-  if (obj.IsArray() && obj.Size() == color.Size) {
-    for (rapidjson::SizeType i = 0; i < color.Size; ++i) {
-      if (!fromJsonValue(obj[i], color.data()[i])) {
-        ESP_ERROR() << "Invalid numeric value specified in JSON "
-                       "Magnum::Color3, index :"
-                    << i;
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
                              JsonAllocator& allocator) {
   return toJsonArrayHelper(vec.data(), vec.Size, allocator);
@@ -112,26 +92,6 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Quaternion& val) {
         ESP_ERROR() << "Invalid numeric vector value specified in JSON "
                        "Magnum::Quaternion, index :"
                     << i;
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
-JsonGenericValue toJsonValue(const Magnum::Color4& color,
-                             JsonAllocator& allocator) {
-  return toJsonArrayHelper(color.data(), color.Size, allocator);
-}
-
-bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
-  if (obj.IsArray() && obj.Size() == val.Size) {
-    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
-      if (!fromJsonValue(obj[i], val.data()[i])) {
-        ESP_ERROR()
-            << "Invalid numeric value specified in JSON Magnum::Color4, index :"
-            << i;
         return false;
       }
     }

--- a/src/esp/io/JsonMagnumTypes.cpp
+++ b/src/esp/io/JsonMagnumTypes.cpp
@@ -29,6 +29,26 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& mat) {
   return false;
 }
 
+JsonGenericValue toJsonValue(const Magnum::Vector2& vec,
+                             JsonAllocator& allocator) {
+  return toJsonArrayHelper(vec.data(), vec.Size, allocator);
+}
+
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector2& val) {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
+        ESP_ERROR() << "Invalid numeric value specified in JSON "
+                       "Magnum::Vector2, index :"
+                    << i;
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
                              JsonAllocator& allocator) {
   return toJsonArrayHelper(vec.data(), vec.Size, allocator);

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -22,11 +22,15 @@
 namespace esp {
 namespace io {
 
-inline JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
-                                    JsonAllocator& allocator) {
-  return toJsonArrayHelper(mat.data(), (mat.Size * mat.Size), allocator);
-}
-
+/**
+ * @brief Specialization to handle Magnum::Matrix3 values. Parses passed value
+ * into JsonGenericValue.
+ *
+ * @param mat Source Magnum::Matrix3 to parse into Json
+ * @return Json value containing data
+ */
+JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
+                             JsonAllocator& allocator);
 /**
  * @brief Specialization to handle Magnum::Matrix3 values. Populate passed @p
  * val with value. Returns whether successfully populated, or not. Logs an error
@@ -38,11 +42,15 @@ inline JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
  */
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val);
 
-inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
-                                    JsonAllocator& allocator) {
-  return toJsonArrayHelper(vec.data(), vec.Size, allocator);
-}
-
+/**
+ * @brief Specialization to handle Magnum::Vector3 values. Parses passed value
+ * into JsonGenericValue.
+ *
+ * @param mat Source Magnum::Vector3 to parse into Json
+ * @return Json value containing data
+ */
+JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
+                             JsonAllocator& allocator);
 /**
  * @brief Specialization to handle Magnum::Vector3 values. Populate passed @p
  * val with value. Returns whether successfully populated, or not. Logs an error
@@ -52,25 +60,17 @@ inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
  * @param val destination value to be populated
  * @return whether successful or not
  */
-inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
-  if (obj.IsArray() && obj.Size() == val.Size) {
-    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
-      if (!fromJsonValue(obj[i], val.data()[i])) {
-        ESP_ERROR() << "Invalid numeric value specified in JSON Vec3, index :"
-                    << i;
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val);
 
-inline JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
-                                    JsonAllocator& allocator) {
-  return toJsonArrayHelper(vec.data(), 4, allocator);
-}
-
+/**
+ * @brief Specialization to handle Magnum::Vector4 values. Parses passed value
+ * into JsonGenericValue.
+ *
+ * @param mat Source Magnum::Vector4 to parse into Json
+ * @return Json value containing data
+ */
+JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
+                             JsonAllocator& allocator);
 /**
  * @brief Specialization to handle Magnum::Vector4 values. Populate passed @p
  * val with value. Returns whether successfully populated, or not. Logs an error
@@ -80,41 +80,17 @@ inline JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
  * @param val destination value to be populated
  * @return whether successful or not
  */
-inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
-  if (obj.IsArray() && obj.Size() == val.Size) {
-    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
-      if (!fromJsonValue(obj[i], val.data()[i])) {
-        ESP_ERROR() << "Invalid numeric value specified in JSON Color4, index :"
-                    << i;
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val);
 
-inline JsonGenericValue toJsonValue(const Magnum::Color3& val,
-                                    JsonAllocator& allocator) {
-  return toJsonValue(static_cast<const Magnum::Vector3&>(val), allocator);
-}
 /**
- * @brief Specialization to handle Magnum::Color3 values. Populate passed @p
- * val with value. Returns whether successfully populated, or not. Logs an error
- * if inappropriate type.
+ * @brief Specialization to handle Magnum::Color4 values. Parses passed value
+ * into JsonGenericValue.
  *
- * @param obj json value to parse
- * @param val destination value to be populated
- * @return whether successful or not
+ * @param mat Source Magnum::Color4 to parse into Json
+ * @return Json value containing data
  */
-inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color3& val) {
-  return fromJsonValue(obj, static_cast<Magnum::Vector3&>(val));
-}
-
-inline JsonGenericValue toJsonValue(const Magnum::Color4& val,
-                                    JsonAllocator& allocator) {
-  return toJsonValue(static_cast<const Magnum::Vector4&>(val), allocator);
-}
+JsonGenericValue toJsonValue(const Magnum::Color4& color,
+                             JsonAllocator& allocator);
 
 /**
  * @brief Specialization to handle Magnum::Color4 values. Populate passed @p
@@ -125,9 +101,15 @@ inline JsonGenericValue toJsonValue(const Magnum::Color4& val,
  * @param val destination value to be populated
  * @return whether successful or not
  */
-inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
-  return fromJsonValue(obj, static_cast<Magnum::Vector4&>(val));
-}
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val);
+
+/**
+ * @brief Specialization to handle Magnum::Quaternion values. Parses passed
+ * value into JsonGenericValue.
+ *
+ * @param mat Source Magnum::Quaternion to parse into Json
+ * @return Json value containing data
+ */
 
 JsonGenericValue toJsonValue(const Magnum::Quaternion& quat,
                              JsonAllocator& allocator);

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -65,6 +65,26 @@ JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val);
 
 /**
+ * @brief Specialization to handle Magnum::Color3 values. Parses passed value
+ * into JsonGenericValue.
+ *
+ * @param color Source Magnum::Color3 to parse into Json
+ * @param allocator
+ * @return Json value containing data
+ */
+JsonGenericValue toJsonValue(const Magnum::Color3& color,
+                             JsonAllocator& allocator);
+/**
+ * @brief Specialization to handle Magnum::Color3 values. Populate passed @p
+ * val with value. Returns whether successfully populated, or not. Logs an error
+ * if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param color destination color to be populated
+ * @return whether successful or not
+ */
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color3& color);
+/**
  * @brief Specialization to handle Magnum::Vector4 values. Parses passed value
  * into JsonGenericValue.
  *
@@ -89,7 +109,7 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val);
  * @brief Specialization to handle Magnum::Color4 values. Parses passed value
  * into JsonGenericValue.
  *
- * @param mat Source Magnum::Color4 to parse into Json
+ * @param color Source Magnum::Color4 to parse into Json
  * @param allocator
  * @return Json value containing data
  */

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -16,14 +16,17 @@
 #include <Corrade/Containers/Optional.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Color.h>
-#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Math/Matrix3.h>
 #include <Magnum/Math/Quaternion.h>
 
 namespace esp {
 namespace io {
 
-JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
-                             JsonAllocator& allocator);
+inline JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
+                                    JsonAllocator& allocator) {
+  return toJsonArrayHelper(mat.data(), (mat.Size * mat.Size), allocator);
+}
+
 /**
  * @brief Specialization to handle Magnum::Matrix3 values. Populate passed @p
  * val with value. Returns whether successfully populated, or not. Logs an error
@@ -37,7 +40,7 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val);
 
 inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
                                     JsonAllocator& allocator) {
-  return toJsonArrayHelper(vec.data(), 3, allocator);
+  return toJsonArrayHelper(vec.data(), vec.Size, allocator);
 }
 
 /**
@@ -50,11 +53,9 @@ inline JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
  * @return whether successful or not
  */
 inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val) {
-  if (obj.IsArray() && obj.Size() == 3) {
-    for (rapidjson::SizeType i = 0; i < 3; ++i) {
-      if (obj[i].IsNumber()) {
-        val[i] = obj[i].GetDouble();
-      } else {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
         ESP_ERROR() << "Invalid numeric value specified in JSON Vec3, index :"
                     << i;
         return false;
@@ -79,13 +80,11 @@ inline JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
  * @param val destination value to be populated
  * @return whether successful or not
  */
-inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val) {
-  if (obj.IsArray() && obj.Size() == 4) {
-    for (rapidjson::SizeType i = 0; i < 4; ++i) {
-      if (obj[i].IsNumber()) {
-        val[i] = obj[i].GetDouble();
-      } else {
-        ESP_ERROR() << "Invalid numeric value specified in JSON Vec4, index :"
+inline bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val) {
+  if (obj.IsArray() && obj.Size() == val.Size) {
+    for (rapidjson::SizeType i = 0; i < val.Size; ++i) {
+      if (!fromJsonValue(obj[i], val.data()[i])) {
+        ESP_ERROR() << "Invalid numeric value specified in JSON Color4, index :"
                     << i;
         return false;
       }

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -65,26 +65,6 @@ JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val);
 
 /**
- * @brief Specialization to handle Magnum::Color3 values. Parses passed value
- * into JsonGenericValue.
- *
- * @param color Source Magnum::Color3 to parse into Json
- * @param allocator
- * @return Json value containing data
- */
-JsonGenericValue toJsonValue(const Magnum::Color3& color,
-                             JsonAllocator& allocator);
-/**
- * @brief Specialization to handle Magnum::Color3 values. Populate passed @p
- * val with value. Returns whether successfully populated, or not. Logs an error
- * if inappropriate type.
- *
- * @param obj json value to parse
- * @param color destination color to be populated
- * @return whether successful or not
- */
-bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color3& color);
-/**
  * @brief Specialization to handle Magnum::Vector4 values. Parses passed value
  * into JsonGenericValue.
  *
@@ -104,28 +84,6 @@ JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
  * @return whether successful or not
  */
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val);
-
-/**
- * @brief Specialization to handle Magnum::Color4 values. Parses passed value
- * into JsonGenericValue.
- *
- * @param color Source Magnum::Color4 to parse into Json
- * @param allocator
- * @return Json value containing data
- */
-JsonGenericValue toJsonValue(const Magnum::Color4& color,
-                             JsonAllocator& allocator);
-
-/**
- * @brief Specialization to handle Magnum::Color4 values. Populate passed @p
- * val with value. Returns whether successfully populated, or not. Logs an error
- * if inappropriate type.
- *
- * @param obj json value to parse
- * @param val destination value to be populated
- * @return whether successful or not
- */
-bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val);
 
 /**
  * @brief Specialization to handle Magnum::Quaternion values. Parses passed

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -27,6 +27,7 @@ namespace io {
  * into JsonGenericValue.
  *
  * @param mat Source Magnum::Matrix3 to parse into Json
+ * @param allocator
  * @return Json value containing data
  */
 JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
@@ -46,7 +47,8 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val);
  * @brief Specialization to handle Magnum::Vector3 values. Parses passed value
  * into JsonGenericValue.
  *
- * @param mat Source Magnum::Vector3 to parse into Json
+ * @param vec Source Magnum::Vector3 to parse into Json
+ * @param allocator
  * @return Json value containing data
  */
 JsonGenericValue toJsonValue(const Magnum::Vector3& vec,
@@ -66,7 +68,8 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector3& val);
  * @brief Specialization to handle Magnum::Vector4 values. Parses passed value
  * into JsonGenericValue.
  *
- * @param mat Source Magnum::Vector4 to parse into Json
+ * @param vec Source Magnum::Vector4 to parse into Json
+ * @param allocator
  * @return Json value containing data
  */
 JsonGenericValue toJsonValue(const Magnum::Vector4& vec,
@@ -87,6 +90,7 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector4& val);
  * into JsonGenericValue.
  *
  * @param mat Source Magnum::Color4 to parse into Json
+ * @param allocator
  * @return Json value containing data
  */
 JsonGenericValue toJsonValue(const Magnum::Color4& color,
@@ -107,7 +111,8 @@ bool fromJsonValue(const JsonGenericValue& obj, Magnum::Color4& val);
  * @brief Specialization to handle Magnum::Quaternion values. Parses passed
  * value into JsonGenericValue.
  *
- * @param mat Source Magnum::Quaternion to parse into Json
+ * @param quat Source Magnum::Quaternion to parse into Json
+ * @param allocator
  * @return Json value containing data
  */
 

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -44,6 +44,27 @@ JsonGenericValue toJsonValue(const Magnum::Matrix3& mat,
 bool fromJsonValue(const JsonGenericValue& obj, Magnum::Matrix3& val);
 
 /**
+ * @brief Specialization to handle Magnum::Vector2 values. Parses passed value
+ * into JsonGenericValue.
+ *
+ * @param vec Source Magnum::Vector2 to parse into Json
+ * @param allocator
+ * @return Json value containing data
+ */
+JsonGenericValue toJsonValue(const Magnum::Vector2& vec,
+                             JsonAllocator& allocator);
+/**
+ * @brief Specialization to handle Magnum::Vector2 values. Populate passed @p
+ * val with value. Returns whether successfully populated, or not. Logs an error
+ * if inappropriate type.
+ *
+ * @param obj json value to parse
+ * @param val destination value to be populated
+ * @return whether successful or not
+ */
+bool fromJsonValue(const JsonGenericValue& obj, Magnum::Vector2& val);
+
+/**
  * @brief Specialization to handle Magnum::Vector3 values. Parses passed value
  * into JsonGenericValue.
  *

--- a/src/esp/metadata/attributes/ObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ObjectAttributes.cpp
@@ -132,6 +132,7 @@ StageAttributes::StageAttributes(const std::string& handle)
   // setting defaults for semantic frame will have changed this to false. change
   // to true so that only used if actually changed.
   setUseFrameForAllOrientation(true);
+
   // setting default for semantic assets having semantically painted textures to
   // false
   setHasSemanticTextures(false);
@@ -172,7 +173,7 @@ std::string StageAttributes::getAbstractObjectInfoHeaderInternal() const {
   std::string res = "Gravity XYZ,Origin XYZ,";
   if (!getUseFrameForAllOrientation()) {
     Cr::Utility::formatInto(res, res.length(), "{}",
-                            "Semantic Up XYZ,Semantic Front XYZ");
+                            "Semantic Up XYZ,Semantic Front XYZ,");
   }
 
   Cr::Utility::formatInto(
@@ -187,7 +188,7 @@ std::string StageAttributes::getAbstractObjectInfoInternal() const {
                                               getAsString("origin"));
 
   if (!getUseFrameForAllOrientation()) {
-    Cr::Utility::formatInto(res, res.length(), "{},{}",
+    Cr::Utility::formatInto(res, res.length(), "{},{},",
                             getAsString("semantic_orient_up"),
                             getAsString("semantic_orient_front"));
   }

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -44,7 +44,13 @@ class PhysicsManagerAttributes : public AbstractAttributes {
    */
   double getTimestep() const { return get<double>("timestep"); }
 
+  /**
+   * @brief Currently not supported.
+   */
   void setMaxSubsteps(int maxSubsteps) { set("max_substeps", maxSubsteps); }
+  /**
+   * @brief Currently not supported.
+   */
   int getMaxSubsteps() const { return get<int>("max_substeps"); }
 
   /**

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -23,8 +23,9 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   // set to no rotation
   setRotation(Mn::Quaternion(Mn::Math::IdentityInit));
   setTranslation(Mn::Vector3());
-  // don't override attributes-specified visibility.
-  set("is_instance_visible", ID_UNDEFINED);
+  // don't override attributes-specified visibility. - sets int value to
+  // ID_UNDEFINED
+  clearIsInstanceVisible();
   // defaults to unknown so that obj instances use scene instance setting
   setTranslationOrigin(
       getTranslationOriginName(SceneInstanceTranslationOrigin::Unknown));
@@ -116,7 +117,7 @@ void SceneObjectInstanceAttributes::writeValuesToJson(
   if (getNonUniformScale() != Mn::Vector3(1.0, 1.0, 1.0)) {
     writeValueToJson("non_uniform_scale", jsonObj, allocator);
   }
-  if (getMassScale() != 1.0f) {
+  if (getMassScale() != 1.0) {
     writeValueToJson("mass_scale", jsonObj, allocator);
   }
 

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -111,6 +111,7 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
     set("is_instance_visible", (isVisible ? 1 : 0));
   }
   int getIsInstanceVisible() const { return get<int>("is_instance_visible"); }
+  void clearIsInstanceVisible() { set("is_instance_visible", ID_UNDEFINED); }
 
   /**
    * @brief Set the motion type for the object.  Ignored for stage instances.
@@ -193,12 +194,9 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Get or set the mass scaling of the instanced object.  Want this
-   * to be a float for consumption in instance creation
+   * @brief Get or set the mass scaling of the instanced object.
    */
-  float getMassScale() const {
-    return static_cast<float>(get<double>("mass_scale"));
-  }
+  double getMassScale() const { return get<double>("mass_scale"); }
   void setMassScale(double mass_scale) { set("mass_scale", mass_scale); }
 
   /**

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -39,16 +39,14 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    * @brief Set the translation from the origin of the described
    * stage/object instance.
    */
-  void setTranslation(const Magnum::Vector3& translation) {
+  void setTranslation(const Mn::Vector3& translation) {
     set("translation", translation);
   }
   /**
    * @brief Get the translation from the origin of the described
    * stage/object instance.
    */
-  Magnum::Vector3 getTranslation() const {
-    return get<Magnum::Vector3>("translation");
-  }
+  Mn::Vector3 getTranslation() const { return get<Mn::Vector3>("translation"); }
 
   /**
    * @brief Set a value representing the mechanism used to create this scene
@@ -92,15 +90,13 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   /**
    * @brief Set the rotation of the object
    */
-  void setRotation(const Magnum::Quaternion& rotation) {
+  void setRotation(const Mn::Quaternion& rotation) {
     set("rotation", rotation);
   }
   /**
    * @brief Get the rotation of the object
    */
-  Magnum::Quaternion getRotation() const {
-    return get<Magnum::Quaternion>("rotation");
-  }
+  Mn::Quaternion getRotation() const { return get<Mn::Quaternion>("rotation"); }
 
   /**
    * @brief If not visible can add dynamic non-rendered object into a scene
@@ -181,15 +177,15 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
    * @brief Get the non-uniform scale vector of the described stage/object
    * instance.
    */
-  Magnum::Vector3 getNonUniformScale() const {
-    return get<Magnum::Vector3>("non_uniform_scale");
+  Mn::Vector3 getNonUniformScale() const {
+    return get<Mn::Vector3>("non_uniform_scale");
   }
 
   /**
    * @brief Set the non-uniform scale vector of the described stage/object
    * instance.
    */
-  void setNonUniformScale(const Magnum::Vector3& non_uniform_scale) {
+  void setNonUniformScale(const Mn::Vector3& non_uniform_scale) {
     set("non_uniform_scale", non_uniform_scale);
   }
 

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -431,7 +431,7 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
       int numConfigSettings = subGroupPtr->loadFromJson(jsonObj);
 
       // save as user_defined subgroup configuration
-      attribs->setSubconfigPtr("user_defined", subGroupPtr);
+      attribs->setSubconfigPtr(subGroupName, subGroupPtr);
 
       return (numConfigSettings > 0);
     }

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -290,6 +290,13 @@ void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
         instanceAttrs->setNonUniformScale(non_uniform_scale);
       });
 
+  // whether particular instance is visible or not - only modify if actually
+  // present in instance json
+  io::jsonIntoSetter<bool>(
+      jCell, "is_instance_visible", [instanceAttrs](bool is_instance_visible) {
+        instanceAttrs->setIsInstanceVisible(is_instance_visible);
+      });
+
   // mass scaling for instance
   io::jsonIntoSetter<double>(jCell, "mass_scale",
                              [instanceAttrs](double mass_scale) {
@@ -320,7 +327,8 @@ std::string SceneInstanceAttributesManager::getTranslationOriginVal(
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << ": translation_origin value in json :`" << tmpTransOriginVal
           << "`|`" << strToLookFor
-          << "` does not map to a valid SceneInstanceTranslationOrigin value, "
+          << "` does not map to a valid SceneInstanceTranslationOrigin "
+             "value, "
              "so defaulting translation origin to "
              "SceneInstanceTranslationOrigin::Unknown.";
     }
@@ -333,8 +341,8 @@ int SceneInstanceAttributesManager::registerObjectFinalize(
     const std::string& sceneInstanceAttributesHandle,
     bool) {
   // adds template to library, and returns either the ID of the existing
-  // template referenced by sceneInstanceAttributesHandle, or the next available
-  // ID if not found.
+  // template referenced by sceneInstanceAttributesHandle, or the next
+  // available ID if not found.
   int datasetTemplateID = this->addObjectToLibrary(
       std::move(sceneInstanceAttributes), sceneInstanceAttributesHandle);
   return datasetTemplateID;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -121,13 +121,6 @@ int PhysicsManager::addObjectInstance(
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
-  // check if an object is being set to be not visible for a particular
-  // instance.
-  int visSet = objInstAttributes->getIsInstanceVisible();
-  if (visSet != ID_UNDEFINED) {
-    // specfied in scene instance
-    objAttributes->setIsVisible(visSet == 1);
-  }
 
   if (!objAttributes) {
     ESP_ERROR() << "Missing/improperly configured objectAttributes"
@@ -136,6 +129,14 @@ int PhysicsManager::addObjectInstance(
                 << "as specified in object instance attributes.";
     return 0;
   }
+  // check if an object is being set to be not visible for a particular
+  // instance.
+  int visSet = objInstAttributes->getIsInstanceVisible();
+  if (visSet != ID_UNDEFINED) {
+    // specfied in scene instance
+    objAttributes->setIsVisible(visSet == 1);
+  }
+
   // set shader type to use for object instance, which may override shadertype
   // specified in object attributes.
   const auto objShaderType = objInstAttributes->getShaderType();
@@ -152,6 +153,9 @@ int PhysicsManager::addObjectInstance(
   // scaling
   objAttributes->setScale(objAttributes->getScale() *
                           objInstAttributes->getNonUniformScale());
+  // set scaled mass
+  objAttributes->setMass(objAttributes->getMass() *
+                         objInstAttributes->getMassScale());
 
   // adding object using provided object attributes
   int objID =
@@ -323,8 +327,9 @@ int PhysicsManager::addArticulatedObjectInstance(
   // managers)
   int aObjID = this->addArticulatedObjectFromURDF(
       filepath, &drawables, aObjInstAttributes->getFixedBase(),
-      aObjInstAttributes->getUniformScale(), aObjInstAttributes->getMassScale(),
-      false, false, lightSetup);
+      aObjInstAttributes->getUniformScale(),
+      static_cast<float>(aObjInstAttributes->getMassScale()), false, false,
+      lightSetup);
   if (aObjID == ID_UNDEFINED) {
     // instancing failed for some reason.
     ESP_ERROR() << "Articulated Object create failed for model filepath"

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -249,8 +249,12 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
                    "`user_double`.";
   }
   CORRADE_COMPARE(userConfig->get<Mn::Vector3>("user_vec3"), vec3_val);
+  // Test access as a color
+  CORRADE_COMPARE(userConfig->get<Mn::Color3>("user_vec3"), vec3_val);
   CORRADE_COMPARE(userConfig->get<Mn::Quaternion>("user_quat"), quat_val);
   CORRADE_COMPARE(userConfig->get<Mn::Vector4>("user_vec4"), vec4_val);
+  // Test access as a color
+  CORRADE_COMPARE(userConfig->get<Mn::Color4>("user_vec4"), vec4_val);
 
 }  // AttributesConfigsTest::testUserDefinedConfigVals
 

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -90,22 +90,14 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * @param str_val Expected string value
    * @param bool_val Expected boolean value
    * @param double_val Exptected double value
-   * @param clr3_val Expected 3 element color value. he JSON label is
-   * expected to contain 'clr' or 'color', case insensitive, to be treated as an
-   * Mn::Color3.
-   * @param vec3_val Expected Mn::Vector3 value. Any field with a label not
-   * meeting Mn::Color3 constraints is treated as an Mn::Vector3.
-   * @param clr4_val Expected 4 element color value. The JSON label is
-   * expected to contain 'clr' or 'color', case insensitive, to be treated as an
-   * Mn::Color4.
+   * @param vec3_val Expected Mn::Vector3 value.
    * @param quat_val Expected quaternion value. Note that the JSON is read
    * with scalar at idx 0, whereas the quaternion constructor takes the vector
    * component in the first position and the scalar in the second. The JSON
    * label is expected to contain 'quat', 'rotat' or 'orient', case insensitive,
    * to be treated as an Mn::Quaternion.
    * @param vec4_val Expected Mn::Vector4 element. Any field with a label not
-   * meeting Mn::Color4 or Mn::Quaternion constraints is treated as an
-   * Mn::Vector4.
+   * meeting Mn::Quaternion constraints is treated as an Mn::Vector4.
    */
   void testUserDefinedConfigVals(
       std::shared_ptr<esp::core::config::Configuration> userConfig,
@@ -113,9 +105,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
       bool bool_val,
       int int_val,
       double double_val,
-      Mn::Color3 clr3_val,
       Mn::Vector3 vec3_val,
-      Mn::Color4 clr4_val,
       Mn::Quaternion quat_val,
       Mn::Vector4 vec4_val);
 
@@ -243,9 +233,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
     bool bool_val,
     int int_val,
     double double_val,
-    Mn::Color3 clr3_val,
     Mn::Vector3 vec3_val,
-    Mn::Color4 clr4_val,
     Mn::Quaternion quat_val,
     Mn::Vector4 vec4_val) {
   // user defined attributes from light instance
@@ -260,9 +248,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
     ESP_DEBUG() << "Temporarily skipping test that triggered CI error on key "
                    "`user_double`.";
   }
-  CORRADE_COMPARE(userConfig->get<Mn::Color3>("user_clr3"), clr3_val);
   CORRADE_COMPARE(userConfig->get<Mn::Vector3>("user_vec3"), vec3_val);
-  CORRADE_COMPARE(userConfig->get<Mn::Color4>("user_clr4"), clr4_val);
   CORRADE_COMPARE(userConfig->get<Mn::Quaternion>("user_quat"), quat_val);
   CORRADE_COMPARE(userConfig->get<Mn::Vector4>("user_vec4"), vec4_val);
 
@@ -281,12 +267,11 @@ void AttributesConfigsTest::testPhysicsAttrVals(
   CORRADE_COMPARE(physMgrAttr->getFrictionCoefficient(), 1.4);
   CORRADE_COMPARE(physMgrAttr->getRestitutionCoefficient(), 1.1);
   // test physics manager attributes-level user config vals
-  testUserDefinedConfigVals(
-      physMgrAttr->getUserConfiguration(), "pm defined string", true, 15, 12.6,
-      Mn::Color3(0.4f, 0.6f, 0.1f), Mn::Vector3(215.4, 217.6, 2110.1),
-      Mn::Color4(0.2f, 0.8f, 0.7f, 0.9f),
-      Mn::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f),
-      Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
+  testUserDefinedConfigVals(physMgrAttr->getUserConfiguration(),
+                            "pm defined string", true, 15, 12.6,
+                            Mn::Vector3(215.4, 217.6, 2110.1),
+                            Mn::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f),
+                            Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
   // remove added template
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(physicsAttributesManager_,
@@ -308,9 +293,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
       "user_bool" : true,
       "user_int" : 15,
       "user_double" : 12.6,
-      "user_clr3" : [0.4, 0.6, 0.1],
       "user_vec3" : [215.4, 217.6, 2110.1],
-      "user_clr4" : [0.2, 0.8, 0.7, 0.9],
       "user_quat" : [0.2, 5.2, 6.2, 7.2],
       "user_vec4" : [3.5, 4.6, 5.7, 6.9]
   }
@@ -360,12 +343,11 @@ void AttributesConfigsTest::testLightAttrVals(
     std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
         lightLayoutAttr) {
   // test light layout attributes-level user config vals
-  testUserDefinedConfigVals(
-      lightLayoutAttr->getUserConfiguration(), "light attribs defined string",
-      true, 23, 2.3, Mn::Color3(0.4f, 0.7f, 0.6f), Mn::Vector3(1.1, 3.3, 5.5),
-      Mn::Color4(0.7f, 0.8f, 0.7f, 0.9f),
-      Mn::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f),
-      Mn::Vector4(1.5f, 1.6f, 1.7f, 1.9f));
+  testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
+                            "light attribs defined string", true, 23, 2.3,
+                            Mn::Vector3(1.1, 3.3, 5.5),
+                            Mn::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f),
+                            Mn::Vector4(1.5f, 1.6f, 1.7f, 1.9f));
   CORRADE_COMPARE(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
   CORRADE_COMPARE(lightLayoutAttr->getNegativeIntensityScale(), 1.5);
   auto lightAttr0 = lightLayoutAttr->getLightInstance("test0");
@@ -401,12 +383,11 @@ void AttributesConfigsTest::testLightAttrVals(
   CORRADE_COMPARE(lightAttr1->getOuterConeAngle(), -1.7_radf);
 
   // test user defined attributes from light instance
-  testUserDefinedConfigVals(
-      lightAttr1->getUserConfiguration(), "light instance defined string",
-      false, 42, 1.2, Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(0.1, 2.3, 4.5),
-      Mn::Color4(0.1f, 0.2f, 0.3f, 0.9f),
-      Mn::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f),
-      Mn::Vector4(1.1f, 1.2f, 1.3f, 1.4f));
+  testUserDefinedConfigVals(lightAttr1->getUserConfiguration(),
+                            "light instance defined string", false, 42, 1.2,
+                            Mn::Vector3(0.1, 2.3, 4.5),
+                            Mn::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f),
+                            Mn::Vector4(1.1f, 1.2f, 1.3f, 1.4f));
 
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(lightLayoutAttributesManager_,
@@ -442,9 +423,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
             "user_bool" : false,
             "user_int" : 42,
             "user_double" : 1.2,
-            "user_clr3" : [0.2, 0.7, 0.3],
             "user_vec3" : [0.1, 2.3, 4.5],
-            "user_clr4" : [0.1, 0.2, 0.3, 0.9],
             "user_quat" : [0.1, 0.2, 0.3, 0.4],
             "user_vec4" : [1.1, 1.2, 1.3, 1.4]
         }
@@ -455,9 +434,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
         "user_bool" : true,
         "user_int" : 23,
         "user_double" : 2.3,
-        "user_clr3" : [0.4, 0.7, 0.6],
         "user_vec3" : [1.1, 3.3, 5.5],
-        "user_clr4" : [0.7, 0.8, 0.7, 0.9],
         "user_quat" : [0.5, 0.6, 0.7, 0.8],
         "user_vec4" : [1.5, 1.6, 1.7, 1.9]
     },
@@ -518,12 +495,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
                   "test_semantic_descriptor_path1");
   // test scene instance attributes-level user config vals
-  testUserDefinedConfigVals(
-      sceneAttr->getUserConfiguration(), "scene instance defined string", true,
-      99, 9.1, Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(12.3, 32.5, 25.07),
-      Mn::Color4(0.3f, 0.4f, 0.9f, 0.9f),
-      Mn::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f),
-      Mn::Vector4(13.5f, 14.6f, 15.7f, 16.9f));
+  testUserDefinedConfigVals(sceneAttr->getUserConfiguration(),
+                            "scene instance defined string", true, 99, 9.1,
+                            Mn::Vector3(12.3, 32.5, 25.07),
+                            Mn::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f),
+                            Mn::Vector4(13.5f, 14.6f, 15.7f, 16.9f));
 
   // verify objects
   auto objectInstanceList = sceneAttr->getObjectInstances();
@@ -542,12 +518,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Mn::Vector3(1.1f, 2.2f, 3.3f));
 
   // test object 0 instance attributes-level user config vals
-  testUserDefinedConfigVals(
-      objInstance->getUserConfiguration(), "obj0 instance defined string",
-      false, 12, 2.3, Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(1.3, 3.5, 5.7),
-      Mn::Color4(0.1f, 0.4f, 0.3f, 0.5f),
-      Mn::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f),
-      Mn::Vector4(4.5f, 3.6f, 2.7f, 1.9f));
+  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
+                            "obj0 instance defined string", false, 12, 2.3,
+                            Mn::Vector3(1.3, 3.5, 5.7),
+                            Mn::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f),
+                            Mn::Vector4(4.5f, 3.6f, 2.7f, 1.9f));
 
   objInstance = objectInstanceList[1];
   CORRADE_COMPARE(objInstance->getHandle(), "test_object_template1");
@@ -561,12 +536,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Mn::Vector3(2.1f, 3.2f, 4.3f));
 
   // test object 1 instance attributes-level user config vals
-  testUserDefinedConfigVals(
-      objInstance->getUserConfiguration(), "obj1 instance defined string",
-      false, 1, 1.1, Mn::Color3(0.2f, 0.7f, 0.3f),
-      Mn::Vector3(10.3, 30.5, -5.07), Mn::Color4(0.2f, 0.4f, 0.76f, 0.9f),
-      Mn::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f),
-      Mn::Vector4(4.5f, 5.6f, 6.7f, 7.9f));
+  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
+                            "obj1 instance defined string", false, 1, 1.1,
+                            Mn::Vector3(10.3, 30.5, -5.07),
+                            Mn::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f),
+                            Mn::Vector4(4.5f, 5.6f, 6.7f, 7.9f));
 
   // verify articulated object instances
   auto artObjInstances = sceneAttr->getArticulatedObjectInstances();
@@ -603,9 +577,8 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template0 instance defined string",
-                            false, 2, 1.22, Mn::Color3(0.2f, 0.7f, 0.3f),
+                            false, 2, 1.22,
                             Mn::Vector3(120.3f, 302.5f, -25.07f),
-                            Mn::Color4(0.2f, 0.3f, 0.4f, 0.8f),
                             Mn::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f),
                             Mn::Vector4(13.5f, 24.6f, 35.7f, 46.9f));
 
@@ -630,9 +603,8 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template1 instance defined string",
-                            false, 21, 11.22, Mn::Color3(0.2f, 0.7f, 0.3f),
+                            false, 21, 11.22,
                             Mn::Vector3(190.3f, 902.5f, -95.07f),
-                            Mn::Color4(0.7f, 0.4f, 0.1f, 0.9f),
                             Mn::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f),
                             Mn::Vector4(13.5f, 4.6f, 25.7f, 76.9f));
 
@@ -650,12 +622,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Mn::Vector3(1.5f, 2.5f, 3.5f));
 
   // test stage instance attributes-level user config vals
-  testUserDefinedConfigVals(
-      stageInstance->getUserConfiguration(), "stage instance defined string",
-      true, 11, 2.2, Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(1.2, 3.4, 5.6),
-      Mn::Color4(0.7f, 0.2f, 0.7f, 0.9f),
-      Mn::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f),
-      Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
+  testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
+                            "stage instance defined string", true, 11, 2.2,
+                            Mn::Vector3(1.2, 3.4, 5.6),
+                            Mn::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f),
+                            Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
 
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(sceneInstanceAttributesManager_,
@@ -678,9 +649,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "user_bool" : true,
           "user_int" : 11,
           "user_double" : 2.2,
-          "user_clr3" : [0.2, 0.7, 0.3],
           "user_vec3" : [1.2, 3.4, 5.6],
-          "user_clr4" : [0.7, 0.2, 0.7, 0.9],
           "user_quat" : [0.4, 0.5, 0.6, 0.7],
           "user_vec4" : [3.5, 4.6, 5.7, 6.9]
       }
@@ -699,9 +668,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
               "user_bool" : false,
               "user_int" : 12,
               "user_double" : 2.3,
-              "user_clr3" : [0.2, 0.7, 0.3],
               "user_vec3" : [1.3, 3.5, 5.7],
-              "user_clr4" : [0.1, 0.4, 0.3, 0.5],
               "user_vec4" : [4.5, 3.6, 2.7, 1.9],
               "user_quat" : [0.3, 0.2, 0.6, 0.1]
           }
@@ -718,9 +685,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
               "user_bool" : false,
               "user_int" : 1,
               "user_double" : 1.1,
-              "user_clr3" : [0.2, 0.7, 0.3],
               "user_vec3" : [10.3, 30.5, -5.07],
-              "user_clr4" : [0.2, 0.4, 0.76, 0.9],
               "user_vec4" : [4.5, 5.6, 6.7, 7.9],
               "user_quat" : [1.3, 1.2, 1.6, 1.1]
           }
@@ -742,9 +707,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
                   "user_bool" : false,
                   "user_int" : 2,
                   "user_double" : 1.22,
-                  "user_clr3" : [0.2, 0.7, 0.3],
                   "user_vec3" : [120.3, 302.5, -25.07],
-                  "user_clr4" : [0.2, 0.3, 0.4, 0.8],
                   "user_vec4" : [13.5, 24.6, 35.7, 46.9],
                   "user_quat" : [1.23, 1.22, 1.26, 1.21],
                   "user_def_obj" : {
@@ -765,9 +728,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
                   "user_bool" : false,
                   "user_int" : 21,
                   "user_double" : 11.22,
-                  "user_clr3" : [0.2, 0.7, 0.3],
                   "user_vec3" : [190.3, 902.5, -95.07],
-                  "user_clr4" : [0.7, 0.4, 0.1, 0.9],
                   "user_vec4" : [13.5, 4.6, 25.7, 76.9],
                   "user_quat" : [1.25, 9.22, 9.26, 0.21]
               }
@@ -781,9 +742,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "user_bool" : true,
           "user_int" : 99,
           "user_double" : 9.1,
-          "user_clr3" : [0.2, 0.7, 0.3],
           "user_vec3" : [12.3, 32.5, 25.07],
-          "user_clr4" : [0.3, 0.4, 0.9, 0.9],
           "user_vec4" : [13.5, 14.6, 15.7, 16.9],
           "user_quat" : [0.3, 3.2, 2.6, 5.1]
       }
@@ -863,9 +822,7 @@ void AttributesConfigsTest::testStageAttrVals(
   // test stage attributes-level user config vals
   testUserDefinedConfigVals(
       stageAttr->getUserConfiguration(), "stage defined string", false, 3, 0.8,
-      Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(5.4, 7.6, 10.1),
-      Mn::Color4(0.3f, 0.5f, 0.7f, 0.9f),
-      Mn::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f),
+      Mn::Vector3(5.4, 7.6, 10.1), Mn::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f),
       Mn::Vector4(14.5f, 15.6f, 16.7f, 17.9f));
 
   // remove json-string built attributes added for test
@@ -898,9 +855,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
             "user_bool" : false,
             "user_int" : 3,
             "user_double" : 0.8,
-            "user_clr3" : [0.2, 0.7, 0.3],
             "user_vec3" : [5.4, 7.6, 10.1],
-            "user_clr4" : [0.3, 0.5, 0.7, 0.9],
             "user_vec4" : [14.5, 15.6, 16.7, 17.9],
             "user_quat" : [0.1, 1.5, 2.6, 3.7]
         }
@@ -994,9 +949,7 @@ void AttributesConfigsTest::testObjectAttrVals(
   // test object attributes-level user config vals
   testUserDefinedConfigVals(
       objAttr->getUserConfiguration(), "object defined string", true, 5, 2.6,
-      Mn::Color3(0.2f, 0.7f, 0.3f), Mn::Vector3(15.4, 17.6, 110.1),
-      Mn::Color4(0.9f, 0.1f, 0.1f, 0.9f),
-      Mn::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f),
+      Mn::Vector3(15.4, 17.6, 110.1), Mn::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f),
       Mn::Vector4(1.5f, 1.6f, 6.7f, 7.9f));
 
   // remove json-string built attributes added for test
@@ -1033,9 +986,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
       "user_bool" : true,
       "user_int" : 5,
       "user_double" : 2.6,
-      "user_clr3" : [0.2, 0.7, 0.3],
       "user_vec3" : [15.4, 17.6, 110.1],
-      "user_clr4" : [0.9, 0.1, 0.1, 0.9],
       "user_vec4" : [1.5, 1.6, 6.7, 7.9],
       "user_quat" : [0.7, 5.5, 6.6, 7.7]
   }

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -90,6 +90,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * @param str_val Expected string value
    * @param bool_val Expected boolean value
    * @param double_val Exptected double value
+   * @param vec2_val Expected Mn::Vector2 value.
    * @param vec3_val Expected Mn::Vector3 value.
    * @param quat_val Expected quaternion value. Note that the JSON is read
    * with scalar at idx 0, whereas the quaternion constructor takes the vector
@@ -105,6 +106,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
       bool bool_val,
       int int_val,
       double double_val,
+      Mn::Vector2 vec2_val,
       Mn::Vector3 vec3_val,
       Mn::Quaternion quat_val,
       Mn::Vector4 vec4_val);
@@ -233,6 +235,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
     bool bool_val,
     int int_val,
     double double_val,
+    Mn::Vector2 vec2_val,
     Mn::Vector3 vec3_val,
     Mn::Quaternion quat_val,
     Mn::Vector4 vec4_val) {
@@ -248,6 +251,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
     ESP_DEBUG() << "Temporarily skipping test that triggered CI error on key "
                    "`user_double`.";
   }
+  CORRADE_COMPARE(userConfig->get<Mn::Vector2>("user_vec2"), vec2_val);
   CORRADE_COMPARE(userConfig->get<Mn::Vector3>("user_vec3"), vec3_val);
   // Test access as a color
   CORRADE_COMPARE(userConfig->get<Mn::Color3>("user_vec3"), vec3_val);
@@ -271,11 +275,11 @@ void AttributesConfigsTest::testPhysicsAttrVals(
   CORRADE_COMPARE(physMgrAttr->getFrictionCoefficient(), 1.4);
   CORRADE_COMPARE(physMgrAttr->getRestitutionCoefficient(), 1.1);
   // test physics manager attributes-level user config vals
-  testUserDefinedConfigVals(physMgrAttr->getUserConfiguration(),
-                            "pm defined string", true, 15, 12.6,
-                            Mn::Vector3(215.4, 217.6, 2110.1),
-                            Mn::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f),
-                            Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
+  testUserDefinedConfigVals(
+      physMgrAttr->getUserConfiguration(), "pm defined string", true, 15, 12.6,
+      Mn::Vector2(1.0f, 2.0f), Mn::Vector3(215.4, 217.6, 2110.1),
+      Mn::Quaternion({5.2f, 6.2f, 7.2f}, 0.2f),
+      Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
   // remove added template
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(physicsAttributesManager_,
@@ -297,6 +301,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
       "user_bool" : true,
       "user_int" : 15,
       "user_double" : 12.6,
+      "user_vec2" : [1.0, 2.0],
       "user_vec3" : [215.4, 217.6, 2110.1],
       "user_quat" : [0.2, 5.2, 6.2, 7.2],
       "user_vec4" : [3.5, 4.6, 5.7, 6.9]
@@ -349,7 +354,7 @@ void AttributesConfigsTest::testLightAttrVals(
   // test light layout attributes-level user config vals
   testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(),
                             "light attribs defined string", true, 23, 2.3,
-                            Mn::Vector3(1.1, 3.3, 5.5),
+                            Mn::Vector2(1.1f, 2.2f), Mn::Vector3(1.1, 3.3, 5.5),
                             Mn::Quaternion({0.6f, 0.7f, 0.8f}, 0.5f),
                             Mn::Vector4(1.5f, 1.6f, 1.7f, 1.9f));
   CORRADE_COMPARE(lightLayoutAttr->getPositiveIntensityScale(), 2.0);
@@ -389,7 +394,7 @@ void AttributesConfigsTest::testLightAttrVals(
   // test user defined attributes from light instance
   testUserDefinedConfigVals(lightAttr1->getUserConfiguration(),
                             "light instance defined string", false, 42, 1.2,
-                            Mn::Vector3(0.1, 2.3, 4.5),
+                            Mn::Vector2(1.2f, 2.1f), Mn::Vector3(0.1, 2.3, 4.5),
                             Mn::Quaternion({0.2f, 0.3f, 0.4f}, 0.1f),
                             Mn::Vector4(1.1f, 1.2f, 1.3f, 1.4f));
 
@@ -427,6 +432,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
             "user_bool" : false,
             "user_int" : 42,
             "user_double" : 1.2,
+            "user_vec2" : [1.2, 2.1],
             "user_vec3" : [0.1, 2.3, 4.5],
             "user_quat" : [0.1, 0.2, 0.3, 0.4],
             "user_vec4" : [1.1, 1.2, 1.3, 1.4]
@@ -438,6 +444,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
         "user_bool" : true,
         "user_int" : 23,
         "user_double" : 2.3,
+        "user_vec2" : [1.1, 2.2],
         "user_vec3" : [1.1, 3.3, 5.5],
         "user_quat" : [0.5, 0.6, 0.7, 0.8],
         "user_vec4" : [1.5, 1.6, 1.7, 1.9]
@@ -499,11 +506,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
                   "test_semantic_descriptor_path1");
   // test scene instance attributes-level user config vals
-  testUserDefinedConfigVals(sceneAttr->getUserConfiguration(),
-                            "scene instance defined string", true, 99, 9.1,
-                            Mn::Vector3(12.3, 32.5, 25.07),
-                            Mn::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f),
-                            Mn::Vector4(13.5f, 14.6f, 15.7f, 16.9f));
+  testUserDefinedConfigVals(
+      sceneAttr->getUserConfiguration(), "scene instance defined string", true,
+      99, 9.1, Mn::Vector2(1.3f, 2.4f), Mn::Vector3(12.3, 32.5, 25.07),
+      Mn::Quaternion({3.2f, 2.6f, 5.1f}, 0.3f),
+      Mn::Vector4(13.5f, 14.6f, 15.7f, 16.9f));
 
   // verify objects
   auto objectInstanceList = sceneAttr->getObjectInstances();
@@ -524,7 +531,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test object 0 instance attributes-level user config vals
   testUserDefinedConfigVals(objInstance->getUserConfiguration(),
                             "obj0 instance defined string", false, 12, 2.3,
-                            Mn::Vector3(1.3, 3.5, 5.7),
+                            Mn::Vector2(1.6f, 2.8f), Mn::Vector3(1.3, 3.5, 5.7),
                             Mn::Quaternion({0.2f, 0.6f, 0.1f}, 0.3f),
                             Mn::Vector4(4.5f, 3.6f, 2.7f, 1.9f));
 
@@ -540,11 +547,11 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
                   Mn::Vector3(2.1f, 3.2f, 4.3f));
 
   // test object 1 instance attributes-level user config vals
-  testUserDefinedConfigVals(objInstance->getUserConfiguration(),
-                            "obj1 instance defined string", false, 1, 1.1,
-                            Mn::Vector3(10.3, 30.5, -5.07),
-                            Mn::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f),
-                            Mn::Vector4(4.5f, 5.6f, 6.7f, 7.9f));
+  testUserDefinedConfigVals(
+      objInstance->getUserConfiguration(), "obj1 instance defined string",
+      false, 1, 1.1, Mn::Vector2(2.1f, 3.2f), Mn::Vector3(10.3, 30.5, -5.07),
+      Mn::Quaternion({1.2f, 1.6f, 1.1f}, 1.3f),
+      Mn::Vector4(4.5f, 5.6f, 6.7f, 7.9f));
 
   // verify articulated object instances
   auto artObjInstances = sceneAttr->getArticulatedObjectInstances();
@@ -581,7 +588,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template0 instance defined string",
-                            false, 2, 1.22,
+                            false, 2, 1.22, Mn::Vector2(3.1f, 4.2f),
                             Mn::Vector3(120.3f, 302.5f, -25.07f),
                             Mn::Quaternion({1.22f, 1.26f, 1.21f}, 1.23f),
                             Mn::Vector4(13.5f, 24.6f, 35.7f, 46.9f));
@@ -607,7 +614,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test test_urdf_template0 ao instance attributes-level user config vals
   testUserDefinedConfigVals(artObjInstance->getUserConfiguration(),
                             "test_urdf_template1 instance defined string",
-                            false, 21, 11.22,
+                            false, 21, 11.22, Mn::Vector2(1.9f, 2.9f),
                             Mn::Vector3(190.3f, 902.5f, -95.07f),
                             Mn::Quaternion({9.22f, 9.26f, 0.21f}, 1.25f),
                             Mn::Vector4(13.5f, 4.6f, 25.7f, 76.9f));
@@ -628,7 +635,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   // test stage instance attributes-level user config vals
   testUserDefinedConfigVals(stageInstance->getUserConfiguration(),
                             "stage instance defined string", true, 11, 2.2,
-                            Mn::Vector3(1.2, 3.4, 5.6),
+                            Mn::Vector2(4.1f, 5.2f), Mn::Vector3(1.2, 3.4, 5.6),
                             Mn::Quaternion({0.5f, 0.6f, 0.7f}, 0.4f),
                             Mn::Vector4(3.5f, 4.6f, 5.7f, 6.9f));
 
@@ -653,6 +660,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "user_bool" : true,
           "user_int" : 11,
           "user_double" : 2.2,
+          "user_vec2" : [4.1, 5.2],
           "user_vec3" : [1.2, 3.4, 5.6],
           "user_quat" : [0.4, 0.5, 0.6, 0.7],
           "user_vec4" : [3.5, 4.6, 5.7, 6.9]
@@ -672,6 +680,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
               "user_bool" : false,
               "user_int" : 12,
               "user_double" : 2.3,
+              "user_vec2" : [1.6, 2.8],
               "user_vec3" : [1.3, 3.5, 5.7],
               "user_vec4" : [4.5, 3.6, 2.7, 1.9],
               "user_quat" : [0.3, 0.2, 0.6, 0.1]
@@ -689,6 +698,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
               "user_bool" : false,
               "user_int" : 1,
               "user_double" : 1.1,
+              "user_vec2" : [2.1, 3.2],
               "user_vec3" : [10.3, 30.5, -5.07],
               "user_vec4" : [4.5, 5.6, 6.7, 7.9],
               "user_quat" : [1.3, 1.2, 1.6, 1.1]
@@ -711,6 +721,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
                   "user_bool" : false,
                   "user_int" : 2,
                   "user_double" : 1.22,
+                  "user_vec2" : [3.1, 4.2],
                   "user_vec3" : [120.3, 302.5, -25.07],
                   "user_vec4" : [13.5, 24.6, 35.7, 46.9],
                   "user_quat" : [1.23, 1.22, 1.26, 1.21],
@@ -732,6 +743,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
                   "user_bool" : false,
                   "user_int" : 21,
                   "user_double" : 11.22,
+                  "user_vec2" : [1.9, 2.9],
                   "user_vec3" : [190.3, 902.5, -95.07],
                   "user_vec4" : [13.5, 4.6, 25.7, 76.9],
                   "user_quat" : [1.25, 9.22, 9.26, 0.21]
@@ -746,6 +758,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
           "user_bool" : true,
           "user_int" : 99,
           "user_double" : 9.1,
+          "user_vec2" : [1.3, 2.4],
           "user_vec3" : [12.3, 32.5, 25.07],
           "user_vec4" : [13.5, 14.6, 15.7, 16.9],
           "user_quat" : [0.3, 3.2, 2.6, 5.1]
@@ -826,7 +839,8 @@ void AttributesConfigsTest::testStageAttrVals(
   // test stage attributes-level user config vals
   testUserDefinedConfigVals(
       stageAttr->getUserConfiguration(), "stage defined string", false, 3, 0.8,
-      Mn::Vector3(5.4, 7.6, 10.1), Mn::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f),
+      Mn::Vector2(2.3f, 4.5f), Mn::Vector3(5.4, 7.6, 10.1),
+      Mn::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f),
       Mn::Vector4(14.5f, 15.6f, 16.7f, 17.9f));
 
   // remove json-string built attributes added for test
@@ -859,6 +873,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
             "user_bool" : false,
             "user_int" : 3,
             "user_double" : 0.8,
+            "user_vec2" : [2.3, 4.5],
             "user_vec3" : [5.4, 7.6, 10.1],
             "user_vec4" : [14.5, 15.6, 16.7, 17.9],
             "user_quat" : [0.1, 1.5, 2.6, 3.7]
@@ -953,7 +968,8 @@ void AttributesConfigsTest::testObjectAttrVals(
   // test object attributes-level user config vals
   testUserDefinedConfigVals(
       objAttr->getUserConfiguration(), "object defined string", true, 5, 2.6,
-      Mn::Vector3(15.4, 17.6, 110.1), Mn::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f),
+      Mn::Vector2(4.1f, 2.8f), Mn::Vector3(15.4, 17.6, 110.1),
+      Mn::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f),
       Mn::Vector4(1.5f, 1.6f, 6.7f, 7.9f));
 
   // remove json-string built attributes added for test
@@ -990,6 +1006,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
       "user_bool" : true,
       "user_int" : 5,
       "user_double" : 2.6,
+      "user_vec2" : [4.1, 2.8],
       "user_vec3" : [15.4, 17.6, 110.1],
       "user_vec4" : [1.5, 1.6, 6.7, 7.9],
       "user_quat" : [0.7, 5.5, 6.6, 7.7]

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -222,28 +222,22 @@ void IOTest::testJson() {
 // esp::io::addMember/esp::io::readMember and assert equality.
 void IOTest::testJsonBuiltinTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  // specify this as the test
+  CORRADE_VERIFY(true);
 
-  int x0{std::numeric_limits<int>::lowest()};
-  _testJsonReadWrite(x0, "myint", d);
+  _testJsonReadWrite(std::numeric_limits<int>::lowest(), "myint", d);
 
-  unsigned x1{std::numeric_limits<unsigned>::max()};
-  _testJsonReadWrite(x1, "myunsigned", d);
+  _testJsonReadWrite(std::numeric_limits<unsigned>::max(), "myunsigned", d);
 
-  int64_t x2{std::numeric_limits<int64_t>::lowest()};
-  _testJsonReadWrite(x2, "myint64_t", d);
+  _testJsonReadWrite(std::numeric_limits<int64_t>::lowest(), "myint64_t", d);
 
-  uint64_t x3{std::numeric_limits<uint64_t>::max()};
-  _testJsonReadWrite(x3, "myuint64_t", d);
+  _testJsonReadWrite(std::numeric_limits<uint64_t>::max(), "myuint64_t", d);
 
-  float x4{1.0 / 7};
-  _testJsonReadWrite(x4, "myfloat", d);
+  _testJsonReadWrite(1.0f / 7.0f, "myfloat", d);
 
-  double x5{1.0 / 13};
-  _testJsonReadWrite(x5, "mydouble", d);
+  _testJsonReadWrite(double{1.0 / 13}, "mydouble", d);
 
-  bool xb{true};
-  _testJsonReadWrite(xb, "mybool", d);
+  _testJsonReadWrite(bool{true}, "mybool", d);
 
   // verify failure to read bool into int
   int x_err{0};
@@ -270,12 +264,10 @@ void IOTest::testJsonStlTypes() {
   CORRADE_COMPARE(pair2, pair);
 
   // test a vector of ints
-  std::vector<int> vec{3, 4, 5, 6};
-  _testJsonReadWrite(vec, "vec", d);
+  _testJsonReadWrite(std::vector<int>{3, 4, 5, 6}, "vec", d);
 
   // test an empty vector
-  std::vector<float> emptyVec{};
-  _testJsonReadWrite(emptyVec, "emptyVec", d);
+  _testJsonReadWrite(std::vector<float>{}, "emptyVec", d);
 
   // test reading a vector of wrong type
   std::vector<std::string> vec3;
@@ -288,15 +280,15 @@ void IOTest::testJsonStlTypes() {
 void IOTest::testJsonMagnumTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  // specify this as the test
+  CORRADE_VERIFY(true);
 
-  Magnum::Vector3 vec{1, 2, 3};
-  _testJsonReadWrite(vec, "myvec", d);
+  _testJsonReadWrite(Magnum::Vector3{1, 2, 3}, "myvec", d);
 
-  Magnum::Quaternion quat{{1, 2, 3}, 4};
-  _testJsonReadWrite(quat, "myquat", d);
+  _testJsonReadWrite(Magnum::Quaternion{{1, 2, 3}, 4}, "myquat", d);
 
-  Magnum::Matrix3 mat{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-  _testJsonReadWrite(mat, "mymat", d);
+  _testJsonReadWrite(Magnum::Matrix3{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, "mymat",
+                     d);
 
   // test reading the wrong type (wrong number of fields)
   Magnum::Quaternion quat3;
@@ -317,11 +309,12 @@ void IOTest::testJsonMagnumTypes() {
 void IOTest::testJsonEspTypes() {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  // specify this as the test
+  CORRADE_VERIFY(true);
 
   {
     // vec3f
-    esp::vec3f vec{1, 2, 3};
-    _testJsonReadWrite(vec, "myvec3f", d);
+    _testJsonReadWrite(esp::vec3f{1, 2, 3}, "myvec3f", d);
 
     // test reading the wrong type (wrong number of fields)
     std::vector<float> wrongNumFieldsVec{1, 3, 4, 4};
@@ -364,6 +357,7 @@ void IOTest::testJsonEspTypes() {
     esp::io::addMember(d, "assetInfo", assetInfo, allocator);
     esp::assets::AssetInfo assetInfo2;
     CORRADE_VERIFY(esp::io::readMember(d, "assetInfo", assetInfo2));
+
     CORRADE_VERIFY(assetInfo2.type == assetInfo.type);
     CORRADE_COMPARE(assetInfo2.filepath, assetInfo.filepath);
     CORRADE_VERIFY(assetInfo2.frame.up().isApprox(assetInfo.frame.up()));

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -40,10 +40,20 @@ def test_core_configuration():
     config.set("py_float", my_float)
     assert config.get("py_float") == my_float
 
+    # Magnum::Vector2 (float)
+    my_vec2 = np.array([1.12345, 2.0])
+    config.set("vec2", my_vec2)
+    assert config.get("vec2") == my_vec2
+
     # Magnum::Vector3 (float)
     my_vec3 = np.array([1.12345, 2.0, -3.0])
     config.set("vec3", my_vec3)
     assert config.get("vec3") == my_vec3
+
+    # Magnum::Vector4 (float)
+    my_vec4 = np.array([1.12345, 2.0, -3.0, 4.32])
+    config.set("vec4", my_vec4)
+    assert config.get("vec4") == my_vec4
 
     # Magnum::Matrix3 (3x3)
     my_mat3x3 = mn.Matrix3((1.1, 2.2, -3.3), (4.4, 5.0, -6.6), (7.7, 8.0, -9.9))


### PR DESCRIPTION
## Motivation and Context
This PR adds Configuration support for Magnum Vector4.  With regard to the user_defined attributes, the type for equivalently sized fields in JSON is determined by substring tags found in the numeric fields' labels -  'orient', 'quat', or 'rotat' will denote a quaternion for a size 4 numeric field, and otherwise the size 4 fields will be Magnum vector4 's.

These are some features that I worked on some before my last contract ended and felt would be useful to add now.

NOTE : I removed Explicit Color3 and Color4 since these were superfluous, but I retrained accessors that would treat Color3 and Color4 getter requests the same as Vector3 and Vector4 respectively.

NOTE : I also added support of user-defined attributes containing a list of variable length of strings, which was already specified as supported in the documentation :) .

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All Python and C++ tests pass. C++ tests were added to exhaustively test label-based type inference.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
