### PR TITLE
Ability to render the viewer content at quarter resolution on very-high-DPI screens

### DIFF
--- a/src/esp/gfx/RenderTarget.cpp
+++ b/src/esp/gfx/RenderTarget.cpp
@@ -216,16 +216,11 @@ struct RenderTarget::Impl {
         flags_ & Flag::RgbaAttachment,
         "RenderTarget::Impl::blitRgbaToDefault(): this render target "
         "was not created with rgba render buffer enabled.", );
-    CORRADE_ASSERT(
-        framebuffer_.viewport().size() == targetRectangle.size(),
-        "RenderTarget::Impl::blitRgbaTo(): target framebuffer has a size of"
-            << targetRectangle.size() << "but expected"
-            << framebuffer_.viewport().size(), );
 
     framebuffer_.mapForRead(RgbaBufferAttachment);
     Mn::GL::AbstractFramebuffer::blit(
         framebuffer_, target, framebuffer_.viewport(), targetRectangle,
-        Mn::GL::FramebufferBlit::Color, Mn::GL::FramebufferBlitFilter::Nearest);
+        Mn::GL::FramebufferBlit::Color, Mn::GL::FramebufferBlitFilter::Linear);
   }
 
   void readFrameRgba(const Mn::MutableImageView2D& view) {

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -248,7 +248,7 @@ class Viewer : public Mn::Platform::Application {
     // window size.
     // on retina displays this scaling calc is necessary to account for HiDPI
     // monitors.
-    Mn::Vector2 scaling = Mn::Vector2{framebufferSize()} * dpiScaling() /
+    Mn::Vector2 scaling = Mn::Vector2{framebufferSize()} /
                           Mn::Vector2{windowSize()};
 
     return Mn::Vector2i(mouseEventPosition * scaling);

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -247,8 +247,8 @@ class Viewer : public Mn::Platform::Application {
     // aquire the mouse position, and scale it based on ratio of actual
     // framebuffer and window size. The two can differ on HiDPI displays or
     // if a quarter-size rendering is active.
-    Mn::Vector2 scaling = Mn::Vector2{scaledFramebufferSize_} /
-                          Mn::Vector2{windowSize()};
+    Mn::Vector2 scaling =
+        Mn::Vector2{scaledFramebufferSize_} / Mn::Vector2{windowSize()};
 
     return Mn::Vector2i(mouseEventPosition * scaling);
   }
@@ -668,7 +668,9 @@ Key Commands:
 #endif  // ESP_BUILD_WITH_AUDIO
 };      // class viewer declaration
 
-void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho, const Mn::Vector2i& framebufferSize) {
+void addSensors(esp::agent::AgentConfiguration& agentConfig,
+                bool isOrtho,
+                const Mn::Vector2i& framebufferSize) {
   auto addCameraSensor = [&](const std::string& uuid,
                              esp::sensor::SensorType sensorType) {
     agentConfig.sensorSpecifications.emplace_back(
@@ -686,7 +688,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho, const
     }
     spec->position = {0.0f, rgbSensorHeight, 0.0f};
     spec->orientation = {0, 0, 0};
-    spec->resolution = viewportSize.flipped();
+    spec->resolution = framebufferSize.flipped();
   };
   // add the camera color sensor
   // for historical reasons, we call it "rgba_camera"
@@ -715,9 +717,9 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho, const
     }
     spec->sensorSubType = esp::sensor::SensorSubType::Fisheye;
     spec->fisheyeModelType = modelType;
-    spec->resolution = viewportSize.flipped();
+    spec->resolution = framebufferSize.flipped();
     // default viewport size: 1600 x 1200
-    spec->principalPointOffset = Mn::Vector2{framebufferSize}/2.0f;
+    spec->principalPointOffset = Mn::Vector2{framebufferSize} / 2.0f;
     if (modelType == esp::sensor::FisheyeSensorModelType::DoubleSphere) {
       // in this demo, we choose "GoPro":
       spec->focalLength = {364.84f, 364.86f};
@@ -759,7 +761,7 @@ void addSensors(esp::agent::AgentConfiguration& agentConfig, bool isOrtho, const
       spec->channels = 1;
     }
     spec->sensorSubType = esp::sensor::SensorSubType::Equirectangular;
-    spec->resolution = viewportSize.flipped();
+    spec->resolution = framebufferSize.flipped();
   };
   // add the equirectangular sensor
   addEquirectangularSensor("rgba_equirectangular",
@@ -808,9 +810,8 @@ Viewer::Viewer(const Arguments& arguments)
                                     .setTitle("Viewer")
                                     .setWindowFlags(
                                         Configuration::WindowFlag::Resizable),
-                                GLConfiguration{}
-                                    .setColorBufferSize(
-                                        Mn::Vector4i(8, 8, 8, 8))},
+                                GLConfiguration{}.setColorBufferSize(
+                                    Mn::Vector4i(8, 8, 8, 8))},
       loggingContext_{},
       simConfig_(),
       MM_(std::make_shared<esp::metadata::MetadataMediator>(simConfig_)),
@@ -862,15 +863,19 @@ Viewer::Viewer(const Arguments& arguments)
                "Specify path to load camera transform from.")
       .addOption("quarter-resolution-scaling-limit", "2.0")
       .setHelp("quarter-resolution-scaling-limit",
-               "Display scaling factor at which to render at quarter " "resolution.")
+               "Display scaling factor at which to render at quarter "
+               "resolution.")
       .parse(arguments.argc, arguments.argv);
 
   /* The size used for actual rendering is size of the framebuffer by default.
      On HiDPI displays with a scaling factor larger or equal to 2, it's quarter
      size instead. */
-  quarterResolutionScalingLimit_ = args.value<Mn::Float>("quarter-resolution-scaling-limit");
+  quarterResolutionScalingLimit_ =
+      args.value<Mn::Float>("quarter-resolution-scaling-limit");
   scaledFramebufferSize_ = framebufferSize();
-  if((Mn::Vector2{framebufferSize()}*dpiScaling()/Mn::Vector2{windowSize()}).max() >= quarterResolutionScalingLimit_)
+  if ((Mn::Vector2{framebufferSize()} * dpiScaling() /
+       Mn::Vector2{windowSize()})
+          .max() >= quarterResolutionScalingLimit_)
     scaledFramebufferSize_ /= 2;
 
   /* Set up text rendering. This is done always at the full framebuffer size
@@ -1035,7 +1040,8 @@ Viewer::Viewer(const Arguments& arguments)
   // initialize sim navmesh, agent, sensors after creation/reconfigure
   initSimPostReconfigure();
 
-  objectPickingHelper_ = std::make_unique<ObjectPickingHelper>(scaledFramebufferSize_);
+  objectPickingHelper_ =
+      std::make_unique<ObjectPickingHelper>(scaledFramebufferSize_);
 
   /**
    * Set up per frame profiler to be aware of bottlenecking in processing data
@@ -1824,7 +1830,9 @@ void Viewer::viewportEvent(ViewportEvent& event) {
   /* Recalculate the scaled framebuffer size based on new values coming from
      the event */
   scaledFramebufferSize_ = event.framebufferSize();
-  if((Mn::Vector2{event.framebufferSize()}*event.dpiScaling()/Mn::Vector2{event.windowSize()}).max() >= quarterResolutionScalingLimit_)
+  if ((Mn::Vector2{event.framebufferSize()} * event.dpiScaling() /
+       Mn::Vector2{event.windowSize()})
+          .max() >= quarterResolutionScalingLimit_)
     scaledFramebufferSize_ /= 2;
 
   for (auto& it : agentBodyNode_->getSubtreeSensors()) {
@@ -1841,7 +1849,7 @@ void Viewer::viewportEvent(ViewportEvent& event) {
             visualSensor.specification().get());
 
         // since the sensor is determined, sensor's focal length is fixed.
-        spec->principalPointOffset = Mn::Vector2{scaledFramebufferSize_}/2.0f;
+        spec->principalPointOffset = Mn::Vector2{scaledFramebufferSize_} / 2.0f;
       }
     }
   }

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -809,8 +809,7 @@ Viewer::Viewer(const Arguments& arguments)
                                         Configuration::WindowFlag::Resizable),
                                 GLConfiguration{}
                                     .setColorBufferSize(
-                                        Mn::Vector4i(8, 8, 8, 8))
-                                    .setSampleCount(4)},
+                                        Mn::Vector4i(8, 8, 8, 8))},
       loggingContext_{},
       simConfig_(),
       MM_(std::make_shared<esp::metadata::MetadataMediator>(simConfig_)),


### PR DESCRIPTION
## Motivation and Context

Changes needed in the native viewer application and the RenderTarget to allow for rendering at a resolution that's smaller than the actual framebuffer. For simplicity halving the framebuffer width and height, thus quarter of the size, however the limit at which this switch is done is configurable, so it's also achievable on non-HiDPI displays if you pass `--quarter-resolution-scaling-limit 1` to the app.

It also:

- Removes use of 4x MSAA which achieved nothing as the content was rendered to a non-multisampled framebuffer in the first place.
- Cleans up various interesting ways of doing vector math.
- Removes an assertion in the RenderTarget that required the source and destination size to match, and switches the filter to linear to not look *that* blocky.
- Removes an errorneous multiplication by `dpiScaling()` when getting a framebuffer-relative mouse position. The DPI scaling value is already baked into the framebuffer size at that point, thus multiplying again gives an incorrect value.

See also https://cvmlp.slack.com/archives/CFN5TAUSD/p1697296903351319 for original context.

## How Has This Been Tested

On my Linux box with a 4K display, 1.6875x DPI scaling and `--quarter-resolution-scaling-limit 1.6`. The way the limit calculation is done it should work on a Mac as well.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
