### PR TITLE
Fix wrong instance structures in replay renderer test.

### DIFF
--- a/src/tests/BatchReplayRendererTest.cpp
+++ b/src/tests/BatchReplayRendererTest.cpp
@@ -208,7 +208,7 @@ BatchReplayRendererTest::BatchReplayRendererTest() {
 
 // test recording and playback through the simulator interface
 void BatchReplayRendererTest::testUnproject() {
-  auto&& data = TestIntegrationData[testCaseInstanceId()];
+  auto&& data = TestUnprojectData[testCaseInstanceId()];
   setTestCaseDescription(data.name);
 
   std::vector<esp::sensor::SensorSpec::ptr> sensorSpecifications;
@@ -582,7 +582,7 @@ void BatchReplayRendererTest::testArticulatedObject() {
 }
 
 void BatchReplayRendererTest::testClose() {
-  auto&& data = TestIntegrationData[testCaseInstanceId()];
+  auto&& data = TestCloseData[testCaseInstanceId()];
   setTestCaseDescription(data.name);
 
   auto sensorSpecifications = getDefaultSensorSpecs(TestFlag::Color);


### PR DESCRIPTION
## Motivation and Context

This changes test instance data structures that were incorrect, but still worked due to luck.

## How Has This Been Tested

Tests pass.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
