### PR TITLE
Restrict navigation to a single floor for 2023 challenge

### DIFF
--- a/src_python/habitat_sim/agent/agent.py
+++ b/src_python/habitat_sim/agent/agent.py
@@ -95,6 +95,8 @@ class AgentState:
 class AgentConfiguration:
     height: float = 1.5
     radius: float = 0.1
+    cell_height: float = 0.2
+    max_climb: float = 0.2
     sensor_specifications: List[hsim.SensorSpec] = attr.Factory(list)
     action_space: Dict[Any, ActionSpec] = attr.Factory(_default_action_space)
     body_type: str = "cylinder"

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -229,6 +229,8 @@ class Simulator(SimulatorBackend):
         default_agent_config = config.agents[config.sim_cfg.default_agent_id]
         needed_settings.agent_radius = default_agent_config.radius
         needed_settings.agent_height = default_agent_config.height
+        needed_settings.agent_max_climb = default_agent_config.max_climb
+        needed_settings.cell_height = default_agent_config.cell_height
         if (
             # If we loaded a navmesh and we need one with different settings,
             # always try and recompute
@@ -246,8 +248,10 @@ class Simulator(SimulatorBackend):
             )
         ):
             logger.info(
-                f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
-                f" {default_agent_config.radius}."
+                f"Recomputing navmesh for agent's height {default_agent_config.height}, "
+                f"agent's radius {default_agent_config.radius}, "
+                f"agent's max climb {default_agent_config.max_climb}, and "
+                f"navmesh cell height {default_agent_config.cell_height}"
             )
             self.recompute_navmesh(self.pathfinder, needed_settings)
 


### PR DESCRIPTION
## Motivation and Context

This change, in conjunction with [this](https://github.com/facebookresearch/habitat-lab/commit/af66c0904dd5c847364f5fa204d144b621cfa2b4) commit in habitat-lab, restricts navigation for habitat 2023 challenges to a single floor. 

## How Has This Been Tested

Tested locally by training ObjectNav agents.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
