### PR TITLE
Revert "Remove RTLD_GLOBAL flag from apps. (#2312)

### DIFF
--- a/examples/motion_viewer.py
+++ b/examples/motion_viewer.py
@@ -2,9 +2,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import ctypes
 import random
+import sys
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
+
+flags = sys.getdlopenflags()
+sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
 import magnum as mn
 from magnum.platform.glfw import Application

--- a/examples/viewer.py
+++ b/examples/viewer.py
@@ -2,12 +2,17 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import ctypes
 import math
 import os
 import string
+import sys
 import time
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+flags = sys.getdlopenflags()
+sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
 import magnum as mn
 import numpy as np

--- a/src_python/habitat_sim/__init__.py
+++ b/src_python/habitat_sim/__init__.py
@@ -6,12 +6,6 @@
 
 import builtins
 
-# Important platform-specific setup steps to do before using bindings.
-try:
-    import magnum
-except ImportError:
-    pass
-
 __version__ = "0.3.1"
 
 if not getattr(builtins, "__HSIM_SETUP__", False):


### PR DESCRIPTION
## Motivation and Context

This reverts commit d890c644a35cefdde1d0962b3e16ecc4f1dd326d (#2312), which is causing downstream issues (for instance, in `habitat-llm`).

The downstream issues will be stabilized prior to re-introducing this change.

## How Has This Been Tested

N/A

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
