### PR TITLE
--[PBR Update 1 of 3] Map materials' extension/layer data to Drawables cache

### DIFF
--- a/src/esp/gfx/GenericDrawable.cpp
+++ b/src/esp/gfx/GenericDrawable.cpp
@@ -198,10 +198,8 @@ void GenericDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // fragment shader
       .setObjectId(
           static_cast<RenderCamera&>(camera).useDrawableIds() ? drawableId_
-          : ((((flags_ & Mn::Shaders::PhongGL::Flag::InstancedObjectId) ==
-               Mn::Shaders::PhongGL::Flag::InstancedObjectId) ||
-              ((flags_ & Mn::Shaders::PhongGL::Flag::ObjectIdTexture)) ==
-                  Mn::Shaders::PhongGL::Flag::ObjectIdTexture))
+          : (((flags_ >= Mn::Shaders::PhongGL::Flag::InstancedObjectId) ||
+              (flags_ >= Mn::Shaders::PhongGL::Flag::ObjectIdTexture)))
               ? 0
               : node_.getSemanticId())
       .setTransformationMatrix(transformationMatrix)

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -375,8 +375,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
       // the fragment shader
       .setObjectId(static_cast<RenderCamera&>(camera).useDrawableIds()
                        ? drawableId_
-                       : ((flags_ & PbrShader::Flag::InstancedObjectId) ==
-                                  PbrShader::Flag::InstancedObjectId
+                       : (flags_ >= PbrShader::Flag::InstancedObjectId
                               ? 0
                               : node_.getSemanticId()))
       .setProjectionMatrix(camera.projectionMatrix())

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -130,13 +130,11 @@ void PbrDrawable::setMaterialValuesInternal(
     if (meshAttributeFlags_ & gfx::Drawable::Flag::HasTangent) {
       flags_ |= PbrShader::Flag::PrecomputedTangent;
     }
-    if (tmpMaterialData.normalTextureScale() != 1.0f) {
-      flags_ |= PbrShader::Flag::NormalTextureScale;
-      matCache.normalTextureScale = tmpMaterialData.normalTextureScale();
-      CORRADE_ASSERT(tmpMaterialData.normalTextureScale() > 0.0f,
-                     "PbrDrawable::PbrDrawable(): the normal texture scale "
-                     "must be positive.", );
-    }
+    // normal texture scale
+    matCache.normalTextureScale = tmpMaterialData.normalTextureScale();
+    CORRADE_ASSERT(tmpMaterialData.normalTextureScale() > 0.0f,
+                   "PbrDrawable::PbrDrawable(): the normal texture scale "
+                   "must be positive.", );
   }
 
   if (const Cr::Containers::Optional<Mn::GL::Texture2D*> emissiveTexturePtr =
@@ -401,6 +399,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
 
   if (flags_ & PbrShader::Flag::NormalTexture) {
     shader_->bindNormalTexture(*matCache.normalTexture);
+    shader_->setNormalTextureScale(matCache.normalTextureScale);
   }
 
   if (flags_ & PbrShader::Flag::EmissiveTexture) {

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -180,10 +180,6 @@ void PbrDrawable::setMaterialValuesInternal(
         // TODO : do we really need to verify if scale
         matCache.cc_NormalTextureScale = ccLayer.normalTextureScale();
       }
-      Cr::Utility::formatInto(
-          debugStr, debugStr.size(),
-          " ClearCoat layer with factor : {} Roughness : {}", cc_LayerFactor,
-          matCache.cc_Roughness);
 
     }  // non-zero layer factor
   }    // has clearcoat layer
@@ -195,8 +191,6 @@ void PbrDrawable::setMaterialValuesInternal(
     if (materialData_->hasAttribute("#KHR_materials_ior", "ior")) {
       matCache.ior_Index =
           materialData_->attribute<float>("#KHR_materials_ior", "ior");
-      Cr::Utility::formatInto(debugStr, debugStr.size(),
-                              " | IOR layer w/IOR = {}", matCache.ior_Index);
     }
 
   }  // has KHR_materials_ior layer
@@ -245,13 +239,6 @@ void PbrDrawable::setMaterialValuesInternal(
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_specular", "specularColorTexturePointer");
     }
-
-    Cr::Utility::formatInto(
-        debugStr, debugStr.size(),
-        " | Specular layer with factor : {} spec clr : [{},{}.{}]",
-        matCache.spec_SpecularFactor, matCache.spec_SpecularColorFactor.r(),
-        matCache.spec_SpecularColorFactor.g(),
-        matCache.spec_SpecularColorFactor.b());
   }  // has KHR_materials_specular layer
 
   ////////////////
@@ -273,13 +260,10 @@ void PbrDrawable::setMaterialValuesInternal(
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_transmission", "transmissionTexturePointer");
     }
-
-    Cr::Utility::formatInto(debugStr, debugStr.size(), " | Transmission layer");
   }  // has KHR_materials_transmission layer
   ////////////////
   // KHR_materials_volume
   if (materialData_->hasLayer("#KHR_materials_volume")) {
-    Cr::Utility::formatInto(debugStr, debugStr.size(), " | Volume layer");
     flags_ |= PbrShader::Flag::VolumeLayer;
 
     if (materialData_->hasAttribute("#KHR_materials_volume",
@@ -312,10 +296,6 @@ void PbrDrawable::setMaterialValuesInternal(
           "#KHR_materials_volume", "attenuationColor");
     }
   }  // has KHR_materials_volume layer
-  if (debugStr.length() > 0) {
-    ESP_WARNING() << "PBR Material:" << debugStr;
-  }
-
 }  // PbrDrawable::setMaterialValuesInternal
 
 void PbrDrawable::setLightSetup(const Mn::ResourceKey& lightSetupKey) {

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -156,29 +156,25 @@ void PbrDrawable::setMaterialValuesInternal(
       // has non-trivial clearcoat layer
       flags_ |= PbrShader::Flag::ClearCoatLayer;
       //
-      matCache.cc_ClearCoatFactor = cc_LayerFactor;
-      matCache.cc_Roughness = ccLayer.roughness();
+      matCache.clearCoat.factor = cc_LayerFactor;
+      matCache.clearCoat.roughnessFactor = ccLayer.roughness();
 
       if (ccLayer.hasAttribute("layerFactorTexturePointer")) {
-        flags_ |= PbrShader::Flag::CCLayer_CCTexture;
-        matCache.cc_ClearCoatTexture =
+        flags_ |= PbrShader::Flag::ClearCoatTexture;
+        matCache.clearCoat.texture =
             ccLayer.attribute<Mn::GL::Texture2D*>("layerFactorTexturePointer");
       }
 
       if (ccLayer.hasAttribute("roughnessTexturePointer")) {
-        flags_ |= PbrShader::Flag::CCLayer_RoughnessTexture;
-        matCache.cc_RoughnessTexture =
+        flags_ |= PbrShader::Flag::ClearCoatRoughnessTexture;
+        matCache.clearCoat.roughnessTexture =
             ccLayer.attribute<Mn::GL::Texture2D*>("roughnessTexturePointer");
-        matCache.cc_Roughness_Texture_Swizzle =
-            ccLayer.roughnessTextureSwizzle();
       }
 
       if (ccLayer.hasAttribute("normalTexturePointer")) {
-        flags_ |= PbrShader::Flag::CCLayer_NormalTexture;
-        matCache.cc_NormalTexture =
+        flags_ |= PbrShader::Flag::ClearCoatNormalTexture;
+        matCache.clearCoat.normalTexture =
             ccLayer.attribute<Mn::GL::Texture2D*>("normalTexturePointer");
-        // TODO : do we really need to verify if scale
-        matCache.cc_NormalTextureScale = ccLayer.normalTextureScale();
       }
 
     }  // non-zero layer factor
@@ -204,7 +200,7 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (materialData_->hasAttribute("#KHR_materials_specular",
                                     "specularFactor")) {
-      matCache.spec_SpecularFactor = materialData_->attribute<float>(
+      matCache.specularLayer.factor = materialData_->attribute<float>(
           "#KHR_materials_specular", "specularFactor");
     }
 
@@ -214,8 +210,8 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (materialData_->hasAttribute("#KHR_materials_specular",
                                     "specularTexturePointer")) {
-      flags_ |= PbrShader::Flag::SpecLayer_SpecTexture;
-      matCache.spec_SpecularTexture =
+      flags_ |= PbrShader::Flag::SpecularLayerTexture;
+      matCache.specularLayer.texture =
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_specular", "specularTexturePointer");
     }
@@ -224,7 +220,7 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (materialData_->hasAttribute("#KHR_materials_specular",
                                     "specularColorFactor")) {
-      matCache.spec_SpecularColorFactor = materialData_->attribute<Mn::Color3>(
+      matCache.specularLayer.colorFactor = materialData_->attribute<Mn::Color3>(
           "#KHR_materials_specular", "specularColorFactor");
     }
     /**
@@ -234,8 +230,8 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (materialData_->hasAttribute("#KHR_materials_specular",
                                     "specularColorTexturePointer")) {
-      flags_ |= PbrShader::Flag::SpecLayer_SpecColorTexture;
-      matCache.spec_SpecularColorTexture =
+      flags_ |= PbrShader::Flag::SpecularLayerColorTexture;
+      matCache.specularLayer.colorTexture =
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_specular", "specularColorTexturePointer");
     }
@@ -248,15 +244,15 @@ void PbrDrawable::setMaterialValuesInternal(
     // transmissionFactor
     if (materialData_->hasAttribute("#KHR_materials_transmission",
                                     "transmissionFactor")) {
-      matCache.trns_TransmissionFactor = materialData_->attribute<float>(
+      matCache.transmissionLayer.factor = materialData_->attribute<float>(
           "#KHR_materials_transmission", "transmissionFactor");
     }
     // transmissionTexturePointer
 
     if (materialData_->hasAttribute("#KHR_materials_transmission",
                                     "transmissionTexturePointer")) {
-      flags_ |= PbrShader::Flag::TransLayer_TransmissionTexture;
-      matCache.trns_TransmissionTexture =
+      flags_ |= PbrShader::Flag::TransmissionLayerTexture;
+      matCache.transmissionLayer.texture =
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_transmission", "transmissionTexturePointer");
     }
@@ -268,14 +264,14 @@ void PbrDrawable::setMaterialValuesInternal(
 
     if (materialData_->hasAttribute("#KHR_materials_volume",
                                     "thicknessFactor")) {
-      matCache.vol_ThicknessFactor = materialData_->attribute<float>(
+      matCache.volumeLayer.thicknessFactor = materialData_->attribute<float>(
           "#KHR_materials_volume", "thicknessFactor");
     }
 
     if (materialData_->hasAttribute("#KHR_materials_volume",
                                     "thicknessTexturePointer")) {
-      flags_ |= PbrShader::Flag::VolLayer_ThicknessTexture;
-      matCache.vol_ThicknessTexture =
+      flags_ |= PbrShader::Flag::VolumeLayerThicknessTexture;
+      matCache.volumeLayer.thicknessTexture =
           materialData_->attribute<Mn::GL::Texture2D*>(
               "#KHR_materials_volume", "thicknessTexturePointer");
     }
@@ -286,14 +282,15 @@ void PbrDrawable::setMaterialValuesInternal(
                                                       "attenuationDistance");
       if (attDist > 0.0f) {
         // Can't be 0 or inf
-        matCache.vol_AttenuationDist = attDist;
+        matCache.volumeLayer.attenuationDist = attDist;
       }
     }
 
     if (materialData_->hasAttribute("#KHR_materials_volume",
                                     "attenuationColor")) {
-      matCache.vol_AttenuationColor = materialData_->attribute<Mn::Color3>(
-          "#KHR_materials_volume", "attenuationColor");
+      matCache.volumeLayer.attenuationColor =
+          materialData_->attribute<Mn::Color3>("#KHR_materials_volume",
+                                               "attenuationColor");
     }
   }  // has KHR_materials_volume layer
 }  // PbrDrawable::setMaterialValuesInternal

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -86,9 +86,6 @@ void PbrDrawable::setMaterialValuesInternal(
     }
     // normal texture scale
     matCache.normalTextureScale = tmpMaterialData.normalTextureScale();
-    ESP_CHECK(abs(matCache.normalTextureScale) > 0.0f,
-              "::setMaterialValuesInternal) : the normal texture scale "
-              "must be non-zero.");
   }
 
   if (const auto emissiveTexturePtr =

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -22,6 +22,8 @@ class PbrDrawable : public Drawable {
    * Magnum MaterialData to speed up access in draw.
    */
   struct PBRMaterialCache {
+    ////////////////
+    // Base layer
     Mn::Color4 baseColor{1.0f};
     float roughness = 1.0f;
     float metalness = 1.0f;
@@ -42,8 +44,99 @@ class PbrDrawable : public Drawable {
     Mn::GL::Texture2D* roughnessTexture = nullptr;
     Mn::GL::Texture2D* metallicTexture = nullptr;
 
-    Mn::GL::Texture2D* normalTexture = nullptr;
     Mn::GL::Texture2D* emissiveTexture = nullptr;
+
+    Mn::GL::Texture2D* normalTexture = nullptr;
+
+    float normalTextureScale = 1.0f;
+
+    ////////////////
+    // ClearCoat layer
+    float cc_ClearCoatFactor = 0.0f;
+    Mn::GL::Texture2D* cc_ClearCoatTexture = nullptr;
+    float cc_Roughness = 0.0f;
+    Mn::GL::Texture2D* cc_RoughnessTexture = nullptr;
+
+    // TODO: is this going to be needed?
+    Mn::Trade::MaterialTextureSwizzle cc_Roughness_Texture_Swizzle =
+        Mn::Trade::MaterialTextureSwizzle::G;
+    float cc_NormalTextureScale = 1.0f;
+    Mn::GL::Texture2D* cc_NormalTexture = nullptr;
+
+    ////////////////
+    // KHR_materials_ior
+
+    /**
+     * Index of refraction of material. Generally between 1-2, although values
+     * higher than 2 are possible. Defaults to 1.5.
+     *
+     * dielectricSpecular = ((ior - 1)/(ior + 1))^2
+     * default ior value evaluates to dielectricSpecular = 0.04
+     */
+    float ior_Index = 1.5;
+
+    ////////////////
+    // KHR_materials_specular layer
+
+    /**
+     * The strength of the specular reflection.
+     */
+    float spec_SpecularFactor = 1.0f;
+
+    /**
+     * A texture that defines the strength of the specular reflection, stored in
+     * the alpha (A) channel. This will be multiplied by specularFactor.
+     */
+    Mn::GL::Texture2D* spec_SpecularTexture = nullptr;
+
+    /**
+     * The F0 color of the specular reflection (linear RGB).
+     */
+    Mn::Color3 spec_SpecularColorFactor{1.0f};
+
+    /**
+     * A texture that defines the F0 color of the specular reflection,
+     * stored in the RGB channels and encoded in sRGB. This texture will be
+     * multiplied by specularColorFactor.
+     */
+    Mn::GL::Texture2D* spec_SpecularColorTexture = nullptr;
+
+    ////////////////
+    // KHR_materials_transmission
+    float trns_TransmissionFactor = 0.0f;
+
+    Mn::GL::Texture2D* trns_TransmissionTexture = nullptr;
+
+    ////////////////
+    // KHR_materials_volume
+
+    /**
+     * The thickness of the volume beneath the surface. The value is given in
+     * the coordinate space of the mesh. If the value is 0 the material is
+     * thin-walled. Otherwise the material is a volume boundary. The doubleSided
+     * property has no effect on volume boundaries. Range is [0, +inf).
+     */
+    float vol_ThicknessFactor = 0.0f;
+
+    /**
+     * A texture that defines the thickness, stored in the G channel. This will
+     * be multiplied by thicknessFactor. Range is [0, 1]
+     */
+    Mn::GL::Texture2D* vol_ThicknessTexture = nullptr;
+
+    /**
+     * Density of the medium given as the average distance that light travels in
+     * the medium before interacting with a particle. The value is given in
+     * world space. Range is (0, +inf). Default is inf (treat -1).
+     */
+    float vol_AttenuationDist = -1.0f;
+
+    /**
+     * The color that white light turns into due to absorption when reaching
+     * the attenuation distance.
+     */
+
+    Mn::Color3 vol_AttenuationColor{1.0f};
   };
 
   /**

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -135,6 +135,37 @@ class PbrDrawable : public Drawable {
 
     } specularLayer;
 
+    ///////////////
+    // KHR_materials_anisotropy layer
+    /**
+     * Structure holdijng anisotropy layer values
+     */
+    struct AnisotropyLayer {
+      /**
+       * The anisotropy strength. When anisotropyTexture is present, this value
+       * is multiplied by the blue channel.
+       */
+      float factor = 0.0f;
+
+      /**
+       * [cos(rotation), sin(rotation)] : Built from the rotation of the
+       * anisotropy in tangent, bitangent space, measured in radians
+       * counter-clockwise from the tangent. When anisotropyTexture is present,
+       * anisotropyRotation provides additional rotation to the vectors in the
+       * texture.
+       */
+      Mn::Vector2 direction{1.0f, 0.0f};
+
+      /**
+       * A texture that defines the strength and orientation of the anisotropy
+       * of the material. Red and green channels represent the anisotropy
+       * direction in [-1, 1] tangent, bitangent space, to be rotated by
+       * anisotropyRotation. The blue channel contains strength as [0, 1] to be
+       * multiplied by anisotropyStrength
+       */
+      Mn::GL::Texture2D* texture = nullptr;
+    } anisotropyLayer;
+
     ////////////////
     // KHR_materials_transmission
 

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -52,16 +52,39 @@ class PbrDrawable : public Drawable {
 
     ////////////////
     // ClearCoat layer
-    float cc_ClearCoatFactor = 0.0f;
-    Mn::GL::Texture2D* cc_ClearCoatTexture = nullptr;
-    float cc_Roughness = 0.0f;
-    Mn::GL::Texture2D* cc_RoughnessTexture = nullptr;
 
-    // TODO: is this going to be needed?
-    Mn::Trade::MaterialTextureSwizzle cc_Roughness_Texture_Swizzle =
-        Mn::Trade::MaterialTextureSwizzle::G;
-    float cc_NormalTextureScale = 1.0f;
-    Mn::GL::Texture2D* cc_NormalTexture = nullptr;
+    /**
+     * Structure holding clearcoat layer values
+     */
+    struct ClearCoat {
+      /**
+       * Clear coat layer intensity
+       */
+      float factor = 0.0f;
+
+      /**
+       * Texture defining clearcoat intensity in R, G, or B channels.Multiplied
+       * by scalar if both are present.
+       */
+      Mn::GL::Texture2D* texture = nullptr;
+
+      /**
+       * Clearcoat layer roughness.
+       */
+      float roughnessFactor = 0.0f;
+
+      /**
+       * Texture describing clear coat roughness in R, G, or B channels.
+       * Multiplied by scalar if both are present.
+       */
+      Mn::GL::Texture2D* roughnessTexture = nullptr;
+
+      /**
+       * Clearcoat Normal map texture, in RGB channels.
+       */
+      Mn::GL::Texture2D* normalTexture = nullptr;
+
+    } clearCoat;
 
     ////////////////
     // KHR_materials_ior
@@ -79,64 +102,89 @@ class PbrDrawable : public Drawable {
     // KHR_materials_specular layer
 
     /**
-     * The strength of the specular reflection.
+     * Structure holdling specular layer values
      */
-    float spec_SpecularFactor = 1.0f;
+    struct SpecularLayer {
+      /**
+       * The strength of the specular reflection.
+       */
+      float factor = 1.0f;
 
-    /**
-     * A texture that defines the strength of the specular reflection, stored in
-     * the alpha (A) channel. This will be multiplied by specularFactor.
-     */
-    Mn::GL::Texture2D* spec_SpecularTexture = nullptr;
+      /**
+       * A texture that defines the strength of the specular reflection, stored
+       * in the alpha (A) channel. This will be multiplied by specularFactor.
+       */
+      Mn::GL::Texture2D* texture = nullptr;
 
-    /**
-     * The F0 color of the specular reflection (linear RGB).
-     */
-    Mn::Color3 spec_SpecularColorFactor{1.0f};
+      /**
+       * The F0 color of the specular reflection (linear RGB).
+       */
+      Mn::Color3 colorFactor{1.0f};
 
-    /**
-     * A texture that defines the F0 color of the specular reflection,
-     * stored in the RGB channels and encoded in sRGB. This texture will be
-     * multiplied by specularColorFactor.
-     */
-    Mn::GL::Texture2D* spec_SpecularColorTexture = nullptr;
+      /**
+       * A texture that defines the F0 color of the specular reflection,
+       * stored in the RGB channels and encoded in sRGB. This texture will be
+       * multiplied by specularColorFactor.
+       */
+      Mn::GL::Texture2D* colorTexture = nullptr;
+
+    } specularLayer;
 
     ////////////////
     // KHR_materials_transmission
-    float trns_TransmissionFactor = 0.0f;
 
-    Mn::GL::Texture2D* trns_TransmissionTexture = nullptr;
+    /**
+     * Structure holding transmission layer values
+     */
+    struct TransmissionLayer {
+      /**
+       * The base percentage of light that is transmitted through the surface.
+       */
+      float factor = 0.0f;
+      /**
+       * A texture that defines the transmission percentage of the surface,
+       * stored in the R channel. This will be multiplied by transmissionFactor.
+       */
+      Mn::GL::Texture2D* texture = nullptr;
+    } transmissionLayer;
 
     ////////////////
     // KHR_materials_volume
 
     /**
-     * The thickness of the volume beneath the surface. The value is given in
-     * the coordinate space of the mesh. If the value is 0 the material is
-     * thin-walled. Otherwise the material is a volume boundary. The doubleSided
-     * property has no effect on volume boundaries. Range is [0, +inf).
+     * Structure holding volume-layer values
      */
-    float vol_ThicknessFactor = 0.0f;
+    struct VolumeLayer {
+      /**
+       * The thickness of the volume beneath the surface. The value is given in
+       * the coordinate space of the mesh. If the value is 0 the material is
+       * thin-walled. Otherwise the material is a volume boundary. The
+       * doubleSided property has no effect on volume boundaries. Range is [0,
+       * +inf).
+       */
+      float thicknessFactor = 0.0f;
 
-    /**
-     * A texture that defines the thickness, stored in the G channel. This will
-     * be multiplied by thicknessFactor. Range is [0, 1]
-     */
-    Mn::GL::Texture2D* vol_ThicknessTexture = nullptr;
+      /**
+       * A texture that defines the thickness, stored in the G channel. This
+       * will be multiplied by thicknessFactor. Range is [0, 1]
+       */
+      Mn::GL::Texture2D* thicknessTexture = nullptr;
 
-    /**
-     * Density of the medium given as the average distance that light travels in
-     * the medium before interacting with a particle. The value is given in
-     * world space. Range is (0, +inf). Default is inf (treat -1).
-     */
-    float vol_AttenuationDist = -1.0f;
+      /**
+       * Density of the medium given as the average distance that light travels
+       * in the medium before interacting with a particle. The value is given in
+       * world space. Range is (0, +inf). Default is inf (treat -1).
+       */
+      float attenuationDist = -1.0f;
 
-    /**
-     * The color that white light turns into due to absorption when reaching
-     * the attenuation distance.
-     */
+      /**
+       * The color that white light turns into due to absorption when reaching
+       * the attenuation distance.
+       */
 
-    Mn::Color3 vol_AttenuationColor{1.0f};
+      Mn::Color3 attenuationColor{1.0f};
+
+    } volumeLayer;
   };
 
   /**

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -32,17 +32,11 @@ class PbrDrawable : public Drawable {
 
     Mn::GL::Texture2D* baseColorTexture = nullptr;
 
-    bool hasAnyMetallicRoughnessTexture = false;
-
-    Mn::GL::Texture2D* useMetallicRoughnessTexture = nullptr;
     /**
-     * Currently we only support a single NoneMetalnessRoughness texture for
-     * both metalness and roughness.  Separate textures will be stored, but only
-     * the useMetallicRoughnessTexture should be sent to the shader
+     * Currently we only support a single noneRoughnessMetallicTexture texture
+     * for both metalness and roughness.
      */
     Mn::GL::Texture2D* noneRoughnessMetallicTexture = nullptr;
-    Mn::GL::Texture2D* roughnessTexture = nullptr;
-    Mn::GL::Texture2D* metallicTexture = nullptr;
 
     Mn::GL::Texture2D* emissiveTexture = nullptr;
 

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -63,8 +63,8 @@ class PbrDrawable : public Drawable {
       float factor = 0.0f;
 
       /**
-       * Texture defining clearcoat intensity in R, G, or B channels.Multiplied
-       * by scalar if both are present.
+       * Texture defining clearcoat intensity in R channel. Multiplied by scalar
+       * if both are present.
        */
       Mn::GL::Texture2D* texture = nullptr;
 
@@ -74,10 +74,15 @@ class PbrDrawable : public Drawable {
       float roughnessFactor = 0.0f;
 
       /**
-       * Texture describing clear coat roughness in R, G, or B channels.
-       * Multiplied by scalar if both are present.
+       * Texture describing clear coat roughness in G channel. Multiplied by
+       * scalar if both are present.
        */
       Mn::GL::Texture2D* roughnessTexture = nullptr;
+
+      /**
+       * Scale value for clearcoat normal texture
+       */
+      float normalTextureScale = 1.0f;
 
       /**
        * Clearcoat Normal map texture, in RGB channels.

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -119,9 +119,6 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
                      ? "#define NONE_ROUGHNESS_METALLIC_TEXTURE\n"
                      : "")
       .addSource(flags_ & Flag::NormalTexture ? "#define NORMAL_TEXTURE\n" : "")
-      .addSource(flags_ & Flag::NormalTextureScale
-                     ? "#define NORMAL_TEXTURE_SCALE\n"
-                     : "")
       .addSource(flags_ & Flag::ObjectId ? "#define OBJECT_ID\n" : "")
       .addSource(flags_ & Flag::ClearCoatLayer ? "#define CLEAR_COAT\n" : "")
       .addSource(flags_ & Flag::PrecomputedTangent
@@ -221,8 +218,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
     lightDirectionsUniform_ = uniformLocation("LightDirections");
   }
 
-  if ((flags_ & Flag::NormalTexture) && (flags_ & Flag::NormalTextureScale) &&
-      lightingIsEnabled()) {
+  if ((flags_ & Flag::NormalTexture) && lightingIsEnabled()) {
     normalTextureScaleUniform_ = uniformLocation("NormalTextureScale");
   }
 
@@ -563,7 +559,7 @@ PbrShader& PbrShader::setNormalTextureScale(float scale) {
                  "PbrShader::setNormalTextureScale(): the shader was not "
                  "created with normal texture enabled",
                  *this);
-  if ((flags_ & Flag::NormalTextureScale) && lightingIsEnabled()) {
+  if (lightingIsEnabled()) {
     setUniform(normalTextureScaleUniform_, scale);
   }
   return *this;

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -123,6 +123,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
                      ? "#define NORMAL_TEXTURE_SCALE\n"
                      : "")
       .addSource(flags_ & Flag::ObjectId ? "#define OBJECT_ID\n" : "")
+      .addSource(flags_ & Flag::ClearCoatLayer ? "#define CLEAR_COAT\n" : "")
       .addSource(flags_ & Flag::PrecomputedTangent
                      ? "#define PRECOMPUTED_TANGENT\n"
                      : "")

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -76,8 +76,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
   }
   // TODO: Occlusion texture to be added.
   const bool isTextured = bool(
-      flags_ & (Flag::BaseColorTexture | Flag::RoughnessTexture |
-                Flag::NoneRoughnessMetallicTexture | Flag::MetallicTexture |
+      flags_ & (Flag::BaseColorTexture | Flag::NoneRoughnessMetallicTexture |
                 Flag::NormalTexture | Flag::EmissiveTexture));
 
   if (isTextured) {
@@ -110,10 +109,6 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
       .addSource(flags_ & Flag::BaseColorTexture ? "#define BASECOLOR_TEXTURE\n"
                                                  : "")
       .addSource(flags_ & Flag::EmissiveTexture ? "#define EMISSIVE_TEXTURE\n"
-                                                : "")
-      .addSource(flags_ & Flag::RoughnessTexture ? "#define ROUGHNESS_TEXTURE\n"
-                                                 : "")
-      .addSource(flags_ & Flag::MetallicTexture ? "#define METALLIC_TEXTURE\n"
                                                 : "")
       .addSource(flags_ & Flag::NoneRoughnessMetallicTexture
                      ? "#define NONE_ROUGHNESS_METALLIC_TEXTURE\n"
@@ -151,8 +146,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
       setUniform(uniformLocation("BaseColorTexture"),
                  pbrTextureUnitSpace::TextureUnit::BaseColor);
     }
-    if (flags_ & (Flag::RoughnessTexture | Flag::MetallicTexture |
-                  Flag::NoneRoughnessMetallicTexture)) {
+    if (flags_ & Flag::NoneRoughnessMetallicTexture) {
       setUniform(uniformLocation("MetallicRoughnessTexture"),
                  pbrTextureUnitSpace::TextureUnit::MetallicRoughness);
     }
@@ -297,8 +291,7 @@ PbrShader& PbrShader::bindBaseColorTexture(Mn::GL::Texture2D& texture) {
 
 PbrShader& PbrShader::bindMetallicRoughnessTexture(Mn::GL::Texture2D& texture) {
   CORRADE_ASSERT(
-      flags_ & (Flag::RoughnessTexture | Flag::MetallicTexture |
-                Flag::NoneRoughnessMetallicTexture),
+      flags_ & (Flag::NoneRoughnessMetallicTexture),
       "PbrShader::bindMetallicRoughnessTexture(): the shader was not "
       "created with metallicRoughness texture enabled.",
       *this);

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -185,28 +185,84 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * will use the node's semantic ID
      */
     InstancedObjectId = (1 << 12) | ObjectId,
+
+    /**
+     * Has ClearCoat layer.
+     */
+    ClearCoatLayer = 1 << 13,
+
+    /**
+     * Has ClearCoat Texture in ClearCoat layer
+     */
+    CCLayer_CCTexture = (1 << 14) | ClearCoatLayer,
+    /**
+     * Has Roughness Texture in ClearCoat layer
+     */
+    CCLayer_RoughnessTexture = (1 << 15) | ClearCoatLayer,
+    /**
+     * Has Normal Texture in ClearCoat layer
+     */
+    CCLayer_NormalTexture = (1 << 16) | ClearCoatLayer,
+
+    CCLayer_NormalTextureScale = (1 << 17) | ClearCoatLayer,
+
+    /**
+     * Has KHR_materials_specular layer
+     */
+    SpecularLayer = 1 << 18,
+
+    /**
+     * Has Specular Texture in KHR_materials_specular layer
+     */
+    SpecLayer_SpecTexture = (1 << 19) | SpecularLayer,
+
+    /**
+     * Has Specular Color Texture in KHR_materials_specular layer
+     */
+    SpecLayer_SpecColorTexture = (1 << 20) | SpecularLayer,
+
+    /**
+     * Has KHR_materials_transmission layer
+     */
+    TransmissionLayer = 1 << 21,
+
+    /**
+     * Has transmission texture in KHR_materials_transmission layer
+     */
+    TransLayer_TransmissionTexture = (1 << 22) | TransmissionLayer,
+
+    /**
+     * Has KHR_materials_volume layer
+     */
+    VolumeLayer = 1 << 23,
+
+    /**
+     * Has Thickness texture in  KHR_materials_volume layer
+     */
+    VolLayer_ThicknessTexture = (1 << 24) | VolumeLayer,
+
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 13,
+    DoubleSided = 1 << 25,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 14,
+    ImageBasedLighting = 1 << 26,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 15,
+    ShadowsVSM = 1 << 27,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 16,
+    DebugDisplay = 1 << 28,
     /*
      * TODO: alphaMask
      */

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -82,59 +82,30 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
     BaseColorTexture = 1 << 0,
 
     /**
-     * Multiply roughness with the roughness texture.
-     * This flag term means the roughness texture is independent, and
-     * "roughness" is stored in the R channel of it.
-     * NOTE:
-     * if NoneRoughnessMetallicTexture or OcclusionRoughnessMetallicTexture are
-     * presented, this texture will be ignored.
-     * @see @ref setRoughness(), @ref bindRoughnessTexture()
-     */
-    RoughnessTexture = 1 << 1,
-
-    /**
-     * Multiply metallic with the metallic texture.
-     * This flag term means the metallic texture is independent, and "metalness"
-     * is stored in the B channel of it.
-     * NOTE:
-     * if NoneRoughnessMetallicTexture or OcclusionRoughnessMetallicTexture are
-     * presented, this texture will be ignored.
-     * @see @ref setMetallic(), @ref bindMetallicTexture()
-     */
-    MetallicTexture = 1 << 2,
-
-    /**
      * This flag term means the NoneRoughnessMetallic texture is present, with
      * the Roughness in G channel and metalness in B channel (R and Alpha
      * channels are not used).
      * @see @ref setMetallic(), @ref bindMetallicTexture()
      */
-    NoneRoughnessMetallicTexture = 1 << 3,
+    NoneRoughnessMetallicTexture = 1 << 1,
 
     /*
-     * The occlusion map texture.
+     * The occlusion map texture is present.
      * The occlusion, Roughness and Metalness are packed together in one
      * texture, with Occlusion in R channel, Roughness in G channel and
      * metalness in B channel (Alpha channels is not used).
      */
-    PackedOcclusionTexture = 1 << 4,
-
-    /*
-     * The occlusion map texture.
-     * The occlusion map texture is separate from the metallicRoughness texture.
-     * The values are sampled from the R channel.
-     */
-    SeparateOcclusionTexture = 1 << 5,
+    OcclusionTexture = 1 << 2,
 
     /**
      * Modify normals according to a texture.
      */
-    NormalTexture = 1 << 6,
+    NormalTexture = 1 << 3,
 
     /**
      * emissive texture
      */
-    EmissiveTexture = 1 << 7,
+    EmissiveTexture = 1 << 4,
 
     /**
      * Enable texture coordinate transformation. If this flag is set,
@@ -146,10 +117,10 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * @ref Flag::OcclusionRoughnessMetallicTexture is enabled as well.
      * @see @ref setTextureMatrix()
      */
-    TextureTransformation = 1 << 8,
+    TextureTransformation = 1 << 5,
 
     /**
-     * TODO: Do we need instanced object? (instanced texture, istanced id etc.)
+     * TODO: Do we need instanced object? (instanced texture, instanced id etc.)
      */
 
     /**
@@ -164,102 +135,102 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * see PBR fragment shader code for more details
      * Requires the @ref Tangent4 attribute to be present.
      */
-    PrecomputedTangent = 1 << 9,
+    PrecomputedTangent = 1 << 6,
 
     /**
      * Enable object ID output for this shader.
      */
-    ObjectId = 1 << 10,
+    ObjectId = 1 << 7,
 
     /**
      * Support Instanced object ID. Retrieves a per-instance / per-vertex
      * object ID from the @ref ObjectId attribute. If this is false, the shader
      * will use the node's semantic ID
      */
-    InstancedObjectId = (1 << 11) | ObjectId,
+    InstancedObjectId = (1 << 8) | ObjectId,
 
     /**
      * Has ClearCoat layer.
      */
-    ClearCoatLayer = 1 << 12,
+    ClearCoatLayer = 1 << 9,
     /**
      * Has ClearCoat Texture in ClearCoat layer
      */
-    ClearCoatTexture = (1 << 13) | ClearCoatLayer,
+    ClearCoatTexture = (1 << 10) | ClearCoatLayer,
     /**
      * Has Roughness Texture in ClearCoat layer
      */
-    ClearCoatRoughnessTexture = (1 << 14) | ClearCoatLayer,
+    ClearCoatRoughnessTexture = (1 << 11) | ClearCoatLayer,
     /**
      * Has Normal Texture in ClearCoat layer
      */
-    ClearCoatNormalTexture = (1 << 15) | ClearCoatLayer,
+    ClearCoatNormalTexture = (1 << 12) | ClearCoatLayer,
 
     /**
      * Has KHR_materials_specular layer
      */
-    SpecularLayer = 1 << 16,
+    SpecularLayer = 1 << 13,
     /**
      * Has Specular Texture in KHR_materials_specular layer
      */
-    SpecularLayerTexture = (1 << 17) | SpecularLayer,
+    SpecularLayerTexture = (1 << 14) | SpecularLayer,
 
     /**
      * Has Specular Color Texture in KHR_materials_specular layer
      */
-    SpecularLayerColorTexture = (1 << 18) | SpecularLayer,
+    SpecularLayerColorTexture = (1 << 15) | SpecularLayer,
 
     /**
      * Has KHR_materials_anisotropy layer
      */
-    AnisotropyLayer = 1 << 19,
+    AnisotropyLayer = 1 << 16,
 
     /**
      * Has Anisotropy Texture in KHR_materials_anisotropy layer
      */
-    AnisotropyLayerTexture = (1 << 20) | AnisotropyLayer,
+    AnisotropyLayerTexture = (1 << 17) | AnisotropyLayer,
 
     /**
      * Has KHR_materials_transmission layer
      */
-    TransmissionLayer = 1 << 21,
+    TransmissionLayer = 1 << 18,
     /**
      * Has transmission texture in KHR_materials_transmission layer
      */
-    TransmissionLayerTexture = (1 << 22) | TransmissionLayer,
+    TransmissionLayerTexture = (1 << 19) | TransmissionLayer,
 
     /**
      * Has KHR_materials_volume layer
      */
-    VolumeLayer = 1 << 23,
+    VolumeLayer = 1 << 20,
 
     /**
      * Has Thickness texture in  KHR_materials_volume layer
      */
-    VolumeLayerThicknessTexture = (1 << 24) | VolumeLayer,
+    VolumeLayerThicknessTexture = (1 << 21) | VolumeLayer,
 
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 25,
+    DoubleSided = 1 << 22,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 26,
+    ImageBasedLighting = 1 << 23,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 27,
+    ShadowsVSM = 1 << 24,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 28,
+    DebugDisplay = 1 << 25,
     /*
      * TODO: alphaMask
      */

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -210,46 +210,56 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
     SpecularLayerColorTexture = (1 << 18) | SpecularLayer,
 
     /**
+     * Has KHR_materials_anisotropy layer
+     */
+    AnisotropyLayer = 1 << 19,
+
+    /**
+     * Has Anisotropy Texture in KHR_materials_anisotropy layer
+     */
+    AnisotropyLayerTexture = (1 << 20) | AnisotropyLayer,
+
+    /**
      * Has KHR_materials_transmission layer
      */
-    TransmissionLayer = 1 << 19,
+    TransmissionLayer = 1 << 21,
     /**
      * Has transmission texture in KHR_materials_transmission layer
      */
-    TransmissionLayerTexture = (1 << 20) | TransmissionLayer,
+    TransmissionLayerTexture = (1 << 22) | TransmissionLayer,
 
     /**
      * Has KHR_materials_volume layer
      */
-    VolumeLayer = 1 << 21,
+    VolumeLayer = 1 << 23,
 
     /**
      * Has Thickness texture in  KHR_materials_volume layer
      */
-    VolumeLayerThicknessTexture = (1 << 22) | VolumeLayer,
+    VolumeLayerThicknessTexture = (1 << 24) | VolumeLayer,
 
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 23,
+    DoubleSided = 1 << 25,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 24,
+    ImageBasedLighting = 1 << 26,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 25,
+    ShadowsVSM = 1 << 27,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 26,
+    DebugDisplay = 1 << 28,
     /*
      * TODO: alphaMask
      */

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -190,79 +190,74 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * Has ClearCoat layer.
      */
     ClearCoatLayer = 1 << 13,
-
     /**
      * Has ClearCoat Texture in ClearCoat layer
      */
-    CCLayer_CCTexture = (1 << 14) | ClearCoatLayer,
+    ClearCoatTexture = (1 << 14) | ClearCoatLayer,
     /**
      * Has Roughness Texture in ClearCoat layer
      */
-    CCLayer_RoughnessTexture = (1 << 15) | ClearCoatLayer,
+    ClearCoatRoughnessTexture = (1 << 15) | ClearCoatLayer,
     /**
      * Has Normal Texture in ClearCoat layer
      */
-    CCLayer_NormalTexture = (1 << 16) | ClearCoatLayer,
-
-    CCLayer_NormalTextureScale = (1 << 17) | ClearCoatLayer,
+    ClearCoatNormalTexture = (1 << 16) | ClearCoatLayer,
 
     /**
      * Has KHR_materials_specular layer
      */
-    SpecularLayer = 1 << 18,
-
+    SpecularLayer = 1 << 17,
     /**
      * Has Specular Texture in KHR_materials_specular layer
      */
-    SpecLayer_SpecTexture = (1 << 19) | SpecularLayer,
+    SpecularLayerTexture = (1 << 18) | SpecularLayer,
 
     /**
      * Has Specular Color Texture in KHR_materials_specular layer
      */
-    SpecLayer_SpecColorTexture = (1 << 20) | SpecularLayer,
+    SpecularLayerColorTexture = (1 << 19) | SpecularLayer,
 
     /**
      * Has KHR_materials_transmission layer
      */
-    TransmissionLayer = 1 << 21,
-
+    TransmissionLayer = 1 << 20,
     /**
      * Has transmission texture in KHR_materials_transmission layer
      */
-    TransLayer_TransmissionTexture = (1 << 22) | TransmissionLayer,
+    TransmissionLayerTexture = (1 << 21) | TransmissionLayer,
 
     /**
      * Has KHR_materials_volume layer
      */
-    VolumeLayer = 1 << 23,
+    VolumeLayer = 1 << 22,
 
     /**
      * Has Thickness texture in  KHR_materials_volume layer
      */
-    VolLayer_ThicknessTexture = (1 << 24) | VolumeLayer,
+    VolumeLayerThicknessTexture = (1 << 23) | VolumeLayer,
 
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 25,
+    DoubleSided = 1 << 24,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 26,
+    ImageBasedLighting = 1 << 25,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 27,
+    ShadowsVSM = 1 << 26,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 28,
+    DebugDisplay = 1 << 27,
     /*
      * TODO: alphaMask
      */

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -132,17 +132,9 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
     NormalTexture = 1 << 6,
 
     /**
-     * Enable normal texture scale
-     * the shader expects that
-     * @ref Flag::NormalTexture is enabled as well.
-     * @see @ref setNormalTextureScale
-     */
-    NormalTextureScale = 1 << 7,
-
-    /**
      * emissive texture
      */
-    EmissiveTexture = 1 << 8,
+    EmissiveTexture = 1 << 7,
 
     /**
      * Enable texture coordinate transformation. If this flag is set,
@@ -154,7 +146,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * @ref Flag::OcclusionRoughnessMetallicTexture is enabled as well.
      * @see @ref setTextureMatrix()
      */
-    TextureTransformation = 1 << 9,
+    TextureTransformation = 1 << 8,
 
     /**
      * TODO: Do we need instanced object? (instanced texture, istanced id etc.)
@@ -172,92 +164,92 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * see PBR fragment shader code for more details
      * Requires the @ref Tangent4 attribute to be present.
      */
-    PrecomputedTangent = 1 << 10,
+    PrecomputedTangent = 1 << 9,
 
     /**
      * Enable object ID output for this shader.
      */
-    ObjectId = 1 << 11,
+    ObjectId = 1 << 10,
 
     /**
      * Support Instanced object ID. Retrieves a per-instance / per-vertex
      * object ID from the @ref ObjectId attribute. If this is false, the shader
      * will use the node's semantic ID
      */
-    InstancedObjectId = (1 << 12) | ObjectId,
+    InstancedObjectId = (1 << 11) | ObjectId,
 
     /**
      * Has ClearCoat layer.
      */
-    ClearCoatLayer = 1 << 13,
+    ClearCoatLayer = 1 << 12,
     /**
      * Has ClearCoat Texture in ClearCoat layer
      */
-    ClearCoatTexture = (1 << 14) | ClearCoatLayer,
+    ClearCoatTexture = (1 << 13) | ClearCoatLayer,
     /**
      * Has Roughness Texture in ClearCoat layer
      */
-    ClearCoatRoughnessTexture = (1 << 15) | ClearCoatLayer,
+    ClearCoatRoughnessTexture = (1 << 14) | ClearCoatLayer,
     /**
      * Has Normal Texture in ClearCoat layer
      */
-    ClearCoatNormalTexture = (1 << 16) | ClearCoatLayer,
+    ClearCoatNormalTexture = (1 << 15) | ClearCoatLayer,
 
     /**
      * Has KHR_materials_specular layer
      */
-    SpecularLayer = 1 << 17,
+    SpecularLayer = 1 << 16,
     /**
      * Has Specular Texture in KHR_materials_specular layer
      */
-    SpecularLayerTexture = (1 << 18) | SpecularLayer,
+    SpecularLayerTexture = (1 << 17) | SpecularLayer,
 
     /**
      * Has Specular Color Texture in KHR_materials_specular layer
      */
-    SpecularLayerColorTexture = (1 << 19) | SpecularLayer,
+    SpecularLayerColorTexture = (1 << 18) | SpecularLayer,
 
     /**
      * Has KHR_materials_transmission layer
      */
-    TransmissionLayer = 1 << 20,
+    TransmissionLayer = 1 << 19,
     /**
      * Has transmission texture in KHR_materials_transmission layer
      */
-    TransmissionLayerTexture = (1 << 21) | TransmissionLayer,
+    TransmissionLayerTexture = (1 << 20) | TransmissionLayer,
 
     /**
      * Has KHR_materials_volume layer
      */
-    VolumeLayer = 1 << 22,
+    VolumeLayer = 1 << 21,
 
     /**
      * Has Thickness texture in  KHR_materials_volume layer
      */
-    VolumeLayerThicknessTexture = (1 << 23) | VolumeLayer,
+    VolumeLayerThicknessTexture = (1 << 22) | VolumeLayer,
 
     /**
      * Enable double-sided rendering.
      * (Temporarily STOP supporting this functionality. See comments in
      * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1 << 24,
+    DoubleSided = 1 << 23,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1 << 25,
+    ImageBasedLighting = 1 << 24,
 
     /**
      * render point light shadows using variance shadow map (VSM)
      */
-    ShadowsVSM = 1 << 26,
+    ShadowsVSM = 1 << 25,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1 << 27,
+    DebugDisplay = 1 << 26,
     /*
      * TODO: alphaMask
      */

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -57,8 +57,7 @@ uniform MaterialData Material;
 #if defined(BASECOLOR_TEXTURE)
 uniform sampler2D BaseColorTexture;
 #endif
-#if defined(METALLIC_TEXTURE) || defined(ROUGHNESS_TEXTURE) || \
-    defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
+#if defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
 uniform sampler2D MetallicRoughnessTexture;
 #endif
 #if defined(NORMAL_TEXTURE)
@@ -312,12 +311,12 @@ void main() {
 #endif
 
   float roughness = Material.roughness;
-#if defined(ROUGHNESS_TEXTURE) || defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
+#if defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
   roughness *= texture(MetallicRoughnessTexture, texCoord).g;
 #endif
 
   float metallic = Material.metallic;
-#if defined(METALLIC_TEXTURE) || defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
+#if defined(NONE_ROUGHNESS_METALLIC_TEXTURE)
   metallic *= texture(MetallicRoughnessTexture, texCoord).b;
 #endif
 


### PR DESCRIPTION
## Motivation and Context
This PR is the first of 3 (or possibly 4) PRs to implement Habitat's new PBR materials extension support, [drawn from the original WIP found here](https://github.com/facebookresearch/habitat-sim/pull/2091).

In this PR the gltf extension data present in the Magnum material are loaded into each drawable's existing cache structure, to be more easily accessed each draw.  No changes to the shader are present in this PR.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing C++ and python tests pass locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
