### PR TITLE
More accurate get_random_navigable_point_near

### DIFF
--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -365,7 +365,7 @@ class IslandSystem {
         bool inRange = false;
         for (int iVert = 0; iVert < poly->vertCount; ++iVert) {
           int nVert = (iVert + 1) % 3;
-          float tseg;
+          float tseg = 0;
           float distSqr = dtDistancePtSegSqr2D(
               circleCenter.data(),
               &tile->verts[static_cast<size_t>(poly->verts[iVert]) * 3],

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -479,8 +479,8 @@ struct PathFinder::Impl {
                                             int maxTries,
                                             int islandIndex /*= ID_UNDEFINED*/);
   vec3f getRandomNavigablePointInCircle(const vec3f& circleCenter,
-                                        float radius,
-                                        int maxTries,
+                                        const float radius,
+                                        const int maxTries,
                                         int islandIndex /*= ID_UNDEFINED*/);
 
   bool findPath(ShortestPath& path);
@@ -1313,7 +1313,7 @@ vec3f PathFinder::Impl::getRandomNavigablePointInCircle(
     }
   }
 
-  // reset the poly flag identifing polys off the target island
+  // reset the poly flag identifying polys off the target island
   islandSystem_->setPolyFlagForIsland(
       navMesh_.get(), PolyFlags::POLYFLAGS_OFF_ISLAND, ID_UNDEFINED,
       /*setFlag=*/false, /*invert=*/true);

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -479,8 +479,8 @@ struct PathFinder::Impl {
                                             int maxTries,
                                             int islandIndex /*= ID_UNDEFINED*/);
   vec3f getRandomNavigablePointInCircle(const vec3f& circleCenter,
-                                        const float radius,
-                                        const int maxTries,
+                                        float radius,
+                                        int maxTries,
                                         int islandIndex /*= ID_UNDEFINED*/);
 
   bool findPath(ShortestPath& path);

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -27,6 +27,7 @@
 #include "esp/assets/MeshData.h"
 #include "esp/core/Esp.h"
 
+#include "DetourCommon.h"
 #include "DetourNavMesh.h"
 #include "DetourNavMeshBuilder.h"
 #include "DetourNavMeshQuery.h"
@@ -313,6 +314,79 @@ class IslandSystem {
     }
   }
 
+  /**
+   * @brief Sets a specified poly flag for all polys specified by the
+   * islandIndex within range of a given circle.
+   *
+   * @param[in] navMesh The navmesh to operate on.
+   * @param[in] flag The flag to set or clear.
+   * @param[in] circleCenter The center of the circle.
+   * @param[in] radius The radius of the circle.
+   * @param[in] islandIndex Specify the island. islandIndex == ID_UNDEFINED
+   * specifies all islands.
+   */
+  inline void setPolyFlagForIslandCircle(dtNavMesh* navMesh,
+                                         ushort flag,
+                                         const vec3f& circleCenter,
+                                         const float radius,
+                                         int islandIndex = ID_UNDEFINED) {
+    assertValidIsland(islandIndex);
+    CORRADE_ASSERT(navMesh != nullptr, "invalid navMesh pointer", );
+    std::vector<int> islands;
+
+    float radSqr = radius * radius;
+
+    // all islands
+    islands.reserve(islandsToPolys_.size());
+    for (auto& itr : islandsToPolys_) {
+      islands.push_back(itr.first);
+    }
+
+    // for each island
+    for (int island : islands) {
+      // for each poly
+      for (auto& polyRef : islandsToPolys_[island]) {
+        // remove all off-island polys immediately
+        if (islandIndex != ID_UNDEFINED && islandIndex != island) {
+          // get current flags
+          ushort f = 0;
+          navMesh->getPolyFlags(polyRef, &f);
+          // set the modified flags
+          navMesh->setPolyFlags(polyRef, orFlag(f, flag));
+          continue;
+        }
+
+        // poly is on island, check if it is outside of range
+        const dtMeshTile* tile = nullptr;
+        const dtPoly* poly = nullptr;
+        navMesh->getTileAndPolyByRefUnsafe(polyRef, &tile, &poly);
+
+        // check if this poly is within range of the circle
+        bool inRange = false;
+        for (int iVert = 0; iVert < poly->vertCount; ++iVert) {
+          int nVert = (iVert + 1) % 3;
+          float tseg;
+          float distSqr = dtDistancePtSegSqr2D(
+              circleCenter.data(),
+              &tile->verts[static_cast<size_t>(poly->verts[iVert]) * 3],
+              &tile->verts[static_cast<size_t>(poly->verts[nVert]) * 3], tseg);
+          if (distSqr < radSqr) {
+            // skip this poly if any edge is within radius
+            inRange = true;
+            break;
+          }
+        }
+        if (!inRange) {
+          // get current flags
+          ushort f = 0;
+          navMesh->getPolyFlags(polyRef, &f);
+          // set the modified flags
+          navMesh->setPolyFlags(polyRef, orFlag(f, flag));
+        }
+      }
+    }
+  }
+
   // Some polygons have zero area for some reason.  When we navigate into a zero
   // area polygon, things crash.  So we find all zero area polygons and mark
   // them as disabled/not navigable.
@@ -404,6 +478,10 @@ struct PathFinder::Impl {
                                             float radius,
                                             int maxTries,
                                             int islandIndex /*= ID_UNDEFINED*/);
+  vec3f getRandomNavigablePointInCircle(const vec3f& circleCenter,
+                                        float radius,
+                                        int maxTries,
+                                        int islandIndex /*= ID_UNDEFINED*/);
 
   bool findPath(ShortestPath& path);
   bool findPath(MultiGoalShortestPath& path);
@@ -1199,6 +1277,57 @@ vec3f PathFinder::Impl::getRandomNavigablePoint(
   return pt;
 }
 
+vec3f PathFinder::Impl::getRandomNavigablePointInCircle(
+    const vec3f& circleCenter,
+    const float radius,
+    const int maxTries,
+    int islandIndex) {
+  float radSqr = radius * radius;
+
+  islandSystem_->assertValidIsland(islandIndex);
+  if (getNavigableArea(islandIndex) <= 0.0)
+    throw std::runtime_error(
+        "NavMesh has no navigable area, this indicates an issue with the "
+        "NavMesh");
+
+  // set the poly flag to identify polys not on the target island
+  islandSystem_->setPolyFlagForIslandCircle(navMesh_.get(),
+                                            PolyFlags::POLYFLAGS_OFF_ISLAND,
+                                            circleCenter, radius, islandIndex);
+  filter_->setExcludeFlags(filter_->getExcludeFlags() |
+                           PolyFlags::POLYFLAGS_OFF_ISLAND);
+
+  vec3f pt;
+  int i = 0;
+  for (i = 0; i < maxTries; ++i) {
+    dtPolyRef ref = 0;
+    dtStatus status =
+        navQuery_->findRandomPoint(filter_.get(), frand, &ref, pt.data());
+    if (dtStatusSucceed(status)) {
+      float xd = circleCenter[0] - pt[0];
+      float yd = circleCenter[2] - pt[2];
+      float d2 = xd * xd + yd * yd;
+      if (d2 < radSqr) {
+        break;
+      }
+    }
+  }
+
+  // reset the poly flag identifing polys off the target island
+  islandSystem_->setPolyFlagForIsland(
+      navMesh_.get(), PolyFlags::POLYFLAGS_OFF_ISLAND, ID_UNDEFINED,
+      /*setFlag=*/false, /*invert=*/true);
+  filter_->setExcludeFlags(filter_->getExcludeFlags() &
+                           ~PolyFlags::POLYFLAGS_OFF_ISLAND);
+
+  if (i == maxTries) {
+    ESP_ERROR() << "Failed to getRandomNavigablePoint.  Try increasing max "
+                   "tries if the navmesh is fine but just hard to sample from";
+    return vec3f::Constant(Mn::Constants::nan());
+  }
+  return pt;
+}
+
 vec3f PathFinder::Impl::getRandomNavigablePointAroundSphere(
     const vec3f& circleCenter,
     const float radius,
@@ -1770,8 +1899,8 @@ vec3f PathFinder::getRandomNavigablePointAroundSphere(
     const float radius,
     const int maxTries,
     int islandIndex /*= ID_UNDEFINED*/) {
-  return pimpl_->getRandomNavigablePointAroundSphere(circleCenter, radius,
-                                                     maxTries, islandIndex);
+  return pimpl_->getRandomNavigablePointInCircle(circleCenter, radius, maxTries,
+                                                 islandIndex);
 }
 
 bool PathFinder::findPath(ShortestPath& path) {


### PR DESCRIPTION
## Motivation and Context

**TL;DR:** This PR adds a new implementation for sampling random points within a circle.

### Context:
Currently, we use a Detour function `findRandomPointAroundCircle` for these queries. This function is implemented with a breadth-first search over navmesh polygons, excluding polygons outside the circle, starting from the closest snap point. 
**The problem with this function is that it excludes regions of the navmesh which are inside the circle, but separated from the region containing the start point.**

For example, this image shows points resulting from the query within the circle centered on the red object. Note that only bed points are considered because the "ramp" off the bed is outside the circle, cutting it off from the rest of that room and the other rooms.

![image](https://github.com/facebookresearch/habitat-sim/assets/1445143/e3ba580c-9125-40de-a9d0-921d6dfa9891)

To fix this behavior and accurately sample all points within the circle, two options are considered:
1. Change Detour to allow the breadth-first search to continue outside the circle by removing [this check](https://github.com/recastnavigation/recastnavigation/blob/cd898904b72a300011fbb24d578620bafa08ef2c/Detour/Source/DetourNavMeshQuery.cpp#L429).
2. (proposed) Implement our own filter function to remove polygons outside the circle and then use a standard sample query with rejection for distance. 

This PR implements option 2 for better efficiency. See performance notes below for details.

### Performance Notes:
The previous method was very fast because it incorrectly only touches polygons connected to the start point and within the circle. Any fix will be inherently slower because it must consider the entire navmesh (or island) to correctly filter candidate polygons.

Option (1) above is empirically about **100x slower** than the original approach and often fails to find a point within the iteration limit. :slightly_frowning_face: Likely due to the overhead of a search based sampling and high rejection rate.

Option (2) is about **10x slower** than the original approach and does not appear to fail, offering better stability. There is overhead in the initial filtering phase, but then sampling is very fast. **Future advantage:** multi-point sampling could be easily batched for additional efficiency as the filter would only need to be set once for the batch.

Profile for the pictured scenario on my machine:
- current: 5.588531494140625e-06
- option 1: 2.3991942405700683e-04
- option 2: 7.155656814575195e-05

### Other Notes:

This is breaking change because the behavior of this function will change for downstream use. It will now more accurately sample points in a circle which could be considered a bug fix.

## How Has This Been Tested

Results with new implementation:
![image](https://github.com/facebookresearch/habitat-sim/assets/1445143/11beaf7f-f111-4212-b326-53974b0b1579)

Navmesh with path between rooms visualized for reference:

![nav_path](https://github.com/facebookresearch/habitat-sim/assets/1445143/531073cb-96a4-48a8-80ae-661dc413a045)


No CI tests presently. Could invent a contrived example to ensure this works.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
