### PR TITLE
Adds config option for including static objects during navmesh construction

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -55,6 +55,9 @@ void initSimBindings(py::module& m) {
           "allow_sliding", &SimulatorConfiguration::allowSliding,
           R"(Whether or not the agent can slide on NavMesh collisions.)")
       .def_readwrite(
+          "include_static_objects_in_navmesh", &SimulatorConfiguration::includeStaticObjectsInNavmesh,
+          R"(Whether or not static objects will be included in the constructed NavMesh.)")
+      .def_readwrite(
           "create_renderer", &SimulatorConfiguration::createRenderer,
           R"(Optimisation for non-visual simulation. If false, no renderer will be created and no materials or textures loaded.)")
       .def_readwrite(

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -55,7 +55,8 @@ void initSimBindings(py::module& m) {
           "allow_sliding", &SimulatorConfiguration::allowSliding,
           R"(Whether or not the agent can slide on NavMesh collisions.)")
       .def_readwrite(
-          "include_static_objects_in_navmesh", &SimulatorConfiguration::includeStaticObjectsInNavmesh,
+          "include_static_objects_in_navmesh",
+          &SimulatorConfiguration::includeStaticObjectsInNavmesh,
           R"(Whether or not static objects will be included in the constructed NavMesh.)")
       .def_readwrite(
           "create_renderer", &SimulatorConfiguration::createRenderer,

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -27,6 +27,7 @@ bool operator==(const SimulatorConfiguration& a,
          a.physicsConfigFile == b.physicsConfigFile &&
          a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
          a.sceneLightSetupKey == b.sceneLightSetupKey;
+         a.includeStaticObjectsInNavmesh == b.includeStaticObjectsInNavmesh;
 }
 
 bool operator!=(const SimulatorConfiguration& a,

--- a/src/esp/sim/SimulatorConfiguration.cpp
+++ b/src/esp/sim/SimulatorConfiguration.cpp
@@ -27,7 +27,7 @@ bool operator==(const SimulatorConfiguration& a,
          a.physicsConfigFile == b.physicsConfigFile &&
          a.overrideSceneLightDefaults == b.overrideSceneLightDefaults &&
          a.sceneLightSetupKey == b.sceneLightSetupKey;
-         a.includeStaticObjectsInNavmesh == b.includeStaticObjectsInNavmesh;
+  a.includeStaticObjectsInNavmesh == b.includeStaticObjectsInNavmesh;
 }
 
 bool operator!=(const SimulatorConfiguration& a,

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -28,6 +28,8 @@ struct SimulatorConfiguration {
   bool createRenderer = true;
   //! Whether or not the agent can slide on NavMesh collisions.
   bool allowSliding = true;
+  //! Whether or not static objects will be included in the constructed NavMesh.
+  bool includeStaticObjectsInNavmesh = false;
   //! Enable or disable the frustum culling optimisation
   bool frustumCulling = true;
   /**

--- a/src_python/habitat_sim/simulator.py
+++ b/src_python/habitat_sim/simulator.py
@@ -248,7 +248,11 @@ class Simulator(SimulatorBackend):
                 f"Recomputing navmesh for agent's height {default_agent_config.height} and radius"
                 f" {default_agent_config.radius}."
             )
-            self.recompute_navmesh(self.pathfinder, needed_settings)
+            self.recompute_navmesh(
+                self.pathfinder,
+                needed_settings,
+                include_static_objects=self.config.sim_cfg.include_static_objects_in_navmesh,
+            )
 
         self.pathfinder.seed(config.sim_cfg.random_seed)
 


### PR DESCRIPTION
## Motivation and Context

HSSD scenes have all scene objects initialized as static ones. Anyone who needs to use these scenes for training agents (using hab-lab) needs to either manually turn on this inclusion of static objects for navmesh construction (and rebuild) or make an explicit `recompute_navmesh` call with this flag turned on.

This PR adds a config option to toggle this inclusion. Corresponding hab-lab PR coming soon.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

By visualizing topdown maps with this flag ON and OFF.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
