### PR TITLE
Add runtime perf stats for troubleshooting perf problems

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2910,6 +2910,12 @@ void ResourceManager::createDrawable(Mn::GL::Mesh* mesh,
                              : nullptr);  // pbr image based lighting
       break;
   }
+
+  drawableCountAndNumFaces_.first += 1;
+  if (mesh) {
+    drawableCountAndNumFaces_.second += mesh->count() / 3;
+  }
+
 }  // ResourceManager::createDrawable
 
 void ResourceManager::initDefaultLightSetups() {

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -727,6 +727,19 @@ class ResourceManager {
       const std::shared_ptr<metadata::attributes::StageAttributes>&
           stageAttributes);
 
+  /**
+   * @brief Get the count of Drawables and the total face count across all
+   * Drawables in the scene. This is helpful for troubleshooting runtime perf.
+   * See also resetDrawableCountAndNumFaces.
+   */
+  auto getDrawableCountAndNumFaces() { return drawableCountAndNumFaces_; }
+
+  /**
+   * @brief Reset this count and this number. See also
+   * getDrawableCountAndNumFaces.
+   */
+  void resetDrawableCountAndNumFaces() { drawableCountAndNumFaces_ = {0, 0}; }
+
  private:
   /**
    * @brief Load the requested mesh info into @ref meshInfo corresponding to
@@ -1196,6 +1209,7 @@ class ResourceManager {
    * @brief The mesh data for loaded assets.
    */
   std::map<int, std::shared_ptr<BaseMesh>> meshes_;
+  std::pair<int, int> drawableCountAndNumFaces_{0, 0};
 
   /**
    * @brief The next available unique ID for loaded textures

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -357,6 +357,12 @@ void initSimBindings(py::module& m) {
            R"(Get a copy of the settings for an existing rigid constraint.)")
       .def("remove_rigid_constraint", &Simulator::removeRigidConstraint,
            "constraint_id"_a, R"(Remove a rigid constraint by id.)")
+      .def(
+          "get_runtime_perf_stat_names", &Simulator::getRuntimePerfStatNames,
+          R"(Runtime perf stats are various scalars helpful for troubleshooting runtime perf. This can be called once at startup. See also get_runtime_perf_stat_values.)")
+      .def(
+          "get_runtime_perf_stat_values", &Simulator::getRuntimePerfStatValues,
+          R"(Runtime perf stats are various scalars helpful for troubleshooting runtime perf. These values generally change after every sim step. See also get_runtime_perf_stat_values.)")
       .def("get_debug_line_render", &Simulator::getDebugLineRender,
            pybind11::return_value_policy::reference,
            R"(Get visualization helper for rendering lines.)");

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -362,7 +362,7 @@ void initSimBindings(py::module& m) {
           R"(Runtime perf stats are various scalars helpful for troubleshooting runtime perf. This can be called once at startup. See also get_runtime_perf_stat_values.)")
       .def(
           "get_runtime_perf_stat_values", &Simulator::getRuntimePerfStatValues,
-          R"(Runtime perf stats are various scalars helpful for troubleshooting runtime perf. These values generally change after every sim step. See also get_runtime_perf_stat_values.)")
+          R"(Runtime perf stats are various scalars helpful for troubleshooting runtime perf. These values generally change after every sim step. See also get_runtime_perf_stat_names.)")
       .def("get_debug_line_render", &Simulator::getDebugLineRender,
            pybind11::return_value_policy::reference,
            R"(Get visualization helper for rendering lines.)");

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1345,14 +1345,18 @@ int Simulator::getAgentObservationSpaces(
 }
 
 std::vector<std::string> Simulator::getRuntimePerfStatNames() {
-  return {"num rigid",           "num active rigid",    "num artic",
-          "num active overlaps", "num active contacts", "draw count",
-          "draw faces"};
+  return {"num rigid",
+          "num active rigid",
+          "num artic",
+          "num active overlaps",
+          "num active contacts",
+          "num drawables",
+          "num faces"};
 }
 
 std::vector<float> Simulator::getRuntimePerfStatValues() {
-  int drawableCount;
-  int drawableNumFaces;
+  int drawableCount = 0;
+  int drawableNumFaces = 0;
   std::tie(drawableCount, drawableNumFaces) =
       resourceManager_->getDrawableCountAndNumFaces();
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -133,6 +133,8 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     resourceManager_->setMetadataMediator(metadataMediator_);
   }
 
+  resourceManager_->resetDrawableCountAndNumFaces();
+
   if (!sceneManager_) {
     sceneManager_ = scene::SceneManager::create_unique();
   }
@@ -1339,5 +1341,33 @@ int Simulator::getAgentObservationSpaces(
   }
   return spaces.size();
 }
+
+std::vector<std::string> Simulator::getRuntimePerfStatNames() {
+  return {"num rigid",           "num active rigid",    "num artic",
+          "num active overlaps", "num active contacts", "draw count",
+          "draw faces"};
+}
+
+std::vector<float> Simulator::getRuntimePerfStatValues() {
+  int drawableCount;
+  int drawableNumFaces;
+  std::tie(drawableCount, drawableNumFaces) =
+      resourceManager_->getDrawableCountAndNumFaces();
+
+  runtimePerfStatValues_.clear();
+  runtimePerfStatValues_.push_back(physicsManager_->getNumRigidObjects());
+  runtimePerfStatValues_.push_back(physicsManager_->checkActiveObjects());
+  runtimePerfStatValues_.push_back(physicsManager_->getNumArticulatedObjects());
+  // todo: num articulated links and num active articulated links
+  runtimePerfStatValues_.push_back(
+      physicsManager_->getNumActiveOverlappingPairs());
+  runtimePerfStatValues_.push_back(
+      physicsManager_->getNumActiveContactPoints());
+  runtimePerfStatValues_.push_back(drawableCount);
+  runtimePerfStatValues_.push_back(drawableNumFaces);
+
+  return runtimePerfStatValues_;
+}
+
 }  // namespace sim
 }  // namespace esp

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -133,6 +133,8 @@ void Simulator::reconfigure(const SimulatorConfiguration& cfg) {
     resourceManager_->setMetadataMediator(metadataMediator_);
   }
 
+  // reset this count and number here because we are resetting (clearing) the
+  // scene
   resourceManager_->resetDrawableCountAndNumFaces();
 
   if (!sceneManager_) {
@@ -1358,7 +1360,6 @@ std::vector<float> Simulator::getRuntimePerfStatValues() {
   runtimePerfStatValues_.push_back(physicsManager_->getNumRigidObjects());
   runtimePerfStatValues_.push_back(physicsManager_->checkActiveObjects());
   runtimePerfStatValues_.push_back(physicsManager_->getNumArticulatedObjects());
-  // todo: num articulated links and num active articulated links
   runtimePerfStatValues_.push_back(
       physicsManager_->getNumActiveOverlappingPairs());
   runtimePerfStatValues_.push_back(

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -959,6 +959,24 @@ class Simulator {
    */
   void setShadowMapsToDrawables();
 
+  /**
+   * @brief Runtime perf stats are various scalars helpful for troubleshooting
+   * runtime perf.
+   *
+   * @return A vector of stat names; currently, this is constant so it can be
+   * called once at startup. See also getRuntimePerfStatValues.
+   */
+  std::vector<std::string> getRuntimePerfStatNames();
+
+  /**
+   * @brief Runtime perf stats are various scalars helpful for troubleshooting
+   * runtime perf.
+   *
+   * @return a vector of stat values. Stat values generally change after every
+   * physics step. See also getRuntimePerfStatNames.
+   */
+  std::vector<float> getRuntimePerfStatValues();
+
  protected:
   Simulator() = default;
 
@@ -1137,6 +1155,8 @@ class Simulator {
   Corrade::Containers::Optional<bool> requiresTextures_;
 
   std::shared_ptr<esp::gfx::DebugLineRender> debugLineRender_;
+
+  std::vector<float> runtimePerfStatValues_;
 
   ESP_SMART_POINTERS(Simulator)
 };

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -14,6 +14,7 @@
 #include <Magnum/PixelFormat.h>
 #include <string>
 
+#include "esp/assets/Asset.h"
 #include "esp/assets/ResourceManager.h"
 #include "esp/metadata/MetadataMediator.h"
 #include "esp/physics/RigidObject.h"
@@ -138,6 +139,7 @@ struct SimTest : Cr::TestSuite::Tester {
 
   void addSensorToObject();
   void createMagnumRenderingOff();
+  void getRuntimePerfStats();
 
   esp::logging::LoggingContext loggingContext_;
   // TODO: remove outlier pixels from image and lower maxThreshold
@@ -182,6 +184,7 @@ SimTest::SimTest() {
             &SimTest::addObjectInvertedScale,
             &SimTest::addSensorToObject}, Cr::Containers::arraySize(SimulatorBuilder) );
   addTests({&SimTest::createMagnumRenderingOff});
+  addTests({&SimTest::getRuntimePerfStats});
   // clang-format on
 }
 void SimTest::basic() {
@@ -1009,6 +1012,59 @@ void SimTest::createMagnumRenderingOff() {
   // check that there is no renderer
   CORRADE_VERIFY(!simulator->getRenderer());
   CORRADE_VERIFY(!cameraSensor.getObservation(*simulator, observation));
+}
+
+void SimTest::getRuntimePerfStats() {
+  // create a simulator
+  SimulatorConfiguration simConfig{};
+  simConfig.activeSceneName = vangogh;
+  simConfig.enablePhysics = true;
+  simConfig.physicsConfigFile = physicsConfigFile;
+  simConfig.overrideSceneLightDefaults = true;
+  auto simulator = Simulator::create_unique(simConfig);
+
+  auto statNames = simulator->getRuntimePerfStatNames();
+
+  constexpr auto numRigidIdx = 0;
+  constexpr auto drawCountIdx = 5;
+  constexpr auto drawFacesIdx = 6;
+  CORRADE_COMPARE(statNames[numRigidIdx], "num rigid");
+  CORRADE_COMPARE(statNames[drawCountIdx], "draw count");
+  CORRADE_COMPARE(statNames[drawFacesIdx], "draw faces");
+
+  auto statValues = simulator->getRuntimePerfStatValues();
+
+  CORRADE_COMPARE(statValues[numRigidIdx], 0);
+  // magic numbers here correspond to the contents of the vangogh 3D asset
+  CORRADE_COMPARE(statValues[drawCountIdx], 15);
+  CORRADE_COMPARE(statValues[drawFacesIdx], 11272);
+
+  {
+    auto objAttrMgr = simulator->getObjectAttributesManager();
+    objAttrMgr->loadAllJSONConfigsFromPath(
+        Cr::Utility::Path::join(TEST_ASSETS, "objects/nested_box"), true);
+    auto rigidObjMgr = simulator->getRigidObjectManager();
+    auto objs = objAttrMgr->getObjectHandlesBySubstring("nested_box");
+    rigidObjMgr->addObjectByHandle(objs[0]);
+  }
+
+  statNames = simulator->getRuntimePerfStatNames();
+  statValues = simulator->getRuntimePerfStatValues();
+
+  CORRADE_COMPARE(statValues[numRigidIdx], 1);
+  // magic numbers here correspond to the contents of the vangogh and nested_box
+  // 3D assets
+  CORRADE_COMPARE(statValues[drawCountIdx], 17);
+  CORRADE_COMPARE(statValues[drawFacesIdx], 11296);
+
+  simConfig.activeSceneName = esp::assets::EMPTY_SCENE;
+  simulator->reconfigure(simConfig);
+
+  statValues = simulator->getRuntimePerfStatValues();
+
+  CORRADE_COMPARE(statValues[numRigidIdx], 0);
+  CORRADE_COMPARE(statValues[drawCountIdx], 0);
+  CORRADE_COMPARE(statValues[drawFacesIdx], 0);
 }
 
 }  // namespace

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -183,8 +183,9 @@ SimTest::SimTest() {
             &SimTest::addObjectByHandle,
             &SimTest::addObjectInvertedScale,
             &SimTest::addSensorToObject}, Cr::Containers::arraySize(SimulatorBuilder) );
-  addTests({&SimTest::createMagnumRenderingOff});
-  addTests({&SimTest::getRuntimePerfStats});
+  addTests({
+    &SimTest::createMagnumRenderingOff,
+    &SimTest::getRuntimePerfStats});
   // clang-format on
 }
 void SimTest::basic() {
@@ -1029,8 +1030,8 @@ void SimTest::getRuntimePerfStats() {
   constexpr auto drawCountIdx = 5;
   constexpr auto drawFacesIdx = 6;
   CORRADE_COMPARE(statNames[numRigidIdx], "num rigid");
-  CORRADE_COMPARE(statNames[drawCountIdx], "draw count");
-  CORRADE_COMPARE(statNames[drawFacesIdx], "draw faces");
+  CORRADE_COMPARE(statNames[drawCountIdx], "num drawables");
+  CORRADE_COMPARE(statNames[drawFacesIdx], "num faces");
 
   auto statValues = simulator->getRuntimePerfStatValues();
 


### PR DESCRIPTION
## Motivation and Context

`Simulator.get_runtime_perf_stat_names` and `get_runtime_perf_stat_values` together are a flexible way to report a large number of arbitrary named scalars to Python. For now, I focus on some physics counts and Drawable counts.

I opted for separate `get...names` and `get...values` so that we can just call `get...values` on every env step and avoid the cost of creating/passing strings every step.

## How Has This Been Tested

Unit test added to SimTest.cpp

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
