### PR TITLE
Fix viewer.py framebuffer size mismatch.

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -53,9 +53,21 @@ class HabitatSimInteractiveViewer(Application):
         )
 
         # Compute environment camera resolution based on the number of environments to render in the window.
-        surface_size: tuple(int, int) = (
+        window_size: tuple(int, int) = (
             self.sim_settings["window_width"],
             self.sim_settings["window_height"],
+        )
+
+        configuration = self.Configuration()
+        configuration.title = "Habitat Sim Interactive Viewer"
+        configuration.size = window_size
+        Application.__init__(self, configuration)
+        self.fps: float = 60.0
+
+        # Compute environment camera resolution based on the number of environments to render in the window.
+        surface_size: tuple(int, int) = (
+            mn.gl.default_framebuffer.viewport.size()[0],
+            mn.gl.default_framebuffer.viewport.size()[1],
         )
         grid_size: tuple(int, int) = ReplayRenderer.environment_grid_size(self.num_env)
         camera_resolution: tuple(int, int) = (
@@ -64,12 +76,6 @@ class HabitatSimInteractiveViewer(Application):
         )
         self.sim_settings["width"] = camera_resolution[0]
         self.sim_settings["height"] = camera_resolution[1]
-
-        configuration = self.Configuration()
-        configuration.title = "Habitat Sim Interactive Viewer"
-        configuration.size = surface_size
-        Application.__init__(self, configuration)
-        self.fps: float = 60.0
 
         # draw Bullet debug line visualizations (e.g. collision meshes)
         self.debug_bullet_draw = False

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -65,10 +65,9 @@ class HabitatSimInteractiveViewer(Application):
         self.fps: float = 60.0
 
         # Compute environment camera resolution based on the number of environments to render in the window.
-        grid_size: tuple(int, int) = ReplayRenderer.environment_grid_size(self.num_env)
-        camera_resolution: mn.Vector2 = (
-            self.framebuffer_size[0] / grid_size[0],
-            self.framebuffer_size[1] / grid_size[1],
+        grid_size: mn.Vector2i = ReplayRenderer.environment_grid_size(self.num_env)
+        camera_resolution: mn.Vector2 = mn.Vector2(self.framebuffer_size) / mn.Vector2(
+            grid_size
         )
         self.sim_settings["width"] = camera_resolution[0]
         self.sim_settings["height"] = camera_resolution[1]
@@ -142,11 +141,10 @@ class HabitatSimInteractiveViewer(Application):
         self.window_text_transform = mn.Matrix3.projection(
             self.framebuffer_size
         ) @ mn.Matrix3.translation(
-            mn.Vector2(
-                self.framebuffer_size[0]
-                * -HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
-                self.framebuffer_size[1]
-                * HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
+            mn.Vector2(self.framebuffer_size)
+            * mn.Vector2(
+                -HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
+                HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
             )
         )
         self.shader = shaders.VectorGL2D()

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -53,7 +53,7 @@ class HabitatSimInteractiveViewer(Application):
         )
 
         # Compute environment camera resolution based on the number of environments to render in the window.
-        window_size: tuple(int, int) = (
+        window_size: mn.Vector2 = (
             self.sim_settings["window_width"],
             self.sim_settings["window_height"],
         )
@@ -65,14 +65,10 @@ class HabitatSimInteractiveViewer(Application):
         self.fps: float = 60.0
 
         # Compute environment camera resolution based on the number of environments to render in the window.
-        surface_size: tuple(int, int) = (
-            mn.gl.default_framebuffer.viewport.size()[0],
-            mn.gl.default_framebuffer.viewport.size()[1],
-        )
         grid_size: tuple(int, int) = ReplayRenderer.environment_grid_size(self.num_env)
-        camera_resolution: tuple(int, int) = (
-            surface_size[0] / grid_size[0],
-            surface_size[1] / grid_size[1],
+        camera_resolution: mn.Vector2 = (
+            self.framebuffer_size[0] / grid_size[0],
+            self.framebuffer_size[1] / grid_size[1],
         )
         self.sim_settings["width"] = camera_resolution[0]
         self.sim_settings["height"] = camera_resolution[1]
@@ -144,11 +140,13 @@ class HabitatSimInteractiveViewer(Application):
         # text object transform in window space is Projection matrix times Translation Matrix
         # put text in top left of window
         self.window_text_transform = mn.Matrix3.projection(
-            mn.Vector2(surface_size)
+            self.framebuffer_size
         ) @ mn.Matrix3.translation(
             mn.Vector2(
-                surface_size[0] * -HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
-                surface_size[1] * HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
+                self.framebuffer_size[0]
+                * -HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
+                self.framebuffer_size[1]
+                * HabitatSimInteractiveViewer.TEXT_DELTA_FROM_CENTER,
             )
         )
         self.shader = shaders.VectorGL2D()


### PR DESCRIPTION
## Motivation and Context

Upon initializing the python viewer, the framebuffer size may differ from the application config size due to environment factors.
This change ensures that the appropriate size is used for rendering.

Fixes: #2049

## How Has This Been Tested

Tested locally.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
