### PR TITLE
--[BE/Bugfix]Modify creation of Articulated Object from URDF file name.

### DIFF
--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -486,13 +486,17 @@ int PhysicsManager::addArticulatedObjectFromURDF(
     const std::string& lightSetup) {
   // Retrieve or create the appropriate ArticulatedObjectAttributes to create
   // this AO.
-  esp::metadata::attributes::ArticulatedObjectAttributes::ptr artObjAttributes =
-      resourceManager_.getAOAttributesManager()->getObjectCopyByHandle(
+
+  bool attribsFound =
+      resourceManager_.getAOAttributesManager()->getObjectLibHasHandle(
           filepath);
-  if (!artObjAttributes) {
-    artObjAttributes =
-        resourceManager_.getAOAttributesManager()->createObject(filepath, true);
-  }
+
+  esp::metadata::attributes::ArticulatedObjectAttributes::ptr artObjAttributes =
+      attribsFound
+          ? resourceManager_.getAOAttributesManager()->getObjectCopyByHandle(
+                filepath)
+          : resourceManager_.getAOAttributesManager()->createObject(filepath,
+                                                                    true);
 
   // Set pertinent values
   artObjAttributes->setUniformScale(globalScale);


### PR DESCRIPTION
All AO creation is driven by ArticulatedObjectAttributes now, with the caveat that to be used, any ArticulatedObjectAttributes must reference an existing and legitimate URDF file by relative path name from which to actually build the AO. ArticulatedObjectAttributes can be created using the name of their corresponding URDF file, in which case they will reference -that- URDF, and there is no need to complain if there is no existing ArticulatedObjectAttributes matching that name, since a legal one will be created .  This PR removes the erroneous and potentially misleading complaint, and proceeds silently to make a new ArticulatedObjectAttributes referencing the passed URDF file if one does not already exist.

This was peeled off [this PR, to minimize topical divergence.](https://github.com/facebookresearch/habitat-sim/pull/2189)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All C++ and python tests pass (it's just a message change)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
