### PR TITLE
--[BugFix] Get rid of double JSON lookups using HasMember

### DIFF
--- a/src/esp/io/JsonAllTypes.h
+++ b/src/esp/io/JsonAllTypes.h
@@ -57,11 +57,14 @@ void addMember(rapidjson::Value& value,
 
 template <typename T>
 bool readMember(const rapidjson::Value& value, const char* tag, T& x) {
-  if (!value.HasMember(tag)) {
+  JsonGenericValue::ConstMemberIterator jsonIter = value.FindMember(tag);
+
+  if (jsonIter == value.MemberEnd()) {
     // return false but don't log an error
     return false;
   }
-  if (!fromJsonValue(value[tag], x)) {
+
+  if (!fromJsonValue(jsonIter->value, x)) {
     ESP_ERROR() << "Failed to parse JSON tag \"" << tag << "\"";
     return false;
   }

--- a/src/esp/io/JsonMagnumTypes.h
+++ b/src/esp/io/JsonMagnumTypes.h
@@ -147,7 +147,8 @@ template <typename T>
 bool readMember(const rapidjson::Value& value,
                 const char* name,
                 Corrade::Containers::Optional<T>& x) {
-  if (value.HasMember(name)) {
+  JsonGenericValue::ConstMemberIterator jsonIter = value.FindMember(name);
+  if (jsonIter != value.MemberEnd()) {
     x = T();
     return readMember(value, name, *x);
   } else {

--- a/src/esp/io/JsonStlTypes.h
+++ b/src/esp/io/JsonStlTypes.h
@@ -106,9 +106,10 @@ template <>
 inline bool readMember(const JsonGenericValue& d,
                        const char* tag,
                        std::map<std::string, std::string>& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsObject()) {
-      const auto& jCell = d[tag];
+  JsonGenericValue::ConstMemberIterator jsonIter = d.FindMember(tag);
+  if (jsonIter != d.MemberEnd()) {
+    if (jsonIter->value.IsObject()) {
+      const auto& jCell = jsonIter->value;
       for (rapidjson::Value::ConstMemberIterator it = jCell.MemberBegin();
            it != jCell.MemberEnd(); ++it) {
         const std::string key = it->name.GetString();
@@ -146,9 +147,10 @@ template <>
 inline bool readMember(const JsonGenericValue& d,
                        const char* tag,
                        std::map<std::string, float>& val) {
-  if (d.HasMember(tag)) {
-    if (d[tag].IsObject()) {
-      const auto& jCell = d[tag];
+  JsonGenericValue::ConstMemberIterator jsonIter = d.FindMember(tag);
+  if (jsonIter != d.MemberEnd()) {
+    if (jsonIter->value.IsObject()) {
+      const auto& jCell = jsonIter->value;
       for (rapidjson::Value::ConstMemberIterator it = jCell.MemberBegin();
            it != jCell.MemberEnd(); ++it) {
         const std::string key = it->name.GetString();

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -411,9 +411,12 @@ template <class T, ManagedObjectAccess Access>
 bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
     const attributes::AbstractAttributes::ptr& attribs,
     const io::JsonGenericValue& jsonConfig) const {
+  const std::string subGroupName = "user_defined";
   // check for user defined attributes and verify it is an object
-  if (jsonConfig.HasMember("user_defined")) {
-    if (!jsonConfig["user_defined"].IsObject()) {
+  io::JsonGenericValue::ConstMemberIterator jsonIter =
+      jsonConfig.FindMember(subGroupName.c_str());
+  if (jsonIter != jsonConfig.MemberEnd()) {
+    if (!jsonIter->value.IsObject()) {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << "> : " << attribs->getSimplifiedHandle()
@@ -421,12 +424,11 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
              "is incorrect, so no user_defined attributes are loaded.";
       return false;
     } else {
-      const std::string subGroupName = "user_defined";
       // get pointer to user_defined subgroup configuration
       std::shared_ptr<Configuration> subGroupPtr =
           attribs->getUserConfiguration();
       // get json object referenced by tag subGroupName
-      const io::JsonGenericValue& jsonObj = jsonConfig[subGroupName.c_str()];
+      const io::JsonGenericValue& jsonObj = jsonIter->value;
 
       // count number of valid user config settings found
       int numConfigSettings = subGroupPtr->loadFromJson(jsonObj);

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -71,11 +71,15 @@ void LightLayoutAttributesManager::setValsFromJSONDoc(
       });
 
   // scaling values are required for light instance processing
+
+  io::JsonGenericValue::ConstMemberIterator jsonIter =
+      jsonConfig.FindMember("lights");
+
   bool hasLights =
-      (jsonConfig.HasMember("lights") && jsonConfig["lights"].IsObject());
+      (jsonIter != jsonConfig.MemberEnd()) && (jsonIter->value.IsObject());
 
   if (hasLights) {
-    const auto& lightCell = jsonConfig["lights"];
+    const auto& lightCell = jsonIter->value;
     int count = 0;
     // iterate through objects
     for (rapidjson::Value::ConstMemberIterator it = lightCell.MemberBegin();
@@ -214,8 +218,10 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
   }
 
   // read spotlight params
-  if (jsonConfig.HasMember("spot")) {
-    if (!jsonConfig["spot"].IsObject()) {
+  io::JsonGenericValue::ConstMemberIterator jsonIter =
+      jsonConfig.FindMember("spot");
+  if (jsonIter != jsonConfig.MemberEnd()) {
+    if (!jsonIter->value.IsObject()) {
       // TODO prune NOTE: component when spotlights are supported
       ESP_WARNING()
           << "\"spot\" cell in JSON config unable to be "
@@ -224,7 +230,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
              "ignored and light will be created as a point light.";
     } else {
       // sets values in light instance subconfig "spot"
-      const auto& spotArea = jsonConfig["spot"];
+      const auto& spotArea = jsonIter->value;
       // set inner cone angle
       io::jsonIntoSetter<Magnum::Rad>(
           spotArea, "innerConeAngle",

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -62,11 +62,13 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
   // Check for translation origin.  Default to unknown.
   attribs->setTranslationOrigin(getTranslationOriginVal(jsonConfig));
 
-  // Check for stage instance existence
-  if (jsonConfig.HasMember("stage_instance")) {
-    if (jsonConfig["stage_instance"].IsObject()) {
+  // Check for stage instance existence in scene instance
+  io::JsonGenericValue::ConstMemberIterator stageJSONIter =
+      jsonConfig.FindMember("stage_instance");
+  if (stageJSONIter != jsonConfig.MemberEnd()) {
+    if (stageJSONIter->value.IsObject()) {
       attribs->setStageInstance(
-          createInstanceAttributesFromJSON(jsonConfig["stage_instance"]));
+          createInstanceAttributesFromJSON(stageJSONIter->value));
     } else {
       // stage instance exists but is not a valid JSON Object
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
@@ -99,10 +101,12 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
   }
 
   // Check for object instances existence
-  if (jsonConfig.HasMember("object_instances")) {
+  io::JsonGenericValue::ConstMemberIterator objJSONIter =
+      jsonConfig.FindMember("object_instances");
+  if (objJSONIter != jsonConfig.MemberEnd()) {
     // object_instances tag exists
-    if (jsonConfig["object_instances"].IsArray()) {
-      const auto& objectArray = jsonConfig["object_instances"];
+    if (objJSONIter->value.IsArray()) {
+      const auto& objectArray = objJSONIter->value;
       for (rapidjson::SizeType i = 0; i < objectArray.Size(); ++i) {
         const auto& objCell = objectArray[i];
         if (objCell.IsObject()) {
@@ -133,11 +137,12 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
   }
 
   // Check for articulated object instances existence
-  if (jsonConfig.HasMember("articulated_object_instances")) {
+  io::JsonGenericValue::ConstMemberIterator artObjJSONIter =
+      jsonConfig.FindMember("articulated_object_instances");
+  if (artObjJSONIter != jsonConfig.MemberEnd()) {
     // articulated_object_instances tag exists
-    if (jsonConfig["articulated_object_instances"].IsArray()) {
-      const auto& articulatedObjArray =
-          jsonConfig["articulated_object_instances"];
+    if (artObjJSONIter->value.IsArray()) {
+      const auto& articulatedObjArray = artObjJSONIter->value;
       for (rapidjson::SizeType i = 0; i < articulatedObjArray.Size(); ++i) {
         const auto& artObjCell = articulatedObjArray[i];
 
@@ -174,8 +179,13 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
 
   // Check for PBR/IBL shader region-based configuration specifications
   // existence.
-  if ((jsonConfig.HasMember("pbr_shader_region_configs")) &&
-      (jsonConfig["pbr_shader_region_configs"].IsObject())) {
+
+  io::JsonGenericValue::ConstMemberIterator pbrShaderRegionJSONIter =
+      jsonConfig.FindMember("pbr_shader_region_configs");
+  if ((pbrShaderRegionJSONIter != jsonConfig.MemberEnd()) &&
+      (pbrShaderRegionJSONIter->value.IsObject())) {
+    const auto& articulatedObjArray = artObjJSONIter->value;
+
     // pbr_shader_region_configs tag exists, and should be an object, holding
     // unique region names and the handle to the PbrShaderAttributes to use for
     // that region.
@@ -184,8 +194,7 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
     // pairs, where the key is some region identifier and the value is a
     // string representing the PbrShaderAttributes to use, as specified in the
     // PbrShaderAttributesManager.
-    const auto& pbrShaderRegionHandles =
-        jsonConfig["pbr_shader_region_configs"];
+    const auto& pbrShaderRegionHandles = pbrShaderRegionJSONIter->value;
     int count = 0;
     // iterate through objects
     for (rapidjson::Value::ConstMemberIterator it =
@@ -298,8 +307,10 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
 
   // only used for articulated objects
   // initial joint pose
-  if (jCell.HasMember("initial_joint_pose")) {
-    if (jCell["initial_joint_pose"].IsArray()) {
+  io::JsonGenericValue::ConstMemberIterator jntPoseJSONIter =
+      jCell.FindMember("initial_joint_pose");
+  if (jntPoseJSONIter != jCell.MemberEnd()) {
+    if (jntPoseJSONIter->value.IsArray()) {
       std::vector<float> poseRes;
       // read values into vector
       io::readMember<float>(jCell, "initial_joint_pose", poseRes);
@@ -309,7 +320,7 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
         instanceAttrs->addInitJointPoseVal(key, v);
       }
 
-    } else if (jCell["initial_joint_pose"].IsObject()) {
+    } else if (jntPoseJSONIter->value.IsObject()) {
       // load values into map
       io::readMember<std::map<std::string, float>>(
           jCell, "initial_joint_pose", instanceAttrs->copyIntoInitJointPose());
@@ -322,8 +333,10 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
   }
   // only used for articulated objects
   // initial joint velocities
-  if (jCell.HasMember("initial_joint_velocities")) {
-    if (jCell["initial_joint_velocities"].IsArray()) {
+  io::JsonGenericValue::ConstMemberIterator jntVelJSONIter =
+      jCell.FindMember("initial_joint_velocities");
+  if (jntVelJSONIter != jCell.MemberEnd()) {
+    if (jntVelJSONIter->value.IsArray()) {
       std::vector<float> poseRes;
       // read values into vector
       io::readMember<float>(jCell, "initial_joint_velocities", poseRes);
@@ -333,7 +346,7 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
         instanceAttrs->addInitJointVelocityVal(key, v);
       }
 
-    } else if (jCell["initial_joint_velocities"].IsObject()) {
+    } else if (jntVelJSONIter->value.IsObject()) {
       // load values into map
       io::readMember<std::map<std::string, float>>(
           jCell, "initial_joint_velocities",

--- a/src/esp/scene/ReplicaSemanticScene.cpp
+++ b/src/esp/scene/ReplicaSemanticScene.cpp
@@ -32,7 +32,10 @@ bool SemanticScene::loadReplicaHouse(
   ESP_VERY_VERBOSE() << "Parsed.";
 
   // check if Replica or ReplicaCAD
-  bool hasObjects = (json.HasMember("objects") && json["objects"].IsArray());
+  io::JsonGenericValue::ConstMemberIterator replicaObjIter =
+      json.FindMember("objects");
+  bool hasObjects =
+      (replicaObjIter != json.MemberEnd()) && (replicaObjIter->value.IsArray());
 
   return buildReplicaHouse(json, scene, hasObjects, worldRotation);
 

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -51,11 +51,20 @@ bool SemanticScene::
         // if not successful then attempt to load known json files
         const io::JsonDocument& jsonDoc = io::parseJsonFile(ssdFileName);
         // if no error thrown, then we have loaded a json file of given name
-        bool hasCorrectObjects =
-            (jsonDoc.HasMember("objects") && jsonDoc["objects"].IsArray());
+
+        io::JsonGenericValue::ConstMemberIterator hasJsonObjIter =
+            jsonDoc.FindMember("objects");
+
+        bool hasCorrectObjects = (hasJsonObjIter != jsonDoc.MemberEnd() &&
+                                  hasJsonObjIter->value.IsArray());
+
+        io::JsonGenericValue::ConstMemberIterator hasJsonClassIter =
+            jsonDoc.FindMember("classes");
+
         // check if also has "classes" tag, otherwise will assume it is a
         // gibson file
-        if (jsonDoc.HasMember("classes") && jsonDoc["classes"].IsArray()) {
+        if (hasJsonClassIter != jsonDoc.MemberEnd() &&
+            hasJsonClassIter->value.IsArray()) {
           // attempt to load replica or replicaCAD if has classes (replicaCAD
           // does not have objects in SSDescriptor)
           success =


### PR DESCRIPTION
## Motivation and Context
Using HasMember and then subsequently accessing a JSON value does a double lookup in the JSON document string. Using FindMember will provide an iterator pointing to the desired value or the end of the document if not found.  

This PR replaces HasMember lookups with iterator-based FindMember ones.  Note : those that remain in URDFParser and SceneDatasetAttributesManager will be removed in the [Articulated Object Attributes/Manager PR](https://github.com/facebookresearch/habitat-sim/pull/2178). 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
<!--- Please describe here how your modifications have been tested. -->
All Tests in c++ and python pass locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
