### PR TITLE
Fix to remove reflection for gfx-replay recording

### DIFF
--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -58,8 +58,11 @@ void Recorder::onCreateRenderAssetInstance(
 
   auto adjustedCreation = creation;
 
-  // bake node scale into creation
+  // We assume constant node scaling over the node's lifetime. Bake node scale
+  // into creation.
   auto nodeScale = node->absoluteTransformation().scaling();
+  // todo: check for reflection (rotationShear.determinant() < 0.0f) and bake
+  // into scaling (negate X scale).
   if (nodeScale != Mn::Vector3(1.f, 1.f, 1.f)) {
     adjustedCreation.scale = adjustedCreation.scale
                                  ? *adjustedCreation.scale * nodeScale
@@ -189,9 +192,17 @@ int Recorder::findInstance(const scene::SceneNode* queryNode) {
 RenderAssetInstanceState Recorder::getInstanceState(
     const scene::SceneNode* node) {
   const auto absTransformMat = node->absoluteTransformation();
-  Transform absTransform{
-      absTransformMat.translation(),
-      Magnum::Quaternion::fromMatrix(absTransformMat.rotationShear())};
+  auto rotationShear = absTransformMat.rotationShear();
+  // Remove reflection (negative scaling) from the matrix. We assume constant
+  // node scaling for the node's lifetime. It is baked into instance-creation so
+  // it doesn't need to be saved into RenderAssetInstanceState. See also
+  // onCreateRenderAssetInstance.
+  if (rotationShear.determinant() < 0.0f) {
+    rotationShear[0] *= -1.f;
+  }
+
+  Transform absTransform{absTransformMat.translation(),
+                         Magnum::Quaternion::fromMatrix(rotationShear)};
 
   return RenderAssetInstanceState{absTransform, node->getSemanticId()};
 }


### PR DESCRIPTION
## Motivation and Context

This avoids a fatal error where `fromMatrix` fails because the input matrix includes a reflection (negative scaling), which a quaternion rotation can't represent.

Notice the todo in the code. I'm still investigating and I may update this PR before merging.

## How Has This Been Tested

Local testing with Floorplanner assets, some of which (apparently) have this reflection built-in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ x I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
