### PR TITLE
--[BUGFIX] Minor bugfixes

### DIFF
--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -611,8 +611,8 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
     if ((copyStrPos != std::string::npos)) {
       // Already is a copy of some existing managed file-based object
       // Get copy number and increment to set as initial count value
-      count =
-          std::stoi(fileNameBase.substr(copyStrPos + 7, copyStrPos + 10)) + 1;
+      const int numStrStartPos = copyStrPos + 7;
+      count = std::stoi(fileNameBase.substr(numStrStartPos, 4)) + 1;
       // Remove ' (copy xxxx)' component from fileNameBase so that a string of
       // (copy xxxx)'s aren't created on successive runs
       fileNameBase = fileNameBase.substr(0, copyStrPos);

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -598,19 +598,31 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
   std::string fileNameBase =
       FileUtil::splitExtension(FileUtil::splitExtension(fileNameRaw).first())
           .first();
-
+  // Note : fileNameBase may be a copy already (i.e. have suffix '(copy xxxx)'
+  // in the name)
   std::string fileName = fileNameBase + "." + this->JSONTypeExt_;
   if (!overwrite) {
     // if not overwrite, then attempt to find a non-conflicting name before
     // attempting to save
     bool nameExists = true;
     int count = 0;
+
+    std::size_t copyStrPos = fileNameBase.find(" (copy ");
+    if ((copyStrPos != std::string::npos)) {
+      // Already is a copy of some base scene instance
+      // Get copy number and increment to set as initial count value
+      count =
+          std::stoi(fileNameBase.substr(copyStrPos + 7, copyStrPos + 10)) + 1;
+      // Remove ' (copy xxxx)' component from fileNameBase so that a string of
+      // (copy xxxx)'s aren't created on successive runs
+      fileNameBase = fileNameBase.substr(0, copyStrPos);
+    }
     while (nameExists) {
       auto tempFullFileName = FileUtil::join(fileDirectory, fileName);
       nameExists = FileUtil::exists(tempFullFileName);
       if (nameExists) {
-        // build a new file name candidate by adding copy plus some integer
-        // value
+        // Otherwise build a new file name candidate by adding copy plus some
+        // integer value
         fileName = Cr::Utility::formatString(
             "{} (copy {:.04d}).{}", fileNameBase, count, this->JSONTypeExt_);
         ++count;

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -609,7 +609,7 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
 
     std::size_t copyStrPos = fileNameBase.find(" (copy ");
     if ((copyStrPos != std::string::npos)) {
-      // Already is a copy of some base scene instance
+      // Already is a copy of some existing managed file-based object
       // Get copy number and increment to set as initial count value
       count =
           std::stoi(fileNameBase.substr(copyStrPos + 7, copyStrPos + 10)) + 1;

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -121,13 +121,13 @@ class SceneDatasetAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Add an entry to the navmeshMap with the passed key.  If @p overwrite
+   * @brief Add an entry to the @ref navmeshMap_ with the passed key.  If @p overwrite
    * then overwrite existing entry, otherwise will modify key and add value with
-   * modified key.  Returns pair of added KV.
+   * modified key.  Returns pair of added Key-Value.
    * @param key The handle for the navmesh path to add
    * @param path The path to the navmesh asset to add
    * @param overwrite Whether to overwrite existing entries or not
-   * @return K-V pair for path being added.
+   * @return Key-Value pair for path being added.
    */
   std::pair<std::string, std::string> addNavmeshPathEntry(
       const std::string& key,
@@ -137,13 +137,13 @@ class SceneDatasetAttributes : public AbstractAttributes {
   }  // addNavmeshPathEntry
 
   /**
-   * @brief Add an entry to the SemanticSceneDescr map with the passed key. If
+   * @brief Add an entry to the @ref semanticSceneDescrMap_ map with the passed key. If
    * @p overwrite then overwrite existing entry,  otherwise will modify key and
-   * add value with modified key.  Returns pair of added KV.
+   * add value with modified key.  Returns pair of added Key-Value.
    * @param key The handle for the SemanticSceneDescr path to add
    * @param path The path to the SemanticSceneDescr asset to add
    * @param overwrite Whether to overwrite existing entries or not
-   * @return K-V pair for SemanticSceneDescr being added.
+   * @return Key-Value pair for SemanticSceneDescr being added.
    */
   std::pair<std::string, std::string> addSemanticSceneDescrPathEntry(
       const std::string& key,
@@ -227,7 +227,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * so adding them.  This is to handle the addition of an existing
    * sceneInstance that might reference stages, objects, navmeshes, etc. that
    * do not exist in the dataset.
-   * @param sceneInstance A Scene Instance Attributes.  It is assumed the @p
+   * @param sceneInstance A pointer to a @ref metadata::attributes::SceneInstanceAttributes.  It is assumed the @p
    * sceneInstance at least references a valid stage.
    * @return whether this sceneInstance was successfully added to the dataset.
    */
@@ -442,7 +442,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
   managers::AOAttributesManager::ptr artObjAttributesManager_ = nullptr;
 
   /**
-   * @brief Manages all construction and access to scene instance attributes
+   * @brief Manages all construction and access to @ref metadata::attributes::SceneInstanceAttributes
    * from this dataset.
    */
   managers::SceneInstanceAttributesManager::ptr

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -75,8 +75,6 @@ enum class PrimObjTypes : uint32_t {
   END_PRIM_OBJ_TYPES
 };
 namespace managers {
-using core::managedContainers::ManagedFileBasedContainer;
-using core::managedContainers::ManagedObjectAccess;
 
 class AssetAttributesManager
     : public AttributesManager<attributes::AbstractPrimitiveAttributes,

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -16,9 +16,6 @@ namespace esp {
 namespace metadata {
 namespace managers {
 
-using core::managedContainers::ManagedFileBasedContainer;
-using core::managedContainers::ManagedObjectAccess;
-
 class LightLayoutAttributesManager
     : public AttributesManager<attributes::LightLayoutAttributes,
                                ManagedObjectAccess::Copy> {

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -15,8 +15,6 @@
 namespace esp {
 namespace metadata {
 namespace managers {
-using core::managedContainers::ManagedFileBasedContainer;
-using core::managedContainers::ManagedObjectAccess;
 
 /**
  * @brief single instance class managing templates describing physical objects

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -32,10 +32,9 @@ PhysicsManagerAttributes::ptr PhysicsAttributesManager::createObject(
 
 void PhysicsAttributesManager::setValsFromJSONDoc(
     PhysicsManagerAttributes::ptr physicsManagerAttributes,
-    const io::JsonGenericValue&
-        jsonConfig) {  // load the simulator preference - default is "none"
-                       // simulator, set in
-  // attributes ctor.
+    const io::JsonGenericValue& jsonConfig) {
+  // load the simulator preference - default is "none"
+  // simulator, set in attributes ctor.
   io::jsonIntoConstSetter<std::string>(
       jsonConfig, "physics_simulator",
       [physicsManagerAttributes](const std::string& simulator) {

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_METADATA_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
-#define ESP_METADATA_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
+#ifndef ESP_METADATA_MANAGERS_PHYSICSATTRIBUTESMANAGER_H_
+#define ESP_METADATA_MANAGERS_PHYSICSATTRIBUTESMANAGER_H_
 
 #include <utility>
 
@@ -17,8 +17,6 @@ namespace Cr = Corrade;
 namespace esp {
 namespace metadata {
 namespace managers {
-using core::managedContainers::ManagedFileBasedContainer;
-using core::managedContainers::ManagedObjectAccess;
 
 class PhysicsAttributesManager
     : public AttributesManager<attributes::PhysicsManagerAttributes,
@@ -145,4 +143,4 @@ class PhysicsAttributesManager
 }  // namespace metadata
 }  // namespace esp
 
-#endif  // ESP_METADATA_MANAGERS_PHYSICSATTRIBUTEMANAGER_H_
+#endif  // ESP_METADATA_MANAGERS_PHYSICSATTRIBUTESMANAGER_H_

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -16,8 +16,6 @@
 namespace esp {
 namespace metadata {
 namespace managers {
-using esp::core::managedContainers::ManagedObjectAccess;
-
 class SceneDatasetAttributesManager
     : public AttributesManager<attributes::SceneDatasetAttributes,
                                ManagedObjectAccess::Share> {

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -71,7 +71,7 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
     } else {
       // stage instance exists but is not a valid JSON Object
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "Stage instance issue in Scene Instance `" << attribsDispName
+          << "Stage Instance issue in Scene Instance `" << attribsDispName
           << "`: JSON cell `stage_instance` is not a valid JSON object.";
     }
   } else {

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -16,7 +16,6 @@ enum class AssetType;
 }  // namespace assets
 namespace metadata {
 namespace managers {
-using esp::core::managedContainers::ManagedObjectAccess;
 
 class StageAttributesManager
     : public AbstractObjectAttributesManager<attributes::StageAttributes,

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -827,7 +827,7 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    * @brief Returns the @ref
    * metadata::attributes::SceneAOInstanceAttributes used to place this
    * Articulated Object initially in the scene.
-   * @return a read-only copy of the scene instance attributes used to place
+   * @return a read-only copy of the @ref metadata::attributes::SceneInstanceAttributes used to place
    * this object in the scene.
    */
   std::shared_ptr<const metadata::attributes::SceneAOInstanceAttributes>

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -278,7 +278,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   /**
    * @brief Returns the @ref metadata::attributes::SceneObjectInstanceAttributes
    * used to place this rigid object in the scene.
-   * @return a read-only copy of the scene instance attributes used to place
+   * @return a read-only copy of the @ref metadata::attributes::SceneInstanceAttributes used to place
    * this object in the scene.
    */
   std::shared_ptr<const metadata::attributes::SceneObjectInstanceAttributes>

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -267,7 +267,7 @@ BulletArticulatedObject::getCurrentStateInstanceAttr() {
   auto sceneArtObjInstanceAttr =
       ArticulatedObject::getCurrentStateInstanceAttr();
   if (!sceneArtObjInstanceAttr) {
-    // if no scene instance attributes specified, no initial state is set
+    // if no Scene Instance Attributes specified, no initial state is set
     return nullptr;
   }
   sceneArtObjInstanceAttr->setAutoClampJointLimits(autoClampJointLimits_);
@@ -291,7 +291,7 @@ BulletArticulatedObject::getCurrentStateInstanceAttr() {
 void BulletArticulatedObject::resetStateFromSceneInstanceAttr() {
   auto sceneObjInstanceAttr = getInitObjectInstanceAttr();
   if (!sceneObjInstanceAttr) {
-    // if no scene instance attributes specified, no initial state is set
+    // if no Scene Instance Attributes specified, no initial state is set
     return;
   }
   // Set whether dofs should be clamped to limits before phys step

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -234,7 +234,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
   // 1. initial setup for scene instancing - sets or creates the
   // current scene instance to correspond to the given name.
 
-  // Get scene instance attributes corresponding to passed active scene name
+  // Get Scene Instance Attributes corresponding to passed active scene name
   // This will retrieve, or construct, an appropriately configured scene
   // instance attributes, depending on what exists in the Scene Dataset library
   // for the current dataset.
@@ -249,7 +249,7 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
           "instance :{} failed due to scene instance not being found. Aborting",
           activeSceneName));
 
-  // 2. Load navmesh specified in current scene instance attributes.
+  // 2. Load navmesh specified in current Scene Instance Attributes.
 
   const std::string& navmeshFileHandle =
       curSceneInstanceAttributes_->getNavmeshHandle();
@@ -272,8 +272,8 @@ bool Simulator::createSceneInstance(const std::string& activeSceneName) {
       ESP_DEBUG() << (pfSuccess ? "Navmesh Loaded." : "Navmesh load error.");
     } else {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "Navmesh file not found, checked at filename : '" << navmeshFileLoc
-          << "'";
+          << "Requested navmesh file not found, checked at filename : '"
+          << navmeshFileLoc << "'";
     }
   }
   // Calling to seeding needs to be done after the pathfinder creation but

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -123,7 +123,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
           lightLayoutAttr);
 
   /**
-   * @brief This test will verify that the Scene Instance attributes' managers'
+   * @brief This test will verify that the Scene Instance Attributes' managers'
    * JSON loading process is working as expected.
    */
   void testSceneInstanceAttrVals(
@@ -645,7 +645,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
 
 void AttributesConfigsTest::testSceneInstanceRootUserDefinedAttrVals(
     std::shared_ptr<esp::core::config::Configuration> userAttrs) {
-  // test scene instance attributes-level user config vals
+  // test Scene Instance Attributes-level user config vals
   testUserDefinedConfigVals(userAttrs, 4, "scene instance defined string", true,
                             99, 9.1, Mn::Vector2(1.3f, 2.4f),
                             Mn::Vector3(12.3, 32.5, 25.07),
@@ -666,7 +666,7 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
   CORRADE_COMPARE(sceneAttr->getNavmeshHandle(), "test_navmesh_path1");
   CORRADE_COMPARE(sceneAttr->getSemanticSceneHandle(),
                   "test_semantic_descriptor_path1");
-  // test scene instance attributes-level user config vals
+  // test Scene Instance Attributes-level user config vals
   testSceneInstanceRootUserDefinedAttrVals(sceneAttr->getUserConfiguration());
 
   // test scene instanct attributes-level user config vals retrieved from MM

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -41,10 +41,6 @@ using Attrs::UVSpherePrimitiveAttributes;
 
 namespace {
 
-// base directory to save test attributes
-const std::string testAttrSaveDir =
-    Cr::Utility::Path::join(DATA_DIR, "test_assets");
-
 /**
  * @brief Test attributes/configuration functionality via setting values from
  * JSON string, saving JSON to file and loading verifying saved JSON matches
@@ -333,7 +329,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testPhysicsAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testPhysicsAttrConfig_saved_JSON.{}", TEST_ASSETS,
       physicsAttributesManager_->getJSONTypeExt());
 
   bool success = physicsAttributesManager_->saveManagedObjectToFile(
@@ -465,7 +461,7 @@ void AttributesConfigsTest::testPbrShaderAttrJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testPbrShaderAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testPbrShaderAttrConfig_saved_JSON.{}", TEST_ASSETS,
       pbrShaderAttributesManager_->getJSONTypeExt());
 
   bool success = pbrShaderAttributesManager_->saveManagedObjectToFile(
@@ -612,7 +608,7 @@ void AttributesConfigsTest::testLightJSONLoad() {
   CORRADE_VERIFY(lightLayoutAttr);
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testLightLayoutAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testLightLayoutAttrConfig_saved_JSON.{}", TEST_ASSETS,
       lightLayoutAttributesManager_->getJSONTypeExt());
 
   bool success = lightLayoutAttributesManager_->saveManagedObjectToFile(
@@ -1013,7 +1009,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testSceneAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testSceneAttrConfig_saved_JSON.{}", TEST_ASSETS,
       sceneInstanceAttributesManager_->getJSONTypeExt());
 
   bool success = sceneInstanceAttributesManager_->saveManagedObjectToFile(
@@ -1140,7 +1136,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
   // now need to change the render and collision assets to make sure they are
   // legal so test can proceed (needs to be actual existing file)
   const std::string stageAssetFile =
-      Cr::Utility::Path::join(testAttrSaveDir, "scenes/plane.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "scenes/plane.glb");
 
   stageAttr->setRenderAssetHandle(stageAssetFile);
   stageAttr->setCollisionAssetHandle(stageAssetFile);
@@ -1151,7 +1147,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testStageAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testStageAttrConfig_saved_JSON.{}", TEST_ASSETS,
       stageAttributesManager_->getJSONTypeExt());
 
   bool success = stageAttributesManager_->saveManagedObjectToFile(
@@ -1266,7 +1262,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
   // now need to change the render and collision assets to make sure they are
   // legal so test can proceed (needs to be actual existing file)
   const std::string objAssetFile =
-      Cr::Utility::Path::join(testAttrSaveDir, "objects/donut.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/donut.glb");
 
   objAttr->setRenderAssetHandle(objAssetFile);
   objAttr->setCollisionAssetHandle(objAssetFile);
@@ -1275,7 +1271,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testObjectAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testObjectAttrConfig_saved_JSON.{}", TEST_ASSETS,
       objectAttributesManager_->getJSONTypeExt());
 
   bool success = objectAttributesManager_->saveManagedObjectToFile(
@@ -1384,9 +1380,9 @@ void AttributesConfigsTest::testArticulatedObjectJSONLoad() {
   // they are legal so the test can proceed (needs to be actual existing file so
   // it can be regsitered)
   const std::string aoURDFFlle =
-      Cr::Utility::Path::join(testAttrSaveDir, "urdf/prim_chain.urdf");
+      Cr::Utility::Path::join(TEST_ASSETS, "urdf/prim_chain.urdf");
   const std::string aoRenderAssetName =
-      Cr::Utility::Path::join(testAttrSaveDir, "objects/skinned_prism.glb");
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/skinned_prism.glb");
 
   artObjAttr->setURDFPath(aoURDFFlle);
   artObjAttr->setRenderAssetHandle(aoRenderAssetName);
@@ -1396,7 +1392,7 @@ void AttributesConfigsTest::testArticulatedObjectJSONLoad() {
 
   // before test, save attributes to disk with new name
   std::string newAttrName = Cr::Utility::formatString(
-      "{}/testArtObjectAttrConfig_saved_JSON.{}", testAttrSaveDir,
+      "{}/testArtObjectAttrConfig_saved_JSON.{}", TEST_ASSETS,
       artObjAttributesManager_->getJSONTypeExt());
 
   bool success = artObjAttributesManager_->saveManagedObjectToFile(

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -43,8 +43,6 @@ using Attrs::StageAttributes;
 using Attrs::UVSpherePrimitiveAttributes;
 
 namespace {
-const std::string TEST_ASSET_DIR =
-    Cr::Utility::Path::join(DATA_DIR, "test_assets/");
 
 /**
  * @brief Test attributesManagers' functionality via loading, creating, copying
@@ -581,7 +579,7 @@ void AttributesManagersTest::testAssetAttributesTemplateCreateFromHandle(
 
 void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
   const std::string physicsConfigFile =
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "testing.physics_config.json");
+      Cr::Utility::Path::join(TEST_ASSETS, "testing.physics_config.json");
 
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
@@ -595,7 +593,7 @@ void AttributesManagersTest::testPhysicsAttributesManagersCreate() {
 
 void AttributesManagersTest::testPbrShaderAttributesManagersCreate() {
   const std::string pbrShaderConfigFile =
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "testing.pbr_config.json");
+      Cr::Utility::Path::join(TEST_ASSETS, "testing.pbr_config.json");
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
       "PbrShaderAttributes  JSON config @"
@@ -609,8 +607,8 @@ void AttributesManagersTest::testPbrShaderAttributesManagersCreate() {
 }  // AttributesManagersTest::testPbrShaderAttributesManagersCreate
 
 void AttributesManagersTest::testArticulatedObjectAttributesManagersCreate() {
-  const std::string artObjConfigFile = Cr::Utility::Path::join(
-      TEST_ASSET_DIR, "urdf/skinned_prism.ao_config.json");
+  const std::string artObjConfigFile =
+      Cr::Utility::Path::join(TEST_ASSETS, "urdf/skinned_prism.ao_config.json");
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
       "AO JSON config @"
@@ -624,8 +622,8 @@ void AttributesManagersTest::testArticulatedObjectAttributesManagersCreate() {
   // Valid URDF files that do not (idx 0) and do (idx 1) have existing
   // JSON articulated object configs with the same name
   const std::string validUrdfFiles[] = {
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "urdf/prim_chain.urdf"),
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "urdf/skinned_prism.urdf")};
+      Cr::Utility::Path::join(TEST_ASSETS, "urdf/prim_chain.urdf"),
+      Cr::Utility::Path::join(TEST_ASSETS, "urdf/skinned_prism.urdf")};
   for (int i = 0; i < 2; ++i) {
     CORRADE_INFO(
         "Start Default Test : Create, Edit, Remove Attributes built from "
@@ -642,7 +640,7 @@ void AttributesManagersTest::testArticulatedObjectAttributesManagersCreate() {
 
 void AttributesManagersTest::testStageAttributesManagersCreate() {
   const std::string stageConfigFile = Cr::Utility::Path::join(
-      TEST_ASSET_DIR, "scenes/stage_floor1.stage_config.json");
+      TEST_ASSETS, "scenes/stage_floor1.stage_config.json");
 
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
@@ -656,8 +654,8 @@ void AttributesManagersTest::testStageAttributesManagersCreate() {
   // Valid render asset files that do not (idx 0) and do (idx 1) have existing
   // JSON stage configs with the same name.
   const std::string validStageAssetFiles[] = {
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "scenes/plane.glb"),
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "scenes/simple_room.glb")};
+      Cr::Utility::Path::join(TEST_ASSETS, "scenes/plane.glb"),
+      Cr::Utility::Path::join(TEST_ASSETS, "scenes/simple_room.glb")};
   for (int i = 0; i < 2; ++i) {
     CORRADE_INFO(
         "Start Default Test : Create, Edit, Remove Attributes built from Stage "
@@ -673,8 +671,8 @@ void AttributesManagersTest::testStageAttributesManagersCreate() {
 }  // AttributesManagersTest::StageAttributesManagersCreate
 
 void AttributesManagersTest::testObjectAttributesManagersCreate() {
-  const std::string objectConfigFile = Cr::Utility::Path::join(
-      TEST_ASSET_DIR, "objects/chair.object_config.json");
+  const std::string objectConfigFile =
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/chair.object_config.json");
 
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "
@@ -690,8 +688,8 @@ void AttributesManagersTest::testObjectAttributesManagersCreate() {
   // Valid render asset files that do not (idx 0) and do (idx 1) have existing
   // JSON object configs with the same name.
   const std::string validObjectAssetFiles[] = {
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "objects/5boxes.glb"),
-      Cr::Utility::Path::join(TEST_ASSET_DIR, "objects/chair.glb")};
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/5boxes.glb"),
+      Cr::Utility::Path::join(TEST_ASSETS, "objects/chair.glb")};
   for (int i = 0; i < 2; ++i) {
     CORRADE_INFO(
         "Start Default Tests : Create, Edit, Remove Attributes built from "
@@ -734,7 +732,7 @@ void AttributesManagersTest::testObjectAttributesManagersCreate() {
 
 void AttributesManagersTest::testLightLayoutAttributesManager() {
   const std::string lightConfigFile = Cr::Utility::Path::join(
-      TEST_ASSET_DIR, "lights/test_lights.lighting_config.json");
+      TEST_ASSETS, "lights/test_lights.lighting_config.json");
 
   CORRADE_INFO(
       "Start Test : Create, Edit, Remove Attributes for "

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -337,11 +337,11 @@ void MetadataMediatorTest::testDataset0() {
   const std::string activeSceneName = sceneAttrHandles[0];
   ESP_WARNING() << "testLoadSceneInstances : Scene instance attr handle :"
                 << activeSceneName;
-  // get scene instance attributes ref
+  // get Scene Instance Attributes ref
   // metadata::attributes::SceneInstanceAttributes::cptr
   // curSceneInstanceAttributes =
   auto sceneAttrs = MM_->getSceneInstanceAttributesByName(activeSceneName);
-  // this should be a scene instance attributes with specific stage and object
+  // this should be a Scene Instance Attributes with specific stage and object
   CORRADE_VERIFY(sceneAttrs);
   // verify default value for translation origin
   CORRADE_COMPARE(static_cast<int>(sceneAttrs->getTranslationOrigin()),

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -86,7 +86,7 @@ struct PhysicsTest : Cr::TestSuite::Tester {
       stageAttributesMgr->setCurrPhysicsManagerAttributesHandle(
           physicsManagerAttributes->getHandle());
     }
-    // create scene instance attributes
+    // create Scene Instance Attributes
     esp::metadata::attributes::SceneInstanceAttributes::cptr
         curSceneInstanceAttributes =
             metadataMediator_->getSceneInstanceAttributesByName(stageFile);


### PR DESCRIPTION
## Motivation and Context
This PR fixes a few minor bugs and updates various comments.
Bugfixes : 
- When saving a Managed File-based Object (such as a SceneInstanceAttributes JSON file) and not wishing to overwrite an existing copy, Habitat sim generates a numbered suffix (copy xxxx) where xxxx will be an integer sequence starting at 0000 and incrementing for each copy saved. Currently on main branch, if such a copy is then loaded in a subsequent execution and then another copy is saved, and 2nd 'copy 0000' string is appended to the name. This PR fixes this, and instead properly increments the existing copy count in the name.
- AttributesConfigsTest and AttributesManagersTest are modified to use the correct TEST_ASSETS test directory macro for file IO.
 - Unnecessary 'using' statements are also removed from various metadata managers.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Local C++ and python tests pass
## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
