### PR TITLE
--Add access to Scene Instance-level user defined attributes.

### DIFF
--- a/src/esp/bindings/MetadataMediatorBindings.cpp
+++ b/src/esp/bindings/MetadataMediatorBindings.cpp
@@ -72,6 +72,11 @@ void initMetadataMediatorBindings(py::module& m) {
       .def(
           "get_scene_handles", &MetadataMediator::getAllSceneInstanceHandles,
           R"(Returns a list the names of all the available scene instances in the currently active dataset.)")
+      .def(
+          "get_scene_user_defined",
+          &MetadataMediator::getSceneInstanceUserConfiguration,
+          R"(Returns the user_defined attributes for the scene instance specified by scene_name)",
+          "scene_name"_a)
       .def_property_readonly(
           "summary", &MetadataMediator::getDatasetsOverview,
           R"(This provides a summary of the datasets currently loaded.)")

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -376,6 +376,19 @@ MetadataMediator::makeSceneAndReferenceStage(
   return sceneInstanceAttributes;
 }  // MetadataMediator::makeSceneAndReferenceStage
 
+std::shared_ptr<esp::core::config::Configuration>
+MetadataMediator::getSceneInstanceUserConfiguration(
+    const std::string& curSceneName) {
+  auto curScene = getSceneInstanceAttributesByName(curSceneName);
+  if (curScene == nullptr) {
+    ESP_ERROR() << "No scene instance specified/exists with name"
+                << curSceneName << ", so Aborting.";
+    return nullptr;
+  }
+  return curScene->getUserConfiguration();
+
+}  // MetadataMediator::getSceneInstanceUserConfiguration
+
 std::string MetadataMediator::getFilePathForHandle(
     const std::string& assetHandle,
     const std::map<std::string, std::string>& assetMapping,

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -386,8 +386,7 @@ MetadataMediator::getSceneInstanceUserConfiguration(
     ESP_ERROR() << "No dataset specified/exists.  Aborting.";
     return nullptr;
   }
-  // directory to look for attributes for this dataset
-  const std::string dsDir = datasetAttr->getFileDirectory();
+
   // get scene instance attribute manager
   managers::SceneInstanceAttributesManager::ptr dsSceneAttrMgr =
       datasetAttr->getSceneInstanceAttributesManager();
@@ -395,7 +394,8 @@ MetadataMediator::getSceneInstanceUserConfiguration(
   attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes = nullptr;
   // get list of scene attributes handles that contain sceneName as a substring
   auto sceneList = dsSceneAttrMgr->getObjectHandlesBySubstring(curSceneName);
-  // sceneName can legally match any one of the following conditions :
+  // returned list of scene names must not be empty, otherwise display error
+  // message and return nullptr
   if (!sceneList.empty()) {
     // Scene instance exists with given name, registered SceneInstanceAttributes
     // in current active dataset.

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -424,7 +424,7 @@ class MetadataMediator {
   /**
    * @brief Return the root-level user defined attributes configuration for the
    * specified scene instance.
-   * @param sceneName The scene name in the currently loaded
+   * @param sceneName The scene name in the currently loaded SceneDataset.
    * @return The scene instance user-defined configuration.
    */
   std::shared_ptr<esp::core::config::Configuration>

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -21,6 +21,10 @@
 
 namespace esp {
 
+namespace core {
+class Configuration;
+}
+
 namespace sim {
 struct SimulatorConfiguration;
 }
@@ -416,6 +420,15 @@ class MetadataMediator {
    * @return Comma-separated string of data describing the desired dataset.
    */
   std::string createDatasetReport(const std::string& sceneDataset = "") const;
+
+  /**
+   * @brief Return the root-level user defined attributes configuration for the
+   * specified scene instance.
+   * @param sceneName The scene name in the currently loaded
+   * @return The scene instance user-defined configuration.
+   */
+  std::shared_ptr<esp::core::config::Configuration>
+  getSceneInstanceUserConfiguration(const std::string& curSceneName);
 
  protected:
   /**


### PR DESCRIPTION
## Motivation and Context
This PR adds access to the user-defined attributes for the scene instance corresponding to the passed name.  If one does not exist, it returns nullptr.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Current Tests pass.  Additional tests would probably be helpful.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
