### PR TITLE
Add python binding to render color sensors into CPU images.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -423,6 +423,15 @@ void initSimBindings(py::module& m) {
                &AbstractReplayRenderer::render),
            R"(Render all sensors onto the specified framebuffer.)")
       .def(
+          "render",
+          [](AbstractReplayRenderer& self,
+             std::vector<Mn::MutableImageView2D> images) {
+            self.render(images);
+          },
+          R"(Render color sensors into the specified image vector (one per environment).
+          The images are required to be pre-allocated.
+          Blocks the thread during the GPU-to-CPU memory transfer operation.)")
+      .def(
           "set_sensor_transforms_from_keyframe",
           &AbstractReplayRenderer::setSensorTransformsFromKeyframe,
           R"(Set the sensor transforms from a keyframe. Sensors are stored as user data and identified using a prefix in their name.)")


### PR DESCRIPTION
## Motivation and Context

This adds a missing replay renderer python binding to transfer sensor output into CPU images.
Note that this function only works for _one color sensor_. This will be revisited as we integrate multiple sensors into the batch renderer.

## How Has This Been Tested

Tested manually in Python from Habitat-Lab.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
