### PR TITLE
Replay renderer partial deletion

### DIFF
--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -4,15 +4,10 @@
 
 #include "Player.h"
 
+#include <Corrade/Containers/StringStl.h>
 #include <Corrade/Utility/Path.h>
 
-#include "esp/assets/ResourceManager.h"
-#include "esp/core/Esp.h"
-#include "esp/gfx/replay/Keyframe.h"
 #include "esp/io/Json.h"
-#include "esp/io/JsonAllTypes.h"
-
-#include <rapidjson/document.h>
 
 namespace esp {
 namespace gfx {

--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -266,6 +266,7 @@ void Player::hackProcessDeletions(const Keyframe& keyframe) {
     }
   } else if (keyframe.deletions.size() > 0) {
     // Cache latest transforms
+    latestTransformCache_.clear();
     for (const auto& pair : this->createdInstances_) {
       const RenderAssetInstanceKey key = pair.first;
       latestTransformCache_[key] =

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -85,14 +85,31 @@ class AbstractPlayerImplementation {
           instances) = 0;
 
   /**
-   * @brief Set node transform
+   * @brief Set node transform from translation and rotation components.
    *
    * The @p handle is expected to be returned from an earlier call to
    * @ref loadAndCreateRenderAssetInstance() on the same instance.
    */
-  virtual void setNodeTransform(NodeHandle node,
+  virtual void setNodeTransform(const NodeHandle node,
                                 const Magnum::Vector3& translation,
                                 const Magnum::Quaternion& rotation) = 0;
+
+  /**
+   * @brief Set node transform.
+   *
+   * The @p handle is expected to be returned from an earlier call to
+   * @ref loadAndCreateRenderAssetInstance() on the same instance.
+   */
+  virtual void setNodeTransform(const NodeHandle node,
+                                const Mn::Matrix4& transform) = 0;
+
+  /**
+   * @brief Get node transform.
+   *
+   * The @p handle is expected to be returned from an earlier call to
+   * @ref loadAndCreateRenderAssetInstance() on the same instance.
+   */
+  virtual const Mn::Matrix4 getNodeTransform(const NodeHandle node) const = 0;
 
   /**
    * @brief Set node semantic ID
@@ -127,9 +144,14 @@ class AbstractSceneGraphPlayerImplementation
       const std::unordered_map<RenderAssetInstanceKey, NodeHandle>& instances)
       override;
 
-  void setNodeTransform(NodeHandle node,
+  void setNodeTransform(const NodeHandle node,
                         const Magnum::Vector3& translation,
                         const Magnum::Quaternion& rotation) override;
+
+  void setNodeTransform(const NodeHandle node,
+                        const Mn::Matrix4& transform) override;
+
+  const Mn::Matrix4 getNodeTransform(const NodeHandle node) const override;
 
   void setNodeSemanticId(NodeHandle node, unsigned id) override;
 };
@@ -258,6 +280,9 @@ class Player {
   std::vector<Keyframe> keyframes_;
   std::unordered_map<std::string, esp::assets::AssetInfo> assetInfos_;
   std::unordered_map<RenderAssetInstanceKey, NodeHandle> createdInstances_;
+  std::unordered_map<RenderAssetInstanceKey,
+                     assets::RenderAssetInstanceCreationInfo>
+      creationInfos_;
   std::set<std::string> failedFilepaths_;
 
   ESP_SMART_POINTERS(Player)

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -272,7 +272,7 @@ class Player {
   void applyKeyframe(const Keyframe& keyframe);
   void readKeyframesFromJsonDocument(const rapidjson::Document& d);
   void clearFrame();
-  void hackProcessBatchRendererDeletions(const Keyframe& keyframe);
+  void hackProcessDeletions(const Keyframe& keyframe);
 
   std::shared_ptr<AbstractPlayerImplementation> implementation_;
 

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -90,7 +90,7 @@ class AbstractPlayerImplementation {
    * The @p handle is expected to be returned from an earlier call to
    * @ref loadAndCreateRenderAssetInstance() on the same instance.
    */
-  virtual void setNodeTransform(const NodeHandle node,
+  virtual void setNodeTransform(NodeHandle node,
                                 const Magnum::Vector3& translation,
                                 const Magnum::Quaternion& rotation) = 0;
 
@@ -100,7 +100,7 @@ class AbstractPlayerImplementation {
    * The @p handle is expected to be returned from an earlier call to
    * @ref loadAndCreateRenderAssetInstance() on the same instance.
    */
-  virtual void setNodeTransform(const NodeHandle node,
+  virtual void setNodeTransform(NodeHandle node,
                                 const Mn::Matrix4& transform) = 0;
 
   /**
@@ -109,7 +109,7 @@ class AbstractPlayerImplementation {
    * The @p handle is expected to be returned from an earlier call to
    * @ref loadAndCreateRenderAssetInstance() on the same instance.
    */
-  virtual const Mn::Matrix4 getNodeTransform(const NodeHandle node) const = 0;
+  virtual Mn::Matrix4 hackGetNodeTransform(NodeHandle node) const = 0;
 
   /**
    * @brief Set node semantic ID
@@ -144,14 +144,13 @@ class AbstractSceneGraphPlayerImplementation
       const std::unordered_map<RenderAssetInstanceKey, NodeHandle>& instances)
       override;
 
-  void setNodeTransform(const NodeHandle node,
+  void setNodeTransform(NodeHandle node,
                         const Magnum::Vector3& translation,
                         const Magnum::Quaternion& rotation) override;
 
-  void setNodeTransform(const NodeHandle node,
-                        const Mn::Matrix4& transform) override;
+  void setNodeTransform(NodeHandle node, const Mn::Matrix4& transform) override;
 
-  const Mn::Matrix4 getNodeTransform(const NodeHandle node) const override;
+  Mn::Matrix4 hackGetNodeTransform(NodeHandle node) const override;
 
   void setNodeSemanticId(NodeHandle node, unsigned id) override;
 };
@@ -273,7 +272,7 @@ class Player {
   void applyKeyframe(const Keyframe& keyframe);
   void readKeyframesFromJsonDocument(const rapidjson::Document& d);
   void clearFrame();
-  void processBatchRendererDeletions(const Keyframe& keyframe);
+  void hackProcessBatchRendererDeletions(const Keyframe& keyframe);
 
   std::shared_ptr<AbstractPlayerImplementation> implementation_;
 
@@ -284,6 +283,8 @@ class Player {
   std::unordered_map<RenderAssetInstanceKey,
                      assets::RenderAssetInstanceCreationInfo>
       creationInfos_;
+  std::unordered_map<RenderAssetInstanceKey, Mn::Matrix4>
+      latestTransformCache_{};
   std::set<std::string> failedFilepaths_;
 
   ESP_SMART_POINTERS(Player)

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -273,6 +273,7 @@ class Player {
   void applyKeyframe(const Keyframe& keyframe);
   void readKeyframesFromJsonDocument(const rapidjson::Document& d);
   void clearFrame();
+  void processBatchRendererDeletions(const Keyframe& keyframe);
 
   std::shared_ptr<AbstractPlayerImplementation> implementation_;
 

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -4,9 +4,6 @@
 
 #include "AbstractReplayRenderer.h"
 
-#include <Magnum/Math/Functions.h>
-#include <Magnum/Math/Vector2.h>
-
 #include "esp/gfx/replay/Player.h"
 
 namespace esp {

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -5,15 +5,8 @@
 #ifndef ESP_SIM_ABSTRACTREPLAYRENDERER_H_
 #define ESP_SIM_ABSTRACTREPLAYRENDERER_H_
 
-#include <Magnum/GL/GL.h>
-#include <Magnum/Magnum.h>
-
-#include "esp/core/Check.h"
-#include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"
 #include "esp/gfx/DebugLineRender.h"
-
-#include <memory>
 
 namespace esp {
 

--- a/src/esp/sim/BatchPlayerImplementation.cpp
+++ b/src/esp/sim/BatchPlayerImplementation.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "BatchPlayerImplementation.h"
+
+#include <esp/gfx_batch/Renderer.h>
+
+#include <Corrade/Containers/StringStl.h>
+
+namespace {
+bool isSupportedRenderAsset(const Corrade::Containers::StringView& filepath) {
+  // Primitives aren't directly supported in the Magnum batch renderer. See
+  // https://docs.google.com/document/d/1ngA73cXl3YRaPfFyICSUHONZN44C-XvieS7kwyQDbkI/edit#bookmark=id.yq39718gqbwz
+
+  const std::array<Corrade::Containers::StringView, 12> primNamePrefixes = {
+      "capsule3DSolid",     "capsule3DWireframe", "coneSolid",
+      "coneWireframe",      "cubeSolid",          "cubeWireframe",
+      "cylinderSolid",      "cylinderWireframe",  "icosphereSolid",
+      "icosphereWireframe", "uvSphereSolid",      "uvSphereWireframe"};
+
+  // primitive render asset filepaths start with one of the above prefixes.
+  // Examples: icosphereSolid_subdivs_1
+  // capsule3DSolid_hemiRings_4_cylRings_1_segments_12_halfLen_3.25_useTexCoords_false_useTangents_false
+  for (const auto& primNamePrefix : primNamePrefixes) {
+    if (filepath.size() < primNamePrefix.size()) {
+      continue;
+    }
+
+    if (filepath.prefix(primNamePrefix.size()) == primNamePrefix) {
+      return false;
+    }
+  }
+
+  return true;
+}
+}  // namespace
+
+namespace esp {
+namespace sim {
+
+BatchPlayerImplementation::BatchPlayerImplementation(
+    gfx_batch::Renderer& renderer,
+    Mn::UnsignedInt sceneId)
+    : renderer_{renderer}, sceneId_{sceneId} {}
+
+gfx::replay::NodeHandle
+BatchPlayerImplementation::loadAndCreateRenderAssetInstance(
+    const esp::assets::AssetInfo& assetInfo,
+    const esp::assets::RenderAssetInstanceCreationInfo& creation) {
+  // TODO anything to use creation.flags for?
+  // TODO is creation.lightSetupKey actually mapping to anything in the
+  //  replay file?
+
+  if (!::isSupportedRenderAsset(creation.filepath)) {
+    ESP_WARNING() << "Unsupported render asset: " << creation.filepath;
+    return nullptr;
+  }
+
+  /* If no such name is known yet, add as a file */
+  if (!renderer_.hasNodeHierarchy(creation.filepath)) {
+    ESP_WARNING()
+        << creation.filepath
+        << "not found in any composite file, loading from the filesystem";
+
+    ESP_CHECK(
+        renderer_.addFile(creation.filepath,
+                          gfx_batch::RendererFileFlag::Whole |
+                              gfx_batch::RendererFileFlag::GenerateMipmap),
+        "addFile failed for " << creation.filepath);
+    CORRADE_INTERNAL_ASSERT(renderer_.hasNodeHierarchy(creation.filepath));
+  }
+
+  return reinterpret_cast<gfx::replay::NodeHandle>(
+      renderer_.addNodeHierarchy(
+          sceneId_, creation.filepath,
+          /* Baking the initial scaling and coordinate frame into the
+             transformation */
+          Mn::Matrix4::scaling(creation.scale ? *creation.scale
+                                              : Mn::Vector3{1.0f}) *
+              Mn::Matrix4::from(
+                  Mn::Quaternion{assetInfo.frame.rotationFrameToWorld()}
+                      .toMatrix(),
+                  {}))
+      /* Returning incremented by 1 because 0 (nullptr) is treated as an
+         error */
+      + 1);
+}
+
+void BatchPlayerImplementation::deleteAssetInstance(
+    const gfx::replay::NodeHandle node) {
+  // TODO actually remove from the scene instead of setting a zero scale
+  renderer_.transformations(sceneId_)[reinterpret_cast<std::size_t>(node) - 1] =
+      Mn::Matrix4{Mn::Math::ZeroInit};
+}
+
+void BatchPlayerImplementation::deleteAssetInstances(
+    const std::unordered_map<gfx::replay::RenderAssetInstanceKey,
+                             gfx::replay::NodeHandle>&) {
+  renderer_.clear(sceneId_);
+}
+
+void BatchPlayerImplementation::setNodeTransform(
+    const gfx::replay::NodeHandle node,
+    const Mn::Vector3& translation,
+    const Mn::Quaternion& rotation) {
+  renderer_.transformations(sceneId_)[reinterpret_cast<std::size_t>(node) - 1] =
+      Mn::Matrix4::from(rotation.toMatrix(), translation);
+}
+
+void BatchPlayerImplementation::setNodeTransform(
+    const gfx::replay::NodeHandle node,
+    const Mn::Matrix4& transform) {
+  renderer_.transformations(sceneId_)[reinterpret_cast<std::size_t>(node) - 1] =
+      transform;
+}
+
+Mn::Matrix4 BatchPlayerImplementation::hackGetNodeTransform(
+    const gfx::replay::NodeHandle node) const {
+  return renderer_.transformations(
+      sceneId_)[reinterpret_cast<std::size_t>(node) - 1];
+}
+
+void BatchPlayerImplementation::changeLightSetup(
+    const esp::gfx::LightSetup& lights) {
+  if (!renderer_.maxLightCount()) {
+    ESP_WARNING() << "Attempted to change" << lights.size()
+                  << "lights for scene" << sceneId_
+                  << "but the renderer is configured without lights";
+    return;
+  }
+
+  renderer_.clearLights(sceneId_);
+  for (std::size_t i = 0; i != lights.size(); ++i) {
+    const gfx::LightInfo& light = lights[i];
+    CORRADE_INTERNAL_ASSERT(light.model == gfx::LightPositionModel::Global);
+
+    const std::size_t nodeId = renderer_.addEmptyNode(sceneId_);
+
+    std::size_t lightId;  // NOLINT
+    if (light.vector.w()) {
+      renderer_.transformations(sceneId_)[nodeId] =
+          Mn::Matrix4::translation(light.vector.xyz());
+      lightId = renderer_.addLight(sceneId_, nodeId,
+                                   gfx_batch::RendererLightType::Point);
+    } else {
+      /* The matrix will be partially NaNs if the light vector is in the
+         direction of the Y axis, but that's fine -- we only really care
+         about the Z axis direction, which is always the "target" vector
+         normalized. */
+      // TODO for more robustness use something that "invents" some
+      //  arbitrary orthogonal axes instead of the NaNs, once Magnum has
+      //  such utility
+      renderer_.transformations(sceneId_)[nodeId] =
+          Mn::Matrix4::lookAt({}, light.vector.xyz(), Mn::Vector3::yAxis());
+      lightId = renderer_.addLight(sceneId_, nodeId,
+                                   gfx_batch::RendererLightType::Directional);
+    }
+
+    renderer_.lightColors(sceneId_)[lightId] = light.color;
+    // TODO use gfx::getAmbientLightColor(lights) once it's not hardcoded
+    //  to an arbitrary value and once it's possible to change the ambient
+    //  factor in the renderer at runtime (and not just in
+    //  RendererConfiguration::setAmbientFactor())
+    // TODO range, once Habitat has that
+  }
+}
+}  // namespace sim
+}  // namespace esp

--- a/src/esp/sim/BatchPlayerImplementation.h
+++ b/src/esp/sim/BatchPlayerImplementation.h
@@ -24,21 +24,20 @@ class BatchPlayerImplementation
       const esp::assets::AssetInfo& assetInfo,
       const esp::assets::RenderAssetInstanceCreationInfo& creation) override;
 
-  void deleteAssetInstance(const gfx::replay::NodeHandle node) override;
+  void deleteAssetInstance(gfx::replay::NodeHandle node) override;
 
   void deleteAssetInstances(
       const std::unordered_map<gfx::replay::RenderAssetInstanceKey,
                                gfx::replay::NodeHandle>&) override;
 
-  void setNodeTransform(const gfx::replay::NodeHandle node,
+  void setNodeTransform(gfx::replay::NodeHandle node,
                         const Mn::Vector3& translation,
                         const Mn::Quaternion& rotation) override;
 
-  void setNodeTransform(const gfx::replay::NodeHandle node,
+  void setNodeTransform(gfx::replay::NodeHandle node,
                         const Mn::Matrix4& transform) override;
 
-  Mn::Matrix4 hackGetNodeTransform(
-      const gfx::replay::NodeHandle node) const override;
+  Mn::Matrix4 hackGetNodeTransform(gfx::replay::NodeHandle node) const override;
 
   void changeLightSetup(const esp::gfx::LightSetup& lights) override;
 

--- a/src/esp/sim/BatchPlayerImplementation.h
+++ b/src/esp/sim/BatchPlayerImplementation.h
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_SIM_BATCHPLAYERIMPLEMENTATION_H_
+#define ESP_SIM_BATCHPLAYERIMPLEMENTATION_H_
+
+#include <esp/gfx/replay/Player.h>
+
+namespace esp {
+namespace gfx_batch {
+class Renderer;
+}
+namespace sim {
+
+class BatchPlayerImplementation
+    : public gfx::replay::AbstractPlayerImplementation {
+ public:
+  BatchPlayerImplementation(gfx_batch::Renderer& renderer,
+                            Mn::UnsignedInt sceneId);
+
+ private:
+  gfx::replay::NodeHandle loadAndCreateRenderAssetInstance(
+      const esp::assets::AssetInfo& assetInfo,
+      const esp::assets::RenderAssetInstanceCreationInfo& creation) override;
+
+  void deleteAssetInstance(const gfx::replay::NodeHandle node) override;
+
+  void deleteAssetInstances(
+      const std::unordered_map<gfx::replay::RenderAssetInstanceKey,
+                               gfx::replay::NodeHandle>&) override;
+
+  void setNodeTransform(const gfx::replay::NodeHandle node,
+                        const Mn::Vector3& translation,
+                        const Mn::Quaternion& rotation) override;
+
+  void setNodeTransform(const gfx::replay::NodeHandle node,
+                        const Mn::Matrix4& transform) override;
+
+  Mn::Matrix4 hackGetNodeTransform(
+      const gfx::replay::NodeHandle node) const override;
+
+  void changeLightSetup(const esp::gfx::LightSetup& lights) override;
+
+  gfx_batch::Renderer& renderer_;
+  Mn::UnsignedInt sceneId_;
+};
+}  // namespace sim
+}  // namespace esp
+
+#endif

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -145,6 +145,18 @@ BatchReplayRenderer::BatchReplayRenderer(
           Mn::Matrix4::from(rotation.toMatrix(), translation);
     }
 
+    void setNodeTransform(const gfx::replay::NodeHandle node,
+                          const Mn::Matrix4& transform) override {
+      renderer_.transformations(
+          sceneId_)[reinterpret_cast<std::size_t>(node) - 1] = transform;
+    }
+
+    const Mn::Matrix4 getNodeTransform(
+        const gfx::replay::NodeHandle node) const override {
+      return renderer_.transformations(
+          sceneId_)[reinterpret_cast<std::size_t>(node) - 1];
+    }
+
     void changeLightSetup(const esp::gfx::LightSetup& lights) override {
       if (!renderer_.maxLightCount()) {
         ESP_WARNING() << "Attempted to change" << lights.size()

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -8,10 +8,8 @@
 #include "esp/sensor/CameraSensor.h"
 
 #include <Corrade/Containers/GrowableArray.h>
-#include <Corrade/Utility/Algorithms.h>
 #include <Magnum/GL/AbstractFramebuffer.h>
 #include <Magnum/GL/Context.h>
-#include <Magnum/Image.h>
 #include <Magnum/ImageView.h>
 
 namespace esp {

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -151,7 +151,7 @@ BatchReplayRenderer::BatchReplayRenderer(
           sceneId_)[reinterpret_cast<std::size_t>(node) - 1] = transform;
     }
 
-    const Mn::Matrix4 getNodeTransform(
+    Mn::Matrix4 hackGetNodeTransform(
         const gfx::replay::NodeHandle node) const override {
       return renderer_.transformations(
           sceneId_)[reinterpret_cast<std::size_t>(node) - 1];

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -5,6 +5,7 @@
 #include "BatchReplayRenderer.h"
 
 #include <esp/gfx_batch/DepthUnprojection.h>
+#include <esp/sim/BatchPlayerImplementation.h>
 #include "esp/sensor/CameraSensor.h"
 
 #include <Corrade/Containers/GrowableArray.h>
@@ -15,7 +16,6 @@
 namespace esp {
 namespace sim {
 
-// clang-tidy you're NOT HELPING
 using namespace Mn::Math::Literals;  // NOLINT
 
 BatchReplayRenderer::BatchReplayRenderer(
@@ -46,170 +46,6 @@ BatchReplayRenderer::BatchReplayRenderer(
 
   theOnlySensorName_ = sensor.uuid;
   theOnlySensorProjection_ = sensor.projectionMatrix();
-
-  class BatchPlayerImplementation
-      : public gfx::replay::AbstractPlayerImplementation {
-   public:
-    BatchPlayerImplementation(gfx_batch::Renderer& renderer,
-                              Mn::UnsignedInt sceneId)
-        : renderer_{renderer}, sceneId_{sceneId} {}
-
-   private:
-    bool isSupportedRenderAsset(
-        const Corrade::Containers::StringView& filepath) {
-      // Primitives aren't directly supported in the Magnum batch renderer. See
-      // https://docs.google.com/document/d/1ngA73cXl3YRaPfFyICSUHONZN44C-XvieS7kwyQDbkI/edit#bookmark=id.yq39718gqbwz
-
-      const std::array<Corrade::Containers::StringView, 12> primNamePrefixes = {
-          "capsule3DSolid",     "capsule3DWireframe", "coneSolid",
-          "coneWireframe",      "cubeSolid",          "cubeWireframe",
-          "cylinderSolid",      "cylinderWireframe",  "icosphereSolid",
-          "icosphereWireframe", "uvSphereSolid",      "uvSphereWireframe"};
-
-      // primitive render asset filepaths start with one of the above prefixes.
-      // Examples: icosphereSolid_subdivs_1
-      // capsule3DSolid_hemiRings_4_cylRings_1_segments_12_halfLen_3.25_useTexCoords_false_useTangents_false
-      for (const auto& primNamePrefix : primNamePrefixes) {
-        if (filepath.size() < primNamePrefix.size()) {
-          continue;
-        }
-
-        if (filepath.prefix(primNamePrefix.size()) == primNamePrefix) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    gfx::replay::NodeHandle loadAndCreateRenderAssetInstance(
-        const esp::assets::AssetInfo& assetInfo,
-        const esp::assets::RenderAssetInstanceCreationInfo& creation) override {
-      // TODO anything to use creation.flags for?
-      // TODO is creation.lightSetupKey actually mapping to anything in the
-      //  replay file?
-
-      if (!isSupportedRenderAsset(creation.filepath)) {
-        ESP_WARNING() << "Unsupported render asset: " << creation.filepath;
-        return nullptr;
-      }
-
-      /* If no such name is known yet, add as a file */
-      if (!renderer_.hasNodeHierarchy(creation.filepath)) {
-        ESP_WARNING()
-            << creation.filepath
-            << "not found in any composite file, loading from the filesystem";
-
-        ESP_CHECK(
-            renderer_.addFile(creation.filepath,
-                              gfx_batch::RendererFileFlag::Whole |
-                                  gfx_batch::RendererFileFlag::GenerateMipmap),
-            "addFile failed for " << creation.filepath);
-        CORRADE_INTERNAL_ASSERT(renderer_.hasNodeHierarchy(creation.filepath));
-      }
-
-      return reinterpret_cast<gfx::replay::NodeHandle>(
-          renderer_.addNodeHierarchy(
-              sceneId_, creation.filepath,
-              /* Baking the initial scaling and coordinate frame into the
-                 transformation */
-              Mn::Matrix4::scaling(creation.scale ? *creation.scale
-                                                  : Mn::Vector3{1.0f}) *
-                  Mn::Matrix4::from(
-                      Mn::Quaternion{assetInfo.frame.rotationFrameToWorld()}
-                          .toMatrix(),
-                      {}))
-          /* Returning incremented by 1 because 0 (nullptr) is treated as an
-             error */
-          + 1);
-    }
-
-    void deleteAssetInstance(const gfx::replay::NodeHandle node) override {
-      // TODO actually remove from the scene instead of setting a zero scale
-      renderer_.transformations(
-          sceneId_)[reinterpret_cast<std::size_t>(node) - 1] =
-          Mn::Matrix4{Mn::Math::ZeroInit};
-    }
-
-    void deleteAssetInstances(
-        const std::unordered_map<gfx::replay::RenderAssetInstanceKey,
-                                 gfx::replay::NodeHandle>&) override {
-      renderer_.clear(sceneId_);
-    }
-
-    void setNodeTransform(const gfx::replay::NodeHandle node,
-                          const Mn::Vector3& translation,
-                          const Mn::Quaternion& rotation) override {
-      renderer_.transformations(
-          sceneId_)[reinterpret_cast<std::size_t>(node) - 1] =
-          Mn::Matrix4::from(rotation.toMatrix(), translation);
-    }
-
-    void setNodeTransform(const gfx::replay::NodeHandle node,
-                          const Mn::Matrix4& transform) override {
-      renderer_.transformations(
-          sceneId_)[reinterpret_cast<std::size_t>(node) - 1] = transform;
-    }
-
-    Mn::Matrix4 hackGetNodeTransform(
-        const gfx::replay::NodeHandle node) const override {
-      return renderer_.transformations(
-          sceneId_)[reinterpret_cast<std::size_t>(node) - 1];
-    }
-
-    void changeLightSetup(const esp::gfx::LightSetup& lights) override {
-      if (!renderer_.maxLightCount()) {
-        ESP_WARNING() << "Attempted to change" << lights.size()
-                      << "lights for scene" << sceneId_
-                      << "but the renderer is configured without lights";
-        return;
-      }
-
-      renderer_.clearLights(sceneId_);
-      for (std::size_t i = 0; i != lights.size(); ++i) {
-        const gfx::LightInfo& light = lights[i];
-        CORRADE_INTERNAL_ASSERT(light.model == gfx::LightPositionModel::Global);
-
-        const std::size_t nodeId = renderer_.addEmptyNode(sceneId_);
-
-        /* Clang Tidy, you're stupid, why do you say that "lightId" is not
-           initialized?! I'm initializing it right in the branches below, I
-           won't zero-init it just to "prevent bugs" because an accidentally
-           zero-initialized variable is *also* a bug, you know? Plus I have
-           range asserts in all functions so your "suggestions" are completely
-           unhelpful. */
-        std::size_t lightId;  // NOLINT
-        if (light.vector.w()) {
-          renderer_.transformations(sceneId_)[nodeId] =
-              Mn::Matrix4::translation(light.vector.xyz());
-          lightId = renderer_.addLight(sceneId_, nodeId,
-                                       gfx_batch::RendererLightType::Point);
-        } else {
-          /* The matrix will be partially NaNs if the light vector is in the
-             direction of the Y axis, but that's fine -- we only really care
-             about the Z axis direction, which is always the "target" vector
-             normalized. */
-          // TODO for more robustness use something that "invents" some
-          //  arbitrary orthogonal axes instead of the NaNs, once Magnum has
-          //  such utility
-          renderer_.transformations(sceneId_)[nodeId] =
-              Mn::Matrix4::lookAt({}, light.vector.xyz(), Mn::Vector3::yAxis());
-          lightId = renderer_.addLight(
-              sceneId_, nodeId, gfx_batch::RendererLightType::Directional);
-        }
-
-        renderer_.lightColors(sceneId_)[lightId] = light.color;
-        // TODO use gfx::getAmbientLightColor(lights) once it's not hardcoded
-        //  to an arbitrary value and once it's possible to change the ambient
-        //  factor in the renderer at runtime (and not just in
-        //  RendererConfiguration::setAmbientFactor())
-        // TODO range, once Habitat has that
-      }
-    }
-
-    gfx_batch::Renderer& renderer_;
-    Mn::UnsignedInt sceneId_;
-  };
 
   for (Mn::UnsignedInt i = 0; i != cfg.numEnvironments; ++i) {
     arrayAppend(

--- a/src/esp/sim/CMakeLists.txt
+++ b/src/esp/sim/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
   sim STATIC
   AbstractReplayRenderer.cpp
   AbstractReplayRenderer.h
+  BatchPlayerImplementation.cpp
+  BatchPlayerImplementation.h
   BatchReplayRenderer.cpp
   BatchReplayRenderer.h
   ClassicReplayRenderer.cpp

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -6,11 +6,8 @@
 
 #include "esp/assets/ResourceManager.h"
 #include "esp/gfx/RenderTarget.h"
-#include "esp/gfx/Renderer.h"
 #include "esp/metadata/MetadataMediator.h"
-#include "esp/sensor/Sensor.h"
 #include "esp/sensor/SensorFactory.h"
-#include "esp/sim/SimulatorConfiguration.h"
 
 #include <Magnum/GL/Context.h>
 #include <Magnum/ImageView.h>
@@ -31,7 +28,7 @@ ClassicReplayRenderer::ClassicReplayRenderer(
   resourceManager_ =
       std::make_unique<assets::ResourceManager>(std::move(metadataMediator));
 
-  // hack to get ReplicCAD non-baked stages to render correctly
+  // hack to get ReplicaCAD non-baked stages to render correctly
   resourceManager_->getShaderManager().setFallback(
       esp::gfx::getDefaultLights());
 


### PR DESCRIPTION
## Motivation and Context

The batch renderer can only delete full scenes - it cannot delete single objects.

To circumvent this, deletions are processed as such:

1. Latest transforms are cached.
2. All instances are deleted.
3. Remaining instances are re-created.
4. Latest transforms are re-applied.

## How Has This Been Tested

Tested locally.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
