### PR TITLE
[P0 - Do not merge] Lighting tweaks for P0.

### DIFF
--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -104,7 +104,7 @@ Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
   } else {
     // todo: add up ambient terms from all lights in lightSetup
     // temp: hard-coded ambient light tuned for ReplicaCAD
-    float ambientIntensity = 0.60;
+    float ambientIntensity = 0.9;
     return Magnum::Color3(ambientIntensity, ambientIntensity, ambientIntensity);
   }
 }

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -104,7 +104,7 @@ Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
   } else {
     // todo: add up ambient terms from all lights in lightSetup
     // temp: hard-coded ambient light tuned for ReplicaCAD
-    float ambientIntensity = 0.4;
+    float ambientIntensity = 0.55;
     return Magnum::Color3(ambientIntensity, ambientIntensity, ambientIntensity);
   }
 }

--- a/src/esp/gfx/LightSetup.cpp
+++ b/src/esp/gfx/LightSetup.cpp
@@ -104,7 +104,7 @@ Magnum::Color3 getAmbientLightColor(const LightSetup& lightSetup) {
   } else {
     // todo: add up ambient terms from all lights in lightSetup
     // temp: hard-coded ambient light tuned for ReplicaCAD
-    float ambientIntensity = 0.55;
+    float ambientIntensity = 0.60;
     return Magnum::Color3(ambientIntensity, ambientIntensity, ambientIntensity);
   }
 }

--- a/src/esp/metadata/attributes/PbrShaderAttributes.cpp
+++ b/src/esp/metadata/attributes/PbrShaderAttributes.cpp
@@ -48,6 +48,13 @@ PbrShaderAttributes::PbrShaderAttributes(const std::string& handle)
   setMapIBLTxtrToLinear(false);
   setMapOutputToSRGB(false);
   setGamma(2.2f);
+
+  // Hack for increasing the light level when replay rendering
+  float scaleVal = 0.7;
+  setDirectDiffuseScale(scaleVal);
+  setDirectSpecularScale(scaleVal);
+  setIBLDiffuseScale(scaleVal);
+  setIBLSpecularScale(scaleVal);
 }  // PbrShaderAttributes ctor
 
 void PbrShaderAttributes::writeValuesToJson(


### PR DESCRIPTION
* Increase ambient intensity to brighten spot and humanoids, which are phong-shaded instead of PBR-shaded.
* Increase PBR light intensity for replay rendering.