### PR TITLE
--[BUGFIX] Reverse directional lights before sending to uniform;

### DIFF
--- a/examples/tutorials/lighting_tutorial.py
+++ b/examples/tutorials/lighting_tutorial.py
@@ -149,7 +149,7 @@ def main(show_imgs=True, save_imgs=False):
 
     # create a custom light setup
     my_default_lighting = [
-        LightInfo(vector=[2.0, 2.0, 1.0, 0.0], model=LightPositionModel.Camera)
+        LightInfo(vector=[-2.0, -2.0, -1.0, 0.0], model=LightPositionModel.Camera)
     ]
     # overwrite the default DEFAULT_LIGHTING_KEY light setup
     sim.set_light_setup(my_default_lighting)
@@ -208,7 +208,7 @@ def main(show_imgs=True, save_imgs=False):
     # create a new setup with an additional light
     new_light_setup = existing_light_setup + [
         LightInfo(
-            vector=[0.0, 0.0, 1.0, 0.0],
+            vector=[0.0, 0.0, -1.0, 0.0],
             color=[1.6, 1.6, 1.4],
             model=LightPositionModel.Camera,
         )

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -144,7 +144,7 @@ void GenericDrawable::updateShaderLightingParameters(
     // flip directional lights to faciliate faster, non-forking calc in
     // shader.  Leave non-directional lights unchanged
     pos *= (pos[3] * 2) - 1;
-    lightPositions.emplace_back(std::move(pos));
+    lightPositions.emplace_back(pos);
 
     const auto& lightColor = (*lightSetup_)[i].color;
     lightColors.emplace_back(lightColor);

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -144,7 +144,7 @@ void GenericDrawable::updateShaderLightingParameters(
     // flip directional lights to faciliate faster, non-forking calc in
     // shader.  Leave non-directional lights unchanged
     pos *= (pos[3] * 2) - 1;
-    lightPositions.emplace_back(pos);
+    lightPositions.emplace_back(std::move(pos));
 
     const auto& lightColor = (*lightSetup_)[i].color;
     lightColors.emplace_back(lightColor);

--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -139,8 +139,12 @@ void GenericDrawable::updateShaderLightingParameters(
 
   for (Mn::UnsignedInt i = 0; i < lightSetup_->size(); ++i) {
     const auto& lightInfo = (*lightSetup_)[i];
-    lightPositions.emplace_back(getLightPositionRelativeToCamera(
-        lightInfo, transformationMatrix, cameraMatrix));
+    Mn::Vector4 pos = getLightPositionRelativeToCamera(
+        lightInfo, transformationMatrix, cameraMatrix);
+    // flip directional lights to faciliate faster, non-forking calc in
+    // shader.  Leave non-directional lights unchanged
+    pos *= (pos[3] * 2) - 1;
+    lightPositions.emplace_back(pos);
 
     const auto& lightColor = (*lightSetup_)[i].color;
     lightColors.emplace_back(lightColor);

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -76,15 +76,12 @@ LightSetup getLightsAtBoxCorners(const Magnum::Range3D& box,
                     {{box.backBottomLeft(), w}, lightColor},
                     {{box.backBottomRight(), w}, lightColor}};
 }
-
 LightSetup getDefaultLights() {
-  return LightSetup{
-      {{0.0, 0.5, 1.0, 0.0}, {2.4, 2.4, 2.4}},     // forward
-      {{0.0, 0.5, -1.0, 0.0}, {2.4, 2.4, 2.4}},    // backward
-      {{-1.0, 1.0, 0.0, 0.0}, {2.0, 2.0, 2.0}},    // top left
-      {{1.0, 1.0, 1.0, 0.0}, {2.0, 2.0, 2.0}},     // top right
-      {{0.0, -1.0, 0.0, 0.0}, {0.64, 0.64, 0.64}}  // bottom
-  };
+  return LightSetup{{{0.0, -0.5, 1.0, 0.0}, {2.4, 2.4, 2.4}},     // forward
+                    {{0.0, -0.5, -1.0, 0.0}, {2.4, 2.4, 2.4}},    // backward
+                    {{1.0, -1.0, 0.0, 0.0}, {2.0, 2.0, 2.0}},     // top left
+                    {{-1.0, -1.0, -1.0, 0.0}, {2.0, 2.0, 2.0}},   // top right
+                    {{0.0, 1.0, 0.0, 0.0}, {0.64, 0.64, 0.64}}};  // bottom
 }
 
 Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -77,8 +77,8 @@ LightSetup getLightsAtBoxCorners(const Magnum::Range3D& box,
                     {{box.backBottomRight(), w}, lightColor}};
 }
 LightSetup getDefaultLights() {
-  return LightSetup{{{0.0, -0.5, 1.0, 0.0}, {2.4, 2.4, 2.4}},     // forward
-                    {{0.0, -0.5, -1.0, 0.0}, {2.4, 2.4, 2.4}},    // backward
+  return LightSetup{{{0.0, -0.5, -1.0, 0.0}, {2.4, 2.4, 2.4}},    // forward
+                    {{0.0, -0.5, 1.0, 0.0}, {2.4, 2.4, 2.4}},     // backward
                     {{1.0, -1.0, 0.0, 0.0}, {2.0, 2.0, 2.0}},     // top left
                     {{-1.0, -1.0, -1.0, 0.0}, {2.0, 2.0, 2.0}},   // top right
                     {{0.0, 1.0, 0.0, 0.0}, {0.64, 0.64, 0.64}}};  // bottom

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -352,7 +352,7 @@ PbrDrawable& PbrDrawable::updateShaderLightDirectionParameters(
     // flip directional lights to faciliate faster, non-forking calc in
     // shader.  Leave non-directional lights unchanged
     pos *= (pos[3] * 2) - 1;
-    lightPositions.emplace_back(pos);
+    lightPositions.emplace_back(std::move(pos));
   }
 
   shader_->setLightVectors(lightPositions);

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -352,7 +352,7 @@ PbrDrawable& PbrDrawable::updateShaderLightDirectionParameters(
     // flip directional lights to faciliate faster, non-forking calc in
     // shader.  Leave non-directional lights unchanged
     pos *= (pos[3] * 2) - 1;
-    lightPositions.emplace_back(std::move(pos));
+    lightPositions.emplace_back(pos);
   }
 
   shader_->setLightVectors(lightPositions);

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -349,6 +349,9 @@ PbrDrawable& PbrDrawable::updateShaderLightDirectionParameters(
     const auto& lightInfo = (*lightSetup_)[iLight];
     Mn::Vector4 pos = getLightPositionRelativeToWorld(
         lightInfo, transformationMatrix, cameraMatrix);
+    // flip directional lights to faciliate faster, non-forking calc in
+    // shader.  Leave non-directional lights unchanged
+    pos *= (pos[3] * 2) - 1;
     lightPositions.emplace_back(pos);
   }
 

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -260,7 +260,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
         Cr::DirectInit, lightCount_,
         // a single directional "fill" light, coming from the center of the
         // camera.
-        Mn::Vector4{0.0f, 0.0f, 1.0f, 0.0f}});
+        Mn::Vector4{0.0f, 0.0f, -1.0f, 0.0f}});
     Cr::Containers::Array<Mn::Color3> colors{Cr::DirectInit, lightCount_,
                                              Mn::Color3{1.0f}};
     setLightColors(colors);

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -279,10 +279,10 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
     if (numLightInstances == 0) {
       // setup default LightInfo instances - lifted from LightSetup.cpp.
       // TODO create default attributes describing these lights?
-      return gfx::LightSetup{{.vector = {1.0, 1.0, 0.0, 0.0},
+      return gfx::LightSetup{{.vector = {-1.0, -1.0, 0.0, 0.0},
                               .color = {0.75, 0.75, 0.75},
                               .model = gfx::LightPositionModel::Global},
-                             {.vector = {-0.5, 0.0, 1.0, 0.0},
+                             {.vector = {0.5, 0.0, -1.0, 0.0},
                               .color = {0.4, 0.4, 0.4},
                               .model = gfx::LightPositionModel::Global}};
     } else {

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -522,7 +522,7 @@ void GfxReplayTest::testLightIntegration() {
   const LightInfo pointLight2{
       {0.0f, 1.2f, -4.0f, 1.0f}, {4.0, 4.0, 4.0}, LightPositionModel::Object};
   const LightInfo dirLight{
-      {0.1f, 0.2f, -0.3f, 0.0f}, {0.0, 0.0, 1.0}, LightPositionModel::Global};
+      {-0.1f, -0.2f, 0.3f, 0.0f}, {0.0, 0.0, 1.0}, LightPositionModel::Global};
   const LightSetup lightSetup0{pointLight0, pointLight1};
   const LightSetup lightSetup1{pointLight2};
   const LightSetup lightSetup2{dirLight};

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -147,10 +147,10 @@ struct SimTest : Cr::TestSuite::Tester {
   // TODO: remove outlier pixels from image and lower maxThreshold
   const Magnum::Float maxThreshold = 255.f;
 
-  LightSetup lightSetup1{{Magnum::Vector4{1.0f, 1.5f, 0.5f, 0.0f},
+  LightSetup lightSetup1{{Magnum::Vector4{-1.0f, -1.5f, -0.5f, 0.0f},
                           {5.0, 5.0, 0.0},
                           LightPositionModel::Camera}};
-  LightSetup lightSetup2{{Magnum::Vector4{0.0f, 0.5f, 1.0f, 0.0f},
+  LightSetup lightSetup2{{Magnum::Vector4{0.0f, -0.5f, -1.0f, 0.0f},
                           {0.0, 5.0, 5.0},
                           LightPositionModel::Camera}};
 };  // struct SimTest

--- a/src/utils/viewer/default_light_override.lighting_config.json
+++ b/src/utils/viewer/default_light_override.lighting_config.json
@@ -2,32 +2,32 @@
   "lights": {
     "forward": {
       "type": "directional",
-      "direction": [0, 0.5, 1],
+      "direction": [0, -0.5, 1],
       "intensity": 2.4,
       "color": [0.93, 0.98, 1]
     },
     "backward": {
       "type": "directional",
-      "direction": [0, 0.5, -1],
+      "direction": [0, -0.5, -1],
       "intensity": 2.4,
       "color": [0.93, 0.98, 1]
     },
     "top_left": {
       "type": "directional",
       "direction": [
-        -1, 1, 0],
+        -1, -1, 0],
       "intensity": 2.0,
       "color": [0.93, 0.98, 1]
     },
     "top_right": {
       "type": "directional",
-      "direction": [1, 1, 0],
+      "direction": [1, -1, 0],
       "intensity": 2.0,
       "color": [0.93, 0.98, 1]
     },
     "bottom": {
       "type": "directional",
-      "direction": [0, -1, 0],
+      "direction": [0, 1, 0],
       "intensity": 0.64,
       "color": [0.93, 0.98, 1]
     }

--- a/src/utils/viewer/default_light_override.lighting_config.json
+++ b/src/utils/viewer/default_light_override.lighting_config.json
@@ -2,26 +2,26 @@
   "lights": {
     "forward": {
       "type": "directional",
-      "direction": [0, -0.5, 1],
+      "direction": [0, -0.5, -1],
       "intensity": 2.4,
       "color": [0.93, 0.98, 1]
     },
     "backward": {
       "type": "directional",
-      "direction": [0, -0.5, -1],
+      "direction": [0, -0.5, 1],
       "intensity": 2.4,
       "color": [0.93, 0.98, 1]
     },
     "top_left": {
       "type": "directional",
       "direction": [
-        -1, -1, 0],
+        1, -1, 0],
       "intensity": 2.0,
       "color": [0.93, 0.98, 1]
     },
     "top_right": {
       "type": "directional",
-      "direction": [1, -1, 0],
+      "direction": [-1, -1, 0],
       "intensity": 2.0,
       "color": [0.93, 0.98, 1]
     },


### PR DESCRIPTION
A long standing issue/bug with Habitat is that our directional lights have always been backwards - pointing away from the direction they are intended to be pointing toward.  This PR fixes this issue, without removing the performance benefit the backwards direction gave (in the phong and pbr shaders).  

The existing light setups using directional lights have been corrected in this PR, but any datasets that provide directional lighting will need to have those lights reversed, so this should probably be considered a breaking change.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
