### PR TITLE
Region Query API

### DIFF
--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -14,7 +14,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
-import habitat.sims.habitat_simulator.sim_utilities as sutils
 import magnum as mn
 import numpy as np
 from magnum import shaders, text
@@ -165,7 +164,6 @@ class HabitatSimInteractiveViewer(Application):
         self.mouse_interaction = MouseMode.LOOK
         self.mouse_grabber: Optional[MouseGrabber] = None
         self.previous_mouse_point = None
-        self.selected_object_id = None
 
         # toggle physics simulation on/off
         self.simulating = True
@@ -229,28 +227,19 @@ class HabitatSimInteractiveViewer(Application):
                 normal=camera_position - cp.position_on_b_in_ws,
             )
 
-    def interp_color(self, c0: mn.Color4, c1: mn.Color4, t: float) -> mn.Color4:
+    def draw_region_debug(self, debug_line_render: Any) -> None:
         """
-        Get a color between c0 and c1 based on t in range [0,1]
+        Draw the semantic region wireframes.
         """
-        new_color = c0 + (c1 - c0) * t
-        return new_color
 
-    def draw_region_debug(
-        self, debug_line_render: Any, region_index: int, color: mn.Color4 = None
-    ) -> None:
-        """
-        Draw the semantic region wireframe.
-        """
-        region = self.sim.semantic_scene.regions[region_index]
-        if color is None:
+        for region in self.sim.semantic_scene.regions:
             color = self.debug_semantic_colors.get(region.id, mn.Color4.magenta())
-        for edge in region.volume_edges:
-            debug_line_render.draw_transformed_line(
-                edge[0],
-                edge[1],
-                color,
-            )
+            for edge in region.volume_edges:
+                debug_line_render.draw_transformed_line(
+                    edge[0],
+                    edge[1],
+                    color,
+                )
 
     def debug_draw(self):
         """
@@ -266,34 +255,12 @@ class HabitatSimInteractiveViewer(Application):
             self.draw_contact_debug(debug_line_render)
 
         if self.semantic_region_debug_draw:
-            if self.selected_object_id is None:
-                # default "draw all" behavior
-                if len(self.debug_semantic_colors) != len(
-                    self.sim.semantic_scene.regions
-                ):
-                    for region in self.sim.semantic_scene.regions:
-                        self.debug_semantic_colors[region.id] = mn.Color4(
-                            mn.Vector3(np.random.random(3))
-                        )
-                for region_index in range(len(self.sim.semantic_scene.regions)):
-                    self.draw_region_debug(debug_line_render, region_index)
-            else:
-                # use selected object to do a query
-                keypoints = sutils.get_object_global_keypoints(
-                    sutils.get_obj_from_id(self.sim, self.selected_object_id)
-                )
-                regions_weights = self.sim.semantic_scene.get_regions_for_points(
-                    keypoints
-                )
-                for region_index, region_weight in regions_weights:
-                    self.draw_region_debug(
-                        debug_line_render,
-                        region_index,
-                        color=self.interp_color(
-                            mn.Color4.green(), mn.Color4.red(), region_weight
-                        ),
+            if len(self.debug_semantic_colors) != len(self.sim.semantic_scene.regions):
+                for region in self.sim.semantic_scene.regions:
+                    self.debug_semantic_colors[region.id] = mn.Color4(
+                        mn.Vector3(np.random.random(3))
                     )
-                print(regions_weights)
+            self.draw_region_debug(debug_line_render)
 
     def draw_event(
         self,
@@ -745,16 +712,12 @@ class HabitatSimInteractiveViewer(Application):
         """
         button = Application.MouseEvent.Button
         physics_enabled = self.sim.get_physics_simulation_library()
-        mod = Application.InputEvent.Modifier
-
-        shift_pressed = bool(event.modifiers & mod.SHIFT)
 
         # if interactive mode is True -> GRAB MODE
         if self.mouse_interaction == MouseMode.GRAB and physics_enabled:
             render_camera = self.render_camera.render_camera
             ray = render_camera.unproject(self.get_mouse_position(event.position))
             raycast_results = self.sim.cast_ray(ray=ray)
-            self.selected_object_id = None
 
             if raycast_results.has_hits():
                 hit_object, ao_link = -1, -1
@@ -802,11 +765,6 @@ class HabitatSimInteractiveViewer(Application):
                     # done checking for AO
 
                     if hit_object >= 0:
-                        if shift_pressed:
-                            sutils.get_obj_from_id(
-                                self.sim, hit_object
-                            ).motion_type = habitat_sim.physics.MotionType.DYNAMIC
-                        self.selected_object_id = hit_object
                         node = self.default_agent.scene_node
                         constraint_settings = physics.RigidConstraintSettings()
 

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -230,7 +230,14 @@ void initSceneBindings(py::module& m) {
       .def_property_readonly("semantic_index_map",
                              &SemanticScene::getSemanticIndexMap)
       .def("semantic_index_to_object_index",
-           &SemanticScene::semanticIndexToObjectIndex);
+           &SemanticScene::semanticIndexToObjectIndex)
+      .def("get_regions_for_point", &SemanticScene::getRegionsForPoint,
+           "Compute all SemanticRegions which contain the point and return a "
+           "list of indices for the regions in this SemanticScene.")
+      .def("get_regions_for_points", &SemanticScene::getRegionsForPoints,
+           "Compute SemanticRegion containment for a set of points. Return a "
+           "sorted list of tuple pairs with each containing region index and "
+           "the percentage of points contained by that region.");
 
   // ==== ObjectControls ====
   py::class_<ObjectControls, ObjectControls::ptr>(m, "ObjectControls")

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -591,5 +591,38 @@ std::vector<uint32_t> SemanticScene::buildSemanticOBBs(
   return unMappedObjectIDXs;
 }  // SemanticScene::buildSemanticOBBs
 
+std::vector<int> SemanticScene::getRegionsForPoint(
+    const Mn::Vector3 point) const {
+  std::vector<int> containingRegions;
+  for (int rix = 0; rix < regions_.size(); ++rix) {
+    if (regions_[rix]->contains(point)) {
+      containingRegions.push_back(rix);
+    }
+  }
+  return containingRegions;
+}
+
+std::vector<std::pair<int, float>> SemanticScene::getRegionsForPoints(
+    const std::vector<Mn::Vector3> points) const {
+  std::vector<std::pair<int, float>> containingRegionWeights;
+  for (int rix = 0; rix < regions_.size(); ++rix) {
+    float containmentCount = 0;
+    for (auto& point : points) {
+      if (regions_[rix]->contains(point)) {
+        containmentCount += 1;
+      }
+    }
+    if (containmentCount > 0) {
+      containingRegionWeights.push_back(
+          std::pair<int, float>(rix, containmentCount / points.size()));
+    }
+  }
+  std::sort(containingRegionWeights.begin(), containingRegionWeights.end(),
+            [](const std::pair<int, float>& a, std::pair<int, float>& b) {
+              return a.second > b.second;
+            });
+  return containingRegionWeights;
+}
+
 }  // namespace scene
 }  // namespace esp

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -607,13 +607,13 @@ std::vector<std::pair<int, float>> SemanticScene::getRegionsForPoints(
   std::vector<std::pair<int, float>> containingRegionWeights;
   for (int rix = 0; rix < regions_.size(); ++rix) {
     float containmentCount = 0;
-    for (auto& point : points) {
+    for (const auto& point : points) {
       if (regions_[rix]->contains(point)) {
         containmentCount += 1;
       }
     }
     if (containmentCount > 0) {
-      containingRegionWeights.push_back(
+      containingRegionWeights.emplace_back(
           std::pair<int, float>(rix, containmentCount / points.size()));
     }
   }

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -592,7 +592,7 @@ std::vector<uint32_t> SemanticScene::buildSemanticOBBs(
 }  // SemanticScene::buildSemanticOBBs
 
 std::vector<int> SemanticScene::getRegionsForPoint(
-    const Mn::Vector3 point) const {
+    const Mn::Vector3& point) const {
   std::vector<int> containingRegions;
   for (int rix = 0; rix < regions_.size(); ++rix) {
     if (regions_[rix]->contains(point)) {
@@ -603,7 +603,7 @@ std::vector<int> SemanticScene::getRegionsForPoint(
 }
 
 std::vector<std::pair<int, float>> SemanticScene::getRegionsForPoints(
-    const std::vector<Mn::Vector3> points) const {
+    const std::vector<Mn::Vector3>& points) const {
   std::vector<std::pair<int, float>> containingRegionWeights;
   for (int rix = 0; rix < regions_.size(); ++rix) {
     float containmentCount = 0;

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -290,7 +290,7 @@ class SemanticScene {
    * @param point The query point.
    * @return A list of indices for regions which contain the point.
    */
-  std::vector<int> getRegionsForPoint(const Mn::Vector3 point) const;
+  std::vector<int> getRegionsForPoint(Mn::Vector3& point) const;
 
   /**
    * @brief Compute SemanticRegion containment for a set of points.
@@ -300,7 +300,7 @@ class SemanticScene {
    * region.
    */
   std::vector<std::pair<int, float>> getRegionsForPoints(
-      const std::vector<Mn::Vector3> points) const;
+      std::vector<Mn::Vector3>& points) const;
 
  protected:
   /**

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -284,6 +284,24 @@ class SemanticScene {
    */
   float CCFractionToUseForBBox() const { return ccLargestVolToUseForBBox_; }
 
+  /**
+   * @brief Compute all SemanticRegions which contain the point and return a
+   * list of indices for regions in this SemanticScene.
+   * @param point The query point.
+   * @return A list of indices for regions which contain the point.
+   */
+  std::vector<int> getRegionsForPoint(const Mn::Vector3 point) const;
+
+  /**
+   * @brief Compute SemanticRegion containment for a set of points.
+   * @param points A set of points to test for semantic containment.
+   * @return std::vector<std::pair<int, float>> A sorted list of tuples
+   * containing region index and percentage of input points contained in that
+   * region.
+   */
+  std::vector<std::pair<int, float>> getRegionsForPoints(
+      const std::vector<Mn::Vector3> points) const;
+
  protected:
   /**
    * @brief Verify a requested file exists.

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -290,7 +290,7 @@ class SemanticScene {
    * @param point The query point.
    * @return A list of indices for regions which contain the point.
    */
-  std::vector<int> getRegionsForPoint(Mn::Vector3& point) const;
+  std::vector<int> getRegionsForPoint(const Mn::Vector3& point) const;
 
   /**
    * @brief Compute SemanticRegion containment for a set of points.
@@ -300,7 +300,7 @@ class SemanticScene {
    * region.
    */
   std::vector<std::pair<int, float>> getRegionsForPoints(
-      std::vector<Mn::Vector3>& points) const;
+      const std::vector<Mn::Vector3>& points) const;
 
  protected:
   /**


### PR DESCRIPTION
## Motivation and Context

Add functions to query region containment for one point and a set of points.

## How Has This Been Tested

Added pytests and a demo in viewer.py.

In the below video when the crib object is selected, containing regions are displayed colored by containment percentage. Red is full containment fading to green with less containment. Notice the hues shift as the object is moved between regions.

https://github.com/facebookresearch/habitat-sim/assets/1445143/695d1aa6-5eb3-4948-914f-ee6d34e98f82

Note: this demo will be reverted before merge.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
