### PR TITLE
Fixed bug for directories containing spaces

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -573,7 +573,6 @@ def clone_repo_source(
     split_command = shlex.split(clone_command)
     split_command.append(f"{version_dir}")
 
-    
     print(" ".join(split_command))
 
     subprocess.check_call(split_command)

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -570,10 +570,13 @@ def clone_repo_source(
         clone_command += f"\"{data_sources[uid]['source']}\""
 
     # place the output in the specified directory
-    clone_command += f" {version_dir}"
+    split_command = shlex.split(clone_command)
+    split_command.append(f"{version_dir}")
 
-    print(f"{clone_command}")
-    subprocess.check_call(shlex.split(clone_command))
+    
+    print(" ".join(split_command))
+
+    subprocess.check_call(split_command)
 
     if prune_lfs:
         # NOTE: we make this optional because older git versions don't support "-f --recent"


### PR DESCRIPTION
## Motivation and Context

Previously the code would not work for directories containing spaces (due to a split function being called). This has now been fixed.

For example, if you try to run the command:
`python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path ./Data"` from the directory: `"/Users/vishnesh/Master/Sample Folder With Spaces"`, you get the following [error.](https://drive.google.com/file/d/1w8-jsi95AV8hJ2O60t0sUWSfw1l45KAg/view?usp=sharing)

## How Has This Been Tested

This has been tested by reviewing how the path is split and by running the same command `python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path ./Data"` without any errors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- Would like some confirmation on whether the bug fix follows the code style or if something needs to be changed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
   - (Not sure where to add tests for this bug fix.)
- [ ] All new and existing tests passed.
