### PR TITLE
Add option to toggle frustum culling in replay renderer.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -379,6 +379,9 @@ void initSimBindings(py::module& m) {
           R"(List of sensor specifications for one simulator. For batch rendering, all simulators must have the same specification.)")
       .def_readwrite("gpu_device_id", &ReplayRendererConfiguration::gpuDeviceId,
                      R"(The system GPU device to use for rendering)")
+      .def_readwrite("enable_frustum_culling",
+                     &ReplayRendererConfiguration::enableFrustumCulling,
+                     R"(Controls whether frustum culling is enabled.)")
       .def_readwrite(
           "force_separate_semantic_scene_graph",
           &ReplayRendererConfiguration::forceSeparateSemanticSceneGraph,

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -55,6 +55,8 @@ class ReplayRendererConfiguration {
    */
   bool leaveContextWithBackgroundRenderer = false;
 
+  bool enableFrustumCulling = true;
+
   std::vector<std::shared_ptr<sensor::SensorSpec>> sensorSpecifications;
 
   ESP_SMART_POINTERS(ReplayRendererConfiguration)

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -236,11 +236,14 @@ void ClassicReplayRenderer::doRender(
       }
 
 #ifdef ESP_BUILD_WITH_BACKGROUND_RENDERER
+      esp::gfx::RenderCamera::Flags flags{};
+      if (config_.enableFrustumCulling) {
+        flags |= gfx::RenderCamera::Flag::FrustumCulling;
+      }
+
       if (imageViews.size() > 0) {
-        renderer_->enqueueAsyncDrawJob(
-            visualSensor, sceneGraph, imageViews[envIndex],
-            esp::gfx::RenderCamera::Flags{
-                gfx::RenderCamera::Flag::FrustumCulling});
+        renderer_->enqueueAsyncDrawJob(visualSensor, sceneGraph,
+                                       imageViews[envIndex], flags);
       }
 #else
       // TODO what am I supposed to do here?
@@ -258,6 +261,10 @@ void ClassicReplayRenderer::doRender(
 void ClassicReplayRenderer::doRender(
     Magnum::GL::AbstractFramebuffer& framebuffer) {
   const Mn::Vector2i gridSize = environmentGridSize(config_.numEnvironments);
+  esp::gfx::RenderCamera::Flags flags{};
+  if (config_.enableFrustumCulling) {
+    flags |= gfx::RenderCamera::Flag::FrustumCulling;
+  }
 
   for (int envIndex = 0; envIndex < config_.numEnvironments; envIndex++) {
     auto& sensorMap = getEnvironmentSensors(envIndex);
@@ -269,9 +276,8 @@ void ClassicReplayRenderer::doRender(
     visualSensor.renderTarget().renderEnter();
 
     auto& sceneGraph = getSceneGraph(envIndex);
-    renderer_->draw(
-        *visualSensor.getRenderCamera(), sceneGraph,
-        esp::gfx::RenderCamera::Flags{gfx::RenderCamera::Flag::FrustumCulling});
+
+    renderer_->draw(*visualSensor.getRenderCamera(), sceneGraph, flags);
 
     if (envIndex == 0 && debugLineRender_) {
       auto* camera = visualSensor.getRenderCamera();

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -24,6 +24,7 @@ ClassicReplayRenderer::ClassicReplayRenderer(
   config_ = cfg;
   SimulatorConfiguration simConfig;
   simConfig.createRenderer = true;
+  simConfig.frustumCulling = cfg.enableFrustumCulling;
   auto metadataMediator = metadata::MetadataMediator::create(simConfig);
   resourceManager_ =
       std::make_unique<assets::ResourceManager>(std::move(metadataMediator));


### PR DESCRIPTION
## Motivation and Context

This changeset adds a config option to disable culling for replay renderers.

The classic replay renderer currently has an issue related to frustum culling. This allows to work-around the issue for immediate needs.

## How Has This Been Tested

Tested locally in Python viewer.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
