### PR TITLE
enable frustum-culling for classic replay renderer

### DIFF
--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -213,10 +213,10 @@ void ClassicReplayRenderer::doRender(
       auto& sceneGraph = getSceneGraph(envIndex);
 
 #ifdef ESP_BUILD_WITH_BACKGROUND_RENDERER
-      // todo: investigate flags (frustum culling?)
-      renderer_->enqueueAsyncDrawJob(visualSensor, sceneGraph,
-                                     imageViews[envIndex],
-                                     esp::gfx::RenderCamera::Flags{});
+      renderer_->enqueueAsyncDrawJob(
+          visualSensor, sceneGraph, imageViews[envIndex],
+          esp::gfx::RenderCamera::Flags{
+              gfx::RenderCamera::Flag::FrustumCulling});
 #else
       // TODO what am I supposed to do here?
       CORRADE_ASSERT_UNREACHABLE("Not implemented yet, sorry.", );
@@ -244,8 +244,9 @@ void ClassicReplayRenderer::doRender(
     visualSensor.renderTarget().renderEnter();
 
     auto& sceneGraph = getSceneGraph(envIndex);
-    renderer_->draw(*visualSensor.getRenderCamera(), sceneGraph,
-                    esp::gfx::RenderCamera::Flags{});
+    renderer_->draw(
+        *visualSensor.getRenderCamera(), sceneGraph,
+        esp::gfx::RenderCamera::Flags{gfx::RenderCamera::Flag::FrustumCulling});
 
     if (envIndex == 0 && debugLineRender_) {
       auto* camera = visualSensor.getRenderCamera();


### PR DESCRIPTION
## Motivation and Context

Bugfix (no good reason to ever disable frustum culling)

## How Has This Been Tested

Local testing on 2019 Macbook Pro

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
