### PR TITLE
Remove RTLD_GLOBAL flag from apps.

### DIFF
--- a/examples/motion_viewer.py
+++ b/examples/motion_viewer.py
@@ -2,16 +2,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
 import random
-import sys
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
-flags = sys.getdlopenflags()
-sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
-
 import magnum as mn
+import numpy as np
 from magnum.platform.glfw import Application
 from viewer import HabitatSimInteractiveViewer, MouseMode, Timer
 

--- a/examples/motion_viewer.py
+++ b/examples/motion_viewer.py
@@ -7,7 +7,6 @@ import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import magnum as mn
-import numpy as np
 from magnum.platform.glfw import Application
 from viewer import HabitatSimInteractiveViewer, MouseMode, Timer
 

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -2,17 +2,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
 import math
 import os
 import string
-import sys
 import time
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
-
-flags = sys.getdlopenflags()
-sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
 import magnum as mn
 import numpy as np

--- a/src_python/habitat_sim/__init__.py
+++ b/src_python/habitat_sim/__init__.py
@@ -4,7 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+
 import builtins
+import ctypes
+import sys
+
+sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
 
 __version__ = "0.3.1"
 

--- a/src_python/habitat_sim/__init__.py
+++ b/src_python/habitat_sim/__init__.py
@@ -4,12 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import builtins
-import ctypes
-import sys
 
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
+# Important platform-specific setup steps to do before using bindings.
+try:
+    import magnum
+except ImportError:
+    pass
 
 __version__ = "0.3.1"
 


### PR DESCRIPTION
## Motivation and Context

This removes the `RTLD_GLOBAL` flag from python apps, which is no longer required since [this magnum update](https://github.com/facebookresearch/habitat-sim/pull/2309).

The flag is also set in `habitat-sim`'s `__init__.py` to handle cases where `habitat-sim` bindings are used before `magnum`/`corrade` is imported.

This flag was required before loading native magnum/habitat modules to de-duplicate globals across shared modules. [This is now done automatically when importing corrade.](https://github.com/mosra/magnum-bindings/commit/b4d437bb3ff7bf925064532a39b02c7e6ee1356f#diff-e6d652e2d587ecbff4369a8f11be89982863d5f613feb96777d9aa95136d1675).

[This PR](https://github.com/facebookresearch/habitat-lab/pull/1783) does the same changes in `habitat-lab`.

## How Has This Been Tested

Tested the viewers locally on Linux.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
