### PR TITLE
--Address inappropriate bitflag check; add vertexID flag to PBR shader

### DIFF
--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -192,12 +192,14 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // e.g., semantic mesh has its own per vertex annotation, which has been
       // uploaded to GPU so simply pass 0 to the uniform "objectId" in the
       // fragment shader
-      .setObjectId(static_cast<RenderCamera&>(camera).useDrawableIds()
-                       ? drawableId_
-                   : ((flags_ & Mn::Shaders::PhongGL::Flag::InstancedObjectId ||
-                       (flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture)))
-                       ? 0
-                       : node_.getSemanticId())
+      .setObjectId(
+          static_cast<RenderCamera&>(camera).useDrawableIds() ? drawableId_
+          : ((((flags_ & Mn::Shaders::PhongGL::Flag::InstancedObjectId) ==
+               Mn::Shaders::PhongGL::Flag::InstancedObjectId) ||
+              ((flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture)) ==
+                  Mn::Shaders::PhongGL::Flag::ObjectIdTexture))
+              ? 0
+              : node_.getSemanticId())
       .setTransformationMatrix(transformationMatrix)
       .setProjectionMatrix(camera.projectionMatrix())
       .setNormalMatrix(normalMatrix);

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -137,7 +137,7 @@ void PbrDrawable::setMaterialValuesInternal(
         materialData_->attribute<Mn::GL::Texture2D*>("emissiveTexturePointer");
   }
   if (materialData_->attribute<bool>("hasPerVertexObjectId")) {
-    flags_ |= PbrShader::Flag::ObjectId;
+    flags_ |= PbrShader::Flag::InstancedObjectId;
   }
   if (materialData_->isDoubleSided()) {
     flags_ |= PbrShader::Flag::DoubleSided;
@@ -201,7 +201,8 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // the fragment shader
       .setObjectId(static_cast<RenderCamera&>(camera).useDrawableIds()
                        ? drawableId_
-                       : (flags_ & PbrShader::Flag::ObjectId
+                       : ((flags_ & PbrShader::Flag::InstancedObjectId) ==
+                                  PbrShader::Flag::InstancedObjectId
                               ? 0
                               : node_.getSemanticId()))
       .setProjectionMatrix(camera.projectionMatrix())

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -175,32 +175,38 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
     PrecomputedTangent = 1 << 10,
 
     /**
-     * Enable object ID output.
+     * Enable object ID output for this shader.
      */
     ObjectId = 1 << 11,
 
+    /**
+     * Support Instanced object ID. Retrieves a per-instance / per-vertex
+     * object ID from the @ref ObjectId attribute. If this is false, the shader
+     * will use the node's semantic ID
+     */
+    InstancedObjectId = (1 << 12) | ObjectId,
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 12,
+    DoubleSided = 1 << 13,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 13,
+    ImageBasedLighting = 1 << 14,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 14,
+    ShadowsVSM = 1 << 15,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 15,
+    DebugDisplay = 1 << 16,
     /*
      * TODO: alphaMask
      */


### PR DESCRIPTION
## Motivation and Context
[This PR introduced](https://github.com/facebookresearch/habitat-sim/pull/2083) syntactically incorrect bitflag checks to the drawables to determine how to handle vertex-level and texture level semantic ids; furthermore, an important check was being performed incorrectly for the PBR shader to support vertex-based Object IDs or not.  This PR fixes #2087 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally tests pass.  
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
