### PR TITLE
Add close() to replay renderer to allow for explicit resource release.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -409,6 +409,9 @@ void initSimBindings(py::module& m) {
             return std::make_shared<BatchReplayRenderer>(cfg);
           },
           R"(Create a replay renderer using the batch render pipeline.)")
+      .def("close", &AbstractReplayRenderer::close,
+           "Releases the graphics context and resources used by the replay "
+           "renderer.")
       .def(
           "preload_file",
           [](AbstractReplayRenderer& self, const std::string& filePath) {

--- a/src/esp/sim/AbstractReplayRenderer.cpp
+++ b/src/esp/sim/AbstractReplayRenderer.cpp
@@ -32,6 +32,10 @@ Mn::Vector2i AbstractReplayRenderer::environmentGridSize(
 
 AbstractReplayRenderer::~AbstractReplayRenderer() = default;
 
+void AbstractReplayRenderer::close() {
+  doClose();
+}
+
 void AbstractReplayRenderer::preloadFile(Cr::Containers::StringView filename) {
   doPreloadFile(filename);
 }

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -66,6 +66,8 @@ class AbstractReplayRenderer {
 
   virtual ~AbstractReplayRenderer();
 
+  void close();
+
   void preloadFile(Corrade::Containers::StringView filename);
 
   unsigned environmentCount() const;
@@ -137,6 +139,8 @@ class AbstractReplayRenderer {
 
   /* Default implementation does nothing */
   virtual void doPreloadFile(Corrade::Containers::StringView filename);
+
+  virtual void doClose() = 0;
 
   virtual unsigned doEnvironmentCount() const = 0;
 

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -54,7 +54,17 @@ BatchReplayRenderer::BatchReplayRenderer(
   }
 }
 
-BatchReplayRenderer::~BatchReplayRenderer() = default;
+BatchReplayRenderer::~BatchReplayRenderer() {
+  doClose();
+}
+
+void BatchReplayRenderer::doClose() {
+  for (int i = 0; i < envs_.size(); ++i) {
+    envs_[i].player_.close();
+  }
+  envs_ = {};
+  renderer_.reset();
+}
 
 void BatchReplayRenderer::doPreloadFile(Cr::Containers::StringView filename) {
   CORRADE_INTERNAL_ASSERT(renderer_->addFile(filename));

--- a/src/esp/sim/BatchReplayRenderer.cpp
+++ b/src/esp/sim/BatchReplayRenderer.cpp
@@ -55,10 +55,14 @@ BatchReplayRenderer::BatchReplayRenderer(
 }
 
 BatchReplayRenderer::~BatchReplayRenderer() {
-  doClose();
+  doCloseImpl();
 }
 
 void BatchReplayRenderer::doClose() {
+  doCloseImpl();
+}
+
+void BatchReplayRenderer::doCloseImpl() {
   for (int i = 0; i < envs_.size(); ++i) {
     envs_[i].player_.close();
   }

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -29,6 +29,8 @@ class BatchReplayRenderer : public AbstractReplayRenderer {
   const void* getCudaDepthBufferDevicePointer() override;
 
  private:
+  void doClose() override;
+
   void doPreloadFile(Corrade::Containers::StringView filename) override;
 
   unsigned doEnvironmentCount() const override;

--- a/src/esp/sim/BatchReplayRenderer.h
+++ b/src/esp/sim/BatchReplayRenderer.h
@@ -31,6 +31,8 @@ class BatchReplayRenderer : public AbstractReplayRenderer {
  private:
   void doClose() override;
 
+  void doCloseImpl();
+
   void doPreloadFile(Corrade::Containers::StringView filename) override;
 
   unsigned doEnvironmentCount() const override;

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -144,6 +144,8 @@ void ClassicReplayRenderer::doClose() {
   }
   envs_.clear();
   resourceManager_.reset();
+  renderer_.reset();
+  context_.reset();
 }
 
 unsigned ClassicReplayRenderer::doEnvironmentCount() const {

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -130,10 +130,14 @@ ClassicReplayRenderer::ClassicReplayRenderer(
 }
 
 ClassicReplayRenderer::~ClassicReplayRenderer() {
-  doClose();
+  doCloseImpl();
 }
 
 void ClassicReplayRenderer::doClose() {
+  doCloseImpl();
+}
+
+void ClassicReplayRenderer::doCloseImpl() {
   for (int envIdx = 0; envIdx < envs_.size(); ++envIdx) {
     envs_[envIdx].player_.close();
     auto& sensorMap = envs_[envIdx].sensorMap_;

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -130,13 +130,19 @@ ClassicReplayRenderer::ClassicReplayRenderer(
 }
 
 ClassicReplayRenderer::~ClassicReplayRenderer() {
-  for (int envIdx = 0; envIdx < config_.numEnvironments; ++envIdx) {
+  doClose();
+}
+
+void ClassicReplayRenderer::doClose() {
+  for (int envIdx = 0; envIdx < envs_.size(); ++envIdx) {
     envs_[envIdx].player_.close();
     auto& sensorMap = envs_[envIdx].sensorMap_;
     for (auto& sensorPair : sensorMap) {
       sensor::SensorFactory::deleteSensor(sensorPair.second);
     }
+    envs_[envIdx].sensorMap_.clear();
   }
+  envs_.clear();
   resourceManager_.reset();
 }
 

--- a/src/esp/sim/ClassicReplayRenderer.h
+++ b/src/esp/sim/ClassicReplayRenderer.h
@@ -60,6 +60,8 @@ class ClassicReplayRenderer : public AbstractReplayRenderer {
                             const Mn::Vector2i& viewportPosition) override;
 
  private:
+  void doClose() override;
+
   unsigned doEnvironmentCount() const override;
 
   Magnum::Vector2i doSensorSize(unsigned envIndex) override;

--- a/src/esp/sim/ClassicReplayRenderer.h
+++ b/src/esp/sim/ClassicReplayRenderer.h
@@ -62,6 +62,8 @@ class ClassicReplayRenderer : public AbstractReplayRenderer {
  private:
   void doClose() override;
 
+  void doCloseImpl();
+
   unsigned doEnvironmentCount() const override;
 
   Magnum::Vector2i doSensorSize(unsigned envIndex) override;


### PR DESCRIPTION
## Motivation and Context

This adds an explicit `close()` method to replay renderer to ensure that resources aren't leaked when being used in Python.

See https://github.com/facebookresearch/habitat-lab/pull/1436.

## How Has This Been Tested

Tested locally and on https://github.com/facebookresearch/habitat-lab/pull/1436.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
