### PR TITLE
--[Bugfix] Add new fields to test asset `skinned_prism.ao_config.json`.

### DIFF
--- a/data/test_assets/urdf/skinned_prism.ao_config.json
+++ b/data/test_assets/urdf/skinned_prism.ao_config.json
@@ -1,5 +1,9 @@
 {
   "render_asset": "../objects/skinned_prism.glb",
   "semantic_id": 100,
-  "debug_render_primitives": false
+  "base_type": "free",
+  "inertia_source": "computed",
+  "link_order": "tree_traversal",
+  "render_mode": "default",
+  "shader_type": "phong"
 }


### PR DESCRIPTION
## Motivation and Context
This PR removes a deprecated field and adds the new fields introduced in [the "ArticulatedObject attributes and managers" PR](https://github.com/facebookresearch/habitat-sim/pull/2178) to the test asset "data/test_assets/urdf/skinned_prism.ao_config.json", except for "urdf_filepath" which is purposely left blank to test that the config load process will successfully find the pertinent urdf, which must reside in the same directory as the json config if it is not specified explicitly in the json.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
