### PR TITLE
Minor fix in python viewer.

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -421,8 +421,8 @@ class HabitatSimInteractiveViewer(Application):
             for sensor_uuid, sensor in sensor_suite.items():
                 transform = sensor._sensor_object.node.absolute_transformation()
                 self.replay_renderer.set_sensor_transform(i, sensor_uuid, transform)
-            # Render
-            self.replay_renderer.render(mn.gl.default_framebuffer)
+        # Render
+        self.replay_renderer.render(mn.gl.default_framebuffer)
 
     def move_and_look(self, repetitions: int) -> None:
         """


### PR DESCRIPTION
## Motivation and Context

This fixes an indentation errors in the python viewer that causes the batch renderer to execute multiple times. This is not an issue under normal usage.

## How Has This Been Tested

Tested locally.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
