### PR TITLE
--[WIP]Object/AO creation refactor and Object/AO Instance save/creation

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -107,6 +107,7 @@ using metadata::managers::AOAttributesManager;
 using metadata::managers::AssetAttributesManager;
 using metadata::managers::ObjectAttributesManager;
 using metadata::managers::PhysicsAttributesManager;
+using metadata::managers::SceneInstanceAttributesManager;
 using metadata::managers::StageAttributesManager;
 using Mn::Trade::MaterialAttribute;
 
@@ -2994,6 +2995,11 @@ ResourceManager::getAOAttributesManager() const {
 metadata::managers::PhysicsAttributesManager::ptr
 ResourceManager::getPhysicsAttributesManager() const {
   return metadataMediator_->getPhysicsAttributesManager();
+}
+
+metadata::managers::SceneInstanceAttributesManager::ptr
+ResourceManager::getSceneInstanceAttributesManager() const {
+  return metadataMediator_->getSceneInstanceAttributesManager();
 }
 
 metadata::managers::StageAttributesManager::ptr

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -536,8 +536,8 @@ bool ResourceManager::loadStage(
     // Either add with pre-built meshGroup if collision assets are loaded
     // or empty vector for mesh group - this should only be the case if
     // we are using None-type physicsManager.
-    bool sceneSuccess =
-        _physicsManager->addStage(stageAttributes, stageInstanceAttributes);
+    bool sceneSuccess = _physicsManager->addStageInstance(
+        stageAttributes, stageInstanceAttributes);
     if (!sceneSuccess) {
       ESP_ERROR() << "Adding Stage" << stageAttributes->getHandle()
                   << "to PhysicsManager failed. Aborting stage initialization.";

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -62,6 +62,7 @@ class AssetAttributesManager;
 class LightLayoutAttributesManager;
 class ObjectAttributesManager;
 class PhysicsAttributesManager;
+class SceneInstanceAttributesManager;
 class StageAttributesManager;
 }  // namespace managers
 }  // namespace metadata
@@ -313,7 +314,14 @@ class ResourceManager {
   getPhysicsAttributesManager() const;
 
   /**
-   * @brief Return manager for construction and access to scene attributes.
+   * @brief Return manager for construction and access to scene instance
+   * attributes.
+   */
+  std::shared_ptr<metadata::managers::SceneInstanceAttributesManager>
+  getSceneInstanceAttributesManager() const;
+
+  /**
+   * @brief Return manager for construction and access to stage attributes.
    */
   std::shared_ptr<metadata::managers::StageAttributesManager>
   getStageAttributesManager() const;

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -56,7 +56,7 @@ PhysicsManager::~PhysicsManager() {
   ESP_DEBUG() << "Deconstructing PhysicsManager";
 }
 
-bool PhysicsManager::addStage(
+bool PhysicsManager::addStageInstance(
     const metadata::attributes::StageAttributes::ptr& initAttributes,
     const metadata::attributes::SceneObjectInstanceAttributes::cptr&
         stageInstanceAttributes) {

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -300,6 +300,10 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * to query @ref esp::metadata::managers::ObjectAttributesManager.
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group. Will create object regardless,
+   * however.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -311,6 +315,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
           objInstAttributes,
       const std::string& attributesHandle,
       bool defaultCOMCorrection = false,
+      DrawableGroup* drawables = nullptr,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
@@ -320,6 +325,10 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    *
    * @param attributesHandle The handle of the object attributes used as the key
    * to query @ref esp::metadata::managers::ObjectAttributesManager.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group. Will create object regardless,
+   * however.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -327,6 +336,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
   int addObject(const std::string& attributesHandle,
+                DrawableGroup* drawables = nullptr,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
@@ -336,6 +346,10 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    *
    * @param attributesID The ID of the object's template in @ref
    * esp::metadata::managers::ObjectAttributesManager
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group. Will create object regardless,
+   * however.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -343,6 +357,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
   int addObject(int attributesID,
+                DrawableGroup* drawables = nullptr,
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
@@ -396,6 +411,9 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @param attributesHandle The handle of the @ref ArticulatedObject attributes
    * used as the key to query @ref esp::metadata::managers::AOAttributesManager
    * for the attributes.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group.
    * @param lightSetup The string name of the desired lighting setup to use.
    * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
    * object in @ref PhysicsManager::existingObjects_ if successful, or
@@ -407,17 +425,20 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
           const esp::metadata::attributes::SceneAOInstanceAttributes>&
           aObjInstAttributes,
       const std::string& attributesHandle,
+      DrawableGroup* drawables = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Instance an @ref ArticulatedObject from an
    * @ref esp::metadata::attributes::ArticulatedObjectAttributes retrieved from the
    * @ref esp::metadata::managers::AOAttributesManager by the given
-   * @p attributesHandle . This method calls @p
-   * addArticulatedObjectQueryDrawables to provide drawables.
+   * @p attributesHandle .
    *
    * @param attributesHandle The handle of the ArticulatedObjectAttributes to
    * use to create the desired @ref ArticulatedObject
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -428,6 +449,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int addArticulatedObject(
       const std::string& attributesHandle,
+      DrawableGroup* drawables = nullptr,
       bool forceReload = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
@@ -435,11 +457,13 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @brief Instance an @ref ArticulatedObject from an
    * @ref esp::metadata::attributes::ArticulatedObjectAttributes retrieved from the
    * @ref esp::metadata::managers::AOAttributesManager by the given
-   * @p attributesID . This method calls @p
-   * addArticulatedObjectQueryDrawables to provide drawables.
+   * @p attributesID .
    *
    * @param attributesID The ID of the ArticulatedObjectAttributes to
    * use to create the desired @ref ArticulatedObject
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group.
    * @param forceReload If true, reload the source URDF from file, replacing the
    * cached model.
    * @param lightSetup The string name of the desired lighting setup to use.
@@ -450,18 +474,20 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int addArticulatedObject(
       int attributesID,
+      DrawableGroup* drawables = nullptr,
       bool forceReload = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /**
    * @brief Load, parse, and import a URDF file instantiating an @ref
-   * ArticulatedObject in the world.  This version will query an existing
-   * simulator for drawables and therefore does not require drawables to be
-   * specified.
+   * ArticulatedObject in the world.
    *
    * Not implemented in base PhysicsManager.
    * @param filepath The fully-qualified filename for the URDF file describing
    * the model the articulated object is to be built from.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group.
    * @param fixedBase Whether the base of the @ref ArticulatedObject should be
    * fixed.
    * @param globalScale A scale multiplier to be applied uniformly in 3
@@ -483,6 +509,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int addArticulatedObjectFromURDF(
       const std::string& filepath,
+      DrawableGroup* drawables = nullptr,
       bool fixedBase = false,
       float globalScale = 1.0,
       float massScale = 1.0,
@@ -899,6 +926,9 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * build a much bigger mesh
    * @param numInterp The number of interpolations between each trajectory
    * point, if smoothed
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object. If nullptr, will attempt to
+   * query Simulator to retrieve a group.
    * @return The ID of the object created for the visualization
    */
   int addTrajectoryObject(const std::string& trajVisName,
@@ -907,7 +937,8 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
                           int numSegments = 3,
                           float radius = .001,
                           bool smooth = false,
-                          int numInterp = 10);
+                          int numInterp = 10,
+                          DrawableGroup* drawables = nullptr);
   /**
    * @brief Remove a trajectory visualization by name.
    * @param trajVisName The name of the trajectory visualization to remove.
@@ -940,24 +971,38 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   }
 
  protected:
-  /** @brief Queries simulator for drawables, if simulator exists, otherwise
-   * passes nullptr, before instancing a physical object from an object
-   * properties template in the @ref
-   * esp::metadata::managers::ObjectAttributesManager by template handle.
-   * @param objectAttributes The object's template in @ref
-   * esp::metadata::managers::ObjectAttributesManager.
+  /**
+   * @brief This method will create a physical object using the passed values by
+   * calling addObjectInternal, will initialize its state and save
+   * it's instantiation attributes.
+   *
+   * @param objectAttributes The object's template to use to instantiate the
+   * object.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
+   * @param defaultCOMCorrection The default value of whether COM-based
+   * translation correction needs to occur. Only non-default from
+   * addObjectInstance method.
+   * @param objInstAttributes The attributes that describe the desired state to
+   * set this object on creation. If nullptr, create an empty default instance
+   * and populate it properly based on the object config.
    * @return the instanced object's ID, mapping to it in @ref
    * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addObjectQueryDrawables(
+  int addObjectAndSaveAttributes(
       const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      DrawableGroup* drawables = nullptr,
       scene::SceneNode* attachmentNode = nullptr,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY,
+      bool defaultCOMCorrection = false,
+      esp::metadata::attributes::SceneObjectInstanceAttributes::cptr
+          objInstAttributes = nullptr);
 
-  /** @brief Instance a physical object from an ObjectAttributes template.
+  /**
+   * @brief Instance a physical object from an ObjectAttributes template.
    * @param objectAttributes The object's template to use to instantiate the
    * object.
    * @param drawables Reference to the scene graph drawables group to enable
@@ -973,26 +1018,32 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       DrawableGroup* drawables,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
-
   /**
-   * @brief Queries simulator for drawables, if simulator exists, otherwise
-   * passes nullptr, before instancing an articulated object from an
-   * @ref esp::metadata::attributes::ArticulatedObjectAttributes template
+   * @brief This method will create a physical object using the passed values by
+   * calling addArticulatedObjectInternal, will initialize its state and save
+   * it's instantiation attributes.
    *
    * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
-   * @param forceReload If true, reload the source URDF from file, replacing the
-   * cached model.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized @ref ArticulatedObject.
+   * @param forceReload If true, force the reload of the source URDF from file,
+   * replacing the cached model if it exists.
    * @param lightSetup The string name of the desired lighting setup to use.
-   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
-   * object in @ref PhysicsManager::existingObjects_ if successful, or
-   * @ref esp::ID_UNDEFINED. These values come from the same pool used
-   * by rigid objects.
+   * @param aObjInstAttributes The attributes that describe the desired initial
+   * state to set for this articulated object. If nullptr, create an empty
+   * default instance attributes and populate it properly based on the
+   * articulated object's configuration config.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
    */
-  int addArticulatedObjectQueryDrawables(
+  int addArticulatedObjectAndSaveAttributes(
       const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
           artObjAttributes,
+      DrawableGroup* drawables = nullptr,
       bool forceReload = false,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY,
+      esp::metadata::attributes::SceneAOInstanceAttributes::cptr
+          artObjInstAttributes = nullptr);
 
   /**
    * @brief Load, parse, and import a URDF file instantiating an @ref

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -286,7 +286,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * to create this stage. Might be empty.
    * @return true if successful and false otherwise
    */
-  bool addStage(
+  bool addStageInstance(
       const metadata::attributes::StageAttributes::ptr& initAttributes,
       const metadata::attributes::SceneObjectInstanceAttributes::cptr&
           stageInstanceAttributes);

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -346,40 +346,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
                 scene::SceneNode* attachmentNode = nullptr,
                 const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
-  /** @brief Queries simulator for drawables, if simulator exists, otherwise
-   * passes nullptr, before instancing a physical object from an object
-   * properties template in the @ref
-   * esp::metadata::managers::ObjectAttributesManager by template handle.
-   * @param objectAttributes The object's template in @ref
-   * esp::metadata::managers::ObjectAttributesManager.
-   * @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
-  int addObjectQueryDrawables(
-      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
-      scene::SceneNode* attachmentNode = nullptr,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
-
-  /** @brief Instance a physical object from an ObjectAttributes template.
-   * @param objectAttributes The object's template to use to instantiate the
-   * object.
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized object.
-   * @param attachmentNode If supplied, attach the new physical object to an
-   * existing SceneNode.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   * @return the instanced object's ID, mapping to it in @ref
-   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
-   */
-  int addObject(
-      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
-      DrawableGroup* drawables,
-      scene::SceneNode* attachmentNode = nullptr,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
-
   /**
    * @brief Create an object wrapper appropriate for this physics manager.
    * Overridden if called by dynamics-library-enabled PhysicsManager
@@ -488,57 +454,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
   /**
-   * @brief Queries simulator for drawables, if simulator exists, otherwise
-   * passes nullptr, before instancing an articulated object from an
-   * @ref esp::metadata::attributes::ArticulatedObjectAttributes template
-   *
-   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
-   * @param forceReload If true, reload the source URDF from file, replacing the
-   * cached model.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
-   * object in @ref PhysicsManager::existingObjects_ if successful, or
-   * @ref esp::ID_UNDEFINED. These values come from the same pool used
-   * by rigid objects.
-   */
-  int addArticulatedObjectQueryDrawables(
-      const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
-          artObjAttributes,
-      bool forceReload = false,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
-
-  /**
-   * @brief Load, parse, and import a URDF file instantiating an @ref
-   * ArticulatedObject in the world based on the urdf filepath specified in @ref
-   * esp::metadata::attributes::ArticulatedObjectAttributes. This version
-   * requires drawables to be provided.
-   *
-   * Not implemented in base PhysicsManager.
-   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized @ref ArticulatedObject.
-   * @param forceReload If true, force the reload of the source URDF from file,
-   * replacing the cached model if it exists.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   *
-   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
-   * object in @ref PhysicsManager::existingObjects_ if successful, or
-   * @ref esp::ID_UNDEFINED. These values come from the same pool used
-   * by rigid objects.
-   */
-  virtual int addArticulatedObject(
-      CORRADE_UNUSED const
-          esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
-              artObjAttributes,
-      CORRADE_UNUSED DrawableGroup* drawables,
-      CORRADE_UNUSED bool forceReload = false,
-      CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
-    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
-                   "--bullet to use this feature.";
-    return ID_UNDEFINED;
-  }
-
-  /**
    * @brief Load, parse, and import a URDF file instantiating an @ref
    * ArticulatedObject in the world.  This version will query an existing
    * simulator for drawables and therefore does not require drawables to be
@@ -576,7 +491,10 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       bool intertiaFromURDF = false,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
 
-  //! Remove an @ref ArticulatedObject from the world by unique id.
+  /**
+   * @brief Remove an @ref ArticulatedObject from the world by unique id.
+   * @param objectId The Id of the object to remove
+   */
   virtual void removeArticulatedObject(int objectId);
 
   //! Get the current number of instanced articulated objects in the world.
@@ -1022,6 +940,91 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   }
 
  protected:
+  /** @brief Queries simulator for drawables, if simulator exists, otherwise
+   * passes nullptr, before instancing a physical object from an object
+   * properties template in the @ref
+   * esp::metadata::managers::ObjectAttributesManager by template handle.
+   * @param objectAttributes The object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObjectQueryDrawables(
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /** @brief Instance a physical object from an ObjectAttributes template.
+   * @param objectAttributes The object's template to use to instantiate the
+   * object.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized object.
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   * @return the instanced object's ID, mapping to it in @ref
+   * PhysicsManager::existingObjects_ if successful, or @ref esp::ID_UNDEFINED.
+   */
+  int addObjectInternal(
+      const esp::metadata::attributes::ObjectAttributes::ptr& objectAttributes,
+      DrawableGroup* drawables,
+      scene::SceneNode* attachmentNode = nullptr,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Queries simulator for drawables, if simulator exists, otherwise
+   * passes nullptr, before instancing an articulated object from an
+   * @ref esp::metadata::attributes::ArticulatedObjectAttributes template
+   *
+   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
+   * @param forceReload If true, reload the source URDF from file, replacing the
+   * cached model.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
+   * object in @ref PhysicsManager::existingObjects_ if successful, or
+   * @ref esp::ID_UNDEFINED. These values come from the same pool used
+   * by rigid objects.
+   */
+  int addArticulatedObjectQueryDrawables(
+      const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
+          artObjAttributes,
+      bool forceReload = false,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Load, parse, and import a URDF file instantiating an @ref
+   * ArticulatedObject in the world based on the urdf filepath specified in @ref
+   * esp::metadata::attributes::ArticulatedObjectAttributes. This version
+   * requires drawables to be provided.
+   *
+   * Not implemented in base PhysicsManager.
+   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized @ref ArticulatedObject.
+   * @param forceReload If true, force the reload of the source URDF from file,
+   * replacing the cached model if it exists.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   *
+   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
+   * object in @ref PhysicsManager::existingObjects_ if successful, or
+   * @ref esp::ID_UNDEFINED. These values come from the same pool used
+   * by rigid objects.
+   */
+  virtual int addArticulatedObjectInternal(
+      CORRADE_UNUSED const
+          esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
+              artObjAttributes,
+      CORRADE_UNUSED DrawableGroup* drawables,
+      CORRADE_UNUSED bool forceReload = false,
+      CORRADE_UNUSED const std::string& lightSetup = DEFAULT_LIGHTING_KEY) {
+    ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
+                   "--bullet to use this feature.";
+    return ID_UNDEFINED;
+  }
+
   /**
    * @brief Internal use only. Remove a trajectory object, its mesh, and all
    * references to it.
@@ -1244,7 +1247,7 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
  public:
   ESP_SMART_POINTERS(PhysicsManager)
-};
+};  // class PhysicsManager
 
 }  // namespace physics
 

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -115,7 +115,7 @@ bool BulletPhysicsManager::makeAndAddRigidObject(
   return objSuccess;
 }
 
-int BulletPhysicsManager::addArticulatedObject(
+int BulletPhysicsManager::addArticulatedObjectInternal(
     const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
         artObjAttributes,
     DrawableGroup* drawables,
@@ -237,7 +237,7 @@ int BulletPhysicsManager::addArticulatedObject(
 
   return articulatedObjectID;
 
-}  // BulletPhysicsManager::addArticulatedObject
+}  // BulletPhysicsManager::addArticulatedObjectInternal
 
 esp::physics::ManagedRigidObject::ptr
 BulletPhysicsManager::getRigidObjectWrapper() {

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -65,31 +65,6 @@ class BulletPhysicsManager : public PhysicsManager {
   //============ Simulator functions =============
 
   /**
-   * @brief Load, parse, and import a URDF file instantiating an @ref
-   * ArticulatedObject in the world based on the urdf filepath specified in @ref
-   * esp::metadata::attributes::ArticulatedObjectAttributes. This version
-   * requires drawables to be provided.
-   *
-   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
-   * @param drawables Reference to the scene graph drawables group to enable
-   * rendering of the newly initialized @ref ArticulatedObject.
-   * @param forceReload If true, force the reload of the source URDF from file,
-   * replacing the cached model if it exists.
-   * @param lightSetup The string name of the desired lighting setup to use.
-   *
-   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
-   * object in @ref PhysicsManager::existingObjects_ if successful, or
-   * @ref esp::ID_UNDEFINED. These values come from the same pool used
-   * by rigid objects.
-   */
-  int addArticulatedObject(
-      const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
-          artObjAttributes,
-      DrawableGroup* drawables,
-      bool forceReload = false,
-      const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
-
-  /**
    * @brief Use the metadata stored in metadata::URDF::Link to instance all
    * visual shapes for a link into the SceneGraph.
    *
@@ -306,6 +281,31 @@ class BulletPhysicsManager : public PhysicsManager {
   }
 
  protected:
+  /**
+   * @brief Load, parse, and import a URDF file instantiating an @ref
+   * ArticulatedObject in the world based on the urdf filepath specified in @ref
+   * esp::metadata::attributes::ArticulatedObjectAttributes. This version
+   * requires drawables to be provided.
+   *
+   * @param artObjAttributes The @ref ArticulatedObject's template to use to create it.
+   * @param drawables Reference to the scene graph drawables group to enable
+   * rendering of the newly initialized @ref ArticulatedObject.
+   * @param forceReload If true, force the reload of the source URDF from file,
+   * replacing the cached model if it exists.
+   * @param lightSetup The string name of the desired lighting setup to use.
+   *
+   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
+   * object in @ref PhysicsManager::existingObjects_ if successful, or
+   * @ref esp::ID_UNDEFINED. These values come from the same pool used
+   * by rigid objects.
+   */
+  int addArticulatedObjectInternal(
+      const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&
+          artObjAttributes,
+      DrawableGroup* drawables,
+      bool forceReload = false,
+      const std::string& lightSetup = DEFAULT_LIGHTING_KEY) override;
+
   //! counter for constraint id generation
   int nextConstraintId_ = 0;
   //! caches for various types of Bullet rigid constraint objects.

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -41,7 +41,7 @@ ArticulatedObjectManager::addArticulatedObjectFromURDF(
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
     int newAObjID = physMgr->addArticulatedObjectFromURDF(
-        filepath, fixedBase, globalScale, massScale, forceReload,
+        filepath, nullptr, fixedBase, globalScale, massScale, forceReload,
         maintainLinkOrder, intertiaFromURDF, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
@@ -54,8 +54,8 @@ ArticulatedObjectManager::addArticulatedObjectByHandle(
     bool forceReload,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
-    int newAObjID = physMgr->addArticulatedObject(attributesHandle, forceReload,
-                                                  lightSetup);
+    int newAObjID = physMgr->addArticulatedObject(attributesHandle, nullptr,
+                                                  forceReload, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;
@@ -67,8 +67,8 @@ ArticulatedObjectManager::addArticulatedObjectByID(
     bool forceReload,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
-    int newAObjID =
-        physMgr->addArticulatedObject(attributesID, forceReload, lightSetup);
+    int newAObjID = physMgr->addArticulatedObject(attributesID, nullptr,
+                                                  forceReload, lightSetup);
     return this->getObjectCopyByID(newAObjID);
   }
   return nullptr;

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -30,8 +30,8 @@ std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByHandle(
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
-    int newObjID =
-        physMgr->addObject(attributesHandle, attachmentNode, lightSetup);
+    int newObjID = physMgr->addObject(attributesHandle, nullptr, attachmentNode,
+                                      lightSetup);
     return this->getObjectCopyByID(newObjID);
   } else {
     return nullptr;
@@ -43,7 +43,8 @@ std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByID(
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
   if (auto physMgr = this->getPhysicsManager()) {
-    int newObjID = physMgr->addObject(attributesID, attachmentNode, lightSetup);
+    int newObjID =
+        physMgr->addObject(attributesID, nullptr, attachmentNode, lightSetup);
     return this->getObjectCopyByID(newObjID);
   } else {
     return nullptr;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -604,7 +604,7 @@ bool Simulator::instanceObjectsForSceneAttributes(
     const metadata::attributes::SceneInstanceAttributes::cptr&
         curSceneInstanceAttributes_) {
   // Load object instances as specified by Scene Instance Attributes.
-  // Get all instances of objects described in scene
+  // Get copies of all instances of objects described in scene
   const std::vector<SceneObjectInstanceAttributes::cptr> objectInstances =
       curSceneInstanceAttributes_->getObjectInstances();
 
@@ -640,9 +640,9 @@ bool Simulator::instanceObjectsForSceneAttributes(
                   "being empty or unknown. Aborting",
                   config_.activeSceneName, objInst->getHandle()));
     // objID =
-    physicsManager_->addObjectInstance(objInst, objAttrFullHandle,
-                                       defaultCOMCorrection, attachmentNode,
-                                       config_.sceneLightSetupKey);
+    physicsManager_->addObjectInstance(
+        objInst, objAttrFullHandle, defaultCOMCorrection, &getDrawableGroup(),
+        attachmentNode, config_.sceneLightSetupKey);
   }  // for each object attributes
   return true;
 }  // Simulator::instanceObjectsForSceneAttributes()
@@ -650,8 +650,8 @@ bool Simulator::instanceObjectsForSceneAttributes(
 bool Simulator::instanceArticulatedObjectsForSceneAttributes(
     const metadata::attributes::SceneInstanceAttributes::cptr&
         curSceneInstanceAttributes_) {
-  // 6. Load all articulated object instances
-  // Get all instances of articulated objects described in scene
+  // Load all articulated object instances
+  // Get copies of all instances of articulated objects described in scene
   const std::vector<SceneAOInstanceAttributes::cptr> artObjInstances =
       curSceneInstanceAttributes_->getArticulatedObjectInstances();
 
@@ -685,6 +685,7 @@ bool Simulator::instanceArticulatedObjectsForSceneAttributes(
     // create articulated object
     // aoID =
     physicsManager_->addArticulatedObjectInstance(artObjInst, artObjAttrHandle,
+                                                  &getDrawableGroup(),
                                                   config_.sceneLightSetupKey);
   }  // for each articulated object instance
   return true;

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -123,12 +123,10 @@ struct PhysicsTest : Cr::TestSuite::Tester {
     if (drawables == nullptr) {
       drawables = &sceneManager_->getSceneGraph(sceneID_).getDrawables();
     }
-    auto objAttr =
-        metadataMediator_->getObjectAttributesManager()->getObjectCopyByHandle(
-            objectFile);
 
     int objectId =
-        physicsManager_->addObject(objAttr, drawables, attachmentNode);
+        physicsManager_->addObject(objectFile, drawables, attachmentNode);
+
 #ifdef ESP_BUILD_WITH_BULLET
     esp::physics::ManagedBulletRigidObject::ptr objectWrapper =
         rigidObjectManager_


### PR DESCRIPTION
## Motivation and Context
This PR is intended to address an issue when saving a scene instance, where an AO 's current configuration is not being saved as a SceneAOInstance.  In the process this PR also simplifies object/AO creation and makes sure some important processes always take place (which was not formerly the case) such as saving an instance creation attributes upon object/ao creation (and creating a default one if none exists)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
All existing c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
