### PR TITLE
Fix conda build CI issue with git commands.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -702,6 +702,7 @@ jobs:
                   <<^ parameters.CI_TEST >> --env << parameters.AIHABITAT_CONDA_CHN_PWD_VAR >> <</ parameters.CI_TEST >> \
                   hsim_condabuild_dcontainer \
                   /bin/bash -c "source ~/.bashrc && conda activate py39 \
+                                && cd /remote/habitat-sim/ && git config --global --add safe.directory '*' \
                                 && cd /remote/habitat-sim/conda-build \
                                 <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} <</ parameters.CI_TEST >> --hostname "aihabitat-conda-ci-builder-linux" \
                                 && python matrix_builder.py \


### PR DESCRIPTION
## Motivation and Context

This fixes an ongoing CI issue with Linux `conda_build_binaries` that was probably caused by an automated update of a git dependency.

Error:
```
Traceback (most recent call last):
  File "/remote/habitat-sim/conda-build/matrix_builder.py", line 160, in <module>
    main()
  File "/remote/habitat-sim/conda-build/matrix_builder.py", line 142, in main
    sha = repo.head.object.hexsha
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/refs/symbolic.py", line 219, in _get_object
    return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/objects/base.py", line 94, in new_from_sha
    oinfo = repo.odb.info(sha1)
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/db.py", line 40, in info
    hexsha, typename, size = self._git.get_object_header(bin_to_hex(binsha))
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/cmd.py", line 1383, in get_object_header
    return self.__get_object_header(cmd, ref)
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/cmd.py", line 1370, in __get_object_header
    return self._parse_object_header(cmd.stdout.readline())
  File "/opt/conda/envs/py39/lib/python3.9/site-packages/git/cmd.py", line 1329, in _parse_object_header
    raise ValueError("SHA could not be resolved, git returned: %r" % (header_line.strip()))
ValueError: SHA could not be resolved, git returned: b''
```

## How Has This Been Tested

Tested on CI.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
