### PR TITLE
Fix clang tidy warning and typos.

### DIFF
--- a/src/esp/gfx/BackgroundRenderer.cpp
+++ b/src/esp/gfx/BackgroundRenderer.cpp
@@ -11,7 +11,6 @@
 #include <thread>
 
 #include "esp/core/Check.h"
-#include "esp/gfx/magnum.h"
 #include "esp/sensor/VisualSensor.h"
 
 namespace Mn = Magnum;
@@ -120,7 +119,7 @@ int BackgroundRenderer::threadRender() {
   std::vector<std::vector<RenderCamera::DrawableTransforms>> jobTransforms(
       jobs_.size());
 
-  for (int i = 0; i < jobs_.size(); ++i) {
+  for (size_t i = 0; i < jobs_.size(); ++i) {
     auto& job = jobs_[i];
     sensor::VisualSensor& sensor = std::get<0>(job);
     scene::SceneGraph& sg = std::get<1>(job);
@@ -140,7 +139,7 @@ int BackgroundRenderer::threadRender() {
   sgLock_.store(0, std::memory_order_release);
   cpp20::atomic_notify_all(&sgLock_);
 
-  for (int i = 0; i < jobs_.size(); ++i) {
+  for (size_t i = 0; i < jobs_.size(); ++i) {
     auto& job = jobs_[i];
     sensor::VisualSensor& sensor = std::get<0>(job);
     RenderCamera::Flags flags = std::get<3>(job);

--- a/src/esp/gfx/BackgroundRenderer.h
+++ b/src/esp/gfx/BackgroundRenderer.h
@@ -9,10 +9,8 @@
 
 #ifdef ESP_BUILD_WITH_BACKGROUND_RENDERER
 
-#include <atomic>
 #include <thread>
 
-#include "esp/core/Esp.h"
 #include "esp/gfx/RenderCamera.h"
 #include "esp/gfx/Renderer.h"
 #include "esp/gfx/WindowlessContext.h"

--- a/src/esp/gfx/DebugLineRender.cpp
+++ b/src/esp/gfx/DebugLineRender.cpp
@@ -280,7 +280,7 @@ void DebugLineRender::drawPathWithEndpointCircles(
   drawCircle(end1, radius, color, numSegments, normal);
 
   Mn::Vector3 prevPos;
-  for (int i = 0; i < points.size(); ++i) {
+  for (size_t i = 0; i < points.size(); ++i) {
     const auto& pos = points[i];
     if (i > 0) {
       if ((prevPos - end0).length() > radius &&

--- a/src/esp/gfx/Drawable.cpp
+++ b/src/esp/gfx/Drawable.cpp
@@ -17,8 +17,8 @@ Drawable::Drawable(scene::SceneNode& node,
     : Magnum::SceneGraph::Drawable3D{node, group},
       type_(type),
       node_(node),
-      mesh_(mesh),
-      drawableId_(drawableIdCounter++) {
+      drawableId_(drawableIdCounter++),
+      mesh_(mesh) {
   if (group) {
     group->registerDrawable(*this);
   }

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -29,8 +29,8 @@ PbrDrawable::PbrDrawable(scene::SceneNode& node,
     : Drawable{node, mesh, DrawableType::Pbr, group},
       shaderManager_{shaderManager},
       lightSetup_{shaderManager.get<LightSetup>(lightSetupKey)},
-      meshAttributeFlags_{meshAttributeFlags},
-      pbrIbl_(pbrIbl) {
+      pbrIbl_(pbrIbl),
+      meshAttributeFlags_{meshAttributeFlags} {
   setMaterialValuesInternal(
       shaderManager.get<Mn::Trade::MaterialData>(materialDataKey));
 
@@ -212,7 +212,7 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (const auto anisotropyStrength = materialData_->findAttribute<Mn::Float>(
             *anisotropyLayerID, "anisotropyStrength")) {
-      if (Mn::Math::abs(*anisotropyStrength) > 0.0) {
+      if (Mn::Math::abs(*anisotropyStrength) > 0.0f) {
         flags_ |= PbrShader::Flag::AnisotropyLayer;
         matCache.anisotropyLayer.factor =
             Mn::Math::clamp(*anisotropyStrength, -1.0f, 1.0f);
@@ -221,7 +221,7 @@ void PbrDrawable::setMaterialValuesInternal(
     } else if (const auto anisotropyStrength =
                    materialData_->findAttribute<Mn::Float>(*anisotropyLayerID,
                                                            "anisotropy")) {
-      if (Mn::Math::abs(*anisotropyStrength) > 0.0) {
+      if (Mn::Math::abs(*anisotropyStrength) > 0.0f) {
         flags_ |= PbrShader::Flag::AnisotropyLayer;
         matCache.anisotropyLayer.factor =
             Mn::Math::clamp(*anisotropyStrength, -1.0f, 1.0f);
@@ -235,7 +235,7 @@ void PbrDrawable::setMaterialValuesInternal(
      */
     if (const auto anisotropyRotation = materialData_->findAttribute<Mn::Float>(
             *anisotropyLayerID, "anisotropyRotation")) {
-      if (*anisotropyRotation != 0.0) {
+      if (*anisotropyRotation != 0.0f) {
         flags_ |= PbrShader::Flag::AnisotropyLayer;
         Mn::Rad rotAngle = Mn::Rad{*anisotropyRotation};
         matCache.anisotropyLayer.direction =
@@ -245,7 +245,7 @@ void PbrDrawable::setMaterialValuesInternal(
     } else if (const auto anisotropyRotation =
                    materialData_->findAttribute<Mn::Float>(
                        *anisotropyLayerID, "anisotropyDirection")) {
-      if (*anisotropyRotation != 0.0) {
+      if (*anisotropyRotation != 0.0f) {
         flags_ |= PbrShader::Flag::AnisotropyLayer;
         Mn::Rad rotAngle = Mn::Rad{*anisotropyRotation};
         matCache.anisotropyLayer.direction =
@@ -393,7 +393,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
       .setEmissiveColor(matCache.emissiveColor);
 
   // TODO:
-  // IN PbrShader class, we set the resonable defaults for the
+  // IN PbrShader class, we set the reasonable defaults for the
   // PbrShader::PbrEquationScales. Here we need a smart way to reset it
   // just in case user would like to do so during the run-time.
 
@@ -437,7 +437,7 @@ void PbrDrawable::draw(const Mn::Matrix4& transformationMatrix,
     CORRADE_ASSERT(shadowMapKeys_->size() <= 3,
                    "PbrDrawable::draw: the number of shadow maps exceeds the "
                    "maximum (current it is 3).", );
-    for (int iShadow = 0; iShadow < shadowMapKeys_->size(); ++iShadow) {
+    for (size_t iShadow = 0; iShadow < shadowMapKeys_->size(); ++iShadow) {
       Mn::Resource<CubeMap> shadowMap =
           (*shadowMapManger_).get<CubeMap>((*shadowMapKeys_)[iShadow]);
 
@@ -527,7 +527,7 @@ PbrDrawable& PbrDrawable::updateShaderLightDirectionParameters(
     const auto& lightInfo = (*lightSetup_)[iLight];
     Mn::Vector4 pos = getLightPositionRelativeToWorld(
         lightInfo, transformationMatrix, cameraMatrix);
-    // flip directional lights to faciliate faster, non-forking calc in
+    // flip directional lights to facilitate faster, non-forking calc in
     // shader.  Leave non-directional lights unchanged
     pos *= (pos[3] * 2) - 1;
     lightPositions.emplace_back(pos);

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -24,8 +24,6 @@
 #include <Magnum/Math/Matrix4.h>
 #include <Magnum/PixelFormat.h>
 
-#include "esp/core/Esp.h"
-
 #include <sstream>
 
 // This is to import the "resources" at runtime. When the resource is
@@ -150,7 +148,7 @@ PbrShader::PbrShader(Flags originalFlags, unsigned int lightCount)
       setUniform(uniformLocation("MetallicRoughnessTexture"),
                  pbrTextureUnitSpace::TextureUnit::MetallicRoughness);
     }
-    // TODO: explore the normal mapping without the precomputer tangent.
+    // TODO: explore the normal mapping without the precomputed tangent.
     // see http://www.thetenthplanet.de/archives/1180
     // also:
     // https://github.com/SaschaWillems/Vulkan-glTF-PBR/blob/master/data/shaders/pbr_khr.frag
@@ -540,7 +538,7 @@ PbrShader& PbrShader::setLightColors(
                  "PbrShader::setLightColors(): expected"
                      << lightCount_ << "items but got" << colors.size(),
                  *this);
-  for (int i = 0; i < colors.size(); ++i) {
+  for (size_t i = 0; i < colors.size(); ++i) {
     setLightColor(i, colors[i]);
   }
   // setUniform(lightColorsUniform_, colors);

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -47,7 +47,8 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
   typedef Magnum::Shaders::GenericGL3D::TextureCoordinates TextureCoordinates;
 
   /**
-   * @brief Tangent direction with the fourth component indicating the handness.
+   * @brief Tangent direction with the fourth component indicating the
+   * handedness.
    *
    * T = Tangent, B = BiTangent, N = Normal
    *
@@ -444,7 +445,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
    *              when vec.w == 1, it means vec.xyz is the light position;
    *  @return Reference to self (for method chaining)
    *  Note:
-   *  If the light was a directional (point) light, it will be overrided as a
+   *  If the light was a directional (point) light, it will be overridden as a
    *  point (directional) light
    */
   PbrShader& setLightVector(unsigned int lightIndex,
@@ -457,7 +458,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
    *  @param pos the position of the light in *camera* space
    *  @return Reference to self (for method chaining)
    *  Note:
-   *  If the light was a directional light, it will be overrided as a point
+   *  If the light was a directional light, it will be overridden as a point
    *  light;
    */
   PbrShader& setLightPosition(unsigned int lightIndex,
@@ -470,7 +471,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
    *  @param dir the direction of the light in *camera* space
    *  @return Reference to self (for method chaining)
    *  NOTE:
-   *  If the light was a point light, it will be overrided as a direction
+   *  If the light was a point light, it will be overridden as a direction
    * light;
    */
   PbrShader& setLightDirection(unsigned int lightIndex,
@@ -541,7 +542,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
   };
 
   /**
-   *  @brief Set the scales for differenct components in the pbr equation
+   *  @brief Set the scales for different components in the pbr equation
    *  @param scales
    *  @return Reference to self (for method chaining)
    */

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -9,8 +9,6 @@
 #include <Magnum/Math/Intersection.h>
 #include <Magnum/Math/Range.h>
 #include <Magnum/SceneGraph/Drawable.h>
-#include "esp/gfx/Drawable.h"
-#include "esp/gfx/DrawableGroup.h"
 #include "esp/scene/SceneGraph.h"
 
 namespace Mn = Magnum;
@@ -25,7 +23,7 @@ namespace gfx {
  * @param frustum, the frustum
  * @param frustumPlaneIndex, the frustum plane in last frame that culled the
  * aabb (default: 0)
- * @return NullOpt if aabb intersects the frustum, otherwise the fustum plane
+ * @return NullOpt if aabb intersects the frustum, otherwise the frustum plane
  * that culls the aabb
  */
 Cr::Containers::Optional<int> rangeFrustum(const Mn::Range3D& range,
@@ -42,7 +40,7 @@ Cr::Containers::Optional<int> rangeFrustum(const Mn::Range3D& range,
 
     const float d = Mn::Math::dot(center, plane.xyz());
     const float r = Mn::Math::dot(extent, absPlaneNormal);
-    if (d + r < -2.0 * plane.w())
+    if (d + r < -2.0f * plane.w())
       return Cr::Containers::Optional<int>{index};
   }
 

--- a/src/esp/gfx/TextureVisualizerShader.cpp
+++ b/src/esp/gfx/TextureVisualizerShader.cpp
@@ -132,11 +132,11 @@ TextureVisualizerShader& TextureVisualizerShader::rebindColorMapTexture() {
 TextureVisualizerShader& TextureVisualizerShader::setColorMapTransformation(
     float offset,
     float scale) {
-  CORRADE_ASSERT(offset >= 0.0,
+  CORRADE_ASSERT(offset >= 0.0f,
                  "TextureVisualizerShader::setColorMapTransformation(): offset"
                      << offset << "is illegal.",
                  *this);
-  CORRADE_ASSERT(scale >= 0.0,
+  CORRADE_ASSERT(scale >= 0.0f,
                  "TextureVisualizerShader::setColorMapTransformation(): scale"
                      << scale << "is illegal.",
                  *this);

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -23,8 +23,8 @@ class NodeDeletionHelper : public Magnum::SceneGraph::AbstractFeature3D {
  public:
   NodeDeletionHelper(scene::SceneNode& node_, Recorder* writer)
       : Magnum::SceneGraph::AbstractFeature3D(node_),
-        node(&node_),
-        recorder_(writer) {}
+        recorder_(writer),
+        node(&node_) {}
 
   ~NodeDeletionHelper() override {
     recorder_->onDeleteRenderAssetInstance(node);


### PR DESCRIPTION
## Motivation and Context

This changeset fixes some `clang_tidy` warnings needed for #2129.

## How Has This Been Tested

Local build,  CI

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
