### PR TITLE
--Support marker set specifications in Object, Stage and AO config jsons

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -80,7 +80,13 @@ void initAttributesBindings(py::module& m) {
       .def_property_readonly(
           "num_user_configs",
           &AbstractAttributes::getNumUserDefinedConfigurations,
-          R"(The number of currently specified user-defined configuration values.)")
+          R"(The number of currently specified user-defined configuration values and
+          subconfigs (does not recurse subordinate subconfigs).)")
+      .def_property_readonly(
+          "total_num_user_configs",
+          &AbstractAttributes::getTotalNumUserDefinedConfigurations,
+          R"(The total number of currently specified user-defined configuration values
+          and subconfigs found by also recursing all subordinate subconfigs.)")
       .def_property_readonly("template_class", &AbstractAttributes::getClassKey,
                              R"(Class name of Attributes template.)")
       .def_property_readonly(

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -237,6 +237,13 @@ void initAttributesBindings(py::module& m) {
       .ao_config.json files.)")
       .def(py::init(&ArticulatedObjectAttributes::create<>))
       .def(py::init(&ArticulatedObjectAttributes::create<const std::string&>))
+      .def("get_marker_sets",
+           &ArticulatedObjectAttributes::editMarkerSetsConfiguration,
+           py::return_value_policy::reference_internal,
+           R"(Returns a reference to the marker-sets configuration object for
+          this Articulated Object attributes, so that it can be viewed or modified.
+          Any changes to this configuration will require the owning attributes to
+          be re-registered.)")
       .def_property(
           "urdf_filepath", &ArticulatedObjectAttributes::getURDFPath,
           &ArticulatedObjectAttributes::setURDFPath,
@@ -283,6 +290,13 @@ void initAttributesBindings(py::module& m) {
              AbstractObjectAttributes::ptr>(m, "AbstractObjectAttributes")
       .def(py::init(&AbstractObjectAttributes::create<const std::string&,
                                                       const std::string&>))
+      .def("get_marker_sets",
+           &AbstractObjectAttributes::editMarkerSetsConfiguration,
+           py::return_value_policy::reference_internal,
+           R"(Returns a reference to the marker-sets configuration object for
+          constructs built using this template, so that it can be viewed or modified.
+          Any changes to this configuration will require the owning attributes to
+          be re-registered.)")
       .def_property(
           "scale", &AbstractObjectAttributes::getScale,
           &AbstractObjectAttributes::setScale,

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -56,7 +56,30 @@ void initConfigBindings(py::module& m) {
 
   py::class_<Configuration, Configuration::ptr>(m, "Configuration")
       .def(py::init(&Configuration::create<>))
-
+      .def_property_readonly(
+          "top_level_num_entries", &Configuration::getNumEntries,
+          R"(Holds the total number of values and subconfigs this Configuration holds
+          at the base level (does not recurse subconfigs).)")
+      .def_property_readonly(
+          "top_level_num_configs", &Configuration::getNumSubconfigs,
+          R"(Holds the total number of subconfigs this Configuration holds at the base
+          level (does not recurse subconfigs).)")
+      .def_property_readonly(
+          "top_level_num_values", &Configuration::getNumValues,
+          R"(Holds the total number of values this Configuration holds at the base
+          level (does not recurse subconfigs).)")
+      .def_property_readonly(
+          "total_num_entries", &Configuration::getConfigTreeNumEntries,
+          R"(Holds the total number of values and subconfigs this Configuration holds
+          across all levels (recurses subconfigs).)")
+      .def_property_readonly(
+          "total_num_configs", &Configuration::getConfigTreeNumSubconfigs,
+          R"(Holds the total number of subconfigs this Configuration holds across all
+          levels (recurses subconfigs).)")
+      .def_property_readonly(
+          "total_num_values", &Configuration::getConfigTreeNumValues,
+          R"(Holds the total number of values this Configuration holds across all
+          levels (recurses subconfigs).)")
       .def(
           "get",
           [](Configuration& self, const std::string& key) {

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -332,7 +332,7 @@ Mn::Debug& operator<<(Mn::Debug& debug, const ConfigValue& value) {
 }
 
 int Configuration::loadOneConfigFromJson(int numConfigSettings,
-                                         const std::string key,
+                                         const std::string& key,
                                          const io::JsonGenericValue& jsonObj) {
   // increment, assuming is valid object
   ++numConfigSettings;

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -331,6 +331,158 @@ Mn::Debug& operator<<(Mn::Debug& debug, const ConfigValue& value) {
                << "|" << value.getType() << Mn::Debug::nospace << ")";
 }
 
+int Configuration::loadOneConfigFromJson(int numConfigSettings,
+                                         const std::string key,
+                                         const io::JsonGenericValue& jsonObj) {
+  // increment, assuming is valid object
+  ++numConfigSettings;
+  if (jsonObj.IsDouble()) {
+    set(key, jsonObj.GetDouble());
+  } else if (jsonObj.IsNumber()) {
+    set(key, jsonObj.GetInt());
+  } else if (jsonObj.IsString()) {
+    set(key, jsonObj.GetString());
+  } else if (jsonObj.IsBool()) {
+    set(key, jsonObj.GetBool());
+  } else if (jsonObj.IsArray() && jsonObj.Size() > 0) {
+    // non-empty array of numeric values
+    if (jsonObj[0].IsNumber()) {
+      // numeric vector, quaternion or matrix
+      if (jsonObj.Size() == 2) {
+        // All size 2 numeric arrays are mapped to Mn::Vector2
+        Mn::Vector2 val{};
+        if (io::fromJsonValue(jsonObj, val)) {
+          set(key, val);
+        }
+      } else if (jsonObj.Size() == 3) {
+        // All size 3 numeric arrays are mapped to Mn::Vector3
+        Mn::Vector3 val{};
+        if (io::fromJsonValue(jsonObj, val)) {
+          set(key, val);
+        }
+      } else if (jsonObj.Size() == 4) {
+        // JSON numeric array of size 4 can be either vector4, quaternion or
+        // color4, so must get type of object that exists with key
+        // NOTE : to properly make use of vector4 and color4 configValues
+        // loaded from JSON, the owning Configuration must be
+        // pre-initialized in its constructor with a default value at the
+        // target key. Otherwise for backwards compatibility, we default to
+        // reading a quaternion
+
+        // Check if this configuration has pre-defined field with given key
+        if (hasValue(key)) {
+          ConfigStoredType valType = get(key).getType();
+          if (valType == ConfigStoredType::MagnumQuat) {
+            // if predefined object is neither
+            Mn::Quaternion val{};
+            if (io::fromJsonValue(jsonObj, val)) {
+              set(key, val);
+            }
+          } else if (valType == ConfigStoredType::MagnumVec4) {
+            // if object exists already @ key and its type is Vector4
+            Mn::Vector4 val{};
+            if (io::fromJsonValue(jsonObj, val)) {
+              set(key, val);
+            }
+          } else {
+            // unknown predefined type of config of size 4
+            // this indicates incomplete implementation of size 4
+            // configuration type.
+            // decrement count for key:obj due to not being handled vector
+            --numConfigSettings;
+
+            ESP_WARNING()
+                << "Config cell in JSON document contains key" << key
+                << "referencing an existing configuration element of size "
+                   "4 of unknown type:"
+                << getNameForStoredType(valType) << "so skipping.";
+          }
+        } else {
+          // This supports fields that do not yet exist.
+          // Check if label contains substrings inferring expected type,
+          // otherwise assume this field is a mn::Vector4
+
+          auto lcaseKey = Cr::Utility::String::lowercase(key);
+          // labels denoting quaternions
+          if ((lcaseKey.find("quat") != std::string::npos) ||
+              (lcaseKey.find("rotat") != std::string::npos) ||
+              (lcaseKey.find("orient") != std::string::npos)) {
+            // object label contains quaternion tag, treat as a
+            // Mn::Quaternion
+            Mn::Quaternion val{};
+            if (io::fromJsonValue(jsonObj, val)) {
+              set(key, val);
+            }
+          } else {
+            // if unrecognized label for user-defined field, default the
+            // value to be treated as a Mn::Vector4
+            Mn::Vector4 val{};
+            if (io::fromJsonValue(jsonObj, val)) {
+              set(key, val);
+            }
+          }
+        }
+      } else if (jsonObj.Size() == 9) {
+        // assume is 3x3 matrix
+        Mn::Matrix3 mat{};
+        if (io::fromJsonValue(jsonObj, mat)) {
+          set(key, mat);
+        }
+      } else {
+        // decrement count for key:obj due to not being handled vector
+        --numConfigSettings;
+        // TODO support numeric array in JSON
+        ESP_WARNING() << "Config cell in JSON document contains key" << key
+                      << "referencing an unsupported numeric array of length :"
+                      << jsonObj.Size() << "so skipping.";
+      }
+    } else if (jsonObj[0].IsString()) {
+      // Array of strings
+
+      // create a new subgroup
+      std::shared_ptr<core::config::Configuration> subGroupPtr =
+          getSubconfigCopy<core::config::Configuration>(key);
+
+      for (size_t i = 0; i < jsonObj.Size(); ++i) {
+        std::string dest;
+        if (!io::fromJsonValue(jsonObj[i], dest)) {
+          ESP_ERROR() << "Failed to parse array element" << i
+                      << "in non-numeric list of values keyed by" << key
+                      << "so skipping this value.";
+        } else {
+          const std::string subKey =
+              Cr::Utility::formatString("{}_{:.02d}", key, i);
+          subGroupPtr->set(subKey, dest);
+          // Increment for each sub-config object
+          ++numConfigSettings;
+        }
+      }
+      // Incremented numConfigSettings for this config already.
+      // save subgroup's subgroup configuration in original config
+      setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
+    }
+  } else if (jsonObj.IsObject()) {
+    // support nested objects
+    // create a new subgroup
+    std::shared_ptr<core::config::Configuration> subGroupPtr =
+        getSubconfigCopy<core::config::Configuration>(key);
+    numConfigSettings += subGroupPtr->loadFromJson(jsonObj);
+    // save subgroup's subgroup configuration in original config
+    setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
+    //
+  } else if (jsonObj.IsArray()) {
+    // support array of values by reading each into subconfig
+  } else {
+    // TODO support other types?
+    // decrement count for key:obj due to not being handled type
+    --numConfigSettings;
+    ESP_WARNING() << "Config cell in JSON document contains key" << key
+                  << "referencing an unknown/unparsable value type, so "
+                     "skipping this key.";
+  }
+  return numConfigSettings;
+}  // Configuration::loadOneConfigFromJson
+
 int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
   // count number of valid user config settings found
   int numConfigSettings = 0;
@@ -338,154 +490,9 @@ int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
        it != jsonObj.MemberEnd(); ++it) {
     // for each key, attempt to parse
     const std::string key{it->name.GetString()};
-    const auto& obj = it->value;
-    // increment, assuming is valid object
-    ++numConfigSettings;
 
-    if (obj.IsDouble()) {
-      set(key, obj.GetDouble());
-    } else if (obj.IsNumber()) {
-      set(key, obj.GetInt());
-    } else if (obj.IsString()) {
-      set(key, obj.GetString());
-    } else if (obj.IsBool()) {
-      set(key, obj.GetBool());
-    } else if (obj.IsArray() && obj.Size() > 0) {
-      // non-empty array of numeric values
-      if (obj[0].IsNumber()) {
-        // numeric vector, quaternion or matrix
-        if (obj.Size() == 2) {
-          // All size 2 numeric arrays are mapped to Mn::Vector2
-          Mn::Vector2 val{};
-          if (io::fromJsonValue(obj, val)) {
-            set(key, val);
-          }
-        } else if (obj.Size() == 3) {
-          // All size 3 numeric arrays are mapped to Mn::Vector3
-          Mn::Vector3 val{};
-          if (io::fromJsonValue(obj, val)) {
-            set(key, val);
-          }
-        } else if (obj.Size() == 4) {
-          // JSON numeric array of size 4 can be either vector4, quaternion or
-          // color4, so must get type of object that exists with key
-          // NOTE : to properly make use of vector4 and color4 configValues
-          // loaded from JSON, the owning Configuration must be
-          // pre-initialized in its constructor with a default value at the
-          // target key. Otherwise for backwards compatibility, we default to
-          // reading a quaternion
-
-          // Check if this configuration has pre-defined field with given key
-          if (hasValue(key)) {
-            ConfigStoredType valType = get(key).getType();
-            if (valType == ConfigStoredType::MagnumQuat) {
-              // if predefined object is neither
-              Mn::Quaternion val{};
-              if (io::fromJsonValue(obj, val)) {
-                set(key, val);
-              }
-            } else if (valType == ConfigStoredType::MagnumVec4) {
-              // if object exists already @ key and its type is Vector4
-              Mn::Vector4 val{};
-              if (io::fromJsonValue(obj, val)) {
-                set(key, val);
-              }
-            } else {
-              // unknown predefined type of config of size 4
-              // this indicates incomplete implementation of size 4
-              // configuration type.
-              // decrement count for key:obj due to not being handled vector
-              --numConfigSettings;
-
-              ESP_WARNING()
-                  << "Config cell in JSON document contains key" << key
-                  << "referencing an existing configuration element of size "
-                     "4 of unknown type:"
-                  << getNameForStoredType(valType) << "so skipping.";
-            }
-          } else {
-            // This supports fields that do not yet exist.
-            // Check if label contains substrings inferring expected type,
-            // otherwise assume this field is a mn::Vector4
-
-            auto lcaseKey = Cr::Utility::String::lowercase(key);
-            // labels denoting quaternions
-            if ((lcaseKey.find("quat") != std::string::npos) ||
-                (lcaseKey.find("rotat") != std::string::npos) ||
-                (lcaseKey.find("orient") != std::string::npos)) {
-              // object label contains quaternion tag, treat as a
-              // Mn::Quaternion
-              Mn::Quaternion val{};
-              if (io::fromJsonValue(obj, val)) {
-                set(key, val);
-              }
-            } else {
-              // if unrecognized label for user-defined field, default the
-              // value to be treated as a Mn::Vector4
-              Mn::Vector4 val{};
-              if (io::fromJsonValue(obj, val)) {
-                set(key, val);
-              }
-            }
-          }
-        } else if (obj.Size() == 9) {
-          // assume is 3x3 matrix
-          Mn::Matrix3 mat{};
-          if (io::fromJsonValue(obj, mat)) {
-            set(key, mat);
-          }
-        } else {
-          // decrement count for key:obj due to not being handled vector
-          --numConfigSettings;
-          // TODO support numeric array in JSON
-          ESP_WARNING()
-              << "Config cell in JSON document contains key" << key
-              << "referencing an unsupported numeric array of length :"
-              << obj.Size() << "so skipping.";
-        }
-      } else if (obj[0].IsString()) {
-        // Array of strings
-
-        // create a new subgroup
-        std::shared_ptr<core::config::Configuration> subGroupPtr =
-            getSubconfigCopy<core::config::Configuration>(key);
-
-        for (size_t i = 0; i < obj.Size(); ++i) {
-          std::string dest;
-          if (!io::fromJsonValue(obj[i], dest)) {
-            ESP_ERROR() << "Failed to parse array element" << i
-                        << "in non-numeric list of values keyed by" << key
-                        << "so skipping this value.";
-          } else {
-            const std::string subKey =
-                Cr::Utility::formatString("{}_{:.02d}", key, i);
-            subGroupPtr->set(subKey, dest);
-            // Increment for each sub-config object
-            ++numConfigSettings;
-          }
-        }
-
-        // Incremented numConfigSettings for this config already.
-        // save subgroup's subgroup configuration in original config
-        setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
-      }
-    } else if (obj.IsObject()) {
-      // support nested objects
-      // create a new subgroup
-      std::shared_ptr<core::config::Configuration> subGroupPtr =
-          getSubconfigCopy<core::config::Configuration>(key);
-      numConfigSettings += subGroupPtr->loadFromJson(obj);
-      // save subgroup's subgroup configuration in original config
-      setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
-      //
-    } else {
-      // TODO support other types?
-      // decrement count for key:obj due to not being handled type
-      --numConfigSettings;
-      ESP_WARNING() << "Config cell in JSON document contains key" << key
-                    << "referencing an unknown/unparsable value type, so "
-                       "skipping this key.";
-    }
+    numConfigSettings +=
+        loadOneConfigFromJson(numConfigSettings, key, it->value);
   }
   return numConfigSettings;
 }  // Configuration::loadFromJson

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -615,15 +615,50 @@ class Configuration {
   int getNumEntries() const { return configMap_.size() + valueMap_.size(); }
 
   /**
+   * @brief Return total number of value and subconfig entries held by this
+   * Configuration and all its subconfigs.
+   */
+  int getConfigTreeNumEntries() const {
+    int num = getNumEntries();
+    for (const auto& subConfig : configMap_) {
+      num += subConfig.second->getConfigTreeNumEntries();
+    }
+    return num;
+  }
+  /**
    * @brief Return number of subconfig entries in this configuration. This only
    * counts each subconfiguration entry as a single entry.
    */
-  int getNumSubconfigEntries() const { return configMap_.size(); }
+  int getNumSubconfigs() const { return configMap_.size(); }
+
+  /**
+   * @brief Return size of entire subconfig tree (i.e. total number of
+   * subconfigs nested under this Configuration.)
+   */
+  int getConfigTreeNumSubconfigs() const {
+    int num = configMap_.size();
+    for (const auto& subConfig : configMap_) {
+      num += subConfig.second->getConfigTreeNumSubconfigs();
+    }
+    return num;
+  }
 
   /**
    * @brief returns number of values in this configuration.
    */
   int getNumValues() const { return valueMap_.size(); }
+
+  /**
+   * @brief Return total number of values held by this Configuration and all its
+   * subconfigs.
+   */
+  int getConfigTreeNumValues() const {
+    int num = valueMap_.size();
+    for (const auto& subConfig : configMap_) {
+      num += subConfig.second->getConfigTreeNumValues();
+    }
+    return num;
+  }
 
   /**
    * @brief Returns whether this @ref Configuration has the passed @p key as a
@@ -801,6 +836,23 @@ class Configuration {
     auto configIter = configMap_.find(name);
     if (configIter != configMap_.end()) {
       return configIter->second->getNumEntries();
+    }
+    ESP_WARNING() << "No Subconfig found named :" << name;
+    return 0;
+  }
+
+  /**
+   * @brief Retrieve the number of entries held by the subconfig with the given
+   * name, recursing subordinate subconfigs
+   * @param name The name of the subconfig to query. If not found, returns 0
+   * with a warning.
+   * @return The number of entries in the named subconfig, including all
+   * subconfigs
+   */
+  int getSubconfigTreeNumEntries(const std::string& name) const {
+    auto configIter = configMap_.find(name);
+    if (configIter != configMap_.end()) {
+      return configIter->second->getConfigTreeNumEntries();
     }
     ESP_WARNING() << "No Subconfig found named :" << name;
     return 0;

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -975,7 +975,7 @@ class Configuration {
    * executes.
    */
   int loadOneConfigFromJson(int numVals,
-                            const std::string key,
+                            const std::string& key,
                             const io::JsonGenericValue& jsonObj);
 
   /**

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -472,7 +472,7 @@ class Configuration {
 
   /**
    * @brief This method will look for the provided key, and return a string
-   * holding the object, if it is found in one of this configuration's maps
+   * holding the object, if it is found in one of this Configuration's maps
    */
   std::string getAsString(const std::string& key) const {
     ValueMapType::const_iterator mapIter = valueMap_.find(key);
@@ -480,7 +480,7 @@ class Configuration {
       return mapIter->second.getAsString();
     }
     std::string retVal = Cr::Utility::formatString(
-        "Key {} does not represent a valid value in this configuration.", key);
+        "Key {} does not represent a valid value in this Configuration.", key);
     ESP_WARNING() << retVal;
     return retVal;
   }
@@ -609,7 +609,7 @@ class Configuration {
   }
 
   /**
-   * @brief Return number of value and subconfig entries in this configuration.
+   * @brief Return number of value and subconfig entries in this Configuration.
    * This only counts each subconfiguration entry as a single entry.
    */
   int getNumEntries() const { return configMap_.size() + valueMap_.size(); }
@@ -626,7 +626,7 @@ class Configuration {
     return num;
   }
   /**
-   * @brief Return number of subconfig entries in this configuration. This only
+   * @brief Return number of subconfig entries in this Configuration. This only
    * counts each subconfiguration entry as a single entry.
    */
   int getNumSubconfigs() const { return configMap_.size(); }
@@ -644,7 +644,7 @@ class Configuration {
   }
 
   /**
-   * @brief returns number of values in this configuration.
+   * @brief returns number of values in this Configuration.
    */
   int getNumValues() const { return valueMap_.size(); }
 
@@ -681,7 +681,7 @@ class Configuration {
   }
 
   /**
-   * @brief Checks if passed @p key is contained in this configuration.
+   * @brief Checks if passed @p key is contained in this Configuration.
    * Returns a list of nested subconfiguration keys, in order, to the
    * configuration where the key was found, ending in the requested @p key.
    * If list is empty, @p key was not found.
@@ -695,7 +695,7 @@ class Configuration {
    * @brief Builds and returns @ref Corrade::Utility::ConfigurationGroup
    * holding the values in this esp::core::config::Configuration.
    *
-   * @return a reference to a configuration group for this configuration
+   * @return a reference to a configuration group for this Configuration
    * object.
    */
   Cr::Utility::ConfigurationGroup getConfigGroup() const {
@@ -706,7 +706,7 @@ class Configuration {
 
   /**
    * @brief This method will build a map of the keys of all the config values
-   * this configuration holds and the types of each of these values.
+   * this Configuration holds and the types of each of these values.
    */
   std::unordered_map<std::string, ConfigStoredType> getValueTypes() const {
     std::unordered_map<std::string, ConfigStoredType> res{};
@@ -776,7 +776,7 @@ class Configuration {
    * , cast to the specified type. This will create a shared pointer to a new
    * sub-configuration if none exists and return it, cast to specified type.
    *
-   * Use this function when you wish to modify this configuration's
+   * Use this function when you wish to modify this Configuration's
    * subgroup, possibly creating it in the process.
    * @tparam The type to cast the @ref esp::core::config::Configuration to. Type
    * is checked to verify that it inherits from Configuration.
@@ -965,6 +965,20 @@ class Configuration {
 
  protected:
   /**
+   * @brief Process passed json object into this Configuration, using passed
+   * key.
+   *
+   * @param numVals number of values/configs loaded so far
+   * @param key key to use to search @p jsonObj and also to set value or
+   * subconfig within this Configuration.
+   * @return the number of total fields successfully loaded after this function
+   * executes.
+   */
+  int loadOneConfigFromJson(int numVals,
+                            const std::string key,
+                            const io::JsonGenericValue& jsonObj);
+
+  /**
    * @brief Friend function.  Checks if passed @p key is contained in @p
    * config. Returns the highest level where @p key was found
    * @param config The configuration to search for passed key
@@ -1038,7 +1052,7 @@ MAGNUM_EXPORT Mn::Debug& operator<<(Mn::Debug& debug,
  * @brief Retrieves a shared pointer to a copy of the subConfig @ref
  * esp::core::config::Configuration that has the passed @p name . This will
  * create a pointer to a new sub-configuration if none exists already with that
- * name, but will not add this configuration to this Configuration's internal
+ * name, but will not add this Configuration to this Configuration's internal
  * storage.
  *
  * @param name The name of the configuration to retrieve.

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -263,6 +263,23 @@ class AbstractObjectAttributes : public AbstractAttributes {
     return get<bool>("use_frame_for_all_orientation");
   }
 
+  /**
+   * @brief Gets a smart pointer reference to a copy of the marker_sets
+   * configuration data from config file.
+   */
+  std::shared_ptr<Configuration> getMarkerSetsConfiguration() const {
+    return getSubconfigCopy<Configuration>("marker_sets");
+  }
+
+  /**
+   * @brief Gets a smart pointer reference to the actual marker_sets
+   * configuration data from config file. This method is for editing the
+   * configuration.
+   */
+  std::shared_ptr<Configuration> editMarkerSetsConfiguration() {
+    return editSubconfig<Configuration>("marker_sets");
+  }
+
  protected:
   /**
    * @brief Whether to use the specified orientation frame for all orientation

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -250,6 +250,23 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
   void writeValuesToJson(io::JsonGenericValue& jsonObj,
                          io::JsonAllocator& allocator) const override;
 
+  /**
+   * @brief Gets a smart pointer reference to a copy of the marker_sets
+   * configuration data from config file.
+   */
+  std::shared_ptr<Configuration> getMarkerSetsConfiguration() const {
+    return getSubconfigCopy<Configuration>("marker_sets");
+  }
+
+  /**
+   * @brief Gets a smart pointer reference to the actual marker_sets
+   * configuration data from config file. This method is for editing the
+   * configuration.
+   */
+  std::shared_ptr<Configuration> editMarkerSetsConfiguration() {
+    return editSubconfig<Configuration>("marker_sets");
+  }
+
  protected:
   /**
    * @brief Retrieve a comma-separated string holding the header values for the

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -80,7 +80,7 @@ class AbstractAttributes
 
   /**
    * @brief Set this attributes name/origin.  Some attributes derive their own
-   * names based on their state, such as @ref AbstractPrimitiveAttributes;  in
+   * names based on their state, such as @ref AbstractPrimitiveAttributes; in
    * such cases this should be overridden with NOP.
    * @param handle the handle to set.
    */
@@ -129,6 +129,14 @@ class AbstractAttributes
    */
   int getNumUserDefinedConfigurations() const {
     return getSubconfigNumEntries("user_defined");
+  }
+
+  /**
+   * @brief Returns the number of user-defined values (within the "user-defined"
+   * sub-ConfigurationGroup) this attributes has.
+   */
+  int getTotalNumUserDefinedConfigurations() const {
+    return getSubconfigTreeNumEntries("user_defined");
   }
 
   /**
@@ -198,7 +206,7 @@ class AbstractAttributes
       const std::shared_ptr<Configuration>& subAttrConfig) const {
     int res = 0;
     if (subConfigNamePrefix.empty()) {
-      return subAttrConfig->getNumSubconfigEntries();
+      return subAttrConfig->getNumSubconfigs();
     }
     // iterator to subAttrConfig's subConfigs
     auto subAttrIter = subAttrConfig->getSubconfigIterator();
@@ -295,7 +303,7 @@ AbstractAttributes::getSubAttributesListInternal(
       "esp::metadata::AbstractAttributes");
   std::vector<std::shared_ptr<const T>> res{};
   // pair of begin/end const iters through subconfig of given name
-  int numSubconfigs = subAttrConfig->getNumSubconfigEntries();
+  int numSubconfigs = subAttrConfig->getNumSubconfigs();
   if (numSubconfigs == 0) {
     return {};
   }
@@ -387,15 +395,14 @@ void AbstractAttributes::setSubAttributesInternal(
       std::is_base_of<AbstractAttributes, T>::value,
       "AbstractAttributes : Desired subconfig type must be derived from "
       "esp::metadata::AbstractAttributes");
-  // get subconfig for articulated object instances, add this ao instance as a
   // set id
   if (!availableIDs.empty()) {
     // use saved value and then remove from storage
     objInst->setID(availableIDs.front());
     availableIDs.pop_front();
   } else {
-    // use size of container to set ID
-    objInst->setID(subAttrConfig->getNumSubconfigEntries());
+    // use current size of destination config to set ID
+    objInst->setID(subAttrConfig->getNumSubconfigs());
   }
   // get last key
   subAttrConfig->setSubconfigPtr<T>(

--- a/src/esp/metadata/managers/AOAttributesManager.cpp
+++ b/src/esp/metadata/managers/AOAttributesManager.cpp
@@ -100,6 +100,8 @@ void AOAttributesManager::setValsFromJSONDoc(
       attributes::AOLinkOrderMap,
       [aoAttr](const std::string& val) { aoAttr->setLinkOrder(val); });
 
+  // check for the existing of markersets
+  this->parseSubconfigJsonVals("marker_sets", aoAttr, jsonConfig);
   // check for user defined attributes
   this->parseUserDefinedJsonVals(aoAttr, jsonConfig);
 

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -518,7 +518,7 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
     const attributes::AbstractAttributes::ptr& attribs,
     const io::JsonGenericValue& jsonConfig) const {
   const std::string subGroupName = "user_defined";
-  // check for user defined attributes and verify it is an object
+  // check for subGroupName tagged-json value and verify it is an object
   io::JsonGenericValue::ConstMemberIterator jsonIter =
       jsonConfig.FindMember(subGroupName.c_str());
   if (jsonIter != jsonConfig.MemberEnd()) {
@@ -526,8 +526,10 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
           << "<" << this->objectType_
           << "> : " << attribs->getSimplifiedHandle()
-          << " attributes specifies user_defined attributes but their format "
-             "is incorrect, so no user_defined attributes are loaded.";
+          << " attributes specifies `" << subGroupName
+          << "` attributes but their format "
+             "is incorrect, so no `"
+          << subGroupName << "` attributes are loaded.";
       return false;
     } else {
       // get pointer to user_defined subgroup configuration
@@ -536,15 +538,15 @@ bool AttributesManager<T, Access>::parseUserDefinedJsonVals(
       // get json object referenced by tag subGroupName
       const io::JsonGenericValue& jsonObj = jsonIter->value;
 
-      // count number of valid user config settings found
+      // count number of valid sub-config settings found
       int numConfigSettings = subGroupPtr->loadFromJson(jsonObj);
 
-      // save as user_defined subgroup configuration
+      // save with requested tag as subgroup configuration
       attribs->setSubconfigPtr(subGroupName, subGroupPtr);
 
       return (numConfigSettings > 0);
     }
-  }  // if has user_defined tag
+  }  // if has reqyested tag
   return false;
 }  // AttributesManager<T, Access>::parseUserDefinedJsonVals
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -127,6 +127,9 @@ void ObjectAttributesManager::setValsFromJSONDoc(
   // if com is set from json, don't compute from shape, and vice versa
   objAttributes->setComputeCOMFromShape(!comIsSet);
 
+  // check for the existing of markersets
+  this->parseSubconfigJsonVals("marker_sets", objAttributes, jsonConfig);
+
   // check for user defined attributes
   this->parseUserDefinedJsonVals(objAttributes, jsonConfig);
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -447,7 +447,8 @@ void StageAttributesManager::setValsFromJSONDoc(
     }
     stageAttributes->setSemanticDescriptorFilename(semanticSceneDescriptor);
   }
-
+  // check for the existing of markersets
+  this->parseSubconfigJsonVals("marker_sets", stageAttributes, jsonConfig);
   // check for user defined attributes
   this->parseUserDefinedJsonVals(stageAttributes, jsonConfig);
 

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -1286,37 +1286,114 @@ void AttributesConfigsTest::testStageAttrVals(
 }  // AttributesConfigsTest::testStageAttrVals
 void AttributesConfigsTest::testStageJSONLoad() {
   // build JSON sample config
-  const std::string& jsonString =
-      R"({
-        "scale":[2,3,4],
-        "margin": 0.9,
-        "friction_coefficient": 0.321,
-        "restitution_coefficient": 0.456,
-        "force_flat_shading": false,
-        "units_to_meters": 1.1,
-        "up":[2.1, 0, 0],
-        "front":[0, 2.1, 0],
-        "has_semantic_textures":true,
-        "render_asset": "testJSONRenderAsset.glb",
-        "collision_asset": "testJSONCollisionAsset.glb",
-        "is_collidable": false,
-        "gravity": [9,8,7],
-        "origin":[1,2,3],
-        "semantic_asset":"testJSONSemanticAsset.glb",
-        "nav_asset":"testJSONNavMeshAsset.glb",
-        "shader_type" : "material",
-        "user_defined" : {
-            "user_str_array" : ["test_00", "test_01", "test_02", "test_03"],
-            "user_string" : "stage defined string",
-            "user_bool" : false,
-            "user_int" : 3,
-            "user_double" : 0.8,
-            "user_vec2" : [2.3, 4.5],
-            "user_vec3" : [5.4, 7.6, 10.1],
-            "user_vec4" : [14.5, 15.6, 16.7, 17.9],
-            "user_quat" : [0.1, 1.5, 2.6, 3.7]
-        }
-      })";
+  const std::string& jsonString = R"({
+  "scale":[2,3,4],
+  "margin": 0.9,
+  "friction_coefficient": 0.321,
+  "restitution_coefficient": 0.456,
+  "force_flat_shading": false,
+  "units_to_meters": 1.1,
+  "up":[2.1, 0, 0],
+  "front":[0, 2.1, 0],
+  "has_semantic_textures":true,
+  "render_asset": "testJSONRenderAsset.glb",
+  "collision_asset": "testJSONCollisionAsset.glb",
+  "is_collidable": false,
+  "gravity": [9,8,7],
+  "origin":[1,2,3],
+  "semantic_asset":"testJSONSemanticAsset.glb",
+  "nav_asset":"testJSONNavMeshAsset.glb",
+  "shader_type" : "material",
+  "marker_sets" : {
+      "marker_set_0_stage_name" : {
+          "link_id_00_stage_name" : {
+              "subset_id_000_stage_name" : {
+                "markers" : [
+                    [1.1, 2.2, 3.3],
+                    [2.1, 3.2, 4.3],
+                    [3.1, 4.2, 5.3],
+                    [4.1, 5.2, 6.3]
+                  ]
+              },
+              "subset_id_001_stage_name" : {
+                "markers" : {
+                    "0":[1.2, 2.3, 3.4],
+                    "1":[2.2, 3.3, 4.4],
+                    "2":[3.2, 4.3, 5.4],
+                    "3":[4.2, 5.3, 6.4]
+                }
+              }
+          },
+          "link_id_01_stage_name" : {
+              "subset_id_010_stage_name" : {
+                "markers" : {
+                    "0":[1.3, 2.4, 3.5],
+                    "1":[2.3, 3.4, 4.5],
+                    "2":[3.3, 4.4, 5.5],
+                    "3":[4.3, 5.4, 6.5]
+                }
+              },
+              "subset_id_011_stage_name" : {
+                "markers" : [
+                    [1.4, 2.5, 3.6],
+                    [2.4, 3.5, 4.6],
+                    [3.4, 4.5, 5.6],
+                    [4.4, 5.5, 6.6]
+                  ]
+              }
+          }
+      },
+      "marker_set_1_stage_name" : {
+          "link_id_10_stage_name" : {
+              "subset_id_100_stage_name" : {
+                "markers" : [
+                    [11.1, 12.2, 13.3],
+                    [12.1, 13.2, 14.3],
+                    [13.1, 14.2, 15.3],
+                    [14.1, 15.2, 16.3]
+                  ]
+              },
+              "subset_id_101_stage_name" : {
+                "markers" : {
+                    "0":[11.2, 12.3, 13.4],
+                    "1":[12.2, 13.3, 14.4],
+                    "2":[13.2, 14.3, 15.4],
+                    "3":[14.2, 15.3, 16.4]
+                }
+              }
+          },
+          "link_id_11_stage_name" : {
+              "subset_id_110_stage_name" : {
+                "markers" : {
+                    "0":[11.3, 12.4, 13.5],
+                    "1":[12.3, 13.4, 14.5],
+                    "2":[13.3, 14.4, 15.5],
+                    "3":[14.3, 15.4, 16.5]
+                }
+              },
+              "subset_id_111_stage_name" : {
+                "markers" : [
+                    [11.4, 12.5, 13.6],
+                    [12.4, 13.5, 14.6],
+                    [13.4, 14.5, 15.6],
+                    [14.4, 15.5, 16.6]
+                  ]
+              }
+          }
+      }
+  },
+  "user_defined" : {
+      "user_str_array" : ["test_00", "test_01", "test_02", "test_03"],
+      "user_string" : "stage defined string",
+      "user_bool" : false,
+      "user_int" : 3,
+      "user_double" : 0.8,
+      "user_vec2" : [2.3, 4.5],
+      "user_vec3" : [5.4, 7.6, 10.1],
+      "user_vec4" : [14.5, 15.6, 16.7, 17.9],
+      "user_quat" : [0.1, 1.5, 2.6, 3.7]
+  }
+})";
 
   // Build an attributes based on the above json string
   // Don't register - registration here verifies that the specified file handles
@@ -1440,6 +1517,84 @@ void AttributesConfigsTest::testObjectJSONLoad() {
   "semantic_id" : 7,
   "COM": [0.1,0.2,0.3],
   "shader_type" : "phong",
+  "marker_sets" : {
+      "marker_set_0_obj_name" : {
+          "link_id_00_obj_name" : {
+              "subset_id_000_obj_name" : {
+                "markers" : [
+                    [1.1, 2.2, 3.3],
+                    [2.1, 3.2, 4.3],
+                    [3.1, 4.2, 5.3],
+                    [4.1, 5.2, 6.3]
+                  ]
+              },
+              "subset_id_001_obj_name" : {
+                "markers" : {
+                    "0":[1.2, 2.3, 3.4],
+                    "1":[2.2, 3.3, 4.4],
+                    "2":[3.2, 4.3, 5.4],
+                    "3":[4.2, 5.3, 6.4]
+                }
+              }
+          },
+          "link_id_01_obj_name" : {
+              "subset_id_010_obj_name" : {
+                "markers" : {
+                    "0":[1.3, 2.4, 3.5],
+                    "1":[2.3, 3.4, 4.5],
+                    "2":[3.3, 4.4, 5.5],
+                    "3":[4.3, 5.4, 6.5]
+                }
+              },
+              "subset_id_011_obj_name" : {
+                "markers" : [
+                    [1.4, 2.5, 3.6],
+                    [2.4, 3.5, 4.6],
+                    [3.4, 4.5, 5.6],
+                    [4.4, 5.5, 6.6]
+                  ]
+              }
+          }
+      },
+      "marker_set_1_obj_name" : {
+          "link_id_10_obj_name" : {
+              "subset_id_100_obj_name" : {
+                "markers" : [
+                    [11.1, 12.2, 13.3],
+                    [12.1, 13.2, 14.3],
+                    [13.1, 14.2, 15.3],
+                    [14.1, 15.2, 16.3]
+                  ]
+              },
+              "subset_id_101_obj_name" : {
+                "markers" : {
+                    "0":[11.2, 12.3, 13.4],
+                    "1":[12.2, 13.3, 14.4],
+                    "2":[13.2, 14.3, 15.4],
+                    "3":[14.2, 15.3, 16.4]
+                }
+              }
+          },
+          "link_id_11_obj_name" : {
+              "subset_id_110_obj_name" : {
+                "markers" : {
+                    "0":[11.3, 12.4, 13.5],
+                    "1":[12.3, 13.4, 14.5],
+                    "2":[13.3, 14.4, 15.5],
+                    "3":[14.3, 15.4, 16.5]
+                }
+              },
+              "subset_id_111_obj_name" : {
+                "markers" : [
+                    [11.4, 12.5, 13.6],
+                    [12.4, 13.5, 14.6],
+                    [13.4, 14.5, 15.6],
+                    [14.4, 15.5, 16.6]
+                  ]
+              }
+          }
+      }
+  },
   "user_defined" : {
       "user_str_array" : ["test_00", "test_01", "test_02", "test_03"],
       "user_string" : "object defined string",
@@ -1555,6 +1710,84 @@ void AttributesConfigsTest::testArticulatedObjectJSONLoad() {
   "link_order" : "tree_traversal",
   "render_mode": "skin",
   "shader_type" : "pbr",
+  "marker_sets" : {
+      "marker_set_0_AO_name" : {
+          "link_id_00_AO_name" : {
+              "subset_id_000_AO_name" : {
+                "markers" : [
+                    [1.1, 2.2, 3.3],
+                    [2.1, 3.2, 4.3],
+                    [3.1, 4.2, 5.3],
+                    [4.1, 5.2, 6.3]
+                  ]
+              },
+              "subset_id_001_AO_name" : {
+                "markers" : {
+                    "0":[1.2, 2.3, 3.4],
+                    "1":[2.2, 3.3, 4.4],
+                    "2":[3.2, 4.3, 5.4],
+                    "3":[4.2, 5.3, 6.4]
+                }
+              }
+          },
+          "link_id_01_AO_name" : {
+              "subset_id_010_AO_name" : {
+                "markers" : {
+                    "0":[1.3, 2.4, 3.5],
+                    "1":[2.3, 3.4, 4.5],
+                    "2":[3.3, 4.4, 5.5],
+                    "3":[4.3, 5.4, 6.5]
+                }
+              },
+              "subset_id_011_AO_name" : {
+                "markers" : [
+                    [1.4, 2.5, 3.6],
+                    [2.4, 3.5, 4.6],
+                    [3.4, 4.5, 5.6],
+                    [4.4, 5.5, 6.6]
+                  ]
+              }
+          }
+      },
+      "marker_set_1_AO_name" : {
+          "link_id_10_AO_name" : {
+              "subset_id_100_AO_name" : {
+                "markers" : [
+                    [11.1, 12.2, 13.3],
+                    [12.1, 13.2, 14.3],
+                    [13.1, 14.2, 15.3],
+                    [14.1, 15.2, 16.3]
+                  ]
+              },
+              "subset_id_101_AO_name" : {
+                "markers" : {
+                    "0":[11.2, 12.3, 13.4],
+                    "1":[12.2, 13.3, 14.4],
+                    "2":[13.2, 14.3, 15.4],
+                    "3":[14.2, 15.3, 16.4]
+                }
+              }
+          },
+          "link_id_11_AO_name" : {
+              "subset_id_110_AO_name" : {
+                "markers" : {
+                    "0":[11.3, 12.4, 13.5],
+                    "1":[12.3, 13.4, 14.5],
+                    "2":[13.3, 14.4, 15.5],
+                    "3":[14.3, 15.4, 16.5]
+                }
+              },
+              "subset_id_111_AO_name" : {
+                "markers" : [
+                    [11.4, 12.5, 13.6],
+                    [12.4, 13.5, 14.6],
+                    [13.4, 14.5, 15.6],
+                    [14.4, 15.5, 16.6]
+                  ]
+              }
+          }
+      }
+  },
   "user_defined" : {
       "user_str_array" : ["test_00", "test_01", "test_02", "test_03", "test_04"],
       "user_string" : "articulated object defined string",

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -96,6 +96,23 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
       Mn::Quaternion quatValue,
       Mn::Vector4 vec4Value);
 
+  typedef std::unordered_map<std::string, Mn::Vector3> MarkersTestMap;
+  typedef std::unordered_map<std::string, MarkersTestMap> SubsetTestMap;
+  typedef std::unordered_map<std::string, SubsetTestMap> LinksTestMap;
+  typedef std::unordered_map<std::string, LinksTestMap> MarkerSetTestMap;
+
+  /**
+   * @brief This method will test the marker-sets configurations being loaded in
+   * stage, object and ao configs.
+   * @param markerSetsConfig The marker-sets configuration object whose contents
+   * are to be tested.
+   * @param markerSetsHierarchy The hieraarchy the marker sets should follow.
+   */
+  void testMarkerSetsConfigVals(
+      std::shared_ptr<esp::core::config::Configuration> markerSetsConfig,
+      const MarkerSetTestMap&  // markers in link subset
+          markerSetsHierarchy);
+
   /**
    * @brief This test will verify that the physics attributes' managers' JSON
    * loading process is working as expected.
@@ -288,6 +305,55 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
   CORRADE_COMPARE(userConfig->get<Mn::Color4>("user_vec4"), vec4Value);
 
 }  // AttributesConfigsTest::testUserDefinedConfigVals
+
+void AttributesConfigsTest::testMarkerSetsConfigVals(
+    std::shared_ptr<esp::core::config::Configuration> markerSetsConfig,
+    const MarkerSetTestMap&  // markers in link subset
+        markerSetsHierarchy) {
+  for (const auto& markerSetInfoEntry : markerSetsHierarchy) {
+    // Key is first
+    const std::string markerSetKey = markerSetInfoEntry.first;
+    CORRADE_VERIFY(markerSetsConfig->hasSubconfig(markerSetKey));
+    // Retrive named markerset
+    const auto markerSet = markerSetsConfig->getSubconfigView(markerSetKey);
+    CORRADE_VERIFY(markerSet);
+    // Submap
+    const auto& markerSetInfoMap = markerSetInfoEntry.second;
+    for (const auto& linkEntry : markerSetInfoMap) {
+      const std::string linkIDKey = linkEntry.first;
+      CORRADE_VERIFY(markerSet->hasSubconfig(linkIDKey));
+      // Retrieve named per-link markerset
+      const auto linkMarkerSet = markerSet->getSubconfigView(linkIDKey);
+      CORRADE_VERIFY(linkMarkerSet);
+      // Per link subsets
+      const auto& linkSetInfoMap = linkEntry.second;
+      for (const auto& linkSubsetEntry : linkSetInfoMap) {
+        const std::string subsetIDKey = linkSubsetEntry.first;
+        CORRADE_VERIFY(linkMarkerSet->hasSubconfig(subsetIDKey));
+        // Retrive a specific link's subset
+        const auto linkSubset = linkMarkerSet->getSubconfigView(subsetIDKey);
+        CORRADE_VERIFY(linkSubset);
+        // Verify that subconfig named "markers' exists"
+        CORRADE_VERIFY(linkSubset->hasSubconfig("markers"));
+        // Get array of markers
+        const auto& markers = linkSubset->getSubconfigView("markers");
+        // key-value map that should match mapping of markers in link subset
+        const auto& markersInfo = linkSubsetEntry.second;
+        // Verify there are the expected number of marker points
+        CORRADE_COMPARE(markers->getNumValues(), markersInfo.size());
+        // Verify that subconfig has each marker point
+        for (const auto& markerInfo : markersInfo) {
+          const std::string markerKey = markerInfo.first;
+          // Verify markers contains a value with passed key
+          CORRADE_VERIFY(markers->hasValue(markerKey));
+          const Mn::Vector3 markerPoint = markerInfo.second;
+          // Make sure marker point is present
+          CORRADE_COMPARE(markers->get<Mn::Vector3>(markerKey), markerPoint);
+        }  // for each marker within subset
+      }    // for each subset within link set
+    }      // for each link set in marker set
+  }        // for each marker_set
+}  // AttributesConfigsTest::testMarkerSetsConfigVals
 
 /////////////  Begin JSON String-based tests
 
@@ -1280,6 +1346,78 @@ void AttributesConfigsTest::testStageAttrVals(
       Mn::Quaternion({1.5f, 2.6f, 3.7f}, 0.1f),
       Mn::Vector4(14.5f, 15.6f, 16.7f, 17.9f));
 
+  {
+    // Test marker sets
+
+    MarkersTestMap subset_id_000_stage_name(
+        {{"markers_03", Mn::Vector3{4.1, 5.2, 6.3}},
+         {"markers_02", Mn::Vector3{3.1, 4.2, 5.3}},
+         {"markers_01", Mn::Vector3{2.1, 3.2, 4.3}},
+         {"markers_00", Mn::Vector3{1.1, 2.2, 3.3}}});
+
+    MarkersTestMap subset_id_001_stage_name(
+        {{"3", Mn::Vector3{4.2, 5.3, 6.4}},
+         {"2", Mn::Vector3{3.2, 4.3, 5.4}},
+         {"1", Mn::Vector3{2.2, 3.3, 4.4}},
+         {"0", Mn::Vector3{1.2, 2.3, 3.4}}});
+
+    SubsetTestMap link_id_00_stage_name(
+        {{"subset_id_000_stage_name", subset_id_000_stage_name},
+         {"subset_id_001_stage_name", subset_id_001_stage_name}});
+
+    LinksTestMap marker_set_0_stage_name{
+        {{"link_id_00_stage_name", link_id_00_stage_name}}};
+
+    MarkersTestMap subset_id_100_stage_name(
+        {{"markers_03", Mn::Vector3{14.1, 15.2, 16.3}},
+         {"markers_02", Mn::Vector3{13.1, 14.2, 15.3}},
+         {"markers_01", Mn::Vector3{12.1, 13.2, 14.3}},
+         {"markers_00", Mn::Vector3{11.1, 12.2, 13.3}}});
+
+    MarkersTestMap subset_id_101_stage_name(
+        {{"3", Mn::Vector3{14.2, 15.3, 16.4}},
+         {"2", Mn::Vector3{13.2, 14.3, 15.4}},
+         {"1", Mn::Vector3{12.2, 13.3, 14.4}},
+         {"0", Mn::Vector3{11.2, 12.3, 13.4}}});
+
+    MarkersTestMap subset_id_102_stage_name(
+        {{"3", Mn::Vector3{124.2, 125.3, 126.4}},
+         {"2", Mn::Vector3{123.2, 124.3, 125.4}},
+         {"1", Mn::Vector3{122.2, 123.3, 124.4}},
+         {"0", Mn::Vector3{121.2, 122.3, 123.4}}});
+
+    SubsetTestMap link_id_10_stage_name(
+        {{"subset_id_100_stage_name", subset_id_100_stage_name},
+         {"subset_id_101_stage_name", subset_id_101_stage_name},
+         {"subset_id_102_stage_name", subset_id_102_stage_name}});
+
+    MarkersTestMap subset_id_110_stage_name(
+        {{"3", Mn::Vector3{14.3, 15.4, 16.5}},
+         {"2", Mn::Vector3{13.3, 14.4, 15.5}},
+         {"1", Mn::Vector3{12.3, 13.4, 14.5}},
+         {"0", Mn::Vector3{11.3, 12.4, 13.5}}});
+
+    MarkersTestMap subset_id_111_stage_name(
+        {{"markers_03", Mn::Vector3{14.4, 15.5, 16.6}},
+         {"markers_02", Mn::Vector3{13.4, 14.5, 15.6}},
+         {"markers_01", Mn::Vector3{12.4, 13.5, 14.6}},
+         {"markers_00", Mn::Vector3{11.4, 12.5, 13.6}}});
+
+    SubsetTestMap link_id_11_stage_name(
+        {{"subset_id_110_stage_name", subset_id_110_stage_name},
+         {"subset_id_110_stage_name", subset_id_110_stage_name}});
+
+    LinksTestMap marker_set_1_stage_name(
+        {{"link_id_10_stage_name", link_id_10_stage_name},
+         {"link_id_11_stage_name", link_id_11_stage_name}});
+
+    MarkerSetTestMap markerSetMap(
+        {{"marker_set_0_stage_name", marker_set_0_stage_name},
+         {"marker_set_1_stage_name", marker_set_1_stage_name}});
+
+    testMarkerSetsConfigVals(stageAttr->getMarkerSetsConfiguration(),
+                             markerSetMap);
+  }
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(stageAttributesManager_,
                                         stageAttr->getHandle());
@@ -1323,24 +1461,6 @@ void AttributesConfigsTest::testStageJSONLoad() {
                     "3":[4.2, 5.3, 6.4]
                 }
               }
-          },
-          "link_id_01_stage_name" : {
-              "subset_id_010_stage_name" : {
-                "markers" : {
-                    "0":[1.3, 2.4, 3.5],
-                    "1":[2.3, 3.4, 4.5],
-                    "2":[3.3, 4.4, 5.5],
-                    "3":[4.3, 5.4, 6.5]
-                }
-              },
-              "subset_id_011_stage_name" : {
-                "markers" : [
-                    [1.4, 2.5, 3.6],
-                    [2.4, 3.5, 4.6],
-                    [3.4, 4.5, 5.6],
-                    [4.4, 5.5, 6.6]
-                  ]
-              }
           }
       },
       "marker_set_1_stage_name" : {
@@ -1359,6 +1479,14 @@ void AttributesConfigsTest::testStageJSONLoad() {
                     "1":[12.2, 13.3, 14.4],
                     "2":[13.2, 14.3, 15.4],
                     "3":[14.2, 15.3, 16.4]
+                }
+              },
+              "subset_id_102_stage_name" : {
+                "markers" : {
+                    "0":[121.2, 122.3, 123.4],
+                    "1":[122.2, 123.3, 124.4],
+                    "2":[123.2, 124.3, 125.4],
+                    "3":[124.2, 125.3, 126.4]
                 }
               }
           },
@@ -1396,8 +1524,8 @@ void AttributesConfigsTest::testStageJSONLoad() {
 })";
 
   // Build an attributes based on the above json string
-  // Don't register - registration here verifies that the specified file handles
-  // in the attributes exist, or it will fail.
+  // Don't register - registration here verifies that the specified file
+  // handles in the attributes exist, or it will fail.
   auto stageAttr = stageAttributesManager_->createObjectFromJSONString(
       "new_template_from_json", jsonString, false);
   // verify exists
@@ -1487,6 +1615,87 @@ void AttributesConfigsTest::testObjectAttrVals(
       Mn::Vector2(4.1f, 2.8f), Mn::Vector3(15.4, 17.6, 110.1),
       Mn::Quaternion({5.5f, 6.6f, 7.7f}, 0.7f),
       Mn::Vector4(1.5f, 1.6f, 6.7f, 7.9f));
+
+  {
+    // Test marker sets
+
+    MarkersTestMap subset_id_000_obj_name(
+        {{"markers_03", Mn::Vector3{4.1, 5.2, 6.3}},
+         {"markers_02", Mn::Vector3{3.1, 4.2, 5.3}},
+         {"markers_01", Mn::Vector3{2.1, 3.2, 4.3}},
+         {"markers_00", Mn::Vector3{1.1, 2.2, 3.3}}});
+
+    MarkersTestMap subset_id_001_obj_name({{"3", Mn::Vector3{4.2, 5.3, 6.4}},
+                                           {"2", Mn::Vector3{3.2, 4.3, 5.4}},
+                                           {"1", Mn::Vector3{2.2, 3.3, 4.4}},
+                                           {"0", Mn::Vector3{1.2, 2.3, 3.4}}});
+
+    SubsetTestMap link_id_00_obj_name(
+        {{"subset_id_000_obj_name", subset_id_000_obj_name},
+         {"subset_id_001_obj_name", subset_id_001_obj_name}});
+
+    MarkersTestMap subset_id_010_obj_name({{"3", Mn::Vector3{4.3, 5.4, 6.5}},
+                                           {"2", Mn::Vector3{3.3, 4.4, 5.5}},
+                                           {"1", Mn::Vector3{2.3, 3.4, 4.5}},
+                                           {"0", Mn::Vector3{1.3, 2.4, 3.5}}});
+
+    MarkersTestMap subset_id_011_obj_name(
+        {{"markers_03", Mn::Vector3{4.4, 5.5, 6.6}},
+         {"markers_02", Mn::Vector3{3.4, 4.5, 5.6}},
+         {"markers_01", Mn::Vector3{2.4, 3.5, 4.6}},
+         {"markers_00", Mn::Vector3{1.4, 2.5, 3.6}}});
+
+    SubsetTestMap link_id_01_obj_name(
+        {{"subset_id_010_obj_name", subset_id_010_obj_name},
+         {"subset_id_011_obj_name", subset_id_011_obj_name}});
+
+    LinksTestMap marker_set_0_obj_name{
+        {{"link_id_00_obj_name", link_id_00_obj_name},
+         {"link_id_01_obj_name", link_id_01_obj_name}}};
+
+    MarkersTestMap subset_id_100_obj_name(
+        {{"markers_03", Mn::Vector3{14.1, 15.2, 16.3}},
+         {"markers_02", Mn::Vector3{13.1, 14.2, 15.3}},
+         {"markers_01", Mn::Vector3{12.1, 13.2, 14.3}},
+         {"markers_00", Mn::Vector3{11.1, 12.2, 13.3}}});
+
+    MarkersTestMap subset_id_101_obj_name(
+        {{"3", Mn::Vector3{14.2, 15.3, 16.4}},
+         {"2", Mn::Vector3{13.2, 14.3, 15.4}},
+         {"1", Mn::Vector3{12.2, 13.3, 14.4}},
+         {"0", Mn::Vector3{11.2, 12.3, 13.4}}});
+
+    SubsetTestMap link_id_10_obj_name(
+        {{"subset_id_100_obj_name", subset_id_100_obj_name},
+         {"subset_id_101_obj_name", subset_id_101_obj_name}});
+
+    MarkersTestMap subset_id_110_obj_name(
+        {{"3", Mn::Vector3{14.3, 15.4, 16.5}},
+         {"2", Mn::Vector3{13.3, 14.4, 15.5}},
+         {"1", Mn::Vector3{12.3, 13.4, 14.5}},
+         {"0", Mn::Vector3{11.3, 12.4, 13.5}}});
+
+    MarkersTestMap subset_id_111_obj_name(
+        {{"markers_03", Mn::Vector3{14.4, 15.5, 16.6}},
+         {"markers_02", Mn::Vector3{13.4, 14.5, 15.6}},
+         {"markers_01", Mn::Vector3{12.4, 13.5, 14.6}},
+         {"markers_00", Mn::Vector3{11.4, 12.5, 13.6}}});
+
+    SubsetTestMap link_id_11_obj_name(
+        {{"subset_id_110_obj_name", subset_id_110_obj_name},
+         {"subset_id_110_obj_name", subset_id_110_obj_name}});
+
+    LinksTestMap marker_set_1_obj_name(
+        {{"link_id_10_obj_name", link_id_10_obj_name},
+         {"link_id_11_obj_name", link_id_11_obj_name}});
+
+    MarkerSetTestMap markerSetMap(
+        {{"marker_set_0_obj_name", marker_set_0_obj_name},
+         {"marker_set_1_obj_name", marker_set_1_obj_name}});
+
+    testMarkerSetsConfigVals(objAttr->getMarkerSetsConfiguration(),
+                             markerSetMap);
+  }
 
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(objectAttributesManager_,
@@ -1609,8 +1818,8 @@ void AttributesConfigsTest::testObjectJSONLoad() {
 })";
 
   // Build an attributes based on the above json string
-  // Don't register - registration here verifies that the specified file handles
-  // in the attributes exist, or it will fail.
+  // Don't register - registration here verifies that the specified file
+  // handles in the attributes exist, or it will fail.
   auto objAttr = objectAttributesManager_->createObjectFromJSONString(
       "new_template_from_json", jsonString, false);
   // verify exists
@@ -1693,6 +1902,110 @@ void AttributesConfigsTest::testArticulatedObjectAttrVals(
                             Mn::Quaternion({5.3f, 6.4f, 7.5f}, 0.8f),
                             Mn::Vector4(1.6f, 1.2f, 6.3f, 7.4f));
 
+  {
+    // Test marker sets
+
+    MarkersTestMap subset_id_000_ao_name(
+        {{"markers_03", Mn::Vector3{14.1, 5.2, 6.3}},
+         {"markers_02", Mn::Vector3{13.1, 4.2, 5.3}},
+         {"markers_01", Mn::Vector3{12.1, 3.2, 4.3}},
+         {"markers_00", Mn::Vector3{11.1, 2.2, 3.3}}});
+
+    MarkersTestMap subset_id_001_ao_name({{"3", Mn::Vector3{14.2, 5.3, 6.4}},
+                                          {"2", Mn::Vector3{13.2, 4.3, 5.4}},
+                                          {"1", Mn::Vector3{12.2, 3.3, 4.4}},
+                                          {"0", Mn::Vector3{11.2, 2.3, 3.4}}});
+
+    SubsetTestMap link_id_00_ao_name(
+        {{"subset_id_000_ao_name", subset_id_000_ao_name},
+         {"subset_id_001_ao_name", subset_id_001_ao_name}});
+
+    MarkersTestMap subset_id_010_ao_name({{"3", Mn::Vector3{14.3, 5.4, 6.5}},
+                                          {"2", Mn::Vector3{13.3, 4.4, 5.5}},
+                                          {"1", Mn::Vector3{12.3, 3.4, 4.5}},
+                                          {"0", Mn::Vector3{11.3, 2.4, 3.5}}});
+
+    MarkersTestMap subset_id_011_ao_name(
+        {{"markers_03", Mn::Vector3{14.4, 5.5, 6.6}},
+         {"markers_02", Mn::Vector3{13.4, 4.5, 5.6}},
+         {"markers_01", Mn::Vector3{12.4, 3.5, 4.6}},
+         {"markers_00", Mn::Vector3{11.4, 2.5, 3.6}}});
+
+    SubsetTestMap link_id_01_ao_name(
+        {{"subset_id_010_ao_name", subset_id_010_ao_name},
+         {"subset_id_011_ao_name", subset_id_011_ao_name}});
+
+    MarkersTestMap subset_id_020_ao_name({{"3", Mn::Vector3{24.3, 5.4, 6.5}},
+                                          {"2", Mn::Vector3{23.3, 4.4, 5.5}},
+                                          {"1", Mn::Vector3{22.3, 3.4, 4.5}},
+                                          {"0", Mn::Vector3{21.3, 2.4, 3.5}}});
+
+    MarkersTestMap subset_id_021_ao_name(
+        {{"markers_03", Mn::Vector3{24.4, 5.5, 6.6}},
+         {"markers_02", Mn::Vector3{23.4, 4.5, 5.6}},
+         {"markers_01", Mn::Vector3{22.4, 3.5, 4.6}},
+         {"markers_00", Mn::Vector3{21.4, 2.5, 3.6}}});
+
+    MarkersTestMap subset_id_022_ao_name(
+        {{"markers_03", Mn::Vector3{224.4, 5.5, 6.6}},
+         {"markers_02", Mn::Vector3{223.4, 4.5, 5.6}},
+         {"markers_01", Mn::Vector3{222.4, 3.5, 4.6}},
+         {"markers_00", Mn::Vector3{221.4, 2.5, 3.6}}});
+
+    SubsetTestMap link_id_02_ao_name(
+        {{"subset_id_020_ao_name", subset_id_020_ao_name},
+         {"subset_id_021_ao_name", subset_id_021_ao_name},
+         {"subset_id_022_ao_name", subset_id_022_ao_name}});
+
+    LinksTestMap marker_set_0_ao_name{
+        {{"link_id_00_ao_name", link_id_00_ao_name},
+         {"link_id_01_ao_name", link_id_01_ao_name},
+         {"link_id_02_ao_name", link_id_02_ao_name}}};
+
+    MarkersTestMap subset_id_100_ao_name(
+        {{"markers_03", Mn::Vector3{114.1, 15.2, 16.3}},
+         {"markers_02", Mn::Vector3{113.1, 14.2, 15.3}},
+         {"markers_01", Mn::Vector3{112.1, 13.2, 14.3}},
+         {"markers_00", Mn::Vector3{111.1, 12.2, 13.3}}});
+
+    MarkersTestMap subset_id_101_ao_name(
+        {{"3", Mn::Vector3{114.2, 15.3, 16.4}},
+         {"2", Mn::Vector3{113.2, 14.3, 15.4}},
+         {"1", Mn::Vector3{112.2, 13.3, 14.4}},
+         {"0", Mn::Vector3{111.2, 12.3, 13.4}}});
+
+    SubsetTestMap link_id_10_ao_name(
+        {{"subset_id_100_ao_name", subset_id_100_ao_name},
+         {"subset_id_101_ao_name", subset_id_101_ao_name}});
+
+    MarkersTestMap subset_id_110_ao_name(
+        {{"3", Mn::Vector3{114.3, 15.4, 16.5}},
+         {"2", Mn::Vector3{113.3, 14.4, 15.5}},
+         {"1", Mn::Vector3{112.3, 13.4, 14.5}},
+         {"0", Mn::Vector3{111.3, 12.4, 13.5}}});
+
+    MarkersTestMap subset_id_111_ao_name(
+        {{"markers_03", Mn::Vector3{114.4, 15.5, 16.6}},
+         {"markers_02", Mn::Vector3{113.4, 14.5, 15.6}},
+         {"markers_01", Mn::Vector3{112.4, 13.5, 14.6}},
+         {"markers_00", Mn::Vector3{111.4, 12.5, 13.6}}});
+
+    SubsetTestMap link_id_11_ao_name(
+        {{"subset_id_110_ao_name", subset_id_110_ao_name},
+         {"subset_id_110_ao_name", subset_id_110_ao_name}});
+
+    LinksTestMap marker_set_1_ao_name(
+        {{"link_id_10_ao_name", link_id_10_ao_name},
+         {"link_id_11_ao_name", link_id_11_ao_name}});
+
+    MarkerSetTestMap markerSetMap(
+        {{"marker_set_0_ao_name", marker_set_0_ao_name},
+         {"marker_set_1_ao_name", marker_set_1_ao_name}});
+
+    testMarkerSetsConfigVals(artObjAttr->getMarkerSetsConfiguration(),
+                             markerSetMap);
+  }
+
   // remove json-string built attributes added for test
   testRemoveAttributesBuiltByJSONString(artObjAttributesManager_,
                                         artObjAttr->getHandle());
@@ -1711,78 +2024,104 @@ void AttributesConfigsTest::testArticulatedObjectJSONLoad() {
   "render_mode": "skin",
   "shader_type" : "pbr",
   "marker_sets" : {
-      "marker_set_0_AO_name" : {
-          "link_id_00_AO_name" : {
-              "subset_id_000_AO_name" : {
+      "marker_set_0_ao_name" : {
+          "link_id_00_ao_name" : {
+              "subset_id_000_ao_name" : {
                 "markers" : [
-                    [1.1, 2.2, 3.3],
-                    [2.1, 3.2, 4.3],
-                    [3.1, 4.2, 5.3],
-                    [4.1, 5.2, 6.3]
+                    [11.1, 2.2, 3.3],
+                    [12.1, 3.2, 4.3],
+                    [13.1, 4.2, 5.3],
+                    [14.1, 5.2, 6.3]
                   ]
               },
-              "subset_id_001_AO_name" : {
+              "subset_id_001_ao_name" : {
                 "markers" : {
-                    "0":[1.2, 2.3, 3.4],
-                    "1":[2.2, 3.3, 4.4],
-                    "2":[3.2, 4.3, 5.4],
-                    "3":[4.2, 5.3, 6.4]
+                    "0":[11.2, 2.3, 3.4],
+                    "1":[12.2, 3.3, 4.4],
+                    "2":[13.2, 4.3, 5.4],
+                    "3":[14.2, 5.3, 6.4]
                 }
               }
           },
-          "link_id_01_AO_name" : {
-              "subset_id_010_AO_name" : {
+          "link_id_01_ao_name" : {
+              "subset_id_010_ao_name" : {
                 "markers" : {
-                    "0":[1.3, 2.4, 3.5],
-                    "1":[2.3, 3.4, 4.5],
-                    "2":[3.3, 4.4, 5.5],
-                    "3":[4.3, 5.4, 6.5]
+                    "0":[11.3, 2.4, 3.5],
+                    "1":[12.3, 3.4, 4.5],
+                    "2":[13.3, 4.4, 5.5],
+                    "3":[14.3, 5.4, 6.5]
                 }
               },
-              "subset_id_011_AO_name" : {
+              "subset_id_011_ao_name" : {
                 "markers" : [
-                    [1.4, 2.5, 3.6],
-                    [2.4, 3.5, 4.6],
-                    [3.4, 4.5, 5.6],
-                    [4.4, 5.5, 6.6]
+                    [11.4, 2.5, 3.6],
+                    [12.4, 3.5, 4.6],
+                    [13.4, 4.5, 5.6],
+                    [14.4, 5.5, 6.6]
+                  ]
+              }
+          },
+          "link_id_02_ao_name" : {
+              "subset_id_020_ao_name" : {
+                "markers" : {
+                    "0":[21.3, 2.4, 3.5],
+                    "1":[22.3, 3.4, 4.5],
+                    "2":[23.3, 4.4, 5.5],
+                    "3":[24.3, 5.4, 6.5]
+                }
+              },
+              "subset_id_021_ao_name" : {
+                "markers" : [
+                    [21.4, 2.5, 3.6],
+                    [22.4, 3.5, 4.6],
+                    [23.4, 4.5, 5.6],
+                    [24.4, 5.5, 6.6]
+                  ]
+              },
+              "subset_id_022_ao_name" : {
+                "markers" : [
+                    [221.4, 2.5, 3.6],
+                    [222.4, 3.5, 4.6],
+                    [223.4, 4.5, 5.6],
+                    [224.4, 5.5, 6.6]
                   ]
               }
           }
       },
-      "marker_set_1_AO_name" : {
-          "link_id_10_AO_name" : {
-              "subset_id_100_AO_name" : {
+      "marker_set_1_ao_name" : {
+          "link_id_10_ao_name" : {
+              "subset_id_100_ao_name" : {
                 "markers" : [
-                    [11.1, 12.2, 13.3],
-                    [12.1, 13.2, 14.3],
-                    [13.1, 14.2, 15.3],
-                    [14.1, 15.2, 16.3]
+                    [111.1, 12.2, 13.3],
+                    [112.1, 13.2, 14.3],
+                    [113.1, 14.2, 15.3],
+                    [114.1, 15.2, 16.3]
                   ]
               },
-              "subset_id_101_AO_name" : {
+              "subset_id_101_ao_name" : {
                 "markers" : {
-                    "0":[11.2, 12.3, 13.4],
-                    "1":[12.2, 13.3, 14.4],
-                    "2":[13.2, 14.3, 15.4],
-                    "3":[14.2, 15.3, 16.4]
+                    "0":[111.2, 12.3, 13.4],
+                    "1":[112.2, 13.3, 14.4],
+                    "2":[113.2, 14.3, 15.4],
+                    "3":[114.2, 15.3, 16.4]
                 }
               }
           },
-          "link_id_11_AO_name" : {
-              "subset_id_110_AO_name" : {
+          "link_id_11_ao_name" : {
+              "subset_id_110_ao_name" : {
                 "markers" : {
-                    "0":[11.3, 12.4, 13.5],
-                    "1":[12.3, 13.4, 14.5],
-                    "2":[13.3, 14.4, 15.5],
-                    "3":[14.3, 15.4, 16.5]
+                    "0":[111.3, 12.4, 13.5],
+                    "1":[112.3, 13.4, 14.5],
+                    "2":[113.3, 14.4, 15.5],
+                    "3":[114.3, 15.4, 16.5]
                 }
               },
-              "subset_id_111_AO_name" : {
+              "subset_id_111_ao_name" : {
                 "markers" : [
-                    [11.4, 12.5, 13.6],
-                    [12.4, 13.5, 14.6],
-                    [13.4, 14.5, 15.6],
-                    [14.4, 15.5, 16.6]
+                    [111.4, 12.5, 13.6],
+                    [112.4, 13.5, 14.6],
+                    [113.4, 14.5, 15.6],
+                    [114.4, 15.5, 16.6]
                   ]
               }
           }
@@ -1811,8 +2150,8 @@ void AttributesConfigsTest::testArticulatedObjectJSONLoad() {
   CORRADE_VERIFY(artObjAttr);
 
   // now need to change urdf filename and render asset file name to make sure
-  // they are legal so the test can proceed (needs to be actual existing file so
-  // it can be regsitered)
+  // they are legal so the test can proceed (needs to be actual existing file
+  // so it can be regsitered)
   const std::string aoURDFFlle =
       Cr::Utility::Path::join(TEST_ASSETS, "urdf/prim_chain.urdf");
   const std::string aoRenderAssetName =

--- a/src/tests/CoreTest.cpp
+++ b/src/tests/CoreTest.cpp
@@ -92,15 +92,14 @@ void CoreTest::verifySubconfigTree(int countPerDepth,
     // Check into tree
     verifySubconfigTree(countPerDepth, curDepth + 1, totalDepth, newCfg);
   }
-  CORRADE_COMPARE(config->getNumSubconfigEntries(), countPerDepth);
+  CORRADE_COMPARE(config->getNumSubconfigs(), countPerDepth);
 
 }  // CoreTest::verifySubconfigTree
 
 void CoreTest::compareSubconfigs(Configuration::cptr& src,
                                  Configuration::cptr& target) {
   // verify target has at least all the number of subconfigs that src has
-  CORRADE_VERIFY(src->getNumSubconfigEntries() <=
-                 target->getNumSubconfigEntries());
+  CORRADE_VERIFY(src->getNumSubconfigs() <= target->getNumSubconfigs());
   // verify that target has all the values that src has, and they are equal.
   auto srcIterValPair = src->getValuesIterator();
   for (auto& cfgIter = srcIterValPair.first; cfgIter != srcIterValPair.second;


### PR DESCRIPTION
## Motivation and Context
This PR supports the loading, modification, and saving of nested marker sets in the configs for AO, objects and stages. 


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
