### PR TITLE
Change default python viewer dataset to 'default'.

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -1113,10 +1113,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--dataset",
-        default="./data/objects/ycb/ycb.scene_dataset_config.json",
+        default="default",
         type=str,
         metavar="DATASET",
-        help='dataset configuration file to use (default: "./data/objects/ycb/ycb.scene_dataset_config.json")',
+        help='dataset configuration file to use (default: "default")',
     )
     parser.add_argument(
         "--disable-physics",


### PR DESCRIPTION
## Motivation and Context

This changes the default dataset to "default", removing a dependency to `ycb` and matching the behavior of `viewer.cpp`.

## How Has This Been Tested

Tested locally.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
