### PR TITLE
--[BE Week]Minor Lighting-related refactoring

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -223,7 +223,7 @@ To quickly test in the viewer application:
 #from the habitat-sim directory
 # C++
 # ./build/viewer if compiling locally
-habitat-viewer --stage-requires-lighting --enable-physics --object-dir ""  --dataset data/objects/ycb/ycb.scene_dataset_config.json -- data/test_assets/scenes/simple_room.glb
+habitat-viewer --use-default-lighting --enable-physics --object-dir ""  --dataset data/objects/ycb/ycb.scene_dataset_config.json -- data/test_assets/scenes/simple_room.glb
 ```
 Then press `'o'` key to add random objects from the dataset.
 

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -1119,9 +1119,9 @@ if __name__ == "__main__":
         help="disable physics simulation (default: False)",
     )
     parser.add_argument(
-        "--stage-requires-lighting",
+        "--use-default-lighting",
         action="store_true",
-        help="Override configured lighting to use synthetic lighting for the stage.",
+        help="Override configured lighting to use default lighting for the stage.",
     )
     parser.add_argument(
         "--ibl",

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -81,7 +81,7 @@ void initSimBindings(py::module& m) {
       .def_readwrite(
           "override_scene_light_defaults",
           &SimulatorConfiguration::overrideSceneLightDefaults,
-          R"(Override scene lighting setup to use with value specified below.)")
+          R"(Override scene lighting setup to use with value specified by `scene_light_setup`.)")
       .def_readwrite("scene_light_setup",
                      &SimulatorConfiguration::sceneLightSetupKey,
                      R"(Light setup key for the scene.)")

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -151,9 +151,8 @@ std::pair<std::string, std::string> SceneDatasetAttributes::addNewValToMap(
 esp::gfx::LightSetup SceneDatasetAttributes::getNamedLightSetup(
     const std::string& lightSetupName) {
   auto lightLayoutAttrName = getLightSetupFullHandle(lightSetupName);
-  if (lightLayoutAttrName == NO_LIGHT_KEY) {
-    return esp::gfx::LightSetup{};
-  }
+  // lightLayoutAttrName == NO_LIGHT_KEY and DEFAULT_LIGHTING_KEY
+  // handled in lightLayoutAttributesManager_
   return lightLayoutAttributesManager_->createLightSetupFromAttributes(
       lightLayoutAttrName);
 

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -308,15 +308,13 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * be found via substring search, so the name is expected to be sufficiently
    * restrictive to have exactly 1 match in dataset.
    * @return the full attributes name corresponding to @p lightSetupName , or
-   * the empty string.
+   * predefined No-Light and Default_lighting key strings.
    */
   inline std::string getLightSetupFullHandle(
       const std::string& lightSetupName) {
-    if (lightSetupName == DEFAULT_LIGHTING_KEY) {
-      return DEFAULT_LIGHTING_KEY;
-    }
-    if (lightSetupName == NO_LIGHT_KEY) {
-      return NO_LIGHT_KEY;
+    if ((lightSetupName == DEFAULT_LIGHTING_KEY) ||
+        (lightSetupName == NO_LIGHT_KEY)) {
+      return lightSetupName;
     }
     return getFullAttrNameFromStr(lightSetupName,
                                   lightLayoutAttributesManager_);

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -271,13 +271,19 @@ int LightLayoutAttributesManager::registerObjectFinalize(
 
 gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
     const std::string& lightConfigName) {
-  // if passing empty key, use default lights for light setup
+  // if passing no-lighting key, return empty light setup
+  if (lightConfigName == NO_LIGHT_KEY) {
+    ESP_VERY_VERBOSE()
+        << "`No-lights` lighting key specified so using empty light setup.";
+    return esp::gfx::LightSetup{};
+  }
+  // if passing DEFAULT_LIGHTING_KEY key, use default lights for light setup
   if (lightConfigName == DEFAULT_LIGHTING_KEY) {
-    // Default lighting key is specified as the empty string. This would
+    // DEFAULT_LIGHTING_KEY is specified as the empty string. This would
     // generate an error if the attributes manager was queried with an empty
     // string
-    ESP_DEBUG() << "Default lighting key specified so using "
-                   "Habitat-Sim-specified default light setup.";
+    ESP_VERY_VERBOSE() << "`Default-lighting` key specified so using "
+                          "Habitat-Sim-specified default light setup.";
     return gfx::getDefaultLights();
   }
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -319,17 +319,28 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
     // SimulatorConfiguration set to override any dataset configuration specs
     // regarding lighting.
     lightSetupKey = config_.sceneLightSetupKey;
-    ESP_DEBUG() << "Using SimulatorConfiguration-specified Light key : -"
-                << lightSetupKey << "-";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Using SimulatorConfiguration-specified Light Setup key : `"
+        // empty lightSetupKey denotes using the default
+        << (lightSetupKey == DEFAULT_LIGHTING_KEY ? "DEFAULT_LIGHTING_KEY"
+                                                  : lightSetupKey)
+        << "`.";
   } else {
-    // Get dataset/scene instance specified lighting
+    // Get scene instance specified lighting
     lightSetupKey = metadataMediator_->getLightSetupFullHandle(
         curSceneInstanceAttributes_->getLightingHandle());
-    ESP_DEBUG() << "Using scene instance-specified Light key : -"
-                << lightSetupKey << "-";
-    if (lightSetupKey != NO_LIGHT_KEY) {
-      // lighting attributes corresponding to this key should exist unless it
-      // is empty; if empty, the following does nothing.
+    ESP_DEBUG() << "Using scene instance-specified Light Setup key : `"
+                // empty lightSetupKey denotes using the default
+                << (lightSetupKey == DEFAULT_LIGHTING_KEY
+                        ? "DEFAULT_LIGHTING_KEY"
+                        : lightSetupKey)
+                << "`.";
+    // Do not query Scene Instance Attributes for lightsetup for these keys.
+    // Both should already be handled by ResourceManager
+    if ((lightSetupKey != NO_LIGHT_KEY) &&
+        (lightSetupKey != DEFAULT_LIGHTING_KEY)) {
+      // lighting attributes corresponding to this key should exist in
+      // LightLayoutAttributesManager.
       esp::gfx::LightSetup lightingSetup =
           metadataMediator_->getLightLayoutAttributesManager()
               ->createLightSetupFromAttributes(lightSetupKey);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -832,9 +832,9 @@ Viewer::Viewer(const Arguments& arguments)
       .addBooleanOption("hbao")
       .setHelp("hbao",
                "NOT YET SUPPORTED : Enable Horizon-based Ambient Occlusion.")
-      .addBooleanOption("stage-requires-lighting")
-      .setHelp("stage-requires-lighting",
-               "Stage asset should be lit with Phong shading.")
+      .addBooleanOption("use-default-lighting")
+      .setHelp("use-default-lighting",
+               "Scene should be lit using the default lighting configuration.")
       .addBooleanOption("debug-bullet")
       .setHelp("debug-bullet", "Render Bullet physics debug wireframes.")
       .addOption("gfx-replay-record-filepath")
@@ -972,8 +972,8 @@ Viewer::Viewer(const Arguments& arguments)
   simConfig_.requiresTextures = true;
   simConfig_.enableGfxReplaySave = !gfxReplayRecordFilepath_.empty();
   simConfig_.useSemanticTexturesIfFound = !args.isSet("no-semantic-textures");
-  if (args.isSet("stage-requires-lighting")) {
-    ESP_DEBUG() << "Stage using DEFAULT_LIGHTING_KEY";
+  if (args.isSet("use-default-lighting")) {
+    ESP_DEBUG() << "Scene lit using DEFAULT_LIGHTING_KEY";
     simConfig_.overrideSceneLightDefaults = true;
     simConfig_.sceneLightSetupKey = esp::DEFAULT_LIGHTING_KEY;
   }


### PR DESCRIPTION
## Motivation and Context
This PR addresses a few minor issues.
- The viewer.py/viewer.cpp tag "--stage-requires-lighting" is renamed to the more accurate "--use-default-lighting"
- Our internally-specified lighting keys "NO_LIGHT_KEY" and "DEFAULT_LIGHTING_KEY" are handled more appropriately when a light setup is requested by name from the LightLayoutAttributesManager.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and Python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
