### PR TITLE
[bugfix]: cylinder primitive collision shape did not use halflength

### DIFF
--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -205,7 +205,7 @@ BulletRigidObject::buildPrimitiveCollisionObject(int primTypeVal,
     case metadata::PrimObjTypes::CYLINDER_WF: {
       // use bullet cylinder shape :btCylinderShape (const btVector3&
       // halfExtents);
-      btVector3 dim(1.0, 1.0, 1.0);
+      btVector3 dim(1.0, halfLength, 1.0);
       obj = std::make_unique<btCylinderShape>(dim);
       break;
     }


### PR DESCRIPTION
## Motivation and Context

Using a modified primitive cylinder shape as a collision asset resulted in erroneous collision shape because constructor ignored configured half-length.

## How Has This Been Tested

Locally. Isn't CI tested. :thinking: 
TODO: Could be tested by comparing render and collision bounding boxes for these edge cases.
Example:
```
def construct_cylinder_object(
        sim: Simulator,
        cyl_radius: float = 0.04,
        cyl_height: float = 0.15,
    ):
        constructed_cyl_obj_handle = f"cylinder_test_obj_r{cyl_radius}_h{cyl_height}"

        otm = sim.metadata_mediator.object_template_manager
        if not otm.get_library_has_handle(constructed_cyl_obj_handle):
            # ensure that a correctly sized asset mesh is available
            atm = sim.metadata_mediator.asset_template_manager
            half_length = (cyl_height / 2.0) / cyl_radius
            custom_prim_name = f"cylinderSolid_rings_1_segments_12_halfLen_{half_length}_useTexCoords_false_useTangents_false_capEnds_true"

            if not atm.get_library_has_handle(custom_prim_name):
                # build the primitive template
                cylinder_prim_handle = atm.get_template_handles("cylinderSolid")[0]
                cyl_template = atm.get_template_by_handle(cylinder_prim_handle)
                # default radius==1, so we modify the half-length
                cyl_template.half_length = half_length
                atm.register_template(cyl_template)

            if not otm.get_library_has_handle(constructed_cyl_obj_handle):
                default_cyl_template_handle = otm.get_synth_template_handles("cylinderSolid")[0]
                default_cyl_template = otm.get_template_by_handle(default_cyl_template_handle)
                default_cyl_template.render_asset_handle = custom_prim_name
                default_cyl_template.collision_asset_handle = custom_prim_name
                # our prim asset has unit radius, so scale the object by desired radius
                default_cyl_template.scale = mn.Vector3(cyl_radius)
                otm.register_template(default_cyl_template, constructed_cyl_obj_handle)
                assert otm.get_library_has_handle(constructed_cyl_obj_handle)
        return constructed_cyl_obj_handle
```
![image](https://user-images.githubusercontent.com/1445143/229958526-07414ecd-1c2b-403c-9c6c-3fde6da519c7.png)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
