### PR TITLE
--[BE Week] Better Attributes Handle search efficiency; Viewer.cpp/Viewer.py text render fixes

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -118,7 +118,7 @@ class HabitatSimInteractiveViewer(Application):
         )
 
         # Glyphs we need to render everything
-        self.glyph_cache = text.GlyphCache(mn.Vector2i(256))
+        self.glyph_cache = text.GlyphCache(mn.Vector2i(256), mn.Vector2i(1))
         self.display_font.fill_glyph_cache(
             self.glyph_cache,
             string.ascii_lowercase
@@ -149,12 +149,7 @@ class HabitatSimInteractiveViewer(Application):
         )
         self.shader = shaders.VectorGL2D()
 
-        # make magnum text background transparent
-        mn.gl.Renderer.enable(mn.gl.Renderer.Feature.BLENDING)
-        mn.gl.Renderer.set_blend_function(
-            mn.gl.Renderer.BlendFunction.ONE,
-            mn.gl.Renderer.BlendFunction.ONE_MINUS_SOURCE_ALPHA,
-        )
+        # Set blend function
         mn.gl.Renderer.set_blend_equation(
             mn.gl.Renderer.BlendEquation.ADD, mn.gl.Renderer.BlendEquation.ADD
         )
@@ -899,6 +894,13 @@ class HabitatSimInteractiveViewer(Application):
         exit(0)
 
     def draw_text(self, sensor_spec):
+        # make magnum text background transparent for text
+        mn.gl.Renderer.enable(mn.gl.Renderer.Feature.BLENDING)
+        mn.gl.Renderer.set_blend_function(
+            mn.gl.Renderer.BlendFunction.ONE,
+            mn.gl.Renderer.BlendFunction.ONE_MINUS_SOURCE_ALPHA,
+        )
+
         self.shader.bind_vector_texture(self.glyph_cache.texture)
         self.shader.transformation_projection_matrix = self.window_text_transform
         self.shader.color = [1.0, 1.0, 1.0]
@@ -918,6 +920,9 @@ Mouse Interaction Mode: {mouse_mode_string}
             """
         )
         self.shader.draw(self.window_text.mesh)
+
+        # Disable blending for text
+        mn.gl.Renderer.disable(mn.gl.Renderer.Feature.BLENDING)
 
     def print_help_text(self) -> None:
         """

--- a/src/esp/core/managedContainers/ManagedContainerBase.cpp
+++ b/src/esp/core/managedContainers/ManagedContainerBase.cpp
@@ -93,12 +93,13 @@ std::vector<std::string> getHandlesBySubStringPerTypeInternal(
              mapOfHandles.begin();
          iter != mapOfHandles.end(); ++iter) {
       std::string rawKey = std::get<Idx>(*iter);
-      std::string key = Cr::Utility::String::lowercase(rawKey);
       // be sure that key is big enough to search in (otherwise find has
       // undefined behavior)
-      if (key.length() < strSize) {
+      if (rawKey.length() < strSize) {
         continue;
       }
+      std::string key = Cr::Utility::String::lowercase(rawKey);
+
       bool found = (std::string::npos != key.find(strToLookFor));
       if (found == contains) {
         // if found and searching for contains, or not found and searching for

--- a/src/esp/core/managedContainers/ManagedContainerBase.h
+++ b/src/esp/core/managedContainers/ManagedContainerBase.h
@@ -381,8 +381,8 @@ class ManagedContainerBase {
       const std::string& name) const;
 
   /**
-   * @brief Get a list of all managed objects of passed type whose origin
-   * handles contain substr, ignoring subStr's case.
+   * @brief Get a list of all managed objects' handles of passed type whose
+   * origin handles contain substr, ignoring subStr's case.
    *
    * This version works on std::unordered_map<int,std::string> maps' values.
    * @param mapOfHandles map containing the desired managed object handles
@@ -400,8 +400,8 @@ class ManagedContainerBase {
       bool sorted) const;
 
   /**
-   * @brief Get a list of all managed objects of passed type whose origin
-   * handles contain substr, ignoring subStr's case.
+   * @brief Get a list of all managed objects' handles of passed type whose
+   * origin handles contain substr, ignoring subStr's case.
    *
    * This version works on std::unordered_map<std::string,
    * std::set<std::string>> maps's keys.

--- a/src/esp/metadata/MetadataMediator.h
+++ b/src/esp/metadata/MetadataMediator.h
@@ -358,6 +358,23 @@ class MetadataMediator {
   }  // getNamedObjectAttributesCopy
 
   /**
+   * @brief Returns articulated object attributes corresponding to passed handle
+   * as substring. Assumes articulated object attributes with @p artObjAttrName
+   * as substring exists in current dataset.
+   * @param artObjAttrName substring to handle of articulated object instance
+   * attributes that exists in current active dataset. The attributes will be
+   * found via substring search, so the name is expected to be sufficiently
+   * restrictive to have exactly 1 match in dataset.
+   * @return smart pointer to articulated object attributes if exists, nullptr
+   * otherwise.
+   */
+  attributes::ArticulatedObjectAttributes::ptr
+  getNamedArticulatedObjectAttributesCopy(const std::string& artObjAttrName) {
+    return getActiveDSAttribs()->getNamedArticulatedObjectAttributesCopy(
+        artObjAttrName);
+  }  // getNamedArticulatedObjectAttributesCopy
+
+  /**
    * @brief Returns a lightsetup object configured by the attributes whose
    * handle contains the passed @p lightSetupName
    * @param lightSetupName Name of the attributes to be used to build the

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -279,6 +279,20 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& objAttrName);
 
   /**
+   * @brief Returns articulated object attributes corresponding to passed handle
+   * as substring. Assumes articulated object attributes with @p artObjAttrName
+   * as substring exists in current dataset.
+   * @param artObjAttrName substring to handle of articulated object instance
+   * attributes that exists in current active dataset. The attributes will be
+   * found via substring search, so the name is expected to be sufficiently
+   * restrictive to have exactly 1 match in dataset.
+   * @return smart pointer to articulated object attributes if exists, nullptr
+   * otherwise.
+   */
+  attributes::ArticulatedObjectAttributes::ptr
+  getNamedArticulatedObjectAttributesCopy(const std::string& artObjAttrName);
+
+  /**
    * @brief Returns a lightsetup object configured by the attributes whose
    * handle contains the passed @p lightSetupName
    * @param lightSetupName Name of the attributes to be used to build the
@@ -301,7 +315,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * or empty string if none.
    */
   inline std::string getStageAttrFullHandle(const std::string& stageAttrName) {
-    return getFullAttrNameFromStr(stageAttrName, stageAttributesManager_);
+    return stageAttributesManager_->getFullAttrNameFromStr(stageAttrName);
   }  // getStageAttrFullHandle
 
   /**
@@ -316,7 +330,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * empty string if none.
    */
   inline std::string getObjAttrFullHandle(const std::string& objAttrName) {
-    return getFullAttrNameFromStr(objAttrName, objectAttributesManager_);
+    return objectAttributesManager_->getFullAttrNameFromStr(objAttrName);
   }  // getObjAttrFullHandle
 
   /**
@@ -332,7 +346,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
    */
   inline std::string getArticulatedObjModelFullHandle(
       const std::string& artObjModelName) {
-    return getFullAttrNameFromStr(artObjModelName, artObjAttributesManager_);
+    return artObjAttributesManager_->getFullAttrNameFromStr(artObjModelName);
     // std::map<std::string, std::string> articulatedObjPaths;
   }
 
@@ -362,8 +376,8 @@ class SceneDatasetAttributes : public AbstractAttributes {
         (lightSetupName == NO_LIGHT_KEY)) {
       return lightSetupName;
     }
-    return getFullAttrNameFromStr(lightSetupName,
-                                  lightLayoutAttributesManager_);
+    return lightLayoutAttributesManager_->getFullAttrNameFromStr(
+        lightSetupName);
   }  // getLightSetupFullHandle
 
   /**
@@ -390,28 +404,6 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * of this managed object.
    */
   std::string getObjectInfoInternal() const override;
-
-  /**
-   * @brief Returns actual attributes handle containing @p attrName as a
-   * substring, or the empty string if none exists, from passed @p attrMgr .
-   * Does a substring search, and returns first value found.
-   * @param attrName name to be used as searching substring in @p attrMgr .
-   * @param attrMgr attributes manager to be searched
-   * @return actual name of attributes in attrMgr, or empty string if does not
-   * exist.
-   */
-  inline std::string getFullAttrNameFromStr(
-      const std::string& attrName,
-      const ManagedContainerBase::ptr& attrMgr) {
-    if (attrMgr->getObjectLibHasHandle(attrName)) {
-      return attrName;
-    }
-    auto handleList = attrMgr->getObjectHandlesBySubstring(attrName);
-    if (!handleList.empty()) {
-      return handleList[0];
-    }
-    return "";
-  }  // getFullAttrNameFromStr
 
   /**
    * @brief This will add a navmesh entry or a semantic scene descriptor entry

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -403,6 +403,9 @@ class SceneDatasetAttributes : public AbstractAttributes {
   inline std::string getFullAttrNameFromStr(
       const std::string& attrName,
       const ManagedContainerBase::ptr& attrMgr) {
+    if (attrMgr->getObjectLibHasHandle(attrName)) {
+      return attrName;
+    }
     auto handleList = attrMgr->getObjectHandlesBySubstring(attrName);
     if (!handleList.empty()) {
       return handleList[0];

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -196,6 +196,25 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
       const attributes::AbstractAttributes::ptr& attribs,
       const io::JsonGenericValue& jsonConfig) const;
 
+  /**
+   * @brief Returns actual attributes handle containing @p attrName as a
+   * substring, or the empty string if none exists.
+   * Does a substring search, and returns first value found.
+   * @param attrName name to be used as searching substring in @p attrMgr
+   * @return actual name of attributes in attrMgr, or empty string if does not
+   * exist.
+   */
+  inline std::string getFullAttrNameFromStr(const std::string& attrName) {
+    if (this->getObjectLibHasHandle(attrName)) {
+      return attrName;
+    }
+    auto handleList = this->getObjectHandlesBySubstring(attrName);
+    if (!handleList.empty()) {
+      return handleList[0];
+    }
+    return "";
+  }  // getFullAttrNameFromStr
+
  protected:
   /**
    * @brief Called intenrally from createObject.  This will create either a

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -61,7 +61,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
 void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
-  this->undeletableObjectNames_.clear();
+  // this->undeletableObjectNames_.clear();
   // build default primtive object templates corresponding to given default
   // asset templates
   std::vector<std::string> lib =

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -61,7 +61,6 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
 }  // ObjectAttributesManager::createPrimBasedAttributesTemplate
 
 void ObjectAttributesManager::createDefaultPrimBasedAttributesTemplates() {
-  // this->undeletableObjectNames_.clear();
   // build default primtive object templates corresponding to given default
   // asset templates
   std::vector<std::string> lib =

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -883,7 +883,7 @@ Viewer::Viewer(const Arguments& arguments)
     if (!font_ || !font_->openData(rs.getRaw("ProggyClean.ttf"), fontSize))
       Mn::Fatal{} << "Cannot open font file";
 
-    fontGlyphCache_.emplace(Mn::Vector2i{256});
+    fontGlyphCache_.emplace(Mn::Vector2i{256}, Mn::Vector2i{1});
     /* Don't destroy the bitmap font with smooth scaling */
     fontGlyphCache_->texture().setMagnificationFilter(
         Mn::SamplerFilter::Nearest);


### PR DESCRIPTION
## Motivation and Context
This PR leverages the recent [updates to our Magnum libs](https://github.com/facebookresearch/habitat-sim/pull/2278) to address some inefficiencies and bugs, and fixes a minor bug with how scene instances were being loaded.

**Viewer.cpp/Viewer.py :** 
1. Improve text rendering in the viewers by using the magnum's new glyph handling.
2. Fix the black-box background around text in viewer.py by enabling, defining and subsequently disabling the appropriate blend state when text is being drawn.

**Attributes** 
1. Speed up string handle match search by checking size of target string before forcing it to lowercase
2. Add missing Articulated Object Attributes verification on Scene Instance load to be consistent with Stage, Object and Lighting Attributes handling.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally all tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
