### PR TITLE
--[BE/Bugfix]properly handle multiple sequential ellipses

### DIFF
--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -41,9 +41,9 @@ std::string normalizePath(const std::string& srcPath) {
   // Get paths leading up to ellipsis-cancelled path
   auto prefixString = srcPath.substr(0, prevLoc);
   // recurses to get subsequent ellipses.
-  auto filteredPath = Cr::Utility::formatString("{}/{}", prefixString,
-                                                normalizePath(suffixString));
-  return filteredPath;
+  auto filteredPath =
+      Cr::Utility::formatString("{}/{}", prefixString, suffixString);
+  return normalizePath(filteredPath);
 }  // normalizePath
 
 std::vector<std::string> globDirs(const std::string& pattern) {

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -108,6 +108,7 @@ void IOTest::testEllipsisFilter() {
   testPath1 = "/test/path/DELETE/../to/test/removal.txt";
   res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "/test/path/to/test/removal.txt");
+
   testPath1 =
       "/test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
   res = esp::io::normalizePath(testPath1);
@@ -121,6 +122,12 @@ void IOTest::testEllipsisFilter() {
       "test/path/DELETE/../to/DELETE/../test/DELETE/../multiple/removal.txt";
   res = esp::io::normalizePath(testPath1);
   CORRADE_COMPARE(res, "test/path/to/test/multiple/removal.txt");
+
+  testPath1 =
+      "/test/path/DELETE/DELETE2/DELETE3/../../../to/DELETE/DELETE2/../../test/"
+      "DELETE/../consecutive/removal.txt";
+  res = esp::io::normalizePath(testPath1);
+  CORRADE_COMPARE(res, "/test/path/to/test/consecutive/removal.txt");
 
   // ignore intitial ellipsis
   testPath1 = "/../test/path/DELETE/../to/test/initial/ignore.txt";


### PR DESCRIPTION
## Motivation and Context
[This PR](https://github.com/facebookresearch/habitat-sim/pull/2218) from yesterday added a path normalization feature to fix ellipses in a path that might span a link, where the backstep would be local to the link destination directory and not the directory holding the link.  This PR modifies this to properly handle sequences of ellispses, so long as the provided path sequence has named subdirs corresponding to each ellipsis.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python. C++ test has been expanded to test this functionality.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
