### PR TITLE
--Don't make needless copy of scene instance attributes when retrieving user defined values

### DIFF
--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -386,12 +386,9 @@ MetadataMediator::getSceneInstanceUserConfiguration(
     ESP_ERROR() << "No dataset specified/exists.  Aborting.";
     return nullptr;
   }
-
   // get scene instance attribute manager
   managers::SceneInstanceAttributesManager::ptr dsSceneAttrMgr =
       datasetAttr->getSceneInstanceAttributesManager();
-
-  attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes = nullptr;
   // get list of scene attributes handles that contain sceneName as a substring
   auto sceneList = dsSceneAttrMgr->getObjectHandlesBySubstring(curSceneName);
   // returned list of scene names must not be empty, otherwise display error
@@ -404,15 +401,12 @@ MetadataMediator::getSceneInstanceUserConfiguration(
                 << "for SceneInstanceAttributes named :" << curSceneName
                 << "yields" << sceneList.size() << "candidates.  Using"
                 << sceneList[0] << Mn::Debug::nospace << ".";
-    sceneInstanceAttributes =
-        dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
-  } else {
-    ESP_ERROR() << "No scene instance specified/exists with name"
-                << curSceneName << ", so Aborting.";
-    return nullptr;
+    return dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0])
+        ->getUserConfiguration();
   }
-
-  return sceneInstanceAttributes->getUserConfiguration();
+  ESP_ERROR() << "No scene instance specified/exists with name" << curSceneName
+              << ", so Aborting.";
+  return nullptr;
 
 }  // MetadataMediator::getSceneInstanceUserConfiguration
 


### PR DESCRIPTION
## Motivation and Context
[This PR](https://github.com/facebookresearch/habitat-sim/pull/2081) added user defined attributes retrieval for scene instance attributes. Unfortunately, in the process it made an unnecessary copy of the existing scene instance attributes.  This PR accesses the existing scene instance without making the copy.  A test was also added to verify that the user attributes retrieved are as expected.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally existing and added C++ and existing python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
