### PR TITLE
Replay renderer: add line-rendering and unproject()

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -454,7 +454,11 @@ void initSimBindings(py::module& m) {
           [](AbstractReplayRenderer& self) {
             return py::capsule(self.getCudaColorBufferDevicePointer());
           },
-          R"(Retrieve the depth buffer as a CUDA device pointer.)");
+          R"(Retrieve the depth buffer as a CUDA device pointer.)")
+      .def("debug_line_render", &AbstractReplayRenderer::getDebugLineRender,
+           R"(Get visualization helper for rendering lines.)")
+      .def("unproject", &AbstractReplayRenderer::unproject,
+           R"(Unproject a screen-space point to a world-space ray.)");
 }
 
 }  // namespace sim

--- a/src/esp/gfx/DebugLineRender.cpp
+++ b/src/esp/gfx/DebugLineRender.cpp
@@ -91,6 +91,11 @@ void DebugLineRender::setLineWidth(float lineWidth) {
 void DebugLineRender::flushLines(const Magnum::Matrix4& camMatrix,
                                  const Magnum::Matrix4& projMatrix,
                                  const Magnum::Vector2i& viewport) {
+  flushLines(projMatrix * camMatrix, viewport);
+}
+
+void DebugLineRender::flushLines(const Magnum::Matrix4& projCamMatrix,
+                                 const Magnum::Vector2i& viewport) {
   CORRADE_ASSERT(_glResources,
                  "DebugLineRender::flushLines: no GL resources; see "
                  "also releaseGLResources", );
@@ -134,7 +139,7 @@ void DebugLineRender::flushLines(const Magnum::Matrix4& camMatrix,
                                  Mn::Vector3(0, x * sqrtOfTwo, 0),
                                  Mn::Vector3(0, -x * sqrtOfTwo, 0)};
 
-  Mn::Matrix4 projCam = projMatrix * camMatrix;
+  const auto& projCam = projCamMatrix;
 
   auto submitLinesWithOffsets = [&]() {
     for (const auto& offset : offsets) {

--- a/src/esp/gfx/DebugLineRender.h
+++ b/src/esp/gfx/DebugLineRender.h
@@ -78,6 +78,9 @@ class DebugLineRender {
                   const Magnum::Matrix4& projMatrix,
                   const Magnum::Vector2i& viewport);
 
+  void flushLines(const Magnum::Matrix4& projCamMatrix,
+                  const Magnum::Vector2i& viewport);
+
   /**
    * @brief Push (multiply) a transform onto the transform stack, affecting all
    * line-drawing until popped. Must be paired with popTransform(). For example,

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -114,5 +114,27 @@ const void* AbstractReplayRenderer::getCudaDepthBufferDevicePointer() {
   return nullptr;
 }
 
+std::shared_ptr<esp::gfx::DebugLineRender>
+AbstractReplayRenderer::getDebugLineRender(unsigned envIndex) {
+  ESP_CHECK(envIndex == 0, "getDebugLineRender is only available for env 0");
+  // We only create this if/when used (lazy creation)
+  if (!debugLineRender_) {
+    debugLineRender_ = std::make_shared<esp::gfx::DebugLineRender>();
+  }
+  return debugLineRender_;
+}
+
+esp::geo::Ray AbstractReplayRenderer::unproject(
+    unsigned envIndex,
+    const Mn::Vector2i& viewportPosition) {
+  checkEnvIndex(envIndex);
+  return doUnproject(envIndex, viewportPosition);
+}
+
+void AbstractReplayRenderer::checkEnvIndex(unsigned envIndex) {
+  ESP_CHECK(envIndex < doEnvironmentCount(),
+            "envIndex " << envIndex << " is out of range");
+}
+
 }  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -116,6 +116,14 @@ class AbstractReplayRenderer {
   std::shared_ptr<esp::gfx::DebugLineRender> getDebugLineRender(
       unsigned envIndex);
 
+  /**
+   * @brief Unproject a 2D viewport point to a 3D ray with origin at camera
+   * position. Ray direction is normalized.
+   *
+   * @param envIndex
+   * @param viewportPosition The 2D point on the viewport to unproject
+   * ([0,width], [0,height]).
+   */
   esp::geo::Ray unproject(unsigned envIndex,
                           const Magnum::Vector2i& viewportPosition);
 

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -8,7 +8,12 @@
 #include <Magnum/GL/GL.h>
 #include <Magnum/Magnum.h>
 
+#include "esp/core/Check.h"
 #include "esp/core/Esp.h"
+#include "esp/geo/Geo.h"
+#include "esp/gfx/DebugLineRender.h"
+
+#include <memory>
 
 namespace esp {
 
@@ -108,6 +113,17 @@ class AbstractReplayRenderer {
   // Retrieve the depth buffer as a CUDA device pointer. */
   virtual const void* getCudaDepthBufferDevicePointer();
 
+  std::shared_ptr<esp::gfx::DebugLineRender> getDebugLineRender(
+      unsigned envIndex);
+
+  esp::geo::Ray unproject(unsigned envIndex,
+                          const Magnum::Vector2i& viewportPosition);
+
+ protected:
+  void checkEnvIndex(unsigned envIndex);
+
+  std::shared_ptr<esp::gfx::DebugLineRender> debugLineRender_;
+
  private:
   /* Implementation of all public API is in the private do*() functions,
      similarly to how e.g. Magnum plugin interfaces work. The public API does
@@ -143,6 +159,9 @@ class AbstractReplayRenderer {
           imageViews) = 0;
 
   virtual void doRender(Magnum::GL::AbstractFramebuffer& framebuffer) = 0;
+
+  virtual esp::geo::Ray doUnproject(unsigned envIndex,
+                                    const Mn::Vector2i& viewportPosition) = 0;
 
   ESP_SMART_POINTERS(AbstractReplayRenderer)
 };

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -288,13 +288,14 @@ void BatchReplayRenderer::doRender(
 }
 
 esp::geo::Ray BatchReplayRenderer::doUnproject(
-    unsigned envIndex,
+    CORRADE_UNUSED unsigned envIndex,
     const Mn::Vector2i& viewportPosition) {
   // temp stub implementation: produce a placeholder ray that varies with
   // viewportPosition
   return esp::geo::Ray(
-      {(float)viewportPosition.x() / renderer_->tileSize().x(), 0.5f,
-       (float)viewportPosition.y() / renderer_->tileSize().y()},
+      {static_cast<float>(viewportPosition.x()) / renderer_->tileSize().x(),
+       0.5f,
+       static_cast<float>(viewportPosition.y()) / renderer_->tileSize().y()},
       {0.f, -1.f, 0.f});
 }
 

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -8,6 +8,7 @@
 
 #include <Corrade/Containers/GrowableArray.h>
 #include <Corrade/Utility/Algorithms.h>
+#include <Magnum/GL/AbstractFramebuffer.h>
 #include <Magnum/GL/Context.h>
 #include <Magnum/Image.h>
 #include <Magnum/ImageView.h>
@@ -256,6 +257,9 @@ void BatchReplayRenderer::doRender(
                  "with a standalone renderer", );
   static_cast<gfx_batch::RendererStandalone&>(*renderer_).draw();
 
+  // todo: integrate debugLineRender_->flushLines
+  CORRADE_INTERNAL_ASSERT(!debugLineRender_);
+
   for (int envIndex = 0; envIndex != envs_.size(); ++envIndex) {
     const auto rectangle = Mn::Range2Di::fromSize(
         renderer_->tileSize() *
@@ -274,6 +278,24 @@ void BatchReplayRenderer::doRender(
                  "a standalone renderer", );
 
   renderer_->draw(framebuffer);
+
+  if (debugLineRender_) {
+    framebuffer.bind();
+    constexpr unsigned envIndex = 0;
+    auto projCamMatrix = renderer_->camera(envIndex);
+    debugLineRender_->flushLines(projCamMatrix, renderer_->tileSize());
+  }
+}
+
+esp::geo::Ray BatchReplayRenderer::doUnproject(
+    unsigned envIndex,
+    const Mn::Vector2i& viewportPosition) {
+  // temp stub implementation: produce a placeholder ray that varies with
+  // viewportPosition
+  return esp::geo::Ray(
+      {(float)viewportPosition.x() / renderer_->tileSize().x(), 0.5f,
+       (float)viewportPosition.y() / renderer_->tileSize().y()},
+      {0.f, -1.f, 0.f});
 }
 
 const void* BatchReplayRenderer::getCudaColorBufferDevicePointer() {

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -49,6 +49,9 @@ class BatchReplayRenderer : public AbstractReplayRenderer {
 
   void doRender(Magnum::GL::AbstractFramebuffer& framebuffer) override;
 
+  esp::geo::Ray doUnproject(unsigned envIndex,
+                            const Mn::Vector2i& viewportPosition) override;
+
   /* If standalone_ is true, renderer_ contains a RendererStandalone. Has to be
      before the EnvironmentRecord array because Player calls
      gfx_batch::Renderer::clear() on destruction. */

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -31,6 +31,10 @@ ClassicReplayRenderer::ClassicReplayRenderer(
   resourceManager_ =
       std::make_unique<assets::ResourceManager>(metadataMediator, flags);
 
+  // hack to get ReplicCAD non-baked stages to render correctly
+  resourceManager_->getShaderManager().setFallback(
+      esp::gfx::getDefaultLights());
+
   sceneManager_ = scene::SceneManager::create_unique();
 
   class SceneGraphPlayerImplementation
@@ -243,6 +247,13 @@ void ClassicReplayRenderer::doRender(
     renderer_->draw(*visualSensor.getRenderCamera(), sceneGraph,
                     esp::gfx::RenderCamera::Flags{});
 
+    if (envIndex == 0 && debugLineRender_) {
+      auto* camera = visualSensor.getRenderCamera();
+      debugLineRender_->flushLines(camera->cameraMatrix(),
+                                   camera->projectionMatrix(),
+                                   camera->viewport());
+    }
+
     visualSensor.renderTarget().renderExit();
 
     // TODO this is calculating the size from scratch for every environment in
@@ -268,6 +279,19 @@ ClassicReplayRenderer::getEnvironmentSensors(unsigned envIndex) {
   CORRADE_INTERNAL_ASSERT(envIndex < envs_.size());
   auto& env = envs_[envIndex];
   return env.sensorMap_;
+}
+
+esp::geo::Ray ClassicReplayRenderer::doUnproject(
+    unsigned envIndex,
+    const Mn::Vector2i& viewportPosition) {
+  auto& sensorMap = getEnvironmentSensors(envIndex);
+  CORRADE_INTERNAL_ASSERT(sensorMap.size() == 1);
+  CORRADE_INTERNAL_ASSERT(sensorMap.begin()->second.get().isVisualSensor());
+  auto& visualSensor =
+      static_cast<esp::sensor::VisualSensor&>(sensorMap.begin()->second.get());
+
+  return visualSensor.getRenderCamera()->unproject(viewportPosition,
+                                                   /*normalized*/ true);
 }
 
 esp::scene::SceneGraph& ClassicReplayRenderer::getSceneGraph(

--- a/src/esp/sim/ClassicReplayRenderer.h
+++ b/src/esp/sim/ClassicReplayRenderer.h
@@ -56,6 +56,9 @@ class ClassicReplayRenderer : public AbstractReplayRenderer {
   std::map<std::string, std::reference_wrapper<esp::sensor::Sensor>>&
   getEnvironmentSensors(unsigned envIndex);
 
+  esp::geo::Ray doUnproject(unsigned envIndex,
+                            const Mn::Vector2i& viewportPosition) override;
+
  private:
   unsigned doEnvironmentCount() const override;
 

--- a/src/tests/BatchReplayRendererTest.cpp
+++ b/src/tests/BatchReplayRendererTest.cpp
@@ -44,6 +44,7 @@ struct BatchReplayRendererTest : Cr::TestSuite::Tester {
   explicit BatchReplayRendererTest();
 
   void testIntegration();
+  void testUnproject();
 
   const Magnum::Float maxThreshold = 255.f;
   const Magnum::Float meanThreshold = 0.75f;
@@ -65,6 +66,19 @@ Mn::MutableImageView2D getRGBView(int width,
   return view;
 }
 
+std::vector<esp::sensor::SensorSpec::ptr> getDefaultSensorSpecs(
+    const std::string& sensorName = "my_rgb") {
+  auto pinholeCameraSpec = esp::sensor::CameraSensorSpec::create();
+  pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
+  pinholeCameraSpec->sensorType = esp::sensor::SensorType::Color;
+  pinholeCameraSpec->position = {0.0f, 0.f, 0.0f};
+  pinholeCameraSpec->resolution = {512, 384};
+  pinholeCameraSpec->uuid = sensorName;
+  std::vector<esp::sensor::SensorSpec::ptr> sensorSpecifications = {
+      pinholeCameraSpec};
+  return sensorSpecifications;
+}
+
 const struct {
   const char* name;
   Cr::Containers::Pointer<esp::sim::AbstractReplayRenderer> (*create)(
@@ -83,7 +97,62 @@ const struct {
 BatchReplayRendererTest::BatchReplayRendererTest() {
   addInstancedTests({&BatchReplayRendererTest::testIntegration},
                     Cr::Containers::arraySize(TestIntegrationData));
+
+  // temp only enable testUnproject for classic
+  addInstancedTests({&BatchReplayRendererTest::testUnproject}, 1);
+  // addInstancedTests({&BatchReplayRendererTest::testUnproject},
+  //                    Cr::Containers::arraySize(TestIntegrationData));
 }  // ctor
+
+// test recording and playback through the simulator interface
+void BatchReplayRendererTest::testUnproject() {
+  auto&& data = TestIntegrationData[testCaseInstanceId()];
+  setTestCaseDescription(data.name);
+
+  std::vector<esp::sensor::SensorSpec::ptr> sensorSpecifications;
+  auto pinholeCameraSpec = esp::sensor::CameraSensorSpec::create();
+  pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
+  pinholeCameraSpec->sensorType = esp::sensor::SensorType::Color;
+  pinholeCameraSpec->position = {1.0f, 2.f, 3.0f};
+  pinholeCameraSpec->resolution = {512, 384};
+  pinholeCameraSpec->uuid = "my_rgb";
+  sensorSpecifications = {pinholeCameraSpec};
+
+  ReplayRendererConfiguration batchRendererConfig;
+  batchRendererConfig.sensorSpecifications = std::move(sensorSpecifications);
+  batchRendererConfig.numEnvironments = 1;
+  {
+    Cr::Containers::Pointer<esp::sim::AbstractReplayRenderer> renderer =
+        data.create(batchRendererConfig);
+
+    const int h = pinholeCameraSpec->resolution.x();
+    const int w = pinholeCameraSpec->resolution.y();
+    constexpr int envIndex = 0;
+    auto ray = renderer->unproject(envIndex, {0, 0});
+    CORRADE_COMPARE(Mn::Vector3(ray.origin),
+                    Mn::Vector3(pinholeCameraSpec->position));
+    CORRADE_COMPARE(Mn::Vector3(ray.direction),
+                    Mn::Vector3(-0.51544, 0.68457, -0.51544));
+
+    // Ug, these tests reveal an off-by-one bug in our implementation in
+    // RenderCamera::unproject. Depending on your convention, we would expect
+    // some of these various corners to have exactly mirrored results, but they
+    // don't.
+    ray = renderer->unproject(envIndex, {w, 0});
+    CORRADE_COMPARE(Mn::Vector3(ray.direction),
+                    Mn::Vector3(0.51544, 0.68457, -0.51544));
+    ray = renderer->unproject(envIndex, {w - 1, 0});
+    CORRADE_COMPARE(Mn::Vector3(ray.direction),
+                    Mn::Vector3(0.513467, 0.68551, -0.51615));
+
+    ray = renderer->unproject(envIndex, {0, h});
+    CORRADE_COMPARE(Mn::Vector3(ray.direction),
+                    Mn::Vector3(-0.51355, -0.68740, -0.51355));
+    ray = renderer->unproject(envIndex, {0, h - 1});
+    CORRADE_COMPARE(Mn::Vector3(ray.direction),
+                    Mn::Vector3(-0.51449, -0.68599, -0.51450));
+  }
+}
 
 // test recording and playback through the simulator interface
 void BatchReplayRendererTest::testIntegration() {
@@ -144,19 +213,8 @@ void BatchReplayRendererTest::testIntegration() {
     serKeyframes.emplace_back(std::move(serKeyframe));
   }
 
-  std::vector<esp::sensor::SensorSpec::ptr> sensorSpecifications;
-  {
-    auto pinholeCameraSpec = esp::sensor::CameraSensorSpec::create();
-    pinholeCameraSpec->sensorSubType = esp::sensor::SensorSubType::Pinhole;
-    pinholeCameraSpec->sensorType = esp::sensor::SensorType::Color;
-    pinholeCameraSpec->position = {0.0f, 0.f, 0.0f};
-    pinholeCameraSpec->resolution = {512, 384};
-    pinholeCameraSpec->uuid = sensorName;
-    sensorSpecifications = {pinholeCameraSpec};
-  }
-
   ReplayRendererConfiguration batchRendererConfig;
-  batchRendererConfig.sensorSpecifications = std::move(sensorSpecifications);
+  batchRendererConfig.sensorSpecifications = getDefaultSensorSpecs(sensorName);
   batchRendererConfig.numEnvironments = numEnvs;
   {
     Cr::Containers::Pointer<esp::sim::AbstractReplayRenderer> renderer =


### PR DESCRIPTION
## Motivation and Context

Adding some features (and hacks) to our experimental replay renderers, needed for a Python application for SIRo.

* integrate DebugLineRender into replay renderers
* add ClassicReplayRenderer.unproject
* stub implementation for BatchReplayRenderer.unproject
* lighting hack in ClassicReplayRenderer to get ReplicaCAD stages to render correctly

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
