### PR TITLE
[CI] - add spot robot assets to CI test set

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -337,6 +337,7 @@ def initialize_test_data_sources(data_path):
             "replica_cad_dataset",
             "hab_fetch",
             "hab_stretch",
+            "hab_spot_arm",
         ],
         "rearrange_task_assets": [
             "replica_cad_dataset",


### PR DESCRIPTION
## Motivation and Context

CI lab test is failing due to missing test asset required by changes in https://github.com/facebookresearch/habitat-lab/pull/1543. Adding that asset appears to resolve the issue.

Thanks @ASzot for the suggested fix.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
