### PR TITLE
--[CI Fix] Fix miniconda versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ commands:
           command: |
               if [ ! -d ~/miniconda ]
               then
-                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-x86_64.sh
                 chmod +x ~/miniconda.sh
                 bash ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh
@@ -302,7 +302,7 @@ jobs:
       - run:
           name: Conda Install OSX
           command: |
-            curl -o ~/miniconda.sh -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            curl -o ~/miniconda.sh -O https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-MacOSX-x86_64.sh
             chmod +x ~/miniconda.sh
             ~/miniconda.sh -b -p $HOME/miniconda
             rm ~/miniconda.sh


### PR DESCRIPTION
## Motivation and Context
Using the latest miniconda versions is referencing python 3.12 which is undesirable, and causes osx builds to break (pkgutil.ImpImporter class was deprecated in python 3.3 and removed in 3.12.)

This PR will freeze our miniconda version to most recent python 3.10 version for both linux and mac.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
