### PR TITLE
[BE] - Error messages for physics specific API calls without implementation

### DIFF
--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -488,7 +488,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED bool maintainLinkOrder = false,
       CORRADE_UNUSED bool intertiaFromURDF = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    ESP_DEBUG() << "Not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
     return ID_UNDEFINED;
   }
 
@@ -528,7 +529,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED bool maintainLinkOrder = false,
       CORRADE_UNUSED bool intertiaFromURDF = false,
       CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    ESP_DEBUG() << "Not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
     return ID_UNDEFINED;
   }
 
@@ -701,11 +703,13 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   virtual void performDiscreteCollisionDetection() {
     /*Does nothing in base PhysicsManager.*/
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
   }
 
   /**
    * @brief Query the number of contact points that were active during the
-   * collision detection check.
+   * most recent collision detection check.
    *
    * Not implemented for default PhysicsManager.
    * @return the number of active contact points.
@@ -789,6 +793,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   virtual RaycastResults castRay(const esp::geo::Ray& ray,
                                  CORRADE_UNUSED double maxDistance = 100.0) {
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
     RaycastResults results;
     results.ray = ray;
     return results;
@@ -844,7 +850,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   virtual int createRigidConstraint(
       CORRADE_UNUSED const RigidConstraintSettings& settings) {
-    ESP_ERROR() << "Not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
     return ID_UNDEFINED;
   }
 
@@ -859,7 +866,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   virtual void updateRigidConstraint(
       CORRADE_UNUSED int constraintId,
       CORRADE_UNUSED const RigidConstraintSettings& settings) {
-    ESP_ERROR() << "Not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
   }
 
   /**
@@ -870,7 +878,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @param constraintId The id of the constraint to remove.
    */
   virtual void removeRigidConstraint(CORRADE_UNUSED int constraintId) {
-    ESP_ERROR() << "Not implemented in base PhysicsManager.";
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
   }
 
   /**

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -149,7 +149,11 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * @return Whether or not the object is in contact with any other collision
    * enabled objects.
    */
-  virtual bool contactTest() { return false; }
+  virtual bool contactTest() {
+    ESP_ERROR()
+        << "Not implemented. Install with --bullet to use this feature.";
+    return false;
+  }
 
   /**
    * @brief Manually set the collision group for an object.

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -99,7 +99,10 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * coordinate system relative to the object's center of mass.
    */
   virtual void applyForce(CORRADE_UNUSED const Magnum::Vector3& force,
-                          CORRADE_UNUSED const Magnum::Vector3& relPos) {}
+                          CORRADE_UNUSED const Magnum::Vector3& relPos) {
+    ESP_ERROR()
+        << "Not implemented. Install with --bullet to use this feature.";
+  }
 
   /**
    * @brief Apply an impulse to an object through a dervied dynamics
@@ -113,7 +116,10 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * coordinate system relative to the object's center of mass.
    */
   virtual void applyImpulse(CORRADE_UNUSED const Magnum::Vector3& impulse,
-                            CORRADE_UNUSED const Magnum::Vector3& relPos) {}
+                            CORRADE_UNUSED const Magnum::Vector3& relPos) {
+    ESP_ERROR()
+        << "Not implemented. Install with --bullet to use this feature.";
+  }
 
   /**
    * @brief Apply an internal torque to an object through a dervied dynamics
@@ -122,7 +128,10 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * @param torque The desired torque on the object in the local coordinate
    * system.
    */
-  virtual void applyTorque(CORRADE_UNUSED const Magnum::Vector3& torque) {}
+  virtual void applyTorque(CORRADE_UNUSED const Magnum::Vector3& torque) {
+    ESP_ERROR()
+        << "Not implemented. Install with --bullet to use this feature.";
+  }
   /**
    * @brief Apply an internal impulse torque to an object through a dervied
    * dynamics implementation. Does nothing for @ref
@@ -133,7 +142,10 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
    * requiring integration through simulation.
    */
   virtual void applyImpulseTorque(
-      CORRADE_UNUSED const Magnum::Vector3& impulse) {}
+      CORRADE_UNUSED const Magnum::Vector3& impulse) {
+    ESP_ERROR()
+        << "Not implemented. Install with --bullet to use this feature.";
+  }
 
   // ==== Getter/Setter functions ===
 

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -316,7 +316,7 @@ class AbstractManagedPhysicsObject
     std::shared_ptr<T> sp = weakObjRef_.lock();
     if (!sp) {
       // TODO: Verify object is removed from manager here?
-      ESP_WARNING()
+      ESP_ERROR()
           << "This object no longer exists.  Please delete any variable "
              "references.";
     }


### PR DESCRIPTION
## Motivation and Context

Physics API calls made without Bullet installed or active return default values. This can cause confusion for users when the code runs, but returns unexpected values. For example, it should be clear that there are no ray cast hits because physics is not available rather than because the ray did not hit anything.

There could be an argument to make these warnings instead of errors. In either case, the code executes rather than crashing. 

## How Has This Been Tested

Locally in viewer application. CI test without physics active.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
