### PR TITLE
additional magnum importer plugins in python build dependencies

### DIFF
--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -350,14 +350,33 @@ if(NOT USE_SYSTEM_MAGNUM)
     # for Python as well; and reset that back to strange build procedures that
     # turn some features off again later can still work.
     if(BUILD_GUI_VIEWERS)
-      set(MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS
-          MagnumPlugins::StbTrueTypeFont Magnum::AnySceneImporter
-          MagnumPlugins::AssimpImporter CACHE STRING "" FORCE
+      set(
+        MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS
+        MagnumPlugins::StbTrueTypeFont
+        Magnum::AnySceneImporter
+        Magnum::AnyImageImporter
+        Magnum::AnyImageConverter
+        MagnumPlugins::StbImageImporter
+        MagnumPlugins::StbImageConverter
+        MagnumPlugins::BasisImporter
+        MagnumPlugins::StanfordImporter
+        MagnumPlugins::GltfImporter
+        MagnumPlugins::AssimpImporter
+        CACHE STRING "" FORCE
       )
     else()
-      set(MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS Magnum::AnySceneImporter
-                                                MagnumPlugins::AssimpImporter
-          CACHE STRING "" FORCE
+      set(
+        MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS
+        Magnum::AnySceneImporter
+        MagnumPlugins::AssimpImporter
+        Magnum::AnyImageImporter
+        Magnum::AnyImageConverter
+        MagnumPlugins::StbImageImporter
+        MagnumPlugins::StbImageConverter
+        MagnumPlugins::BasisImporter
+        MagnumPlugins::StanfordImporter
+        MagnumPlugins::GltfImporter
+        CACHE STRING "" FORCE
       )
     endif()
     add_subdirectory("${DEPS_DIR}/magnum-bindings")

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -357,7 +357,6 @@ if(NOT USE_SYSTEM_MAGNUM)
       MagnumPlugins::AssimpImporter
       MagnumPlugins::BasisImporter
       MagnumPlugins::GltfImporter
-      MagnumPlugins::StanfordImporter
       MagnumPlugins::StbImageConverter
       MagnumPlugins::StbImageImporter
     )

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -349,35 +349,25 @@ if(NOT USE_SYSTEM_MAGNUM)
     # Make Magnum text rendering plugins (used by the native viewer) available
     # for Python as well; and reset that back to strange build procedures that
     # turn some features off again later can still work.
+    set(
+      common_plugins
+      Magnum::AnyImageConverter
+      Magnum::AnyImageImporter
+      Magnum::AnySceneImporter
+      MagnumPlugins::AssimpImporter
+      MagnumPlugins::BasisImporter
+      MagnumPlugins::GltfImporter
+      MagnumPlugins::StanfordImporter
+      MagnumPlugins::StbImageConverter
+      MagnumPlugins::StbImageImporter
+    )
     if(BUILD_GUI_VIEWERS)
-      set(
-        MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS
-        MagnumPlugins::StbTrueTypeFont
-        Magnum::AnySceneImporter
-        Magnum::AnyImageImporter
-        Magnum::AnyImageConverter
-        MagnumPlugins::StbImageImporter
-        MagnumPlugins::StbImageConverter
-        MagnumPlugins::BasisImporter
-        MagnumPlugins::StanfordImporter
-        MagnumPlugins::GltfImporter
-        MagnumPlugins::AssimpImporter
-        CACHE STRING "" FORCE
+      set(MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS ${common_plugins}
+                                                MagnumPlugins::StbTrueTypeFont
+          CACHE STRING "" FORCE
       )
     else()
-      set(
-        MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS
-        Magnum::AnySceneImporter
-        MagnumPlugins::AssimpImporter
-        Magnum::AnyImageImporter
-        Magnum::AnyImageConverter
-        MagnumPlugins::StbImageImporter
-        MagnumPlugins::StbImageConverter
-        MagnumPlugins::BasisImporter
-        MagnumPlugins::StanfordImporter
-        MagnumPlugins::GltfImporter
-        CACHE STRING "" FORCE
-      )
+      set(MAGNUM_PYTHON_BINDINGS_STATIC_PLUGINS ${common_plugins} CACHE STRING "" FORCE)
     endif()
     add_subdirectory("${DEPS_DIR}/magnum-bindings")
   endif()


### PR DESCRIPTION
## Motivation and Context

Python importer used in Habitat-lab requires linked Magnum plugins from Habitat=sim.

## How Has This Been Tested

NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
