### PR TITLE
--Update reference to deprecated Magnum 'angle' function

### DIFF
--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -325,11 +325,11 @@ void PhysicsTest::testCollisionBoundingBox() {
         // object is being pushed, so should be moving
         CORRADE_COMPARE_AS(position, prevPosition,
                            Cr::TestSuite::Compare::NotEqual);
-        Magnum::Rad q_angle =
-            Magnum::Math::angle(orientation, Magnum::Quaternion({0, 0, 0}, 1));
+        Magnum::Rad q_halfAngle = Magnum::Math::halfAngle(
+            orientation, Magnum::Quaternion({0, 0, 0}, 1));
         if (i == 1) {
           // bounding box for collision, so the sphere should not be rolling
-          CORRADE_COMPARE_AS(q_angle, Magnum::Rad{0.1},
+          CORRADE_COMPARE_AS(q_halfAngle, Magnum::Rad{0.1},
                              Cr::TestSuite::Compare::LessOrEqual);
         } else {
           // no bounding box, so the sphere should be rolling


### PR DESCRIPTION
## Motivation and Context
The Magnum::Math::angle() function has been[ renamed/deprecated in this PR](https://github.com/facebookresearch/habitat-sim/pull/2243). This PR addresses a leftover reference to the deprecated function call.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
