### PR TITLE
[CI] - fix doxygen version at 1.9.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ jobs:
               git submodule update --init --recursive --jobs 8
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
-              conda install -y -c conda-forge doxygen
+              conda install -y -c conda-forge doxygen=1.9.5
               conda install -y  jinja2 pygments docutils
               while [ ! -f ~/cuda_installed ]; do sleep 2; done # wait for CUDA
               sudo apt install --allow-change-held-packages \
@@ -477,7 +477,7 @@ jobs:
               pip install -e habitat-lab
 
               cd docs
-              conda install -y -c conda-forge doxygen
+              conda install -y -c conda-forge doxygen=1.9.5
               conda install -y  jinja2 pygments docutils
               ./build-public.sh
       - save_cache:


### PR DESCRIPTION
## Motivation and Context

New Doxygen version 1.9.7 breaks on our doc build system, so fix the version at 1.9.5 for now.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
