### PR TITLE
enable recompute_navmesh when creating sim with create_renderer==false

### DIFF
--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -242,7 +242,6 @@ class Simulator(SimulatorBackend):
             or (
                 not self.pathfinder.is_loaded
                 and config.sim_cfg.scene_id.lower() != "none"
-                and config.sim_cfg.create_renderer
             )
         ):
             logger.info(


### PR DESCRIPTION
## Motivation and Context

The navmesh is needed for blind agents, batch rendering, and other use cases where the sim is created with `create_renderer==false`.

Note a potential source of confusion: when `create_renderer==false`, we don't load textures, upload mesh vertices to the GPU, or create "GL meshes". However, we still load mesh data from disk, so we can still generate a navmesh on the CPU.

## How Has This Been Tested

Local testing on 2019 Macbook Pro

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
