### PR TITLE
support instance sensor -> it can be used in viewer.cpp directly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.12)
 
+set(CMAKE_CUDA_COMPILER "/usr/local/cuda/bin/nvcc")
+
 option(BUILD_WITH_CUDA "Build Habitat-Sim with CUDA features enabled -- Requires CUDA"
        OFF
 )

--- a/src/esp/gfx/BackgroundRenderer.cpp
+++ b/src/esp/gfx/BackgroundRenderer.cpp
@@ -171,7 +171,7 @@ int BackgroundRenderer::threadRender() {
     if (sensorType == sensor::SensorType::Depth)
       sensor.renderTarget().readFrameDepth(view);
 
-    if (sensorType == sensor::SensorType::Semantic)
+    if (sensorType == sensor::SensorType::Semantic || sensorType == sensor::SensorType::Instance)
       sensor.renderTarget().readFrameObjectId(view);
   }
 

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -114,6 +114,14 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
   Mn::Matrix4 modelMatrix =
       camera.cameraMatrix().inverted() * transformationMatrix;
 
+  int specificID = 0;
+  if(static_cast<RenderCamera&>(camera).getIsInstanceId()) {
+    specificID = node_.getInstanceId();
+  }
+  else {
+    specificID = node_.getSemanticId();
+  }
+
   (*shader_)
       // e.g., semantic mesh has its own per vertex annotation, which has been
       // uploaded to GPU so simply pass 0 to the uniform "objectId" in the
@@ -121,7 +129,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
       .setObjectId(
           static_cast<RenderCamera&>(camera).useDrawableIds()
               ? drawableId_
-              : (materialData_->perVertexObjectId ? 0 : node_.getSemanticId()))
+              : (materialData_->perVertexObjectId ? 0 : specificID))
       .setProjectionMatrix(camera.projectionMatrix())
       .setViewMatrix(camera.cameraMatrix())
       .setModelMatrix(modelMatrix)  // NOT modelview matrix!

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -214,6 +214,11 @@ class RenderCamera : public MagnumCamera {
   size_t filterTransforms(DrawableTransforms& drawableTransforms,
                           Flags flags = {});
 
+
+  void setIsInstanceId(bool isInstanceId) { isInstanceId_ = isInstanceId; }
+
+  bool getIsInstanceId() const { return isInstanceId_; }
+
   /**
    * @brief if the "immediate" following rendering pass is to use drawable ids
    * as the object ids.
@@ -245,6 +250,7 @@ class RenderCamera : public MagnumCamera {
  protected:
   size_t previousNumVisibleDrawables_ = 0;
   bool useDrawableIds_ = false;
+  bool isInstanceId_ = false;
   ESP_SMART_POINTERS(RenderCamera)
 };
 

--- a/src/esp/metadata/attributes/ObjectAttributes.h
+++ b/src/esp/metadata/attributes/ObjectAttributes.h
@@ -367,6 +367,10 @@ class ObjectAttributes : public AbstractObjectAttributes {
 
   uint32_t getSemanticId() const { return get<int>("semantic_id"); }
 
+  void setInstanceId(int instance_id) { set("instance_id", instance_id); }
+
+  uint32_t getInstanceId() const { return get<int>("instance_id"); }
+
  protected:
   /**
    * @brief Write object-specific values to json object

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -121,6 +121,9 @@ int PhysicsManager::addObjectInstance(
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
           attributesHandle);
+  // Make its semantic id to be the instance id
+  objAttributes->setInstanceId(objInstAttributes->getID());
+
   // check if an object is being set to be not visible for a particular
   // instance.
   int visSet = objInstAttributes->getIsInstanceVisible();

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -387,6 +387,22 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 
   /**
+   * @brief Get the Instance ID for this object.
+   */
+  int getInstanceId() const { return visualNode_->getInstanceId(); }
+
+  /**
+   * @brief Set the @ref esp::scene::SceneNode::InstanceId_ for all visual nodes
+   * belonging to the object.
+   * @param InstanceId The desired Instance id for the object.
+   */
+  void setInstanceId(uint32_t instanceId) {
+    for (auto* node : visualNodes_) {
+      node->setInstanceId(instanceId);
+    }
+  }
+
+  /**
    * @brief Get pointers to this rigid's visual SceneNodes.
    * @return vector of pointers to the rigid's visual scene nodes.
    */

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -49,6 +49,7 @@ bool RigidObject::finalizeObject() {
 
   // set the visualization semantic id
   setSemanticId(ObjectAttributes->getSemanticId());
+  setInstanceId(ObjectAttributes->getInstanceId());
 
   // finish object by instancing any dynamics library-specific code required
   return finalizeObject_LibSpecific();

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -127,6 +127,12 @@ class SceneNode : public MagnumObject,
   //! Sets node semanticId
   virtual void setSemanticId(int semanticId) { semanticId_ = semanticId; }
 
+  //! Returns node instanceId
+  virtual int getInstanceId() const { return instanceId_; }
+
+  //! Sets node instanceId
+  virtual void setInstanceId(int instanceId) { instanceId_ = instanceId; }
+
   Magnum::Vector3 absoluteTranslation() const;
 
   Magnum::Vector3 absoluteTranslation();
@@ -234,6 +240,7 @@ class SceneNode : public MagnumObject,
   //! The semantic category of this node. Used to render attached Drawables with
   //! Semantic sensor when no perVertexObjectIds are present.
   uint32_t semanticId_ = 0;
+  uint32_t instanceId_ = 0;
 
   //! the local bounding box for meshes stored at this node
   Magnum::Range3D meshBB_;

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -134,7 +134,12 @@ bool CameraSensor::drawObservation(sim::Simulator& sim) {
     flags |= gfx::RenderCamera::Flag::FrustumCulling;
   }
 
-  if (cameraSensorSpec_->sensorType == SensorType::Semantic) {
+  if (cameraSensorSpec_->sensorType == SensorType::Semantic || cameraSensorSpec_->sensorType == SensorType::Instance) {
+    if (cameraSensorSpec_->sensorType == SensorType::Semantic) {
+      renderCamera_->setIsInstanceId(false);
+    } else {
+      renderCamera_->setIsInstanceId(true);
+    }
     // TODO: check sim has semantic scene graph
     bool twoSceneGraphs =
         (&sim.getActiveSemanticSceneGraph() != &sim.getActiveSceneGraph());

--- a/src/esp/sensor/CubeMapSensorBase.cpp
+++ b/src/esp/sensor/CubeMapSensorBase.cpp
@@ -57,6 +57,9 @@ CubeMapSensorBase::CubeMapSensorBase(scene::SceneNode& cameraNode,
     case SensorType::Semantic:
       cubeMapFlags |= gfx::CubeMap::Flag::ObjectIdTexture;
       break;
+    case SensorType::Instance:
+      cubeMapFlags |= gfx::CubeMap::Flag::ObjectIdTexture;
+      break;
     default:
       CORRADE_INTERNAL_ASSERT_UNREACHABLE();
       break;
@@ -78,6 +81,9 @@ CubeMapSensorBase::CubeMapSensorBase(scene::SceneNode& cameraNode,
       cubeMapShaderBaseFlags_ |= gfx::CubeMapShaderBase::Flag::DepthTexture;
       break;
     case SensorType::Semantic:
+      cubeMapShaderBaseFlags_ |= gfx::CubeMapShaderBase::Flag::ObjectIdTexture;
+      break;
+    case SensorType::Instance:
       cubeMapShaderBaseFlags_ |= gfx::CubeMapShaderBase::Flag::ObjectIdTexture;
       break;
     // sensor type list is too long, have to use default
@@ -121,7 +127,7 @@ bool CubeMapSensorBase::renderToCubemapTexture(sim::Simulator& sim) {
 
   // generate the cubemap texture
   const char* defaultDrawableGroupName = "";
-  if (cubeMapSensorBaseSpec_->sensorType == SensorType::Semantic) {
+  if (cubeMapSensorBaseSpec_->sensorType == SensorType::Semantic || cubeMapSensorBaseSpec_->sensorType == SensorType::Instance) {
     bool twoSceneGraphs =
         (&sim.getActiveSemanticSceneGraph() != &sim.getActiveSceneGraph());
 
@@ -164,7 +170,8 @@ void CubeMapSensorBase::drawWith(gfx::CubeMapShaderBase& shader) {
     shader.bindDepthTexture(
         cubeMap_->getTexture(gfx::CubeMap::TextureType::Depth));
   }
-  if (cubeMapSensorBaseSpec_->sensorType == SensorType::Semantic) {
+  if (cubeMapSensorBaseSpec_->sensorType == SensorType::Semantic ||
+      cubeMapSensorBaseSpec_->sensorType == SensorType::Instance) {
     shader.bindObjectIdTexture(
         cubeMap_->getTexture(gfx::CubeMap::TextureType::ObjectId));
   }

--- a/src/esp/sensor/Sensor.h
+++ b/src/esp/sensor/Sensor.h
@@ -33,6 +33,7 @@ enum class SensorType : int32_t {
   Tensor,
   Text,
   Audio,
+  Instance,
   SensorTypeCount,  // add new type above this term!!
 };
 

--- a/src/esp/sensor/VisualSensor.cpp
+++ b/src/esp/sensor/VisualSensor.cpp
@@ -24,7 +24,7 @@ void VisualSensorSpec::sanityCheck() const {
   SensorSpec::sanityCheck();
   bool isVisualSensor =
       (sensorType == SensorType::Color || sensorType == SensorType::Depth ||
-       sensorType == SensorType::Normal || sensorType == SensorType::Semantic);
+       sensorType == SensorType::Normal || sensorType == SensorType::Semantic || sensorType == SensorType::Instance);
   CORRADE_ASSERT(
       isVisualSensor,
       "VisualSensorSpec::sanityCheck(): sensorType must be Color, Depth, "
@@ -90,7 +90,7 @@ bool VisualSensor::getObservationSpace(ObservationSpace& space) {
                  static_cast<size_t>(visualSensorSpec_->resolution[1]),
                  static_cast<size_t>(visualSensorSpec_->channels)};
   space.dataType = core::DataType::DT_UINT8;
-  if (visualSensorSpec_->sensorType == SensorType::Semantic) {
+  if (visualSensorSpec_->sensorType == SensorType::Semantic or visualSensorSpec_->sensorType == SensorType::Instance) {
     space.dataType = core::DataType::DT_UINT32;
   } else if (visualSensorSpec_->sensorType == SensorType::Depth) {
     space.dataType = core::DataType::DT_FLOAT;
@@ -110,7 +110,7 @@ void VisualSensor::readObservation(Observation& obs) {
 
   // TODO: have different classes for the different types of sensors
   // TODO: do we need to flip axis?
-  if (visualSensorSpec_->sensorType == SensorType::Semantic) {
+  if (visualSensorSpec_->sensorType == SensorType::Semantic or visualSensorSpec_->sensorType == SensorType::Instance) {
     renderTarget().readFrameObjectId(Magnum::MutableImageView2D{
         Magnum::PixelFormat::R32UI, renderTarget().framebufferSize(),
         obs.buffer->data});
@@ -153,7 +153,7 @@ VisualSensor::MoveSemanticSensorNodeHelper::MoveSemanticSensorNodeHelper(
     sim::Simulator& sim)
     : visualSensor_(visualSensor), sim_(sim) {
   CORRADE_INTERNAL_ASSERT(visualSensor_.specification()->sensorType ==
-                          SensorType::Semantic);
+                          SensorType::Semantic || visualSensor_.specification()->sensorType == SensorType::Instance);
   scene::SceneNode& node = visualSensor_.node();
   CORRADE_ASSERT(
       !scene::SceneGraph::isRootNode(node),
@@ -189,7 +189,7 @@ VisualSensor::MoveSemanticSensorNodeHelper::MoveSemanticSensorNodeHelper(
 
 VisualSensor::MoveSemanticSensorNodeHelper::~MoveSemanticSensorNodeHelper() {
   CORRADE_INTERNAL_ASSERT(visualSensor_.specification()->sensorType ==
-                          SensorType::Semantic);
+                          SensorType::Semantic or visualSensor_.specification()->sensorType == SensorType::Instance);
 
   scene::SceneNode& node = visualSensor_.node();
   CORRADE_ASSERT(


### PR DESCRIPTION
## Motivation and Context

The instance sensor can directly give the instance id for each object, like the semantic sensor for semantic id. But instance sensor is much more flexible. Given a instance id, we can fetch anything we want, including the semantic id. And in this way, we can easily change the semantic mapping without creating a new dataset, but just manually give some new mapping. 

## How Has This Been Tested

This sensor has been tested in the viewer.cpp. Now if you use key '7' to switch the sensor, the fourth sensor is the instance sensor after the semantic sensor. 

## Types of changes

To implement the instance sensor, I follow the logic of semantic sensor. For the semantic sensor, it will fetch the object semantic id and bake it into the buffer of GL. I add some logical condition to judge if it's an instance sensor, then fetch the instance id. (I additionally store the instance id into the object when creating the scene using the objects). The modification is very simple and easy to use


## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
