### PR TITLE
Fix standalone batch renderer context deletion.

### DIFF
--- a/src/esp/gfx_batch/Renderer.h
+++ b/src/esp/gfx_batch/Renderer.h
@@ -447,7 +447,7 @@ class Renderer {
     create(configuration);
   }
 
-  ~Renderer();
+  virtual ~Renderer();
 
   /**
    * @brief Global renderer flags

--- a/src/esp/gfx_batch/RendererStandalone.cpp
+++ b/src/esp/gfx_batch/RendererStandalone.cpp
@@ -135,8 +135,8 @@ RendererStandalone::RendererStandalone(
 }
 
 RendererStandalone::~RendererStandalone() {
-  /* Yup, shitty, but as we hold the GL context we can't let any GL resources
-     to be destructed after our destructor. Better ideas? */
+  /* As we hold the GL context, GL resources have to be destructed before this
+   * destructor. */
   Renderer::destroy();
 }
 

--- a/src/esp/gfx_batch/RendererStandalone.h
+++ b/src/esp/gfx_batch/RendererStandalone.h
@@ -128,7 +128,7 @@ class RendererStandalone : public Renderer {
       const RendererConfiguration& configuration,
       const RendererStandaloneConfiguration& standaloneConfiguration);
 
-  ~RendererStandalone();
+  ~RendererStandalone() override;
 
   /**
    * @brief Global standalone renderer flags


### PR DESCRIPTION
## Motivation and Context

This fixes `RendererStandalone` leaking its context.

## How Has This Been Tested

Tested on Habitat-Lab and updated replay batch renderer test.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
