### PR TITLE
Fix building gfx target with MSVC

### DIFF
--- a/src/deps/atomic_wait/atomic_wait.cpp
+++ b/src/deps/atomic_wait/atomic_wait.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include <atomic_wait.h>
 
+#ifdef __TABLE
 // 256 since we are using the last 8
 // bits of the atomic to determine which lock is
 // being waited on in the table
@@ -32,3 +33,4 @@ contended_t contention[256];
 contended_t* __contention(volatile void const* p) {
   return contention + ((uintptr_t)p & 255);
 }
+#endif

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -3168,7 +3168,7 @@ void ResourceManager::mapSkinnedModelToArticulatedObject(
 
     // Map the articulated object link associated with the skin joint
     if (linkId != linkIds.end()) {
-      auto* articulatedObjectNode = &rig->getLink(*linkId.base()).node();
+      auto* articulatedObjectNode = &rig->getLink(*linkId).node();
 
       // This node will be used for rendering.
       auto& transformNode = articulatedObjectNode->createChild();

--- a/src/esp/core/MathInclude.h
+++ b/src/esp/core/MathInclude.h
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_CORE_MATHINCLUDE_H_
+#define ESP_CORE_MATHINCLUDE_H_
+
+// The _USE_MATH_DEFINES macro is used to enable the definition of mathematical
+// constants like M_PI and M_PI_2 in the <cmath> header. This is typically
+// needed in Microsoft Visual Studio environments where these constants are not
+// defined by default.
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+// In environments other than Microsoft Visual Studio, or when <cmath> is
+// included before this header by external dependencies, the _USE_MATH_DEFINES
+// macro may not enable the definition of M_PI and M_PI_2. In such cases, we
+// provide manual definitions for these constants to ensure they are available.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef M_PI_2
+#define M_PI_2 1.57079632679489661923
+#endif
+
+#endif  // ESP_CORE_MATHINCLUDE_H_

--- a/src/esp/core/Utility.h
+++ b/src/esp/core/Utility.h
@@ -12,8 +12,8 @@
 #include <Magnum/Math/Matrix4.h>
 #include <Magnum/Math/Quaternion.h>
 #include <Magnum/Math/Vector3.h>
-#include <cmath>
 #include <cstdlib>
+#include "esp/core/MathInclude.h"
 
 namespace esp {
 namespace core {

--- a/src/esp/geo/Geo.cpp
+++ b/src/esp/geo/Geo.cpp
@@ -4,12 +4,13 @@
 
 #include "esp/geo/Geo.h"
 
+#include "esp/core/MathInclude.h"
+
 #include <Magnum/Math/Color.h>
 #include <Magnum/Math/FunctionsBatch.h>
 #include <Magnum/Math/Matrix4.h>
 #include <Magnum/Primitives/Circle.h>
 #include <Magnum/Trade/MeshData.h>
-#include <cmath>
 #include <numeric>
 
 namespace Mn = Magnum;

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -67,6 +67,7 @@ LightSetup getLightsAtBoxCorners(const Magnum::Range3D& box,
   using namespace Magnum::Math::Literals;
 
   constexpr float w = 1;
+#if __cplusplus >= 202002L
   return LightSetup{{{box.frontTopLeft(), w}, lightColor},
                     {{box.frontTopRight(), w}, lightColor},
                     {{box.frontBottomLeft(), w}, lightColor},
@@ -75,9 +76,22 @@ LightSetup getLightsAtBoxCorners(const Magnum::Range3D& box,
                     {{box.backTopRight(), w}, lightColor},
                     {{box.backBottomLeft(), w}, lightColor},
                     {{box.backBottomRight(), w}, lightColor}};
+#else
+  LightSetup lights;
+  lights.emplace_back(LightInfo{{box.frontTopLeft(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.frontTopRight(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.frontBottomLeft(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.frontBottomRight(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.backTopLeft(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.backTopRight(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.backBottomLeft(), w}, lightColor});
+  lights.emplace_back(LightInfo{{box.backBottomRight(), w}, lightColor});
+  return lights;
+#endif
 }
 
 LightSetup getDefaultLights() {
+#if __cplusplus >= 202002L
   return LightSetup{
       {{0.0, -0.5, -0.5, 0.0},
        {0.5, 0.5, 0.5},
@@ -92,6 +106,22 @@ LightSetup getDefaultLights() {
        {0.5, 0.5, 0.5},
        LightPositionModel::Global},  // +x
   };
+#else
+  LightSetup lights;
+  lights.emplace_back(LightInfo{{0.0, -0.5, -0.5, 0.0},
+                                {0.5, 0.5, 0.5},
+                                LightPositionModel::Global});  // -z
+  lights.emplace_back(LightInfo{{0.0, -0.5, 0.5, 0.0},
+                                {0.5, 0.5, 0.5},
+                                LightPositionModel::Global});  // +z
+  lights.emplace_back(LightInfo{{-0.5, -0.5, 0.0, 0.0},
+                                {0.5, 0.5, 0.5},
+                                LightPositionModel::Global});  // -x
+  lights.emplace_back(LightInfo{{0.5, -0.5, 0.0, 0.0},
+                                {0.5, 0.5, 0.5},
+                                LightPositionModel::Global});  // +x
+  return lights;
+#endif
 }
 
 Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {

--- a/src/esp/gfx/LightSetup.h
+++ b/src/esp/gfx/LightSetup.h
@@ -40,7 +40,12 @@ struct LightInfo {
   // directional light with no distance attenuation.
   Magnum::Vector4 vector;
   Magnum::Color3 color{1};
-  LightPositionModel model = LightPositionModel::Global;
+  LightPositionModel model;
+
+  explicit LightInfo(const Magnum::Vector4& vec = Magnum::Vector4(),
+                     const Magnum::Color3& col = Magnum::Color3(),
+                     const LightPositionModel& mod = LightPositionModel::Global)
+      : vector(vec), color(col), model(mod) {}
 };
 
 bool operator==(const LightInfo& a, const LightInfo& b);

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -180,7 +180,7 @@ class Player {
   explicit Player(std::shared_ptr<AbstractPlayerImplementation> implementation);
 
   /* Deliberately move-only, it's heavy */
-  Player(const Player&&) = delete;
+  Player(const Player&) = delete;
   Player(Player&&) noexcept = default;
   Player& operator=(const Player&) = delete;
   Player& operator=(Player&&) noexcept = default;

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -21,8 +21,7 @@ add_library(
 
 target_link_libraries(
   io
-  PUBLIC core
-  $<$<PLATFORM_ID:Linux>:stdc++fs>
+  PUBLIC core $<$<PLATFORM_ID:Linux>:stdc++fs>
 )
 
 target_compile_features(io PUBLIC cxx_std_17)

--- a/src/esp/io/CMakeLists.txt
+++ b/src/esp/io/CMakeLists.txt
@@ -22,4 +22,7 @@ add_library(
 target_link_libraries(
   io
   PUBLIC core
+  $<$<PLATFORM_ID:Linux>:stdc++fs>
 )
+
+target_compile_features(io PUBLIC cxx_std_17)

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -338,8 +338,12 @@ gfx::LightSetup LightLayoutAttributesManager::createLightSetupFromAttributes(
             lightVector = {lightAttr->getPosition(), 1.0f};
           }
         }  // switch on type
+#if __cplusplus >= 202002L
         res.push_back(
             {.vector = lightVector, .color = color, .model = posModelEnum});
+#else
+        res.push_back(gfx::LightInfo(lightVector, color, posModelEnum));
+#endif
       }  // for each light instance described
     }    // if >0 light instances described
   }      // lightLayoutAttributes of requested name exists

--- a/src/esp/nav/GreedyFollower.cpp
+++ b/src/esp/nav/GreedyFollower.cpp
@@ -9,6 +9,7 @@
 #include <Magnum/EigenIntegration/Integration.h>
 
 #include "esp/core/Esp.h"
+#include "esp/core/MathInclude.h"
 #include "esp/geo/Geo.h"
 
 namespace Mn = Magnum;

--- a/src/esp/nav/PathFinder.cpp
+++ b/src/esp/nav/PathFinder.cpp
@@ -18,14 +18,12 @@
 #include <Corrade/Utility/Path.h>
 
 #include <cstdio>
-// NOLINTNEXTLINE
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include <limits>
 #include <utility>
 
 #include "esp/assets/MeshData.h"
 #include "esp/core/Esp.h"
+#include "esp/core/MathInclude.h"
 
 #include "DetourNavMesh.h"
 #include "DetourNavMeshBuilder.h"

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -14,6 +14,7 @@
 #include "BulletURDFImporter.h"
 #include "esp/assets/RenderAssetInstanceCreationInfo.h"
 #include "esp/assets/ResourceManager.h"
+#include "esp/core/MathInclude.h"
 #include "esp/metadata/attributes/PhysicsManagerAttributes.h"
 #include "esp/physics/objectManagers/ArticulatedObjectManager.h"
 #include "esp/physics/objectManagers/RigidObjectManager.h"

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -525,7 +525,8 @@ Mn::Matrix4 BulletURDFImporter::convertURDF2BulletInternal(
           break;
         }
         default: {
-          ESP_VERY_VERBOSE() << "Invalid joint type." btAssert(0);
+          ESP_VERY_VERBOSE() << "Invalid joint type.";
+          btAssert(0);
         }
       }
     }

--- a/src/esp/sensor/CameraSensor.cpp
+++ b/src/esp/sensor/CameraSensor.cpp
@@ -7,9 +7,9 @@
 #include <Magnum/ImageView.h>
 #include <Magnum/Math/Algorithms/GramSchmidt.h>
 #include <Magnum/PixelFormat.h>
-#include <cmath>
 
 #include "CameraSensor.h"
+#include "esp/core/MathInclude.h"
 #include "esp/gfx_batch/DepthUnprojection.h"
 #include "esp/sim/Simulator.h"
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -16,6 +16,7 @@
 #include <Magnum/GL/Renderer.h>
 
 #include "esp/core/Esp.h"
+#include "esp/core/MathInclude.h"
 #include "esp/gfx/CubeMapCamera.h"
 #include "esp/gfx/Drawable.h"
 #include "esp/gfx/PbrDrawable.h"


### PR DESCRIPTION
## Motivation and Context

This PR aims to revive the effort towards extending Windows support (#127), by ensuring the `gfx` target can be built with MSVC. The key modifications encapsulated in this PR include:

- Reinstating a move constructor that was inadvertently removed.
- Ensuring that `<cmath>` is included with `_USE_MATH_DEFINES` defined, to enable the use of mathematical constants.
- Removing the use of named initializations, a feature exclusive to C++20, to maintain compatibility with earlier C++ standards.
- Addressing an invalid use of an iterator.

I have not conducted any tests locally but just building the target, and will be relying on the CI to ascertain that these changes do not introduce any regressions.

## How Has This Been Tested

```
# on Windows
cd src; make build; cd build
cmake ..
cmake --build . --parallel --target gfx
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
