### PR TITLE
--[BUGFIX] Background renderer should not create extra contexts

### DIFF
--- a/src/esp/gfx/BackgroundRenderer.cpp
+++ b/src/esp/gfx/BackgroundRenderer.cpp
@@ -190,8 +190,6 @@ void BackgroundRenderer::runLoopThread() {
 
   threadOwnsContext_ = true;
 
-  // Renderer::setupMagnumFeatures(); // TODO probably also for nothing, drop
-
   threadReleaseContext();
   done_.store(1, std::memory_order_release);
   cpp20::atomic_notify_all(&done_);

--- a/src/esp/gfx/BackgroundRenderer.h
+++ b/src/esp/gfx/BackgroundRenderer.h
@@ -17,9 +17,6 @@
 #include "esp/scene/SceneGraph.h"
 #include "esp/sensor/VisualSensor.h"
 
-#include <Corrade/Containers/Pointer.h>
-#include <Magnum/Platform/GLContext.h>
-
 namespace esp {
 namespace gfx {
 class BackgroundRenderer {
@@ -60,7 +57,6 @@ class BackgroundRenderer {
   bool threadIsWorking_, threadInitialized_;
 
   bool threadOwnsContext_;
-  Corrade::Containers::Pointer<Magnum::Platform::GLContext> threadContext_;
   Task task_;
   std::vector<std::tuple<std::reference_wrapper<sensor::VisualSensor>,
                          std::reference_wrapper<scene::SceneGraph>,


### PR DESCRIPTION
## Motivation and Context
This PR fixes an issue where an additional GL context was being created in the Background Renderer, which was causing problems, including seg faults with [examples/tutorials/async_rendering.py
](https://github.com/facebookresearch/habitat-sim/blob/main/examples/tutorials/async_rendering.py)


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
