### PR TITLE
--Have pre-commit use node version compatible with Ubuntu 18.04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ exclude: '^(build|data/datasets|data/scene_datasets|node_modules/|src/deps|src/o
 
 default_language_version:
     python: python3
-    node: system
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -137,6 +136,7 @@ repos:
     hooks:
     -   id: eslint
         args: [--fix, --ext .html,.js]
+        language_version: 14.18.2
         additional_dependencies:
         - eslint@6.4.0
         - eslint-config-prettier@6.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
     hooks:
     -   id: eslint
         args: [--fix, --ext .html,.js]
-        language_version: 14.18.2
+        language_version: 14.21.3
         additional_dependencies:
         - eslint@6.4.0
         - eslint-config-prettier@6.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ exclude: '^(build|data/datasets|data/scene_datasets|node_modules/|src/deps|src/o
 
 default_language_version:
     python: python3
+    node: system
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Motivation and Context
Apparently pre-commit 's default behavior is to install node as part of the prep process.  This PR tells pre-commit to use the system version of node if it exists.  (This was causing a problem on Ubuntu 18.04 since the installed version of node was requiring glibc 2.28 and 18.04 uses 2.27.)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Pre-commit now works properly on 18.04

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
