### PR TITLE
Set the default fallback material as Phong.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -2181,6 +2181,17 @@ Mn::Trade::MaterialData ResourceManager::buildDefaultMaterial() {
   return materialData;
 }  // ResourceManager::buildDefaultMaterial
 
+// Specifically for building materials that relied on old defaults
+Mn::Trade::MaterialData ResourceManager::buildDefaultPhongMaterial() {
+  Mn::Trade::MaterialData materialData{
+      Mn::Trade::MaterialType::Phong,
+      {{Mn::Trade::MaterialAttribute::AmbientColor, Mn::Color4{0.1}},
+       {Mn::Trade::MaterialAttribute::DiffuseColor, Mn::Color4{0.7 * 0.175}},
+       {Mn::Trade::MaterialAttribute::SpecularColor, Mn::Color4{0.2 * 0.175}},
+       {Mn::Trade::MaterialAttribute::Shininess, 80.0f}}};
+  return materialData;
+}  // ResourceManager::buildDefaultPhongMaterial
+
 Mn::Trade::MaterialData ResourceManager::setMaterialDefaultUserAttributes(
     const Mn::Trade::MaterialData& material,
     ObjectInstanceShaderType shaderTypeToUse,
@@ -2297,10 +2308,14 @@ void ResourceManager::initDefaultMaterials() {
                                               std::move(vertIdMaterialData));
 
   // Build default material for fallback material
-  auto fallBackMaterial = buildDefaultMaterial();
+  // TODO: Skinning only works with Phong.
+  //       The default material is loaded when the simulation is only using
+  //       depth sensors. We set the fallback as Phong to avoid breaking
+  //       skinning with depth sensors.
+  auto fallBackMaterial = buildDefaultPhongMaterial();
   // Set expected user-defined attributes
-  fallBackMaterial =
-      setMaterialDefaultUserAttributes(fallBackMaterial, defaultMaterialShader);
+  fallBackMaterial = setMaterialDefaultUserAttributes(
+      fallBackMaterial, ObjectInstanceShaderType::Phong);
   // Add to shaderManager as fallback material
   shaderManager_.setFallback<Mn::Trade::MaterialData>(
       std::move(fallBackMaterial));

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -722,6 +722,11 @@ class ResourceManager {
   Mn::Trade::MaterialData buildDefaultMaterial();
 
   /**
+   * @brief Build a default Phong material.
+   */
+  Mn::Trade::MaterialData buildDefaultPhongMaterial();
+
+  /**
    * @brief Define and set user-defined attributes for the passed
    * @ref Magnum::Trade::MaterialData.
    * @param material The material to initialize with the expected


### PR DESCRIPTION
## Motivation and Context

The default materials were changed to PBR [here](https://github.com/facebookresearch/habitat-sim/pull/2235), including the default fallback material. When rendering with depth cameras, no texture is loaded from materials. The fallback material is instead applied to objects.

Because skinning only works with Phong, it breaks when the only sensors present in the simulation are depth.

This changes the default fallback material to Phong. We can revert this change when skinning support is added to PBR.

## How Has This Been Tested

Tested locally on the SIRo HITL tool.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
