### PR TITLE
viewer.py - disable Simulator default agent navmesh override

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -1179,6 +1179,7 @@ if __name__ == "__main__":
     sim_settings["window_width"] = args.width
     sim_settings["window_height"] = args.height
     sim_settings["pbr_image_based_lighting"] = args.ibl
+    sim_settings["default_agent_navmesh"] = False
 
     # start the application
     HabitatSimInteractiveViewer(sim_settings).exec()


### PR DESCRIPTION
## Motivation and Context

#2111 introduced default agent navmesh setup through settings.py. The viewer application already has logic for this and using the default agent settings will override SceneDataset configured navmeshes if the config is non-default. It should therefore be disabled in the app. 

## How Has This Been Tested

Local

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
