### PR TITLE
[P0 - Do not merge] Lighting tweaks for P0.

### DIFF
--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -104,7 +104,7 @@ Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
   } else {
     // todo: add up ambient terms from all lights in lightSetup
     // temp: hard-coded ambient light tuned for ReplicaCAD
-    float ambientIntensity = 0.4;
+    float ambientIntensity = 0.55;
     return Magnum::Color3(ambientIntensity, ambientIntensity, ambientIntensity);
   }
 }


### PR DESCRIPTION
* Increase ambient intensity to make spot and humanoids brighter for P0.

![p0_lighting](https://github.com/facebookresearch/habitat-sim/assets/110583667/92524291-b5e9-4842-b56a-8396158176fd)

| Before | After |
| -------- | ------- |
| ![p0_lighting_before](https://github.com/facebookresearch/habitat-sim/assets/110583667/3abc42a5-8f99-4f92-81c1-529856991047) | ![p0_lighting_after](https://github.com/facebookresearch/habitat-sim/assets/110583667/6609d2e3-35f8-4746-a4d6-7ac88021e8d3) |
