### PR TITLE
Add intertiaFromURDF option to URDF loading API

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -560,13 +560,31 @@ class HabitatSimInteractiveViewer(Application):
                 self.cached_urdf = urdf_file_path
                 aom = self.sim.get_articulated_object_manager()
                 ao = aom.add_articulated_object_from_urdf(
-                    urdf_file_path, fixed_base, 1.0, 1.0, True
+                    urdf_file_path,
+                    fixed_base,
+                    1.0,
+                    1.0,
+                    True,
+                    maintain_link_order=False,
+                    intertia_from_urdf=False,
                 )
                 ao.translation = (
                     self.default_agent.scene_node.transformation.transform_point(
                         [0.0, 1.0, -1.5]
                     )
                 )
+                # check removal and auto-creation
+                joint_motor_settings = habitat_sim.physics.JointMotorSettings(
+                    position_target=0.0,
+                    position_gain=1.0,
+                    velocity_target=0.0,
+                    velocity_gain=1.0,
+                    max_impulse=1000.0,
+                )
+                existing_motor_ids = ao.existing_joint_motor_ids
+                for motor_id in existing_motor_ids:
+                    ao.remove_joint_motor(motor_id)
+                ao.create_all_motors(joint_motor_settings)
             else:
                 logger.warn("Load URDF: input file not found. Aborting.")
 

--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -286,7 +286,7 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
 
           "filepath"_a, "fixed_base"_a = false, "global_scale"_a = 1.0,
           "mass_scale"_a = 1.0, "force_reload"_a = false,
-          "maintain_link_order"_a = false,
+          "maintain_link_order"_a = false, "intertia_from_urdf"_a = false,
           "light_setup_key"_a = DEFAULT_LIGHTING_KEY,
           R"(Load and parse a URDF file using the given 'filepath' into a model,
           then use this model to instantiate an Articulated Object in the world.

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -329,7 +329,7 @@ int PhysicsManager::addArticulatedObjectInstance(
       filepath, &drawables, aObjInstAttributes->getFixedBase(),
       aObjInstAttributes->getUniformScale(),
       static_cast<float>(aObjInstAttributes->getMassScale()), false, false,
-      lightSetup);
+      false, lightSetup);
   if (aObjID == ID_UNDEFINED) {
     // instancing failed for some reason.
     ESP_ERROR() << "Articulated Object create failed for model filepath"

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -472,6 +472,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref BulletArticulatedObject, allocated from
@@ -484,6 +486,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
       CORRADE_UNUSED bool maintainLinkOrder = false,
+      CORRADE_UNUSED bool intertiaFromURDF = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;
@@ -508,6 +511,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -521,6 +526,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED float massScale = 1.0,
       CORRADE_UNUSED bool forceReload = false,
       CORRADE_UNUSED bool maintainLinkOrder = false,
+      CORRADE_UNUSED bool intertiaFromURDF = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     ESP_DEBUG() << "Not implemented in base PhysicsManager.";
     return ID_UNDEFINED;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -116,11 +116,12 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     float massScale,
     bool forceReload,
     bool maintainLinkOrder,
+    bool intertiaFromURDF,
     const std::string& lightSetup) {
   auto& drawables = simulator_->getDrawableGroup();
-  return addArticulatedObjectFromURDF(filepath, &drawables, fixedBase,
-                                      globalScale, massScale, forceReload,
-                                      maintainLinkOrder, lightSetup);
+  return addArticulatedObjectFromURDF(
+      filepath, &drawables, fixedBase, globalScale, massScale, forceReload,
+      maintainLinkOrder, intertiaFromURDF, lightSetup);
 }
 
 int BulletPhysicsManager::addArticulatedObjectFromURDF(
@@ -131,6 +132,7 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
     float massScale,
     bool forceReload,
     bool maintainLinkOrder,
+    bool inertiaFromURDF,
     const std::string& lightSetup) {
   if (simulator_ != nullptr) {
     // acquire context if available
@@ -161,6 +163,9 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(
   u2b->flags = 0;
   if (maintainLinkOrder) {
     u2b->flags |= CUF_MAINTAIN_LINK_ORDER;
+  }
+  if (inertiaFromURDF) {
+    u2b->flags |= CUF_USE_URDF_INERTIA;
   }
   u2b->initURDF2BulletCache();
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -82,6 +82,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -94,6 +96,7 @@ class BulletPhysicsManager : public PhysicsManager {
       float massScale = 1.0,
       bool forceReload = false,
       bool maintainLinkOrder = false,
+      bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
 
   /**
@@ -113,6 +116,8 @@ class BulletPhysicsManager : public PhysicsManager {
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A unique id for the @ref ArticulatedObject, allocated from the same
@@ -126,6 +131,7 @@ class BulletPhysicsManager : public PhysicsManager {
       float massScale = 1.0,
       bool forceReload = false,
       bool maintainLinkOrder = false,
+      bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
 
   /**

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -37,11 +37,12 @@ ArticulatedObjectManager::addArticulatedObjectFromURDF(
     float massScale,
     bool forceReload,
     bool maintainLinkOrder,
+    bool intertiaFromURDF,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
     int newAObjID = physMgr->addArticulatedObjectFromURDF(
         filepath, fixedBase, globalScale, massScale, forceReload,
-        maintainLinkOrder, lightSetup);
+        maintainLinkOrder, intertiaFromURDF, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;
@@ -56,11 +57,12 @@ ArticulatedObjectManager::addArticulatedObjectFromURDFWithDrawables(
     float massScale,
     bool forceReload,
     bool maintainLinkOrder,
+    bool intertiaFromURDF,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
     int newAObjID = physMgr->addArticulatedObjectFromURDF(
         filepath, drawables, fixedBase, globalScale, massScale, forceReload,
-        maintainLinkOrder, lightSetup);
+        maintainLinkOrder, intertiaFromURDF, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.h
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.h
@@ -38,6 +38,8 @@ class ArticulatedObjectManager
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -49,6 +51,7 @@ class ArticulatedObjectManager
       float massScale = 1.0,
       bool forceReload = false,
       bool maintainLinkOrder = false,
+      bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /**
@@ -67,6 +70,8 @@ class ArticulatedObjectManager
    * cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -78,11 +83,12 @@ class ArticulatedObjectManager
       float massScale = 1.0,
       bool forceReload = false,
       bool maintainLinkOrder = false,
+      bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
     std::shared_ptr<ManagedArticulatedObject> objPtr =
         addArticulatedObjectFromURDF(filepath, fixedBase, globalScale,
                                      massScale, forceReload, maintainLinkOrder,
-                                     lightSetup);
+                                     intertiaFromURDF, lightSetup);
 
     if (std::shared_ptr<ManagedBulletArticulatedObject> castObjPtr =
             std::dynamic_pointer_cast<ManagedBulletArticulatedObject>(objPtr)) {
@@ -108,6 +114,8 @@ class ArticulatedObjectManager
    * the cached model.
    * @param maintainLinkOrder If true, maintain the order of link definitions
    * from the URDF file as the link indices.
+   * @param intertiaFromURDF If true, load the link inertia matrices from the
+   * URDF file instead of computing automatically from collision shapes.
    * @param lightSetup The string name of the desired lighting setup to use.
    *
    * @return A reference to the created ArticulatedObject
@@ -121,6 +129,7 @@ class ArticulatedObjectManager
       float massScale = 1.0,
       bool forceReload = false,
       bool maintainLinkOrder = false,
+      bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
  protected:


### PR DESCRIPTION
## Motivation and Context

As discussed in issue #2095 some URDF files behave poorly when inertia is computed automatically from collision shapes. This PR adds the API option to parse inertia matrices directly from the URDF file instead.

Also the viewer URDF loader now creates JointMotors by default.

## How Has This Been Tested

In the viewer app (as shown in the linked issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
