### PR TITLE
--[BUGFIX] Single channel texture support

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2961,15 +2961,27 @@ void ResourceManager::loadTextures(Importer& importer,
         if (image->isCompressed()) {
           format = Mn::GL::textureFormat(image->compressedFormat());
         } else {
-          format = Mn::GL::textureFormat(image->format());
+          const auto pixelFormat = image->format();
+          format = Mn::GL::textureFormat(pixelFormat);
           // Modify swizzle for single channel textures so that they are
           // greyscale
-          if (pixelFormatSize(image->format()) == 1) {
+          if (pixelFormatChannelCount(pixelFormat) == 1) {
 #ifdef MAGNUM_TARGET_WEBGL
-            ESP_WARNING() << "Single Channel Texture ID" << iTexture
-                          << "Loaded as RGB";
+            ESP_WARNING() << "Single Channel Greyscale Texture : ID" << iTexture
+                          << "incorrecting displays as red instead of "
+                             "greyscale due to greyscale expansion"
+                             "not yet supported in WebGL.";
 #else
             currentTexture->setSwizzle<'r', 'r', 'r', '1'>();
+#endif
+          } else if (pixelFormatChannelCount(pixelFormat) == 2) {
+#ifdef MAGNUM_TARGET_WEBGL
+            ESP_WARNING() << "Two Channel Greyscale + Alpha Texture : ID"
+                          << iTexture
+                          << "incorrecting displays due to greyscale expansion"
+                             "not yet supported in WebGL.";
+#else
+            currentTexture->setSwizzle<'r', 'r', 'r', 'g'>();
 #endif
           }
         }

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2962,6 +2962,16 @@ void ResourceManager::loadTextures(Importer& importer,
           format = Mn::GL::textureFormat(image->compressedFormat());
         } else {
           format = Mn::GL::textureFormat(image->format());
+          // Modify swizzle for single channel textures so that they are
+          // greyscale
+          if (pixelFormatSize(image->format()) == 1) {
+#ifdef MAGNUM_TARGET_WEBGL
+            ESP_WARNING() << "Single Channel Texture ID" << iTexture
+                          << "Loaded as RGB";
+#else
+            currentTexture->setSwizzle<'r', 'r', 'r', '1'>();
+#endif
+          }
         }
 
         // For the very first level, allocate the texture

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2965,21 +2965,22 @@ void ResourceManager::loadTextures(Importer& importer,
           format = Mn::GL::textureFormat(pixelFormat);
           // Modify swizzle for single channel textures so that they are
           // greyscale
-          if (pixelFormatChannelCount(pixelFormat) == 1) {
+          Mn::UnsignedInt pixelCount = pixelFormatChannelCount(pixelFormat);
+          if (pixelCount == 1) {
 #ifdef MAGNUM_TARGET_WEBGL
             ESP_WARNING() << "Single Channel Greyscale Texture : ID" << iTexture
-                          << "incorrecting displays as red instead of "
+                          << "incorrectly displays as red instead of "
                              "greyscale due to greyscale expansion"
-                             "not yet supported in WebGL.";
+                             "not yet implemented in WebGL.";
 #else
             currentTexture->setSwizzle<'r', 'r', 'r', '1'>();
 #endif
-          } else if (pixelFormatChannelCount(pixelFormat) == 2) {
+          } else if (pixelCount == 2) {
 #ifdef MAGNUM_TARGET_WEBGL
             ESP_WARNING() << "Two Channel Greyscale + Alpha Texture : ID"
                           << iTexture
-                          << "incorrecting displays due to greyscale expansion"
-                             "not yet supported in WebGL.";
+                          << "incorrectly displays due to greyscale expansion"
+                             "not yet implemented in WebGL.";
 #else
             currentTexture->setSwizzle<'r', 'r', 'r', 'g'>();
 #endif

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2965,8 +2965,8 @@ void ResourceManager::loadTextures(Importer& importer,
           format = Mn::GL::textureFormat(pixelFormat);
           // Modify swizzle for single channel textures so that they are
           // greyscale
-          Mn::UnsignedInt pixelCount = pixelFormatChannelCount(pixelFormat);
-          if (pixelCount == 1) {
+          Mn::UnsignedInt channelCount = pixelFormatChannelCount(pixelFormat);
+          if (channelCount == 1) {
 #ifdef MAGNUM_TARGET_WEBGL
             ESP_WARNING() << "Single Channel Greyscale Texture : ID" << iTexture
                           << "incorrectly displays as red instead of "
@@ -2975,7 +2975,7 @@ void ResourceManager::loadTextures(Importer& importer,
 #else
             currentTexture->setSwizzle<'r', 'r', 'r', '1'>();
 #endif
-          } else if (pixelCount == 2) {
+          } else if (channelCount == 2) {
 #ifdef MAGNUM_TARGET_WEBGL
             ESP_WARNING() << "Two Channel Greyscale + Alpha Texture : ID"
                           << iTexture


### PR DESCRIPTION
## Motivation and Context
We were not handling single channel textures, causing them to display red.  This PR addresses this - any single channel textures get their swizzle modified to pull RGB from the R channel.  This currently is not supported in magnum for WebGL builds, so a warning is displayed instead.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python Tests pass locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
