### PR TITLE
[Ovmm] Typecast to double to fix build error

### DIFF
--- a/src/esp/gfx/ssao/nvpro_core/nvh/cameramanipulator.cpp
+++ b/src/esp/gfx/ssao/nvpro_core/nvh/cameramanipulator.cpp
@@ -530,10 +530,10 @@ void CameraManipulator::fit(const nvmath::vec3f& boxMin,
       {
         // Keep the largest offset to see that vertex
         offset =
-            std::max(fabs(vct.y) / tan(nv_to_rad * yfov * 0.5f) + fabs(vct.z),
+            std::max(double(fabs(vct.y)) / tan(nv_to_rad * yfov * 0.5f) + fabs(vct.z),
                      double(offset));
         offset =
-            std::max(fabs(vct.x) / tan(nv_to_rad * xfov * 0.5f) + fabs(vct.z),
+            std::max(double(fabs(vct.x)) / tan(nv_to_rad * xfov * 0.5f) + fabs(vct.z),
                      double(offset));
       }
     }


### PR DESCRIPTION
## Motivation and Context

```
Build fails with 
sim/src/esp/gfx/ssao/nvpro_core/nvh/cameramanipulator.cpp:534:36: error: no matching function for call to 'max(float, double)'
                      double(offset));
```
Typecast first argument to `double` to fix this

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Builds succesfully
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
