### PR TITLE
Fix the semantic sensor that are incorrect for some dataset

### DIFF
--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -201,7 +201,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // the fragment shader
       .setObjectId(static_cast<RenderCamera&>(camera).useDrawableIds()
                        ? drawableId_
-                       : (flags_ & PbrShader::Flag::ObjectId
+                       : (materialData_->attribute<bool>("hasPerVertexObjectId")
                               ? 0
                               : node_.getSemanticId()))
       .setProjectionMatrix(camera.projectionMatrix())


### PR DESCRIPTION
## Motivation and Context

Fix the issue in #2087 

## How Has This Been Tested

Test on FP dataset

## Types of changes

The Flags_ in PbrDrawable is initialized with ObjectId, which makes useless to judge in the shader setting

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
