### PR TITLE
--[BUGFIX] -Ellipses in paths

### DIFF
--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -23,8 +23,33 @@ std::string changeExtension(const std::string& filename,
 
 }  // changeExtension
 
+std::string filterPath(const std::string& srcPath) {
+  std::size_t ellipsisLoc = srcPath.find("/../");
+  if ((ellipsisLoc == std::string::npos) || (ellipsisLoc == 0)) {
+    // not found
+    return srcPath;
+  }
+  // ellipsisLoc is location of first instance of "/../"
+  // Get rid of ellipsis inside a specified path, and the previous directory
+  // it references, so that if the ellisis spans a link, consumers don't get
+  // lost.
+
+  // Get end of path/filename after location of ellipsis
+  auto suffixString = srcPath.substr(ellipsisLoc + 4);
+  // Get beginning of path up to directory before ellipsis
+  std::size_t prevLoc = srcPath.find_last_of('/', ellipsisLoc - 1);
+  // Get paths leading up to ellipsis-cancelled path
+  auto prefixString = srcPath.substr(0, prevLoc);
+  // recurses to get subsequent ellipses.
+  auto filteredPath = Cr::Utility::formatString("{}/{}", prefixString,
+                                                filterPath(suffixString));
+  return filteredPath;
+}  // filterPath
+
 std::vector<std::string> globDirs(const std::string& pattern) {
+  // Check for ellipsis, if so process here.
   glob_t glob_result;
+
   glob(pattern.c_str(), GLOB_MARK, nullptr, &glob_result);
   std::vector<std::string> ret(glob_result.gl_pathc);
   for (int i = 0; i < glob_result.gl_pathc; ++i) {

--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -23,7 +23,7 @@ std::string changeExtension(const std::string& filename,
 
 }  // changeExtension
 
-std::string filterPath(const std::string& srcPath) {
+std::string normalizePath(const std::string& srcPath) {
   std::size_t ellipsisLoc = srcPath.find("/../");
   if ((ellipsisLoc == std::string::npos) || (ellipsisLoc == 0)) {
     // not found
@@ -42,9 +42,9 @@ std::string filterPath(const std::string& srcPath) {
   auto prefixString = srcPath.substr(0, prevLoc);
   // recurses to get subsequent ellipses.
   auto filteredPath = Cr::Utility::formatString("{}/{}", prefixString,
-                                                filterPath(suffixString));
+                                                normalizePath(suffixString));
   return filteredPath;
-}  // filterPath
+}  // normalizePath
 
 std::vector<std::string> globDirs(const std::string& pattern) {
   // Check for ellipsis, if so process here.

--- a/src/esp/io/Io.h
+++ b/src/esp/io/Io.h
@@ -28,7 +28,7 @@ std::string changeExtension(const std::string& file, const std::string& ext);
  * @param srcPath The path to filter
  * @return The filtered path.
  */
-std::string filterPath(const std::string& srcPath);
+std::string normalizePath(const std::string& srcPath);
 
 /**
  * @brief This function will perform [glob-based pattern matching]

--- a/src/esp/io/Io.h
+++ b/src/esp/io/Io.h
@@ -20,10 +20,11 @@ namespace io {
 std::string changeExtension(const std::string& file, const std::string& ext);
 
 /**
- * @brief This function will remove any ellipsis in paths or path patterns, as
- * well as the parent directory the ellisis is bypassing. This is so that if the
- * ellipsis spans an OS link any function consuming the path does not get lost.
- * If the ellipsis is at the beginning of @p srcPath then it is ignored.
+ * @brief This function will recursively remove any ellipsis in paths or path
+ * patterns, as well as the parent directory the ellisis is bypassing. This is
+ * so that if the ellipsis spans an OS link any function consuming the path does
+ * not get lost. If the ellipsis is at the beginning of @p srcPath then it is
+ * ignored.
  * @param srcPath The path to filter
  * @return The filtered path.
  */

--- a/src/esp/io/Io.h
+++ b/src/esp/io/Io.h
@@ -20,6 +20,16 @@ namespace io {
 std::string changeExtension(const std::string& file, const std::string& ext);
 
 /**
+ * @brief This function will remove any ellipsis in paths or path patterns, as
+ * well as the parent directory the ellisis is bypassing. This is so that if the
+ * ellipsis spans an OS link any function consuming the path does not get lost.
+ * If the ellipsis is at the beginning of @p srcPath then it is ignored.
+ * @param srcPath The path to filter
+ * @return The filtered path.
+ */
+std::string filterPath(const std::string& srcPath);
+
+/**
  * @brief This function will perform [glob-based pattern matching]
  * (https://en.wikipedia.org/wiki/Glob_(programming)) to find and return all the
  * files and directories that match the pattern.

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -370,7 +370,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
           << ". Skipping.";
       continue;
     }
-    std::string absolutePath = io::filterPath(
+    std::string absolutePath = io::normalizePath(
         Cr::Utility::Path::join(configDir, filePaths[i].GetString()));
     std::vector<std::string> globPaths = io::globDirs(absolutePath);
     if (globPaths.size() > 0) {

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -362,6 +362,7 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const std::string& configDir,
     const std::string& extType,
     const io::JsonGenericValue& filePaths) {
+  std::size_t cfgLastDirLoc = configDir.find_last_of('/');
   for (rapidjson::SizeType i = 0; i < filePaths.Size(); ++i) {
     if (!filePaths[i].IsString()) {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
@@ -370,21 +371,33 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
           << ". Skipping.";
       continue;
     }
-    std::string absolutePath = io::normalizePath(
-        Cr::Utility::Path::join(configDir, filePaths[i].GetString()));
-    std::vector<std::string> globPaths = io::globDirs(absolutePath);
+    const char* fileString = filePaths[i].GetString();
+    // Only normalize paths for paths from config starting with ellipses.
+    // This is so that glob doesn't fail when the filepath from the config is
+    // trying to back-pedal across an OS link.
+    bool normalizePaths = (fileString[0] == '.') && (fileString[1] == '.') &&
+                          (fileString[2] == '/');
+
+    // TODO Eventually we should normalize all metadata paths in the system
+    std::string dsFilePath =
+        normalizePaths
+            ? Cr::Utility::Path::join(configDir.substr(0, cfgLastDirLoc),
+                                      std::string(fileString).substr(3))
+            : Cr::Utility::Path::join(configDir, fileString);
+
+    std::vector<std::string> globPaths = io::globDirs(dsFilePath);
     if (globPaths.size() > 0) {
       for (const auto& globPath : globPaths) {
-        // load all object templates available as configs in absolutePath
+        // load all object templates available as configs in dsFilePath
         ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
             << "<" << this->objectType_ << "> : Glob path result for"
-            << absolutePath << ":" << globPath;
+            << dsFilePath << ":" << globPath;
         this->loadAllTemplatesFromPathAndExt(globPath, extType, true);
       }
     } else {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_ << "> : No Glob path result found for `"
-          << absolutePath << "` so unable to load templates from that path.";
+          << dsFilePath << "` so unable to load templates from that path.";
     }
   }
   ESP_DEBUG(Mn::Debug::Flag::NoSpace)

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -364,20 +364,21 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const io::JsonGenericValue& filePaths) {
   for (rapidjson::SizeType i = 0; i < filePaths.Size(); ++i) {
     if (!filePaths[i].IsString()) {
-      ESP_WARNING() << "<" << this->objectType_
-                    << "> : Invalid path value in file path array element @ idx"
-                    << i << ". Skipping.";
+      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+          << "<" << this->objectType_
+          << "> : Invalid path value in file path array element @ idx" << i
+          << ". Skipping.";
       continue;
     }
-    std::string absolutePath =
-        Cr::Utility::Path::join(configDir, filePaths[i].GetString());
+    std::string absolutePath = io::filterPath(
+        Cr::Utility::Path::join(configDir, filePaths[i].GetString()));
     std::vector<std::string> globPaths = io::globDirs(absolutePath);
     if (globPaths.size() > 0) {
       for (const auto& globPath : globPaths) {
         // load all object templates available as configs in absolutePath
-        ESP_VERY_VERBOSE() << "<" << this->objectType_
-                           << "> : Glob path result for" << absolutePath << ":"
-                           << globPath;
+        ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+            << "<" << this->objectType_ << "> : Glob path result for"
+            << absolutePath << ":" << globPath;
         this->loadAllTemplatesFromPathAndExt(globPath, extType, true);
       }
     } else {

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -102,29 +102,29 @@ void IOTest::fileReplaceExtTest() {
 
 void IOTest::testEllipsisFilter() {
   std::string testPath1 = "/test/path/to/test/no-op.txt";
-  std::string res = esp::io::filterPath(testPath1);
+  std::string res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "/test/path/to/test/no-op.txt");
 
   testPath1 = "/test/path/DELETE/../to/test/removal.txt";
-  res = esp::io::filterPath(testPath1);
+  res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "/test/path/to/test/removal.txt");
   testPath1 =
       "/test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
-  res = esp::io::filterPath(testPath1);
+  res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "/test/path/to/test/multiple/removal.txt");
 
   testPath1 = "test/path/DELETE/../to/test/removal.txt";
-  res = esp::io::filterPath(testPath1);
+  res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "test/path/to/test/removal.txt");
 
   testPath1 =
       "test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
-  res = esp::io::filterPath(testPath1);
+  res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "test/path/to/test/multiple/removal.txt");
 
   // ignore intitial ellipsis
   testPath1 = "/../test/path/DELETE/../to/test/initial/ignore.txt";
-  res = esp::io::filterPath(testPath1);
+  res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "/../test/path/DELETE/../to/test/initial/ignore.txt");
 
 }  // IOTest::testEllipsisFilter

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -27,6 +27,7 @@ const std::string dataDir = Corrade::Utility::Path::join(SCENE_DATASETS, "../");
 struct IOTest : Cr::TestSuite::Tester {
   explicit IOTest();
   void fileReplaceExtTest();
+  void testEllipsisFilter();
   void parseURDF();
   void testJson();
   void testJsonBuiltinTypes();
@@ -50,7 +51,8 @@ struct IOTest : Cr::TestSuite::Tester {
 };
 
 IOTest::IOTest() {
-  addTests({&IOTest::fileReplaceExtTest, &IOTest::parseURDF, &IOTest::testJson,
+  addTests({&IOTest::fileReplaceExtTest, &IOTest::testEllipsisFilter,
+            &IOTest::parseURDF, &IOTest::testJson,
             &IOTest::testJsonBuiltinTypes, &IOTest::testJsonStlTypes,
             &IOTest::testJsonMagnumTypes, &IOTest::testJsonEspTypes,
             &IOTest::testJsonUserType});
@@ -97,6 +99,35 @@ void IOTest::fileReplaceExtTest() {
   result = esp::io::changeExtension(cornerCase, cornerCaseExt);
   CORRADE_COMPARE(result, ".jpg.png");
 }
+
+void IOTest::testEllipsisFilter() {
+  std::string testPath1 = "/test/path/to/test/no-op.txt";
+  std::string res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "/test/path/to/test/no-op.txt");
+
+  testPath1 = "/test/path/DELETE/../to/test/removal.txt";
+  res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "/test/path/to/test/removal.txt");
+  testPath1 =
+      "/test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
+  res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "/test/path/to/test/multiple/removal.txt");
+
+  testPath1 = "test/path/DELETE/../to/test/removal.txt";
+  res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "test/path/to/test/removal.txt");
+
+  testPath1 =
+      "test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
+  res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "test/path/to/test/multiple/removal.txt");
+
+  // ignore intitial ellipsis
+  testPath1 = "/../test/path/DELETE/../to/test/initial/ignore.txt";
+  res = esp::io::filterPath(testPath1);
+  CORRADE_COMPARE(res, "/../test/path/DELETE/../to/test/initial/ignore.txt");
+
+}  // IOTest::testEllipsisFilter
 
 void IOTest::parseURDF() {
   const std::string iiwaURDF = Cr::Utility::Path::join(


### PR DESCRIPTION
## Motivation and Context
If an ellipsis is specified in a path and this ellipsis attempts to back-step across an OS link, functions that attempt to read this path will get lost. On such function we use is **glob()**.  Such path configurations may be present in our scene dataset configurations, where the user might wish to access assets from another installed dataset that requires navigating to their directory outside the current dataset directory.

This PR adds a function that recursively removes ellipses if it can remove their parent directory (so a path with leading ellipses would be ignored). Tests are also added to verify functionality, and the path data being used for glob calls is now being appropriately filtered, albeit only in the case where the path within the scene dataset config path list starts with leading ellipses (in order to access assets or configs in another dataset, for instance). 

For a future TODO I want to normalize all the metadata paths in the system, but that is outside the scope of what I need to do for Habitat 3.0 right now.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally (c++ test cases have been added to test the functionality)
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
