### PR TITLE
[CI]- downgrade numpy to avoid erroneous ValueError in pose_extractor test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imageio
 imageio-ffmpeg
 matplotlib
 numba
-numpy
+numpy>=1.20.0,<1.24.3
 numpy-quaternion
 pillow
 scipy>=1.3.0


### PR DESCRIPTION
## Motivation and Context

ValueError on CI pose_extractor test appears to be the result of a numpy dependency upgrade. For now restricting version to avoid this issue (and seek parity with habitat-lab requirements)

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
