### PR TITLE
--[BugFix]Testing disabled renderer in simtest should only happen 1 time

### DIFF
--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -171,8 +171,8 @@ SimTest::SimTest() {
             &SimTest::loadingObjectTemplates,
             &SimTest::buildingPrimAssetObjectTemplates,
             &SimTest::addObjectByHandle,
-            &SimTest::addSensorToObject,
-            &SimTest::createMagnumRenderingOff}, Cr::Containers::arraySize(SimulatorBuilder) );
+            &SimTest::addSensorToObject}, Cr::Containers::arraySize(SimulatorBuilder) );
+  addTests({&SimTest::createMagnumRenderingOff});
   // clang-format on
 }
 void SimTest::basic() {
@@ -271,11 +271,9 @@ void SimTest::checkPinholeCameraRGBAObservation(
 void SimTest::getSceneRGBAObservation() {
   ESP_DEBUG() << "Starting Test : getSceneRGBAObservation";
   setTestCaseName(CORRADE_FUNCTION);
-  ESP_DEBUG() << "About to build simulator";
   auto&& data = SimulatorBuilder[testCaseInstanceId()];
   setTestCaseDescription(data.name);
   auto simulator = data.creator(*this, vangogh, esp::NO_LIGHT_KEY);
-  ESP_DEBUG() << "Built simulator";
   checkPinholeCameraRGBAObservation(*simulator, "SimTestExpectedScene.png",
                                     maxThreshold, 0.75f);
 }


### PR DESCRIPTION
## Motivation and Context
Currently the tests in simtest are instanced in such a way that they are each executed 2 times, once with a direct simulator creation, and once with a simulator created with a pre-existing metadata mediator, using Magnum's instanced testing protocols.  [This PR (#1308)](https://github.com/facebookresearch/habitat-sim/pull/1308) added support and testing for creating simulator without a renderer. 

The test that was added (createMagnumRenderingOff) did not follow the existing protocol for creating sims (calling the appropriate array of function pointers), but instead directly built it within the test's body. Due to this, the same test of the same functionality is being executed twice.

This PR makes the createMagnumRenderingOff test a regular test, and not an instanced one, so that it is executed only 1 time.  An alternative solution to this would be to test rendering off with both a directly-built simulator and one built using a prebuilt MM, but this would require further redesign of the testing protocol/layout to work properly.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Current c++ tests pass, and createMagnumRenderingOff test is only executed once.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
