### PR TITLE
--PBR Primitive support and gl context bugfix

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1186,8 +1186,8 @@ std::vector<Mn::Matrix4> ResourceManager::computeAbsoluteTransformations(
 
 void ResourceManager::buildPrimitiveAssetData(
     const std::string& primTemplateHandle) {
-  // use default material if none specified
-  buildPrimitiveAssetData(primTemplateHandle, DEFAULT_MATERIAL_KEY);
+  // use metallic material for primitives
+  buildPrimitiveAssetData(primTemplateHandle, METALLIC_MATERIAL_KEY);
 
 }  // ResourceManager::buildPrimitiveAssetData
 
@@ -1214,7 +1214,8 @@ void ResourceManager::buildPrimitiveAssetData(
   // RenderAssetCreationInfo structure, so that queries of resourceDict_ using
   // RenderAssetCreationInfo will work properly.
   auto primAssetHandle =
-      (materialKey == "")
+      // Default metallic primitive material
+      (materialKey == METALLIC_MATERIAL_KEY)
           ? primTemplate->getHandle()
           : Cr::Utility::formatString("{}_{}", primTemplate->getHandle(),
                                       materialKey);
@@ -2255,8 +2256,6 @@ void ResourceManager::initDefaultMaterials() {
   Mn::Trade::MaterialData whiteMaterialData = buildDefaultMaterial();
   whiteMaterialData.mutableAttribute<Mn::Color4>(
       Mn::Trade::MaterialAttribute::AmbientColor) = Mn::Color4{1.0};
-  whiteMaterialData.mutableAttribute<Mn::Color4>(
-      Mn::Trade::MaterialAttribute::BaseColor) = Mn::Color4{1.0};
   whiteMaterialData.mutableAttribute<Mn::Float>(
       Mn::Trade::MaterialAttribute::Metalness) = 0.0f;
   whiteMaterialData.mutableAttribute<Mn::Float>(
@@ -2267,12 +2266,25 @@ void ResourceManager::initDefaultMaterials() {
   // Add to shaderManager at specified key location
   shaderManager_.set<Mn::Trade::MaterialData>(WHITE_MATERIAL_KEY,
                                               std::move(whiteMaterialData));
+
+  // Build metallic material
+  Mn::Trade::MaterialData metalMaterialData = buildDefaultMaterial();
+  metalMaterialData.mutableAttribute<Mn::Color4>(
+      Mn::Trade::MaterialAttribute::SpecularColor) = Mn::Color4{1.0};
+  metalMaterialData.mutableAttribute<Mn::Float>(
+      Mn::Trade::MaterialAttribute::Shininess) = 250.0f;
+  metalMaterialData.mutableAttribute<Mn::Float>(
+      Mn::Trade::MaterialAttribute::Metalness) = 0.7f;
+  // Set expected user-defined attributes
+  metalMaterialData = setMaterialDefaultUserAttributes(metalMaterialData,
+                                                       defaultMaterialShader);
+  // Add to shaderManager at specified key location
+  shaderManager_.set<Mn::Trade::MaterialData>(METALLIC_MATERIAL_KEY,
+                                              std::move(metalMaterialData));
   // Build white vertex ID material
   Mn::Trade::MaterialData vertIdMaterialData = buildDefaultMaterial();
   vertIdMaterialData.mutableAttribute<Mn::Color4>(
       Mn::Trade::MaterialAttribute::AmbientColor) = Mn::Color4{1.0};
-  vertIdMaterialData.mutableAttribute<Mn::Color4>(
-      Mn::Trade::MaterialAttribute::BaseColor) = Mn::Color4{1.0};
   vertIdMaterialData.mutableAttribute<Mn::Float>(
       Mn::Trade::MaterialAttribute::Metalness) = 0.0f;
   vertIdMaterialData.mutableAttribute<Mn::Float>(

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -3304,6 +3304,11 @@ void ResourceManager::initDefaultLightSetups() {
 std::shared_ptr<gfx::PbrIBLHelper> ResourceManager::getOrBuildPBRIBLHelper(
     const std::shared_ptr<esp::metadata::attributes::PbrShaderAttributes>&
         pbrShaderAttr) {
+  // Don't attempt to retrieve or create IBL maps if no gl context is available
+  if (!getCreateRenderer()) {
+    return nullptr;
+  }
+
   auto helperKey = pbrShaderAttr->getPbrShaderHelperKey();
 
   ESP_DEBUG(Mn::Debug::Flag::NoSpace)

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1842,10 +1842,18 @@ bool ResourceManager::buildTrajectoryVisualization(
       Mn::Trade::MaterialAttribute::SpecularColor) = Mn::Color4{1.0};
   materialData.mutableAttribute<Mn::Float>(
       Mn::Trade::MaterialAttribute::Shininess) = 160.0f;
+  materialData.mutableAttribute<Mn::Color4>(
+      Mn::Trade::MaterialAttribute::BaseColor) = Mn::Color4{1.0};
+  materialData.mutableAttribute<Mn::Float>(
+      Mn::Trade::MaterialAttribute::Metalness) = 0.05f;
+  materialData.mutableAttribute<Mn::Float>(
+      Mn::Trade::MaterialAttribute::Roughness) = 0.05f;
+
   // Set expected user-defined attributes
   materialData = setMaterialDefaultUserAttributes(
-      materialData, ObjectInstanceShaderType::Phong, true);
+      materialData, ObjectInstanceShaderType::PBR, true);
 
+  meshMetaData.root.materialID = std::to_string(nextMaterialID_++);
   shaderManager_.set<Mn::Trade::MaterialData>(meshMetaData.root.materialID,
                                               std::move(materialData));
 
@@ -2355,7 +2363,7 @@ void ResourceManager::loadMaterials(Importer& importer,
       if ((shaderTypeToUse != ObjectInstanceShaderType::Material) &&
           (shaderTypeToUse != ObjectInstanceShaderType::Flat) &&
           !(compareShaderTypeToMnMatType(shaderTypeToUse, *materialData))) {
-        // Only create this string if veryverbose logging is enabled
+        // Only create this string if debug logging is enabled
         if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
           materialExpandStr = Cr::Utility::formatString(
               "Forcing to {} shader (material requires expansion to support it "

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -699,14 +699,26 @@ class ResourceManager {
       bool forceFlatShading);
 
   /**
-   * @brief Build a primitive asset based on passed template parameters.  If
-   * exists already, does nothing.  Will use primitiveImporter_ to call
-   * appropriate method to construct asset.
+   * @brief Build a primitive asset based on the template parameters encoded in
+   * @p primTemplateHandle , using the predefined material referenced by
+   * DEFAULT_MATERIAL_KEY. If primitive asset exists already, does nothing. Will
+   * use primitiveImporter_ to call appropriate method to construct asset.
    * @param primTemplateHandle the handle referring to the attributes describing
    * primitive to instantiate
    */
   void buildPrimitiveAssetData(const std::string& primTemplateHandle);
 
+  /**
+   * @brief Build a primitive asset based on passed template parameters and
+   * passed material key. If exists already, does nothing. Will use
+   * primitiveImporter_ to call appropriate method to construct asset.
+   * @param primTemplateHandle the handle referring to the attributes describing
+   * primitive to instantiate
+   * @param materialKey The key to the existing material being used for this
+   * primitive.
+   */
+  void buildPrimitiveAssetData(const std::string& primTemplateHandle,
+                               const std::string& materialKey);
   /**
    * @brief this will build a MaterialData compatible with Flat, Phong and
    * PBR @ref Magnum::Trade::MaterialData, using default attributes

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -708,11 +708,12 @@ class ResourceManager {
   void buildPrimitiveAssetData(const std::string& primTemplateHandle);
 
   /**
-   * @brief this will build a Phong @ref Magnum::Trade::MaterialData using
-   * default attributes from deprecated/removed esp::gfx::PhongMaterialData.
-   * @return The new phong color populated with default values
+   * @brief this will build a MaterialData compatible with Flat, Phong and
+   * PBR @ref Magnum::Trade::MaterialData, using default attributes
+   * from deprecated/removed habitat material default values.
+   * @return The new material populated with default values
    */
-  Mn::Trade::MaterialData buildDefaultPhongMaterial();
+  Mn::Trade::MaterialData buildDefaultMaterial();
 
   /**
    * @brief Define and set user-defined attributes for the passed

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -1118,6 +1118,11 @@ class ResourceManager {
   void initDefaultMaterials();
 
   /**
+   * @brief Retrieve the shader type to use for the various default materials.
+   */
+  ObjectInstanceShaderType getDefaultMaterialShaderType();
+
+  /**
    * @brief Checks if light setup is compatible with loaded asset
    */
   bool isLightSetupCompatible(const LoadedAssetData& loadedAssetData,

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -102,9 +102,15 @@ constexpr char DEFAULT_MATERIAL_KEY[] = "";
 
 /**
  *@brief The @ref esp::gfx::ShaderManager key for full ambient white @ref
- *esp::gfx::MaterialInfo used for primitive wire-meshes
+ *esp::gfx::MaterialInfo
  */
 constexpr char WHITE_MATERIAL_KEY[] = "ambient_white";
+
+/**
+ *@brief The @ref esp::gfx::ShaderManager key for shiny metallic @ref
+ *esp::gfx::MaterialInfo
+ */
+constexpr char METALLIC_MATERIAL_KEY[] = "metallic_gray";
 
 /**
  *@brief The @ref ShaderManager key for @ref MaterialInfo with per-vertex

--- a/src/esp/gfx/PbrDrawable.cpp
+++ b/src/esp/gfx/PbrDrawable.cpp
@@ -327,6 +327,12 @@ void PbrDrawable::setMaterialValuesInternal(
       matCache.volumeLayer.attenuationColor = *attenuationColor;
     }
   }  // has KHR_materials_volume layer
+
+  // Vertex colors (for synth assets)
+  if (meshAttributeFlags_ & Drawable::Flag::HasVertexColor) {
+    flags_ |= PbrShader::Flag::VertexColor;
+  }
+
   // If not reset then make sure the same shader is used
   if (!reset) {
     flags_ = oldFlags;

--- a/src/esp/gfx/PbrShader.cpp
+++ b/src/esp/gfx/PbrShader.cpp
@@ -107,6 +107,11 @@ PbrShader::PbrShader(Flags originalFlags,
     attributeLocationsStream << Cr::Utility::formatString(
         "#define ATTRIBUTE_LOCATION_TANGENT4 {}\n", Tangent4::Location);
   }
+  if (flags_ >= Flag::VertexColor) {
+    attributeLocationsStream << Cr::Utility::formatString(
+        "#define ATTRIBUTE_LOCATION_COLOR {}\n", Color4::Location);
+  }
+
   // TODO: Occlusion texture to be added.
 
   if (isTextured_) {
@@ -126,6 +131,7 @@ PbrShader::PbrShader(Flags originalFlags,
       .addSource(isTextured_ && (flags_ >= Flag::TextureTransformation)
                      ? "#define TEXTURE_TRANSFORMATION\n"
                      : "")
+      .addSource(flags_ >= Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
       .addSource(rs.getString("pbr.vert"));
 
   std::stringstream outputAttributeLocationsStream;
@@ -146,6 +152,7 @@ PbrShader::PbrShader(Flags originalFlags,
       .addSource(flags_ >= Flag::NormalTexture ? "#define NORMAL_TEXTURE\n"
                                                : "")
       .addSource(flags_ >= Flag::ObjectId ? "#define OBJECT_ID\n" : "")
+      .addSource(flags_ >= Flag::VertexColor ? "#define VERTEX_COLOR\n" : "")
 
       // Clearcoat layer
       .addSource(flags_ >= Flag::ClearCoatLayer ? "#define CLEAR_COAT\n" : "")

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -109,6 +109,11 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
     EmissiveTexture = 1ULL << 4,
 
     /**
+     * Support mesh vertex colors
+     */
+    VertexColor = 1ULL << 5,
+
+    /**
      * Enable texture coordinate transformation. If this flag is set,
      * the shader expects that at least one of
      * @ref Flag::BaseColorTexture, @ref Flag::RoughnessTexture,
@@ -118,7 +123,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * @ref Flag::OcclusionRoughnessMetallicTexture is enabled as well.
      * @see @ref setTextureMatrix()
      */
-    TextureTransformation = 1ULL << 5,
+    TextureTransformation = 1ULL << 6,
 
     /**
      * TODO: Do we need instanced object? (instanced texture, instanced id etc.)
@@ -136,86 +141,84 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * see PBR fragment shader code for more details
      * Requires the @ref Tangent4 attribute to be present.
      */
-    PrecomputedTangent = 1ULL << 6,
+    PrecomputedTangent = 1ULL << 7,
 
     /**
      * Enable object ID output for this shader.
      */
-    ObjectId = 1ULL << 7,
+    ObjectId = 1ULL << 8,
 
     /**
      * Support Instanced object ID. Retrieves a per-instance / per-vertex
      * object ID from the @ref ObjectId attribute. If this is false, the shader
      * will use the node's semantic ID
      */
-    InstancedObjectId = (1ULL << 8) | ObjectId,
+    InstancedObjectId = (1ULL << 9) | ObjectId,
 
     /**
      * Has ClearCoat layer.
      */
-    ClearCoatLayer = 1ULL << 9,
+    ClearCoatLayer = 1ULL << 10,
     /**
      * Has ClearCoat Texture in ClearCoat layer
      */
-    ClearCoatTexture = (1ULL << 10) | ClearCoatLayer,
+    ClearCoatTexture = (1ULL << 11) | ClearCoatLayer,
     /**
      * Has Roughness Texture in ClearCoat layer
      */
-    ClearCoatRoughnessTexture = (1ULL << 11) | ClearCoatLayer,
+    ClearCoatRoughnessTexture = (1ULL << 12) | ClearCoatLayer,
     /**
      * Has Normal Texture in ClearCoat layer
      */
-    ClearCoatNormalTexture = (1ULL << 12) | ClearCoatLayer,
+    ClearCoatNormalTexture = (1ULL << 13) | ClearCoatLayer,
 
     /**
      * Has KHR_materials_specular layer
      */
-    SpecularLayer = 1ULL << 13,
+    SpecularLayer = 1ULL << 14,
     /**
      * Has Specular Texture in KHR_materials_specular layer
      */
-    SpecularLayerTexture = (1ULL << 14) | SpecularLayer,
+    SpecularLayerTexture = (1ULL << 15) | SpecularLayer,
 
     /**
      * Has Specular Color Texture in KHR_materials_specular layer
      */
-    SpecularLayerColorTexture = (1ULL << 15) | SpecularLayer,
+    SpecularLayerColorTexture = (1ULL << 16) | SpecularLayer,
 
     /**
      * Has KHR_materials_anisotropy layer
      */
-    AnisotropyLayer = 1ULL << 16,
+    AnisotropyLayer = 1ULL << 17,
 
     /**
      * Has Anisotropy Texture in KHR_materials_anisotropy layer
      */
-    AnisotropyLayerTexture = (1ULL << 17) | AnisotropyLayer,
+    AnisotropyLayerTexture = (1ULL << 18) | AnisotropyLayer,
 
     /**
      * Has KHR_materials_transmission layer
      */
-    TransmissionLayer = 1ULL << 18,
+    TransmissionLayer = 1ULL << 19,
     /**
      * Has transmission texture in KHR_materials_transmission layer
      */
-    TransmissionLayerTexture = (1ULL << 19) | TransmissionLayer,
+    TransmissionLayerTexture = (1ULL << 20) | TransmissionLayer,
 
     /**
      * Has KHR_materials_volume layer
      */
-    VolumeLayer = 1ULL << 20,
+    VolumeLayer = 1ULL << 21,
 
     /**
      * Has Thickness texture in  KHR_materials_volume layer
      */
-    VolumeLayerThicknessTexture = (1ULL << 21) | VolumeLayer,
+    VolumeLayerThicknessTexture = (1ULL << 22) | VolumeLayer,
 
     /**
      * Enable double-sided rendering.
-     * (Temporarily STOP supporting this functionality. See comments in
-     * the PbrDrawable::draw() function)
      */
-    DoubleSided = 1ULL << 22,
+    DoubleSided = 1ULL << 23,
 
     ///////////////////////////////
     // PbrShaderAttributes provides these values to configure the shader
@@ -224,12 +227,12 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * If not set, disable direct lighting regardless of presence of lights.
      * Ignored if no direct lights present.
      */
-    DirectLighting = 1ULL << 23,
+    DirectLighting = 1ULL << 24,
 
     /**
      * Enable image based lighting
      */
-    ImageBasedLighting = 1ULL << 24,
+    ImageBasedLighting = 1ULL << 25,
 
     /**
      * Whether or not the direct lighting diffuse calculation should use the
@@ -238,7 +241,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf
      * Lambertian is simpler and quicker to calculate but may not look as 'nice'
      */
-    UseBurleyDiffuse = 1ULL << 25,
+    UseBurleyDiffuse = 1ULL << 26,
 
     /**
      * If set, skip TBN frame calculation in fragment shader. This calculation
@@ -246,7 +249,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * provided.
      * TODO : implement in shader.
      */
-    SkipMissingTBNCalc = 1ULL << 26,
+    SkipMissingTBNCalc = 1ULL << 27,
 
     /**
      * Use the Mikkelsen algorithm to calculate TBN, as per
@@ -256,7 +259,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * https://github.com/KhronosGroup/Vulkan-Samples/blob/main/shaders/pbr.frag,
      * which empirically seems to give equivalent results.
      */
-    UseMikkelsenTBN = 1ULL << 27,
+    UseMikkelsenTBN = 1ULL << 28,
 
     /**
      * Whether we should use shader-based srgb->linear approx remapping of
@@ -264,7 +267,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * and IBL. This field should be removed/ignored when Magnum fully supports
      * sRGB texture conversion on load.
      */
-    MapMatTxtrToLinear = 1ULL << 28,
+    MapMatTxtrToLinear = 1ULL << 29,
 
     /**
      * Whether we should use shader-based srgb->linear approx remapping of
@@ -272,7 +275,7 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * calculations. This field should be removed/ignored when Magnum fully
      * supports sRGB texture conversion on load.
      */
-    MapIBLTxtrToLinear = 1ULL << 29,
+    MapIBLTxtrToLinear = 1ULL << 30,
 
     /**
      * Whether we should use shader-based linear->srgb approx remapping of
@@ -280,17 +283,17 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * field should be removed/ignored when an appropriate framebuffer is used
      * for output to handle this conversion.
      */
-    MapOutputToSRGB = 1ULL << 30,
+    MapOutputToSRGB = 1ULL << 31,
 
     /**
      * Whether or not to use tonemappping for direct lighting.
      */
-    UseDirectLightTonemap = 1ULL << 31,
+    UseDirectLightTonemap = 1ULL << 32,
 
     /**
      * Whether or not to use tonemappping for image-based lighting.
      */
-    UseIBLTonemap = 1ULL << 32,
+    UseIBLTonemap = 1ULL << 33,
 
     ////////////////
     // Testing and debugging
@@ -299,25 +302,25 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
      * sent to the shader, but no actual calcuations will be performed if this
      * is set.
      */
-    SkipClearCoatLayer = 1ULL << 33,
+    SkipClearCoatLayer = 1ULL << 34,
     /**
      * Whether we should skip all specular layer calcs. Values will still be
      * sent to the shader, but no actual calcuations will be performed if this
      * is set.
      */
-    SkipSpecularLayer = 1ULL << 34,
+    SkipSpecularLayer = 1ULL << 35,
     /**
      * Whether we should skip all anisotropy layer calcs. Values will still be
      * sent to the shader, but no actual calcuations will be performed if this
      * is set.
      */
-    SkipAnisotropyLayer = 1ULL << 35,
+    SkipAnisotropyLayer = 1ULL << 36,
 
     /**
      * Enable shader debug mode. Then developer can set the uniform
      * PbrDebugDisplay in the fragment shader for debugging
      */
-    DebugDisplay = 1ULL << 36,
+    DebugDisplay = 1ULL << 37,
     /*
      * TODO: alphaMask
      */

--- a/src/esp/gfx/PbrShader.h
+++ b/src/esp/gfx/PbrShader.h
@@ -53,6 +53,11 @@ class PbrShader : public Magnum::GL::AbstractShaderProgram {
    */
   typedef Magnum::Shaders::GenericGL3D::Tangent4 Tangent4;
 
+  /**
+   * @brief Four-component vertex color
+   */
+  typedef Magnum::Shaders::GenericGL3D::Color4 Color4;
+
   enum : Magnum::UnsignedInt {
     /**
      * Color shader output. @ref shaders-generic "Generic output",

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -242,6 +242,13 @@ class MetadataMediator {
   }
 
   /**
+   * @brief Retrieve the shader type to use for the various default materials.
+   */
+  attributes::ObjectInstanceShaderType getDefaultMaterialShaderType() {
+    return getActiveDSAttribs()->getDefaultMaterialShaderType();
+  }
+
+  /**
    * @brief Get a list of all scene instances available in the currently active
    * dataset
    */

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -24,6 +24,8 @@ SceneDatasetAttributes::SceneDatasetAttributes(
   stageAttributesManager_ =
       managers::StageAttributesManager::create(physAttrMgr);
   stageAttributesManager_->setAssetAttributesManager(assetAttributesManager_);
+  // Use PBR as default materials.Override this in SceneDataset config
+  setDefaultMaterialIsPBR(true);
 }  // ctor
 
 bool SceneDatasetAttributes::addNewSceneInstanceToDataset(

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -91,6 +91,24 @@ class SceneDatasetAttributes : public AbstractAttributes {
   }
 
   /**
+   * @brief Retrieve the shader type to use for the various default materials,
+   * either Phong of PBR
+   */
+  ObjectInstanceShaderType getDefaultMaterialShaderType() const {
+    return get<bool>("default_material_is_pbr")
+               ? ObjectInstanceShaderType::PBR
+               : ObjectInstanceShaderType::Phong;
+  }
+
+  /**
+   * @brief Set whether to use PBR or Phong for the default material values
+   * defined in resource Manager.
+   */
+  void setDefaultMaterialIsPBR(bool default_material_is_pbr) {
+    set("default_material_is_pbr", default_material_is_pbr);
+  }
+
+  /**
    * @brief Return the map for navmesh file locations
    */
   const std::map<std::string, std::string>& getNavmeshMap() const {

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -173,6 +173,20 @@ AssetAttributesManager::createTemplateFromHandle(
                                   registerTemplate);
 }  // AssetAttributesManager::createTemplateFromHandle
 
+attributes::AbstractPrimitiveAttributes::cptr
+AssetAttributesManager::getOrCreateTemplateFromHandle(
+    const std::string& templateHandle,
+    bool registerTemplate) {
+  if (!getObjectLibHasHandle(templateHandle)) {
+    // If doesn't exist, create template from handle
+    createTemplateFromHandle(templateHandle, registerTemplate);
+  }
+  // Returns the actual template, not a copy
+  attributes::AbstractPrimitiveAttributes::cptr resTemplate =
+      getObjectByHandle(templateHandle);
+  return resTemplate;
+}  // AssetAttributesManager::createTemplateFromHandle
+
 int AssetAttributesManager::registerObjectFinalize(
     AbstractPrimitiveAttributes::ptr primAttributesTemplate,
     const std::string&,

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -153,6 +153,23 @@ class AssetAttributesManager
       bool registerTemplate = true);
 
   /**
+   * @brief Retrieves the template specified by the supplied handle, creating
+   * the template if none exists. Since the primitive asset attributes templates
+   * encode their structure in their handles, and these handles are not user
+   * editable, a properly configured handle can be used to build a template.
+   * @param templateHandle The template handle to use to create the attributes.
+   * @param registerTemplate whether to add this template to the library.
+   * If the user is going to edit this template, this should be false - any
+   * subsequent editing will require re-registration. Defaults to true. If
+   * specified as true, then this function returns a copy of the registered
+   * template.
+   * @return The attributes that most closely matches the given handle.
+   */
+  attributes::AbstractPrimitiveAttributes::cptr getOrCreateTemplateFromHandle(
+      const std::string& templateHandle,
+      bool registerTemplate = true);
+
+  /**
    * @brief Should only be called internally. Creates an instance of a
    * primtive asset attributes template described by passed enum value. For
    * primitive assets this mapes to the Magnum primitive class name

--- a/src/shaders/gfx/pbr.vert
+++ b/src/shaders/gfx/pbr.vert
@@ -15,6 +15,10 @@ layout(location = ATTRIBUTE_LOCATION_TEXCOORD) in highp vec2 vertexTexCoord;
 layout(location = ATTRIBUTE_LOCATION_TANGENT4) in highp vec4 vertexTangent;
 #endif
 
+#ifdef VERTEX_COLOR
+layout(location = ATTRIBUTE_LOCATION_COLOR) in highp vec4 vertexColor;
+#endif
+
 // -------------- output ---------------------
 // position, normal, tangent in *world* space, NOT camera space!
 out highp vec3 position;
@@ -33,7 +37,9 @@ uniform highp mat3 uTextureMatrix
 out highp vec3 tangent;
 out highp vec3 biTangent;
 #endif
-
+#ifdef VERTEX_COLOR
+out highp vec4 interpolatedVertexColor;
+#endif
 // ------------ uniform ----------------------
 uniform highp mat4 uViewMatrix;
 uniform highp mat3 uNormalMatrix;  // inverse transpose of 3x3 model matrix, NOT
@@ -63,6 +69,10 @@ void main() {
   // later in .frag, TBN will transform the normal perturbation
   // (read from normal map) from tangent space to world space,
   // NOT camera space
+#endif
+#ifdef VERTEX_COLOR
+  /* Vertex colors, if enabled */
+  interpolatedVertexColor = vertexColor;
 #endif
 
   gl_Position = uProjectionMatrix * uViewMatrix * vertexWorldPosition;

--- a/src/shaders/gfx/pbrMaterials.glsl
+++ b/src/shaders/gfx/pbrMaterials.glsl
@@ -150,7 +150,11 @@ PBRData buildPBRData() {
   pbrInfo.n_dot_v = clamp(dot(pbrInfo.n, pbrInfo.view), 0.0, 1.0);
   //////////////////////
   // colors
-  pbrInfo.baseColor = uMaterial.baseColor;
+  pbrInfo.baseColor = uMaterial.baseColor
+#ifdef VERTEX_COLOR
+                      * interpolatedVertexColor
+#endif
+      ;
 #if defined(BASECOLOR_TEXTURE)
 
 #if defined(MAP_MAT_TXTRS_TO_LINEAR)

--- a/src/shaders/gfx/pbrUniforms.glsl
+++ b/src/shaders/gfx/pbrUniforms.glsl
@@ -16,7 +16,9 @@ in highp vec2 texCoord;
 in highp vec3 tangent;
 in highp vec3 biTangent;
 #endif
-
+#ifdef VERTEX_COLOR
+in highp vec4 interpolatedVertexColor;
+#endif
 // -------------- uniforms ----------------
 #if defined(OBJECT_ID)
 uniform highp uint uObjectId;


### PR DESCRIPTION
## Motivation and Context
This PR introduces PBR material support and generation for primitives and generated meshes such as trajectories, which were formerly restricted to just phong materials, which looked out of place in scenes that were predominantly rendered using PBR with image-based lighting.  This also adds vertex color support for PBR materials.  Lastly, this also fixes a bug that was present if trying to build a PBR containing scene without a context (which was being done in a few of the tests).

This functionality was originally going to be part of the PBRTesting PR but I chose to go a different direction with that test due to the difficulty in assigning custom materials to primitive assets on creation.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
C++ and python tests pass locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
