### PR TITLE
Add max decimal place option to recorder.

### DIFF
--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -66,9 +66,8 @@ void initGfxReplayBindings(py::module& m) {
                   "replay save not enabled. See "
                   "SimulatorConfiguration.enable_gfx_replay_save.");
             }
-            return esp::gfx::replay::Recorder::keyframeToString(
-                self.getRecorder()->extractKeyframe(),
-                self.getRecorder()->getMaxDecimalPlaces());
+            return self.getRecorder()->keyframeToString(
+                self.getRecorder()->extractKeyframe());
           },
           R"(Extract the current keyframe as a JSON-formatted string.)")
 

--- a/src/esp/bindings/GfxReplayBindings.cpp
+++ b/src/esp/bindings/GfxReplayBindings.cpp
@@ -67,7 +67,8 @@ void initGfxReplayBindings(py::module& m) {
                   "SimulatorConfiguration.enable_gfx_replay_save.");
             }
             return esp::gfx::replay::Recorder::keyframeToString(
-                self.getRecorder()->extractKeyframe());
+                self.getRecorder()->extractKeyframe(),
+                self.getRecorder()->getMaxDecimalPlaces());
           },
           R"(Extract the current keyframe as a JSON-formatted string.)")
 
@@ -124,7 +125,31 @@ void initGfxReplayBindings(py::module& m) {
           R"(Write all saved keyframes to individual strings. See Recorder.h for details.)")
 
       .def("read_keyframes_from_file", &ReplayManager::readKeyframesFromFile,
-           R"(Create a Player object from a replay file.)");
+           R"(Create a Player object from a replay file.)")
+
+      .def(
+          "set_max_decimal_places",
+          [](ReplayManager& self, int maxDecimalPlaces) {
+            if (!self.getRecorder()) {
+              throw std::runtime_error(
+                  "Replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
+            }
+            self.getRecorder()->setMaxDecimalPlaces(maxDecimalPlaces);
+          },
+          R"(Set the precision of the floating points serialized by this recorder.)")
+
+      .def(
+          "get_max_decimal_places",
+          [](ReplayManager& self) {
+            if (!self.getRecorder()) {
+              throw std::runtime_error(
+                  "Replay save not enabled. See "
+                  "SimulatorConfiguration.enable_gfx_replay_save.");
+            }
+            return self.getRecorder()->getMaxDecimalPlaces();
+          },
+          R"(Get the precision of the floating points serialized by this recorder.)");
 }
 
 }  // namespace replay

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -300,7 +300,7 @@ Recorder::writeIncrementalSavedKeyframesToStringArray() {
   results.reserve(savedKeyframes_.size());
 
   for (const auto& keyframe : savedKeyframes_) {
-    results.emplace_back(keyframeToString(keyframe, maxDecimalPlaces_));
+    results.emplace_back(keyframeToString(keyframe));
   }
 
   // note we don't call consolidateSavedKeyframes. Use this function if you are
@@ -321,12 +321,11 @@ int Recorder::getMaxDecimalPlaces() const {
   return maxDecimalPlaces_;
 }
 
-std::string Recorder::keyframeToString(const Keyframe& keyframe,
-                                       int maxDecimalPlaces) {
+std::string Recorder::keyframeToString(const Keyframe& keyframe) {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   esp::io::addMember(d, "keyframe", keyframe, allocator);
-  return esp::io::jsonToString(d, maxDecimalPlaces);
+  return esp::io::jsonToString(d, maxDecimalPlaces_);
 }
 
 void Recorder::consolidateSavedKeyframes() {

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -321,7 +321,7 @@ int Recorder::getMaxDecimalPlaces() const {
   return maxDecimalPlaces_;
 }
 
-std::string Recorder::keyframeToString(const Keyframe& keyframe) {
+std::string Recorder::keyframeToString(const Keyframe& keyframe) const {
   rapidjson::Document d(rapidjson::kObjectType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   esp::io::addMember(d, "keyframe", keyframe, allocator);

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -167,9 +167,7 @@ class Recorder {
   /**
    * @brief returns JSONized version of given keyframe.
    */
-  static std::string keyframeToString(
-      const Keyframe& keyframe,
-      int maxDecimalPlaces = DEFAULT_MAX_DECIMAL_PLACES);
+  std::string keyframeToString(const Keyframe& keyframe);
 
   /**
    * @brief Reserved for unit-testing.

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -153,12 +153,14 @@ class Recorder {
   std::vector<std::string> writeIncrementalSavedKeyframesToStringArray();
 
   /**
-   * @brief Set the precision of the floating points serialized by this recorder.
+   * @brief Set the precision of the floating points serialized by this
+   * recorder.
    */
   void setMaxDecimalPlaces(int maxDecimalPlaces);
 
   /**
-   * @brief Get the precision of the floating points serialized by this recorder.
+   * @brief Get the precision of the floating points serialized by this
+   * recorder.
    */
   int getMaxDecimalPlaces() const;
 

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -24,6 +24,8 @@ namespace gfx {
 struct Rig;
 namespace replay {
 
+const int DEFAULT_MAX_DECIMAL_PLACES = 7;
+
 class NodeDeletionHelper;
 
 /**
@@ -151,16 +153,28 @@ class Recorder {
   std::vector<std::string> writeIncrementalSavedKeyframesToStringArray();
 
   /**
+   * @brief Set the precision of the floating points serialized by this recorder.
+   */
+  void setMaxDecimalPlaces(int maxDecimalPlaces);
+
+  /**
+   * @brief Get the precision of the floating points serialized by this recorder.
+   */
+  int getMaxDecimalPlaces() const;
+
+  /**
    * @brief returns JSONized version of given keyframe.
    */
-  static std::string keyframeToString(const Keyframe& keyframe);
+  static std::string keyframeToString(
+      const Keyframe& keyframe,
+      int maxDecimalPlaces = DEFAULT_MAX_DECIMAL_PLACES);
 
   /**
    * @brief Reserved for unit-testing.
    */
   const std::vector<Keyframe>& debugGetSavedKeyframes() const {
     return savedKeyframes_;
-  }
+  };
 
  private:
   // NodeDeletionHelper calls onDeleteRenderAssetInstance
@@ -200,6 +214,7 @@ class Recorder {
   RenderAssetInstanceKey nextInstanceKey_ = 0;
   std::unordered_map<int, std::vector<scene::SceneNode*>> rigNodes_;
   std::unordered_map<int, std::vector<Magnum::Matrix4>> rigNodeTransformCache_;
+  int maxDecimalPlaces_ = DEFAULT_MAX_DECIMAL_PLACES;
 
   ESP_SMART_POINTERS(Recorder)
 };

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -167,7 +167,7 @@ class Recorder {
   /**
    * @brief returns JSONized version of given keyframe.
    */
-  std::string keyframeToString(const Keyframe& keyframe);
+  std::string keyframeToString(const Keyframe& keyframe) const;
 
   /**
    * @brief Reserved for unit-testing.

--- a/src/esp/io/Json.cpp
+++ b/src/esp/io/Json.cpp
@@ -86,9 +86,12 @@ JsonDocument parseJsonString(const std::string& jsonString) {
   return d;
 }
 
-std::string jsonToString(const JsonDocument& d) {
+std::string jsonToString(const JsonDocument& d, int maxDecimalPlaces) {
   rapidjson::StringBuffer buffer{};
   rapidjson::Writer<rapidjson::StringBuffer> writer{buffer};
+  if (maxDecimalPlaces != -1) {
+    writer.SetMaxDecimalPlaces(maxDecimalPlaces);
+  }
   d.Accept(writer);
   return buffer.GetString();
 }

--- a/src/esp/io/Json.h
+++ b/src/esp/io/Json.h
@@ -48,7 +48,7 @@ JsonDocument parseJsonFile(const std::string& file);
 JsonDocument parseJsonString(const std::string& jsonString);
 
 //! Return string representation of given JsonDocument
-std::string jsonToString(const JsonDocument& d);
+std::string jsonToString(const JsonDocument& d, int maxDecimalPlaces = -1);
 
 //! Return Vec3f coordinates representation of given JsonObject of array type
 esp::vec3f jsonToVec3f(const JsonGenericValue& jsonArray);

--- a/src/tests/BatchReplayRendererTest.cpp
+++ b/src/tests/BatchReplayRendererTest.cpp
@@ -313,8 +313,8 @@ void BatchReplayRendererTest::testIntegration() {
                                    Mn::Vector3(0.f, 1.f, 0.f)));
     }
 
-    std::string serKeyframe = esp::gfx::replay::Recorder::keyframeToString(
-        recorder.extractKeyframe());
+    std::string serKeyframe =
+        recorder.keyframeToString(recorder.extractKeyframe());
     serKeyframes.emplace_back(std::move(serKeyframe));
   }
 
@@ -547,8 +547,8 @@ void BatchReplayRendererTest::testArticulatedObject() {
                                      Mn::Vector3(0.0f, 1.0f, 0.0f)));
       }
 
-      std::string serKeyframe = esp::gfx::replay::Recorder::keyframeToString(
-          recorder.extractKeyframe());
+      std::string serKeyframe =
+          recorder.keyframeToString(recorder.extractKeyframe());
       serKeyframes.emplace_back(std::move(serKeyframe));
     }
   }

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -6,6 +6,7 @@
 
 #include <Corrade/Containers/Optional.h>
 #include <Corrade/TestSuite/Compare/Numeric.h>
+#include <Corrade/TestSuite/Compare/String.h>
 #include <Corrade/TestSuite/Tester.h>
 #include <Corrade/Utility/Path.h>
 #include <Magnum/Math/Range.h>
@@ -765,10 +766,14 @@ void GfxReplayTest::testDecimalPlaces() {
 
   // read the playback strings
   {
-    CORRADE_VERIFY(keyframe3Decimals.find("0.555") != std::string::npos);
-    CORRADE_VERIFY(keyframe3Decimals.find("0.5555") == std::string::npos);
-    CORRADE_VERIFY(keyframe5Decimals.find("0.55555") != std::string::npos);
-    CORRADE_VERIFY(keyframe5Decimals.find("0.555555") == std::string::npos);
+    CORRADE_COMPARE_AS(keyframe3Decimals, "0.555",
+                       Cr::TestSuite::Compare::StringContains);
+    CORRADE_COMPARE_AS(keyframe3Decimals, "0.5555",
+                       Cr::TestSuite::Compare::StringNotContains);
+    CORRADE_COMPARE_AS(keyframe5Decimals, "0.55555",
+                       Cr::TestSuite::Compare::StringContains);
+    CORRADE_COMPARE_AS(keyframe5Decimals, "0.555555",
+                       Cr::TestSuite::Compare::StringNotContains);
   }
 }
 


### PR DESCRIPTION
## Motivation and Context

This changes the gfx-replay `Recorder` to make the maximum float decimal places configurable.

This is an easy way to increase performance of JSON-based systems, as well as making the output text more compact.

**Example usage:**
```
sim.gfx_replay_manager.set_max_decimal_places(3)
[...]
sim.gfx_replay_manager.save_keyframe()
keyframe = sim.gfx_replay_manager.write_saved_keyframes_to_string()
```

**Example data (update frames):**
| Default | 3 Decimal Places |
|---|---|
| 4223 bytes| 3656 bytes |
| ![jsonbefore](https://github.com/facebookresearch/habitat-sim/assets/110583667/52f5be08-cec2-424a-8cd1-963a085a7379) | ![jsonafter](https://github.com/facebookresearch/habitat-sim/assets/110583667/66f46adf-80a5-4cbf-9fa7-cce50ea50d87) |


## How Has This Been Tested

Added a unit test, and tested locally on the HITL tool.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
