### PR TITLE
Articulated object semantics

### DIFF
--- a/data/test_assets/urdf/skinned_prism.ao_config.json
+++ b/data/test_assets/urdf/skinned_prism.ao_config.json
@@ -1,4 +1,5 @@
 {
     "render_asset": "../objects/skinned_prism.glb",
+    "semantic_id": 100,
     "debug_render_primitives": false
 }

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -128,9 +128,10 @@ bool Model::loadJsonAttributes(const std::string& filename) {
 
   // check for render asset
   const char* attrRenderAsset = "render_asset";
+  const char* attrSemanticId = "semantic_id";
   const char* attrDebugRenderPrimitives = "debug_render_primitives";
 
-  bool hasRenderAsset = false;
+  // Parse render_asset
   if (jsonConfig.HasMember(attrRenderAsset)) {
     if (!jsonConfig[attrRenderAsset].IsString()) {
       ESP_WARNING() << "<Model> : Json Config file specifies a render_asset "
@@ -149,9 +150,22 @@ bool Model::loadJsonAttributes(const std::string& filename) {
                          "ao_config.json file.";
       }
       m_renderAsset = std::string(renderAssetPath.data());
-      hasRenderAsset = true;
     }
   }
+
+  // Parse semantic_id
+  if (jsonConfig.HasMember(attrSemanticId)) {
+    if (!jsonConfig[attrSemanticId].IsInt()) {
+      ESP_WARNING() << "<Model> : Json Config file specifies semantic_id "
+                       "attribute but it is not an it. Skipping semantic_id "
+                       "config load.";
+      return false;
+    } else {
+      m_semanticId = jsonConfig[attrSemanticId].GetInt();
+    }
+  }
+
+  // Parse debug_render_primitives
   if (jsonConfig.HasMember(attrDebugRenderPrimitives)) {
     if (!jsonConfig[attrDebugRenderPrimitives].IsBool()) {
       ESP_WARNING()
@@ -193,11 +207,6 @@ bool Model::loadJsonAttributes(const std::string& filename) {
     return (numConfigSettings > 0);
   }  // if has user_defined tag
 
-  if (!hasRenderAsset) {
-    ESP_WARNING() << "<Model> : Json Config file exists but \"" << subGroupName
-                  << "\" and \"" << attrRenderAsset
-                  << "\" tags not found within file.";
-  }
   return false;
 }  // Model::loadJsonAttributes
 

--- a/src/esp/io/URDFParser.cpp
+++ b/src/esp/io/URDFParser.cpp
@@ -121,6 +121,7 @@ bool Model::loadJsonAttributes(const std::string& filename) {
     ESP_ERROR() << "<Model> : Failed to parse" << jsonName << "as JSON.";
     return false;
   }
+
   // JSON file exists and has been loaded; use to build this model's
   // configuration attributes
   // convert doc to const Json Generic val
@@ -157,7 +158,7 @@ bool Model::loadJsonAttributes(const std::string& filename) {
   if (jsonConfig.HasMember(attrSemanticId)) {
     if (!jsonConfig[attrSemanticId].IsInt()) {
       ESP_WARNING() << "<Model> : Json Config file specifies semantic_id "
-                       "attribute but it is not an it. Skipping semantic_id "
+                       "attribute but it is not an int. Skipping semantic_id "
                        "config load.";
       return false;
     } else {

--- a/src/esp/io/URDFParser.h
+++ b/src/esp/io/URDFParser.h
@@ -377,6 +377,16 @@ class Model {
   }
 
   /**
+   * @brief Set the semantic ID of the URDF model.
+   */
+  void setSemanticId(int semanticId) { m_semanticId = semanticId; }
+
+  /**
+   * @brief Get the semantic ID of this URDF model.
+   */
+  int getSemanticId() const { return m_semanticId; }
+
+  /**
    * @brief Set hint to render articulated object primitives even if a render
    * asset is present.
    */
@@ -437,6 +447,9 @@ class Model {
 
   //! Path to a render asset associated with this articulated object.
   Cr::Containers::Optional<std::string> m_renderAsset = Cr::Containers::NullOpt;
+
+  //! Semantic ID of this model.
+  int m_semanticId = 0;
 
   //! Forces link primitives to be rendered even if a render asset is present.
   bool m_debugRenderPrimitives = false;

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -79,11 +79,12 @@ void BulletArticulatedObject::initializeFromURDF(
 
   auto urdfModel = u2b.getModel();
 
+  node().setSemanticId(urdfModel->getSemanticId());
+
   // cache the global scaling from the source model
   globalScale_ = urdfModel->getGlobalScaling();
 
   int urdfLinkIndex = u2b.getRootLinkIndex();
-  // int rootIndex = u2b.getRootLinkIndex();
 
   bool recursive = (u2b.flags & CUF_MAINTAIN_LINK_ORDER) == 0;
 

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -95,11 +95,11 @@ class BulletArticulatedObject : public ArticulatedObject {
                           scene::SceneNode* physicsNode) override;
 
   /**
-   * @brief Cosntruct a Static btRigidObject to act as a proxy collision object
+   * @brief Construct a Static btRigidObject to act as a proxy collision object
    * for the fixed base.
    *
    * This optimization reduces the collision island size for articulated objects
-   * with heavy branching (e.g. a counter with many drawers) resuling in better
+   * with heavy branching (e.g. a counter with many drawers) resulting in better
    * sleeping behavior (e.g. contact with the countertop should not activate all
    * drawers and contained objects).
    *
@@ -409,7 +409,7 @@ class BulletArticulatedObject : public ArticulatedObject {
    *
    * By default, state is interpreted as position targets unless `velocities` is
    * specified. Expected input is the full length position or velocity array for
-   * this object. This function will safely skip states for jointa which don't
+   * this object. This function will safely skip states for joints which don't
    * support JointMotors.
    *
    * Note: No base implementation. See @ref bullet::BulletArticulatedObject.
@@ -457,7 +457,7 @@ class BulletArticulatedObject : public ArticulatedObject {
   //! maps local link id to parent joint's limit constraint
   std::unordered_map<int, JointLimitConstraintInfo> jointLimitConstraints;
 
-  // scratch datastrcutures for updateKinematicState
+  // scratch data structures for updateKinematicState
   btAlignedObjectArray<btQuaternion> scratch_q_;
   btAlignedObjectArray<btVector3> scratch_m_;
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -181,7 +181,7 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
     flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
     creationInfo.flags = flags;
-    auto gfxNode = resourceManager_.loadAndCreateRenderAssetInstance(
+    auto* gfxNode = resourceManager_.loadAndCreateRenderAssetInstance(
         assetInfo, creationInfo, objectNode, drawables);
     // Propagate the semantic ID to the graphics subtree
     esp::scene::setSemanticIdForSubtree(
@@ -211,7 +211,8 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
             u2b->cache->m_urdfLinkIndices2BulletLinkIndices[urdfLinkIx];
         ArticulatedLink& linkObject = articulatedObject->getLink(bulletLinkIx);
         ESP_CHECK(
-            attachLinkGeometry(&linkObject, urdfLink, drawables, lightSetup),
+            attachLinkGeometry(&linkObject, urdfLink, drawables, lightSetup,
+                               articulatedObject->node().getSemanticId()),
             "BulletPhysicsManager::addArticulatedObjectFromURDF(): Failed to "
             "instance render asset (attachGeometry) for link"
                 << urdfLinkIx << ".");
@@ -278,9 +279,9 @@ bool BulletPhysicsManager::attachLinkGeometry(
     ArticulatedLink* linkObject,
     const std::shared_ptr<io::URDF::Link>& link,
     gfx::DrawableGroup* drawables,
-    const std::string& lightSetup) {
+    const std::string& lightSetup,
+    int semanticId) {
   const bool forceFlatShading = (lightSetup == esp::NO_LIGHT_KEY);
-  bool geomSuccess = false;
 
   for (auto& visual : link->m_visualArray) {
     bool visualSetupSuccess = true;
@@ -374,19 +375,22 @@ bool BulletPhysicsManager::attachLinkGeometry(
       assets::RenderAssetInstanceCreationInfo creation(
           visualMeshInfo.filepath, Mn::Vector3{1}, flags, lightSetup);
 
-      geomSuccess = resourceManager_.loadAndCreateRenderAssetInstance(
-                        visualMeshInfo, creation, &visualGeomComponent,
-                        drawables, &linkObject->visualNodes_) != nullptr;
+      auto* geomNode = resourceManager_.loadAndCreateRenderAssetInstance(
+          visualMeshInfo, creation, &visualGeomComponent, drawables,
+          &linkObject->visualNodes_);
 
-      // cache the visual component for later query
-      if (geomSuccess) {
+      if (geomNode) {
+        // Propagate the semantic ID to the graphics subtree
+        esp::scene::setSemanticIdForSubtree(&visualGeomComponent, semanticId);
+        // cache the visual component for later query
         linkObject->visualAttachments_.emplace_back(
             &visualGeomComponent, visual.m_geometry.m_meshFileName);
+        return true;
       }
     }
   }
 
-  return geomSuccess;
+  return false;
 }
 
 void BulletPhysicsManager::setGravity(const Magnum::Vector3& gravity) {

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -166,7 +166,6 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
 
   articulatedObject->initializeFromURDF(*urdfImporter_, {}, physicsNode_);
   auto model = u2b->getModel();
-  const int semanticId = articulatedObject->node().getSemanticId();
 
   // if the URDF model specifies a render asset, load and link it
   const auto renderAssetPath = model->getRenderAsset();

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -145,7 +145,8 @@ class BulletPhysicsManager : public PhysicsManager {
   bool attachLinkGeometry(ArticulatedLink* linkObject,
                           const std::shared_ptr<io::URDF::Link>& link,
                           gfx::DrawableGroup* drawables,
-                          const std::string& lightSetup);
+                          const std::string& lightSetup,
+                          int semanticId);
 
   /**
    * @brief Override of @ref PhysicsManager::removeObject to also remove any

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -1094,6 +1094,8 @@ void SimTest::testArticulatedObjectSkinned() {
   auto ao = aoManager->addArticulatedObjectFromURDF(urdfFile);
   CORRADE_COMPARE(aoManager->getNumObjects(), 1);
 
+  CORRADE_COMPARE(ao->getSceneNode()->getSemanticId(), 100);
+
   CORRADE_VERIFY(ao);
   CORRADE_COMPARE(ao->getNumLinks(), 4);
 


### PR DESCRIPTION
## Motivation and Context

This changeset adds support for semantic rendering of skinned articulated objects.

The semantic ID of an articulated object can be defined in the corresponding `ao_config.json` file as such:
```
{
    "render_asset": "human.glb",
    "semantic_id": 100
}
```

The identifiers can be specified in a semantic map, e.g. `object_semantic_id_mapping.json` as such:
```
{
    <...>
    "table": 98,
    "plant": 99,
    "human": 100,
    <...>
}
```

![human_semantics](https://user-images.githubusercontent.com/110583667/234701295-612bd12e-5c40-42ca-9030-25e2cff8573a.png)

![human_semantics_rigidbodies](https://user-images.githubusercontent.com/110583667/234928750-4c9bd8cd-f5fa-46c4-a969-f798d88655f8.png)

## How Has This Been Tested

Tested locally and in `SimTest::testArticulatedObjectSkinned`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
