### PR TITLE
Hack to hide high-vertex-count drawables

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -3187,6 +3187,7 @@ void ResourceManager::addComponent(
 
     gfx::Drawable::Flags meshAttributeFlags{};
     const auto& meshData = meshes_.at(meshID)->getMeshData();
+    Mn::Range3D* pbb = nullptr;
     if (meshData != Cr::Containers::NullOpt) {
       if (meshData->hasAttribute(Mn::Trade::MeshAttribute::Tangent)) {
         meshAttributeFlags |= gfx::Drawable::Flag::HasTangent;
@@ -3200,22 +3201,64 @@ void ResourceManager::addComponent(
       if (meshData->hasAttribute(Mn::Trade::MeshAttribute::Color)) {
         meshAttributeFlags |= gfx::Drawable::Flag::HasVertexColor;
       }
+
+      GenericMeshData& gltfMeshData =
+          dynamic_cast<GenericMeshData&>(*meshes_.at(meshID).get());
+      pbb = &gltfMeshData.BB;
     }
 
-    createDrawable(mesh,                // render mesh
-                   meshAttributeFlags,  // mesh attribute flags
-                   node,                // scene node
-                   lightSetupKey,       // lightSetup Key
-                   materialKey,         // material key
-                   drawables,           // drawable group
-                   skinData);           // instance skinning data
+    bool doUsePlaceholderMesh = false;
+    {
+      static int numRequestedDrawables = 0;
+      static int numHidDrawables = 0;
+      numRequestedDrawables++;
+
+      constexpr float halfSize = 0.1f;
+      Mn::Range3D defaultBB({-halfSize, -halfSize, -halfSize},
+                            {halfSize, halfSize, halfSize});
+      if (!pbb) {
+        pbb = &defaultBB;
+      }
+
+      // float bbArea = (bb.sizeX() * bb.sizeY()) + (bb.sizeX() * bb.sizeZ())
+      //   + (bb.sizeY() * bb.sizeZ());
+      // const CollisionMeshData& meshData =
+      // gltfMeshData.getCollisionMeshData();
+      int numVerts = mesh->count();
+      constexpr int threshold = 5000;  // todo: expose to Python as tuning var
+      // if (float(numVerts) / bbArea > threshold)
+      if (numVerts > threshold) {
+        const auto& bb = *pbb;
+        Magnum::Vector3 scale = bb.size() / 2.0;
+        auto& bbNode = node.createChild();
+        bbNode.MagnumObject::setScaling(scale);
+        bbNode.MagnumObject::setTranslation(bb.center());
+        addPrimitiveToDrawables(0, bbNode, drawables);
+        doUsePlaceholderMesh = true;
+        numHidDrawables++;
+        ESP_WARNING() << "hid " << std::to_string(numHidDrawables) << "/"
+                      << std::to_string(numRequestedDrawables) << " drawables";
+      }
+    }
+
+    if (!doUsePlaceholderMesh) {
+      createDrawable(mesh,                // render mesh
+                     meshAttributeFlags,  // mesh attribute flags
+                     node,                // scene node
+                     lightSetupKey,       // lightSetup Key
+                     materialKey,         // material key
+                     drawables,           // drawable group
+                     skinData);           // instance skinning data
+    }
 
     // compute the bounding box for the mesh we are adding
     if (computeAbsoluteAABBs) {
       staticDrawableInfo.emplace_back(StaticDrawableInfo{node, meshID});
     }
     BaseMesh* meshBB = meshes_.at(meshID).get();
-    node.setMeshBB(computeMeshBB(meshBB));
+    auto bb = computeMeshBB(meshBB);
+    CORRADE_INTERNAL_ASSERT(!pbb || *pbb == bb);
+    node.setMeshBB(bb);
   }
 
   // Recursively add children

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -35,6 +35,8 @@ ClassicReplayRenderer::ClassicReplayRenderer(
   resourceManager_->getShaderManager().setFallback(
       esp::gfx::getDefaultLights());
 
+  resourceManager_->initDefaultPrimAttributes();  // needed for wireframeCube
+
   sceneManager_ = scene::SceneManager::create_unique();
 
   class SceneGraphPlayerImplementation


### PR DESCRIPTION
## Motivation and Context

Hack to hide high-vertex-count drawables and replace them with wireframe bounding boxes. See `ResourceManager.cpp threshold` to tune. This is a workaround for displaying Floorplanner scenes in the SIRo sandbox tool on older Macbooks.

We probably won't merge any version of this to `main`.

## How Has This Been Tested

Local testing on 2019 Macbook Pro.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
