### PR TITLE
--Refactor Semantic Mesh loading/flattening to remove deprecated functionality and improve efficiency 

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1474,8 +1474,8 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
         Mn::SceneTools::flattenTransformationHierarchy3D(
             *scene, Mn::Trade::SceneField::Mesh, reframeTransform);
 
-    Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes{
-        Cr::NoInit, meshesMaterials.size()};
+    Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
+    Cr::Containers::arrayReserve(flattenedMeshes, meshesMaterials.size());
 
     for (std::size_t i = 0; i != meshesMaterials.size(); ++i) {
       Mn::UnsignedInt iMesh = meshesMaterials[i].second().first();

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1474,7 +1474,8 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
         Mn::SceneTools::flattenTransformationHierarchy3D(
             *scene, Mn::Trade::SceneField::Mesh, reframeTransform);
 
-    Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
+    Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes{
+        Cr::NoInit, meshesMaterials.size()};
 
     for (std::size_t i = 0; i != meshesMaterials.size(); ++i) {
       Mn::UnsignedInt iMesh = meshesMaterials[i].second().first();

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -37,7 +37,7 @@
 #include <Magnum/MeshTools/Transform.h>
 #include <Magnum/PixelFormat.h>
 #include <Magnum/SceneGraph/Object.h>
-#include <Magnum/SceneTools/FlattenMeshHierarchy.h>
+#include <Magnum/SceneTools/FlattenTransformationHierarchy.h>
 #include <Magnum/Trade/AbstractImporter.h>
 #include <Magnum/Trade/FlatMaterialData.h>
 #include <Magnum/Trade/ImageData.h>
@@ -1464,16 +1464,24 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
     Cr::Containers::Optional<Mn::Trade::SceneData> scene =
         fileImporter.scene(sceneID);
 
+    // To access the mesh id
+    Cr::Containers::Array<Cr::Containers::Pair<
+        Mn::UnsignedInt, Cr::Containers::Pair<Mn::UnsignedInt, Mn::Int>>>
+        meshesMaterials = scene->meshesMaterialsAsArray();
+    // All the transformations, flattened and indexed by mesh id, with
+    // reframeTransform applied to each
+    Cr::Containers::Array<Mn::Matrix4> transformations =
+        Mn::SceneTools::flattenTransformationHierarchy3D(
+            *scene, Mn::Trade::SceneField::Mesh, reframeTransform);
+
     Cr::Containers::Array<Mn::Trade::MeshData> flattenedMeshes;
-    for (const Cr::Containers::Triple<Mn::UnsignedInt, Mn::Int, Mn::Matrix4>&
-             meshTransformation :
-         Mn::SceneTools::flattenMeshHierarchy3D(*scene)) {
-      int iMesh = meshTransformation.first();
+
+    for (std::size_t i = 0; i != meshesMaterials.size(); ++i) {
+      Mn::UnsignedInt iMesh = meshesMaterials[i].second().first();
       if (Cr::Containers::Optional<Mn::Trade::MeshData> mesh =
               fileImporter.mesh(iMesh)) {
-        const auto transform = reframeTransform * meshTransformation.third();
         arrayAppend(flattenedMeshes,
-                    Mn::MeshTools::transform3D(*mesh, transform));
+                    Mn::MeshTools::transform3D(*mesh, transformations[i]));
       }
     }
 


### PR DESCRIPTION
## Motivation and Context
A Magnum function that we were using to flatten transformations in semantic meshes was deprecated and replaced with one with a slightly different API.  This PR addresses this, replacing the deprecated function and updating the code appropriately; also, a global transformation is now being applied more efficiently, as the flatten transformations are being built.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All existing tests pass.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
