### PR TITLE
bugfix for setArticulatedObjectModelFilename causing garbage log output

### DIFF
--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -284,7 +284,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
   void setArticulatedObjectModelFilename(const std::string& key,
                                          const std::string& val) {
     auto artObjPathIter = articulatedObjPaths.find(key);
-    if (artObjPathIter == articulatedObjPaths.end()) {
+    if (artObjPathIter != articulatedObjPaths.end()) {
       ESP_WARNING() << "Articulated model filepath named" << key
                     << "already exists (" << artObjPathIter->second
                     << "), so this is being overwritten by" << val << ".";


### PR DESCRIPTION
## Motivation and Context

A logic bug here was causing dereference of a past-the-end iterator (`artObjPathIter->second`), causing this log statement to print garbage text.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
