### PR TITLE
Fix clang-tidy issue with PbrDrawable + typo fixes.

### DIFF
--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -54,10 +54,9 @@ void PbrDrawable::setMaterialValuesInternal(
       materialData_->as<Mn::Trade::PbrMetallicRoughnessMaterialData>();
   flags_ = PbrShader::Flag::ObjectId;
   if (reset) {
-    matCache = {tmpMaterialData.baseColor()};  // baseColor;
-  } else {
-    matCache.baseColor = tmpMaterialData.baseColor();
+    matCache = {};
   }
+  matCache.baseColor = tmpMaterialData.baseColor();
   matCache.roughness = tmpMaterialData.roughness();
   matCache.metalness = tmpMaterialData.metalness();
   matCache.emissiveColor = tmpMaterialData.emissiveColor();

--- a/src/esp/gfx/PbrDrawable.h
+++ b/src/esp/gfx/PbrDrawable.h
@@ -101,7 +101,7 @@ class PbrDrawable : public Drawable {
     // KHR_materials_specular layer
 
     /**
-     * Structure holdling specular layer values
+     * Structure holding specular layer values
      */
     struct SpecularLayer {
       /**
@@ -132,7 +132,7 @@ class PbrDrawable : public Drawable {
     ///////////////
     // KHR_materials_anisotropy layer
     /**
-     * Structure holdijng anisotropy layer values
+     * Structure holding anisotropy layer values
      */
     struct AnisotropyLayer {
       /**
@@ -271,7 +271,7 @@ class PbrDrawable : public Drawable {
             Mn::SceneGraph::Camera3D& camera) override;
 
   /**
-   *  @brief Update the shader so it can correcly handle the current material,
+   *  @brief Update the shader so it can correctly handle the current material,
    *         light setup
    *  @return Reference to self (for method chaining)
    */
@@ -286,7 +286,7 @@ class PbrDrawable : public Drawable {
   /**
    *  @brief Update light direction (or position) in *camera* space to the
    * shader
-   *  @param transformationMatrix describes a tansformation from object
+   *  @param transformationMatrix describes a transformation from object
    * (model) space to camera space
    *  @param camera the camera, which views and renders the world
    *  @return Reference to self (for method chaining)
@@ -319,7 +319,7 @@ class PbrDrawable : public Drawable {
    */
   const gfx::Drawable::Flags meshAttributeFlags_;
   /**
-   * Material to use to render this PBR drawawble
+   * Material to use to render this PBR drawable
    */
   Mn::Resource<Mn::Trade::MaterialData, Mn::Trade::MaterialData> materialData_;
   ShadowMapManager* shadowMapManger_ = nullptr;


### PR DESCRIPTION
## Motivation and Context

This fixes the following clang-tidy error:

```
/home/circleci/project/habitat-sim/src/esp/gfx/PbrDrawable.cpp:57:44: error: missing field 'clearCoat' initializer [clang-diagnostic-missing-field-initializers,-warnings-as-errors]
matCache = {tmpMaterialData.baseColor()};  // baseColor;
```

## How Has This Been Tested

Tested on CI.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
