### PR TITLE
--[BE Week]More informative and appropriate data/metadata load and processing messages

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -298,9 +298,10 @@ bool ResourceManager::loadSemanticSceneDescriptor(
     bool success = false;
     // semantic scene descriptor might not exist
     semanticScene_ = scene::SemanticScene::create();
-    ESP_DEBUG() << "SceneInstance :" << activeSceneName
-                << "proposed Semantic Scene Descriptor filename :"
-                << ssdFilename;
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "SceneInstance : `" << activeSceneName
+        << "` proposed Semantic Scene Descriptor filename : `" << ssdFilename
+        << "`.";
 
     bool fileExists = FileUtil::exists(ssdFilename);
     if (fileExists) {
@@ -309,14 +310,16 @@ bool ResourceManager::loadSemanticSceneDescriptor(
       success = scene::SemanticScene::loadSemanticSceneDescriptor(
           ssdFilename, *semanticScene_);
       if (success) {
-        ESP_DEBUG() << "SSD with SceneInstanceAttributes-provided name "
-                    << ssdFilename << "successfully found and loaded";
+        ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+            << "SSD with SceneInstanceAttributes-provided name `" << ssdFilename
+            << "` successfully found and loaded.";
       } else {
         // here if provided file exists but does not correspond to appropriate
         // SSD
-        ESP_ERROR() << "SSD Load Failure! File with "
-                       "SceneInstanceAttributes-provided name "
-                    << ssdFilename << "exists but was unable to be loaded.";
+        ESP_ERROR(Mn::Debug::Flag::NoSpace)
+            << "SSD Load Failure! File with "
+               "SceneInstanceAttributes-provided name `"
+            << ssdFilename << "` exists but failed to load.";
       }
       return success;
       // if not success then try to construct a name
@@ -331,25 +334,27 @@ bool ResourceManager::loadSemanticSceneDescriptor(
         success = scene::SemanticScene::loadReplicaHouse(constructedFilename,
                                                          *semanticScene_);
         if (success) {
-          ESP_DEBUG() << "SSD for Replica using constructed file :"
-                      << constructedFilename << "in directory with"
-                      << ssdFilename << "loaded successfully";
+          ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+              << "SSD for Replica using constructed file : `"
+              << constructedFilename << "` in directory with `" << ssdFilename
+              << "` loaded successfully";
         } else {
           // here if constructed file exists but does not correspond to
           // appropriate SSD or some loading error occurred.
-          ESP_ERROR() << "SSD Load Failure! Replica file with constructed name "
-                      << ssdFilename << "exists but was unable to be loaded.";
+          ESP_ERROR(Mn::Debug::Flag::NoSpace)
+              << "SSD Load Failure! Replica file with constructed name `"
+              << ssdFilename << "` exists but failed to load.";
         }
         return success;
       } else {
         // neither provided non-empty filename nor constructed filename
         // exists. This is probably due to an incorrect naming in the
         // SceneInstanceAttributes
-        ESP_WARNING() << "SSD File Naming Issue! Neither "
-                         "SceneInstanceAttributes-provided name :"
-                      << ssdFilename
-                      << " nor constructed filename :" << constructedFilename
-                      << "exist on disk.";
+        ESP_WARNING(Mn::Debug::Flag::NoSpace)
+            << "SSD File Naming Issue! Neither "
+               "SceneInstanceAttributes-provided name : `"
+            << ssdFilename << "` nor constructed filename : `"
+            << constructedFilename << "` exist on disk.";
         return false;
       }
     }  // if given SSD file name specified exists
@@ -361,7 +366,7 @@ bool ResourceManager::loadSemanticSceneDescriptor(
 void ResourceManager::buildSemanticColorMap() {
   CORRADE_ASSERT(semanticScene_,
                  "Unable to build Semantic Color map due to no semanticScene "
-                 "being loaded.", );
+                 "existing/having been loaded.", );
 
   semanticColorMapBeingUsed_.clear();
   semanticColorAsInt_.clear();
@@ -372,7 +377,7 @@ void ResourceManager::buildSemanticColorMap() {
 
   // The color map was built with first maxSemanticID elements in proper order
   // to match provided semantic IDs (so that ID is IDX of semantic color in
-  // map).  Any overflow colors will be uniquely mapped 1-to-1 to unmapped
+  // map). Any overflow colors will be uniquely mapped 1-to-1 to unmapped
   // semantic IDs as their index.
   semanticColorMapBeingUsed_.assign(ssdClrMap.begin(), ssdClrMap.end());
   buildSemanticColorAsIntMap();
@@ -432,7 +437,8 @@ bool ResourceManager::loadStage(
     AssetInfo semanticInfo = semanticInfoIter->second;
     auto semanticStageFilename = semanticInfo.filepath;
     if (Cr::Utility::Path::exists(semanticStageFilename)) {
-      ESP_DEBUG() << "Loading Semantic Stage mesh :" << semanticStageFilename;
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Loading Semantic Stage mesh : `" << semanticStageFilename << "`.";
       activeSemanticSceneID = sceneManagerPtr->initSceneGraph();
 
       auto& semanticSceneGraph =
@@ -462,16 +468,19 @@ bool ResourceManager::loadStage(
       // regardless of load failure, original code still changed
       // activeSemanticSceneID_
       if (!semanticStageSuccess) {
-        ESP_ERROR() << "Semantic Stage mesh load failed.";
+        ESP_ERROR(Mn::Debug::Flag::NoSpace)
+            << "Load of Semantic Stage mesh : `" << semanticStageFilename
+            << "` failed.";
         return false;
       }
-      ESP_DEBUG() << "Semantic Stage mesh :" << semanticStageFilename
-                  << "loaded.";
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Semantic Stage mesh : `" << semanticStageFilename << "` loaded.";
 
-    } else if (semanticStageFilename !=
-               "") {  // semantic file name does not exist but house does
-      ESP_ERROR() << "Not loading semantic mesh with File Name :"
-                  << semanticStageFilename << "does not exist.";
+    } else if (semanticStageFilename != "") {
+      // semantic file name is not found on disk
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "Unable to load requested Semantic Stage mesh : `"
+          << semanticStageFilename << "` : File not found.";
     }
   } else {  // not wanting to create semantic mesh
     ESP_DEBUG() << "Not loading semantic mesh";
@@ -535,7 +544,7 @@ bool ResourceManager::loadStage(
                             nullptr);  // drawable group
 
       if (!collisionMeshSuccess) {
-        ESP_ERROR() << "Stage collision mesh load failed.  Aborting stage "
+        ESP_ERROR() << "Stage collision mesh load failed. Aborting stage "
                        "initialization.";
         return false;
       }
@@ -628,10 +637,13 @@ ResourceManager::createStageAssetInfosFromAttributes(
       stageAttributes->getForceFlatShading()    // forceFlatShading
   };
   renderInfo.shaderTypeToUse = stageAttributes->getShaderType();
-  std::string debugStr = "Frame :";
-  Cr::Utility::formatInto(debugStr, debugStr.size(),
-                          "{} for render mesh named : {}",
-                          renderInfo.frame.toString(), renderInfo.filepath);
+  std::string debugStr{};
+  // Only construct debug string if debug logging level is enabled
+  if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
+    Cr::Utility::formatInto(debugStr, debugStr.size(),
+                            "Frame : {} for Render mesh : `{}`",
+                            renderInfo.frame.toString(), renderInfo.filepath);
+  }
   resMap["render"] = renderInfo;
   if (createCollisionInfo) {
     // create collision asset info if requested
@@ -644,6 +656,13 @@ ResourceManager::createStageAssetInfosFromAttributes(
         virtualUnitToMeters,                         // virtualUnitToMeters
         true                                         // forceFlatShading
     };
+    // Only construct debug string if debug logging level is enabled
+    if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
+      Cr::Utility::formatInto(debugStr, debugStr.size(),
+                              " and Collision mesh : `{}`",
+                              collisionInfo.filepath);
+    }
+
     resMap["collision"] = collisionInfo;
   }
   if (createSemanticInfo) {
@@ -673,18 +692,22 @@ ResourceManager::createStageAssetInfosFromAttributes(
     // dataset config) and if the  user has requested them (via
     // SimulatorConfiguration::useSemanticTexturesIfFound)
     semanticInfo.hasSemanticTextures = stageAttributes->useSemanticTextures();
-
-    Cr::Utility::formatInto(
-        debugStr, debugStr.size(),
-        "|{} for semantic mesh named : {} with type specified as {}|Semantic "
-        "Txtrs : {}",
-        frame.toString(), semanticInfo.filepath,
-        esp::metadata::attributes::getMeshTypeName(semanticInfo.type),
-        (semanticInfo.hasSemanticTextures ? "True" : "False"));
+    // Only construct debug string if debug logging level is enabled
+    if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
+      Cr::Utility::formatInto(
+          debugStr, debugStr.size(),
+          "|{} for semantic mesh : `{}` of type `{}`|Semantic Txtrs : {}",
+          frame.toString(), semanticInfo.filepath,
+          esp::metadata::attributes::getMeshTypeName(semanticInfo.type),
+          (semanticInfo.hasSemanticTextures ? "True" : "False"));
+    }
     resMap["semantic"] = semanticInfo;
   } else {
-    Cr::Utility::formatInto(debugStr, debugStr.size(),
-                            "|No Semantic asset info specified.");
+    // Only construct debug string if debug logging level is enabled
+    if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
+      Cr::Utility::formatInto(debugStr, debugStr.size(),
+                              "|No Semantic asset info specified.");
+    }
   }
   ESP_DEBUG() << debugStr;
   return resMap;
@@ -701,12 +724,12 @@ esp::geo::CoordinateFrame ResourceManager::buildFrameFromAttributes(
     const vec3f originEigen{Mn::EigenIntegration::cast<vec3f>(origin)};
     esp::geo::CoordinateFrame frame{upEigen, frontEigen, originEigen};
     return frame;
-  } else {
-    ESP_DEBUG() << "Specified frame in Attributes :" << attribName
-                << "is not orthogonal, so returning default frame.";
-    esp::geo::CoordinateFrame frame;
-    return frame;
   }
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Specified frame in Attributes `" << attribName
+      << "` is not orthogonal, so returning default frame.";
+  esp::geo::CoordinateFrame frame;
+  return frame;
 }  // ResourceManager::buildFrameFromAttributes
 
 scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
@@ -722,8 +745,8 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
     // sensors.
     if (!(creation.isSemantic() && creation.isRGBD())) {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "Unsupported instance creation flags for asset ["
-          << assetInfo.filepath << "]";
+          << "Unsupported instance creation flags for asset `"
+          << assetInfo.filepath << "`.";
       return nullptr;
     }
     sceneID = activeSceneIDs[0];
@@ -733,9 +756,9 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
         // Because we have a separate semantic scene graph, we can't support a
         // static instance with both isSemantic and isRGBD.
         ESP_WARNING(Mn::Debug::Flag::NoSpace)
-            << "Unsupported instance creation flags for asset ["
+            << "Unsupported instance creation flags for asset `"
             << assetInfo.filepath
-            << "] with "
+            << "` with "
                "SimulatorConfiguration::forceSeparateSemanticSceneGraph=true.";
         return nullptr;
       }
@@ -745,9 +768,9 @@ scene::SceneNode* ResourceManager::loadAndCreateRenderAssetInstance(
         // A separate semantic scene graph wasn't constructed, so we can't
         // support a Semantic-only (or RGBD-only) instance.
         ESP_WARNING(Mn::Debug::Flag::NoSpace)
-            << "Unsupported instance creation flags for asset ["
+            << "Unsupported instance creation flags for asset `"
             << assetInfo.filepath
-            << "] with "
+            << "` with "
                "SimulatorConfiguration::forceSeparateSemanticSceneGraph=false.";
         return nullptr;
       }
@@ -817,14 +840,17 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
     defaultInfo.overridePhongMaterial = Cr::Containers::NullOpt;
 
     if (info.type == AssetType::PRIMITIVE) {
-      ESP_DEBUG() << "Building Prim named:" << info.filepath;
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Building Prim named `" << info.filepath << "`.";
       buildPrimitiveAssetData(info.filepath);
       meshSuccess = true;
     } else if (info.type == AssetType::INSTANCE_MESH) {
-      ESP_DEBUG() << "Loading Semantic Mesh asset named:" << info.filepath;
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Loading Semantic Mesh asset named `" << info.filepath << "`.";
       meshSuccess = loadSemanticRenderAsset(defaultInfo);
     } else if (isRenderAssetGeneral(info.type)) {
-      ESP_DEBUG() << "Loading general asset named:" << info.filepath;
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Loading general asset named `" << info.filepath << "`.";
       meshSuccess = loadRenderAssetGeneral(defaultInfo);
     } else {
       // loadRenderAsset doesn't yet support the requested asset type
@@ -900,10 +926,10 @@ scene::SceneNode* ResourceManager::createRenderAssetInstance(
 
   const LoadedAssetData& loadedAssetData = resourceDictIter->second;
   if (!isLightSetupCompatible(loadedAssetData, creation.lightSetupKey)) {
-    ESP_WARNING()
-        << "Instantiating render asset" << creation.filepath
-        << "with incompatible light setup, instance will not be correctly lit."
-           "For objects, please ensure 'requires lighting' is enabled in "
+    ESP_WARNING(Mn::Debug::Flag::NoSpace)
+        << "Instantiating render asset `" << creation.filepath
+        << "` with incompatible light setup, instance will not be correctly "
+           "lit. For objects, please ensure 'requires lighting' is enabled in "
            "object config file.";
   }
 
@@ -937,13 +963,14 @@ bool ResourceManager::loadStageInternal(
     DrawableGroup* drawables) {
   // scene mesh loading
   const std::string& filename = info.filepath;
-  ESP_DEBUG() << "Attempting to load stage" << filename << "";
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Attempting to load stage" << filename << "";
   bool meshSuccess = true;
   if (filename != EMPTY_SCENE) {
     if (!Cr::Utility::Path::exists(filename)) {
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "Attempting to load stage but cannot find specified asset file : '"
-          << filename << "'. Aborting.";
+          << "Attempting to load stage but cannot find specified asset file : `"
+          << filename << "`. Aborting load.";
       meshSuccess = false;
     } else {
       // load render asset if necessary
@@ -957,9 +984,10 @@ bool ResourceManager::loadStageInternal(
           // Right now, we only allow for an asset to be loaded with one
           // configuration, since generated mesh data may be invalid for a new
           // configuration
-          ESP_ERROR() << "Reloading asset" << filename
-                      << "with different configuration not currently supported."
-                      << "Asset may not be rendered correctly.";
+          ESP_ERROR(Mn::Debug::Flag::NoSpace)
+              << "Reloading asset `" << filename
+              << "` with different configuration not currently supported."
+              << "Asset may not be rendered correctly.";
         }
       }
       // create render asset instance if requested
@@ -970,8 +998,9 @@ bool ResourceManager::loadStageInternal(
       return true;
     }
   } else {
-    ESP_DEBUG() << "Loading empty scene since" << filename
-                << "specified as filename.";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Loading empty scene since `" << filename
+        << "` specified as filename.";
     // EMPTY_SCENE (ie. "NONE") string indicates desire for an empty scene (no
     // scene mesh): welcome to the void
   }
@@ -1023,9 +1052,10 @@ bool ResourceManager::loadObjectMeshDataFromFile(
         objectAttributes->getOrientFront(), {0, 0, 0});
     success = loadRenderAsset(meshInfo);
     if (!success) {
-      ESP_ERROR() << "Failed to load a physical object ("
-                  << objectAttributes->getHandle() << ")'s" << meshType
-                  << "mesh from file :" << filename;
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "Failed to load a physical object `"
+          << objectAttributes->getHandle() << "`'s " << meshType
+          << " mesh from file : `" << filename << "`.";
     }
   }
   return success;
@@ -1153,9 +1183,10 @@ void ResourceManager::buildPrimitiveAssetData(
         primTemplateHandle);
     // if still null, fail.
     if (newTemplate == nullptr) {
-      ESP_ERROR() << "Attempting to reference or build a "
-                     "primitive template from an unknown/malformed handle :"
-                  << primTemplateHandle << ".  Aborting";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "Attempting to reference or build a "
+             "primitive template from an unknown/malformed handle : `"
+          << primTemplateHandle << "`, so aborting build.";
       return;
     }
     // we do not want a copy of the newly created template, but the actual
@@ -1167,7 +1198,8 @@ void ResourceManager::buildPrimitiveAssetData(
   // already - don't remake if so
   auto primAssetHandle = primTemplate->getHandle();
   if (resourceDict_.count(primAssetHandle) > 0) {
-    ESP_DEBUG() << "Primitive Asset exists already :" << primAssetHandle;
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Primitive Asset exists already : `" << primAssetHandle << "`.";
     return;
   }
 
@@ -1230,11 +1262,11 @@ void ResourceManager::buildPrimitiveAssetData(
   auto inserted =
       resourceDict_.emplace(primAssetHandle, std::move(loadedAssetData));
 
-  ESP_DEBUG() << "Primitive Asset Added : ID :" << primTemplate->getID()
-              << ": attr lib key :" << primTemplate->getHandle()
-              << "| instance class :" << primClassName
-              << "| Conf has group for this obj type :"
-              << conf.hasGroup(primClassName);
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "Primitive Asset Added : ID : " << primTemplate->getID()
+      << ": Attributes key : `" << primTemplate->getHandle() << "`| Class : `"
+      << primClassName << "` | Importer Conf has group for this obj type : "
+      << conf.hasGroup(primClassName);
 
 }  // ResourceManager::buildPrimitiveAssetData
 
@@ -1732,22 +1764,22 @@ bool ResourceManager::buildTrajectoryVisualization(
     radius = .001;
   }
   if (pts.size() < 2) {
-    ESP_ERROR()
-        << "Cannot build a trajectory from fewer than 2 points. Aborting.";
+    ESP_ERROR() << "Cannot build a trajectory from fewer than 2 points, so "
+                   "trajectory build failed.";
     return false;
   }
 
-  ESP_DEBUG() << "Calling trajectoryTubeSolid to build a tube named :"
-              << trajVisName << "with" << pts.size()
-              << "points, building a tube of radius :" << radius << "using"
-              << numSegments << "circular segments and" << numInterp
-              << "interpolated points between each trajectory point.";
+  ESP_VERY_VERBOSE() << "Calling trajectoryTubeSolid to build a tube named"
+                     << trajVisName << "with tube radius" << radius << "using"
+                     << pts.size() << "points," << numSegments
+                     << "circular segments and" << numInterp
+                     << "interpolated points between each trajectory point.";
 
   // create mesh tube
   Cr::Containers::Optional<Mn::Trade::MeshData> trajTubeMesh =
       geo::buildTrajectoryTubeSolid(pts, colorVec, numSegments, radius, smooth,
                                     numInterp);
-  ESP_DEBUG() << "Successfully returned from trajectoryTubeSolid";
+  ESP_VERY_VERBOSE() << "Successfully returned from trajectoryTubeSolid";
 
   // make assetInfo
   AssetInfo info{AssetType::PRIMITIVE};
@@ -2240,9 +2272,9 @@ void ResourceManager::loadMaterials(Importer& importer,
           importer.material(iMaterial);
 
       if (!materialData) {
-        ESP_ERROR() << "Material load failed for index" << iMaterial
-                    << "so skipping that material for asset" << assetName
-                    << ".";
+        ESP_ERROR(Mn::Debug::Flag::NoSpace)
+            << "Material load failed for index " << iMaterial
+            << " so skipping that material for asset `" << assetName << "`.";
         continue;
       }
       // Semantic texture-based mapping
@@ -2277,9 +2309,9 @@ void ResourceManager::loadMaterials(Importer& importer,
           importer.material(iMaterial);
 
       if (!materialData) {
-        ESP_ERROR() << "Material load failed for index" << iMaterial
-                    << "so skipping that material for asset" << assetName
-                    << ".";
+        ESP_ERROR(Mn::Debug::Flag::NoSpace)
+            << "Material load failed for index " << iMaterial
+            << " so skipping that material for asset `" << assetName << "`.";
         continue;
       }
 
@@ -2344,7 +2376,7 @@ void ResourceManager::loadMaterials(Importer& importer,
             false,
             Cr::Utility::formatString(
                 "Unhandled ShaderType specification : {} and/or unmanaged "
-                "type specified in material @ idx: {} for asset {}.",
+                "type specified in material @ idx: {} for asset `{}`.",
                 shaderTypeToUseName, iMaterial, assetName));
       }
 
@@ -2543,6 +2575,9 @@ ObjectInstanceShaderType ResourceManager::getMaterialShaderType(
   // if specified to be force-flat, then should be flat shaded, regardless of
   // material or other settings.
   if (info.forceFlatShading) {
+    ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+        << "Asset `" << Cr::Utility::Path::split(info.filepath).second()
+        << "` is being forced to use Flat shader by configuration.";
     return ObjectInstanceShaderType::Flat;
   }
   ObjectInstanceShaderType infoSpecShaderType = info.shaderTypeToUse;
@@ -2551,10 +2586,10 @@ ObjectInstanceShaderType ResourceManager::getMaterialShaderType(
     // use the material's inherent shadertype
     infoSpecShaderType = ObjectInstanceShaderType::Material;
   }
-  ESP_DEBUG() << "Shadertype being used for file :"
-              << Cr::Utility::Path::split(info.filepath).second()
-              << "| shadertype name :"
-              << metadata::attributes::getShaderTypeName(infoSpecShaderType);
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "Asset `" << Cr::Utility::Path::split(info.filepath).second()
+      << "` is using shadertype `"
+      << metadata::attributes::getShaderTypeName(infoSpecShaderType) << "`.";
   return infoSpecShaderType;
 }  // ResourceManager::getMaterialShaderType
 
@@ -2690,7 +2725,7 @@ void ResourceManager::loadTextures(Importer& importer,
       auto textureData = importer.texture(iTexture);
       if (!textureData ||
           textureData->type() != Mn::Trade::TextureType::Texture2D) {
-        ESP_ERROR() << "Cannot load texture" << iTexture << "skipping";
+        ESP_ERROR() << "Cannot load texture" << iTexture << "so skipping";
         currentTexture = nullptr;
         continue;
       }
@@ -2703,7 +2738,7 @@ void ResourceManager::loadTextures(Importer& importer,
       Cr::Containers::Optional<Mn::Trade::ImageData2D> image =
           importer.image2D(textureData->image(), 0);
       if (!image) {
-        ESP_ERROR() << "Cannot load texture image, skipping";
+        ESP_ERROR() << "Cannot load semantic texture image, skipping";
         currentTexture = nullptr;
         continue;
       }
@@ -2726,7 +2761,7 @@ void ResourceManager::loadTextures(Importer& importer,
       auto textureData = importer.texture(iTexture);
       if (!textureData ||
           textureData->type() != Mn::Trade::TextureType::Texture2D) {
-        ESP_ERROR() << "Cannot load texture" << iTexture << "skipping";
+        ESP_ERROR() << "Cannot load texture" << iTexture << "so skipping";
         currentTexture = nullptr;
         continue;
       }
@@ -2835,12 +2870,11 @@ bool ResourceManager::instantiateAssetsOnDemand(
   // attributes for objects requires object rebuilding.
   if (objectAttributes->getIsDirty()) {
     CORRADE_ASSERT(
-        (ID_UNDEFINED != getObjectAttributesManager()->registerObject(
-                             objectAttributes, objectTemplateHandle)),
+        (getObjectAttributesManager()->registerObject(
+             objectAttributes, objectTemplateHandle) != ID_UNDEFINED),
         "::instantiateAssetsOnDemand : Unknown failure "
         "attempting to register modified template :"
-            << objectTemplateHandle
-            << "before asset instantiation.  Aborting. ",
+            << objectTemplateHandle << "before asset instantiation. Aborting. ",
         false);
   }
 
@@ -2859,8 +2893,8 @@ bool ResourceManager::instantiateAssetsOnDemand(
         // expected name.  should never happen
         ESP_ERROR() << "No primitive asset attributes exists with name :"
                     << renderAssetHandle
-                    << "so unable to instantiate primitive-based render "
-                       "object.  Aborting.";
+                    << "so instantiateAssetsOnDemand of primitive-based render "
+                       "object failed.";
         return false;
       }
       // build primitive asset for this object based on defined primitive
@@ -3227,8 +3261,9 @@ void ResourceManager::joinHierarchy(
             ->getCollisionMeshData();
     int lastIndex = mesh.vbo.size();
     if (meshData.primitive != Mn::MeshPrimitive::Triangles) {
-      ESP_WARNING() << "Unsupported mesh primitive in join: "
-                    << meshData.primitive << Mn::Debug::nospace << ", skipping";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "Unsupported mesh primitive in join: `" << meshData.primitive
+          << "` so skipping join.";
     } else {
       for (const auto& pos : meshData.positions) {
         mesh.vbo.push_back(Mn::EigenIntegration::cast<vec3f>(

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -131,7 +131,7 @@ class ManagedContainer : public ManagedContainerBase {
       ESP_ERROR(Magnum::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << "> : Invalid (null) managed object passed to "
-             "registration. Aborting.";
+             "registration, so registration aborted.";
       return ID_UNDEFINED;
     }
     if ("" != objectHandle) {
@@ -142,8 +142,8 @@ class ManagedContainer : public ManagedContainerBase {
     if ("" == handleToSet) {
       ESP_ERROR(Magnum::Debug::Flag::NoSpace)
           << "<" << this->objectType_
-          << "> : No valid handle specified to register this "
-          << this->objectType_ << " managed object. Aborting.";
+          << "> : No valid handle specified to register this managed object, "
+             "so registration aborted.";
       return ID_UNDEFINED;
     }
     return registerObjectFinalize(std::move(managedObject), handleToSet,

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -34,7 +34,8 @@ std::string ManagedContainerBase::getRandomObjectHandlePerType(
   std::size_t numVals = mapOfHandles.size();
   if (numVals == 0) {
     ESP_ERROR() << "Attempting to get a random" << type << objectType_
-                << "managed object handle but none are loaded; Aboring";
+                << "managed object handle but none are loaded, so no handles "
+                   "will be returned.";
     return "";
   }
   int randIDX = rand() % numVals;
@@ -177,7 +178,7 @@ int ManagedContainerBase::getObjectIDByHandleOrNew(
     ESP_ERROR(Magnum::Debug::Flag::NoSpace)
         << "<" << this->objectType_ << "> : No " << objectType_
         << " managed object with handle " << objectHandle
-        << " exists. Aborting.";
+        << " exists, so aborting ID query.";
     return ID_UNDEFINED;
   }
   return getUnusedObjectID();

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -203,7 +203,8 @@ class ManagedContainerBase {
     auto objKeyByIDIter = objectLibKeyByID_.find(objectID);
     if (objKeyByIDIter == objectLibKeyByID_.end()) {
       ESP_ERROR() << "Unknown" << objectType_
-                  << "managed object ID:" << objectID << ". Aborting";
+                  << "managed object ID:" << objectID
+                  << ", so unable to retrieve handle.";
       // never will have registered object with registration handle == ""
       return "";
     }
@@ -326,8 +327,9 @@ class ManagedContainerBase {
   bool checkExistsWithMessage(const std::string& objectHandle,
                               const std::string& src) const {
     if (!getObjectLibHasHandle(objectHandle)) {
-      ESP_ERROR() << src << ": Unknown" << objectType_
-                  << "managed object handle :" << objectHandle << ". Aborting";
+      ESP_ERROR(Magnum::Debug::Flag::NoSpace)
+          << src << ":" << objectType_ << " managed object handle `"
+          << objectHandle << "` not found in ManagedContainer, so aborting.";
       return false;
     }
     return true;

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -70,8 +70,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (!success) {
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
-          << "> : Failure reading document as JSON : " << filename
-          << ". Aborting.";
+          << "> : Failure reading document as JSON : `" << filename
+          << "`, so unable to create object.";
       return nullptr;
     }
     // convert doc to const value
@@ -94,8 +94,9 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
                                              CORRADE_UNUSED const U& config) {
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "<" << this->objectType_
-        << "> : Failure loading attributes from document :" << filename
-        << " of unknown type :" << typeid(U).name() << ". Aborting.";
+        << "> : Failure loading attributes from document `" << filename
+        << "` of unknown type `" << typeid(U).name()
+        << "` so unaable to build object.";
   }
   /**
    * @brief Method to load a Managed Object's data from a file.  This is the
@@ -140,9 +141,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (!this->getObjectLibHasHandle(objectHandle)) {
       // Object not found
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_
-          << ">::saveManagedObjectToFile : No object exists with handle "
-          << objectHandle << " to save as JSON. Aborting.";
+          << "<" << this->objectType_ << "> : No object exists with handle `"
+          << objectHandle << "`, so aborting save to file.";
       return false;
     }
     // Managed file-based object to save
@@ -179,9 +179,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (!this->getObjectLibHasHandle(objectHandle)) {
       // Object not found
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_
-          << ">::saveManagedObjectToFile : No object exists with handle "
-          << objectHandle << " to save as JSON. Aborting.";
+          << "<" << this->objectType_ << "> : No object exists with handle "
+          << objectHandle << "`, so aborting save to file.";
       return false;
     }
 
@@ -221,10 +220,11 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (!FileUtil::exists(fileDirectory)) {
       // output directory not found
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_ << "> : Destination directory "
-          << fileDirectory << " does not exist to save "
+          << "<" << this->objectType_ << "> : Destination directory `"
+          << fileDirectory << "` does not exist to save `"
           << managedObject->getSimplifiedHandle()
-          << " object with requested filename :" << fileName << ". Aborting.";
+          << "` object with requested filename `" << fileName
+          << "`, so aborting save to file.";
       return false;
     }
 
@@ -297,19 +297,23 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     if (!doc.ObjectEmpty()) {
       // save to file if doc exists
       bool success = io::writeJsonToFile(doc, fullFilename, true, 7);
-
-      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_
-          << "> : Attempt to save to Filename: " << fullFilename << " : "
-          << (success ? "Successful." : "Failed.");
+      if (success) {
+        ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+            << "<" << this->objectType_ << "> : Attempt to save to Filename `"
+            << fullFilename << "` Successful.";
+      } else {
+        ESP_ERROR(Mn::Debug::Flag::NoSpace)
+            << "<" << this->objectType_ << "> : Attempt to save to Filename `"
+            << fullFilename << "` Failed!";
+      }
 
       return success;
 
     } else {
-      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_
-          << "> : Attempt to save to Filename: " << fullFilename
-          << " Failed due to derived document being empty.";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_ << "> : Attempt to save to Filename `"
+          << fullFilename
+          << "` failed due to derived document describing object being empty.";
 
       // don't save an empty file/
       return false;
@@ -333,9 +337,8 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
                           CORRADE_UNUSED std::unique_ptr<U>& resDoc) {
     // by here always fail - means document type U is unsupported
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
-        << "<" << this->objectType_ << "> : Load file : " << filename
-        << " failed due to unsupported file type : `" << typeid(U).name()
-        << "`";
+        << "<" << this->objectType_ << "> : Load file `" << filename
+        << "` failed due to unsupported file type `" << typeid(U).name() << "`";
     return false;
   }  // ManagedContainerBase::verifyLoadDocument
   /**
@@ -465,16 +468,16 @@ bool ManagedFileBasedContainer<T, Access>::verifyLoadDocument(
       jsonDoc = std::make_unique<io::JsonDocument>(io::parseJsonFile(filename));
     } catch (...) {
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_ << "> : Failed to parse " << filename
-          << " as JSON.";
+          << "<" << this->objectType_ << "> : Failed to parse `" << filename
+          << "` as JSON.";
       return false;
     }
     return true;
   } else {
     // by here always fail
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
-        << "<" << this->objectType_ << "> : File " << filename
-        << " does not exist";
+        << "<" << this->objectType_ << "> : File `" << filename
+        << "` does not exist.";
     return false;
   }
 }  // ManagedFileBasedContainer<T, Access>::verifyLoadDocument

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -96,7 +96,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
         << "<" << this->objectType_
         << "> : Failure loading attributes from document `" << filename
         << "` of unknown type `" << typeid(U).name()
-        << "` so unaable to build object.";
+        << "` so unable to build object.";
   }
   /**
    * @brief Method to load a Managed Object's data from a file.  This is the

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -88,9 +88,10 @@ bool MetadataMediator::createPhysicsManagerAttributes(
     if (physAttrs == nullptr) {
       // something failed during creation process.
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "Unknown physics manager configuration file : `"
+          << "Unknown PhysicsManager Attributes configuration file : `"
           << _physicsManagerAttributesPath
-          << "` does not exist and is not able to be created. Aborting.";
+          << "` does not exist and no PhysicsManager Attributes is able to be "
+             "created for it, so creation failed.";
       return false;
     }
   }  // if dne then create
@@ -166,7 +167,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     ESP_WARNING(Mn::Debug::Flag::NoSpace)
         << "SceneDatasetAttributes `" << sceneDatasetName
         << "` unable to be deleted, probably due to it being marked "
-           "undeleteable in manager. Aborting.";
+           "undeleteable in manager, so aborting dataset delete.";
     return false;
   }
   // Should always have a default dataset. Use this process to remove extraneous
@@ -449,7 +450,8 @@ MetadataMediator::getSceneInstanceUserConfiguration(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // this should never happen
   if (datasetAttr == nullptr) {
-    ESP_ERROR() << "No active dataset specified/exists. Aborting.";
+    ESP_ERROR() << "No active dataset specified/exists, so aborting User "
+                   "Configuration retrieval.";
     return nullptr;
   }
   // get scene instance attribute manager
@@ -518,7 +520,8 @@ std::string MetadataMediator::createDatasetReport(
   } else {
     // unknown dataset
     ESP_ERROR() << "Dataset" << sceneDataset
-                << "is not found in the MetadataMediator. Aborting.";
+                << "is not found in the MetadataMediator, so unable to create "
+                   "Dataset Report.";
     return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
   }
   return Corrade::Utility::formatString(

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -131,8 +131,9 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
   // lock dataset to prevent accidental deletion
   // should only be removable via MetadataMediator::removeSceneDataset.
   sceneDatasetAttributesManager_->setLock(sceneDatasetName, true);
-  ESP_DEBUG(Mn::Debug::Flag::NoSpace) << "Dataset `" << sceneDatasetName
-                                      << "` successfully created and locked.";
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "Dataset `" << sceneDatasetName
+      << "` successfully created and locked.";
 
   return true;
 }  // namespace metadata
@@ -167,7 +168,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     ESP_WARNING(Mn::Debug::Flag::NoSpace)
         << "SceneDatasetAttributes `" << sceneDatasetName
         << "` unable to be deleted, probably due to it being marked "
-           "undeleteable in manager, so aborting dataset delete.";
+           "undeletable in manager, so aborting dataset delete.";
     return false;
   }
   // Should always have a default dataset. Use this process to remove extraneous
@@ -177,7 +178,7 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
     // dataset.
     createSceneDataset("default", true);
   }
-  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
       << "SceneDatasetAttributes `" << sceneDatasetName
       << "` successfully removed.";
   return true;
@@ -385,7 +386,7 @@ MetadataMediator::makeSceneAndReferenceStage(
           << Mn::Debug::nospace << activeSceneDataset_ << Mn::Debug::nospace
           << "` to load scene '" << Mn::Debug::nospace << sceneName
           << Mn::Debug::nospace
-          << "'. This would only occur due to an internaal Habitat-Sim error.");
+          << "'. This would only occur due to an internal Habitat-Sim error.");
 
   // Verify that a StageAttributes exists in SceneInstance for requested Scene
   ESP_CHECK(
@@ -486,7 +487,7 @@ std::string MetadataMediator::getFilePathForHandle(
       assetMapping.find(assetHandle);
   if (mapIter == assetMapping.end()) {
     ESP_WARNING() << msgString << ": Unable to find file path for"
-                  << assetHandle << ". Aborting.";
+                  << assetHandle << ", so returning empty string.";
     return "";
   }
   return mapIter->second;
@@ -522,7 +523,7 @@ std::string MetadataMediator::createDatasetReport(
     ESP_ERROR() << "Dataset" << sceneDataset
                 << "is not found in the MetadataMediator, so unable to create "
                    "Dataset Report.";
-    return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
+    return "Requested SceneDataset `" + sceneDataset + "` unknown.";
   }
   return Corrade::Utility::formatString(
       "Scene Dataset {}\n{}\n", ds->getObjectInfoHeader(), ds->getObjectInfo());

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -35,23 +35,25 @@ bool MetadataMediator::setSimulatorConfiguration(
   simConfig_ = cfg;
 
   // set current active dataset name - if unchanged, does nothing
-  bool success = setActiveSceneDatasetName(simConfig_.sceneDatasetConfigFile);
-  if (!success) {
-    // something failed about setting up active scene dataset
-    ESP_ERROR()
-        << "Some error prevented current scene dataset name to be changed to"
-        << simConfig_.sceneDatasetConfigFile;
-    return false;
-  }
-
+  ESP_CHECK(setActiveSceneDatasetName(simConfig_.sceneDatasetConfigFile),
+            // something failed about setting up active scene dataset
+            "Some error prevented currently active Scene Dataset `"
+                << Mn::Debug::nospace << activeSceneDataset_
+                << Mn::Debug::nospace << "` being changed to `"
+                << Mn::Debug::nospace << simConfig_.sceneDatasetConfigFile
+                << Mn::Debug::nospace
+                << "` as requested in the Simulator Configuration so aborting. "
+                   "Verify requested Scene Dataset file name in Simulator "
+                   "Configuration is correct.");
   // set active physics attributes handle - if unchanged, does nothing
-  success = setCurrPhysicsAttributesHandle(simConfig_.physicsConfigFile);
-  if (!success) {
-    // something failed about setting up physics attributes
-    ESP_ERROR() << "Some error prevented current physics attributes to"
-                << simConfig_.physicsConfigFile;
-    return false;
-  }
+  ESP_CHECK(setCurrPhysicsAttributesHandle(simConfig_.physicsConfigFile),
+            // something failed about setting up physics attributes
+            "Some error prevented changing current Physics Attributes to `"
+                << Mn::Debug::nospace << simConfig_.physicsConfigFile
+                << Mn::Debug::nospace
+                << "` as requested in the Simulator Configuration so aborting. "
+                   "Verify requested physics config filename in Simulator "
+                   "Configuration is correct.");
 
   // get a ref to current dataset attributes
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
@@ -60,15 +62,18 @@ bool MetadataMediator::setSimulatorConfiguration(
     datasetAttr->setCurrCfgVals(simConfig_.sceneLightSetupKey,
                                 simConfig_.frustumCulling);
   } else {
-    ESP_ERROR() << "No active dataset exists or has been specified. Aborting";
-    return false;
+    // No active dataset exists, so fail. Always should have an active dataset,
+    // even if it is default.
+    ESP_CHECK(false,
+              "No active dataset exists or has been specified. Aborting");
   }
-  ESP_DEBUG() << "Set new simulator config for scene/stage :"
-              << simConfig_.activeSceneName
-              << "and dataset :" << simConfig_.sceneDatasetConfigFile << "which"
-              << (activeSceneDataset_ == simConfig_.sceneDatasetConfigFile
-                      ? "is currently active dataset."
-                      : "is NOT active dataset (THIS IS PROBABLY AN ERROR.)");
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Set new simulator config for scene/stage : `"
+      << simConfig_.activeSceneName << "` and dataset : `"
+      << simConfig_.sceneDatasetConfigFile << "` which "
+      << (activeSceneDataset_ == simConfig_.sceneDatasetConfigFile
+              ? "is currently active dataset."
+              : "is NOT active dataset (THIS IS PROBABLY AN ERROR.)");
   return true;
 }  // MetadataMediator::setSimulatorConfiguration
 
@@ -82,10 +87,10 @@ bool MetadataMediator::createPhysicsManagerAttributes(
 
     if (physAttrs == nullptr) {
       // something failed during creation process.
-      ESP_WARNING()
-          << "Unknown physics manager configuration file :"
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "Unknown physics manager configuration file : `"
           << _physicsManagerAttributesPath
-          << "does not exist and is not able to be created.  Aborting.";
+          << "` does not exist and is not able to be created. Aborting.";
       return false;
     }
   }  // if dne then create
@@ -99,45 +104,54 @@ bool MetadataMediator::createSceneDataset(const std::string& sceneDatasetName,
   if (exists) {
     // check if not overwrite and exists already
     if (!overwrite) {
-      ESP_WARNING() << "Scene Dataset" << sceneDatasetName
-                    << "already exists.  To reload and overwrite existing "
-                       "data, set overwrite to true. Aborting.";
-      return false;
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "Scene Dataset `" << sceneDatasetName
+          << "` already exists. To reload and overwrite existing "
+             "data, set overwrite to true. Using existing Scene Dataset.";
+      // Treat as if created, since it exists.
+      return true;
     }
     // overwrite specified, make sure not locked
     sceneDatasetAttributesManager_->setLock(sceneDatasetName, false);
   }
-  // by here dataset either does not exist or exists but is unlocked.
+  // by here dataset either does not exist or exists but is unlocked and
+  // overwrite is specified. attempt to create new/overwrite
   auto datasetAttribs =
       sceneDatasetAttributesManager_->createObject(sceneDatasetName, true);
-  if (datasetAttribs == nullptr) {
-    // not created, do not set name
-    ESP_WARNING() << "Unknown dataset" << sceneDatasetName
-                  << "does not exist and is not able to be created.  Aborting.";
-    return false;
-  }
+  // Failure here means some catastrophic error attempting to create the dataset
+  // attributes. Should fail code
+  ESP_CHECK(datasetAttribs,
+            "Scene Dataset `"
+                << Mn::Debug::nospace << sceneDatasetName << Mn::Debug::nospace
+                << "` does not exist and is unable to be "
+                   "created using that name. Verify the given file name.");
+
   // if not null then successfully created
-  ESP_DEBUG() << "Dataset" << sceneDatasetName << "successfully created.";
   // lock dataset to prevent accidental deletion
+  // should only be removable via MetadataMediator::removeSceneDataset.
   sceneDatasetAttributesManager_->setLock(sceneDatasetName, true);
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace) << "Dataset `" << sceneDatasetName
+                                      << "` successfully created and locked.";
+
   return true;
-}  // MetadataMediator::createSceneDataset
+}  // namespace metadata
 
 bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   // First check if SceneDatasetAttributes exists
   if (!sceneDatasetExists(sceneDatasetName)) {
     // DNE, do nothing
-    ESP_WARNING() << "SceneDatasetAttributes" << sceneDatasetName
-                  << "does not exist. Aborting.";
-    return false;
+    ESP_WARNING(Mn::Debug::Flag::NoSpace)
+        << "SceneDatasetAttributes `" << sceneDatasetName
+        << "` does not exist, so it cannot be removed.";
+
+    return true;
   }
 
   // Next check if is current activeSceneDataset_, and if so skip with warning
   if (sceneDatasetName == activeSceneDataset_) {
-    ESP_WARNING() << "Cannot remove "
-                     "active SceneDatasetAttributes"
-                  << sceneDatasetName
-                  << ".  Switch to another dataset before removing.";
+    ESP_WARNING(Mn::Debug::Flag::NoSpace)
+        << "Cannot remove currently active SceneDatasetAttributes `"
+        << sceneDatasetName << "`. Switch to another dataset before removing.";
     return false;
   }
 
@@ -147,10 +161,12 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   auto delDataset =
       sceneDatasetAttributesManager_->removeObjectByHandle(sceneDatasetName);
   // if failed here, probably means SceneDatasetAttributes was set to
-  // undeletable, return message and false
+  // undeletable, give warning and return false
   if (delDataset == nullptr) {
-    ESP_WARNING() << "SceneDatasetAttributes" << sceneDatasetName
-                  << "unable to be deleted. Aborting.";
+    ESP_WARNING(Mn::Debug::Flag::NoSpace)
+        << "SceneDatasetAttributes `" << sceneDatasetName
+        << "` unable to be deleted, probably due to it being marked "
+           "undeleteable in manager. Aborting.";
     return false;
   }
   // Should always have a default dataset. Use this process to remove extraneous
@@ -158,10 +174,11 @@ bool MetadataMediator::removeSceneDataset(const std::string& sceneDatasetName) {
   if (sceneDatasetName == "default") {
     // removing default dataset should still create another, empty, default
     // dataset.
-    createSceneDataset("default");
+    createSceneDataset("default", true);
   }
-  ESP_DEBUG() << "SceneDatasetAttributes" << sceneDatasetName
-              << "successfully removed.";
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "SceneDatasetAttributes `" << sceneDatasetName
+      << "` successfully removed.";
   return true;
 
 }  // MetadataMediator::removeSceneDataset
@@ -172,9 +189,10 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
   if (physicsAttributesManager_->getObjectLibHasHandle(
           _physicsManagerAttributesPath)) {
     if (currPhysicsManagerAttributes_ != _physicsManagerAttributesPath) {
-      ESP_DEBUG() << "Old physics manager attributes"
-                  << currPhysicsManagerAttributes_ << "changed to"
-                  << _physicsManagerAttributesPath << "successfully.";
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Old physics manager attributes `" << currPhysicsManagerAttributes_
+          << "` changed to `" << _physicsManagerAttributesPath
+          << "` successfully.";
       currPhysicsManagerAttributes_ = _physicsManagerAttributesPath;
     }
     sceneDatasetAttributesManager_->setCurrPhysicsManagerAttributesHandle(
@@ -182,6 +200,9 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
     return true;
   }
   // if this handle does not exist, create the attributes for it.
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Attempting to create new physics manager attributes `"
+      << _physicsManagerAttributesPath << "`.";
   bool success = createPhysicsManagerAttributes(_physicsManagerAttributesPath);
   // if successfully created, set default name to physics manager attributes in
   // SceneDatasetAttributesManager
@@ -191,6 +212,11 @@ bool MetadataMediator::setCurrPhysicsAttributesHandle(
         currPhysicsManagerAttributes_);
     /// setCurrPhysicsManagerAttributesHandle
   }
+  ESP_DEBUG() << "Attempt to create new  Physics Manager Attributes from `"
+              << _physicsManagerAttributesPath << "`"
+              << (success ? " succeeded." : " failed.")
+              << "Currently active Physics Manager Attributes :"
+              << currPhysicsManagerAttributes_;
   return success;
 
 }  // MetadataMediator::setCurrPhysicsAttributesHandle
@@ -200,23 +226,26 @@ bool MetadataMediator::setActiveSceneDatasetName(
   // first check if dataset exists/is loaded, if so then set as default
   if (sceneDatasetExists(sceneDatasetName)) {
     if (activeSceneDataset_ != sceneDatasetName) {
-      ESP_DEBUG() << "Previous active dataset" << activeSceneDataset_
-                  << "changed to" << sceneDatasetName << "successfully.";
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Previous active Scene Dataset `" << activeSceneDataset_
+          << "` changed to `" << sceneDatasetName << "` successfully.";
       activeSceneDataset_ = sceneDatasetName;
     }
     return true;
   }
   // if does not exist, attempt to create it
-  ESP_DEBUG() << "Attempting to create new dataset" << sceneDatasetName;
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Attempting to create new dataset `" << sceneDatasetName << "`.";
   bool success = createSceneDataset(sceneDatasetName);
   // if successfully created, set default name to access dataset attributes in
   // SceneDatasetAttributesManager
   if (success) {
     activeSceneDataset_ = sceneDatasetName;
   }
-  ESP_DEBUG() << "Attempt to create new dataset" << sceneDatasetName << ""
-              << (success ? " succeeded." : " failed.")
-              << "Currently active dataset :" << activeSceneDataset_;
+  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+      << "Attempt to create new Scene Dataset from `" << sceneDatasetName << "`"
+      << (success ? " succeeded." : " failed. ")
+      << "Currently active Scene Dataset : `" << activeSceneDataset_ << "`.";
   return success;
 }  // MetadataMediator::setActiveSceneDatasetName
 
@@ -225,11 +254,12 @@ MetadataMediator::getSceneInstanceAttributesByName(
     const std::string& sceneName) {
   // get current dataset attributes
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
-  // this should never happen
-  if (datasetAttr == nullptr) {
-    ESP_ERROR() << "No dataset specified/exists.";
-    return nullptr;
-  }
+
+  // this should never happen, and would indicate someone did an end-run around
+  // management code and inappropriately deleted the dataset without resetting
+  // the activeSceneDataset_ tag.
+  ESP_CHECK(datasetAttr, "No active Scene Dataset specified/exists.");
+
   // directory to look for attributes for this dataset
   const std::string dsDir = datasetAttr->getFileDirectory();
   // get appropriate attr managers for the current dataset
@@ -243,13 +273,14 @@ MetadataMediator::getSceneInstanceAttributesByName(
   auto sceneList = dsSceneAttrMgr->getObjectHandlesBySubstring(sceneName);
   // sceneName can legally match any one of the following conditions :
   if (!sceneList.empty()) {
-    // 1.  Existing, registered SceneInstanceAttributes in current active
+    // 1. Existing, registered SceneInstanceAttributes in current active
     // dataset.
     //    In this case the SceneInstanceAttributes is returned.
-    ESP_DEBUG() << "Query dataset :" << activeSceneDataset_
-                << "for SceneInstanceAttributes named :" << sceneName
-                << "yields" << sceneList.size() << "candidates.  Using"
-                << sceneList[0] << Mn::Debug::nospace << ".";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Querying Scene Dataset : `" << activeSceneDataset_
+        << "` for Scene Instance Attributes named : `" << sceneName
+        << "` yielded " << sceneList.size() << " candidates. Using `"
+        << sceneList[0] << "` (first candidate).";
     sceneInstanceAttributes =
         dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0]);
   } else {
@@ -257,14 +288,17 @@ MetadataMediator::getSceneInstanceAttributesByName(
         dsSceneAttrMgr->getFormattedJSONFileName(sceneName);
 
     if (Cr::Utility::Path::exists(sceneFilenameCandidate)) {
-      // 2.  Existing, valid SceneInstanceAttributes file on disk, but not in
+      // 2. Existing, valid SceneInstanceAttributes file on disk, but not in
       // dataset.
       //    If this is the case, then the SceneInstanceAttributes should be
       //    loaded, registered, added to the dataset and returned.
-      ESP_DEBUG() << "Dataset :" << activeSceneDataset_
-                  << "does not reference a SceneInstanceAttributes named"
-                  << sceneName << "but a SceneInstanceAttributes config named"
-                  << sceneFilenameCandidate << "was found on disk, so loading.";
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "Scene Dataset : `" << activeSceneDataset_
+          << "` does not reference a Scene Instance Attributes named `"
+          << sceneName << "` but a Scene Instance Attributes config named `"
+          << sceneFilenameCandidate
+          << "` was found on disk, so this will be loaded and added to the "
+             "currently active Scene Dataset.";
       sceneInstanceAttributes = dsSceneAttrMgr->createObjectFromJSONFile(
           sceneFilenameCandidate, true);
     } else {
@@ -272,17 +306,19 @@ MetadataMediator::getSceneInstanceAttributesByName(
       // substring
       auto stageList = dsStageAttrMgr->getObjectHandlesBySubstring(sceneName);
       if (!stageList.empty()) {
-        // 3.  Existing, registered StageAttributes in current active dataset.
+        // 3. Existing, registered StageAttributes in current active dataset.
         //    In this case, a SceneInstanceAttributes is created amd registered
         //    using sceneName, referencing the StageAttributes of the same name;
         //    This sceneInstanceAttributes is returned.
-        ESP_DEBUG()
-            << "No existing scene instance attributes containing name"
-            << sceneName << "found in Dataset :" << activeSceneDataset_ << "but"
-            << stageList.size() << "StageAttributes found.  Using"
+        ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+            << "Scene Dataset : `" << activeSceneDataset_
+            << "` does not reference a Scene Instance Attributes named `"
+            << sceneName << "` but `" << stageList.size()
+            << " Stage Attributes were found with a similar name. Using `"
             << stageList[0]
-            << "as stage and to construct a SceneInstanceAttributes with same "
-               "name that will be added to Dataset.";
+            << "` (first entry) as stage and will construct a Scene Instance "
+               "Attributes with the same name that will be added to the "
+               "currently active Scene Dataset.";
         // create a new SceneInstanceAttributes, and give it a
         // SceneObjectInstanceAttributes for the stage with the same name.
         sceneInstanceAttributes = makeSceneAndReferenceStage(
@@ -290,17 +326,19 @@ MetadataMediator::getSceneInstanceAttributesByName(
             dsSceneAttrMgr, sceneName);
 
       } else {
-        // 4.  Either existing stage config/asset on disk, but not in current
+        // 4. Either existing stage config/asset on disk, but not in current
         // dataset, or no stage config/asset exists with passed name.
         //    In this case, a stage attributes is loaded/created and registered,
         //    then added to current dataset, and then 3. is performed.
-        ESP_DEBUG() << "Dataset :" << activeSceneDataset_
-                    << "has no preloaded SceneInstanceAttributes or "
-                       "StageAttributes named :"
-                    << sceneName
-                    << "so loading/creating a new StageAttributes with this "
-                       "name, and then creating a SceneInstanceAttributes with "
-                       "the same name that references this stage.";
+        ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+            << "Scene Dataset : `" << activeSceneDataset_
+            << "` does not reference a Scene Instance Attributes or Stage "
+               "Attributes named `"
+            << sceneName
+            << "` so loading/creating a new Stage Attributes with this "
+               "name, and then creating a Scene Instance Attributes with "
+               "the same name that references this stage, which will be added "
+               "to the currently active Scene Dataset.";
         // create and register stage attributes
         auto stageAttributes = dsStageAttrMgr->createObject(sceneName, true);
         // create a new SceneInstanceAttributes, and give it a
@@ -325,12 +363,40 @@ MetadataMediator::makeSceneAndReferenceStage(
     const attributes::StageAttributes::ptr& stageAttributes,
     const managers::SceneInstanceAttributesManager::ptr& dsSceneAttrMgr,
     const std::string& sceneName) {
-  ESP_CHECK(datasetAttr != nullptr && stageAttributes != nullptr &&
-                dsSceneAttrMgr != nullptr,
-            "Missing (at least) one of scene dataset attributes, stage "
-            "attributes, or scene instance attributes for scene '"
-                << Mn::Debug::nospace << sceneName << Mn::Debug::nospace
-                << "'.  Likely an invalid scene name.");
+  // Verify that a Scene Dataset (possibly default) exists.
+  ESP_CHECK(
+      datasetAttr,
+      "No Scene Dataset Attributes exists for currently active Scene Dataset `"
+          << Mn::Debug::nospace << activeSceneDataset_ << Mn::Debug::nospace
+          << "` from which to load scene '" << Mn::Debug::nospace << sceneName
+          << Mn::Debug::nospace
+          << "'. Likely the Scene Dataset Configuration file requested was not "
+             "found and so an attempt to create a new, empty Scene Dataset was "
+             "made and failed somehow. Verify the Scene Dataset Configuration "
+             "file name used.");
+
+  // Verify that the Scene Instance Attributes manager exists
+  // This should never fire - there should always be a
+  // SceneInstanceAttributesManager
+  ESP_CHECK(
+      dsSceneAttrMgr,
+      "No Scene Instance Attributes Manager was created for Scene Dataset `"
+          << Mn::Debug::nospace << activeSceneDataset_ << Mn::Debug::nospace
+          << "` to load scene '" << Mn::Debug::nospace << sceneName
+          << Mn::Debug::nospace
+          << "'. This would only occur due to an internaal Habitat-Sim error.");
+
+  // Verify that a StageAttributes exists in SceneInstance for requested Scene
+  ESP_CHECK(
+      stageAttributes,
+      "No Stage Attributes exists for requested scene '"
+          << Mn::Debug::nospace << sceneName << Mn::Debug::nospace
+          << "' in currently specified Scene Dataset `" << Mn::Debug::nospace
+          << activeSceneDataset_ << Mn::Debug::nospace
+          << "`. Likely the Scene Dataset Configuration requested was not "
+             "found and so a new, empty Scene Dataset was created. Verify the "
+             "Scene Dataset Configuration file name used.");
+
   // create scene attributes with passed name
   attributes::SceneInstanceAttributes::ptr sceneInstanceAttributes =
       dsSceneAttrMgr->createDefaultObject(sceneName, false);
@@ -346,20 +412,20 @@ MetadataMediator::makeSceneAndReferenceStage(
   // instance attributes only.
 
   // add a ref to the navmesh path from the stage attributes to scene
-  // attributes, giving it an appropriately obvious name.  This entails adding
+  // attributes, giving it an appropriately obvious name. This entails adding
   // the path itself to the dataset, if it does not already exist there, keyed
   // by the ref that the scene attributes will use.
   std::pair<std::string, std::string> navmeshEntry =
       datasetAttr->addNavmeshPathEntry(
           sceneName, stageAttributes->getNavmeshAssetHandle(), false);
   // navmeshEntry holds the navmesh key-value in the dataset to use by this
-  // scene instance.  NOTE : the key may have changed from what was passed if a
+  // scene instance. NOTE : the key may have changed from what was passed if a
   // collision occurred with same key but different value, so we need to add
-  // this key to the scene instance attributes.
+  // this key to the Scene Instance Attributes.
   sceneInstanceAttributes->setNavmeshHandle(navmeshEntry.first);
 
   // add a ref to semantic scene descriptor ("house file") from stage attributes
-  // to scene attributes, giving it an appropriately obvious name.  This entails
+  // to scene attributes, giving it an appropriately obvious name. This entails
   // adding the path itself to the dataset, if it does not already exist there,
   // keyed by the ref that the scene attributes will use.
   std::pair<std::string, std::string> ssdEntry =
@@ -368,7 +434,7 @@ MetadataMediator::makeSceneAndReferenceStage(
   // ssdEntry holds the ssd key in the dataset to use by this scene instance.
   // NOTE : the key may have changed from what was passed if a collision
   // occurred with same key but different value, so we need to add this key to
-  // the scene instance attributes.
+  // the Scene Instance Attributes.
   sceneInstanceAttributes->setSemanticSceneHandle(ssdEntry.first);
 
   // register SceneInstanceAttributes object
@@ -383,7 +449,7 @@ MetadataMediator::getSceneInstanceUserConfiguration(
   attributes::SceneDatasetAttributes::ptr datasetAttr = getActiveDSAttribs();
   // this should never happen
   if (datasetAttr == nullptr) {
-    ESP_ERROR() << "No dataset specified/exists.  Aborting.";
+    ESP_ERROR() << "No active dataset specified/exists. Aborting.";
     return nullptr;
   }
   // get scene instance attribute manager
@@ -399,7 +465,7 @@ MetadataMediator::getSceneInstanceUserConfiguration(
     //    In this case the SceneInstanceAttributes is returned.
     ESP_DEBUG() << "Query dataset :" << activeSceneDataset_
                 << "for SceneInstanceAttributes named :" << curSceneName
-                << "yields" << sceneList.size() << "candidates.  Using"
+                << "yields" << sceneList.size() << "candidates. Using"
                 << sceneList[0] << Mn::Debug::nospace << ".";
     return dsSceneAttrMgr->getObjectCopyByHandle(sceneList[0])
         ->getUserConfiguration();
@@ -418,7 +484,7 @@ std::string MetadataMediator::getFilePathForHandle(
       assetMapping.find(assetHandle);
   if (mapIter == assetMapping.end()) {
     ESP_WARNING() << msgString << ": Unable to find file path for"
-                  << assetHandle << ".  Aborting.";
+                  << assetHandle << ". Aborting.";
     return "";
   }
   return mapIter->second;
@@ -452,7 +518,7 @@ std::string MetadataMediator::createDatasetReport(
   } else {
     // unknown dataset
     ESP_ERROR() << "Dataset" << sceneDataset
-                << "is not found in the MetadataMediator.  Aborting.";
+                << "is not found in the MetadataMediator. Aborting.";
     return "Requeseted SceneDataset `" + sceneDataset + "` unknown.";
   }
   return Corrade::Utility::formatString(

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -67,11 +67,11 @@ class MetadataMediator {
                           bool overwrite = false);
 
   /**
-   * @brief Load a @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * @brief Load a @ref esp::metadata::attributes::PhysicsManagerAttributes
    * defined by passed string file path.
    * @param _physicsManagerAttributesPath The path to look for the physics
    * config file.
-   * @return Whether a @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * @return Whether a @ref esp::metadata::attributes::PhysicsManagerAttributes
    * exists based on the requested path, either new or pre-existing.
    */
   bool createPhysicsManagerAttributes(
@@ -98,7 +98,7 @@ class MetadataMediator {
   std::string getActiveSceneDatasetName() const { return activeSceneDataset_; }
 
   /**
-   * @brief Sets desired @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * @brief Sets desired @ref esp::metadata::attributes::PhysicsManagerAttributes
    * handle.  Will load if does not exist.
    * @param _physicsManagerAttributesPath The path to look for the physics
    * config file.
@@ -108,7 +108,7 @@ class MetadataMediator {
       const std::string& _physicsManagerAttributesPath);
   /**
    * @brief Returns the name of the currently used
-   * @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * @ref esp::metadata::attributes::PhysicsManagerAttributes
    */
   std::string getCurrPhysicsAttributesHandle() {
     return currPhysicsManagerAttributes_;
@@ -179,7 +179,7 @@ class MetadataMediator {
 
   /**
    * @brief Return a copy of the current
-   * @ref esp::metadata::sttributes::PhysicsManagerAttributes.
+   * @ref esp::metadata::attributes::PhysicsManagerAttributes.
    */
   attributes::PhysicsManagerAttributes::ptr
   getCurrentPhysicsManagerAttributes() {

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -56,20 +56,23 @@ class MetadataMediator {
   /**
    * @brief Creates a dataset attributes using @p sceneDatasetName, and
    * registers it. NOTE If an existing dataset attributes exists with this
-   * handle, then this will exit with a message unless @p overwrite is true.
+   * handle, then this will only overwrite this existing dataset if @p overwrite
+   * is set to true.
    * @param sceneDatasetName The name of the dataset to load or create.
    * @param overwrite Whether to overwrite an existing dataset or not
-   * @return Whether successfully created a new dataset or not.
+   * @return Whether a dataset with @p sceneDatasetName exists (either new or
+   * pre-existing).
    */
   bool createSceneDataset(const std::string& sceneDatasetName,
                           bool overwrite = false);
 
   /**
-   * @brief Load a physics manager attributes defined by passed string file path
+   * @brief Load a @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * defined by passed string file path.
    * @param _physicsManagerAttributesPath The path to look for the physics
    * config file.
-   * @return Whether successfully created a new physics manager attributes or
-   * not.
+   * @return Whether a @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * exists based on the requested path, either new or pre-existing.
    */
   bool createPhysicsManagerAttributes(
       const std::string& _physicsManagerAttributesPath =
@@ -95,8 +98,8 @@ class MetadataMediator {
   std::string getActiveSceneDatasetName() const { return activeSceneDataset_; }
 
   /**
-   * @brief Sets desired physics manager attributes handle.  Will load if does
-   * not exist.
+   * @brief Sets desired @ref esp::metadata::sttributes::PhysicsManagerAttributes
+   * handle.  Will load if does not exist.
    * @param _physicsManagerAttributesPath The path to look for the physics
    * config file.
    * @return whether successful or not
@@ -104,7 +107,8 @@ class MetadataMediator {
   bool setCurrPhysicsAttributesHandle(
       const std::string& _physicsManagerAttributesPath);
   /**
-   * @brief Returns the name of the currently used physics manager attributes
+   * @brief Returns the name of the currently used
+   * @ref esp::metadata::sttributes::PhysicsManagerAttributes
    */
   std::string getCurrPhysicsAttributesHandle() {
     return currPhysicsManagerAttributes_;
@@ -113,7 +117,7 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to asset attributes for
    * current dataset.
-   * @return The current dataset's @ref managers::AssetAttributesManager::ptr,
+   * @return The current dataset's @ref esp::metadata::managers::AssetAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
   const managers::AssetAttributesManager::ptr& getAssetAttributesManager() {
@@ -135,7 +139,7 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to object attributes for
    * current dataset.
-   * @return The current dataset's @ref managers::ObjectAttributesManager::ptr,
+   * @return The current dataset's @ref esp::metadata::managers::ObjectAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
   const managers::ObjectAttributesManager::ptr& getObjectAttributesManager() {
@@ -152,8 +156,8 @@ class MetadataMediator {
   }  // getPhysicsAttributesManager
 
   /**
-   * @brief Return manager for construction and access to scene instance
-   * attributes for current dataset.
+   * @brief Return manager for construction and access to
+   * @ref esp::attributes::SceneInstanceAttributes for current dataset.
    * @return The current dataset's @ref
    * managers::SceneInstanceAttributesManager::ptr, or nullptr if no current
    * dataset.
@@ -166,7 +170,7 @@ class MetadataMediator {
   /**
    * @brief Return manager for construction and access to stage attributes for
    * current dataset.
-   * @return The current dataset's @ref managers::StageAttributesManager::ptr,
+   * @return The current dataset's @ref esp::metadata::managers::StageAttributesManager::ptr,
    * or nullptr if no current dataset.
    */
   const managers::StageAttributesManager::ptr& getStageAttributesManager() {
@@ -174,7 +178,8 @@ class MetadataMediator {
   }  // MetadataMediator::getStageAttributesManager
 
   /**
-   * @brief Return a copy of the current physics manager attributes.
+   * @brief Return a copy of the current
+   * @ref esp::metadata::sttributes::PhysicsManagerAttributes.
    */
   attributes::PhysicsManagerAttributes::ptr
   getCurrentPhysicsManagerAttributes() {
@@ -249,10 +254,12 @@ class MetadataMediator {
   }  // MetadataMediator::getNavMeshPathByHandle
 
   /**
-   * @brief Returns an appropriate scene instance attributes corresponding to
-   * the passed sceneID/name.  For back-compat, this function needs to manage
-   * various conditions pertaining to the passed name.  It will always return a
-   * valid SceneInstanceAttributes for the current active dataset.
+   * @brief Returns an appropriate @ref esp::metadata::attributes::SceneInstanceAttributes
+   * corresponding to the passed sceneID/name.  For back-compat, this function
+   * needs to manage various conditions pertaining to the passed name.  It will
+   * always return a valid SceneInstanceAttributes for the current active
+   * dataset.
+   *
    * @param sceneName A string representation of the desired
    * SceneInstanceAttributes.  May only correspond to a stage on disk, in which
    * case a new SceneInstanceAttributes will be constructed and properly
@@ -379,18 +386,20 @@ class MetadataMediator {
   /**
    * @brief Allow removal of the named @ref
    * esp::metadata::attributes::SceneDatasetAttributes.  Will silently force
-   * removal of locked attributes.  If @p datasetName references @ref
+   * removal of locked attributes. If @p datasetName references @ref
    * activeSceneDataset_ then will fail, returning false.
    *
-   * @param sceneDatasetName The name of the SceneDatasetAttributes to remove.
+   * @param sceneDatasetName The name of the @ref esp::metadata::attributes::SceneDatasetAttributes
+   * to remove.
    * @return whether successful or not.
    */
   bool removeSceneDataset(const std::string& sceneDatasetName);
 
   /**
    * @brief Checks if passed handle exists as scene dataset.
-   * @param sceneDatasetName The name of the SceneDatasetAttributes to remove.
-   * @return whether successful or not.
+   * @param sceneDatasetName The name of the @ref esp::metadata::attributes::SceneDatasetAttributes
+   * to check for.
+   * @return whether @ref esp::metadata::attributes::SceneDatasetAttributes exists.
    */
   inline bool sceneDatasetExists(const std::string& sceneDatasetName) const {
     return sceneDatasetAttributesManager_->getObjectLibHasHandle(
@@ -399,7 +408,7 @@ class MetadataMediator {
 
   /**
    * @brief Returns the createRenderer flag that was set in the associated
-   * SimulatorConfiguration.
+   * @ref esp::sim::SimulatorConfiguration.
    * @return the boolean flag.
    */
   bool getCreateRenderer() const { return simConfig_.createRenderer; }
@@ -446,13 +455,13 @@ class MetadataMediator {
       const std::string& msgString);
 
   /**
-   * @brief This will create a new, empty @ref SceneInstanceAttributes with the
-   * passed name, and create a SceneObjectInstance for the stage also using the
-   * passed name. It is assuming that the dataset has the stage registered, and
-   * that the calling function will register the created SceneInstance with the
-   * dataset.  This method will also register navmesh and scene descriptor file
-   * paths that are synthesized for newly made SceneInstanceAttributes. TODO:
-   * get rid of these fields in stageAttributes.
+   * @brief This will create a new, empty @ref esp::metadata::attributes::SceneInstanceAttributes
+   * with the passed name, and create a SceneObjectInstance for the stage also
+   * using the passed name. It is assuming that the dataset has the stage
+   * registered, and that the calling function will register the created
+   * SceneInstance with the dataset.  This method will also register navmesh and
+   * scene descriptor file paths that are synthesized for newly made
+   * SceneInstanceAttributes. TODO: get rid of these fields in stageAttributes.
    *
    * @param datasetAttr The current dataset attributes
    * @param stageAttributes Readonly version of stage to use to synthesize scene
@@ -471,8 +480,8 @@ class MetadataMediator {
       const std::string& sceneName);
 
   /**
-   * @brief This function will build the @ref managers::PhysicsAttributesManager
-   * and @ref managers::SceneDatasetAttributesManager this mediator will manage.
+   * @brief This function will build the @ref esp::metadata::managers::PhysicsAttributesManager
+   * and @ref esp::metadata::managers::SceneDatasetAttributesManager this mediator will manage.
    * This should only be called from constructor or reset (TODO).
    */
   void buildAttributesManagers();
@@ -485,12 +494,13 @@ class MetadataMediator {
     // do not get copy of dataset attributes
     auto datasetAttr =
         sceneDatasetAttributesManager_->getObjectByHandle(activeSceneDataset_);
-    // this should never happen - there will always be a dataset with the name
+    // this should never happen - there should always be a dataset with the name
     // activeSceneDataset_
     if (datasetAttr == nullptr) {
-      ESP_ERROR() << "Unable to set active dataset due to Unknown dataset named"
-                  << activeSceneDataset_
-                  << "so changing dataset to \"default\".";
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
+          << "Unable to set active Scene Dataset due to unknown dataset named `"
+          << activeSceneDataset_
+          << "` so changing Scene Dataset  to `default`.";
       activeSceneDataset_ = "default";
 
       datasetAttr = sceneDatasetAttributesManager_->getObjectByHandle(
@@ -511,12 +521,17 @@ class MetadataMediator {
    * @brief String name of current, default dataset.
    */
   std::string activeSceneDataset_;
+
   /**
    * @brief String name of current Physis Manager attributes
    */
   std::string currPhysicsManagerAttributes_;
+
   /**
    * @brief Manages all construction and access to all scene dataset attributes.
+   * Users should never directly access this, or it could inadvertently get in a
+   * broken and unrecoverable state.  All access to SceneDatasetAttributes
+   * should be currated/governed by MetadataMediator.
    */
   managers::SceneDatasetAttributesManager::ptr sceneDatasetAttributesManager_ =
       nullptr;

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -185,7 +185,7 @@ class AbstractPrimitiveAttributes : public AbstractAttributes {
     std::size_t keyLoc = configStr.find(key);
     if (keyLoc == std::string::npos) {
       ESP_WARNING() << "Key" << key << "not found in configStr" << configStr
-                    << ". Aborting.";
+                    << ", so retrieving empty string.";
       return "";
     }
     std::size_t keyLen = key.length(), keyEnd = keyLoc + keyLen;

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -267,7 +267,8 @@ class SceneDatasetAttributes : public AbstractAttributes {
     auto artObjPathIter = articulatedObjPaths.find(artObjModelName);
     if (artObjPathIter == articulatedObjPaths.end()) {
       ESP_ERROR() << "No Articulatd Model with name" << artObjModelName
-                  << "could be found.  Aborting.";
+                  << "could be found, so getArticulatedObjModelFullHandle "
+                     "aborting and returning empty string.";
       return "";
     }
     return artObjPathIter->second;

--- a/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManagerBase.h
@@ -99,7 +99,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
    * @return an appropriately cast attributes pointer with base class fields
    * filled in.
    */
-  AbsObjAttrPtr loadAbstractObjectAttributesFromJson(
+  AbsObjAttrPtr setAbstractObjectAttributesFromJson(
       AbsObjAttrPtr attributes,
       const io::JsonGenericValue& jsonDoc);
 
@@ -193,8 +193,8 @@ auto AbstractObjectAttributesManager<T, Access>::createObject(
 
 template <class T, ManagedObjectAccess Access>
 auto AbstractObjectAttributesManager<T, Access>::
-    loadAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
-                                         const io::JsonGenericValue& jsonDoc)
+    setAbstractObjectAttributesFromJson(AbsObjAttrPtr attributes,
+                                        const io::JsonGenericValue& jsonDoc)
         -> AbsObjAttrPtr {
   // scale
   io::jsonIntoConstSetter<Magnum::Vector3>(
@@ -319,7 +319,7 @@ auto AbstractObjectAttributesManager<T, Access>::
   }
 
   return attributes;
-}  // AbstractObjectAttributesManager<AbsObjAttrPtr>::createObjectAttributesFromJson
+}  // AbstractObjectAttributesManager<AbsObjAttrPtr>::setAbstractObjectAttributesFromJson
 
 template <class T, ManagedObjectAccess Access>
 std::string

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -139,7 +139,8 @@ AssetAttributesManager::createTemplateFromHandle(
     // handle is of incorrect format
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "Given template handle : `" << templateHandle
-        << "` is not the correct format for a primitive.  Aborting.";
+        << "` is not the correct format for a primitive, so "
+           "createTemplateFromHandle aborting.";
     return nullptr;
   }
   std::string primClassName = templateHandle.substr(0, nameEndLoc);
@@ -148,7 +149,8 @@ AssetAttributesManager::createTemplateFromHandle(
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "Requested primitive type : `" << primClassName
         << "` from given template handle : `" << templateHandle
-        << "` is not a valid Magnum::Primitives class.  Aborting.";
+        << "` is not a valid Magnum::Primitives class, so "
+           "createTemplateFromHandle aborting.";
     return nullptr;
   }
   // create but do not register template for this prim class, since it will be
@@ -181,7 +183,8 @@ int AssetAttributesManager::registerObjectFinalize(
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "Primitive asset attributes template named `" << primAttributesHandle
         << "` is not configured properly for specified prmitive `"
-        << primAttributesTemplate->getPrimObjClassName() << "`. Aborting.";
+        << primAttributesTemplate->getPrimObjClassName()
+        << "`, so Primitive asset attributes NOT registered.";
     return ID_UNDEFINED;
   }
 

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -193,7 +193,8 @@ class AssetAttributesManager
       bool contains = true) const {
     if (primType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
       ESP_ERROR() << "Illegal primtitive type "
-                     "name PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
+                     "name PrimObjTypes::END_PRIM_OBJ_TYPES, so no template "
+                     "handles exist to retrieve.";
       return {};
     }
     std::string subStr = PrimitiveNames3DMap.at(primType);
@@ -414,7 +415,7 @@ class AssetAttributesManager
       override {
     ESP_WARNING()
         << "Overriding default objects for PrimitiveAssetAttributes not "
-           "currently supported.  Aborting.";
+           "currently supported so default is set to nullptr.";
     this->defaultObj_ = nullptr;
   }  // AssetAttributesManager::setDefaultObject
 
@@ -495,7 +496,8 @@ class AssetAttributesManager
     auto primTypeCtorIter = primTypeConstructorMap_.find(primClassName);
     if (primTypeCtorIter == primTypeConstructorMap_.end()) {
       ESP_ERROR() << "No primitive class" << primClassName
-                  << "exists in Magnum::Primitives. Aborting.";
+                  << "exists in Magnum::Primitives, so unable to initialize "
+                     "new Primitive object.";
       return nullptr;
     }
     // these attributes ignore any default setttings.
@@ -513,7 +515,8 @@ class AssetAttributesManager
     if (primitiveType == PrimObjTypes::END_PRIM_OBJ_TYPES) {
       ESP_ERROR() << "Cannot instantiate "
                      "attributes::AbstractPrimitiveAttributes object for "
-                     "PrimObjTypes::END_PRIM_OBJ_TYPES. Aborting.";
+                     "PrimObjTypes::END_PRIM_OBJ_TYPES, so create Primitive "
+                     "Attributes failed.";
       return nullptr;
     }
     int idx = static_cast<int>(primitiveType);

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -301,8 +301,8 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   const bool dirExists = Dir::isDirectory(path);
   if (dirExists) {
     ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-        << "Parsing " << this->objectType_
-        << " library directory: " + path + " for \'" + extType + "\' files";
+        << "Parsing " << this->objectType_ << " library directory: `" << path
+        << "` for `" << extType << "` files";
     for (auto& file : *Dir::list(path, Dir::ListFlag::SortAscending)) {
       std::string absoluteSubfilePath = Dir::join(path, file);
       if (Cr::Utility::String::endsWith(absoluteSubfilePath, extType)) {
@@ -319,9 +319,9 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
       paths.push_back(attributesFilepath);
     } else {  // neither a directory or a file
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_ << "> : Parsing" << this->objectType_
-          << ": Cannot find " << path << " as directory or "
-          << attributesFilepath << " as config file. Aborting parse.";
+          << "<" << this->objectType_ << "> : Parsing " << this->objectType_
+          << " files : Cannot find `" << path << "` as directory or `"
+          << attributesFilepath << "` as config file, so template load failed.";
       return templateIndices;
     }  // if fileExists else
   }    // if dirExists else
@@ -339,9 +339,9 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const io::JsonGenericValue& filePaths) {
   for (rapidjson::SizeType i = 0; i < filePaths.Size(); ++i) {
     if (!filePaths[i].IsString()) {
-      ESP_ERROR() << "<" << this->objectType_
-                  << "> : Invalid path value in file path array element @ idx"
-                  << i << ". Skipping.";
+      ESP_WARNING() << "<" << this->objectType_
+                    << "> : Invalid path value in file path array element @ idx"
+                    << i << ". Skipping.";
       continue;
     }
     std::string absolutePath =
@@ -350,19 +350,21 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     if (globPaths.size() > 0) {
       for (const auto& globPath : globPaths) {
         // load all object templates available as configs in absolutePath
-        ESP_DEBUG() << "<" << this->objectType_ << "> : Glob path result for"
-                    << absolutePath << ":" << globPath;
+        ESP_VERY_VERBOSE() << "<" << this->objectType_
+                           << "> : Glob path result for" << absolutePath << ":"
+                           << globPath;
         this->loadAllTemplatesFromPathAndExt(globPath, extType, true);
       }
     } else {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_ << "> : No Glob path result for "
-          << absolutePath << " so unable to load templates.";
+          << "<" << this->objectType_ << "> : No Glob path result found for `"
+          << absolutePath << "` so unable to load templates from that path.";
     }
   }
   ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-      << "<" << this->objectType_ << ">:" << std::to_string(filePaths.Size())
-      << "paths specified in JSON doc for" << this->objectType_ << "templates.";
+      << "<" << this->objectType_ << "> : " << std::to_string(filePaths.Size())
+      << " paths specified in JSON doc for " << this->objectType_
+      << " configuration files.";
 }  // AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
 
 template <class T, ManagedObjectAccess Access>
@@ -380,16 +382,15 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
   // Check if this configuration file exists and if so use it to build
   // attributes
   bool jsonFileExists = Cr::Utility::Path::exists(jsonAttrFileName);
-  ESP_DEBUG(Mn::Debug::Flag::NoSpace)
-      << "<" << this->objectType_
-      << ">: Proposing JSON name : " << jsonAttrFileName
-      << " from original name : " << filename << "| This file"
-      << (jsonFileExists ? " exists." : " does not exist.");
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "<" << this->objectType_ << ">: Proposing JSON name `"
+      << jsonAttrFileName << "` from original name `" << filename
+      << "`| This file" << (jsonFileExists ? " exists." : " does not exist.");
   if (jsonFileExists) {
     // configuration file exists with requested name, use to build Attributes
     attrs = this->createObjectFromJSONFile(jsonAttrFileName, registerObj);
     if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
-      msg = "JSON Configuration File (" + jsonAttrFileName + ") based";
+      msg = "JSON Configuration File `" + jsonAttrFileName + "` based";
     }
   } else {
     // An existing, valid configuration file could not be found using the
@@ -403,11 +404,11 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
       // only populate msg if appropriate logging level is enabled
       if (fileExists) {
-        msg = "File (" + filename +
-              ") exists but is not a recognized config filename extension, so "
+        msg = "File `" + filename +
+              "` exists but is not a recognized config filename extension, so "
               "new default";
       } else {
-        msg = "File (" + filename + ") not found, so new default";
+        msg = "File `" + filename + "` not found, so new default";
       }
     }
   }
@@ -424,8 +425,8 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << "> : " << attribs->getSimplifiedHandle()
-          << " attributes specifies user_defined attributes but they are not "
-             "of the correct format. Skipping.";
+          << " attributes specifies user_defined attributes but their format "
+             "is incorrect, so no user_defined attributes are loaded.";
       return false;
     } else {
       const std::string subGroupName = "user_defined";

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -31,8 +31,9 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   // verify that a primitive asset with the given handle exists
   if (!this->isValidPrimitiveAttributes(primAttrTemplateHandle)) {
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
-        << "No primitive with handle '" << primAttrTemplateHandle
-        << "' exists so cannot build physical object.  Aborting.";
+        << "No primitive with handle `" << primAttrTemplateHandle
+        << "` exists so cannot build physical object, so "
+           "createPrimBasedAttributesTemplate for object aborted.";
     return nullptr;
   }
 
@@ -217,7 +218,8 @@ int ObjectAttributesManager::registerObjectFinalize(
   if (objectTemplate->getRenderAssetHandle() == "") {
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "Attributes template named `" << objectTemplateHandle
-        << "` does not have a valid render asset handle specified. Aborting.";
+        << "` does not have a valid render asset handle specified, so "
+           "registration is aborted.";
     return ID_UNDEFINED;
   }
 
@@ -258,7 +260,7 @@ int ObjectAttributesManager::registerObjectFinalize(
         << "` specified in object template with handle : `"
         << objectTemplateHandle
         << "` does not correspond to any existing file or primitive render "
-           "asset.  Aborting.";
+           "asset, so registration is aborted.";
     return ID_UNDEFINED;
   }
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -77,7 +77,7 @@ void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
 void ObjectAttributesManager::setValsFromJSONDoc(
     attributes::ObjectAttributes::ptr objAttributes,
     const io::JsonGenericValue& jsonConfig) {
-  this->loadAbstractObjectAttributesFromJson(objAttributes, jsonConfig);
+  this->setAbstractObjectAttributesFromJson(objAttributes, jsonConfig);
 
   // Populate with object-specific fields found in json, if any are there.
   // object mass

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -74,7 +74,7 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
     // No stage_instance specified in SceneInstance configuration.
     // We expect a scene instance to be present always, except for the default
     // Scene Dataset that is empty.
-    if (attribsDispName.compare("default_attributes") == 0) {
+    if (attribsDispName == "default_attributes") {
       // Default attributes is empty
       ESP_DEBUG(Mn::Debug::Flag::NoSpace)
           << "No Stage Instance specified in Default Scene Instance, so "

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -71,10 +71,28 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
           << "`: JSON cell `stage_instance` is not a valid JSON object.";
     }
   } else {
-    // no stage instance exists. This should always at least be present
-    ESP_WARNING(Mn::Debug::Flag::NoSpace)
-        << "No Stage instance specified in Scene Instance `" << attribsDispName
-        << "`: JSON cell `stage_instance` does not exist.";
+    // No stage_instance specified in SceneInstance configuration.
+    // We expect a scene instance to be present always, except for the default
+    // Scene Dataset that is empty.
+    if (attribsDispName.compare("default_attributes") == 0) {
+      // Default attributes is empty
+      ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+          << "No Stage Instance specified in Default Scene Instance, so "
+             "setting empty/NONE Stage as Stage instance.";
+      SceneObjectInstanceAttributes::ptr instanceAttrs =
+          createEmptyInstanceAttributes("");
+      // Set to use none stage
+      instanceAttrs->setHandle("NONE");
+      attribs->setStageInstance(instanceAttrs);
+    } else {
+      // no stage instance exists in Scene Instance config JSON. This should not
+      // happen and would indicate an error in the dataset.
+      ESP_CHECK(false,
+                "No JSON cell `stage_instance` specified in Scene Instance `"
+                    << Mn::Debug::nospace << attribsDispName
+                    << Mn::Debug::nospace
+                    << "` so no Stage can be created for this Scene.");
+    }
   }
 
   // Check for object instances existence

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -210,7 +210,7 @@ SceneInstanceAttributesManager::createInstanceAttributesFromJSON(
   SceneObjectInstanceAttributes::ptr instanceAttrs =
       createEmptyInstanceAttributes("");
   // populate attributes
-  this->loadAbstractObjectAttributesFromJson(instanceAttrs, jCell);
+  this->setAbstractObjectAttributesFromJson(instanceAttrs, jCell);
   return instanceAttrs;
 }  // SceneInstanceAttributesManager::createInstanceAttributesFromJSON
 
@@ -220,7 +220,7 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
   SceneAOInstanceAttributes::ptr instanceAttrs =
       createEmptyAOInstanceAttributes("");
   // populate attributes
-  this->loadAbstractObjectAttributesFromJson(instanceAttrs, jCell);
+  this->setAbstractObjectAttributesFromJson(instanceAttrs, jCell);
 
   // only used for articulated objects
   // fixed base
@@ -290,7 +290,7 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
 
 }  // SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON
 
-void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
+void SceneInstanceAttributesManager::setAbstractObjectAttributesFromJson(
     const attributes::SceneObjectInstanceAttributes::ptr& instanceAttrs,
     const io::JsonGenericValue& jCell) const {
   // template handle describing stage/object instance
@@ -368,7 +368,7 @@ void SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson(
   // check for user defined attributes
   this->parseUserDefinedJsonVals(instanceAttrs, jCell);
 
-}  // SceneInstanceAttributesManager::loadAbstractObjectAttributesFromJson
+}  // SceneInstanceAttributesManager::setAbstractObjectAttributesFromJson
 
 std::string SceneInstanceAttributesManager::getTranslationOriginVal(
     const io::JsonGenericValue& jsonDoc) const {

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.h
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.h
@@ -119,7 +119,7 @@ class SceneInstanceAttributesManager
    * @param attributes the attributes to populate with JSON values
    * @param jCell JSON document to parse
    */
-  void loadAbstractObjectAttributesFromJson(
+  void setAbstractObjectAttributesFromJson(
       const attributes::SceneObjectInstanceAttributes::ptr& attributes,
       const io::JsonGenericValue& jCell) const;
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -49,9 +49,10 @@ int StageAttributesManager::registerObjectFinalize(
     const std::string& stageAttributesHandle,
     bool forceRegistration) {
   if (stageAttributes->getRenderAssetHandle() == "") {
-    ESP_ERROR()
-        << "Attributes template named" << stageAttributesHandle
-        << "does not have a valid render asset handle specified. Aborting.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Attributes template named `" << stageAttributesHandle
+        << "` does not have a valid render asset handle specified, so "
+           "StageAttributes registration is aborted.";
     return ID_UNDEFINED;
   }
 
@@ -78,16 +79,17 @@ int StageAttributesManager::registerObjectFinalize(
   } else if (forceRegistration) {
     ESP_WARNING()
         << "Render asset template handle :" << renderAssetHandle
-        << "specified in stage template with handle :" << stageAttributesHandle
-        << "does not correspond to any existing file or primitive render "
+        << "specified in stage template with handle `" << stageAttributesHandle
+        << "` does not correspond to any existing file or primitive render "
            "asset. This attributes is not in a valid state.";
   } else {
     // If renderAssetHandle is not valid file name needs to  fail
-    ESP_ERROR()
-        << "Render asset template handle :" << renderAssetHandle
-        << "specified in stage template with handle :" << stageAttributesHandle
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Render asset template handle `" << renderAssetHandle
+        << "` specified in stage template with handle :"
+        << stageAttributesHandle
         << "does not correspond to any existing file or primitive render "
-           "asset.  Aborting.";
+           "asset, so StageAttributes registration is aborted.";
     return ID_UNDEFINED;
   }
 
@@ -136,7 +138,8 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
   if (!StageAttributesManager::isValidPrimitiveAttributes(primAssetHandle)) {
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "No primitive with handle '" << primAssetHandle
-        << "' exists so cannot build physical object.  Aborting.";
+        << "' exists so cannot build physical object, so "
+           "createPrimBasedAttributesTemplate for stage aborted.";
     return nullptr;
   }
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -363,7 +363,7 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
 void StageAttributesManager::setValsFromJSONDoc(
     attributes::StageAttributes::ptr stageAttributes,
     const io::JsonGenericValue& jsonConfig) {
-  this->loadAbstractObjectAttributesFromJson(stageAttributes, jsonConfig);
+  this->setAbstractObjectAttributesFromJson(stageAttributes, jsonConfig);
 
   // directory location where stage files are found
   std::string stageLocFileDir = stageAttributes->getFileDirectory();

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -219,7 +219,7 @@ int PhysicsManager::addObject(
   if (!objectAttributes) {
     // should never run, but just in case
     ESP_ERROR() << "Object creation failed due to nonexistant "
-                   "objectAttributes";
+                   "objectAttributes, so addObject aborted.";
     return ID_UNDEFINED;
   }
   // verify whether necessary assets exist, and if not, instantiate them
@@ -228,7 +228,8 @@ int PhysicsManager::addObject(
       resourceManager_.instantiateAssetsOnDemand(objectAttributes);
   if (!objectSuccess) {
     ESP_ERROR() << "ResourceManager::instantiateAssetsOnDemand "
-                   "unsuccessful. Aborting.";
+                   "unsuccessful, so addObject `"
+                << objectAttributes->getHandle() << "` aborted.";
     return ID_UNDEFINED;
   }
 
@@ -247,8 +248,9 @@ int PhysicsManager::addObject(
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
-    ESP_ERROR() << "PhysicsManager::makeRigidObject unsuccessful. "
-                   " Aborting.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "PhysicsManager::makeAndAddRigidObject unsuccessful, so addObject `"
+        << objectAttributes->getHandle() << "` aborted.";
     return ID_UNDEFINED;
   }
 
@@ -272,7 +274,8 @@ int PhysicsManager::addObject(
   if (!objectSuccess) {
     // if failed for some reason, remove and return
     removeObject(nextObjectID_, true, true);
-    ESP_ERROR() << "PhysicsManager::finalizeObject unsuccessful.  Aborting.";
+    ESP_ERROR() << "PhysicsManager::finalizeObject unsuccessful, so addObject `"
+                << objectAttributes->getHandle() << "` aborted.";
     return ID_UNDEFINED;
   }
   // Valid object exists by here.
@@ -332,10 +335,11 @@ int PhysicsManager::addArticulatedObjectInstance(
       false, lightSetup);
   if (aObjID == ID_UNDEFINED) {
     // instancing failed for some reason.
-    ESP_ERROR() << "Articulated Object create failed for model filepath"
-                << filepath << ", whose handle is"
-                << aObjInstAttributes->getHandle()
-                << "as specified in articulated object instance attributes.";
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Articulated Object create failed for model filepath `" << filepath
+        << "`, whose handle is `" << aObjInstAttributes->getHandle()
+        << "` as specified in articulated object instance attributes, so "
+           "addArticulatedObjectInstance aborted.";
     return ID_UNDEFINED;
   }
 
@@ -406,7 +410,7 @@ int PhysicsManager::addTrajectoryObject(const std::string& trajVisName,
       trajVisName, uniquePts, colorVec, numSegments, radius, smooth, numInterp);
   if (!success) {
     ESP_ERROR() << "Failed to create Trajectory visualization mesh for"
-                << trajVisName;
+                << trajVisName << "so addTrajectoryObject aborted.";
     return ID_UNDEFINED;
   }
   // 2. create object attributes for the trajectory
@@ -422,7 +426,7 @@ int PhysicsManager::addTrajectoryObject(const std::string& trajVisName,
   if (trajVisID == ID_UNDEFINED) {
     // failed to add object - need to delete asset from resourceManager.
     ESP_ERROR() << "Failed to create Trajectory visualization object for"
-                << trajVisName;
+                << trajVisName << "so addTrajectoryObject aborted.";
     // TODO : support removing asset by removing from resourceDict_ properly
     // using trajVisName
     return ID_UNDEFINED;

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -86,7 +86,8 @@ class RigidStage : public RigidBase {
    */
   void setMotionType(CORRADE_UNUSED MotionType mt) override {
     ESP_WARNING() << "Stages cannot have their "
-                     "motion type changed from MotionType::STATIC.  Aborting.";
+                     "motion type changed from MotionType::STATIC, so "
+                     "aborting; motion type is unchanged.";
   }
 
  public:

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -262,8 +262,8 @@ void BulletRigidObject::setCollisionFromBB() {
 
 void BulletRigidObject::setMotionType(MotionType mt) {
   if (mt == MotionType::UNDEFINED) {
-    ESP_WARNING() << "Cannot set motion type "
-                     "to MotionType::UNDEFINED.  Aborting.";
+    ESP_WARNING() << "Cannot set motion type to MotionType::UNDEFINED, so "
+                     "aborting; motion type is unchanged.";
     return;
   }
   if (mt == objectMotionType_) {

--- a/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
+++ b/src/esp/physics/objectManagers/PhysicsObjectBaseManager.h
@@ -105,8 +105,8 @@ class PhysicsObjectBaseManager
         managedObjTypeConstructorMap_.find(objectTypeName);
     if (mgdObjTypeCtorMapIter == managedObjTypeConstructorMap_.end()) {
       ESP_ERROR(Mn::Debug::Flag::NoSpace)
-          << "<" << this->objectType_ << "> Unknown constructor type"
-          << objectTypeName << ".  Aborting.";
+          << "<" << this->objectType_ << "> Unknown constructor type "
+          << objectTypeName << ", so initNewObject aborted.";
       return nullptr;
     }
     auto newWrapper = (*this.*(mgdObjTypeCtorMapIter->second))();


### PR DESCRIPTION
## Motivation and Context
This PR addresses a few key issues with regard to the data load process and providing the user meaningful feedback on progress and issues that may arise.  Along with clarifying many messages, the following changes were made :

**MetadataMediator** 
- Some errors were updated to ESP_CHECK so that they would end the load process immediately if issues were present in the dataset load.
- A compound ESP_CHECK pertaining to the initial loading of the scene dataset was broken up into 3 individual checks, so that specific errors could be clearly communicated to the user.

**ResourceManager/AttributesManagers**
- Some Debug messages were demoted to Very Verbose
- Conditionally build a compound debug message string only if Debug-level messages are enabled.

**SceneInstanceAttributes**
The default empty Scene Instance will no longer complain about not having a Stage Instance, a misleading message about an expected state. On the other hand, if a non-default Scene Instance attempts to load with no Stage Instance, this will fail an ESP_CHECK, since we expect at the very least a Stage Instance for any scene to load correctly. 

**General**
Usage of 'Abort' in non-ESP_CHECK() messages : '**Aborting**' is a commonly used tag we put at the end of failed assertion messages, implying program exit due to a specific check or line of code producing an unrecoverable error. However, many ESP_ERROR() streams (And even a few ESP_WARNING() streams) currently end just with the term "Aborting." as well, in an ambiguous attempt to infer that the function's execution is ending early, possibly with a non-useful return result, such as nullptr or ID_UNDEFINED. I have replaced these 'Aborting' messages where I could find them with clearer descriptions of what was happening in the guilty function as a result of the error.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
