### PR TITLE
--[BE Week] Update projection matrix near/far plane calcs

### DIFF
--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -207,12 +207,13 @@ esp::geo::Ray RenderCamera::unproject(const Mn::Vector2i& viewportPosition,
       2 * Magnum::Vector2{viewPos} / Magnum::Vector2{viewport()} -
           Magnum::Vector2{1.0f},
       1.0};
-  const auto projMat = projectionMatrix();
+  const Mn::Matrix4 projMat = projectionMatrix();
 
   // compute the far plane distance
   // If projMat[3][3] == 0 then perpsective, otherwise ortho
-  auto farDistance = (projMat[3][3] == 0 ? projMat.perspectiveProjectionFar()
-                                         : projMat.orthographicProjectionFar());
+  const Mn::Float farDistance =
+      (projMat[3][3] == 0 ? projMat.perspectiveProjectionFar()
+                          : projMat.orthographicProjectionFar());
 
   ray.direction =
       ((object().absoluteTransformationMatrix() * invertedProjectionMatrix)

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -19,9 +19,9 @@ namespace gfx {
 
 /**
  * @brief do frustum culling with temporal coherence
- * @param range, the axis-aligned bounding box
- * @param frustum, the frustum
- * @param frustumPlaneIndex, the frustum plane in last frame that culled the
+ * @param range the axis-aligned bounding box
+ * @param frustum the frustum
+ * @param frustumPlaneIndex the frustum plane in last frame that culled the
  * aabb (default: 0)
  * @return NullOpt if aabb intersects the frustum, otherwise the frustum plane
  * that culls the aabb
@@ -207,10 +207,12 @@ esp::geo::Ray RenderCamera::unproject(const Mn::Vector2i& viewportPosition,
       2 * Magnum::Vector2{viewPos} / Magnum::Vector2{viewport()} -
           Magnum::Vector2{1.0f},
       1.0};
+  const auto projMat = projectionMatrix();
 
   // compute the far plane distance
-  auto farDistance =
-      projectionMatrix()[3][2] / (1.0f + projectionMatrix()[2][2]);
+  // If projMat[3][3] == 0 then perpsective, otherwise ortho
+  auto farDistance = (projMat[3][3] == 0 ? projMat.perspectiveProjectionFar()
+                                         : projMat.orthographicProjectionFar());
 
   ray.direction =
       ((object().absoluteTransformationMatrix() * invertedProjectionMatrix)

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -210,7 +210,7 @@ esp::geo::Ray RenderCamera::unproject(const Mn::Vector2i& viewportPosition,
   const Mn::Matrix4 projMat = projectionMatrix();
 
   // compute the far plane distance
-  // If projMat[3][3] == 0 then perpsective, otherwise ortho
+  // If projMat[3][3] == 0 then perspective, otherwise ortho
   const Mn::Float farDistance =
       (projMat[3][3] == 0 ? projMat.perspectiveProjectionFar()
                           : projMat.orthographicProjectionFar());

--- a/src/esp/gfx_batch/Hbao.cpp
+++ b/src/esp/gfx_batch/Hbao.cpp
@@ -832,19 +832,14 @@ void prepareHbaoData(
 
 Mn::Vector4 buildClipInfo(const Mn::Matrix4& projectionMatrix,
                           bool orthographic) {
-  // TODO this still looks like there's some better way this should be
-  // extracted.  Definitely change to use near and far calcs upstream when
-  // available!!
-  // Ref :
-  // https://github.com/mosra/magnum/commit/0d31f7461b31698ea5bf92ec66ff5056a6ad7360
   if (orthographic) {
-    auto nearPlane = (projectionMatrix[3][2] + 1.0f) / projectionMatrix[2][2];
-    auto farPlane = (projectionMatrix[3][2] - 1.0f) / projectionMatrix[2][2];
+    auto nearPlane = projectionMatrix.orthographicProjectionNear();
+    auto farPlane = projectionMatrix.orthographicProjectionFar();
     return {nearPlane * farPlane, nearPlane - farPlane, farPlane, 0.0f};
   }
   // perspective
-  auto nearPlane = projectionMatrix[3][2] / (projectionMatrix[2][2] - 1.0f);
-  auto farPlane = projectionMatrix[3][2] / (projectionMatrix[2][2] + 1.0f);
+  auto nearPlane = projectionMatrix.perspectiveProjectionNear();
+  auto farPlane = projectionMatrix.perspectiveProjectionFar();
   return {nearPlane * farPlane, nearPlane - farPlane, farPlane, 1.0f};
 }
 }  // namespace

--- a/src/esp/sensor/CameraSensor.h
+++ b/src/esp/sensor/CameraSensor.h
@@ -90,10 +90,9 @@ class CameraSensor : public VisualSensor {
   void setFOV(Mn::Deg FOV) {
     hfov_ = FOV;
     if (cameraSensorSpec_->sensorSubType != SensorSubType::Pinhole) {
-      ESP_DEBUG()
-          << "Only Perspective-base CameraSensors use "
-             "FOV. Specified value saved but will not be consumed by this "
-             "CameraSensor.";
+      ESP_DEBUG() << "Only Perspective-based CameraSensors use "
+                     "FOV. Specified value will be saved but will not be "
+                     "consumed by this CameraSensor.";
     }
     recomputeBaseProjectionMatrix();
   }  // CameraSensor::setFOV

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -437,6 +437,8 @@ Key Commands:
     }
   }
 
+  float timeSinceLastSimulation_ = 0.0;
+
   /**
    * @brief vector holding past agent locations to build trajectory
    * visualization
@@ -1113,6 +1115,7 @@ void Viewer::initSimPostReconfigure() {
   // Refresh local simConfig_ to track results from scene load
   simConfig_ = MM_->getSimulatorConfiguration();
   timeline_.start();
+  timeSinceLastSimulation_ = 0.0;
 }  // initSimPostReconfigure
 
 void Viewer::switchCameraType() {
@@ -1538,7 +1541,6 @@ void Viewer::setSensorVisID() {
       sensorVisID_);
 }  // Viewer::setSensorVisID
 
-float timeSinceLastSimulation = 0.0;
 void Viewer::drawEvent() {
   // Wrap profiler measurements around all methods to render images from
   // RenderCamera
@@ -1547,12 +1549,12 @@ void Viewer::drawEvent() {
                                    Mn::GL::FramebufferClear::Depth);
 
   // Agent actions should occur at a fixed rate per second
-  timeSinceLastSimulation += timeline_.previousFrameDuration();
-  int numAgentActions = timeSinceLastSimulation * agentActionsPerSecond;
+  timeSinceLastSimulation_ += timeline_.previousFrameDuration();
+  int numAgentActions = timeSinceLastSimulation_ * agentActionsPerSecond;
   moveAndLook(numAgentActions);
 
   // occasionally a frame will pass quicker than 1/60 seconds
-  if (timeSinceLastSimulation >= 1.0 / 60.0) {
+  if (timeSinceLastSimulation_ >= 1.0 / 60.0) {
     if (simulating_ || simulateSingleStep_) {
       // step physics at a fixed rate
       // In the interest of frame rate, only a single step is taken,
@@ -1565,7 +1567,7 @@ void Viewer::drawEvent() {
       }
     }
     // reset timeSinceLastSimulation, accounting for potential overflow
-    timeSinceLastSimulation = fmod(timeSinceLastSimulation, 1.0 / 60.0);
+    timeSinceLastSimulation_ = fmod(timeSinceLastSimulation_, 1.0 / 60.0);
   }
 
   uint32_t visibles = renderCamera_->getPreviousNumVisibleDrawables();


### PR DESCRIPTION
## Motivation and Context
This PR fixes or updates a few things related to the near/far plane calculation for projection matrices : 
- The manual calculations in sim have been replaced with recently implemented Magnum calls
- The projection matrix far plane calculation for the `RenderCamera::unproject` function now not only calls the Magnum function, but also picks the correct calculation based on the nature of the Projection matrix, using the element at mat[3][3] to determine whether the matrix is perspective or orthographic.
- Some minor cleanup in Viewer.cpp

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
