### PR TITLE
Disable broken JS test and make --no-web-apps the default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,7 +528,8 @@ jobs:
       - run:
           name: Build Javascript bindings
           command: |
-              # wait for npm and emscripten install
+              # Wait for npm and emscripten install. Note that npm is not strictly
+              # required (see also Run JavaScript tests in this file).
               while [[ ! -f ~/emscripten_installed && ! -f ~/npm_deps_installed ]]; do sleep 2; done
               # switch to cmake 3.20 just for this step. The JS build requires
               # static Bullet libs, and Bullet static libs required CMake 3.13+.
@@ -538,9 +539,8 @@ jobs:
               . ~/.bashrc
               export PATH=$HOME/miniconda/bin:$PATH
               . activate habitat
-              nvm use v11.9.0
               . ~/emsdk/emsdk_env.sh
-              CMAKE_GENERATOR=Ninja ./build_js.sh --bullet
+              CMAKE_GENERATOR=Ninja ./build_js.sh --bullet --no-web-apps
               # switch back to cmake 3.12
               sudo rm /usr/local/bin/cmake
               sudo ln -s /opt/cmake312/bin/cmake /usr/local/bin/cmake
@@ -567,15 +567,17 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
-      - run:
-          name: Run JavaScript tests
-          command: |
-            cd habitat-sim
-            . ~/.bashrc
-            export PATH=$HOME/miniconda/bin:$PATH
-            . activate habitat
-            nvm use v11.9.0
-            npm run test
+
+      # reference code to test our JS build using npm/html/JS
+      # - run:
+      #     name: Run JavaScript tests
+      #     command: |
+      #       cd habitat-sim
+      #       . ~/.bashrc
+      #       export PATH=$HOME/miniconda/bin:$PATH
+      #       . activate habitat
+      #       nvm use v11.9.0
+      #       npm run test
       - run:
           name: Run sim tests
           no_output_timeout: 25m
@@ -608,11 +610,11 @@ jobs:
               ./build.sh --headless --cmake-args='-DCMAKE_CXX_FLAGS="--coverage"'
               PYTHONPATH=src_python pytest -n 4 --durations=10 --cov-report=xml --cov=./ --cov-append tests/test_physics.py tests/test_sensors.py
 
-              . ~/.bashrc
-              nvm use v11.9.0
-              . ~/emsdk/emsdk_env.sh
-              # Generate JS CodeConv
-              npm run test_with_coverage
+              # reference code to generate JS CodeConv
+              # . ~/.bashrc
+              # nvm use v11.9.0
+              # . ~/emsdk/emsdk_env.sh
+              # npm run test_with_coverage
       - run: &upload_coverage
           name: Upload test coverage
           command: |
@@ -624,8 +626,8 @@ jobs:
               #Uploading test coverage for Python code
               ./codecov -f coverage.xml -cF Python
 
-              # Uploading test coverage for JS code
-              ./codecov coverage_js/coverage-final.json -cF JavaScript
+              # reference code for uploading test coverage for JS code
+              # ./codecov coverage_js/coverage-final.json -cF JavaScript
 
               #Uploading test coverage for C++ code
               lcov --directory . --capture --output-file coverage.info


### PR DESCRIPTION
## Motivation and Context

This javascript test is broken, probably just due to timing out. Habitat JS support is still experimental so it's not vital to have this JS tested for now. We'll revisit CI for the JS build in the future.

I'm also making `--no-web-apps` the default for the JS build. This is a simpler build that doesn't rely on npm or webpack and should make the Habitat JS build more accessible and easy to understand for new folks looking to experiment here.

More background and specifics: the Habitat JS build is a version of our C++ library that is emscripten-compiled into a WebAssembly module (a `.wasm` file). This can be imported into a webpage and used by Javascript. Our legacy web apps (bindings.html, viewer.html) are examples of using the Habitat JS build, but they're not a required part of the JS build. 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
