### PR TITLE
Bump isort to 5.12.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
                 flake8-return \
                 flake8-simplify \
                 hypothesis==6.29.3 \
-                isort==5.11.5 \
+                isort==5.12.0 \
                 mypy \
                 numpy \
                 pytest \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     -   id: python-check-blanket-type-ignore
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
     -   id: isort
         exclude: docs/
@@ -115,7 +115,7 @@ repos:
         additional_dependencies:
             - 'nbformat<=5.0.8'
             - black==23.1.0
-            - isort==5.11.5
+            - isort==5.12.0
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1


### PR DESCRIPTION
## Motivation and Context

Bump `isort` to `5.12.0`.
The dependency was previously pinned at `5.11.5` due to dropped support of Python 3.7. We have since upgraded Habitat's python version. See https://github.com/facebookresearch/habitat-lab/pull/1107.

## How Has This Been Tested

Tested on CI.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
