### PR TITLE
--[WIP][BE Week]Rework ESP_CHECK to not abort; Add ESP_FATAL to provide core dumps

### DIFF
--- a/src/esp/bindings/Bindings.cpp
+++ b/src/esp/bindings/Bindings.cpp
@@ -47,8 +47,15 @@ PYBIND11_MODULE(habitat_sim_bindings, m) {
 
   /* This function pointer is used by ESP_CHECK(). If it's null, it
      std::abort()s, if not, it calls it to cause a Python AssertionError */
-  esp::core::throwInPython = [](const char* const message) {
+  esp::core::throwAssertInPython = [](const char* const message) {
     PyErr_SetString(PyExc_AssertionError, message);
+    throw pybind11::error_already_set{};
+  };
+
+  /* This function pointer is used by ESP_FATAL(). If it's null, it
+     std::exit()s, if not, it calls it to cause a Python RuntimeError */
+  esp::core::throwRuntimeInPython = [](const char* const message) {
+    PyErr_SetString(PyExc_RuntimeError, message);
     throw pybind11::error_already_set{};
   };
 

--- a/src/esp/core/Check.cpp
+++ b/src/esp/core/Check.cpp
@@ -9,19 +9,20 @@
 namespace esp {
 namespace core {
 
-void (*throwInPython)(const char*) = nullptr;
+void (*throwAssertInPython)(const char*) = nullptr;
+void (*throwRuntimeInPython)(const char*) = nullptr;
 
 /* [[noreturn]] will help the compiler optimize -- it basically tells it that
    the condition passed to HABITAT_EXCEPTION() can be assumed to be always true
    in the following code, because if not then the execution ends in this
    function. */
 [[noreturn]] void throwIfInPythonOtherwiseAbort(const char* message) {
-  /* The throwInPython function pointer gets filled during Python bindings
+  /* The throwAssertInPython function pointer gets filled during Python bindings
      startup. If it's nullptr, we're in plain C++ code. */
-  if (throwInPython) {
-    throwInPython(message);
-    /* I failed to apply the NORETURN attribute to the throwInPython function
-       pointer so at least this */
+  if (throwAssertInPython) {
+    throwAssertInPython(message);
+    /* I failed to apply the NORETURN attribute to the throwAssertInPython
+       function pointer so at least this */
     CORRADE_INTERNAL_ASSERT_UNREACHABLE();
   }
 
@@ -31,6 +32,23 @@ void (*throwInPython)(const char*) = nullptr;
      should throw. */
   Corrade::Utility::Error{Corrade::Utility::Error::defaultOutput()} << message;
   std::abort();
+}
+
+[[noreturn]] void throwIfInPythonOtherwiseExit(const char* message) {
+  /* The throwRuntimeInPython function pointer gets filled during Python
+     bindings startup. If it's nullptr, we're in plain C++ code. */
+  if (throwRuntimeInPython) {
+    throwRuntimeInPython(message);
+
+    std::exit(1);
+  }
+
+  /* If it isn't defined, do an abort the same way as CORRADE_ASSERT(). This
+     could be in an `else` block but I like to play with fire, so it's not --
+     the NORETURN above should tell that to the compiler and the function
+     should throw. */
+  Corrade::Utility::Fatal{Corrade::Utility::Fatal::defaultOutput(), 1}
+      << message;
 }
 
 }  // namespace core


### PR DESCRIPTION
## Motivation and Context
Currently our ESP_CHECK macro was exiting the program via std::abort(), providing a core dump. However, it is most often used to verify data or check the results of file IO, for which a core dump is undesirable.  This PR changes ESP_CHECK to std::exit(1) and instead adds a new macro ESP_FATAL that will provide a core dump on fail.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Current C++ and Python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
