### PR TITLE
Fix rigs not being deleted from the recorder.

### DIFF
--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -182,7 +182,7 @@ void Recorder::onDeleteRenderAssetInstance(const scene::SceneNode* node) {
 
   const auto& instanceRecord = instanceRecords_[index];
   const auto& instanceKey = instanceRecord.instanceKey;
-  const auto& rigId = instanceRecord.rigId;
+  const int rigId = instanceRecord.rigId;
 
   checkAndAddDeletion(&getKeyframe(), instanceKey);
 


### PR DESCRIPTION
## Motivation and Context

A sneaky reference was causing the `rigId` to reset to the default value (`-1`) after the instance record was cleared, causing the removal from internal maps to fail.

## How Has This Been Tested

Tested locally with the sandbox tool humanoid switching.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
