### PR TITLE
--[Habitat3.0] Removal of out-of-date/deprecated flags for IBL

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -1124,11 +1124,6 @@ if __name__ == "__main__":
         help="Override configured lighting to use default lighting for the stage.",
     )
     parser.add_argument(
-        "--ibl",
-        action="store_true",
-        help="Enable image-based lighting. Only applicable to scenes built with PBR materials.",
-    )
-    parser.add_argument(
         "--enable-batch-renderer",
         action="store_true",
         help="Enable batch rendering mode. The number of concurrent environments is specified with the num-environments parameter.",
@@ -1178,7 +1173,6 @@ if __name__ == "__main__":
     sim_settings["composite_files"] = args.composite_files
     sim_settings["window_width"] = args.width
     sim_settings["window_height"] = args.height
-    sim_settings["pbr_image_based_lighting"] = args.ibl
     sim_settings["default_agent_navmesh"] = False
 
     # start the application

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -99,10 +99,6 @@ void initSimBindings(py::module& m) {
       .def_readwrite(
           "navmesh_settings", &SimulatorConfiguration::navMeshSettings,
           R"(Optionally provide a pre-configured NavMeshSettings. If provided, the NavMesh will be recomputed with the provided settings if: A. no NavMesh was loaded, or B. the loaded NavMesh's settings differ from the configured settings. If not provided, no NavMesh recompute will be done automatically.)")
-      .def_readwrite(
-          "pbr_image_based_lighting",
-          &SimulatorConfiguration::pbrImageBasedLighting,
-          R"(DEPRECATED : Use PbrShaderAttributes to specify whether IBL is enabled or disabled.)")
       .def(py::self == py::self)
       .def(py::self != py::self);
 

--- a/src/esp/sim/SimulatorConfiguration.h
+++ b/src/esp/sim/SimulatorConfiguration.h
@@ -87,12 +87,6 @@ struct SimulatorConfiguration {
   std::string sceneLightSetupKey = esp::NO_LIGHT_KEY;
 
   /**
-   * @brief Setup the image based lighting for pbr rendering. @deprecated use
-   * configs to enable/disable IBL.
-   */
-  bool pbrImageBasedLighting = false;
-
-  /**
    * @brief Use texture-based semantics if the specified asset/dataset support
    * them.
    */

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -862,10 +862,6 @@ Viewer::Viewer(const Arguments& arguments)
       .addOption("agent-transform-filepath")
       .setHelp("agent-transform-filepath",
                "Specify path to load camera transform from.")
-      .addBooleanOption("ibl")
-      .setHelp("ibl",
-               "Image Based Lighting (it works only when PBR models exist in "
-               "the scene.")
       .parse(arguments.argc, arguments.argv);
 
   const auto viewportSize = Mn::GL::defaultFramebuffer.viewport().size();
@@ -995,9 +991,6 @@ Viewer::Viewer(const Arguments& arguments)
   ESP_DEBUG() << "Scene Dataset Configuration file location :"
               << simConfig_.sceneDatasetConfigFile
               << "| Loading Scene :" << simConfig_.activeSceneName;
-
-  // image based lighting (PBR)
-  simConfig_.pbrImageBasedLighting = args.isSet("ibl");
 
   // create simulator instance
   simulator_ = esp::sim::Simulator::create_unique(simConfig_, MM_);

--- a/src_python/habitat_sim/utils/settings.py
+++ b/src_python/habitat_sim/utils/settings.py
@@ -57,7 +57,6 @@ default_sim_settings: Dict[str, Any] = {
     "default_agent_navmesh": True,
     # if configuring a navmesh, should STATIC MotionType objects be included
     "navmesh_include_static_objects": False,
-    "pbr_image_based_lighting": False,
 }
 # [/default_sim_settings]
 
@@ -84,7 +83,6 @@ def make_cfg(settings: Dict[str, Any]):
         sim_cfg.physics_config_file = settings["physics_config_file"]
     if "scene_light_setup" in settings:
         sim_cfg.scene_light_setup = settings["scene_light_setup"]
-    sim_cfg.pbr_image_based_lighting = settings.get("pbr_image_based_lighting", False)
     sim_cfg.gpu_device_id = 0
 
     if not hasattr(sim_cfg, "scene_id"):


### PR DESCRIPTION
## Motivation and Context
IBL is now enabled and balanced against direct lighting in the PBR shader by settings in xxx.pbr_config.json files and programmatically via PbrShaderAttributes configurations. 

These flags have been ignored since the [IBL rework was merged here](https://github.com/facebookresearch/habitat-sim/pull/2155) but this PR removes them.

NOTE : This is a breaking change, in that any code that is setting the flag will now break. Any code doing this can be removed without issue, since whatever the flag is set to has been ignored since the PBR/IBL rework.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
