### PR TITLE
--[BugFix] GibsonSemanticScene JSON access.

### DIFF
--- a/src/esp/scene/GibsonSemanticScene.cpp
+++ b/src/esp/scene/GibsonSemanticScene.cpp
@@ -69,12 +69,17 @@ bool SemanticScene::buildGibsonHouse(const io::JsonDocument& jsonDoc,
       object->category_ = std::move(category);
     }
 
-    if (jsonObject.HasMember("location")) {
-      const auto& jsonCenter = jsonObject["location"];
+    io::JsonGenericValue::ConstMemberIterator jsonLocIter =
+        jsonObject.FindMember("location");
+    if (jsonLocIter != jsonObject.MemberEnd()) {
+      // if (jsonObject.HasMember("location")) {
+      const auto& jsonCenter = jsonLocIter->value;
       vec3f center = rotation * io::jsonToVec3f(jsonCenter);
       vec3f size = vec3f::Zero();
-      if (jsonObject.HasMember("size")) {
-        const auto& jsonSize = jsonObject["size"];
+      io::JsonGenericValue::ConstMemberIterator jsonSizeIter =
+          jsonObject.FindMember("size");
+      if (jsonSizeIter != jsonObject.MemberEnd()) {
+        const auto& jsonSize = jsonSizeIter->value;
         // Rotating sizes
         size = (rotation * io::jsonToVec3f(jsonSize)).array().abs();
       } else {

--- a/src/esp/scene/GibsonSemanticScene.cpp
+++ b/src/esp/scene/GibsonSemanticScene.cpp
@@ -53,7 +53,7 @@ bool SemanticScene::buildGibsonHouse(const io::JsonDocument& jsonDoc,
       scene.objects_.resize(id + 1, nullptr);
     }
     object->index_ = id;
-
+    // Assuming class_ -always- exists
     const std::string categoryName = jsonObject["class_"].GetString();
     auto it = categories.find(categoryName);
     if (it != categories.end()) {
@@ -69,12 +69,12 @@ bool SemanticScene::buildGibsonHouse(const io::JsonDocument& jsonDoc,
       object->category_ = std::move(category);
     }
 
-    const auto& jsonCenter = jsonObject["location"];
-    if (!jsonCenter.IsNull()) {
+    if (jsonObject.HasMember("location")) {
+      const auto& jsonCenter = jsonObject["location"];
       vec3f center = rotation * io::jsonToVec3f(jsonCenter);
-      const auto& jsonSize = jsonObject["size"];
       vec3f size = vec3f::Zero();
-      if (!jsonSize.IsNull()) {
+      if (jsonObject.HasMember("size")) {
+        const auto& jsonSize = jsonObject["size"];
         // Rotating sizes
         size = (rotation * io::jsonToVec3f(jsonSize)).array().abs();
       } else {


### PR DESCRIPTION
## Motivation and Context
Reading a JSON element should be check exists then read, not attempt to read then check if null, which is what the GibsonSemanticScene attempts to do.  This was failing an assertion in RapidJSON that was only visible if compiled in Debug mode; in Release RapidJSON silenced the assertion and attempted to work around the problem.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests (in both release and debug)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
