### PR TITLE
Decrease minimum required GL version for most shaders

### DIFF
--- a/src/esp/gfx/DoubleSphereCameraShader.cpp
+++ b/src/esp/gfx/DoubleSphereCameraShader.cpp
@@ -35,7 +35,7 @@ DoubleSphereCameraShader::DoubleSphereCameraShader(
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file

--- a/src/esp/gfx/EquirectangularShader.cpp
+++ b/src/esp/gfx/EquirectangularShader.cpp
@@ -40,7 +40,7 @@ EquirectangularShader::EquirectangularShader(Flags flags)
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file

--- a/src/esp/gfx/PbrEquiRectangularToCubeMapShader.cpp
+++ b/src/esp/gfx/PbrEquiRectangularToCubeMapShader.cpp
@@ -40,7 +40,7 @@ PbrEquiRectangularToCubeMapShader::PbrEquiRectangularToCubeMapShader() {
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file

--- a/src/esp/gfx/PbrPrecomputedMapShader.cpp
+++ b/src/esp/gfx/PbrPrecomputedMapShader.cpp
@@ -48,7 +48,7 @@ PbrPrecomputedMapShader::PbrPrecomputedMapShader(Flags flags) : flags_(flags) {
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -54,7 +54,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file

--- a/src/esp/gfx/VarianceShadowMapShader.cpp
+++ b/src/esp/gfx/VarianceShadowMapShader.cpp
@@ -41,7 +41,7 @@ VarianceShadowMapShader::VarianceShadowMapShader() {
 #ifdef MAGNUM_TARGET_WEBGL
   Mn::GL::Version glVersion = Mn::GL::Version::GLES300;
 #else
-  Mn::GL::Version glVersion = Mn::GL::Version::GL410;
+  Mn::GL::Version glVersion = Mn::GL::Version::GL330;
 #endif
 
   // this is not the file name, but the group name in the config file


### PR DESCRIPTION
## Motivation and Context
* Some of our more rarely used shaders use GL versions that some GPUs don't fully support despite the fact we aren't using any features that necessitate these new versions. Downgrade the GL version where appropriate to improve shader compatibility.  Fixes #2089
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally with pytest test suite
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
