### PR TITLE
--Region query tools

### DIFF
--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -256,19 +256,10 @@ void initSceneBindings(py::module& m) {
       .def("get_regions_for_points", &SemanticScene::getRegionsForPoints,
            R"("Compute SemanticRegion containment for a set of points. Return a
               sorted list of tuple pairs with each containing region index and
-              the percentage of points contained by that region.)",
-           "points"_a)
-      .def(
-          "get_weighted_regions_for_points",
-          &SemanticScene::getWeightedRegionsForPoints,
-          R"("Compute SemanticRegion containment for a set of points, accounting
-           for possible nested regions. Return a sorted list of tuple pairs with
-           each containing region index and the weighted fraction of points contained by
-           that region, where smaller, nested regions get higher weight than the larger
-           regions that contain them. If no regions are nested, than the returned weight
-           value corresponds with the percentage of the list of points contained in a
-           particular region.)",
-          "points"_a);
+              the percentage of points contained by that region. In the case of nested
+              regions, points are considered belonging to the nested region with the
+              smallest area that they are found in.)",
+           "points"_a);
 
   // ==== ObjectControls ====
   py::class_<ObjectControls, ObjectControls::ptr>(m, "ObjectControls")

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -257,8 +257,8 @@ void initSceneBindings(py::module& m) {
            R"("Compute SemanticRegion containment for a set of points. Return a
               sorted list of tuple pairs with each containing region index and
               the percentage of points contained by that region. In the case of nested
-              regions, points are considered belonging to the nested region with the
-              smallest area that they are found in.)",
+              regions, points are considered belonging to every region the point is
+              found in.)",
            "points"_a);
 
   // ==== ObjectControls ====

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -240,9 +240,20 @@ void initSceneBindings(py::module& m) {
       .def("semantic_index_to_object_index",
            &SemanticScene::semanticIndexToObjectIndex)
       .def("get_regions_for_point", &SemanticScene::getRegionsForPoint,
+           "point"_a,
            "Compute all SemanticRegions which contain the point and return a "
            "list of indices for the regions in this SemanticScene.")
+      .def(
+          "get_weighted_regions_for_point",
+          &SemanticScene::getWeightedRegionsForPoint, "point"_a,
+          "Find all SemanticRegions which contain the point and return a "
+          "sorted list of tuple pairs of the region index and a score of that"
+          "region, derived as 1 - (region_area/ttl_region_area), where"
+          "ttl_region_area is the area of all the regions containing the point,"
+          "so that smaller regions are weighted higher. If only one region "
+          "contains the passed point, its weight will be 1.")
       .def("get_regions_for_points", &SemanticScene::getRegionsForPoints,
+           "points"_a,
            "Compute SemanticRegion containment for a set of points. Return a "
            "sorted list of tuple pairs with each containing region index and "
            "the percentage of points contained by that region.");

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -228,35 +228,47 @@ void initSceneBindings(py::module& m) {
           "file"_a, "scene"_a, "rotation"_a)
       .def_property_readonly("aabb", &SemanticScene::aabb)
       .def_property_readonly("categories", &SemanticScene::categories,
-                             "All semantic categories in the house")
+                             "All semantic categories in the scene")
       .def_property_readonly("levels", &SemanticScene::levels,
-                             "All levels in the house")
+                             "All levels in the scene")
       .def_property_readonly("regions", &SemanticScene::regions,
-                             "All regions in the house")
+                             "All regions in the scene")
       .def_property_readonly("objects", &SemanticScene::objects,
-                             "All object in the house")
+                             "All object in the scene")
       .def_property_readonly("semantic_index_map",
                              &SemanticScene::getSemanticIndexMap)
       .def("semantic_index_to_object_index",
            &SemanticScene::semanticIndexToObjectIndex)
       .def("get_regions_for_point", &SemanticScene::getRegionsForPoint,
-           "point"_a,
-           "Compute all SemanticRegions which contain the point and return a "
-           "list of indices for the regions in this SemanticScene.")
-      .def(
-          "get_weighted_regions_for_point",
-          &SemanticScene::getWeightedRegionsForPoint, "point"_a,
-          "Find all SemanticRegions which contain the point and return a "
-          "sorted list of tuple pairs of the region index and a score of that"
-          "region, derived as 1 - (region_area/ttl_region_area), where"
-          "ttl_region_area is the area of all the regions containing the point,"
-          "so that smaller regions are weighted higher. If only one region "
-          "contains the passed point, its weight will be 1.")
+           R"(Compute all SemanticRegions which contain the point and return a
+             list of indices for the regions in this SemanticScene.)",
+           "point"_a)
+      .def("get_weighted_regions_for_point",
+           &SemanticScene::getWeightedRegionsForPoint,
+           R"("Find all SemanticRegions which contain the point and return a
+              sorted list of tuple pairs of the region index and a score of that
+              region, derived as
+                    1 - (region_area/ttl_region_area)
+              where ttl_region_area is the area of all the regions containing
+              the point, so that smaller regions are weighted higher. If only
+              one region contains the passed point, its weight will be 1.)",
+           "point"_a)
       .def("get_regions_for_points", &SemanticScene::getRegionsForPoints,
-           "points"_a,
-           "Compute SemanticRegion containment for a set of points. Return a "
-           "sorted list of tuple pairs with each containing region index and "
-           "the percentage of points contained by that region.");
+           R"("Compute SemanticRegion containment for a set of points. Return a
+              sorted list of tuple pairs with each containing region index and
+              the percentage of points contained by that region.)",
+           "points"_a)
+      .def(
+          "get_weighted_regions_for_points",
+          &SemanticScene::getWeightedRegionsForPoints,
+          R"("Compute SemanticRegion containment for a set of points, accounting
+           for possible nested regions. Return a sorted list of tuple pairs with
+           each containing region index and the weighted fraction of points contained by
+           that region, where smaller, nested regions get higher weight than the larger
+           regions that contain them. If no regions are nested, than the returned weight
+           value corresponds with the percentage of the list of points contained in a
+           particular region.)",
+          "points"_a);
 
   // ==== ObjectControls ====
   py::class_<ObjectControls, ObjectControls::ptr>(m, "ObjectControls")

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -656,8 +656,9 @@ std::vector<std::pair<int, double>> SemanticScene::getRegionsForPoints(
     std::vector<double> allRegionWeights(regions_.size(), 0);
     // Set the weight for the containing region with the smallest area (if
     // nested regions) for this particular point.
-    if (regWeightsForPoint.size() > 0) {
-      allRegionWeights[regWeightsForPoint[0].first] = 1.0;
+    // Set the vote for each region to be equal.
+    for (const std::pair<int, double>& regionWeight : regWeightsForPoint) {
+      allRegionWeights[regionWeight.first] = 1.0;
     }
     // Save this points region weight vector
     regAreaWeightsForPoints.emplace_back(allRegionWeights);

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -612,7 +612,12 @@ std::vector<int> SemanticScene::getRegionsForPoint(
 std::vector<std::pair<int, double>> SemanticScene::getWeightedRegionsForPoint(
     const Mn::Vector3& point) const {
   std::vector<int> containingRegions = getRegionsForPoint(point);
+  if (containingRegions.size() == 0) {
+    return {};
+  }
+
   std::vector<std::pair<int, double>> containingRegionWeights;
+  containingRegionWeights.reserve(containingRegions.size());
   // Only 1 containing region, so return region idx and weight of 1
   if (containingRegions.size() == 1) {
     containingRegionWeights.emplace_back(
@@ -620,7 +625,7 @@ std::vector<std::pair<int, double>> SemanticScene::getWeightedRegionsForPoint(
     return containingRegionWeights;
   }
 
-  // Sum up all areas
+  // Sum up all areas containing point
   double ttlArea = 0.0f;
   for (int rix : containingRegions) {
     ttlArea += regions_[rix]->getArea();
@@ -642,6 +647,8 @@ std::vector<std::pair<int, double>> SemanticScene::getWeightedRegionsForPoint(
 std::vector<std::pair<int, double>> SemanticScene::getRegionsForPoints(
     const std::vector<Mn::Vector3>& points) const {
   std::vector<std::pair<int, double>> containingRegionWeights;
+  // Will only have at max the number of regions in the scene
+  containingRegionWeights.reserve(regions_.size());
   for (int rix = 0; rix < regions_.size(); ++rix) {
     double containmentCount = 0;
     for (const auto& point : points) {
@@ -654,6 +661,9 @@ std::vector<std::pair<int, double>> SemanticScene::getRegionsForPoints(
           std::pair<int, double>(rix, containmentCount / points.size()));
     }
   }
+  // Free up unused capacity - every region probably does not contain a tested
+  // point
+  containingRegionWeights.shrink_to_fit();
   std::sort(containingRegionWeights.begin(), containingRegionWeights.end(),
             [](const std::pair<int, double>& a, std::pair<int, double>& b) {
               return a.second > b.second;
@@ -661,5 +671,46 @@ std::vector<std::pair<int, double>> SemanticScene::getRegionsForPoints(
   return containingRegionWeights;
 }  // SemanticScene::getRegionsForPoints
 
+std::vector<std::pair<int, double>> SemanticScene::getWeightedRegionsForPoints(
+    const std::vector<Mn::Vector3>& points) const {
+  // Weights for every point for every region
+  std::vector<std::vector<double>> regAreaWeightsForPoints;
+  regAreaWeightsForPoints.reserve(points.size());
+  for (int i = 0; i < points.size(); ++i) {
+    // Get this point's weighted regions
+    auto regWeightsForPoint = getWeightedRegionsForPoint(points[i]);
+    // Initialize all region weights to be 0
+    std::vector<double> allRegionWeights(regions_.size(), 0);
+    // Set the weights for the containing regions for this particular point
+    for (const std::pair<int, double>& regionWeight : regWeightsForPoint) {
+      allRegionWeights[regionWeight.first] = regionWeight.second;
+    }
+    // Save this points region weight vector
+    regAreaWeightsForPoints.emplace_back(allRegionWeights);
+  }
+
+  std::vector<std::pair<int, double>> containingRegionWeights;
+  // Will only have at max the number of regions in the scene
+  containingRegionWeights.reserve(regions_.size());
+  for (int rix = 0; rix < regions_.size(); ++rix) {
+    double containmentWeight = 0;
+    for (int i = 0; i < points.size(); ++i) {
+      std::vector<double> regWtsForPoint = regAreaWeightsForPoints[i];
+      containmentWeight += regWtsForPoint[rix];
+    }
+    if (containmentWeight > 0) {
+      containingRegionWeights.emplace_back(
+          std::pair<int, double>(rix, containmentWeight / points.size()));
+    }
+  }
+  // Free up unused capacity - every region probably does not contain a tested
+  // point
+  containingRegionWeights.shrink_to_fit();
+  std::sort(containingRegionWeights.begin(), containingRegionWeights.end(),
+            [](const std::pair<int, double>& a, std::pair<int, double>& b) {
+              return a.second > b.second;
+            });
+  return containingRegionWeights;
+}  // SemanticScene::getRegionsForPoints
 }  // namespace scene
 }  // namespace esp

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -304,13 +304,29 @@ class SemanticScene {
       const Mn::Vector3& point) const;
 
   /**
-   * @brief Compute SemanticRegion containment for a set of points.
+   * @brief Compute SemanticRegion containment for a set of points. It is
+   * assumed the set of points belong to the same construct (i.e. points from an
+   * individual object's mesh)
    * @param points A set of points to test for semantic containment.
    * @return std::vector<std::pair<int, float>> A sorted list of tuples
    * containing region index and percentage of input points contained in that
    * region.
    */
   std::vector<std::pair<int, double>> getRegionsForPoints(
+      const std::vector<Mn::Vector3>& points) const;
+
+  /**
+   * @brief Compute weighted SemanticRegion containment for a set of points. It
+   * is assumed the set of points belong to the same construct (i.e. points from
+   * an individual object's mesh). Each point is checked for region containment
+   * via @ref getWeightedRegionsForPoint, to account for possibly nested region
+   * containment.
+   * @param points A set of points to test for semantic containment.
+   * @return std::vector<std::pair<int, float>> A sorted list of tuples
+   * containing region index and percentage of input points contained in that
+   * region.
+   */
+  std::vector<std::pair<int, double>> getWeightedRegionsForPoints(
       const std::vector<Mn::Vector3>& points) const;
 
  protected:

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -293,13 +293,24 @@ class SemanticScene {
   std::vector<int> getRegionsForPoint(const Mn::Vector3& point) const;
 
   /**
+   * @brief Compute all the SemanticRegions that contain the passed point, and
+   * return a vector of indices and weights for each region, where the weights
+   * are inverted area of the region (smaller regions weighted higher)
+   * @param point The query point.
+   * @return std::vector<std::pair<int, float>> A sorted list of tuples
+   * containing region index and inverse area of that region
+   */
+  std::vector<std::pair<int, double>> getWeightedRegionsForPoint(
+      const Mn::Vector3& point) const;
+
+  /**
    * @brief Compute SemanticRegion containment for a set of points.
    * @param points A set of points to test for semantic containment.
    * @return std::vector<std::pair<int, float>> A sorted list of tuples
    * containing region index and percentage of input points contained in that
    * region.
    */
-  std::vector<std::pair<int, float>> getRegionsForPoints(
+  std::vector<std::pair<int, double>> getRegionsForPoints(
       const std::vector<Mn::Vector3>& points) const;
 
  protected:
@@ -521,6 +532,17 @@ class SemanticRegion {
 
   SemanticCategory::ptr category() const { return category_; }
 
+  /**
+   * @brief Returns the area of the polyloop forming the base of the region
+   * extrusion
+   */
+  double getArea() const { return area_; }
+  /**
+   * @brief Returns the volume of the polyloop-based extrusion defining the
+   * bounds of this region.
+   */
+  double getVolume() const { return area_ * extrusionHeight_; }
+
  protected:
   int index_{};
   int parentIndex_{};
@@ -529,6 +551,9 @@ class SemanticRegion {
   box3f bbox_;
 
   std::string name_;
+
+  // The area of the surface enclosed by the region
+  double area_{};
 
   // Height of extrusion for Extruded poly-loop-based volumes
   double extrusionHeight_{};
@@ -545,7 +570,7 @@ class SemanticRegion {
   std::shared_ptr<SemanticLevel> level_;
   friend SemanticScene;
   ESP_SMART_POINTERS(SemanticRegion)
-};
+};  // class SemanticRegion
 
 //! Represents a distinct semantically annotated object
 class SemanticObject {

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -315,20 +315,6 @@ class SemanticScene {
   std::vector<std::pair<int, double>> getRegionsForPoints(
       const std::vector<Mn::Vector3>& points) const;
 
-  /**
-   * @brief Compute weighted SemanticRegion containment for a set of points. It
-   * is assumed the set of points belong to the same construct (i.e. points from
-   * an individual object's mesh). Each point is checked for region containment
-   * via @ref getWeightedRegionsForPoint, to account for possibly nested region
-   * containment.
-   * @param points A set of points to test for semantic containment.
-   * @return std::vector<std::pair<int, float>> A sorted list of tuples
-   * containing region index and percentage of input points contained in that
-   * region.
-   */
-  std::vector<std::pair<int, double>> getWeightedRegionsForPoints(
-      const std::vector<Mn::Vector3>& points) const;
-
  protected:
   /**
    * @brief Verify a requested file exists.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -73,16 +73,6 @@ class Simulator {
   void seed(uint32_t newSeed);
 
   std::shared_ptr<gfx::Renderer> getRenderer() { return renderer_; }
-  std::shared_ptr<scene::SemanticScene> getSemanticScene() {
-    return resourceManager_->getSemanticScene();
-  }
-
-  /**
-   * @brief Return a view of the currently set Semantic scene colormap.
-   */
-  const std::vector<Mn::Vector3ub>& getSemanticSceneColormap() const {
-    return resourceManager_->getSemanticSceneColormap();
-  }
 
   inline void getRenderGLContext() {
     // acquire GL context from background thread, if background rendering
@@ -92,29 +82,6 @@ class Simulator {
     }
   }
 
-  /** @brief check if the semantic scene exists.*/
-  bool semanticSceneExists() const {
-    return resourceManager_->semanticSceneExists();
-  }
-
-  /**
-   * @brief get the current active scene graph
-   */
-  scene::SceneGraph& getActiveSceneGraph() {
-    CORRADE_INTERNAL_ASSERT(std::size_t(activeSceneID_) < sceneID_.size());
-    return sceneManager_->getSceneGraph(activeSceneID_);
-  }
-
-  /** @brief Check to see if there is a SemanticSceneGraph for rendering */
-  bool semanticSceneGraphExists() const {
-    return std::size_t(activeSemanticSceneID_) < sceneID_.size();
-  }
-
-  /** @brief get the semantic scene's SceneGraph for rendering */
-  scene::SceneGraph& getActiveSemanticSceneGraph() {
-    CORRADE_INTERNAL_ASSERT(semanticSceneGraphExists());
-    return sceneManager_->getSceneGraph(activeSemanticSceneID_);
-  }
   std::shared_ptr<gfx::replay::ReplayManager> getGfxReplayManager() {
     return gfxReplayMgr_;
   }
@@ -218,7 +185,44 @@ class Simulator {
   }
 
   /**
-   * @brief Build a map keyed by semantic color/id referencing a vector
+   * @brief get the current active scene graph
+   */
+  scene::SceneGraph& getActiveSceneGraph() {
+    CORRADE_INTERNAL_ASSERT(std::size_t(activeSceneID_) < sceneID_.size());
+    return sceneManager_->getSceneGraph(activeSceneID_);
+  }
+
+  ///////////////////////////
+  // Semantic Scene and Data
+  std::shared_ptr<scene::SemanticScene> getSemanticScene() {
+    return resourceManager_->getSemanticScene();
+  }
+
+  /**
+   * @brief Return a view of the currently set Semantic scene colormap.
+   */
+  const std::vector<Mn::Vector3ub>& getSemanticSceneColormap() const {
+    return resourceManager_->getSemanticSceneColormap();
+  }
+
+  /** @brief check if the semantic scene exists.*/
+  bool semanticSceneExists() const {
+    return resourceManager_->semanticSceneExists();
+  }
+
+  /** @brief Check to see if there is a SemanticSceneGraph for rendering */
+  bool semanticSceneGraphExists() const {
+    return std::size_t(activeSemanticSceneID_) < sceneID_.size();
+  }
+
+  /** @brief get the semantic scene's SceneGraph for rendering */
+  scene::SceneGraph& getActiveSemanticSceneGraph() {
+    CORRADE_INTERNAL_ASSERT(semanticSceneGraphExists());
+    return sceneManager_->getSceneGraph(activeSemanticSceneID_);
+  }
+
+  /**
+   * @brief Build a map keyed by semantic color/id referencing a list of
    * connected component-based Semantic objects.
    */
   std::unordered_map<uint32_t, std::vector<scene::CCSemanticObject::ptr>>
@@ -247,6 +251,9 @@ class Simulator {
                      "semantic mesh exists.";
     return {};
   }
+
+  ///////////////////////////
+  // End Semantic Scene and Data
 
   /**
    * @brief Builds a @ref esp::metadata::attributes::SceneInstanceAttributes describing the

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -104,12 +104,6 @@ def test_semantic_regions():
         )
         assert regions_weights[0][0] == 0
         assert regions_weights[0][1] >= 0.49  # half or more points contained
-        weighted_region_weights = semantic_scene.get_weighted_regions_for_points(
-            hit_test_points + miss_test_points
-        )
-        assert len(weighted_region_weights) == len(regions_weights)
-        assert weighted_region_weights[0][0] == regions_weights[0][0]
-        assert weighted_region_weights[0][1] >= regions_weights[0][1]
 
         # positive X region
         region = regions[1]
@@ -149,16 +143,6 @@ def test_semantic_regions():
         assert (
             abs(regions_weights[1][1] - (1.0 - regions_weights[0][1])) < 0.001
         )  # kitchen should have the remainder of total percent
-        # test again with weighted regions. Since not nested, should have identical results
-        weighted_region_weights = semantic_scene.get_weighted_regions_for_points(
-            mixed_points
-        )
-        # verify identical results
-        assert len(weighted_region_weights) == len(regions_weights)
-        assert weighted_region_weights[0][0] == regions_weights[0][0]
-        assert weighted_region_weights[0][1] >= regions_weights[0][1]
-        assert weighted_region_weights[1][0] == regions_weights[1][0]
-        assert weighted_region_weights[1][1] >= regions_weights[1][1]
 
 
 @pytest.mark.parametrize("scene", _test_scenes)

--- a/tests/test_semantic_scene.py
+++ b/tests/test_semantic_scene.py
@@ -104,6 +104,12 @@ def test_semantic_regions():
         )
         assert regions_weights[0][0] == 0
         assert regions_weights[0][1] >= 0.49  # half or more points contained
+        weighted_region_weights = semantic_scene.get_weighted_regions_for_points(
+            hit_test_points + miss_test_points
+        )
+        assert len(weighted_region_weights) == len(regions_weights)
+        assert weighted_region_weights[0][0] == regions_weights[0][0]
+        assert weighted_region_weights[0][1] >= regions_weights[0][1]
 
         # positive X region
         region = regions[1]
@@ -135,7 +141,6 @@ def test_semantic_regions():
             (-1 * p) for p in hit_test_points
         ]  # add one less to create imbalance
         regions_weights = semantic_scene.get_regions_for_points(mixed_points)
-        print(f"regions_weights = {regions_weights}")
         assert regions_weights[0][0] == 1  # bathroom with more points comes first
         assert (
             regions_weights[0][1] >= 0.51
@@ -144,6 +149,16 @@ def test_semantic_regions():
         assert (
             abs(regions_weights[1][1] - (1.0 - regions_weights[0][1])) < 0.001
         )  # kitchen should have the remainder of total percent
+        # test again with weighted regions. Since not nested, should have identical results
+        weighted_region_weights = semantic_scene.get_weighted_regions_for_points(
+            mixed_points
+        )
+        # verify identical results
+        assert len(weighted_region_weights) == len(regions_weights)
+        assert weighted_region_weights[0][0] == regions_weights[0][0]
+        assert weighted_region_weights[0][1] >= regions_weights[0][1]
+        assert weighted_region_weights[1][0] == regions_weights[1][0]
+        assert weighted_region_weights[1][1] >= regions_weights[1][1]
 
 
 @pytest.mark.parametrize("scene", _test_scenes)


### PR DESCRIPTION
## Motivation and Context
This PR adds functions to test for point-region membership and point collection-region membership with a weighting factor, to account for possibly nested regions. If a point is only found in a single region, its weighting in that region is 1. 

Otherwise, each region is assigned a weighting that is inversely proportional to the area of a particular region containing the point.  The weighting is calculated like so : 
 ` 

         1 - (region_area/total_region_area)

`
where `region_area` is the area of a specific region the point is found in and total_region_area is the total area of all regions that point is found in. 

For collections of points that are assumed to belong to the same construct, the region membership check has been modified to give ~~a weighting value only to the innermost (i.e. smallest area) region in nested regions. In other words, in the case of nested regions, a point is only considered found in the innermost region.~~ the same weighting value to all regions containing a particular point. In the case of nested regions, this may result in an object being fully contained within the containing region, while only partially contained within the nested internal region.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests. Python test modified to verify that with non-nested regions it returns the same result as the non-weighted versions

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
