### PR TITLE
Gfx-replay polish: workaround for material-overrides; new keyframe getter

### DIFF
--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -111,17 +111,17 @@ void initGfxReplayBindings(py::module& m) {
           R"(Write all saved keyframes to a string, then discard the keyframes.)")
 
       .def(
-          "write_saved_keyframes_to_string_array",
-          [](ReplayManager& self, bool incremental) {
+          "write_incremental_saved_keyframes_to_string_array",
+          [](ReplayManager& self) {
             if (!self.getRecorder()) {
               throw std::runtime_error(
                   "replay save not enabled. See "
                   "SimulatorConfiguration.enable_gfx_replay_save.");
             }
-            return self.getRecorder()->writeSavedKeyframesToStringArray(
-                incremental);
+            return self.getRecorder()
+                ->writeIncrementalSavedKeyframesToStringArray();
           },
-          R"(Write all saved keyframes to individual strings, then discard the keyframes. See Recorder.h for details.)")
+          R"(Write all saved keyframes to individual strings. See Recorder.h for details.)")
 
       .def("read_keyframes_from_file", &ReplayManager::readKeyframesFromFile,
            R"(Create a Player object from a replay file.)");

--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -110,6 +110,19 @@ void initGfxReplayBindings(py::module& m) {
           },
           R"(Write all saved keyframes to a string, then discard the keyframes.)")
 
+      .def(
+          "write_saved_keyframes_to_string_array",
+          [](ReplayManager& self, bool incremental) {
+            if (!self.getRecorder()) {
+              throw std::runtime_error(
+                  "replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
+            }
+            return self.getRecorder()->writeSavedKeyframesToStringArray(
+                incremental);
+          },
+          R"(Write all saved keyframes to individual strings, then discard the keyframes. See Recorder.h for details.)")
+
       .def("read_keyframes_from_file", &ReplayManager::readKeyframesFromFile,
            R"(Create a Player object from a replay file.)");
 }

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -232,8 +232,8 @@ std::string Recorder::writeSavedKeyframesToString() {
   return esp::io::jsonToString(document);
 }
 
-std::vector<std::string> Recorder::writeSavedKeyframesToStringArray(
-    bool incremental) {
+std::vector<std::string>
+Recorder::writeIncrementalSavedKeyframesToStringArray() {
   std::vector<std::string> results;
   results.reserve(savedKeyframes_.size());
 
@@ -241,11 +241,12 @@ std::vector<std::string> Recorder::writeSavedKeyframesToStringArray(
     results.emplace_back(keyframeToString(keyframe));
   }
 
-  if (incremental) {
-    savedKeyframes_.clear();
-  } else {
-    consolidateSavedKeyframes();
-  }
+  // note we don't call consolidateSavedKeyframes. Use this function if you are
+  // using keyframes incrementally, e.g. repeated calls to this function and
+  // feeding them to a renderer. Contrast with writeSavedKeyframesToFile, which
+  // "consolidates" before discarding old keyframes to avoid losing state
+  // information.
+  savedKeyframes_.clear();
 
   return results;
 }

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -232,6 +232,24 @@ std::string Recorder::writeSavedKeyframesToString() {
   return esp::io::jsonToString(document);
 }
 
+std::vector<std::string> Recorder::writeSavedKeyframesToStringArray(
+    bool incremental) {
+  std::vector<std::string> results;
+  results.reserve(savedKeyframes_.size());
+
+  for (const auto& keyframe : savedKeyframes_) {
+    results.emplace_back(keyframeToString(keyframe));
+  }
+
+  if (incremental) {
+    savedKeyframes_.clear();
+  } else {
+    consolidateSavedKeyframes();
+  }
+
+  return results;
+}
+
 std::string Recorder::keyframeToString(const Keyframe& keyframe) {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -133,15 +133,13 @@ class Recorder {
   /**
    * @brief write saved keyframes as individual strings ['{"keyframe": ...}',
    * '{"keyframe": ...}', ...]
-   * @param incremental whether future saved keyframes will be incremental
    *
-   * Set incremental to true if you are using keyframes incrementally, e.g.
-   * repeated calls to this function and feeding them to a renderer. Set to
-   * false if you want the next call to writeSavedKeyframes* to be "standalone",
-   * i.e. the next frame will properly initialize all scene state and not rely
-   * on previous keyframes.
+   * Use this function if you are using keyframes incrementally, e.g.
+   * repeated calls to this function and feeding them to a renderer. Contrast
+   * with writeSavedKeyframesToFile, which "consolidates" before discarding old
+   * keyframes to avoid losing state information.
    */
-  std::vector<std::string> writeSavedKeyframesToStringArray(bool incremental);
+  std::vector<std::string> writeIncrementalSavedKeyframesToStringArray();
 
   /**
    * @brief returns JSONized version of given keyframe.

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -126,9 +126,22 @@ class Recorder {
                                  bool usePrettyWriter = false);
 
   /**
-   * @brief write saved keyframes to string.
+   * @brief write saved keyframes to string. '{"keyframes": [{...},{...},...]}'
    */
   std::string writeSavedKeyframesToString();
+
+  /**
+   * @brief write saved keyframes as individual strings ['{"keyframe": ...}',
+   * '{"keyframe": ...}', ...]
+   * @param incremental whether future saved keyframes will be incremental
+   *
+   * Set incremental to true if you are using keyframes incrementally, e.g.
+   * repeated calls to this function and feeding them to a renderer. Set to
+   * false if you want the next call to writeSavedKeyframes* to be "standalone",
+   * i.e. the next frame will properly initialize all scene state and not rely
+   * on previous keyframes.
+   */
+  std::vector<std::string> writeSavedKeyframesToStringArray(bool incremental);
 
   /**
    * @brief returns JSONized version of given keyframe.

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -99,11 +99,12 @@ BatchReplayRenderer::BatchReplayRenderer(
         ESP_WARNING()
             << creation.filepath
             << "not found in any composite file, loading from the filesystem";
-        // TODO asserts might be TOO BRUTAL?
-        CORRADE_INTERNAL_ASSERT_OUTPUT(
+
+        ESP_CHECK(
             renderer_.addFile(creation.filepath,
                               gfx_batch::RendererFileFlag::Whole |
-                                  gfx_batch::RendererFileFlag::GenerateMipmap));
+                                  gfx_batch::RendererFileFlag::GenerateMipmap),
+            "addFile failed for " << creation.filepath);
         CORRADE_INTERNAL_ASSERT(renderer_.hasNodeHierarchy(creation.filepath));
       }
 


### PR DESCRIPTION
## Motivation and Context

Some polish needed to get the batch renderer working in a new Python application.

## How Has This Been Tested

Ran it locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
