### PR TITLE
Add replay renderer flag to enable HBAO.

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -382,6 +382,9 @@ void initSimBindings(py::module& m) {
                      &ReplayRendererConfiguration::enableFrustumCulling,
                      R"(Controls whether frustum culling is enabled.)")
       .def_readwrite(
+          "enable_hbao", &ReplayRendererConfiguration::enableHBAO,
+          R"(Controls whether horizon-based ambient occlusion is enabled.)")
+      .def_readwrite(
           "force_separate_semantic_scene_graph",
           &ReplayRendererConfiguration::forceSeparateSemanticSceneGraph,
           R"(Required to support playback of any gfx replay that includes a

--- a/src/esp/sim/AbstractReplayRenderer.h
+++ b/src/esp/sim/AbstractReplayRenderer.h
@@ -57,6 +57,8 @@ class ReplayRendererConfiguration {
 
   bool enableFrustumCulling = true;
 
+  bool enableHBAO = false;
+
   std::vector<std::shared_ptr<sensor::SensorSpec>> sensorSpecifications;
 
   ESP_SMART_POINTERS(ReplayRendererConfiguration)

--- a/src/esp/sim/ClassicReplayRenderer.cpp
+++ b/src/esp/sim/ClassicReplayRenderer.cpp
@@ -100,6 +100,10 @@ ClassicReplayRenderer::ClassicReplayRenderer(
     }
 
     gfx::Renderer::Flags flags;
+
+    if (config_.enableHBAO)
+      flags |= gfx::Renderer::Flag::HorizonBasedAmbientOcclusion;
+
 #ifdef ESP_BUILD_WITH_BACKGROUND_RENDERER
     if (context_)
       flags |= gfx::Renderer::Flag::BackgroundRenderer;


### PR DESCRIPTION
## Motivation and Context

This adds a flag to `ReplayRendererConfiguration` to enable HBAO.

## How Has This Been Tested

Tested in `viewer.py` and HITL tool.

![HITL_HBAO](https://github.com/facebookresearch/habitat-sim/assets/110583667/e318d410-0075-4502-ac3a-1790b242083c)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
