### PR TITLE
--MarkerSets assignment to objects, 'interface' class and bindings

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -11,6 +11,7 @@
 #include "esp/metadata/attributes/ArticulatedObjectAttributes.h"
 #include "esp/metadata/attributes/AttributesBase.h"
 #include "esp/metadata/attributes/LightLayoutAttributes.h"
+#include "esp/metadata/attributes/MarkerSets.h"
 #include "esp/metadata/attributes/ObjectAttributes.h"
 #include "esp/metadata/attributes/PbrShaderAttributes.h"
 #include "esp/metadata/attributes/PhysicsManagerAttributes.h"
@@ -33,6 +34,10 @@ using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
 using Attrs::LightInstanceAttributes;
 using Attrs::LightLayoutAttributes;
+using Attrs::LinkMarkerSets;
+using Attrs::LinkMarkerSubset;
+using Attrs::MarkerSet;
+using Attrs::MarkerSets;
 using Attrs::ObjectAttributes;
 using Attrs::PbrShaderAttributes;
 using Attrs::PhysicsManagerAttributes;
@@ -228,6 +233,20 @@ void initAttributesBindings(py::module& m) {
              metadata::attributes::ArticulatedObjectLinkOrder::URDFOrder)
       .value("TREE_TRAVERSAL",
              metadata::attributes::ArticulatedObjectLinkOrder::TreeTraversal);
+
+  // ==== Markersets and subordinate classes ===
+
+  py::class_<LinkMarkerSubset, LinkMarkerSubset::ptr>(m, "LinkMarkerSubset")
+      .def(py::init(&LinkMarkerSubset::create<>));
+
+  py::class_<LinkMarkerSets, LinkMarkerSets::ptr>(m, "LinkMarkerSets")
+      .def(py::init(&LinkMarkerSets::create<>));
+
+  py::class_<MarkerSet, MarkerSet::ptr>(m, "MarkerSet")
+      .def(py::init(&MarkerSet::create<>));
+
+  py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
+      .def(py::init(&MarkerSets::create<>));
 
   // ==== ArticulatedObjectAttributes ====
   py::class_<ArticulatedObjectAttributes, AbstractAttributes,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -237,13 +237,51 @@ void initAttributesBindings(py::module& m) {
   // ==== Markersets and subordinate classes ===
 
   py::class_<LinkMarkerSubset, LinkMarkerSubset::ptr>(m, "LinkMarkerSubset")
-      .def(py::init(&LinkMarkerSubset::create<>));
+      .def(py::init(&LinkMarkerSubset::create<>))
+      .def_property_readonly(
+          "num_markers", &LinkMarkerSubset::getNumMarkers,
+          R"(The current number of markers present in this subset.)")
+      .def("get_markers", &LinkMarkerSubset::getMarkers,
+           R"(Get an ordered list of all the 3D point markers in this subset)")
+      .def(
+          "set_markers", &LinkMarkerSubset::setMarkers,
+          R"(Set the markers for this subset to be the passed list of 3D points)",
+          "markers"_a);
 
   py::class_<LinkMarkerSets, LinkMarkerSets::ptr>(m, "LinkMarkerSets")
-      .def(py::init(&LinkMarkerSets::create<>));
+      .def(py::init(&LinkMarkerSets::create<>))
+      .def_property_readonly(
+          "num_subsets", &LinkMarkerSets::getNumLinkSubsets,
+          R"(The current number of marker subsets present in this link description.)")
+      .def(
+          "has_named_subset", &LinkMarkerSets::hasNamedLinkSubset,
+          R"(Whether or not this link has a marker subset with the given name)",
+          "subset_name"_a)
+      .def("get_all_subset_names", &LinkMarkerSets::getAllLinkSubsetNames,
+           R"(Get a list of all the subset names associated with this link)")
+      .def("get_named_link_subset", &LinkMarkerSets::editNamedLinkSubset,
+           R"(Get an editable reference to the specified LinkMarkerSubset, or
+          None if it does not exist.)",
+           "subset_name"_a)
+      .def("set_subset_markers", &LinkMarkerSets::setLinkSubsetMarkers,
+           R"(Sets the markers for this link's named subset)", "subset_name"_a,
+           "marker_list"_a)
+      .def("get_subset_markers", &LinkMarkerSets::getLinkSubsetMarkers,
+           R"(Gets the markers for the named subset of this link)",
+           "subset_name"_a)
+      .def("set_all_markers", &LinkMarkerSets::setAllMarkers,
+           R"(Sets the markers for all the subsets of this link to the
+          passed dictionary of values, keyed by subset name)",
+           "subset_dict"_a)
+      .def("get_all_markers", &LinkMarkerSets::getAllMarkers,
+           R"(Get a dictionary keyed by subset name where each value is a
+            list of the marker points for that subset)");
 
   py::class_<MarkerSet, MarkerSet::ptr>(m, "MarkerSet")
-      .def(py::init(&MarkerSet::create<>));
+      .def(py::init(&MarkerSet::create<>))
+      .def_property_readonly(
+          "num_link_sets", &MarkerSet::getNumLinkSets,
+          R"(The current number of per-link marker subsets present in this Markerset.)");
 
   py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
       .def(py::init(&MarkerSets::create<>))

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -246,7 +246,9 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&MarkerSet::create<>));
 
   py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
-      .def(py::init(&MarkerSets::create<>));
+      .def(py::init(&MarkerSets::create<>))
+      .def_property_readonly("num_marker_sets", &MarkerSets::getNumMarkerSets,
+                             R"(The current number of Markersets present.)");
 
   // ==== ArticulatedObjectAttributes ====
   py::class_<ArticulatedObjectAttributes, AbstractAttributes,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -257,7 +257,7 @@ void initAttributesBindings(py::module& m) {
       .def("has_markerset", &LinkSet::hasMarkerSet,
            R"(Whether or not this LinkSet has a MarkerSet with the given name)",
            "markerset_name"_a)
-      .def("get_all_pointset_names", &LinkSet::getAllMarkerSetNames,
+      .def("get_all_markerset_names", &LinkSet::getAllMarkerSetNames,
            R"(Get a list of all the MarkerSet names within this LinkSet)")
       .def("get_markerset", &LinkSet::editMarkerSet,
            R"(Get an editable reference to the specified MarkerSet, possibly

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -391,7 +391,8 @@ void initAttributesBindings(py::module& m) {
           R"(Set the marker points for every MarkerSet of every LinkSet of every TaskSet present to the values in
           the passed dict of dicts of dicts. The format should be dictionary, keyed by TaskSet name, of dictionaries,
           keyed by link name, of dictionary, each keyed by MarkerSet name and value being a list
-          of that MarkerSet's marker points)",
+          of that MarkerSet's marker points. TaskSets, LinkSets and MarkerSet which are not referenced
+          in the passed dict will remain untouched by this setter.)",
           "task_link_markerset_dict"_a)
       .def(
           "get_taskset_points", &MarkerSets::getTaskSetPoints,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -287,6 +287,10 @@ void initAttributesBindings(py::module& m) {
       .def("has_linkset", &TaskSet::hasLinkSet,
            R"(Whether or not this TaskSet has a LinkSet with the given name)",
            "linkset_name"_a)
+      .def(
+          "has_link_markerset", &TaskSet::hasLinkMarkerSet,
+          R"(Whether or not this TaskSet has a MarkerSet within a LinkSet with the given names)",
+          "linkset_name"_a, "markerset_dict"_a)
       .def("get_all_linkset_names", &TaskSet::getAllLinkSetNames,
            R"(Get a list of all the LinkSet names within this TaskSet)")
       .def("get_linkset", &TaskSet::editLinkSet,
@@ -294,31 +298,30 @@ void initAttributesBindings(py::module& m) {
             empty if it does not exist)",
            "linkset_name"_a)
       .def(
-          "set_link_markerset_points", &TaskSet::setLinkMarkerSetPoints,
-          R"(Set the marker points for the specified LinkSet's specified MarkerSet
-          to the given list of 3d points)",
-          "linkset_name"_a, "markerset_name"_a, "marker_list"_a)
-      .def(
           "set_linkset_points", &TaskSet::setLinkSetPoints,
           R"(Set the marker points in each of the MarkerSets for the specified LinkSet
           to the given dictionary of 3d points, keyed by the MarkerSet name)",
           "linkset_name"_a, "markerset_dict"_a)
+      .def(
+          "set_link_markerset_points", &TaskSet::setLinkMarkerSetPoints,
+          R"(Set the marker points for the specified LinkSet's specified MarkerSet
+          to the given list of 3d points)",
+          "linkset_name"_a, "markerset_name"_a, "marker_list"_a)
       .def(
           "set_all_points", &TaskSet::setAllMarkerPoints,
           R"(Set the marker points for every MarkerSet of every link in this TaskSet to the values in
           the passed dict of dicts. The format should be dictionary keyed by link name of dictionaries,
           each keyed by MarkerSet name for the particular link with the value being a list of 3d points)",
           "link_markerset_dict"_a)
-
-      .def(
-          "get_link_markerset_points", &TaskSet::getLinkMarkerSetPoints,
-          R"(Get the marker points for the specified LinkSet's specified MarkerSet as a list of 3d points)",
-          "linkset_name"_a, "markerset_name"_a)
       .def(
           "get_linkset_points", &TaskSet::getLinkSetPoints,
           R"(Get the marker points in each of the MarkerSets for the specified LinkSet
           as a dictionary of lists of 3d points, keyed by the LinkSet's MarkerSet name)",
           "linkset_name"_a)
+      .def(
+          "get_link_markerset_points", &TaskSet::getLinkMarkerSetPoints,
+          R"(Get the marker points for the specified LinkSet's specified MarkerSet as a list of 3d points)",
+          "linkset_name"_a, "markerset_name"_a)
       .def(
           "get_all_points", &TaskSet::getAllMarkerPoints,
           R"(Get the marker points for every MarkerSet of every link in this TaskSet as a dict
@@ -333,12 +336,32 @@ void initAttributesBindings(py::module& m) {
       .def("has_taskset", &MarkerSets::hasTaskSet,
            R"(Whether or not a TaskSet with the given name exists)",
            "taskset_name"_a)
+      .def("has_taskset", &MarkerSets::hasTaskLinkSet,
+           R"(Whether or not a LinkSet with the given name within the TaskSet
+          with the given name exists)",
+           "taskset_name"_a, "linkset_name"_a)
+      .def("has_task_link_markerset", &MarkerSets::hasTaskLinkMarkerSet,
+           R"(Whether or not a MarkerSet exists within an existing Linkset in
+          an existing TaskSet with the given names)",
+           "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
       .def("get_all_taskset_names", &MarkerSets::getAllTaskSetNames,
            R"(Get a list of all the existing TaskSet names)")
       .def("get_taskset", &MarkerSets::editTaskSet,
            R"(Get an editable reference to the specified TaskSet, possibly
             empty if it does not exist)",
            "taskset_name"_a)
+      .def(
+          "set_taskset_points", &MarkerSets::setTaskSetPoints,
+          R"(Set all the marker points in the specified TaskSet to the 3d point values in the
+          passed dict of dicts. The format should be a dictionary keyed by LinkSet name, of
+          dictionaries, each keyed by MarkerSet name and referencing a list of 3d points)",
+          "taskset_name"_a, "link_markerset_dict"_a)
+      .def(
+          "set_task_linkset_points", &MarkerSets::setTaskLinkSetPoints,
+          R"(Set the points in all the MarkerSets of the specified LinkSet, in the
+          specified TaskSet, to the given dictionary, keyed by each MarkerSet's name
+          and referencing a list of 3d points.)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_dict"_a)
       .def(
           "set_task_link_markerset_points",
           &MarkerSets::setTaskLinkMarkerSetPoints,
@@ -347,18 +370,6 @@ void initAttributesBindings(py::module& m) {
           "taskset_name"_a, "linkset_name"_a, "markerset_name"_a,
           "marker_list"_a)
       .def(
-          "set_task_linkset_points", &MarkerSets::setTaskLinkSetPoints,
-          R"(Set the points in all the MarkerSets of the specified LinkSet, in the
-          specified TaskSet, to the given dictionary, keyed by each MarkerSet's name
-          and referencing a list of 3d points.)",
-          "taskset_name"_a, "linkset_name"_a, "markerset_dict"_a)
-      .def(
-          "set_taskset_points", &MarkerSets::setTaskSetPoints,
-          R"(Set all the marker points in the specified TaskSet to the 3d point values in the
-          passed dict of dicts. The format should be a dictionary keyed by LinkSet name, of
-          dictionaries, each keyed by MarkerSet name and referencing a list of 3d points)",
-          "taskset_name"_a, "link_markerset_dict"_a)
-      .def(
           "set_all_points", &MarkerSets::setAllMarkerPoints,
           R"(Set the marker points for every MarkerSet of every LinkSet of every TaskSet present to the values in
           the passed dict of dicts of dicts. The format should be dictionary, keyed by TaskSet name, of dictionaries,
@@ -366,24 +377,23 @@ void initAttributesBindings(py::module& m) {
           of that MarkerSet's marker points)",
           "task_link_markerset_dict"_a)
       .def(
-          "get_task_link_markerset_points",
-          &MarkerSets::getTaskLinkMarkerSetPoints,
-          R"(Get the marker points for the specified TaskSet's specified LinkSet's specified MarkerSet
-           as a list of 3d points)",
-          "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
+          "get_taskset_points", &MarkerSets::getTaskSetPoints,
+          R"(Get all the marker points in the specified TaskSet as a dict of dicts.
+          The format is a dictionary keyed by LinkSet name, of dictionaries,
+          each keyed by MarkerSet name and referencing a list of 3d points)",
+          "taskset_name"_a)
       .def(
           "get_task_linkset_points", &MarkerSets::getTaskLinkSetPoints,
           R"(Get the points in all the MarkerSets of the specified LinkSet, in the
           specified TaskSet, as a dictionary, keyed by each MarkerSet's name
           and referencing a list of 3d points.)",
           "taskset_name"_a, "linkset_name"_a)
-
       .def(
-          "get_taskset_points", &MarkerSets::getTaskSetPoints,
-          R"(Get all the marker points in the specified TaskSet as a dict of dicts.
-          The format is a dictionary keyed by LinkSet name, of dictionaries,
-          each keyed by MarkerSet name and referencing a list of 3d points)",
-          "taskset_name"_a)
+          "get_task_link_markerset_points",
+          &MarkerSets::getTaskLinkMarkerSetPoints,
+          R"(Get the marker points for the specified TaskSet's specified LinkSet's specified MarkerSet
+           as a list of 3d points)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
       .def(
           "get_all_marker_points", &MarkerSets::getAllMarkerPoints,
           R"(Get the marker points for every MarkerSet of every link of every TaskSet present as a dict

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -236,7 +236,8 @@ void initAttributesBindings(py::module& m) {
 
   // ==== Markersets and subordinate classes ===
 
-  py::class_<MarkerSet, MarkerSet::ptr>(m, "MarkerSet")
+  py::class_<MarkerSet, esp::core::config::Configuration, MarkerSet::ptr>(
+      m, "MarkerSet")
       .def(py::init(&MarkerSet::create<>))
       .def_property_readonly(
           "num_points", &MarkerSet::getNumPoints,
@@ -249,7 +250,8 @@ void initAttributesBindings(py::module& m) {
           R"(Set the marker points for this MarkerSet to be the passed list of 3D points)",
           "markers"_a);
 
-  py::class_<LinkSet, LinkSet::ptr>(m, "LinkSet")
+  py::class_<LinkSet, esp::core::config::Configuration, LinkSet::ptr>(m,
+                                                                      "LinkSet")
       .def(py::init(&LinkSet::create<>))
       .def_property_readonly(
           "num_markersets", &LinkSet::getNumMarkerSets,
@@ -279,7 +281,8 @@ void initAttributesBindings(py::module& m) {
            R"(Get a dictionary holding all the points in this LinkSet, keyed by
            MarkerSet name, referencing lists of the MarkerSet's 3d points)");
 
-  py::class_<TaskSet, TaskSet::ptr>(m, "TaskSet")
+  py::class_<TaskSet, esp::core::config::Configuration, TaskSet::ptr>(m,
+                                                                      "TaskSet")
       .def(py::init(&TaskSet::create<>))
       .def_property_readonly(
           "num_linksets", &TaskSet::getNumLinkSets,
@@ -332,7 +335,8 @@ void initAttributesBindings(py::module& m) {
           of dicts. The format is a dictionary keyed by link name of dictionaries,
           each keyed by MarkerSet name for the particular link with the value being a list
           of the marker points)");
-  py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
+  py::class_<MarkerSets, esp::core::config::Configuration, MarkerSets::ptr>(
+      m, "MarkerSets")
       .def(py::init(&MarkerSets::create<>))
       .def_property_readonly(
           "num_tasksets", &MarkerSets::getNumTaskSets,
@@ -419,7 +423,8 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&ArticulatedObjectAttributes::create<>))
       .def(py::init(&ArticulatedObjectAttributes::create<const std::string&>))
       .def("get_marker_sets",
-           &ArticulatedObjectAttributes::editMarkerSetsConfiguration,
+           static_cast<MarkerSets::ptr (ArticulatedObjectAttributes::*)(void)>(
+               &ArticulatedObjectAttributes::editMarkerSetsConfiguration),
            py::return_value_policy::reference_internal,
            R"(Returns a reference to the marker-sets configuration object for
           this Articulated Object attributes, so that it can be viewed or modified.
@@ -472,7 +477,8 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&AbstractObjectAttributes::create<const std::string&,
                                                       const std::string&>))
       .def("get_marker_sets",
-           &AbstractObjectAttributes::editMarkerSetsConfiguration,
+           static_cast<MarkerSets::ptr (AbstractObjectAttributes::*)(void)>(
+               &AbstractObjectAttributes::editMarkerSetsConfiguration),
            py::return_value_policy::reference_internal,
            R"(Returns a reference to the marker-sets configuration object for
           constructs built using this template, so that it can be viewed or modified.

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -261,10 +261,11 @@ void initAttributesBindings(py::module& m) {
            "markerset_name"_a)
       .def("get_all_markerset_names", &LinkSet::getAllMarkerSetNames,
            R"(Get a list of all the MarkerSet names within this LinkSet)")
-      .def("get_markerset", &LinkSet::editMarkerSet,
-           R"(Get an editable reference to the specified MarkerSet, possibly
+      .def(
+          "get_markerset", &LinkSet::editMarkerSet,
+          R"(Get an editable reference to the specified MarkerSet, possibly new and
             empty if it does not exist)",
-           "markerset_name"_a)
+          "markerset_name"_a)
       .def("set_markerset_points", &LinkSet::setMarkerSetPoints,
            R"(Sets the marker points for the specified MarkerSet)",
            "markerset_name"_a, "marker_list"_a)
@@ -294,16 +295,18 @@ void initAttributesBindings(py::module& m) {
           "has_link_markerset", &TaskSet::hasLinkMarkerSet,
           R"(Whether or not this TaskSet has a MarkerSet within a LinkSet with the given names)",
           "linkset_name"_a, "markerset_dict"_a)
-      .def("init_link_markerset", &TaskSet::initLinkMarkerSet,
-           R"(Initialize a MarkerSet within a LinkSet with the given names in
-          this TaskSet)",
-           "linkset_name"_a, "markerset_dict"_a)
+      .def(
+          "init_link_markerset", &TaskSet::initLinkMarkerSet,
+          R"(Initialize a MarkerSet within a LinkSet within this TaskSet from a dict
+           mapping markerset names to lists of points.)",
+          "linkset_name"_a, "markerset_dict"_a)
       .def("get_all_linkset_names", &TaskSet::getAllLinkSetNames,
            R"(Get a list of all the LinkSet names within this TaskSet)")
-      .def("get_linkset", &TaskSet::editLinkSet,
-           R"(Get an editable reference to the specified LinkSet, possibly
+      .def(
+          "get_linkset", &TaskSet::editLinkSet,
+          R"(Get an editable reference to the specified LinkSet, possibly new and
             empty if it does not exist)",
-           "linkset_name"_a)
+          "linkset_name"_a)
       .def(
           "set_linkset_points", &TaskSet::setLinkSetPoints,
           R"(Set the marker points in each of the MarkerSets for the specified LinkSet
@@ -359,10 +362,11 @@ void initAttributesBindings(py::module& m) {
           "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
       .def("get_all_taskset_names", &MarkerSets::getAllTaskSetNames,
            R"(Get a list of all the existing TaskSet names)")
-      .def("get_taskset", &MarkerSets::editTaskSet,
-           R"(Get an editable reference to the specified TaskSet, possibly
+      .def(
+          "get_taskset", &MarkerSets::editTaskSet,
+          R"(Get an editable reference to the specified TaskSet, possibly new and
             empty if it does not exist)",
-           "taskset_name"_a)
+          "taskset_name"_a)
       .def(
           "set_taskset_points", &MarkerSets::setTaskSetPoints,
           R"(Set all the marker points in the specified TaskSet to the 3d point values in the

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -291,6 +291,10 @@ void initAttributesBindings(py::module& m) {
           "has_link_markerset", &TaskSet::hasLinkMarkerSet,
           R"(Whether or not this TaskSet has a MarkerSet within a LinkSet with the given names)",
           "linkset_name"_a, "markerset_dict"_a)
+      .def("init_link_markerset", &TaskSet::initLinkMarkerSet,
+           R"(Initialize a MarkerSet within a LinkSet with the given names in
+          this TaskSet)",
+           "linkset_name"_a, "markerset_dict"_a)
       .def("get_all_linkset_names", &TaskSet::getAllLinkSetNames,
            R"(Get a list of all the LinkSet names within this TaskSet)")
       .def("get_linkset", &TaskSet::editLinkSet,
@@ -336,7 +340,7 @@ void initAttributesBindings(py::module& m) {
       .def("has_taskset", &MarkerSets::hasTaskSet,
            R"(Whether or not a TaskSet with the given name exists)",
            "taskset_name"_a)
-      .def("has_taskset", &MarkerSets::hasTaskLinkSet,
+      .def("has_task_linkset", &MarkerSets::hasTaskLinkSet,
            R"(Whether or not a LinkSet with the given name within the TaskSet
           with the given name exists)",
            "taskset_name"_a, "linkset_name"_a)
@@ -344,6 +348,11 @@ void initAttributesBindings(py::module& m) {
            R"(Whether or not a MarkerSet exists within an existing Linkset in
           an existing TaskSet with the given names)",
            "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
+      .def(
+          "init_task_link_markerset", &MarkerSets::initTaskLinkMarkerSet,
+          R"(Initialize a MarkerSet within a LinkSet within a new TaskSet with the given
+           names in this collection)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
       .def("get_all_taskset_names", &MarkerSets::getAllTaskSetNames,
            R"(Get a list of all the existing TaskSet names)")
       .def("get_taskset", &MarkerSets::editTaskSet,

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -34,14 +34,14 @@ using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
 using Attrs::LightInstanceAttributes;
 using Attrs::LightLayoutAttributes;
-using Attrs::LinkMarkerSet;
-using Attrs::LinkMarkerSubset;
+using Attrs::LinkSet;
 using Attrs::MarkerSet;
 using Attrs::MarkerSets;
 using Attrs::ObjectAttributes;
 using Attrs::PbrShaderAttributes;
 using Attrs::PhysicsManagerAttributes;
 using Attrs::StageAttributes;
+using Attrs::TaskSet;
 using Attrs::UVSpherePrimitiveAttributes;
 using esp::core::managedContainers::AbstractFileBasedManagedObject;
 using esp::core::managedContainers::AbstractManagedObject;
@@ -236,160 +236,166 @@ void initAttributesBindings(py::module& m) {
 
   // ==== Markersets and subordinate classes ===
 
-  py::class_<LinkMarkerSubset, LinkMarkerSubset::ptr>(m, "LinkMarkerSubset")
-      .def(py::init(&LinkMarkerSubset::create<>))
-      .def_property_readonly(
-          "num_markers", &LinkMarkerSubset::getNumMarkers,
-          R"(The current number of markers present in this subset.)")
-      .def("get_markers", &LinkMarkerSubset::getMarkers,
-           R"(Get an ordered list of all the 3D point markers in this subset)")
-      .def(
-          "set_markers", &LinkMarkerSubset::setMarkers,
-          R"(Set the markers for this subset to be the passed list of 3D points)",
-          "markers"_a);
-
-  py::class_<LinkMarkerSet, LinkMarkerSet::ptr>(m, "LinkMarkerSet")
-      .def(py::init(&LinkMarkerSet::create<>))
-      .def_property_readonly(
-          "num_subsets", &LinkMarkerSet::getNumLinkSubsets,
-          R"(The current number of marker subsets present in this link description.)")
-      .def(
-          "has_named_subset", &LinkMarkerSet::hasNamedLinkSubset,
-          R"(Whether or not this link has a marker subset with the given name)",
-          "subset_name"_a)
-      .def("get_all_subset_names", &LinkMarkerSet::getAllLinkSubsetNames,
-           R"(Get a list of all the subset names associated with this link)")
-      .def("get_named_subset", &LinkMarkerSet::editNamedLinkSubset,
-           R"(Get an editable reference to the specified LinkMarkerSubset, or
-          None if it does not exist.)",
-           "subset_name"_a)
-      .def("set_subset_markers", &LinkMarkerSet::setLinkSubsetMarkers,
-           R"(Sets the markers for this link's named subset)", "subset_name"_a,
-           "marker_list"_a)
-      .def("get_subset_markers", &LinkMarkerSet::getLinkSubsetMarkers,
-           R"(Gets the markers for the named subset of this link)",
-           "subset_name"_a)
-      .def("set_all_markers", &LinkMarkerSet::setAllMarkers,
-           R"(Sets the markers for all the subsets of this link to the
-          passed dictionary of values, keyed by subset name)",
-           "subset_marker_dict"_a)
-      .def("get_all_markers", &LinkMarkerSet::getAllMarkers,
-           R"(Get a dictionary keyed by subset name where each value is a
-            list of the marker points for that subset)");
-
   py::class_<MarkerSet, MarkerSet::ptr>(m, "MarkerSet")
       .def(py::init(&MarkerSet::create<>))
       .def_property_readonly(
-          "num_link_sets", &MarkerSet::getNumLinkSets,
-          R"(The current number of per-link marker subsets present in this Markerset.)")
+          "num_points", &MarkerSet::getNumPoints,
+          R"(The current number of marker points present in this MarkerSet.)")
+      .def(
+          "get_points", &MarkerSet::getAllPoints,
+          R"(Get an ordered list of all the 3D marker points in this MarkerSet)")
+      .def(
+          "set_points", &MarkerSet::setAllPoints,
+          R"(Set the marker points for this MarkerSet to be the passed list of 3D points)",
+          "markers"_a);
+
+  py::class_<LinkSet, LinkSet::ptr>(m, "LinkSet")
+      .def(py::init(&LinkSet::create<>))
+      .def_property_readonly(
+          "num_markersets", &LinkSet::getNumMarkerSets,
+          R"(The current number of MarkerSets present in this LinkSet.)")
+      .def("has_markerset", &LinkSet::hasMarkerSet,
+           R"(Whether or not this LinkSet has a MarkerSet with the given name)",
+           "markerset_name"_a)
+      .def("get_all_pointset_names", &LinkSet::getAllMarkerSetNames,
+           R"(Get a list of all the MarkerSet names within this LinkSet)")
+      .def("get_markerset", &LinkSet::editMarkerSet,
+           R"(Get an editable reference to the specified MarkerSet, possibly
+            empty if it does not exist)",
+           "markerset_name"_a)
+      .def("set_markerset_points", &LinkSet::setMarkerSetPoints,
+           R"(Sets the marker points for the specified MarkerSet)",
+           "markerset_name"_a, "marker_list"_a)
+      .def("get_markerset_points", &LinkSet::getMarkerSetPoints,
+           R"(Gets the marker points for the named MarkerSet of this LinkSet)",
+           "markerset_name"_a)
+      .def(
+          "set_all_points", &LinkSet::setAllMarkerPoints,
+          R"(Sets the marker points for all the MarkerSets of this LinkSet to the
+          passed dictionary of values, keyed by MarkerSet name, referencing a list
+          of 3d points)",
+          "markerset_dict"_a)
+      .def("get_all_points", &LinkSet::getAllMarkerPoints,
+           R"(Get a dictionary holding all the points in this LinkSet, keyed by
+           MarkerSet name, referencing lists of the MarkerSet's 3d points)");
+
+  py::class_<TaskSet, TaskSet::ptr>(m, "TaskSet")
+      .def(py::init(&TaskSet::create<>))
+      .def_property_readonly(
+          "num_linksets", &TaskSet::getNumLinkSets,
+          R"(The current number of LinkSets present in this TaskSet.)")
+      .def("has_linkset", &TaskSet::hasLinkSet,
+           R"(Whether or not this TaskSet has a LinkSet with the given name)",
+           "linkset_name"_a)
+      .def("get_all_linkset_names", &TaskSet::getAllLinkSetNames,
+           R"(Get a list of all the LinkSet names within this TaskSet)")
+      .def("get_linkset", &TaskSet::editLinkSet,
+           R"(Get an editable reference to the specified LinkSet, possibly
+            empty if it does not exist)",
+           "linkset_name"_a)
+      .def(
+          "set_link_markerset_points", &TaskSet::setLinkMarkerSetPoints,
+          R"(Set the marker points for the specified LinkSet's specified MarkerSet
+          to the given list of 3d points)",
+          "linkset_name"_a, "markerset_name"_a, "marker_list"_a)
+      .def(
+          "set_linkset_points", &TaskSet::setLinkSetPoints,
+          R"(Set the marker points in each of the MarkerSets for the specified LinkSet
+          to the given dictionary of 3d points, keyed by the MarkerSet name)",
+          "linkset_name"_a, "markerset_dict"_a)
+      .def(
+          "set_all_points", &TaskSet::setAllMarkerPoints,
+          R"(Set the marker points for every MarkerSet of every link in this TaskSet to the values in
+          the passed dict of dicts. The format should be dictionary keyed by link name of dictionaries,
+          each keyed by MarkerSet name for the particular link with the value being a list of 3d points)",
+          "link_markerset_dict"_a)
 
       .def(
-          "has_named_link_set", &MarkerSet::hasNamedLinkSet,
-          R"(Whether or not this Markerset has a LinkMarkerSet with the given name)",
+          "get_link_markerset_points", &TaskSet::getLinkMarkerSetPoints,
+          R"(Get the marker points for the specified LinkSet's specified MarkerSet as a list of 3d points)",
+          "linkset_name"_a, "markerset_name"_a)
+      .def(
+          "get_linkset_points", &TaskSet::getLinkSetPoints,
+          R"(Get the marker points in each of the MarkerSets for the specified LinkSet
+          as a dictionary of lists of 3d points, keyed by the LinkSet's MarkerSet name)",
           "linkset_name"_a)
       .def(
-          "get_all_link_set_names", &MarkerSet::getAllLinkSetNames,
-          R"(Get a list of all the LinkMarkerSet names associated with this Markerset)")
-      .def("get_named_link_set", &MarkerSet::editNamedLinkSet,
-           R"(Get an editable reference to the specified LinkMarkerSet, or
-          None if it does not exist.)",
-           "linkset_name"_a)
-      .def(
-          "set_link_subset_markers", &MarkerSet::setLinkSetSubsetMarkers,
-          R"(Set the markers for the specified link's specified subset to the given list of points)",
-          "linkset_name"_a, "subset_name"_a, "marker_list"_a)
-      .def("set_all_link_markers", &MarkerSet::setLinkSetMarkers,
-           R"(Set the markers in each of the subsets for the specified link
-          to the given dictionary of points, keyed by the link's subset name)",
-           "linkset_name"_a, "subset_marker_dict"_a)
-      .def(
-          "set_all_markers", &MarkerSet::setAllMarkers,
-          R"(Set the marker points for every subset of every link in this markerset to the values in
-          the passed dict of dicts. The format should be dictionary keyed by link name of dictionaries,
-          each keyed by subset name for the particular link with the value being a list of points)",
-          "link_subset_marker_dict"_a)
-
-      .def(
-          "get_link_subset_markers", &MarkerSet::getLinkSetSubsetMarkers,
-          R"(Get the markers for the specified link's specified subset as a list of points)",
-          "linkset_name"_a, "subset_name"_a)
-      .def("get_all_link_markers", &MarkerSet::getLinkSetMarkers,
-           R"(Get the markers in each of the subsets for the specified link
-          as a dictionary of points, keyed by the link's subset name)",
-           "linkset_name"_a)
-      .def(
-          "get_all_markers", &MarkerSet::getAllMarkers,
-          R"(Get the marker points for every subset of every link in this markerset as a dict
+          "get_all_points", &TaskSet::getAllMarkerPoints,
+          R"(Get the marker points for every MarkerSet of every link in this TaskSet as a dict
           of dicts. The format is a dictionary keyed by link name of dictionaries,
-          each keyed by subset name for the particular link with the value being a list
+          each keyed by MarkerSet name for the particular link with the value being a list
           of the marker points)");
   py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
       .def(py::init(&MarkerSets::create<>))
-      .def_property_readonly("num_marker_sets", &MarkerSets::getNumMarkerSets,
-                             R"(The current number of Markersets present.)")
-      .def("has_named_marker_set", &MarkerSets::hasNamedMarkerSet,
-           R"(Whether or not a Markerset with the given name exists)",
-           "markerset_name"_a)
-      .def("get_all_marker_set_names", &MarkerSets::getAllMarkerSetNames,
-           R"(Get a list of all the existing MarkerSet names)")
-      .def("get_named_marker_set", &MarkerSets::editNamedMarkerSet,
-           R"(Get an editable reference to the specified MarkerSet, or
-          None if it does not exist.)",
-           "markerset_name"_a)
-      .def("set_markerset_link_subset_markers",
-           &MarkerSets::setMarkerSetLinkSetSubsetMarkers,
-           R"(Set the markers for the specified MarkerSet's specified link's
-          specified subset to the given list of points)",
-           "markerset_name"_a, "linkset_name"_a, "subset_name"_a,
-           "marker_list"_a)
+      .def_property_readonly(
+          "num_tasksets", &MarkerSets::getNumTaskSets,
+          R"(The current number of TaskSets present in the MarkerSets collection.)")
+      .def("has_taskset", &MarkerSets::hasTaskSet,
+           R"(Whether or not a TaskSet with the given name exists)",
+           "taskset_name"_a)
+      .def("get_all_taskset_names", &MarkerSets::getAllTaskSetNames,
+           R"(Get a list of all the existing TaskSet names)")
+      .def("get_taskset", &MarkerSets::editTaskSet,
+           R"(Get an editable reference to the specified TaskSet, possibly
+            empty if it does not exist)",
+           "taskset_name"_a)
       .def(
-          "set_markerset_link_markers", &MarkerSets::setMarkerSetLinkSetMarkers,
-          R"(Set the markers in all of the specified Markerset's specified link's subsets
-          to the given dictionary of points, keyed by the link's subset name)",
-          "markerset_name"_a, "linkset_name"_a, "subset_marker_dict"_a)
+          "set_task_link_markerset_points",
+          &MarkerSets::setTaskLinkMarkerSetPoints,
+          R"(Set the marker points for the specified TaskSet's specified LinkSet's
+          specified MarkerSet to the given list of 3d points)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_name"_a,
+          "marker_list"_a)
+      .def(
+          "set_task_linkset_points", &MarkerSets::setTaskLinkSetPoints,
+          R"(Set the points in all the MarkerSets of the specified LinkSet, in the
+          specified TaskSet, to the given dictionary, keyed by each MarkerSet's name
+          and referencing a list of 3d points.)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_dict"_a)
+      .def(
+          "set_taskset_points", &MarkerSets::setTaskSetPoints,
+          R"(Set all the marker points in the specified TaskSet to the 3d point values in the
+          passed dict of dicts. The format should be a dictionary keyed by LinkSet name, of
+          dictionaries, each keyed by MarkerSet name and referencing a list of 3d points)",
+          "taskset_name"_a, "link_markerset_dict"_a)
+      .def(
+          "set_all_points", &MarkerSets::setAllMarkerPoints,
+          R"(Set the marker points for every MarkerSet of every LinkSet of every TaskSet present to the values in
+          the passed dict of dicts of dicts. The format should be dictionary, keyed by TaskSet name, of dictionaries,
+          keyed by link name, of dictionary, each keyed by MarkerSet name and value being a list
+          of that MarkerSet's marker points)",
+          "task_link_markerset_dict"_a)
+      .def(
+          "get_task_link_markerset_points",
+          &MarkerSets::getTaskLinkMarkerSetPoints,
+          R"(Get the marker points for the specified TaskSet's specified LinkSet's specified MarkerSet
+           as a list of 3d points)",
+          "taskset_name"_a, "linkset_name"_a, "markerset_name"_a)
+      .def(
+          "get_task_linkset_points", &MarkerSets::getTaskLinkSetPoints,
+          R"(Get the points in all the MarkerSets of the specified LinkSet, in the
+          specified TaskSet, as a dictionary, keyed by each MarkerSet's name
+          and referencing a list of 3d points.)",
+          "taskset_name"_a, "linkset_name"_a)
 
-      .def("set_markerset_markers", &MarkerSets::setMarkerSetMarkers,
-           R"(Set the markers in all of the specified Markerset's link's subsets
-          to the values given by the dict of dicts. The data should be a dictionary, keyed by link
-          name, of dictionaries, keyed by subset name with the value being lists of points for that subset)",
-           "markerset_name"_a, "link_subset_marker_dict"_a)
       .def(
-          "set_all_markers", &MarkerSets::setAllMarkers,
-          R"(Set the marker points for every subset of every link of every MarkerSet present to the values in
-          the passed dict of dicts of dicts. The format should be dictionary, keyed by MarkerSet name, of dictionaries,
-          keyed by link name, of dictionary, each keyed by subset name and value being a list
-          of that subset's marker points)",
-          "markerset_link_subset_marker_dict"_a)
+          "get_taskset_points", &MarkerSets::getTaskSetPoints,
+          R"(Get all the marker points in the specified TaskSet as a dict of dicts.
+          The format is a dictionary keyed by LinkSet name, of dictionaries,
+          each keyed by MarkerSet name and referencing a list of 3d points)",
+          "taskset_name"_a)
       .def(
-          "get_markerset_link_subset_markers",
-          &MarkerSets::getMarkerSetLinkSetSubsetMarkers,
-          R"(Get the markers for the specified MarkerSet's specified link's specified subset
-           as a list of points)",
-          "markerset_name"_a, "linkset_name"_a, "subset_name"_a)
-      .def(
-          "get_markerset_link_markers", &MarkerSets::getMarkerSetLinkSetMarkers,
-          R"(Get the markers in all of the specified Markerset's specified link's subsets
-          as a dictionary of points, keyed by the link's subset name)",
-          "markerset_name"_a, "linkset_name"_a)
-
-      .def("get_markerset_markers", &MarkerSets::getMarkerSetMarkers,
-           R"(Get the markers in all of the specified Markerset's link's subsets
-          as a dict of dicts. The format is dictionary, keyed by link
-          name, of dictionaries, keyed by subset name with the value being the
-          subset's list of points)",
-           "markerset_name"_a)
-      .def(
-          "get_all_markers", &MarkerSets::getAllMarkers,
-          R"(Get the marker points for every subset of every link of every MarkerSet present as a dict
-          of dicts of dicts. The format is a dictionary, keyed by MarkerSet name, of dictionaries,
-          keyed by link name, of dictionary, each keyed by subset name and value being a list
-          of that subset's marker points)");
+          "get_all_marker_points", &MarkerSets::getAllMarkerPoints,
+          R"(Get the marker points for every MarkerSet of every link of every TaskSet present as a dict
+          of dicts of dicts. The format is a dictionary keyed by TaskSet name, of dictionaries,
+          keyed by LinkSet name, of dictionaries, each keyed by MarkerSet name referencing a list
+          of that MarkerSet's marker points)");
 
   // ==== ArticulatedObjectAttributes ====
   py::class_<ArticulatedObjectAttributes, AbstractAttributes,
              ArticulatedObjectAttributes::ptr>(
       m, "ArticulatedObjectAttributes",
-      R"(A metadata template for articulated object configurations. Can be imported from
+      R"(A metadata template for articulated object configurations. Is imported from
       .ao_config.json files.)")
       .def(py::init(&ArticulatedObjectAttributes::create<>))
       .def(py::init(&ArticulatedObjectAttributes::create<const std::string&>))
@@ -489,12 +495,15 @@ void initAttributesBindings(py::module& m) {
           "rolling_friction_coefficient",
           &AbstractObjectAttributes::getRollingFrictionCoefficient,
           &AbstractObjectAttributes::setRollingFrictionCoefficient,
-          R"(Rolling friction coefficient for constructions built from this template. Damps angular velocity about axis orthogonal to the contact normal to prevent rounded shapes from rolling forever.)")
+          R"(Rolling friction coefficient for constructions built from this template.
+          Damps angular velocity about axis orthogonal to the contact normal to
+          prevent rounded shapes from rolling forever.)")
       .def_property(
           "spinning_friction_coefficient",
           &AbstractObjectAttributes::getSpinningFrictionCoefficient,
           &AbstractObjectAttributes::setSpinningFrictionCoefficient,
-          R"(Spinning friction coefficient for constructions built from this template. Damps angular velocity about the contact normal.)")
+          R"(Spinning friction coefficient for constructions built from this template.
+          Damps angular velocity about the contact normal.)")
       .def_property(
           "restitution_coefficient",
           &AbstractObjectAttributes::getRestitutionCoefficient,
@@ -562,7 +571,7 @@ void initAttributesBindings(py::module& m) {
       m, "ObjectAttributes",
       R"(A metadata template for rigid objects pre-instantiation. Defines asset paths, physical
       properties, scale, semantic ids, shader type overrides, and user defined metadata.
-      ManagedRigidObjects are instantiated from these blueprints. Can be imported from
+      ManagedRigidObjects are instantiated from these blueprints. Is imported from
       .object_config.json files.)")
       .def(py::init(&ObjectAttributes::create<>))
       .def(py::init(&ObjectAttributes::create<const std::string&>))
@@ -614,7 +623,11 @@ void initAttributesBindings(py::module& m) {
   // ==== StageAttributes ====
   py::class_<StageAttributes, AbstractObjectAttributes, StageAttributes::ptr>(
       m, "StageAttributes",
-      R"(A metadata template for stages pre-instantiation. Defines asset paths, collision properties, gravity direction, shader type overrides, semantic asset information, and user defined metadata. Consumed to instantiate the static background of a scene (e.g. the building architecture). Can be imported from .stage_config.json files.)")
+      R"(A metadata template for stages pre-instantiation. Defines asset paths,
+      collision properties, gravity direction, shader type overrides, semantic
+      asset information, and user defined metadata. Consumed to instantiate the
+      static background of a scene (e.g. the building architecture).
+      Is imported from .stage_config.json files.)")
       .def(py::init(&StageAttributes::create<>))
       .def(py::init(&StageAttributes::create<const std::string&>))
       .def_property(
@@ -662,7 +675,8 @@ void initAttributesBindings(py::module& m) {
   py::class_<LightInstanceAttributes, AbstractAttributes,
              LightInstanceAttributes::ptr>(
       m, "LightInstanceAttributes",
-      R"(A metadata template for light configurations. Supports point and directional lights. Can be imported from .lighting_config.json files.)")
+      R"(A metadata template for light configurations. Supports point and directional lights.
+      Is imported from .lighting_config.json files.)")
       .def(py::init(&LightInstanceAttributes::create<>))
       .def(py::init(&LightInstanceAttributes::create<const std::string&>))
       .def_property(
@@ -701,7 +715,7 @@ void initAttributesBindings(py::module& m) {
       m, "PbrShaderAttributes",
       R"(A metadata template for PBR shader creation and control values and multipliers,
       such as enabling Image Based Lighting and controlling the mix of direct and indirect
-      lighting contributions. Can be imported from .pbr_config.json files.)")
+      lighting contributions. Is imported from .pbr_config.json files.)")
       .def(py::init(&PbrShaderAttributes::create<>))
       .def(py::init(&PbrShaderAttributes::create<const std::string&>))
       .def_property(
@@ -857,7 +871,7 @@ void initAttributesBindings(py::module& m) {
       m, "PhysicsManagerAttributes",
       R"(A metadata template for Simulation parameters (e.g. timestep, simulation backend,
       default gravity direction) and defaults. Consumed to instace a Simulator object.
-      Can be imported from .physics_config.json files.)")
+      Is imported from .physics_config.json files.)")
       .def(py::init(&PhysicsManagerAttributes::create<>))
       .def(py::init(&PhysicsManagerAttributes::create<const std::string&>))
       .def_property_readonly(

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -34,7 +34,7 @@ using Attrs::CylinderPrimitiveAttributes;
 using Attrs::IcospherePrimitiveAttributes;
 using Attrs::LightInstanceAttributes;
 using Attrs::LightLayoutAttributes;
-using Attrs::LinkMarkerSets;
+using Attrs::LinkMarkerSet;
 using Attrs::LinkMarkerSubset;
 using Attrs::MarkerSet;
 using Attrs::MarkerSets;
@@ -248,32 +248,32 @@ void initAttributesBindings(py::module& m) {
           R"(Set the markers for this subset to be the passed list of 3D points)",
           "markers"_a);
 
-  py::class_<LinkMarkerSets, LinkMarkerSets::ptr>(m, "LinkMarkerSets")
-      .def(py::init(&LinkMarkerSets::create<>))
+  py::class_<LinkMarkerSet, LinkMarkerSet::ptr>(m, "LinkMarkerSet")
+      .def(py::init(&LinkMarkerSet::create<>))
       .def_property_readonly(
-          "num_subsets", &LinkMarkerSets::getNumLinkSubsets,
+          "num_subsets", &LinkMarkerSet::getNumLinkSubsets,
           R"(The current number of marker subsets present in this link description.)")
       .def(
-          "has_named_subset", &LinkMarkerSets::hasNamedLinkSubset,
+          "has_named_subset", &LinkMarkerSet::hasNamedLinkSubset,
           R"(Whether or not this link has a marker subset with the given name)",
           "subset_name"_a)
-      .def("get_all_subset_names", &LinkMarkerSets::getAllLinkSubsetNames,
+      .def("get_all_subset_names", &LinkMarkerSet::getAllLinkSubsetNames,
            R"(Get a list of all the subset names associated with this link)")
-      .def("get_named_link_subset", &LinkMarkerSets::editNamedLinkSubset,
+      .def("get_named_subset", &LinkMarkerSet::editNamedLinkSubset,
            R"(Get an editable reference to the specified LinkMarkerSubset, or
           None if it does not exist.)",
            "subset_name"_a)
-      .def("set_subset_markers", &LinkMarkerSets::setLinkSubsetMarkers,
+      .def("set_subset_markers", &LinkMarkerSet::setLinkSubsetMarkers,
            R"(Sets the markers for this link's named subset)", "subset_name"_a,
            "marker_list"_a)
-      .def("get_subset_markers", &LinkMarkerSets::getLinkSubsetMarkers,
+      .def("get_subset_markers", &LinkMarkerSet::getLinkSubsetMarkers,
            R"(Gets the markers for the named subset of this link)",
            "subset_name"_a)
-      .def("set_all_markers", &LinkMarkerSets::setAllMarkers,
+      .def("set_all_markers", &LinkMarkerSet::setAllMarkers,
            R"(Sets the markers for all the subsets of this link to the
           passed dictionary of values, keyed by subset name)",
-           "subset_dict"_a)
-      .def("get_all_markers", &LinkMarkerSets::getAllMarkers,
+           "subset_marker_dict"_a)
+      .def("get_all_markers", &LinkMarkerSet::getAllMarkers,
            R"(Get a dictionary keyed by subset name where each value is a
             list of the marker points for that subset)");
 
@@ -281,12 +281,109 @@ void initAttributesBindings(py::module& m) {
       .def(py::init(&MarkerSet::create<>))
       .def_property_readonly(
           "num_link_sets", &MarkerSet::getNumLinkSets,
-          R"(The current number of per-link marker subsets present in this Markerset.)");
+          R"(The current number of per-link marker subsets present in this Markerset.)")
 
+      .def(
+          "has_named_link_set", &MarkerSet::hasNamedLinkSet,
+          R"(Whether or not this Markerset has a LinkMarkerSet with the given name)",
+          "linkset_name"_a)
+      .def(
+          "get_all_link_set_names", &MarkerSet::getAllLinkSetNames,
+          R"(Get a list of all the LinkMarkerSet names associated with this Markerset)")
+      .def("get_named_link_set", &MarkerSet::editNamedLinkSet,
+           R"(Get an editable reference to the specified LinkMarkerSet, or
+          None if it does not exist.)",
+           "linkset_name"_a)
+      .def(
+          "set_link_subset_markers", &MarkerSet::setLinkSetSubsetMarkers,
+          R"(Set the markers for the specified link's specified subset to the given list of points)",
+          "linkset_name"_a, "subset_name"_a, "marker_list"_a)
+      .def("set_all_link_markers", &MarkerSet::setLinkSetMarkers,
+           R"(Set the markers in each of the subsets for the specified link
+          to the given dictionary of points, keyed by the link's subset name)",
+           "linkset_name"_a, "subset_marker_dict"_a)
+      .def(
+          "set_all_markers", &MarkerSet::setAllMarkers,
+          R"(Set the marker points for every subset of every link in this markerset to the values in
+          the passed dict of dicts. The format should be dictionary keyed by link name of dictionaries,
+          each keyed by subset name for the particular link with the value being a list of points)",
+          "link_subset_marker_dict"_a)
+
+      .def(
+          "get_link_subset_markers", &MarkerSet::getLinkSetSubsetMarkers,
+          R"(Get the markers for the specified link's specified subset as a list of points)",
+          "linkset_name"_a, "subset_name"_a)
+      .def("get_all_link_markers", &MarkerSet::getLinkSetMarkers,
+           R"(Get the markers in each of the subsets for the specified link
+          as a dictionary of points, keyed by the link's subset name)",
+           "linkset_name"_a)
+      .def(
+          "get_all_markers", &MarkerSet::getAllMarkers,
+          R"(Get the marker points for every subset of every link in this markerset as a dict
+          of dicts. The format is a dictionary keyed by link name of dictionaries,
+          each keyed by subset name for the particular link with the value being a list
+          of the marker points)");
   py::class_<MarkerSets, MarkerSets::ptr>(m, "MarkerSets")
       .def(py::init(&MarkerSets::create<>))
       .def_property_readonly("num_marker_sets", &MarkerSets::getNumMarkerSets,
-                             R"(The current number of Markersets present.)");
+                             R"(The current number of Markersets present.)")
+      .def("has_named_marker_set", &MarkerSets::hasNamedMarkerSet,
+           R"(Whether or not a Markerset with the given name exists)",
+           "markerset_name"_a)
+      .def("get_all_marker_set_names", &MarkerSets::getAllMarkerSetNames,
+           R"(Get a list of all the existing MarkerSet names)")
+      .def("get_named_marker_set", &MarkerSets::editNamedMarkerSet,
+           R"(Get an editable reference to the specified MarkerSet, or
+          None if it does not exist.)",
+           "markerset_name"_a)
+      .def("set_markerset_link_subset_markers",
+           &MarkerSets::setMarkerSetLinkSetSubsetMarkers,
+           R"(Set the markers for the specified MarkerSet's specified link's
+          specified subset to the given list of points)",
+           "markerset_name"_a, "linkset_name"_a, "subset_name"_a,
+           "marker_list"_a)
+      .def(
+          "set_markerset_link_markers", &MarkerSets::setMarkerSetLinkSetMarkers,
+          R"(Set the markers in all of the specified Markerset's specified link's subsets
+          to the given dictionary of points, keyed by the link's subset name)",
+          "markerset_name"_a, "linkset_name"_a, "subset_marker_dict"_a)
+
+      .def("set_markerset_markers", &MarkerSets::setMarkerSetMarkers,
+           R"(Set the markers in all of the specified Markerset's link's subsets
+          to the values given by the dict of dicts. The data should be a dictionary, keyed by link
+          name, of dictionaries, keyed by subset name with the value being lists of points for that subset)",
+           "markerset_name"_a, "link_subset_marker_dict"_a)
+      .def(
+          "set_all_markers", &MarkerSets::setAllMarkers,
+          R"(Set the marker points for every subset of every link of every MarkerSet present to the values in
+          the passed dict of dicts of dicts. The format should be dictionary, keyed by MarkerSet name, of dictionaries,
+          keyed by link name, of dictionary, each keyed by subset name and value being a list
+          of that subset's marker points)",
+          "markerset_link_subset_marker_dict"_a)
+      .def(
+          "get_markerset_link_subset_markers",
+          &MarkerSets::getMarkerSetLinkSetSubsetMarkers,
+          R"(Get the markers for the specified MarkerSet's specified link's specified subset
+           as a list of points)",
+          "markerset_name"_a, "linkset_name"_a, "subset_name"_a)
+      .def(
+          "get_markerset_link_markers", &MarkerSets::getMarkerSetLinkSetMarkers,
+          R"(Get the markers in all of the specified Markerset's specified link's subsets
+          as a dictionary of points, keyed by the link's subset name)",
+          "markerset_name"_a, "linkset_name"_a)
+
+      .def("get_markerset_markers", &MarkerSets::getMarkerSetMarkers,
+           R"(Get the markers in all of the specified Markerset's link's subsets
+          as a dict of dicts. The format is dictionary, keyed by link
+          name, of dictionaries, keyed by subset name with the value being the
+          subset's list of points)",
+           "markerset_name"_a)
+      .def(
+          "get_all_markers", &MarkerSets::getAllMarkers,
+          R"(Get the marker points for every subset of every link of every MarkerSet present as a dict
+          of dicts of dicts. The format is a dictionary, keyed by MarkerSet name, of dictionaries,
+          keyed by link name, of dictionary, each keyed by subset name and value being a list
+          of that subset's marker points)");
 
   // ==== ArticulatedObjectAttributes ====
   py::class_<ArticulatedObjectAttributes, AbstractAttributes,

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -169,10 +169,10 @@ void initConfigBindings(py::module& m) {
           R"(Retrieves a string representation of the value referred to by the passed key.)")
 
       .def(
-          "get_keys_by_type", &Configuration::getStoredKeys,
+          "get_keys_by_type", &Configuration::getKeysByType,
           R"(Retrieves a list of all the keys of values of the specified types. Takes ConfigValType
-          enum value as argument.)",
-          "value_type"_a)
+          enum value as argument, and whether the keys should be sorted or not.)",
+          "value_type"_a, "sorted"_a = false)
 
       .def("get_keys_and_types", &Configuration::getValueTypes,
            R"(Returns a dictionary where the keys are the names of the values
@@ -202,7 +202,9 @@ void initConfigBindings(py::module& m) {
       // subconfigs
       .def(
           "get_subconfig_keys", &Configuration::getSubconfigKeys,
-          R"(Retrieves a list of the keys of this configuration's subconfigurations)")
+          R"(Retrieves a list of the keys of this configuration's subconfigurations,
+          specifying whether the keys should be sorted or not)",
+          "sorted"_a = false)
 
       .def("get_subconfig", &Configuration::editSubconfig<Configuration>,
            py::return_value_policy::reference_internal,

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -222,7 +222,8 @@ void initConfigBindings(py::module& m) {
           R"(Returns true if specified key references an existing subconfiguration within this configuration.)")
       .def(
           "remove_subconfig", &Configuration::removeSubconfig,
-          R"(Removes and returns subconfiguration corresponding to passed key, if found. Gives warning otherwise.)");
+          R"(Removes and returns subconfiguration corresponding to passed key, if found. Gives warning otherwise.)")
+      .def("__repr__", &Configuration::getAllValsAsString, "new_line"_a = "\n");
 
 }  // initConfigBindings
 

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -206,6 +206,7 @@ void declareBasePhysicsObjectWrapper(py::module& m,
               .c_str())
       .def_property_readonly(
           "marker_sets", &PhysObjWrapper::getMarkerSets,
+          py::return_value_policy::reference_internal,
           ("The MarkerSets defined for " + objType + " this object.").c_str())
 
       .def_property_readonly(

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -66,6 +66,20 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           ("Get or set the translation vector of this " + objType +
            "'s root SceneNode. If modified, sim state will be updated.")
               .c_str())
+      .def(
+          "transform_world_pts_to_local",
+          &PhysObjWrapper::transformWorldPointsToLocal,
+          R"(Given the list of passed points in world space, return those points
+          transformed to this object's local space. The link_id is for articulated
+          objects and is ignored for rigid objects and stages )",
+          "ws_points"_a, "link_id"_a)
+      .def(
+          "transform_local_pts_to_world",
+          &PhysObjWrapper::transformLocalPointsToWorld,
+          R"(Given the list of passed points in this object's local space, return
+          those points transformed to world space. The link_id is for articulated
+          objects and is ignored for rigid objects and stages )",
+          "ws_points"_a, "link_id"_a)
       .def_property(
           "rotation", &PhysObjWrapper::getRotation,
           &PhysObjWrapper::setRotation,
@@ -484,7 +498,7 @@ void declareArticulatedObjectWrapper(py::module& m,
                .c_str(),
            "link_id"_a)
       .def("get_link_name", &ManagedArticulatedObject::getLinkName,
-           ("Get the name of the this " + objType +
+           ("Get the name of this " + objType +
             "'s link specified by the given link_id.")
                .c_str(),
            "link_id"_a)

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -201,9 +201,13 @@ void declareBasePhysicsObjectWrapper(py::module& m,
       .def_property_readonly(
           "user_attributes", &PhysObjWrapper::getUserAttributes,
           ("User-defined " + objType +
-           " attributes.  These are not used internally by Habitat in any "
+           " attributes. These are not used internally by Habitat in any "
            "capacity, but are available for a user to consume how they wish.")
               .c_str())
+      .def_property_readonly(
+          "marker_sets", &PhysObjWrapper::getMarkerSets,
+          ("The MarkerSets defined for " + objType + " this object.").c_str())
+
       .def_property_readonly(
           "csv_info", &PhysObjWrapper::getObjectInfo,
           ("Comma-separated informational string describing this " + objType +

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -416,6 +416,13 @@ void declareArticulatedObjectWrapper(py::module& m,
                              ("Get a dict mapping Habitat object ids to this " +
                               objType + "'s link ids.")
                                  .c_str())
+      .def("get_link_id_from_name",
+           &ManagedArticulatedObject::getLinkIdFromName,
+           ("Get this " + objType +
+            "'s articulated link id specified by the passed "
+            "link_name.")
+               .c_str(),
+           "link_name"_a)
       .def_property_readonly(
           "num_links", &ManagedArticulatedObject::getNumLinks,
           ("Get the number of links this " + objType + " holds.").c_str())

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -364,7 +364,20 @@ void declareRigidObjectWrapper(py::module& m,
       .def_property_readonly(
           "creation_attributes",
           &ManagedRigidObject::getInitializationAttributes,
-          ("Get a copy of the attributes used to create this " + objType + ".")
+          ("Get a copy of the template attributes describing the initial state "
+           "of this " +
+           objType +
+           ". These attributes have the combination of date from the "
+           "original " +
+           objType +
+           " attributes and specific instance attributes "
+           "used to create this " +
+           objType +
+           ". Note : values will reflect "
+           "both sources, and should not be saved to disk as " +
+           objType +
+           " attributes, since instance attribute modifications will "
+           "still occur on subsequent loads.")
               .c_str())
       .def_property_readonly(
           "velocity_control", &ManagedRigidObject::getVelocityControl,
@@ -385,7 +398,20 @@ void declareArticulatedObjectWrapper(py::module& m,
       .def_property_readonly(
           "creation_attributes",
           &ManagedArticulatedObject::getInitializationAttributes,
-          ("Get a copy of the attributes used to create this " + objType + ".")
+          ("Get a copy of the template attributes describing the initial state "
+           "of this " +
+           objType +
+           ". These attributes have the combination of date from the "
+           "original " +
+           objType +
+           " attributes and specific instance attributes "
+           "used to create this " +
+           objType +
+           ". Note : values will reflect "
+           "both sources, and should not be saved to disk as " +
+           objType +
+           " attributes, since instance attribute modifications will "
+           "still occur on subsequent loads.")
               .c_str())
       .def_property_readonly(
           "global_scale", &ManagedArticulatedObject::getGlobalScale,

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -79,7 +79,7 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           R"(Given the list of passed points in this object's local space, return
           those points transformed to world space. The link_id is for articulated
           objects and is ignored for rigid objects and stages )",
-          "ws_points"_a, "link_id"_a)
+          "ls_points"_a, "link_id"_a)
       .def_property(
           "rotation", &PhysObjWrapper::getRotation,
           &PhysObjWrapper::setRotation,
@@ -367,7 +367,7 @@ void declareRigidObjectWrapper(py::module& m,
           ("Get a copy of the template attributes describing the initial state "
            "of this " +
            objType +
-           ". These attributes have the combination of date from the "
+           ". These attributes have the combination of data from the "
            "original " +
            objType +
            " attributes and specific instance attributes "
@@ -401,7 +401,7 @@ void declareArticulatedObjectWrapper(py::module& m,
           ("Get a copy of the template attributes describing the initial state "
            "of this " +
            objType +
-           ". These attributes have the combination of date from the "
+           ". These attributes have the combination of data from the "
            "original " +
            objType +
            " attributes and specific instance attributes "

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -496,7 +496,7 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
 
         for (size_t i = 0; i < jsonObj.Size(); ++i) {
           const std::string subKey =
-              Cr::Utility::formatString("{}_{:.02d}", key, i);
+              Cr::Utility::formatString("{}_{:.03d}", key, i);
           numConfigSettings += subGroupPtr->loadOneConfigFromJson(
               numConfigSettings, subKey, jsonObj[i]);
         }
@@ -511,7 +511,7 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
 
       for (size_t i = 0; i < jsonObj.Size(); ++i) {
         const std::string subKey =
-            Cr::Utility::formatString("{}_{:.02d}", key, i);
+            Cr::Utility::formatString("{}_{:.03d}", key, i);
         numConfigSettings += subGroupPtr->loadOneConfigFromJson(
             numConfigSettings, subKey, jsonObj[i]);
       }
@@ -662,7 +662,7 @@ int Configuration::rekeyAllValues() {
   // Get all sorted key-value pairs of values
   std::map<std::string, ConfigValue> sortedValMap(valueMap_.begin(),
                                                   valueMap_.end());
-  // clear out existing value map
+  // clear out existing value map - subconfigs are not touched.
   valueMap_.clear();
   // place sorted values with newly constructed keys
   int keyIter = 0;

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -648,7 +648,7 @@ template <>
 std::shared_ptr<Configuration> Configuration::editSubconfig<Configuration>(
     const std::string& name) {
   // retrieve existing (or create new) subgroup, with passed name
-  return addOrEditSubgroup(name).first->second;
+  return addOrEditSubgroup<Configuration>(name).first->second;
 }
 
 template <>
@@ -675,7 +675,7 @@ int Configuration::rekeyAllValues() {
 
 int Configuration::rekeySubconfigValues(const std::string& subconfigKey) {
   std::pair<ConfigMapType::iterator, bool> rekeySubconfigEntry =
-      addOrEditSubgroup(subconfigKey);
+      addOrEditSubgroup<Configuration>(subconfigKey);
   // check if subconfig existed already - result from addOrEditSubgroup would
   // be false if add failed.
   if (rekeySubconfigEntry.second) {

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -576,10 +576,10 @@ void Configuration::writeValuesToJson(io::JsonGenericValue& jsonObj,
       auto jsonVal = valIter->second.writeToJsonObject(allocator);
       jsonObj.AddMember(name, jsonVal, allocator);
     } else {
-      ESP_VERY_VERBOSE()
-          << "Unitialized ConfigValue in Configuration @ key ["
+      ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+          << "Unitialized ConfigValue in Configuration @ key `"
           << valIter->first
-          << "], so nothing will be written to JSON for this key.";
+          << "`, so nothing will be written to JSON for this key.";
     }
   }  // iterate through all values
 }  // Configuration::writeValuesToJson
@@ -600,10 +600,10 @@ void Configuration::writeSubconfigsToJson(io::JsonGenericValue& jsonObj,
           cfgIter->second->writeToJsonObject(allocator);
       jsonObj.AddMember(name, subObj, allocator);
     } else {
-      ESP_VERY_VERBOSE()
-          << "Unitialized/empty Subconfig in Configuration @ key ["
+      ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+          << "Unitialized/empty Subconfig in Configuration @ key `"
           << cfgIter->first
-          << "], so nothing will be written to JSON for this key.";
+          << "`, so nothing will be written to JSON for this key.";
     }
   }  // iterate through all configurations
 
@@ -648,7 +648,7 @@ template <>
 std::shared_ptr<Configuration> Configuration::editSubconfig<Configuration>(
     const std::string& name) {
   // retrieve existing (or create new) subgroup, with passed name
-  return addSubgroup(name);
+  return addOrEditSubgroup(name).first->second;
 }
 
 template <>
@@ -656,7 +656,50 @@ void Configuration::setSubconfigPtr<Configuration>(
     const std::string& name,
     std::shared_ptr<Configuration>& configPtr) {
   configMap_[name] = std::move(configPtr);
-}  // setSubconfigPtr
+}
+
+int Configuration::rekeyAllValues() {
+  // Get all sorted key-value pairs of values
+  std::map<std::string, ConfigValue> sortedValMap(valueMap_.begin(),
+                                                  valueMap_.end());
+  // clear out existing value map
+  valueMap_.clear();
+  // place sorted values with newly constructed keys
+  int keyIter = 0;
+  for (auto it = sortedValMap.cbegin(); it != sortedValMap.cend(); ++it) {
+    std::string newKey = Cr::Utility::formatString("{:.03d}", keyIter++);
+    valueMap_[newKey] = it->second;
+  }
+  return keyIter;
+}  // Configuration::rekeyAllValues()
+
+int Configuration::rekeySubconfigValues(const std::string& subconfigKey) {
+  std::pair<ConfigMapType::iterator, bool> rekeySubconfigEntry =
+      addOrEditSubgroup(subconfigKey);
+  // check if subconfig existed already - result from addOrEditSubgroup would
+  // be false if add failed.
+  if (rekeySubconfigEntry.second) {
+    // Subconfig did not exist, was created by addOrEdit, so delete and return
+    // 0.
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "No subconfig found with key `" << subconfigKey
+        << "` so rekeying aborted.";
+    configMap_.erase(rekeySubconfigEntry.first);
+    return 0;
+  }
+  // retrieve subconfig
+  auto rekeySubconfig = rekeySubconfigEntry.first->second;
+  if (rekeySubconfig->getNumValues() == 0) {
+    // Subconfig exists but has no values defined, so no rekeying possible
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Subconfig with key `" << subconfigKey
+        << "` has no values, so no rekeying accomplished.";
+    return 0;
+  }
+  // rekey subconfig and return the number of values affected
+  return rekeySubconfig->rekeyAllValues();
+
+}  // Configuration::rekeySubconfig
 
 int Configuration::findValueInternal(const Configuration& config,
                                      const std::string& key,

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -879,7 +879,8 @@ class Configuration {
                   "Configuration : Desired subconfig must be derived from "
                   "core::config::Configuration");
     // retrieve existing (or create new) subgroup, with passed name
-    return std::static_pointer_cast<T>(addOrEditSubgroup(name).first->second);
+    return std::static_pointer_cast<T>(
+        addOrEditSubgroup<T>(name).first->second);
   }
 
   /**
@@ -967,7 +968,7 @@ class Configuration {
     for (const auto& subConfig : src->configMap_) {
       const auto name = subConfig.first;
       // make if DNE and merge src subconfig
-      addOrEditSubgroup(name).first->second->overwriteWithConfig(
+      addOrEditSubgroup<Configuration>(name).first->second->overwriteWithConfig(
           subConfig.second);
     }
   }
@@ -1141,15 +1142,18 @@ class Configuration {
    * Configuration, and a boolean value that denotes whether this is a new
    * Configuration or it existed already.
    */
-
+  template <typename T>
   std::pair<ConfigMapType::iterator, bool> addOrEditSubgroup(
       const std::string& name) {
+    static_assert(std::is_base_of<Configuration, T>::value,
+                  "Configuration : Desired subconfig must be derived from "
+                  "core::config::Configuration");
     // Attempt to insert an empty pointer
-    auto result = configMap_.emplace(name, std::shared_ptr<Configuration>{});
+    auto result = configMap_.emplace(name, std::shared_ptr<T>{});
     // If name not already present (insert succeeded) then add new
     // configuration
     if (result.second) {
-      result.first->second = std::make_shared<Configuration>();
+      result.first->second = std::make_shared<T>();
     }
     return result;
   }

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -1078,6 +1078,11 @@ class Configuration {
    */
   int rekeyAllValues();
 
+  /**
+   * @brief Clear all key-value pairs from this Configuration's valueMap
+   */
+  void _clearAllValues() { valueMap_.clear(); }
+
  protected:
   /**
    * @brief Process passed json object into this Configuration, using passed

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   attributes/ArticulatedObjectAttributes.cpp
   attributes/LightLayoutAttributes.h
   attributes/LightLayoutAttributes.cpp
+  attributes/MarkerSets.h
   attributes/ObjectAttributes.h
   attributes/ObjectAttributes.cpp
   attributes/PhysicsManagerAttributes.h

--- a/src/esp/metadata/URDFParser.cpp
+++ b/src/esp/metadata/URDFParser.cpp
@@ -839,7 +839,7 @@ bool Parser::validateMeshFile(std::string& meshFilename) {
 bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
   // every link has children links and joints, but no parents, so we create a
   // local convenience data structure for keeping child->parent relations
-  std::map<std::string, std::string> parentLinkTree;
+  model->m_parentLinkTree.clear();
 
   // loop through all joints, for every link, assign children links and children
   // joints
@@ -875,7 +875,7 @@ bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
     childLink->m_parentJoint = joint;
     parentLink->m_childJoints.push_back(joint);
     parentLink->m_childLinks.push_back(childLink);
-    parentLinkTree[childLink->m_name] = parentLink->m_name;
+    model->m_parentLinkTree[childLink->m_name] = parentLink->m_name;
   }
 
   // search for children that have no parent, those are 'root'

--- a/src/esp/metadata/URDFParser.cpp
+++ b/src/esp/metadata/URDFParser.cpp
@@ -838,7 +838,7 @@ bool Parser::validateMeshFile(std::string& meshFilename) {
 
 bool Parser::initTreeAndRoot(const std::shared_ptr<Model>& model) const {
   // every link has children links and joints, but no parents, so we create a
-  // local convenience data structure for keeping child->parent relations
+  // convenience data structure in the model for keeping child->parent relations
   model->m_parentLinkTree.clear();
 
   // loop through all joints, for every link, assign children links and children

--- a/src/esp/metadata/URDFParser.h
+++ b/src/esp/metadata/URDFParser.h
@@ -285,6 +285,9 @@ class Model {
   //! list of root links (usually 1)
   std::vector<std::shared_ptr<Link>> m_rootLinks;
 
+  //! Keyed by child link name, provides reference to parent link
+  std::map<std::string, std::string> m_parentLinkTree{};
+
   //! if true, force this model to produce a fixed base instance (e.g. the root
   //! is not dynamic)
   bool m_overrideFixedBase{false};

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
@@ -33,6 +33,8 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setUnitsToMeters(1.0);
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
+  // set up an existing subgroup for marker_sets attributes
+  addOrEditSubgroup("marker_sets");
 }  // AbstractObjectAttributes ctor
 
 std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
@@ -34,7 +34,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   setRenderAssetHandle("");
   setCollisionAssetHandle("");
   // set up an existing subgroup for marker_sets attributes
-  addOrEditSubgroup("marker_sets");
+  addOrEditSubgroup<MarkerSets>("marker_sets");
 }  // AbstractObjectAttributes ctor
 
 std::string AbstractObjectAttributes::getObjectInfoHeaderInternal() const {

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -281,6 +281,15 @@ class AbstractObjectAttributes : public AbstractAttributes {
     return editSubconfig<MarkerSets>("marker_sets");
   }
 
+  /**
+   * @brief Rekey all the markers in the marker_sets subconfiguration such that
+   * each point is keyed by a sequential numeric string that preserves the
+   * natural ordering of the key strings.
+   */
+  int rekeyAllMarkerSets() {
+    return editSubconfig<MarkerSets>("marker_sets")->rekeyAllMarkers();
+  }
+
  protected:
   /**
    * @brief Whether to use the specified orientation frame for all orientation

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -6,6 +6,7 @@
 #define ESP_METADATA_ATTRIBUTES_ABSTRACTOBJECTATTRIBUTES_H_
 
 #include "AttributesBase.h"
+#include "MarkerSets.h"
 
 namespace esp {
 namespace metadata {
@@ -267,8 +268,8 @@ class AbstractObjectAttributes : public AbstractAttributes {
    * @brief Gets a smart pointer reference to a copy of the marker_sets
    * configuration data from config file.
    */
-  std::shared_ptr<Configuration> getMarkerSetsConfiguration() const {
-    return getSubconfigCopy<Configuration>("marker_sets");
+  std::shared_ptr<MarkerSets> getMarkerSetsConfiguration() const {
+    return getSubconfigCopy<MarkerSets>("marker_sets");
   }
 
   /**
@@ -276,8 +277,8 @@ class AbstractObjectAttributes : public AbstractAttributes {
    * configuration data from config file. This method is for editing the
    * configuration.
    */
-  std::shared_ptr<Configuration> editMarkerSetsConfiguration() {
-    return editSubconfig<Configuration>("marker_sets");
+  std::shared_ptr<MarkerSets> editMarkerSetsConfiguration() {
+    return editSubconfig<MarkerSets>("marker_sets");
   }
 
  protected:

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
@@ -30,7 +30,8 @@ ArticulatedObjectAttributes::ArticulatedObjectAttributes(
 
   setUniformScale(1.0f);
   setMassScale(1.0);
-
+  // set up an existing subgroup for marker_sets attributes
+  addOrEditSubgroup("marker_sets");
 }  // ArticulatedObjectAttributes ctor
 
 void ArticulatedObjectAttributes::writeValuesToJson(

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
@@ -31,7 +31,7 @@ ArticulatedObjectAttributes::ArticulatedObjectAttributes(
   setUniformScale(1.0f);
   setMassScale(1.0);
   // set up an existing subgroup for marker_sets attributes
-  addOrEditSubgroup("marker_sets");
+  addOrEditSubgroup<MarkerSets>("marker_sets");
 }  // ArticulatedObjectAttributes ctor
 
 void ArticulatedObjectAttributes::writeValuesToJson(

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -6,6 +6,7 @@
 #define ESP_METADATA_ATTRIBUTES_ARTICULATEDOBJECTATTRIBUTES_H_
 
 #include "AttributesBase.h"
+#include "MarkerSets.h"
 
 namespace esp {
 namespace metadata {
@@ -254,8 +255,8 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
    * @brief Gets a smart pointer reference to a copy of the marker_sets
    * configuration data from config file.
    */
-  std::shared_ptr<Configuration> getMarkerSetsConfiguration() const {
-    return getSubconfigCopy<Configuration>("marker_sets");
+  std::shared_ptr<MarkerSets> getMarkerSetsConfiguration() const {
+    return getSubconfigCopy<MarkerSets>("marker_sets");
   }
 
   /**
@@ -263,8 +264,8 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
    * configuration data from config file. This method is for editing the
    * configuration.
    */
-  std::shared_ptr<Configuration> editMarkerSetsConfiguration() {
-    return editSubconfig<Configuration>("marker_sets");
+  std::shared_ptr<MarkerSets> editMarkerSetsConfiguration() {
+    return editSubconfig<MarkerSets>("marker_sets");
   }
 
  protected:

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -267,6 +267,14 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
   std::shared_ptr<MarkerSets> editMarkerSetsConfiguration() {
     return editSubconfig<MarkerSets>("marker_sets");
   }
+  /**
+   * @brief Rekey all the markers in the marker_sets subconfiguration such that
+   * each point is keyed by a sequential numeric string that preserves the
+   * natural ordering of the key strings.
+   */
+  int rekeyAllMarkerSets() {
+    return editSubconfig<MarkerSets>("marker_sets")->rekeyAllMarkers();
+  }
 
  protected:
   /**

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -31,7 +31,7 @@ AbstractAttributes::AbstractAttributes(const std::string& attributesClassKey,
                                        const std::string& handle)
     : Configuration() {
   // set up an existing subgroup for user_defined attributes
-  addSubgroup("user_defined");
+  addOrEditSubgroup("user_defined");
   AbstractAttributes::setClassKey(attributesClassKey);
   AbstractAttributes::setHandle(handle);
   // set initial vals, will be overwritten when registered

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -31,7 +31,7 @@ AbstractAttributes::AbstractAttributes(const std::string& attributesClassKey,
                                        const std::string& handle)
     : Configuration() {
   // set up an existing subgroup for user_defined attributes
-  addOrEditSubgroup("user_defined");
+  addOrEditSubgroup<Configuration>("user_defined");
   AbstractAttributes::setClassKey(attributesClassKey);
   AbstractAttributes::setHandle(handle);
   // set initial vals, will be overwritten when registered

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -41,7 +41,7 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
     std::vector<Mn::Vector3> res;
     res.reserve(markerTags.size());
     for (const auto& tag : markerTags) {
-      res.emplace_back(std::move(markersPtr->get<Mn::Vector3>(tag)));
+      res.emplace_back(markersPtr->get<Mn::Vector3>(tag));
     }
     return res;
   }

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -52,7 +52,7 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
   void setMarkers(const std::vector<Mn::Vector3>& markers) {
     auto markersPtr = editSubconfig<Configuration>("markers");
     for (std::size_t i = 0; i < markers.size(); ++i) {
-      const std::string key = Cr::Utility::formatString("{:.03d}", i);
+      const std::string& key = Cr::Utility::formatString("{:.03d}", i);
       markersPtr->set(key, markers[i]);
     }
   }
@@ -172,7 +172,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
     std::unordered_map<std::string, std::vector<Mn::Vector3>> resMap;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      resMap[key] = std::move(getLinkSubsetMarkers(key));
+      resMap[key] = getLinkSubsetMarkers(key);
     }
     return resMap;
   }  // getAllMarkers
@@ -183,7 +183,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * link's marker subsets.
    */
   int rekeyAllMarkers() {
-    int res;
+    int res = 0;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
       res += editNamedLinkSubset(key)->rekeyAllMarkers();
@@ -268,7 +268,7 @@ class MarkerSet : public esp::core::config::Configuration {
    * @brief Set a specified link's specified subset's markers.
    */
   void setLinkSubsetMarkers(const std::string& linkSetName,
-                            const std::string linkSubsetName,
+                            const std::string& linkSubsetName,
                             const std::vector<Mn::Vector3>& markers) {
     editNamedLinkSets(linkSetName)
         ->setLinkSubsetMarkers(linkSubsetName, markers);
@@ -293,7 +293,6 @@ class MarkerSet : public esp::core::config::Configuration {
                      std::string,
                      std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
                          markerMap) {
-    const auto& subsetKeys = getSubconfigKeys();
     for (const auto& markers : markerMap) {
       setLinkSetMarkers(markers.first, markers.second);
     }
@@ -329,7 +328,7 @@ class MarkerSet : public esp::core::config::Configuration {
         resMap;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& linkName : subsetKeys) {
-      resMap[linkName] = std::move(getLinkSetMarkers(linkName));
+      resMap[linkName] = getLinkSetMarkers(linkName);
     }
     return resMap;
   }  // getAllMarkers
@@ -340,7 +339,7 @@ class MarkerSet : public esp::core::config::Configuration {
    * markerset.
    */
   int rekeyAllMarkers() {
-    int res;
+    int res = 0;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
       res += editNamedLinkSets(key)->rekeyAllMarkers();
@@ -425,7 +424,7 @@ class MarkerSets : public esp::core::config::Configuration {
    */
   void setMarkerSetLinkSubsetMarkers(const std::string& markerSetName,
                                      const std::string& linkSetName,
-                                     const std::string linkSubsetName,
+                                     const std::string& linkSubsetName,
                                      const std::vector<Mn::Vector3>& markers) {
     editNamedMarkerSet(markerSetName)
         ->setLinkSubsetMarkers(linkSetName, linkSubsetName, markers);
@@ -518,7 +517,7 @@ class MarkerSets : public esp::core::config::Configuration {
         resMap;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& markerSetName : subsetKeys) {
-      resMap[markerSetName] = std::move(getMarkerSetMarkers(markerSetName));
+      resMap[markerSetName] = getMarkerSetMarkers(markerSetName);
     }
     return resMap;
   }  // getAllMarkers
@@ -528,7 +527,7 @@ class MarkerSets : public esp::core::config::Configuration {
    * @return returns how many markers have been processed with new keys.
    */
   int rekeyAllMarkers() {
-    int res;
+    int res = 0;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
       res += editNamedMarkerSet(key)->rekeyAllMarkers();

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -109,6 +109,16 @@ class LinkMarkerSets : public esp::core::config::Configuration {
   }
 
   /**
+   * @brief Retrieve a view of the naamed LinkMarkerSubset, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkMarkerSubset::cptr getNamedLinkMarkerSubsetView(
+      const std::string& linkSubsetName) const {
+    return std::static_pointer_cast<const LinkMarkerSubset>(
+        getSubconfigView(linkSubsetName));
+  }
+
+  /**
    * @brief Retrieves a reference to a (potentially newly created)
    * LinkMarkerSubset with the given @p linkSubsetName , which can be modified
    * and the modifications will be retained.
@@ -127,6 +137,47 @@ class LinkMarkerSets : public esp::core::config::Configuration {
   void removeNamedMarkerSet(const std::string& linkSubsetName) {
     removeSubconfig(linkSubsetName);
   }
+
+  /**
+   * @brief Set the specified name's subset markers to the given marker values.
+   */
+  void setLinkSubsetMarkers(const std::string& linkSubsetName,
+                            const std::vector<Mn::Vector3>& markers) {
+    editNamedLinkMarkerSubset(linkSubsetName)->setMarkers(markers);
+  }
+
+  /**
+   * @brief Set the markers of all the subsets specified by name in the passed
+   * map.
+   */
+  void setAllMarkers(
+      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
+          markerMap) {
+    for (const auto& markers : markerMap) {
+      setLinkSubsetMarkers(markers.first, markers.second);
+    }
+  }
+
+  /**
+   * @brief Retrieve all the markers for the named link subset for this link
+   */
+  std::vector<Mn::Vector3> getLinkSubsetMarkers(const std::string& key) const {
+    return getNamedLinkMarkerSubsetView(key)->getMarkers();
+  }
+
+  /**
+   * @brief this retrieves all the markers across all subests for this link
+   */
+  std::unordered_map<std::string, std::vector<Mn::Vector3>> getAllMarkers()
+      const {
+    std::unordered_map<std::string, std::vector<Mn::Vector3>> resMap;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      resMap[key] = std::move(getLinkSubsetMarkers(key));
+    }
+    return resMap;
+  }  // getAllMarkers
+
   /**
    * @brief Rekeys all marker collections to have vector IDXs as string keys
    * @return returns how many markers have been processed with new keys in this
@@ -186,6 +237,16 @@ class MarkerSet : public esp::core::config::Configuration {
   }
 
   /**
+   * @brief Retrieve a view of the naamed LinkMarkerSet, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkMarkerSets::cptr getNamedLinkMarkerSetsView(
+      const std::string& linkSetName) const {
+    return std::static_pointer_cast<const LinkMarkerSets>(
+        getSubconfigView(linkSetName));
+  }
+
+  /**
    * @brief Retrieves a reference to a (potentially newly created)
    * LinkMarkerSets with the given @p linkSetName , which can be modified and
    * the modifications will be retained.
@@ -203,6 +264,76 @@ class MarkerSet : public esp::core::config::Configuration {
   void removeNamedMarkerSet(const std::string& linkSetName) {
     removeSubconfig(linkSetName);
   }
+
+  /**
+   * @brief Set a specified link's specified subset's markers.
+   */
+  void setLinkSubsetMarkers(const std::string& linkSetName,
+                            const std::string linkSubsetName,
+                            const std::vector<Mn::Vector3>& markers) {
+    editNamedLinkMarkerSets(linkSetName)
+        ->setLinkSubsetMarkers(linkSubsetName, markers);
+  }
+
+  /**
+   * @brief Sets all the specified name's link markers to the given marker
+   * values specified by the link subset name.
+   */
+  void setLinkSetMarkers(
+      const std::string& linkSetName,
+      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
+          markers) {
+    editNamedLinkMarkerSets(linkSetName)->setAllMarkers(markers);
+  }
+
+  /**
+   * @brief Set the markers of all the links specified by name in the passed
+   * map.
+   */
+  void setAllMarkers(const std::unordered_map<
+                     std::string,
+                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
+                         markerMap) {
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& markers : markerMap) {
+      setLinkSetMarkers(markers.first, markers.second);
+    }
+  }
+
+  /**
+   * @brief Get the markers for a specified link's specified subset.
+   */
+  std::vector<Mn::Vector3> getLinkSubsetMarkers(
+      const std::string& linkName,
+      const std::string& linkSubsetName) const {
+    return getNamedLinkMarkerSetsView(linkName)->getLinkSubsetMarkers(
+        linkSubsetName);
+  }
+
+  /**
+   * @brief Retrieve all the markers for the named link within this markerset
+   */
+  std::unordered_map<std::string, std::vector<Mn::Vector3>> getLinkSetMarkers(
+      const std::string& linkName) const {
+    return getNamedLinkMarkerSetsView(linkName)->getAllMarkers();
+  }
+
+  /**
+   * @brief this retrieves all the markers for across all links in this
+   * markerset
+   */
+  std::unordered_map<std::string,
+                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>
+  getAllMarkers() const {
+    std::unordered_map<
+        std::string, std::unordered_map<std::string, std::vector<Mn::Vector3>>>
+        resMap;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& linkName : subsetKeys) {
+      resMap[linkName] = std::move(getLinkSetMarkers(linkName));
+    }
+    return resMap;
+  }  // getAllMarkers
 
   /**
    * @brief Rekeys all marker collections to have vector IDXs as string keys
@@ -261,6 +392,16 @@ class MarkerSets : public esp::core::config::Configuration {
   }
 
   /**
+   * @brief Retrieve a view of the naamed MarkerSet, if it exists, and
+   * nullptr if it does not.
+   */
+  MarkerSet::cptr getNamedMarkerSetView(
+      const std::string& markerSetName) const {
+    return std::static_pointer_cast<const MarkerSet>(
+        getSubconfigView(markerSetName));
+  }
+
+  /**
    * @brief Retrieves a reference to a (potentially newly created) MarkerSet
    * with the given @p markerSetName , which can be modified and the
    * modifications will be retained.
@@ -278,6 +419,110 @@ class MarkerSets : public esp::core::config::Configuration {
   void removeNamedMarkerSet(const std::string& markerSetName) {
     removeSubconfig(markerSetName);
   }
+
+  /**
+   * @brief Set a specified MarkerSet's specified link's specified subset's
+   * markers.
+   */
+  void setMarkerSetLinkSubsetMarkers(const std::string& markerSetName,
+                                     const std::string& linkSetName,
+                                     const std::string linkSubsetName,
+                                     const std::vector<Mn::Vector3>& markers) {
+    editNamedMarkerSet(markerSetName)
+        ->setLinkSubsetMarkers(linkSetName, linkSubsetName, markers);
+  }
+
+  /**
+   * @brief Sets all the specified marker's specified link's subsets' markers to
+   * the given marker values specified in the map.
+   */
+  void setMarkerSetLinkSetMarkers(
+      const std::string& markerSetName,
+      const std::string& linkSetName,
+      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
+          markers) {
+    editNamedMarkerSet(markerSetName)->setLinkSetMarkers(linkSetName, markers);
+  }
+
+  /**
+   * @brief Sets all the specified MarkerSet's links' subset markers to the
+   * given marker values specified in the map.
+   */
+  void setMarkerSetMarkers(
+      const std::string& markerSetName,
+      const std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>& markers) {
+    editNamedMarkerSet(markerSetName)->setAllMarkers(markers);
+  }
+
+  /**
+   * @brief Set the markers of all the links specified by name in the passed
+   * map.
+   */
+  void setAllMarkers(
+      const std::unordered_map<
+          std::string,
+          std::unordered_map<
+              std::string,
+              std::unordered_map<std::string, std::vector<Mn::Vector3>>>>&
+          markerMap) {
+    for (const auto& markers : markerMap) {
+      setMarkerSetMarkers(markers.first, markers.second);
+    }
+  }
+
+  /**
+   * @brief Return a single MarkerSet's Link's Subset of markers
+   */
+  std::vector<Mn::Vector3> getMarkerSetLinkSubsetMarkers(
+      const std::string& markerSetName,
+      const std::string& linkSetName,
+      const std::string& linkSubsetName) const {
+    return getNamedMarkerSetView(markerSetName)
+        ->getLinkSubsetMarkers(linkSetName, linkSubsetName);
+  }
+  /**
+   * @brief Return all of a MarkerSet's Link's Subsets of markers
+   */
+
+  std::unordered_map<std::string, std::vector<Mn::Vector3>>
+  getMarkerSetLinkSetMarkers(const std::string& markerSetName,
+                             const std::string& linkSetName) const {
+    return getNamedMarkerSetView(markerSetName)->getLinkSetMarkers(linkSetName);
+  }
+
+  /**
+   * @brief Retrieve all the markers for the named markerset
+   */
+  std::unordered_map<std::string,
+                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>
+  getMarkerSetMarkers(const std::string& markerSetName) const {
+    return getNamedMarkerSetView(markerSetName)->getAllMarkers();
+  }
+
+  /**
+   * @brief this retrieves all the markers across all the markersets, keyed by
+   * MarkerSet name, Link Id and Link subset name
+   */
+  std::unordered_map<
+      std::string,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
+  getAllMarkers() const {
+    std::unordered_map<
+        std::string,
+        std::unordered_map<
+            std::string,
+            std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
+        resMap;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& markerSetName : subsetKeys) {
+      resMap[markerSetName] = std::move(getMarkerSetMarkers(markerSetName));
+    }
+    return resMap;
+  }  // getAllMarkers
 
   /**
    * @brief Rekeys all marker collections to have vector IDXs as string keys

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -31,48 +31,13 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief whether the given @p markerName exists as a marker in
-   * this LinkMarkerSubset.
-   *
-   * @param markerName The desired marker set's name.
-   * @return whether the name is found as a marker value.
-   */
-  bool hasNamedMarker(const std::string& markerName) const {
-    return getSubconfigView("markers")->hasValue(markerName);
-  }
-
-  /**
-   * @brief Retrieve the marker point specified by the given @p markerName
-   */
-  Mn::Vector3 getNamedMarker(const std::string& markerName) const {
-    return getSubconfigView("markers")->get<Mn::Vector3>(markerName);
-  }
-
-  /**
-   * @brief Adds passed marker. Uses naming convention from load - key for this
-   * marker will be "markers_{numCurrentMarkers}"
-   */
-  void addMarker(const Magnum::Vector3& marker) {
-    auto markersPtr = editSubconfig<Configuration>("markers");
-    const std::string markerKey = Cr::Utility::formatString(
-        "markers_{:.02d}", markersPtr->getNumValues());
-    markersPtr->set(markerKey, marker);
-  }
-
-  /**
-   * @brief Retrieve a listing of all the marker handles in this
-   * LinkMarkerSubset.
-   */
-  std::vector<std::string> getAllMarkerNames() const {
-    return getSubconfigView("markers")->getKeys();
-  }
-
-  /**
    * @brief Returns a list of all markers in this LinkMarkerSubset
    */
-  std::vector<Mn::Vector3> getAllMarkers() const {
+  std::vector<Mn::Vector3> getMarkers() const {
     const auto markersPtr = getSubconfigView("markers");
     std::vector<std::string> markerTags = markersPtr->getKeys();
+    // Sort the keys
+    std::sort(markerTags.begin(), markerTags.end());
     std::vector<Mn::Vector3> res;
     res.reserve(markerTags.size());
     for (const auto& tag : markerTags) {
@@ -82,11 +47,14 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Remove a named marker.
+   * @brief Set the list of marker points
    */
-  Mn::Vector3 removeMarker(const std::string& markerKey) {
-    return editSubconfig<Configuration>("markers")->remove<Mn::Vector3>(
-        markerKey);
+  void setMarkers(const std::vector<Mn::Vector3>& markers) {
+    auto markersPtr = editSubconfig<Configuration>("markers");
+    for (std::size_t i = 0; i < markers.size(); ++i) {
+      const std::string key = Cr::Utility::formatString("{:.03d}", i);
+      markersPtr->set(key, markers[i]);
+    }
   }
 
   ESP_SMART_POINTERS(LinkMarkerSubset)

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -11,29 +11,29 @@ namespace metadata {
 namespace attributes {
 /** @file
  * @brief Class @ref esp::metadata::attributes::Markersets,
- * Class @ref esp::metadata::attributes::MarkerSet,
- * Class @ref esp::metadata::attributes::LinkMarkerSet,
- * Class @ref esp::metadata::attributes::LinkMarkerSubset
+ * Class @ref esp::metadata::attributes::TaskSet,
+ * Class @ref esp::metadata::attributes::LinkSet,
+ * Class @ref esp::metadata::attributes::MarkerSet
  */
 
 /**
- * @brief This class provides an alias for a single configuration holding 1 or
- * more marker points for a particular link.
+ * @brief This class provides an alias for a single Configuration holding 1 or
+ * more marker points within a particular LinkSet.
  */
-class LinkMarkerSubset : public esp::core::config::Configuration {
+class MarkerSet : public esp::core::config::Configuration {
  public:
-  LinkMarkerSubset() : Configuration() {}
+  MarkerSet() : Configuration() {}
   /**
-   * @brief Returns the number of existing markers in this LinkMarkerSubset.
+   * @brief Returns the number of existing marker points in this MarkerSet.
    */
-  int getNumMarkers() const {
+  int getNumPoints() const {
     return getSubconfigView("markers")->getNumValues();
   }
 
   /**
-   * @brief Returns a list of all markers in this LinkMarkerSubset
+   * @brief Returns a list of all the marker points in this MarkerSet
    */
-  std::vector<Mn::Vector3> getMarkers() const {
+  std::vector<Mn::Vector3> getAllPoints() const {
     const auto markersPtr = getSubconfigView("markers");
     // Get all vector3 keys from subconfig in sorted vector
     std::vector<std::string> markerTags = markersPtr->getKeysByType(
@@ -47,11 +47,11 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Set the list of marker points
+   * @brief Set the list of all the marker points for this MarkerSet
    */
-  void setMarkers(const std::vector<Mn::Vector3>& markers) {
+  void setAllPoints(const std::vector<Mn::Vector3>& markers) {
     auto markersPtr = editSubconfig<Configuration>("markers");
-    // Remove all existing markers
+    // Remove all existing marker points
     markersPtr->_clearAllValues();
     for (std::size_t i = 0; i < markers.size(); ++i) {
       const std::string& key = Cr::Utility::formatString("{:.03d}", i);
@@ -60,332 +60,53 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Rekeys all markers to have vector IDXs as string keys
-   * @return returns how many markers have been processed with new keys.
+   * @brief Rekeys all marker points to have vector IDXs as string keys,
+   * retaining their original keys' natural ordering.
+   * @return returns how many marker points have been processed with new keys.
    */
   int rekeyAllMarkers() { return rekeySubconfigValues("markers"); }
-
-  ESP_SMART_POINTERS(LinkMarkerSubset)
-};  // class LinkMarkerSubset
-
-/**
- * @brief This class provides an alias for the nested configuration tree used
- * for a single link's 1 or more marker subsets that should be attached to the
- * named link.
- */
-class LinkMarkerSet : public esp::core::config::Configuration {
- public:
-  LinkMarkerSet() : Configuration() {}
-
-  /**
-   * @brief Returns the number of existing LinkSubset in this collection.
-   */
-  int getNumLinkSubsets() const { return getNumSubconfigs(); }
-
-  /**
-   * @brief whether the given @p linkSubsetName exists as a LinkSubset in
-   * this collection.
-   *
-   * @param linkSubsetName The desired marker set's name.
-   * @return whether the name is found as a LinkSubset subconfiguration.
-   */
-  bool hasNamedLinkSubset(const std::string& linkSubsetName) const {
-    return hasSubconfig(linkSubsetName);
-  }
-
-  /**
-   * @brief Retrieve a listing of all the LinkSubset handles in this
-   * collection.
-   */
-  std::vector<std::string> getAllLinkSubsetNames() const {
-    return getSubconfigKeys(true);
-  }
-
-  /**
-   * @brief Retrivess a copy of the named LinkSubset, if it exists, and
-   * nullptr if it does not.
-   */
-  LinkMarkerSubset::ptr getNamedLinkSubsetCopy(
-      const std::string& linkSubsetName) {
-    return getSubconfigCopy<LinkMarkerSubset>(linkSubsetName);
-  }
-
-  /**
-   * @brief Retrieve a view of the naamed LinkSubset, if it exists, and
-   * nullptr if it does not.
-   */
-  LinkMarkerSubset::cptr getNamedLinkSubsetView(
-      const std::string& linkSubsetName) const {
-    return std::static_pointer_cast<const LinkMarkerSubset>(
-        getSubconfigView(linkSubsetName));
-  }
-
-  /**
-   * @brief Retrieves a reference to a (potentially newly created)
-   * LinkMarkerSubset with the given @p linkSubsetName , which can be modified
-   * and the modifications will be retained.
-   *
-   * @param linkSubsetName The desired LinkMarkerSubset set's name.
-   * @return a reference to the LinkMarkerSubset set.
-   */
-  LinkMarkerSubset::ptr editNamedLinkSubset(const std::string& linkSubsetName) {
-    return editSubconfig<LinkMarkerSubset>(linkSubsetName);
-  }
-
-  /**
-   * @brief Removes named LinkMarkerSubset. Does nothing if DNE.
-   */
-  void removeNamedLinkSet(const std::string& linkSubsetName) {
-    removeSubconfig(linkSubsetName);
-  }
-
-  /**
-   * @brief Set the specified name's subset markers to the given marker values.
-   */
-  void setLinkSubsetMarkers(const std::string& linkSubsetName,
-                            const std::vector<Mn::Vector3>& markers) {
-    editNamedLinkSubset(linkSubsetName)->setMarkers(markers);
-  }
-
-  /**
-   * @brief Set the markers of all the subsets specified by name in the passed
-   * map.
-   */
-  void setAllMarkers(
-      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
-          markerMap) {
-    for (const auto& markers : markerMap) {
-      setLinkSubsetMarkers(markers.first, markers.second);
-    }
-  }
-
-  /**
-   * @brief Retrieve all the markers for the named link subset for this link
-   */
-  std::vector<Mn::Vector3> getLinkSubsetMarkers(const std::string& key) const {
-    return getNamedLinkSubsetView(key)->getMarkers();
-  }
-
-  /**
-   * @brief this retrieves all the markers across all subests for this link
-   */
-  std::unordered_map<std::string, std::vector<Mn::Vector3>> getAllMarkers()
-      const {
-    std::unordered_map<std::string, std::vector<Mn::Vector3>> resMap;
-    const auto& subsetKeys = getSubconfigKeys();
-    for (const auto& key : subsetKeys) {
-      resMap[key] = getLinkSubsetMarkers(key);
-    }
-    return resMap;
-  }  // getAllMarkers
-
-  /**
-   * @brief Rekeys all marker collections to have vector IDXs as string keys
-   * @return returns how many markers have been processed with new keys in this
-   * link's marker subsets.
-   */
-  int rekeyAllMarkers() {
-    int res = 0;
-    const auto& subsetKeys = getSubconfigKeys();
-    for (const auto& key : subsetKeys) {
-      res += editNamedLinkSubset(key)->rekeyAllMarkers();
-    }
-    return res;
-  }
-
-  ESP_SMART_POINTERS(LinkMarkerSet)
-};  // class LinkMarkerSet
-
-/**
- * @brief This class provides an alias for the nested configuration tree used
- * for a single MarkerSet, covering 1 or more links
- */
-class MarkerSet : public esp::core::config::Configuration {
- public:
-  MarkerSet() : Configuration() {}
-
-  /**
-   * @brief Returns the number of existing LinkMarkerSet in this collection.
-   */
-  int getNumLinkSets() const { return getNumSubconfigs(); }
-
-  /**
-   * @brief whether the given @p linkSetName exists as a LinkMarkerSet in this
-   * collection.
-   *
-   * @param linkSetName The desired LinkMarkerSet' name.
-   * @return whether the name is found as a LinkMarkerSet subconfiguration.
-   */
-  bool hasNamedLinkSet(const std::string& linkSetName) const {
-    return hasSubconfig(linkSetName);
-  }
-
-  /**
-   * @brief Retrieve a listing of all the LinkMarkerSet handles in this
-   * collection.
-   */
-  std::vector<std::string> getAllLinkSetNames() const {
-    return getSubconfigKeys(true);
-  }
-
-  /**
-   * @brief Retrivess a copy of the named LinkMarkerSet, if it exists, and
-   * nullptr if it does not.
-   */
-  LinkMarkerSet::ptr getNamedLinkSetCopy(const std::string& linkSetName) {
-    return getSubconfigCopy<LinkMarkerSet>(linkSetName);
-  }
-
-  /**
-   * @brief Retrieve a view of the naamed LinkMarkerSet, if it exists, and
-   * nullptr if it does not.
-   */
-  LinkMarkerSet::cptr getNamedLinkSetView(
-      const std::string& linkSetName) const {
-    return std::static_pointer_cast<const LinkMarkerSet>(
-        getSubconfigView(linkSetName));
-  }
-
-  /**
-   * @brief Retrieves a reference to a (potentially newly created)
-   * LinkMarkerSet with the given @p linkSetName , which can be modified and
-   * the modifications will be retained.
-   *
-   * @param linkSetName The desired marker set's name.
-   * @return a reference to the marker set.
-   */
-  LinkMarkerSet::ptr editNamedLinkSet(const std::string& linkSetName) {
-    return editSubconfig<LinkMarkerSet>(linkSetName);
-  }
-
-  /**
-   * @brief Removes named LinkMarkerSet. Does nothing if DNE.
-   */
-  void removeNamedLinkSet(const std::string& linkSetName) {
-    removeSubconfig(linkSetName);
-  }
-
-  /**
-   * @brief Set a specified link's specified subset's markers.
-   */
-  void setLinkSetSubsetMarkers(const std::string& linkSetName,
-                               const std::string& linkSubsetName,
-                               const std::vector<Mn::Vector3>& markers) {
-    editNamedLinkSet(linkSetName)
-        ->setLinkSubsetMarkers(linkSubsetName, markers);
-  }
-
-  /**
-   * @brief Sets all the specified name's link markers to the given marker
-   * values specified by the link subset name.
-   */
-  void setLinkSetMarkers(
-      const std::string& linkSetName,
-      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
-          markers) {
-    editNamedLinkSet(linkSetName)->setAllMarkers(markers);
-  }
-
-  /**
-   * @brief Set the markers of all the links specified by name in the passed
-   * map.
-   */
-  void setAllMarkers(const std::unordered_map<
-                     std::string,
-                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
-                         markerMap) {
-    for (const auto& markers : markerMap) {
-      setLinkSetMarkers(markers.first, markers.second);
-    }
-  }
-
-  /**
-   * @brief Get the markers for a specified link's specified subset.
-   */
-  std::vector<Mn::Vector3> getLinkSetSubsetMarkers(
-      const std::string& linkName,
-      const std::string& linkSubsetName) const {
-    return getNamedLinkSetView(linkName)->getLinkSubsetMarkers(linkSubsetName);
-  }
-
-  /**
-   * @brief Retrieve all the markers for the named link within this markerset
-   */
-  std::unordered_map<std::string, std::vector<Mn::Vector3>> getLinkSetMarkers(
-      const std::string& linkName) const {
-    return getNamedLinkSetView(linkName)->getAllMarkers();
-  }
-
-  /**
-   * @brief this retrieves all the markers for across all links in this
-   * markerset
-   */
-  std::unordered_map<std::string,
-                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>
-  getAllMarkers() const {
-    std::unordered_map<
-        std::string, std::unordered_map<std::string, std::vector<Mn::Vector3>>>
-        resMap;
-    const auto& subsetKeys = getSubconfigKeys();
-    for (const auto& linkName : subsetKeys) {
-      resMap[linkName] = getLinkSetMarkers(linkName);
-    }
-    return resMap;
-  }  // getAllMarkers
-
-  /**
-   * @brief Rekeys all marker collections to have vector IDXs as string keys
-   * @return returns how many markers have been processed with new keys in this
-   * markerset.
-   */
-  int rekeyAllMarkers() {
-    int res = 0;
-    const auto& subsetKeys = getSubconfigKeys();
-    for (const auto& key : subsetKeys) {
-      res += editNamedLinkSet(key)->rekeyAllMarkers();
-    }
-    return res;
-  }
 
   ESP_SMART_POINTERS(MarkerSet)
 };  // class MarkerSet
 
 /**
- * @brief This class provides an alias for the nested configuration tree used
- * to hold multiple MarkerSets.
+ * @brief This class provides an alias for the nested Configuration tree used
+ * for a single link's 1 or more NarkerSets that should be attached to the
+ * named link.
  */
-class MarkerSets : public esp::core::config::Configuration {
+class LinkSet : public esp::core::config::Configuration {
  public:
-  MarkerSets() : Configuration() {}
+  LinkSet() : Configuration() {}
 
   /**
-   * @brief Returns the number of existing MarkerSets in this collection.
+   * @brief Returns the number of existing MarkerSets in this LinkSet.
    */
   int getNumMarkerSets() const { return getNumSubconfigs(); }
 
   /**
-   * @brief whether the given @p markerSetName exists as a markerSet in this
-   * collection.
+   * @brief whether the given @p markerSetName exists as a MarkerSet in
+   * this LinkSet.
    *
    * @param markerSetName The desired marker set's name.
-   * @return whether the name is found as a MarkerSet subconfiguration.
+   * @return whether the name is found as a MarkerSet subConfiguration.
    */
-  bool hasNamedMarkerSet(const std::string& markerSetName) const {
+  bool hasMarkerSet(const std::string& markerSetName) const {
     return hasSubconfig(markerSetName);
   }
 
   /**
-   * @brief Retrieve a listing of all the MarkerSet handles in this collection.
+   * @brief Retrieve a listing of all the MarkerSet handles in this
+   * LinkSet.
    */
   std::vector<std::string> getAllMarkerSetNames() const {
     return getSubconfigKeys(true);
   }
 
   /**
-   * @brief Retrivess a copy of the named MarkerSet, if it exists, and nullptr
-   * if it does not.
+   * @brief Retrivess a copy of the named MarkerSet, if it exists, and
+   * nullptr if it does not.
    */
-  MarkerSet::ptr getNamedMarkerSetCopy(const std::string& markerSetName) {
+  MarkerSet::ptr getMarkerSetCopy(const std::string& markerSetName) {
     return getSubconfigCopy<MarkerSet>(markerSetName);
   }
 
@@ -393,73 +114,394 @@ class MarkerSets : public esp::core::config::Configuration {
    * @brief Retrieve a view of the naamed MarkerSet, if it exists, and
    * nullptr if it does not.
    */
-  MarkerSet::cptr getNamedMarkerSetView(
-      const std::string& markerSetName) const {
+  MarkerSet::cptr getMarkerSetView(const std::string& markerSetName) const {
     return std::static_pointer_cast<const MarkerSet>(
         getSubconfigView(markerSetName));
   }
 
   /**
-   * @brief Retrieves a reference to a (potentially newly created) MarkerSet
-   * with the given @p markerSetName , which can be modified and the
-   * modifications will be retained.
+   * @brief Retrieves a reference to a (potentially newly created)
+   * MarkerSet with the given @p markerSetName , which can be modified
+   * and the modifications will be retained.
    *
-   * @param markerSetName The desired marker set's name.
-   * @return a reference to the marker set.
+   * @param markerSetName The desired MarkerSet name.
+   * @return a reference to the MarkerSet.
    */
-  MarkerSet::ptr editNamedMarkerSet(const std::string& markerSetName) {
+  MarkerSet::ptr editMarkerSet(const std::string& markerSetName) {
     return editSubconfig<MarkerSet>(markerSetName);
   }
 
   /**
    * @brief Removes named MarkerSet. Does nothing if DNE.
    */
-  void removeNamedMarkerSet(const std::string& markerSetName) {
+  void removeLinkSet(const std::string& markerSetName) {
     removeSubconfig(markerSetName);
   }
 
   /**
-   * @brief Set a specified MarkerSet's specified link's specified subset's
-   * markers.
+   * @brief Set the specified MarkerSet's points to the given values.
+   * @param markerSetName the name of the MarkerSet
+   * @param markerList the list of the specified MarkerSet's points.
    */
-  void setMarkerSetLinkSetSubsetMarkers(
-      const std::string& markerSetName,
-      const std::string& linkSetName,
-      const std::string& linkSubsetName,
-      const std::vector<Mn::Vector3>& markers) {
-    editNamedMarkerSet(markerSetName)
-        ->setLinkSetSubsetMarkers(linkSetName, linkSubsetName, markers);
+  void setMarkerSetPoints(const std::string& markerSetName,
+                          const std::vector<Mn::Vector3>& markerList) {
+    editMarkerSet(markerSetName)->setAllPoints(markerList);
   }
 
   /**
-   * @brief Sets all the specified marker's specified link's subsets' markers to
-   * the given marker values specified in the map.
+   * @brief Set the marker points of all the MarkerSets specified by name in the
+   * passed map.
+   * @param markerMap a map holding all the MarkerSet points within this
+   * LinkSet, with MarkerSet name as the key, referncing a vector of 3d points,
    */
-  void setMarkerSetLinkSetMarkers(
-      const std::string& markerSetName,
+  void setAllMarkerPoints(
+      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
+          markerMap) {
+    for (const auto& markers : markerMap) {
+      setMarkerSetPoints(markers.first, markers.second);
+    }
+  }
+
+  /**
+   * @brief Retrieve all the marker points for the specified MarkerSet in this
+   * LinkSet
+   * @return a vector of 3d points
+   */
+  std::vector<Mn::Vector3> getMarkerSetPoints(const std::string& key) const {
+    return getMarkerSetView(key)->getAllPoints();
+  }
+
+  /**
+   * @brief Retrieve all the marker points across all MarkerSets for this link,
+   * as a map.
+   * @return a map holding all the MarkerSet points within this LinkSet, with
+   * MarkerSet name as the key, referncing a vector of 3d points
+   */
+  std::unordered_map<std::string, std::vector<Mn::Vector3>> getAllMarkerPoints()
+      const {
+    std::unordered_map<std::string, std::vector<Mn::Vector3>> resMap;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      resMap[key] = getMarkerSetPoints(key);
+    }
+    return resMap;
+  }  // getAllMarkerPoints
+
+  /**
+   * @brief Rekeys all marker collections to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys in this
+   * LinkSet's MarkerSets.
+   */
+  int rekeyAllMarkers() {
+    int res = 0;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      res += editMarkerSet(key)->rekeyAllMarkers();
+    }
+    return res;
+  }
+
+  ESP_SMART_POINTERS(LinkSet)
+};  // class LinkSet
+
+/**
+ * @brief This class provides an alias for the nested Configuration tree used
+ * for a single TaskSet, holding 1 or more LinkSets
+ */
+class TaskSet : public esp::core::config::Configuration {
+ public:
+  TaskSet() : Configuration() {}
+
+  /**
+   * @brief Returns the number of existing LinkSets in this collection.
+   */
+  int getNumLinkSets() const { return getNumSubconfigs(); }
+
+  /**
+   * @brief Whether the given @p linkSetName exists as a LinkSet in this
+   * collection.
+   *
+   * @param linkSetName The desired LinkSet' name.
+   * @return whether the name is found as a LinkSet subConfiguration.
+   */
+  bool hasLinkSet(const std::string& linkSetName) const {
+    return hasSubconfig(linkSetName);
+  }
+
+  /**
+   * @brief Retrieve a listing of all the LinkSet handles in this
+   * collection.
+   */
+  std::vector<std::string> getAllLinkSetNames() const {
+    return getSubconfigKeys(true);
+  }
+
+  /**
+   * @brief Retrivess a copy of the named LinkSet, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkSet::ptr getLinkSetCopy(const std::string& linkSetName) {
+    return getSubconfigCopy<LinkSet>(linkSetName);
+  }
+
+  /**
+   * @brief Retrieve a view of the naamed LinkSet, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkSet::cptr getLinkSetView(const std::string& linkSetName) const {
+    return std::static_pointer_cast<const LinkSet>(
+        getSubconfigView(linkSetName));
+  }
+
+  /**
+   * @brief Retrieves a reference to a (potentially newly created)
+   * LinkSet with the given @p linkSetName , which can be modified and
+   * the modifications will be retained.
+   *
+   * @param linkSetName The desired LinkSet's name.
+   * @return a reference to the LinkSet.
+   */
+  LinkSet::ptr editLinkSet(const std::string& linkSetName) {
+    return editSubconfig<LinkSet>(linkSetName);
+  }
+
+  /**
+   * @brief Removes named LinkSet. Does nothing if DNE.
+   */
+  void removeLinkSet(const std::string& linkSetName) {
+    removeSubconfig(linkSetName);
+  }
+
+  /**
+   * @brief Set a specified LinkSet's specified MarkerSet's points to the given
+   * list of points.
+   * @param linkSetName the name of the LinkSet
+   * @param markerSetName the name of the MarkerSet within @p linkSetName
+   * @param markerList the list of the specified MarkerSet's points.
+   */
+  void setLinkMarkerSetPoints(const std::string& linkSetName,
+                              const std::string& markerSetName,
+                              const std::vector<Mn::Vector3>& markerList) {
+    editLinkSet(linkSetName)->setMarkerSetPoints(markerSetName, markerList);
+  }
+
+  /**
+   * @brief Sets all the MarkerSet points in the specified LinkSet to the given
+   * marker values specified in the map.
+   * @param linkSetName the name of the LinkSet within @p taskSetName
+   * @param markerMap a map holding all the MarkerSet points within the
+   * specified LinkSet, with MarkerSet name as the key, referncing a vector of
+   * 3d points,
+   */
+  void setLinkSetPoints(
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markers) {
-    editNamedMarkerSet(markerSetName)->setLinkSetMarkers(linkSetName, markers);
+    editLinkSet(linkSetName)->setAllMarkerPoints(markers);
   }
 
   /**
-   * @brief Sets all the specified MarkerSet's links' subset markers to the
-   * given marker values specified in the map.
+   * @brief Sets all the LinkSet's MarkerSets' points in this TaskSet
+   * to the given marker values specified in the map.
+   * @param markerMap an unordered map keyed by LinkSet name of unordered maps,
+   * each keyed by MarkerSet name of Markers as a vector of 3d points.
    */
-  void setMarkerSetMarkers(
-      const std::string& markerSetName,
+  void setAllMarkerPoints(
       const std::unordered_map<
           std::string,
-          std::unordered_map<std::string, std::vector<Mn::Vector3>>>& markers) {
-    editNamedMarkerSet(markerSetName)->setAllMarkers(markers);
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
+          markerMap) {
+    for (const auto& markers : markerMap) {
+      setLinkSetPoints(markers.first, markers.second);
+    }
   }
 
   /**
-   * @brief Set the markers of all the links specified by name in the passed
-   * map.
+   * @brief Retrieve the specified LinkSet's MarkerSet as a vector of 3d
+   * points.
+   * @param linkSetName the name of the LinkSet
+   * @param markerSetName the name of the MarkerSet within @p linkSetName
+   * @return a vector of 3d points
    */
-  void setAllMarkers(
+  std::vector<Mn::Vector3> getLinkMarkerSetPoints(
+      const std::string& linkSetName,
+      const std::string& markerSetName) const {
+    return getLinkSetView(linkSetName)->getMarkerSetPoints(markerSetName);
+  }
+
+  /**
+   * @brief Retrieve all the MarkerSet points for the specified LinkSet within
+   * this TaskSet.
+   * @param linkSetName the name of the LinkSet
+   * @return  a map holding all the MarkerSet points within the
+   * specified LinkSet, with MarkerSet name as the key, referncing a vector of
+   * 3d points.
+   */
+  std::unordered_map<std::string, std::vector<Mn::Vector3>> getLinkSetPoints(
+      const std::string& linkSetName) const {
+    return getLinkSetView(linkSetName)->getAllMarkerPoints();
+  }
+
+  /**
+   * @brief this retrieves all the marker points across all the LinkSets in this
+   * TaskSet.
+   * @return an unordered map keyed by LinkSet name of unordered maps, each
+   * keyed by MarkerSet name of Markers as a vector of 3d points.
+   */
+  std::unordered_map<std::string,
+                     std::unordered_map<std::string, std::vector<Mn::Vector3>>>
+  getAllMarkerPoints() const {
+    std::unordered_map<
+        std::string, std::unordered_map<std::string, std::vector<Mn::Vector3>>>
+        resMap;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& linkSetName : subsetKeys) {
+      resMap[linkSetName] = getLinkSetPoints(linkSetName);
+    }
+    return resMap;
+  }  // getAllMarkerPoints
+
+  /**
+   * @brief Rekeys all marker collections to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys in this
+   * TaskSet.
+   */
+  int rekeyAllMarkers() {
+    int res = 0;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      res += editLinkSet(key)->rekeyAllMarkers();
+    }
+    return res;
+  }
+
+  ESP_SMART_POINTERS(TaskSet)
+};  // class TaskSet
+
+/**
+ * @brief This class provides an alias for the nested Configuration tree used
+ * to hold multiple TaskSets.
+ */
+class MarkerSets : public esp::core::config::Configuration {
+ public:
+  MarkerSets() : Configuration() {}
+
+  /**
+   * @brief Returns the number of existing TaskSets in this collection.
+   */
+  int getNumTaskSets() const { return getNumSubconfigs(); }
+
+  /**
+   * @brief whether the given @p taskSetName exists as a TaskSet in this
+   * collection.
+   *
+   * @param taskSetName The desired TaskSet's name.
+   * @return whether the name is found as a TaskSet subConfiguration.
+   */
+  bool hasTaskSet(const std::string& taskSetName) const {
+    return hasSubconfig(taskSetName);
+  }
+
+  /**
+   * @brief Retrieve a listing of all the TaskSet handles in this collection.
+   */
+  std::vector<std::string> getAllTaskSetNames() const {
+    return getSubconfigKeys(true);
+  }
+
+  /**
+   * @brief Retrivess a copy of the named TaskSet, if it exists, and nullptr
+   * if it does not.
+   */
+  TaskSet::ptr getTaskSetCopy(const std::string& taskSetName) {
+    return getSubconfigCopy<TaskSet>(taskSetName);
+  }
+
+  /**
+   * @brief Retrieve a view of the naamed TaskSet, if it exists, and
+   * nullptr if it does not.
+   */
+  TaskSet::cptr getTaskSetView(const std::string& taskSetName) const {
+    return std::static_pointer_cast<const TaskSet>(
+        getSubconfigView(taskSetName));
+  }
+
+  /**
+   * @brief Retrieves a reference to a (potentially newly created) TaskSet
+   * with the given @p taskSetName , which can be modified and the
+   * modifications will be retained.
+   *
+   * @param taskSetName The desired TaskSet's name.
+   * @return a reference to the TaskSet.
+   */
+  TaskSet::ptr editTaskSet(const std::string& taskSetName) {
+    return editSubconfig<TaskSet>(taskSetName);
+  }
+
+  /**
+   * @brief Removes named TaskSet. Does nothing if DNE.
+   */
+  void removeTaskSet(const std::string& taskSetName) {
+    removeSubconfig(taskSetName);
+  }
+
+  /**
+   * @brief Set the specified TaskSet's specified LinkSet's specified
+   * MarkerSet's marker points.
+   * @param taskSetName the name of the TaskSet
+   * @param linkSetName the name of the LinkSet within @p taskSetName
+   * @param markerSetName the name of the MarkerSet within @p linkSetName
+   * @param markerList the list of the specified MarkerSet' points.
+   */
+  void setTaskLinkMarkerSetPoints(const std::string& taskSetName,
+                                  const std::string& linkSetName,
+                                  const std::string& markerSetName,
+                                  const std::vector<Mn::Vector3>& markerList) {
+    editTaskSet(taskSetName)
+        ->setLinkMarkerSetPoints(linkSetName, markerSetName, markerList);
+  }
+
+  /**
+   * @brief Sets all the MarkerSet points in the specified TaskSet's specified
+   * LinkSet to the given marker values specified in the map.
+   * @param taskSetName the name of the TaskSet
+   * @param linkSetName the name of the LinkSet within @p taskSetName
+   * @param markerMap a map holding all the MarkerSet points within the
+   * specified LinkSet, with MarkerSet name as the key, referncing a vector of
+   * 3d points,
+   */
+  void setTaskLinkSetPoints(
+      const std::string& taskSetName,
+      const std::string& linkSetName,
+      const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
+          markerMap) {
+    editTaskSet(taskSetName)->setLinkSetPoints(linkSetName, markerMap);
+  }
+
+  /**
+   * @brief Sets all the LinkSet's MarkerSets' points in the specified TaskSet
+   * to the given marker values specified in the map.
+   * @param taskSetName the name of the TaskSet
+   * @param markerMap an unordered map keyed by LinkSet name of unordered maps,
+   * each keyed by MarkerSet name of Markers as a vector of 3d points.
+   */
+  void setTaskSetPoints(
+      const std::string& taskSetName,
+      const std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
+          markerMap) {
+    editTaskSet(taskSetName)->setAllMarkerPoints(markerMap);
+  }
+
+  /**
+   * @brief Set all the marker points across every TaskSet using the values in
+   * the passed map.
+   * @param markerMap an unordered map keyed by TaskSet name, of unordered maps,
+   * each keyed by LinkSet name, of unordered maps, each keyed by MarkerSet name
+   * of Markers as a vector of 3d points.
+   */
+  void setAllMarkerPoints(
       const std::unordered_map<
           std::string,
           std::unordered_map<
@@ -467,49 +509,68 @@ class MarkerSets : public esp::core::config::Configuration {
               std::unordered_map<std::string, std::vector<Mn::Vector3>>>>&
           markerMap) {
     for (const auto& markers : markerMap) {
-      setMarkerSetMarkers(markers.first, markers.second);
+      setTaskSetPoints(markers.first, markers.second);
     }
   }
 
   /**
-   * @brief Return a single MarkerSet's Link's Subset of markers
+   * @brief Retrieve a single TaskSet's LinkSet's MarkerSet as a vector of 3d
+   * points.
+   * @param taskSetName the name of the TaskSet
+   * @param linkSetName the name of the LinkSet within @p taskSetName
+   * @param markerSetName the name of the MarkerSet within @p linkSetName
+   * @return a vector of 3d points
    */
-  std::vector<Mn::Vector3> getMarkerSetLinkSetSubsetMarkers(
-      const std::string& markerSetName,
+  std::vector<Mn::Vector3> getTaskLinkMarkerSetPoints(
+      const std::string& taskSetName,
       const std::string& linkSetName,
-      const std::string& linkSubsetName) const {
-    return getNamedMarkerSetView(markerSetName)
-        ->getLinkSetSubsetMarkers(linkSetName, linkSubsetName);
+      const std::string& markerSetName) const {
+    return getTaskSetView(taskSetName)
+        ->getLinkMarkerSetPoints(linkSetName, markerSetName);
   }
+
   /**
-   * @brief Return all of a MarkerSet's Link's Subsets of markers
+   * @brief Retrieve all of the MarkerSets for a particular LinkSet within the
+   * specified TaskSet, as an unordered map keyed by MarkerSet name of
+   * Markers as a vector of 3d points.
+   * @param taskSetName the name of the TaskSet
+   * @param linkSetName the name of the LinkSet within @p taskSetName
+   * @return a map holding all the MarkerSet points within the specified
+   * LinkSet, with MarkerSet name as the key, referncing a vector of 3d points,
    */
 
   std::unordered_map<std::string, std::vector<Mn::Vector3>>
-  getMarkerSetLinkSetMarkers(const std::string& markerSetName,
-                             const std::string& linkSetName) const {
-    return getNamedMarkerSetView(markerSetName)->getLinkSetMarkers(linkSetName);
+  getTaskLinkSetPoints(const std::string& taskSetName,
+                       const std::string& linkSetName) const {
+    return getTaskSetView(taskSetName)->getLinkSetPoints(linkSetName);
   }
 
   /**
-   * @brief Retrieve all the markers for the named markerset
+   * @brief Retrieve all the marker points for the named TaskSet, as an
+   * unordered map keyed by LinkSet name of unordered maps, each keyed by
+   * MarkerSet name of Markers as a vector of 3d points.
+   * @param taskSetName the name of the TaskSet
+   * @return an unordered map keyed by LinkSet name of unordered maps, each
+   * keyed by MarkerSet name of Markers as a vector of 3d points.
    */
   std::unordered_map<std::string,
                      std::unordered_map<std::string, std::vector<Mn::Vector3>>>
-  getMarkerSetMarkers(const std::string& markerSetName) const {
-    return getNamedMarkerSetView(markerSetName)->getAllMarkers();
+  getTaskSetPoints(const std::string& taskSetName) const {
+    return getTaskSetView(taskSetName)->getAllMarkerPoints();
   }
 
   /**
-   * @brief this retrieves all the markers across all the markersets, keyed by
-   * MarkerSet name, Link Id and Link subset name
+   * @brief Retrieve all the MarkerSet points across all the TaskSets.
+   * @return an unordered map keyed by TaskSet name, of unordered maps, each
+   * keyed by LinkSet name, of unordered maps, each keyed by MarkerSet name of
+   * Markers as a vector of 3d points.
    */
   std::unordered_map<
       std::string,
       std::unordered_map<
           std::string,
           std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
-  getAllMarkers() const {
+  getAllMarkerPoints() const {
     std::unordered_map<
         std::string,
         std::unordered_map<
@@ -517,28 +578,24 @@ class MarkerSets : public esp::core::config::Configuration {
             std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
         resMap;
     const auto& subsetKeys = getSubconfigKeys();
-    for (const auto& markerSetName : subsetKeys) {
-      resMap[markerSetName] = getMarkerSetMarkers(markerSetName);
+    for (const auto& taskSetName : subsetKeys) {
+      resMap[taskSetName] = getTaskSetPoints(taskSetName);
     }
     return resMap;
-  }  // getAllMarkers
+  }  // getAllMarkerPoints
 
   /**
    * @brief Rekeys all marker collections to have vector IDXs as string keys
-   * @return returns how many markers have been processed with new keys.
+   * @return returns how many marker points have been processed with new keys.
    */
   int rekeyAllMarkers() {
     int res = 0;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      res += editNamedMarkerSet(key)->rekeyAllMarkers();
+      res += editTaskSet(key)->rekeyAllMarkers();
     }
     return res;
   }
-
-  /**
-   * @brief Remove the specified MarkerSet
-   */
 
   ESP_SMART_POINTERS(MarkerSets)
 };  // class MarkerSets

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -12,7 +12,7 @@ namespace attributes {
 /** @file
  * @brief Class @ref esp::metadata::attributes::Markersets,
  * Class @ref esp::metadata::attributes::MarkerSet,
- * Class @ref esp::metadata::attributes::LinkMarkerSets,
+ * Class @ref esp::metadata::attributes::LinkMarkerSet,
  * Class @ref esp::metadata::attributes::LinkMarkerSubset
  */
 
@@ -73,9 +73,9 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
  * for a single link's 1 or more marker subsets that should be attached to the
  * named link.
  */
-class LinkMarkerSets : public esp::core::config::Configuration {
+class LinkMarkerSet : public esp::core::config::Configuration {
  public:
-  LinkMarkerSets() : Configuration() {}
+  LinkMarkerSet() : Configuration() {}
 
   /**
    * @brief Returns the number of existing LinkSubset in this collection.
@@ -135,7 +135,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
   /**
    * @brief Removes named LinkMarkerSubset. Does nothing if DNE.
    */
-  void removeNamedMarkerSet(const std::string& linkSubsetName) {
+  void removeNamedLinkSet(const std::string& linkSubsetName) {
     removeSubconfig(linkSubsetName);
   }
 
@@ -193,8 +193,8 @@ class LinkMarkerSets : public esp::core::config::Configuration {
     return res;
   }
 
-  ESP_SMART_POINTERS(LinkMarkerSets)
-};  // class LinkMarkerSets
+  ESP_SMART_POINTERS(LinkMarkerSet)
+};  // class LinkMarkerSet
 
 /**
  * @brief This class provides an alias for the nested configuration tree used
@@ -205,74 +205,73 @@ class MarkerSet : public esp::core::config::Configuration {
   MarkerSet() : Configuration() {}
 
   /**
-   * @brief Returns the number of existing LinkMarkerSets in this collection.
+   * @brief Returns the number of existing LinkMarkerSet in this collection.
    */
   int getNumLinkSets() const { return getNumSubconfigs(); }
 
   /**
-   * @brief whether the given @p linkSetName exists as a LinkMarkerSets in this
+   * @brief whether the given @p linkSetName exists as a LinkMarkerSet in this
    * collection.
    *
-   * @param linkSetName The desired LinkMarkerSets' name.
-   * @return whether the name is found as a LinkMarkerSets subconfiguration.
+   * @param linkSetName The desired LinkMarkerSet' name.
+   * @return whether the name is found as a LinkMarkerSet subconfiguration.
    */
-  bool hasNamedLinkSets(const std::string& linkSetName) const {
+  bool hasNamedLinkSet(const std::string& linkSetName) const {
     return hasSubconfig(linkSetName);
   }
 
   /**
-   * @brief Retrieve a listing of all the LinkMarkerSets handles in this
+   * @brief Retrieve a listing of all the LinkMarkerSet handles in this
    * collection.
    */
-  std::vector<std::string> getAllLinkMarkerSetsNames() const {
+  std::vector<std::string> getAllLinkSetNames() const {
     return getSubconfigKeys(true);
   }
 
   /**
-   * @brief Retrivess a copy of the named LinkMarkerSets, if it exists, and
+   * @brief Retrivess a copy of the named LinkMarkerSet, if it exists, and
    * nullptr if it does not.
    */
-  LinkMarkerSets::ptr getNamedLinkMarkerSetsCopy(
-      const std::string& linkSetName) {
-    return getSubconfigCopy<LinkMarkerSets>(linkSetName);
+  LinkMarkerSet::ptr getNamedLinkSetCopy(const std::string& linkSetName) {
+    return getSubconfigCopy<LinkMarkerSet>(linkSetName);
   }
 
   /**
    * @brief Retrieve a view of the naamed LinkMarkerSet, if it exists, and
    * nullptr if it does not.
    */
-  LinkMarkerSets::cptr getNamedLinkMarkerSetsView(
+  LinkMarkerSet::cptr getNamedLinkSetView(
       const std::string& linkSetName) const {
-    return std::static_pointer_cast<const LinkMarkerSets>(
+    return std::static_pointer_cast<const LinkMarkerSet>(
         getSubconfigView(linkSetName));
   }
 
   /**
    * @brief Retrieves a reference to a (potentially newly created)
-   * LinkMarkerSets with the given @p linkSetName , which can be modified and
+   * LinkMarkerSet with the given @p linkSetName , which can be modified and
    * the modifications will be retained.
    *
    * @param linkSetName The desired marker set's name.
    * @return a reference to the marker set.
    */
-  LinkMarkerSets::ptr editNamedLinkSets(const std::string& linkSetName) {
-    return editSubconfig<LinkMarkerSets>(linkSetName);
+  LinkMarkerSet::ptr editNamedLinkSet(const std::string& linkSetName) {
+    return editSubconfig<LinkMarkerSet>(linkSetName);
   }
 
   /**
-   * @brief Removes named LinkMarkerSets. Does nothing if DNE.
+   * @brief Removes named LinkMarkerSet. Does nothing if DNE.
    */
-  void removeNamedMarkerSet(const std::string& linkSetName) {
+  void removeNamedLinkSet(const std::string& linkSetName) {
     removeSubconfig(linkSetName);
   }
 
   /**
    * @brief Set a specified link's specified subset's markers.
    */
-  void setLinkSubsetMarkers(const std::string& linkSetName,
-                            const std::string& linkSubsetName,
-                            const std::vector<Mn::Vector3>& markers) {
-    editNamedLinkSets(linkSetName)
+  void setLinkSetSubsetMarkers(const std::string& linkSetName,
+                               const std::string& linkSubsetName,
+                               const std::vector<Mn::Vector3>& markers) {
+    editNamedLinkSet(linkSetName)
         ->setLinkSubsetMarkers(linkSubsetName, markers);
   }
 
@@ -284,7 +283,7 @@ class MarkerSet : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markers) {
-    editNamedLinkSets(linkSetName)->setAllMarkers(markers);
+    editNamedLinkSet(linkSetName)->setAllMarkers(markers);
   }
 
   /**
@@ -303,11 +302,10 @@ class MarkerSet : public esp::core::config::Configuration {
   /**
    * @brief Get the markers for a specified link's specified subset.
    */
-  std::vector<Mn::Vector3> getLinkSubsetMarkers(
+  std::vector<Mn::Vector3> getLinkSetSubsetMarkers(
       const std::string& linkName,
       const std::string& linkSubsetName) const {
-    return getNamedLinkMarkerSetsView(linkName)->getLinkSubsetMarkers(
-        linkSubsetName);
+    return getNamedLinkSetView(linkName)->getLinkSubsetMarkers(linkSubsetName);
   }
 
   /**
@@ -315,7 +313,7 @@ class MarkerSet : public esp::core::config::Configuration {
    */
   std::unordered_map<std::string, std::vector<Mn::Vector3>> getLinkSetMarkers(
       const std::string& linkName) const {
-    return getNamedLinkMarkerSetsView(linkName)->getAllMarkers();
+    return getNamedLinkSetView(linkName)->getAllMarkers();
   }
 
   /**
@@ -344,7 +342,7 @@ class MarkerSet : public esp::core::config::Configuration {
     int res = 0;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      res += editNamedLinkSets(key)->rekeyAllMarkers();
+      res += editNamedLinkSet(key)->rekeyAllMarkers();
     }
     return res;
   }
@@ -424,12 +422,13 @@ class MarkerSets : public esp::core::config::Configuration {
    * @brief Set a specified MarkerSet's specified link's specified subset's
    * markers.
    */
-  void setMarkerSetLinkSubsetMarkers(const std::string& markerSetName,
-                                     const std::string& linkSetName,
-                                     const std::string& linkSubsetName,
-                                     const std::vector<Mn::Vector3>& markers) {
+  void setMarkerSetLinkSetSubsetMarkers(
+      const std::string& markerSetName,
+      const std::string& linkSetName,
+      const std::string& linkSubsetName,
+      const std::vector<Mn::Vector3>& markers) {
     editNamedMarkerSet(markerSetName)
-        ->setLinkSubsetMarkers(linkSetName, linkSubsetName, markers);
+        ->setLinkSetSubsetMarkers(linkSetName, linkSubsetName, markers);
   }
 
   /**
@@ -475,12 +474,12 @@ class MarkerSets : public esp::core::config::Configuration {
   /**
    * @brief Return a single MarkerSet's Link's Subset of markers
    */
-  std::vector<Mn::Vector3> getMarkerSetLinkSubsetMarkers(
+  std::vector<Mn::Vector3> getMarkerSetLinkSetSubsetMarkers(
       const std::string& markerSetName,
       const std::string& linkSetName,
       const std::string& linkSubsetName) const {
     return getNamedMarkerSetView(markerSetName)
-        ->getLinkSubsetMarkers(linkSetName, linkSubsetName);
+        ->getLinkSetSubsetMarkers(linkSetName, linkSubsetName);
   }
   /**
    * @brief Return all of a MarkerSet's Link's Subsets of markers

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -35,9 +35,9 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
    */
   std::vector<Mn::Vector3> getMarkers() const {
     const auto markersPtr = getSubconfigView("markers");
-    std::vector<std::string> markerTags = markersPtr->getKeys();
-    // Sort the keys
-    std::sort(markerTags.begin(), markerTags.end());
+    // Get all vector3 keys from subconfig in sorted vector
+    std::vector<std::string> markerTags = markersPtr->getKeysByType(
+        esp::core::config::ConfigValType::MagnumVec3, true);
     std::vector<Mn::Vector3> res;
     res.reserve(markerTags.size());
     for (const auto& tag : markerTags) {
@@ -72,7 +72,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
   /**
    * @brief Returns the number of existing LinkMarkerSubset in this collection.
    */
-  int getNumLinkMarkeSubsets() const { return getNumSubconfigs(); }
+  int getNumLinkMarkerSubsets() const { return getNumSubconfigs(); }
 
   /**
    * @brief whether the given @p linkSubsetName exists as a LinkMarkerSubset in
@@ -81,7 +81,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * @param linkSubsetName The desired marker set's name.
    * @return whether the name is found as a LinkMarkerSubset subconfiguration.
    */
-  bool hasNamedLinkMarkeSubset(const std::string& linkSubsetName) const {
+  bool hasNamedLinkMarkerSubset(const std::string& linkSubsetName) const {
     return hasSubconfig(linkSubsetName);
   }
 
@@ -89,15 +89,15 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * @brief Retrieve a listing of all the LinkMarkerSubset handles in this
    * collection.
    */
-  std::vector<std::string> getAllLinkMarkeSubsetNames() const {
-    return getSubconfigKeys();
+  std::vector<std::string> getAllLinkMarkerSubsetNames() const {
+    return getSubconfigKeys(true);
   }
 
   /**
    * @brief Retrivess a copy of the named LinkMarkerSubset, if it exists, and
    * nullptr if it does not.
    */
-  LinkMarkerSubset::ptr getNamedLinkMarkeSubsetCopy(
+  LinkMarkerSubset::ptr getNamedLinkMarkerSubsetCopy(
       const std::string& linkSubsetName) {
     return getSubconfigCopy<LinkMarkerSubset>(linkSubsetName);
   }
@@ -110,7 +110,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * @param linkSubsetName The desired LinkMarkerSubset set's name.
    * @return a reference to the LinkMarkerSubset set.
    */
-  LinkMarkerSubset::ptr editNamedLinkMarkeSubset(
+  LinkMarkerSubset::ptr editNamedLinkMarkerSubset(
       const std::string& linkSubsetName) {
     return editSubconfig<LinkMarkerSubset>(linkSubsetName);
   }
@@ -154,7 +154,7 @@ class MarkerSet : public esp::core::config::Configuration {
    * collection.
    */
   std::vector<std::string> getAllLinkMarkerSetsNames() const {
-    return getSubconfigKeys();
+    return getSubconfigKeys(true);
   }
 
   /**
@@ -216,7 +216,7 @@ class MarkerSets : public esp::core::config::Configuration {
    * @brief Retrieve a listing of all the MarkerSet handles in this collection.
    */
   std::vector<std::string> getAllMarkerSetNames() const {
-    return getSubconfigKeys();
+    return getSubconfigKeys(true);
   }
 
   /**

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -229,6 +229,21 @@ class TaskSet : public esp::core::config::Configuration {
   }
 
   /**
+   * @brief Whether the given @p markerSetName and @p linkSetName exist in this
+   * TaskSet.
+   *
+   * @param linkSetName The desired LinkSet' name.
+   * @return whether the named MarkerSet exists within the named LinkSet.
+   */
+  bool hasLinkMarkerSet(const std::string& linkSetName,
+                        const std::string& markerSetName) const {
+    if (hasSubconfig(linkSetName)) {
+      return getLinkSetView(linkSetName)->hasMarkerSet(markerSetName);
+    }
+    return false;
+  }
+
+  /**
    * @brief Retrieve a listing of all the LinkSet handles in this
    * collection.
    */
@@ -403,7 +418,46 @@ class MarkerSets : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Retrieve a listing of all the TaskSet handles in this collection.
+   * @brief Whether the given @p linkSetName and @p taskSetName exist in this
+   * collection.
+   *
+   * @param taskSetName The desired TaskSet's name.
+   * @param linkSetName The desired LinkSet's name, to be found in the given
+   * TaskSet.
+   * @return wwhether the names are found as expected.
+   */
+  bool hasTaskLinkSet(const std::string& taskSetName,
+                      const std::string& linkSetName) const {
+    if (hasSubconfig(taskSetName)) {
+      return getTaskSetView(taskSetName)->hasLinkSet(linkSetName);
+    }
+    return false;
+  }
+
+  /**
+   * @brief Whether the given hierarchy of @p markerSetName, @p linkSetName and
+   * @p taskSetName all exist in this collection.
+   *
+   * @param taskSetName The desired TaskSet's name.
+   * @param linkSetName The desired LinkSet's name, to be found in the given
+   * TaskSet.
+   * @param markerSetName The desired MarkerSet's name, to be found in the given
+   * LinkSet.
+   * @return wwhether the names are found as expected.
+   */
+  bool hasTaskLinkMarkerSet(const std::string& taskSetName,
+                            const std::string& linkSetName,
+                            const std::string& markerSetName) const {
+    if (hasSubconfig(taskSetName)) {
+      return getTaskSetView(taskSetName)
+          ->hasLinkMarkerSet(linkSetName, markerSetName);
+    }
+    return false;
+  }
+
+  /**
+   * @brief Retrieve a listing of all the TaskSet handles in this
+   * collection.
    */
   std::vector<std::string> getAllTaskSetNames() const {
     return getSubconfigKeys(true);
@@ -482,8 +536,8 @@ class MarkerSets : public esp::core::config::Configuration {
    * @brief Sets all the LinkSet's MarkerSets' points in the specified TaskSet
    * to the given marker values specified in the map.
    * @param taskSetName the name of the TaskSet
-   * @param markerMap an unordered map keyed by LinkSet name of unordered maps,
-   * each keyed by MarkerSet name of Markers as a vector of 3d points.
+   * @param markerMap an unordered map keyed by LinkSet name of unordered
+   * maps, each keyed by MarkerSet name of Markers as a vector of 3d points.
    */
   void setTaskSetPoints(
       const std::string& taskSetName,
@@ -497,9 +551,9 @@ class MarkerSets : public esp::core::config::Configuration {
   /**
    * @brief Set all the marker points across every TaskSet using the values in
    * the passed map.
-   * @param markerMap an unordered map keyed by TaskSet name, of unordered maps,
-   * each keyed by LinkSet name, of unordered maps, each keyed by MarkerSet name
-   * of Markers as a vector of 3d points.
+   * @param markerMap an unordered map keyed by TaskSet name, of unordered
+   * maps, each keyed by LinkSet name, of unordered maps, each keyed by
+   * MarkerSet name of Markers as a vector of 3d points.
    */
   void setAllMarkerPoints(
       const std::unordered_map<
@@ -536,7 +590,8 @@ class MarkerSets : public esp::core::config::Configuration {
    * @param taskSetName the name of the TaskSet
    * @param linkSetName the name of the LinkSet within @p taskSetName
    * @return a map holding all the MarkerSet points within the specified
-   * LinkSet, with MarkerSet name as the key, referncing a vector of 3d points,
+   * LinkSet, with MarkerSet name as the key, referncing a vector of 3d
+   * points,
    */
 
   std::unordered_map<std::string, std::vector<Mn::Vector3>>

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -76,43 +76,43 @@ class LinkMarkerSets : public esp::core::config::Configuration {
   LinkMarkerSets() : Configuration() {}
 
   /**
-   * @brief Returns the number of existing LinkMarkerSubset in this collection.
+   * @brief Returns the number of existing LinkSubset in this collection.
    */
-  int getNumLinkMarkerSubsets() const { return getNumSubconfigs(); }
+  int getNumLinkSubsets() const { return getNumSubconfigs(); }
 
   /**
-   * @brief whether the given @p linkSubsetName exists as a LinkMarkerSubset in
+   * @brief whether the given @p linkSubsetName exists as a LinkSubset in
    * this collection.
    *
    * @param linkSubsetName The desired marker set's name.
-   * @return whether the name is found as a LinkMarkerSubset subconfiguration.
+   * @return whether the name is found as a LinkSubset subconfiguration.
    */
-  bool hasNamedLinkMarkerSubset(const std::string& linkSubsetName) const {
+  bool hasNamedLinkSubset(const std::string& linkSubsetName) const {
     return hasSubconfig(linkSubsetName);
   }
 
   /**
-   * @brief Retrieve a listing of all the LinkMarkerSubset handles in this
+   * @brief Retrieve a listing of all the LinkSubset handles in this
    * collection.
    */
-  std::vector<std::string> getAllLinkMarkerSubsetNames() const {
+  std::vector<std::string> getAllLinkSubsetNames() const {
     return getSubconfigKeys(true);
   }
 
   /**
-   * @brief Retrivess a copy of the named LinkMarkerSubset, if it exists, and
+   * @brief Retrivess a copy of the named LinkSubset, if it exists, and
    * nullptr if it does not.
    */
-  LinkMarkerSubset::ptr getNamedLinkMarkerSubsetCopy(
+  LinkMarkerSubset::ptr getNamedLinkSubsetCopy(
       const std::string& linkSubsetName) {
     return getSubconfigCopy<LinkMarkerSubset>(linkSubsetName);
   }
 
   /**
-   * @brief Retrieve a view of the naamed LinkMarkerSubset, if it exists, and
+   * @brief Retrieve a view of the naamed LinkSubset, if it exists, and
    * nullptr if it does not.
    */
-  LinkMarkerSubset::cptr getNamedLinkMarkerSubsetView(
+  LinkMarkerSubset::cptr getNamedLinkSubsetView(
       const std::string& linkSubsetName) const {
     return std::static_pointer_cast<const LinkMarkerSubset>(
         getSubconfigView(linkSubsetName));
@@ -126,8 +126,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * @param linkSubsetName The desired LinkMarkerSubset set's name.
    * @return a reference to the LinkMarkerSubset set.
    */
-  LinkMarkerSubset::ptr editNamedLinkMarkerSubset(
-      const std::string& linkSubsetName) {
+  LinkMarkerSubset::ptr editNamedLinkSubset(const std::string& linkSubsetName) {
     return editSubconfig<LinkMarkerSubset>(linkSubsetName);
   }
 
@@ -143,7 +142,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    */
   void setLinkSubsetMarkers(const std::string& linkSubsetName,
                             const std::vector<Mn::Vector3>& markers) {
-    editNamedLinkMarkerSubset(linkSubsetName)->setMarkers(markers);
+    editNamedLinkSubset(linkSubsetName)->setMarkers(markers);
   }
 
   /**
@@ -162,7 +161,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    * @brief Retrieve all the markers for the named link subset for this link
    */
   std::vector<Mn::Vector3> getLinkSubsetMarkers(const std::string& key) const {
-    return getNamedLinkMarkerSubsetView(key)->getMarkers();
+    return getNamedLinkSubsetView(key)->getMarkers();
   }
 
   /**
@@ -187,7 +186,7 @@ class LinkMarkerSets : public esp::core::config::Configuration {
     int res;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      res += editSubconfig<LinkMarkerSubset>(key)->rekeyAllMarkers();
+      res += editNamedLinkSubset(key)->rekeyAllMarkers();
     }
     return res;
   }
@@ -206,7 +205,7 @@ class MarkerSet : public esp::core::config::Configuration {
   /**
    * @brief Returns the number of existing LinkMarkerSets in this collection.
    */
-  int getNumLinkMarkerSets() const { return getNumSubconfigs(); }
+  int getNumLinkSets() const { return getNumSubconfigs(); }
 
   /**
    * @brief whether the given @p linkSetName exists as a LinkMarkerSets in this
@@ -215,7 +214,7 @@ class MarkerSet : public esp::core::config::Configuration {
    * @param linkSetName The desired LinkMarkerSets' name.
    * @return whether the name is found as a LinkMarkerSets subconfiguration.
    */
-  bool hasNamedLinkMarkerSets(const std::string& linkSetName) const {
+  bool hasNamedLinkSets(const std::string& linkSetName) const {
     return hasSubconfig(linkSetName);
   }
 
@@ -254,7 +253,7 @@ class MarkerSet : public esp::core::config::Configuration {
    * @param linkSetName The desired marker set's name.
    * @return a reference to the marker set.
    */
-  LinkMarkerSets::ptr editNamedLinkMarkerSets(const std::string& linkSetName) {
+  LinkMarkerSets::ptr editNamedLinkSets(const std::string& linkSetName) {
     return editSubconfig<LinkMarkerSets>(linkSetName);
   }
 
@@ -271,7 +270,7 @@ class MarkerSet : public esp::core::config::Configuration {
   void setLinkSubsetMarkers(const std::string& linkSetName,
                             const std::string linkSubsetName,
                             const std::vector<Mn::Vector3>& markers) {
-    editNamedLinkMarkerSets(linkSetName)
+    editNamedLinkSets(linkSetName)
         ->setLinkSubsetMarkers(linkSubsetName, markers);
   }
 
@@ -283,7 +282,7 @@ class MarkerSet : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markers) {
-    editNamedLinkMarkerSets(linkSetName)->setAllMarkers(markers);
+    editNamedLinkSets(linkSetName)->setAllMarkers(markers);
   }
 
   /**
@@ -344,7 +343,7 @@ class MarkerSet : public esp::core::config::Configuration {
     int res;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      res += editSubconfig<LinkMarkerSets>(key)->rekeyAllMarkers();
+      res += editNamedLinkSets(key)->rekeyAllMarkers();
     }
     return res;
   }
@@ -532,7 +531,7 @@ class MarkerSets : public esp::core::config::Configuration {
     int res;
     const auto& subsetKeys = getSubconfigKeys();
     for (const auto& key : subsetKeys) {
-      res += editSubconfig<MarkerSet>(key)->rekeyAllMarkers();
+      res += editNamedMarkerSet(key)->rekeyAllMarkers();
     }
     return res;
   }

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -1,0 +1,201 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#ifndef ESP_METADATA_ATTRIBUTES_MARKERSETS_H_
+#define ESP_METADATA_ATTRIBUTES_MARKERSETS_H_
+
+#include "esp/core/Configuration.h"
+namespace esp {
+namespace metadata {
+namespace attributes {
+/** @file
+ * @brief Class @ref esp::metadata::attributes::Markersets,
+ * Class @ref esp::metadata::attributes::MarkerSet,
+ * Class @ref esp::metadata::attributes::LinkMarkerSets,
+ * Class @ref esp::metadata::attributes::LinkMarkerSubset
+ */
+
+/**
+ * @brief This class provides an alias for a single configuration holding 1 or
+ * more marker points for a particular link.
+ */
+class LinkMarkerSubset : public esp::core::config::Configuration {
+ public:
+  LinkMarkerSubset() : Configuration() {}
+
+  ESP_SMART_POINTERS(LinkMarkerSubset)
+};  // class LinkMarkerSubset
+
+/**
+ * @brief This class provides an alias for the nested configuration tree used
+ * for a single link's 1 or more marker subsets that should be attached to the
+ * named link.
+ */
+class LinkMarkerSets : public esp::core::config::Configuration {
+ public:
+  LinkMarkerSets() : Configuration() {}
+
+  /**
+   * @brief Returns the number of existing LinkMarkerSubset in this collection.
+   */
+  int getNumLinkMarkeSubsets() const { return getNumSubconfigs(); }
+
+  /**
+   * @brief whether the given @p linkSubsetName exists as a LinkMarkerSubset in
+   * this collection.
+   *
+   * @param linkSubsetName The desired marker set's name.
+   * @return whether the name is found as a LinkMarkerSubset subconfiguration.
+   */
+  bool hasNamedLinkMarkeSubset(const std::string& linkSubsetName) const {
+    return hasSubconfig(linkSubsetName);
+  }
+
+  /**
+   * @brief Retrieve a listing of all the LinkMarkerSubset handles in this
+   * collection.
+   */
+  std::vector<std::string> getAllLinkMarkeSubsetNames() const {
+    return getSubconfigKeys();
+  }
+
+  /**
+   * @brief Retrivess a copy of the named LinkMarkerSubset, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkMarkerSubset::ptr getNamedLinkMarkeSubsetCopy(
+      const std::string& linkSubsetName) {
+    return getSubconfigCopy<LinkMarkerSubset>(linkSubsetName);
+  }
+
+  /**
+   * @brief Retrieves a reference to a (potentially newly created)
+   * LinkMarkerSubset with the given @p linkSubsetName , which can be modified
+   * and the modifications will be retained.
+   *
+   * @param linkSubsetName The desired LinkMarkerSubset set's name.
+   * @return a reference to the LinkMarkerSubset set.
+   */
+  LinkMarkerSubset::ptr editNamedLinkMarkeSubset(
+      const std::string& linkSubsetName) {
+    return editSubconfig<LinkMarkerSubset>(linkSubsetName);
+  }
+
+  ESP_SMART_POINTERS(LinkMarkerSets)
+};  // class LinkMarkerSets
+
+/**
+ * @brief This class provides an alias for the nested configuration tree used
+ * for a single markerset, covering 1 or more links
+ */
+class MarkerSet : public esp::core::config::Configuration {
+ public:
+  MarkerSet() : Configuration() {}
+
+  /**
+   * @brief Returns the number of existing LinkMarkerSets in this collection.
+   */
+  int getNumLinkMarkerSets() const { return getNumSubconfigs(); }
+
+  /**
+   * @brief whether the given @p linkSetName exists as a LinkMarkerSets in this
+   * collection.
+   *
+   * @param linkSetName The desired LinkMarkerSets' name.
+   * @return whether the name is found as a LinkMarkerSets subconfiguration.
+   */
+  bool hasNamedLinkMarkerSets(const std::string& linkSetName) const {
+    return hasSubconfig(linkSetName);
+  }
+
+  /**
+   * @brief Retrieve a listing of all the LinkMarkerSets handles in this
+   * collection.
+   */
+  std::vector<std::string> getAllLinkMarkerSetsNames() const {
+    return getSubconfigKeys();
+  }
+
+  /**
+   * @brief Retrivess a copy of the named LinkMarkerSets, if it exists, and
+   * nullptr if it does not.
+   */
+  LinkMarkerSets::ptr getNamedLinkMarkerSetsCopy(
+      const std::string& linkSetName) {
+    return getSubconfigCopy<LinkMarkerSets>(linkSetName);
+  }
+
+  /**
+   * @brief Retrieves a reference to a (potentially newly created)
+   * LinkMarkerSets with the given @p linkSetName , which can be modified and
+   * the modifications will be retained.
+   *
+   * @param linkSetName The desired marker set's name.
+   * @return a reference to the marker set.
+   */
+  LinkMarkerSets::ptr editNamedLinkMarkerSets(const std::string& linkSetName) {
+    return editSubconfig<LinkMarkerSets>(linkSetName);
+  }
+
+  ESP_SMART_POINTERS(MarkerSet)
+};  // class MarkerSet
+
+/**
+ * @brief This class provides an alias for the nested configuration tree used
+ * for markersets.
+ */
+class MarkerSets : public esp::core::config::Configuration {
+ public:
+  MarkerSets() : Configuration() {}
+
+  /**
+   * @brief Returns the number of existing MarkerSets in this collection.
+   */
+  int getNumMarkerSets() const { return getNumSubconfigs(); }
+
+  /**
+   * @brief whether the given @p markerSetName exists as a markerSet in this
+   * collection.
+   *
+   * @param markerSetName The desired marker set's name.
+   * @return whether the name is found as a MarkerSet subconfiguration.
+   */
+  bool hasNamedMarkerSet(const std::string& markerSetName) const {
+    return hasSubconfig(markerSetName);
+  }
+
+  /**
+   * @brief Retrieve a listing of all the markerset handles in this collection.
+   */
+  std::vector<std::string> getAllMarkerSetNames() const {
+    return getSubconfigKeys();
+  }
+
+  /**
+   * @brief Retrivess a copy of the named markerset, if it exists, and nullptr
+   * if it does not.
+   */
+  MarkerSet::ptr getNamedMarkerSetCopy(const std::string& markerSetName) {
+    return getSubconfigCopy<MarkerSet>(markerSetName);
+  }
+
+  /**
+   * @brief Retrieves a reference to a (potentially newly created) MarkerSet
+   * with the given @p markerSetName , which can be modified and the
+   * modifications will be retained.
+   *
+   * @param markerSetName The desired marker set's name.
+   * @return a reference to the marker set.
+   */
+  MarkerSet::ptr editNamedMarkerSet(const std::string& markerSetName) {
+    return editSubconfig<MarkerSet>(markerSetName);
+  }
+
+  ESP_SMART_POINTERS(MarkerSets)
+};  // class MarkerSets
+
+}  // namespace attributes
+}  // namespace metadata
+}  // namespace esp
+
+#endif  // ESP_METADATA_ATTRIBUTES_MARKERSETS_H_

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -57,6 +57,12 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
     }
   }
 
+  /**
+   * @brief Rekeys all markers to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys.
+   */
+  int rekeyAllMarkers() { return rekeySubconfigValues("markers"); }
+
   ESP_SMART_POINTERS(LinkMarkerSubset)
 };  // class LinkMarkerSubset
 
@@ -120,6 +126,19 @@ class LinkMarkerSets : public esp::core::config::Configuration {
    */
   void removeNamedMarkerSet(const std::string& linkSubsetName) {
     removeSubconfig(linkSubsetName);
+  }
+  /**
+   * @brief Rekeys all marker collections to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys in this
+   * link's marker subsets.
+   */
+  int rekeyAllMarkers() {
+    int res;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      res += editSubconfig<LinkMarkerSubset>(key)->rekeyAllMarkers();
+    }
+    return res;
   }
 
   ESP_SMART_POINTERS(LinkMarkerSets)
@@ -185,6 +204,20 @@ class MarkerSet : public esp::core::config::Configuration {
     removeSubconfig(linkSetName);
   }
 
+  /**
+   * @brief Rekeys all marker collections to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys in this
+   * markerset.
+   */
+  int rekeyAllMarkers() {
+    int res;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      res += editSubconfig<LinkMarkerSets>(key)->rekeyAllMarkers();
+    }
+    return res;
+  }
+
   ESP_SMART_POINTERS(MarkerSet)
 };  // class MarkerSet
 
@@ -244,6 +277,19 @@ class MarkerSets : public esp::core::config::Configuration {
    */
   void removeNamedMarkerSet(const std::string& markerSetName) {
     removeSubconfig(markerSetName);
+  }
+
+  /**
+   * @brief Rekeys all marker collections to have vector IDXs as string keys
+   * @return returns how many markers have been processed with new keys.
+   */
+  int rekeyAllMarkers() {
+    int res;
+    const auto& subsetKeys = getSubconfigKeys();
+    for (const auto& key : subsetKeys) {
+      res += editSubconfig<MarkerSet>(key)->rekeyAllMarkers();
+    }
+    return res;
   }
 
   /**

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -51,6 +51,8 @@ class LinkMarkerSubset : public esp::core::config::Configuration {
    */
   void setMarkers(const std::vector<Mn::Vector3>& markers) {
     auto markersPtr = editSubconfig<Configuration>("markers");
+    // Remove all existing markers
+    markersPtr->_clearAllValues();
     for (std::size_t i = 0; i < markers.size(); ++i) {
       const std::string& key = Cr::Utility::formatString("{:.03d}", i);
       markersPtr->set(key, markers[i]);

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -71,7 +71,7 @@ class MarkerSet : public esp::core::config::Configuration {
 
 /**
  * @brief This class provides an alias for the nested Configuration tree used
- * for a single link's 1 or more NarkerSets that should be attached to the
+ * for a single link's 1 or more MarkerSets that should be attached to the
  * named link.
  */
 class LinkSet : public esp::core::config::Configuration {
@@ -111,7 +111,7 @@ class LinkSet : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Retrieve a view of the naamed MarkerSet, if it exists, and
+   * @brief Retrieve a view of the named MarkerSet, if it exists, and
    * nullptr if it does not.
    */
   MarkerSet::cptr getMarkerSetView(const std::string& markerSetName) const {
@@ -276,7 +276,7 @@ class TaskSet : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Retrieve a view of the naamed LinkSet, if it exists, and
+   * @brief Retrieve a view of the named LinkSet, if it exists, and
    * nullptr if it does not.
    */
   LinkSet::cptr getLinkSetView(const std::string& linkSetName) const {
@@ -523,7 +523,7 @@ class MarkerSets : public esp::core::config::Configuration {
   }
 
   /**
-   * @brief Retrieve a view of the naamed TaskSet, if it exists, and
+   * @brief Retrieve a view of the named TaskSet, if it exists, and
    * nullptr if it does not.
    */
   TaskSet::cptr getTaskSetView(const std::string& taskSetName) const {

--- a/src/esp/metadata/managers/AOAttributesManager.cpp
+++ b/src/esp/metadata/managers/AOAttributesManager.cpp
@@ -101,7 +101,7 @@ void AOAttributesManager::setValsFromJSONDoc(
       [aoAttr](const std::string& val) { aoAttr->setLinkOrder(val); });
 
   // check for the existing of markersets
-  this->parseSubconfigJsonVals("marker_sets", aoAttr, jsonConfig);
+  this->parseMarkerSets(aoAttr, jsonConfig);
   // check for user defined attributes
   this->parseUserDefinedJsonVals(aoAttr, jsonConfig);
 

--- a/src/esp/metadata/managers/AOAttributesManager.cpp
+++ b/src/esp/metadata/managers/AOAttributesManager.cpp
@@ -48,7 +48,8 @@ void AOAttributesManager::setValsFromJSONDoc(
   if (io::readMember<std::string>(jsonConfig, "render_asset", render_asset)) {
     // If specified render_asset is not found directly, prefix it with file
     // directory where the configuration file was found.
-    if (!Corrade::Utility::Path::exists(render_asset)) {
+    if ((!Corrade::Utility::Path::exists(render_asset)) &&
+        !render_asset.empty()) {
       render_asset =
           Cr::Utility::Path::join(aoAttr->getFileDirectory(), render_asset);
     }

--- a/src/esp/metadata/managers/AOAttributesManager.h
+++ b/src/esp/metadata/managers/AOAttributesManager.h
@@ -75,6 +75,27 @@ class AOAttributesManager
 
  protected:
   /**
+   * @brief Parse Marker_sets object in json, if present.
+   * @param attribs (out) an existing attributes to be modified.
+   * @param jsonConfig json document to parse
+   * @return true if tag is found, of appropriate configuration, and holds
+   * actual values.
+   */
+  bool parseMarkerSets(
+      const attributes::ArticulatedObjectAttributes::ptr& attribs,
+      const io::JsonGenericValue& jsonConfig) const {
+    // check for the existing of markersets
+    bool hasMarkersets =
+        this->parseSubconfigJsonVals("marker_sets", attribs, jsonConfig);
+    if (hasMarkersets) {
+      // Cast markerset Configuration to MarkerSets object and reorder all
+      // markers
+      attribs->rekeyAllMarkerSets();
+    }
+    return hasMarkersets;
+  }
+
+  /**
    * @brief Used Internally.  Create and configure newly-created attributes with
    * any default values, before any specific values are set.
    *

--- a/src/esp/metadata/managers/AOAttributesManager.h
+++ b/src/esp/metadata/managers/AOAttributesManager.h
@@ -88,8 +88,9 @@ class AOAttributesManager
     bool hasMarkersets =
         this->parseSubconfigJsonVals("marker_sets", attribs, jsonConfig);
     if (hasMarkersets) {
-      // Cast markerset Configuration to MarkerSets object and reorder all
-      // markers
+      // Cast "marker_sets" Configuration to MarkerSets object and rekey all
+      // markers to make keys consistent while preserving the natural order of
+      // their original keys.
       attribs->rekeyAllMarkerSets();
     }
     return hasMarkersets;

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -98,6 +98,25 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
       bool registerTemplate = true) = 0;
 
  protected:
+  /**
+   * @brief Parse Marker_sets object in json, if present.
+   * @param attribs (out) an existing attributes to be modified.
+   * @param jsonConfig json document to parse
+   * @return true if tag is found, of appropriate configuration, and holds
+   * actual values.
+   */
+  bool parseMarkerSets(const AbsObjAttrPtr& attribs,
+                       const io::JsonGenericValue& jsonConfig) const {
+    // check for the existing of markersets
+    bool hasMarkersets =
+        this->parseSubconfigJsonVals("marker_sets", attribs, jsonConfig);
+    if (hasMarkersets) {
+      // Cast markerset Configuration to MarkerSets object and reorder all
+      // markers
+      attribs->rekeyAllMarkerSets();
+    }
+    return hasMarkersets;
+  }
   //======== Common JSON import functions ========
 
   /**
@@ -346,6 +365,9 @@ auto AbstractObjectAttributesManager<T, Access>::
       jsonDoc, "shader_type", "ShaderTypeNamesMap", false,
       attributes::ShaderTypeNamesMap,
       [attributes](const std::string& val) { attributes->setShaderType(val); });
+
+  // Markersets for stages or objects
+  this->parseMarkerSets(attributes, jsonDoc);
 
   return attributes;
 }  // AbstractObjectAttributesManager<AbsObjAttrPtr>::setAbstractObjectAttributesFromJson

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -111,8 +111,9 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
     bool hasMarkersets =
         this->parseSubconfigJsonVals("marker_sets", attribs, jsonConfig);
     if (hasMarkersets) {
-      // Cast markerset Configuration to MarkerSets object and reorder all
-      // markers
+      // Cast "marker_sets" Configuration to MarkerSets object and rekey all
+      // markers to make keys consistent while preserving the natural order of
+      // their original keys.
       attribs->rekeyAllMarkerSets();
     }
     return hasMarkersets;

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -127,9 +127,6 @@ void ObjectAttributesManager::setValsFromJSONDoc(
   // if com is set from json, don't compute from shape, and vice versa
   objAttributes->setComputeCOMFromShape(!comIsSet);
 
-  // check for the existing of markersets
-  this->parseSubconfigJsonVals("marker_sets", objAttributes, jsonConfig);
-
   // check for user defined attributes
   this->parseUserDefinedJsonVals(objAttributes, jsonConfig);
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -426,7 +426,8 @@ void StageAttributesManager::setValsFromJSONDoc(
     // if "nav mesh" is specified in stage json set value (override default).
     // navmesh filename might already be fully qualified; if not, might just be
     // file name
-    if (!Corrade::Utility::Path::exists(navmeshFName)) {
+    if (!Corrade::Utility::Path::exists(navmeshFName) &&
+        !navmeshFName.empty()) {
       navmeshFName = Cr::Utility::Path::join(stageLocFileDir, navmeshFName);
     }
     stageAttributes->setNavmeshAssetHandle(navmeshFName);
@@ -438,7 +439,8 @@ void StageAttributesManager::setValsFromJSONDoc(
     // (override default).
     // semanticSceneDescriptor filename might already be fully qualified; if
     // not, might just be file name
-    if (!Corrade::Utility::Path::exists(semanticSceneDescriptor)) {
+    if (!Corrade::Utility::Path::exists(semanticSceneDescriptor) &&
+        !semanticSceneDescriptor.empty()) {
       semanticSceneDescriptor =
           Cr::Utility::Path::join(stageLocFileDir, semanticSceneDescriptor);
     }

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -444,8 +444,6 @@ void StageAttributesManager::setValsFromJSONDoc(
     }
     stageAttributes->setSemanticDescriptorFilename(semanticSceneDescriptor);
   }
-  // check for the existing of markersets
-  this->parseSubconfigJsonVals("marker_sets", stageAttributes, jsonConfig);
   // check for user defined attributes
   this->parseUserDefinedJsonVals(stageAttributes, jsonConfig);
 

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -444,6 +444,15 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   }
 
   /**
+   * @brief Find the link ID for the given link name
+   */
+  int getLinkIdFromName(const std::string& _name) const {
+    auto linkIdIter = linkNamesToIDs_.find(_name);
+    CORRADE_INTERNAL_ASSERT(linkIdIter != linkNamesToIDs_.end());
+    return linkIdIter->second;
+  }
+
+  /**
    * @brief Get a map of object ids to link ids.
    *
    * @return A a map of Habitat object ids to link ids for this AO's links.
@@ -923,6 +932,9 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
 
   //! map linkId to ArticulatedLink
   std::map<int, ArticulatedLink::uptr> links_;
+
+  //! convenience mapping from link name to link id
+  std::map<std::string, int> linkNamesToIDs_;
 
   //! link object for the AO base
   ArticulatedLink::uptr baseLink_;

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -331,7 +331,10 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
       return baseLink_->node();
     }
     auto linkIter = links_.find(linkId);
-    CORRADE_INTERNAL_ASSERT(linkIter != links_.end());
+    ESP_CHECK(
+        linkIter != links_.end(),
+        "ArticulatedObject::getLinkSceneNode - no link found with linkId ="
+            << linkId);
     return linkIter->second->node();
   }
 
@@ -347,7 +350,10 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
       return baseLink_->visualNodes_;
     }
     auto linkIter = links_.find(linkId);
-    CORRADE_INTERNAL_ASSERT(linkIter != links_.end());
+    ESP_CHECK(linkIter != links_.end(),
+              "ArticulatedObject::getLinkVisualSceneNodes - no link found with "
+              "linkId ="
+                  << linkId);
     return linkIter->second->visualNodes_;
   }
 
@@ -403,7 +409,8 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
     }
 
     auto linkIter = links_.find(id);
-    CORRADE_INTERNAL_ASSERT(linkIter != links_.end());
+    ESP_CHECK(linkIter != links_.end(),
+              "ArticulatedObject::getLink - no link found with linkId =" << id);
     return *linkIter->second;
   }
 
@@ -448,7 +455,9 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    */
   int getLinkIdFromName(const std::string& _name) const {
     auto linkIdIter = linkNamesToIDs_.find(_name);
-    CORRADE_INTERNAL_ASSERT(linkIdIter != linkNamesToIDs_.end());
+    ESP_CHECK(linkIdIter != linkNamesToIDs_.end(),
+              "ArticulatedObject::getLinkIdFromName - no link found with name ="
+                  << _name);
     return linkIdIter->second;
   }
 
@@ -465,34 +474,36 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    * @brief Given the list of passed points in this object's local space, return
    * those points transformed to world space.
    * @param points vector of points in object local space
-   * @param linkID Unused for rigids.
+   * @param linkId Internal link index.
    * @return vector of points transformed into world space
    */
   std::vector<Mn::Vector3> transformLocalPointsToWorld(
       const std::vector<Mn::Vector3>& points,
-      int linkID) const override {
-    auto linkIter = links_.find(linkID);
-    if (linkIter != links_.end()) {
-      return linkIter->second->transformLocalPointsToWorld(points, linkID);
-    }
-    return points;
+      int linkId) const override {
+    auto linkIter = links_.find(linkId);
+    ESP_CHECK(linkIter != links_.end(),
+              "ArticulatedObject::getLinkVisualSceneNodes - no link found with "
+              "linkId ="
+                  << linkId);
+    return linkIter->second->transformLocalPointsToWorld(points, linkId);
   }
 
   /**
    * @brief Given the list of passed points in world space, return
    * those points transformed to this object's local space.
    * @param points vector of points in world space
-   * @param linkID Unused for rigids.
+   * @param linkId Internal link index.
    * @return vector of points transformed to be in local space
    */
   std::vector<Mn::Vector3> transformWorldPointsToLocal(
       const std::vector<Mn::Vector3>& points,
-      int linkID) const override {
-    auto linkIter = links_.find(linkID);
-    if (linkIter != links_.end()) {
-      return linkIter->second->transformWorldPointsToLocal(points, linkID);
-    }
-    return points;
+      int linkId) const override {
+    auto linkIter = links_.find(linkId);
+    ESP_CHECK(linkIter != links_.end(),
+              "ArticulatedObject::getLinkVisualSceneNodes - no link found with "
+              "linkId ="
+                  << linkId);
+    return linkIter->second->transformWorldPointsToLocal(points, linkId);
   }
 
   /**
@@ -661,11 +672,12 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    * @param linkId The link's index.
    * @return The link's parent joint's name.
    */
-  virtual std::string getLinkJointName(CORRADE_UNUSED int linkId) const {
+  virtual std::string getLinkJointName(int linkId) const {
     auto linkIter = links_.find(linkId);
-    ESP_CHECK(linkIter != links_.end(),
-              "ArticulatedObject::getLinkJointName - no link with linkId ="
-                  << linkId);
+    ESP_CHECK(
+        linkIter != links_.end(),
+        "ArticulatedObject::getLinkJointName - no link found with linkId ="
+            << linkId);
     return linkIter->second->linkJointName;
   }
 
@@ -675,15 +687,15 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    * @param linkId The link's index. -1 for base link.
    * @return The link's name.
    */
-  virtual std::string getLinkName(CORRADE_UNUSED int linkId) const {
+  virtual std::string getLinkName(int linkId) const {
     if (linkId == -1) {
       return baseLink_->linkName;
     }
 
     auto linkIter = links_.find(linkId);
-    ESP_CHECK(
-        linkIter != links_.end(),
-        "ArticulatedObject::getLinkName - no link with linkId =" << linkId);
+    ESP_CHECK(linkIter != links_.end(),
+              "ArticulatedObject::getLinkName - no link found with linkId ="
+                  << linkId);
     return linkIter->second->linkName;
   }
 

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -174,16 +174,17 @@ class ArticulatedLink : public RigidBase {
     return true;
   }
 
+  void initializeArticulatedLink(const std::string& _linkName,
+                                 const Mn::Vector3& _scale) {
+    linkName = _linkName;
+    setScale(_scale);
+  }
+
   /**
    * @brief Finalize the creation of the link.
    * @return whether successful finalization.
    */
   bool finalizeObject() override { return true; }
-
-  Magnum::Vector3 getScale() const override {
-    ESP_DEBUG() << "ArticulatedLink does not currently support this.";
-    return {};
-  }
 
   void setTransformation(
       CORRADE_UNUSED const Magnum::Matrix4& transformation) override {
@@ -449,6 +450,40 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    */
   std::unordered_map<int, int> getLinkObjectIds() const {
     return objectIdToLinkId_;
+  }
+
+  /**
+   * @brief Given the list of passed points in this object's local space, return
+   * those points transformed to world space.
+   * @param points vector of points in object local space
+   * @param linkID Unused for rigids.
+   * @return vector of points transformed into world space
+   */
+  std::vector<Mn::Vector3> transformLocalPointsToWorld(
+      const std::vector<Mn::Vector3>& points,
+      int linkID) const override {
+    auto linkIter = links_.find(linkID);
+    if (linkIter != links_.end()) {
+      return linkIter->second->transformLocalPointsToWorld(points, linkID);
+    }
+    return points;
+  }
+
+  /**
+   * @brief Given the list of passed points in world space, return
+   * those points transformed to this object's local space.
+   * @param points vector of points in world space
+   * @param linkID Unused for rigids.
+   * @return vector of points transformed to be in local space
+   */
+  std::vector<Mn::Vector3> transformWorldPointsToLocal(
+      const std::vector<Mn::Vector3>& points,
+      int linkID) const override {
+    auto linkIter = links_.find(linkID);
+    if (linkIter != links_.end()) {
+      return linkIter->second->transformWorldPointsToLocal(points, linkID);
+    }
+    return points;
   }
 
   /**

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -180,6 +180,11 @@ class ArticulatedLink : public RigidBase {
    */
   bool finalizeObject() override { return true; }
 
+  Magnum::Vector3 getScale() const override {
+    ESP_DEBUG() << "ArticulatedLink does not currently support this.";
+    return {};
+  }
+
   void setTransformation(
       CORRADE_UNUSED const Magnum::Matrix4& transformation) override {
     ESP_DEBUG() << "ArticulatedLink can't do this.";

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -903,7 +903,13 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   }
 
   /**
-   * @brief Get a copy of the template used to initialize this object.
+   * @brief Get a copy of the template attributes describing the initial state
+   * of this articulated object. These attributes have the combination of date
+   * from the original articulated object attributes and specific instance
+   * attributes used to create this articulated object. Note : values will
+   * reflect both sources, and should not be saved to disk as articulated object
+   * attributes, since instance attribute modifications will still occur on
+   * subsequent loads
    *
    * @return A copy of the @ref esp::metadata::attributes::ArticulatedObjectAttributes
    * template used to create this object.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -638,7 +638,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /**
    * @brief Stores a reference to the markersets for this object, held as a
-   * smart pointer to a MarkerSets construct, which is an alia for
+   * smart pointer to a MarkerSets construct, which is an alias for
    * a @ref esp::core::config::Configuration.
    */
   metadata::attributes::MarkerSets::ptr markerSets_ = nullptr;

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -9,6 +9,7 @@
 #include <Corrade/Containers/Reference.h>
 #include "esp/core/RigidState.h"
 #include "esp/gfx/ShaderManager.h"
+#include "esp/metadata/attributes/MarkerSets.h"
 #include "esp/metadata/attributes/SceneInstanceAttributes.h"
 #include "esp/physics/CollisionGroupHelper.h"
 
@@ -495,7 +496,6 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * @brief This function will overwrite this object's existing user-defined
    * attributes with @p attr.
    * @param attr A ptr to the user defined attributes specified for this object.
-   * merge into them.
    */
   void setUserAttributes(core::config::Configuration::ptr attr) {
     userAttributes_ = std::move(attr);
@@ -504,11 +504,37 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief This function will merge this object's existing user-defined
    * attributes with @p attr by overwriting it with @p attr.
-   * @param attr A ptr to the user defined attributes specified for this object.
-   * merge into them.
+   * @param attr A ptr to the user defined attributes that are to be merged into
+   * this object's existing user-defined attributes.
    */
   void mergeUserAttributes(const core::config::Configuration::ptr& attr) {
     userAttributes_->overwriteWithConfig(attr);
+  }
+
+  /**
+   * @brief Get a reference to the existing MarkerSets for this object.
+   */
+  metadata::attributes::MarkerSets::ptr getMarkerSets() const {
+    return markerSets_;
+  }
+
+  /**
+   * @brief This function will overwrite this object's existing MarkerSets
+   * attributes with @p attr.
+   * @param attr A ptr to the MarkerSets attributes specified for this object.
+   */
+  void setMarkerSets(metadata::attributes::MarkerSets::ptr attr) {
+    markerSets_ = std::move(attr);
+  }
+
+  /**
+   * @brief This function will merge this object's existing MarkerSets
+   * attributes with @p attr by overwriting it with @p attr.
+   * @param attr A ptr to the user defined attributes specified for this object.
+   * with mergee into them.
+   */
+  void mergeMarkerSets(const metadata::attributes::MarkerSets::ptr& attr) {
+    markerSets_->overwriteWithConfig(attr);
   }
 
   /** @brief Get the scale of the object set during initialization.
@@ -609,6 +635,13 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * user to access and save important information and metadata.
    */
   core::config::Configuration::ptr userAttributes_ = nullptr;
+
+  /**
+   * @brief Stores a reference to the markersets for this object, held as a
+   * smart pointer to a MarkerSets construct, which is an alia for
+   * a @ref esp::core::config::Configuration.
+   */
+  metadata::attributes::MarkerSets::ptr markerSets_ = nullptr;
 
   /**
    * @brief Saved attributes when the object was initialized.

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -253,7 +253,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     lsPoints.reserve(points.size());
     Mn::Vector3 objScale = getScale();
     Mn::Matrix4 worldTransform = getTransformation();
-    for (const auto wsPoint : points) {
+    for (const auto& wsPoint : points) {
       lsPoints.emplace_back(worldTransform.inverted().transformPoint(wsPoint) /
                             objScale);
     }

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -361,15 +361,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   virtual void setRestitutionCoefficient(
       CORRADE_UNUSED const double restitutionCoefficient) {}
 
-  /** @brief Get the scale of the object set during initialization.
-   * @return The scaling for the object relative to its initially loaded meshes.
-   */
-  virtual Magnum::Vector3 getScale() const {
-    return PhysicsObjectBase::getInitializationAttributes<
-               metadata::attributes::AbstractObjectAttributes>()
-        ->getScale();
-  }
-
   /**
    * @brief Get the semantic ID for this object.
    */

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -25,6 +25,7 @@ bool RigidObject::initialize(
   // save the copy of the template used to create the object at initialization
   // time
   setUserAttributes(initAttributes->getUserConfiguration());
+  setMarkerSets(initAttributes->getMarkerSetsConfiguration());
   initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -20,6 +20,8 @@ bool RigidObject::initialize(
     return false;
   }
 
+  setScale(initAttributes->getScale());
+
   // save the copy of the template used to create the object at initialization
   // time
   setUserAttributes(initAttributes->getUserConfiguration());

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -119,7 +119,12 @@ class RigidObject : public RigidBase {
   bool finalizeObject() override;
 
   /**
-   * @brief Get a copy of the template used to initialize this object.
+   * @brief Get a copy of the template attributes describing the initial state
+   * of this object. These attributes have the combination of date from the
+   * original object attributes and specific instance attributes used to create
+   * this object. Note : values will reflect both sources, and should not be
+   * saved to disk as object attributes, since instance attribute modifications
+   * will still occur on subsequent loads
    *
    * @return A copy of the @ref esp::metadata::attributes::ObjectAttributes
    * template used to create this object.

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -25,6 +25,7 @@ bool RigidStage::initialize(
   // save the copy of the template used to create the object at initialization
   // time
   setUserAttributes(initAttributes->getUserConfiguration());
+  setMarkerSets(initAttributes->getMarkerSetsConfiguration());
   initializationAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -20,6 +20,8 @@ bool RigidStage::initialize(
   objectMotionType_ = MotionType::STATIC;
   objectName_ = Cr::Utility::formatString(
       "Stage from {}", initAttributes->getSimplifiedHandle());
+
+  setScale(initAttributes->getScale());
   // save the copy of the template used to create the object at initialization
   // time
   setUserAttributes(initAttributes->getUserConfiguration());

--- a/src/esp/physics/RigidStage.h
+++ b/src/esp/physics/RigidStage.h
@@ -40,7 +40,12 @@ class RigidStage : public RigidBase {
                       initAttributes) override;
 
   /**
-   * @brief Get a copy of the template used to initialize this stage object.
+   * @brief Get a copy of the template attributes describing the initial state
+   * of this stage object. These attributes have the combination of date from
+   * the original object attributes and specific instance attributes used to
+   * create this stage object. Note : values will reflect both sources, and
+   * should not be saved to disk as object attributes, since instance attribute
+   * modifications will still occur on subsequent loads
    *
    * @return A copy of the @ref esp::metadata::attributes::StageAttributes
    * template used to create this stage object.

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -87,6 +87,7 @@ void BulletArticulatedObject::initializeFromURDF(
 
   // cache the global scaling from the source model
   globalScale_ = urdfModel->getGlobalScaling();
+  setScale(Mn::Vector3{globalScale_, globalScale_, globalScale_});
 
   u2b.convertURDFToBullet(rootTransformInWorldSpace, bWorld_.get(),
                           linkCompoundShapes_, linkChildShapes_);
@@ -145,6 +146,7 @@ void BulletArticulatedObject::initializeFromURDF(
         }
         linkObject = baseLink_.get();
       }
+      linkObject->initializeArticulatedLink(urdfLink->m_name, getScale());
       linkObject->linkName = urdfLink->m_name;
 
       linkObject->node().setType(esp::scene::SceneNodeType::OBJECT);

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -148,6 +148,7 @@ void BulletArticulatedObject::initializeFromURDF(
       }
       linkObject->initializeArticulatedLink(urdfLink->m_name, getScale());
       linkObject->linkName = urdfLink->m_name;
+      linkNamesToIDs_[linkObject->linkName] = bulletLinkIx;
 
       linkObject->node().setType(esp::scene::SceneNodeType::OBJECT);
     }

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -170,6 +170,7 @@ void BulletArticulatedObject::initializeFromURDF(
   }
   // set user config and initialization attributes
   setUserAttributes(initAttributes->getUserConfiguration());
+  setMarkerSets(initAttributes->getMarkerSetsConfiguration());
   initializationAttributes_ = initAttributes;
 }
 

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -493,8 +493,6 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
 
       switch (jointType) {
         case metadata::URDF::SphericalJoint: {
-          // TODO: link mapping?
-          // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
           cache->m_bulletMultiBody->setupSpherical(
               mbLinkIndex, mass, btVector3(localInertiaDiagonal), mbParentIndex,
               btQuaternion(parentRotToThis), btVector3(offsetInA.translation()),
@@ -503,8 +501,6 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
           break;
         }
         case metadata::URDF::PlanarJoint: {
-          // TODO: link mapping?
-          // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
           cache->m_bulletMultiBody->setupPlanar(
               mbLinkIndex, mass, btVector3(localInertiaDiagonal), mbParentIndex,
               btQuaternion(parentRotToThis),
@@ -515,17 +511,14 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
           break;
         }
         case metadata::URDF::FloatingJoint:
-
         case metadata::URDF::FixedJoint: {
-          if ((jointType == metadata::URDF::FloatingJoint) ||
-              (jointType == metadata::URDF::PlanarJoint)) {
-            printf(
-                "Warning: joint unsupported, creating a fixed joint instead.");
+          if (jointType == metadata::URDF::FloatingJoint)
+          //|| (jointType == metadata::URDF::PlanarJoint))
+          {
+            ESP_WARNING() << "Warning: Floating joint unsupported, creating a "
+                             "fixed joint instead.";
           }
-          // TODO: link mapping?
-          // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
-
-          // todo: adjust the center of mass transform and pivot axis properly
+          // TODO: adjust the center of mass transform and pivot axis properly
           cache->m_bulletMultiBody->setupFixed(
               mbLinkIndex, mass, btVector3(localInertiaDiagonal), mbParentIndex,
               btQuaternion(parentRotToThis), btVector3(offsetInA.translation()),
@@ -534,9 +527,6 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
         }
         case metadata::URDF::ContinuousJoint:
         case metadata::URDF::RevoluteJoint: {
-          // TODO: link mapping?
-          // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
-
           cache->m_bulletMultiBody->setupRevolute(
               mbLinkIndex, mass, btVector3(localInertiaDiagonal), mbParentIndex,
               btQuaternion(parentRotToThis),
@@ -561,9 +551,6 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
           break;
         }
         case metadata::URDF::PrismaticJoint: {
-          // TODO: link mapping?
-          // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
-
           cache->m_bulletMultiBody->setupPrismatic(
               mbLinkIndex, mass, btVector3(localInertiaDiagonal), mbParentIndex,
               btQuaternion(parentRotToThis),
@@ -590,6 +577,8 @@ Mn::Matrix4 BulletURDFImporter::convertURDFToBulletInternal(
           ESP_VERY_VERBOSE() << "Invalid joint type." btAssert(0);
         }
       }
+      // TODO: link mapping?
+      // creation.addLinkMapping(urdfLinkIndex, mbLinkIndex);
     }
 
     {

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -24,6 +24,15 @@ class ManagedArticulatedObject
       : AbstractManagedPhysicsObject<esp::physics::ArticulatedObject>(
             classKey) {}
 
+  /**
+   * @brief Get a copy of the template attributes describing the initial state
+   * of this articulated object. These attributes have the combination of date
+   * from the original articulated object attributes and specific instance
+   * attributes used to create this articulated object. Note : values will
+   * reflect both sources, and should not be saved to disk as articulated object
+   * attributes, since instance attribute modifications will still occur on
+   * subsequent loads
+   */
   std::shared_ptr<metadata::attributes::ArticulatedObjectAttributes>
   getInitializationAttributes() const {
     if (auto sp = this->getObjectReference()) {

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -81,6 +81,13 @@ class ManagedArticulatedObject
     return {};
   }
 
+  int getLinkIdFromName(const std::string& _name) const {
+    if (auto sp = getObjectReference()) {
+      return sp->getLinkIdFromName(_name);
+    }
+    return -1;
+  }
+
   std::unordered_map<int, int> getLinkObjectIds() const {
     if (auto sp = getObjectReference()) {
       return sp->getLinkObjectIds();

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -135,7 +135,7 @@ class AbstractManagedPhysicsObject
     }
     return nullptr;
   }
-  core::config::Configuration::ptr getMarkerSets() const {
+  esp::metadata::attributes::MarkerSets::ptr getMarkerSets() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getMarkerSets();
     }

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -135,6 +135,12 @@ class AbstractManagedPhysicsObject
     }
     return nullptr;
   }
+  core::config::Configuration::ptr getMarkerSets() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getMarkerSets();
+    }
+    return nullptr;
+  }
   // ==== Transformations ===
 
   Magnum::Matrix4 getTransformation() const {

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -175,7 +175,7 @@ class AbstractManagedPhysicsObject
       const std::vector<Mn::Vector3>& points,
       int linkID) const {
     if (auto sp = this->getObjectReference()) {
-      sp->transformLocalPointsToWorld(points, linkID);
+      return sp->transformLocalPointsToWorld(points, linkID);
     }
     return {};
   }
@@ -192,7 +192,7 @@ class AbstractManagedPhysicsObject
       const std::vector<Mn::Vector3>& points,
       int linkID) const {
     if (auto sp = this->getObjectReference()) {
-      sp->transformWorldPointsToLocal(points, linkID);
+      return sp->transformWorldPointsToLocal(points, linkID);
     }
     return {};
   }

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -163,6 +163,40 @@ class AbstractManagedPhysicsObject
     }
   }  // setTranslation
 
+  /**
+   * @brief Given the list of passed points in this object's local space, return
+   * those points transformed to world space.
+   * @param points vector of points in object local space
+   * @param linkID The link ID for the object (only pertinent for articulated
+   * objects). Ignored for rigid objects and stages.
+   * @return vector of points transformed into world space
+   */
+  std::vector<Mn::Vector3> transformLocalPointsToWorld(
+      const std::vector<Mn::Vector3>& points,
+      int linkID) const {
+    if (auto sp = this->getObjectReference()) {
+      sp->transformLocalPointsToWorld(points, linkID);
+    }
+    return {};
+  }
+
+  /**
+   * @brief Given the list of passed points in world space, return
+   * those points transformed to this object's local space.
+   * @param points vector of points in world space
+   * @param linkID The link ID for the object (only pertinent for articulated
+   * objects). Ignored for rigid objects and stages.
+   * @return vector of points transformed to be in local space
+   */
+  std::vector<Mn::Vector3> transformWorldPointsToLocal(
+      const std::vector<Mn::Vector3>& points,
+      int linkID) const {
+    if (auto sp = this->getObjectReference()) {
+      sp->transformWorldPointsToLocal(points, linkID);
+    }
+    return {};
+  }
+
   Magnum::Quaternion getRotation() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getRotation();

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -24,6 +24,14 @@ class ManagedRigidObject
       : AbstractManagedRigidBase<
             esp::physics::RigidObject>::AbstractManagedRigidBase(classKey) {}
 
+  /**
+   * @brief Get a copy of the template attributes describing the initial state
+   * of this object. These attributes have the combination of date from the
+   * original object attributes and specific instance attributes used to create
+   * this object. Note : values will reflect both sources, and should not
+   * be saved to disk as object attributes, since instance attribute
+   * modifications will still occur on subsequent loads
+   */
   std::shared_ptr<metadata::attributes::ObjectAttributes>
   getInitializationAttributes() const {
     if (auto sp = this->getObjectReference()) {

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -278,7 +278,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
   // ["test_00", "test_01", "test_02", "test_03"],
   for (int i = 0; i < strListSize; ++i) {
     const std::string subKey =
-        Cr::Utility::formatString("user_str_array_{:.02d}", i);
+        Cr::Utility::formatString("user_str_array_{:.03d}", i);
     const std::string fieldVal = Cr::Utility::formatString("test_{:.02d}", i);
 
     CORRADE_COMPARE(userStrListSubconfig->get<std::string>(subKey), fieldVal);

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -1350,16 +1350,16 @@ void AttributesConfigsTest::testStageAttrVals(
     // Test marker sets
 
     MarkersTestMap subset_id_000_stage_name(
-        {{"markers_03", Mn::Vector3{4.1, 5.2, 6.3}},
-         {"markers_02", Mn::Vector3{3.1, 4.2, 5.3}},
-         {"markers_01", Mn::Vector3{2.1, 3.2, 4.3}},
-         {"markers_00", Mn::Vector3{1.1, 2.2, 3.3}}});
+        {{"003", Mn::Vector3{4.1, 5.2, 6.3}},
+         {"002", Mn::Vector3{3.1, 4.2, 5.3}},
+         {"001", Mn::Vector3{2.1, 3.2, 4.3}},
+         {"000", Mn::Vector3{1.1, 2.2, 3.3}}});
 
     MarkersTestMap subset_id_001_stage_name(
-        {{"3", Mn::Vector3{4.2, 5.3, 6.4}},
-         {"2", Mn::Vector3{3.2, 4.3, 5.4}},
-         {"1", Mn::Vector3{2.2, 3.3, 4.4}},
-         {"0", Mn::Vector3{1.2, 2.3, 3.4}}});
+        {{"003", Mn::Vector3{4.2, 5.3, 6.4}},
+         {"002", Mn::Vector3{3.2, 4.3, 5.4}},
+         {"001", Mn::Vector3{2.2, 3.3, 4.4}},
+         {"000", Mn::Vector3{1.2, 2.3, 3.4}}});
 
     SubsetTestMap link_id_00_stage_name(
         {{"subset_id_000_stage_name", subset_id_000_stage_name},
@@ -1369,22 +1369,22 @@ void AttributesConfigsTest::testStageAttrVals(
         {{"link_id_00_stage_name", link_id_00_stage_name}}};
 
     MarkersTestMap subset_id_100_stage_name(
-        {{"markers_03", Mn::Vector3{14.1, 15.2, 16.3}},
-         {"markers_02", Mn::Vector3{13.1, 14.2, 15.3}},
-         {"markers_01", Mn::Vector3{12.1, 13.2, 14.3}},
-         {"markers_00", Mn::Vector3{11.1, 12.2, 13.3}}});
+        {{"003", Mn::Vector3{14.1, 15.2, 16.3}},
+         {"002", Mn::Vector3{13.1, 14.2, 15.3}},
+         {"001", Mn::Vector3{12.1, 13.2, 14.3}},
+         {"000", Mn::Vector3{11.1, 12.2, 13.3}}});
 
     MarkersTestMap subset_id_101_stage_name(
-        {{"3", Mn::Vector3{14.2, 15.3, 16.4}},
-         {"2", Mn::Vector3{13.2, 14.3, 15.4}},
-         {"1", Mn::Vector3{12.2, 13.3, 14.4}},
-         {"0", Mn::Vector3{11.2, 12.3, 13.4}}});
+        {{"003", Mn::Vector3{14.2, 15.3, 16.4}},
+         {"002", Mn::Vector3{13.2, 14.3, 15.4}},
+         {"001", Mn::Vector3{12.2, 13.3, 14.4}},
+         {"000", Mn::Vector3{11.2, 12.3, 13.4}}});
 
     MarkersTestMap subset_id_102_stage_name(
-        {{"3", Mn::Vector3{124.2, 125.3, 126.4}},
-         {"2", Mn::Vector3{123.2, 124.3, 125.4}},
-         {"1", Mn::Vector3{122.2, 123.3, 124.4}},
-         {"0", Mn::Vector3{121.2, 122.3, 123.4}}});
+        {{"003", Mn::Vector3{124.2, 125.3, 126.4}},
+         {"002", Mn::Vector3{123.2, 124.3, 125.4}},
+         {"001", Mn::Vector3{122.2, 123.3, 124.4}},
+         {"000", Mn::Vector3{121.2, 122.3, 123.4}}});
 
     SubsetTestMap link_id_10_stage_name(
         {{"subset_id_100_stage_name", subset_id_100_stage_name},
@@ -1392,16 +1392,17 @@ void AttributesConfigsTest::testStageAttrVals(
          {"subset_id_102_stage_name", subset_id_102_stage_name}});
 
     MarkersTestMap subset_id_110_stage_name(
-        {{"3", Mn::Vector3{14.3, 15.4, 16.5}},
-         {"2", Mn::Vector3{13.3, 14.4, 15.5}},
-         {"1", Mn::Vector3{12.3, 13.4, 14.5}},
-         {"0", Mn::Vector3{11.3, 12.4, 13.5}}});
+        {{"003", Mn::Vector3{14.3, 15.4, 16.5}},
+         {"002", Mn::Vector3{13.3, 14.4, 15.5}},
+         {"001", Mn::Vector3{12.3, 13.4, 14.5}},
+         {"000", Mn::Vector3{11.3, 12.4, 13.5}}});
 
     MarkersTestMap subset_id_111_stage_name(
-        {{"markers_03", Mn::Vector3{14.4, 15.5, 16.6}},
-         {"markers_02", Mn::Vector3{13.4, 14.5, 15.6}},
-         {"markers_01", Mn::Vector3{12.4, 13.5, 14.6}},
-         {"markers_00", Mn::Vector3{11.4, 12.5, 13.6}}});
+        {{"003", Mn::Vector3{14.4, 15.5, 16.6}},
+         {"002", Mn::Vector3{13.4, 14.5, 15.6}},
+         {"004", Mn::Vector3{15.4, 16.5, 17.6}},
+         {"001", Mn::Vector3{12.4, 13.5, 14.6}},
+         {"000", Mn::Vector3{11.4, 12.5, 13.6}}});
 
     SubsetTestMap link_id_11_stage_name(
         {{"subset_id_110_stage_name", subset_id_110_stage_name},
@@ -1504,7 +1505,8 @@ void AttributesConfigsTest::testStageJSONLoad() {
                     [11.4, 12.5, 13.6],
                     [12.4, 13.5, 14.6],
                     [13.4, 14.5, 15.6],
-                    [14.4, 15.5, 16.6]
+                    [14.4, 15.5, 16.6],
+                    [15.4, 16.5, 17.6]
                   ]
               }
           }
@@ -1620,30 +1622,32 @@ void AttributesConfigsTest::testObjectAttrVals(
     // Test marker sets
 
     MarkersTestMap subset_id_000_obj_name(
-        {{"markers_03", Mn::Vector3{4.1, 5.2, 6.3}},
-         {"markers_02", Mn::Vector3{3.1, 4.2, 5.3}},
-         {"markers_01", Mn::Vector3{2.1, 3.2, 4.3}},
-         {"markers_00", Mn::Vector3{1.1, 2.2, 3.3}}});
+        {{"003", Mn::Vector3{4.1, 5.2, 6.3}},
+         {"002", Mn::Vector3{3.1, 4.2, 5.3}},
+         {"001", Mn::Vector3{2.1, 3.2, 4.3}},
+         {"000", Mn::Vector3{1.1, 2.2, 3.3}}});
 
-    MarkersTestMap subset_id_001_obj_name({{"3", Mn::Vector3{4.2, 5.3, 6.4}},
-                                           {"2", Mn::Vector3{3.2, 4.3, 5.4}},
-                                           {"1", Mn::Vector3{2.2, 3.3, 4.4}},
-                                           {"0", Mn::Vector3{1.2, 2.3, 3.4}}});
+    MarkersTestMap subset_id_001_obj_name(
+        {{"003", Mn::Vector3{4.2, 5.3, 6.4}},
+         {"002", Mn::Vector3{3.2, 4.3, 5.4}},
+         {"001", Mn::Vector3{2.2, 3.3, 4.4}},
+         {"000", Mn::Vector3{1.2, 2.3, 3.4}}});
 
     SubsetTestMap link_id_00_obj_name(
         {{"subset_id_000_obj_name", subset_id_000_obj_name},
          {"subset_id_001_obj_name", subset_id_001_obj_name}});
 
-    MarkersTestMap subset_id_010_obj_name({{"3", Mn::Vector3{4.3, 5.4, 6.5}},
-                                           {"2", Mn::Vector3{3.3, 4.4, 5.5}},
-                                           {"1", Mn::Vector3{2.3, 3.4, 4.5}},
-                                           {"0", Mn::Vector3{1.3, 2.4, 3.5}}});
+    MarkersTestMap subset_id_010_obj_name(
+        {{"003", Mn::Vector3{4.3, 5.4, 6.5}},
+         {"002", Mn::Vector3{3.3, 4.4, 5.5}},
+         {"001", Mn::Vector3{2.3, 3.4, 4.5}},
+         {"000", Mn::Vector3{1.3, 2.4, 3.5}}});
 
     MarkersTestMap subset_id_011_obj_name(
-        {{"markers_03", Mn::Vector3{4.4, 5.5, 6.6}},
-         {"markers_02", Mn::Vector3{3.4, 4.5, 5.6}},
-         {"markers_01", Mn::Vector3{2.4, 3.5, 4.6}},
-         {"markers_00", Mn::Vector3{1.4, 2.5, 3.6}}});
+        {{"003", Mn::Vector3{4.4, 5.5, 6.6}},
+         {"002", Mn::Vector3{3.4, 4.5, 5.6}},
+         {"001", Mn::Vector3{2.4, 3.5, 4.6}},
+         {"000", Mn::Vector3{1.4, 2.5, 3.6}}});
 
     SubsetTestMap link_id_01_obj_name(
         {{"subset_id_010_obj_name", subset_id_010_obj_name},
@@ -1654,32 +1658,32 @@ void AttributesConfigsTest::testObjectAttrVals(
          {"link_id_01_obj_name", link_id_01_obj_name}}};
 
     MarkersTestMap subset_id_100_obj_name(
-        {{"markers_03", Mn::Vector3{14.1, 15.2, 16.3}},
-         {"markers_02", Mn::Vector3{13.1, 14.2, 15.3}},
-         {"markers_01", Mn::Vector3{12.1, 13.2, 14.3}},
-         {"markers_00", Mn::Vector3{11.1, 12.2, 13.3}}});
+        {{"003", Mn::Vector3{14.1, 15.2, 16.3}},
+         {"002", Mn::Vector3{13.1, 14.2, 15.3}},
+         {"001", Mn::Vector3{12.1, 13.2, 14.3}},
+         {"000", Mn::Vector3{11.1, 12.2, 13.3}}});
 
     MarkersTestMap subset_id_101_obj_name(
-        {{"3", Mn::Vector3{14.2, 15.3, 16.4}},
-         {"2", Mn::Vector3{13.2, 14.3, 15.4}},
-         {"1", Mn::Vector3{12.2, 13.3, 14.4}},
-         {"0", Mn::Vector3{11.2, 12.3, 13.4}}});
+        {{"003", Mn::Vector3{14.2, 15.3, 16.4}},
+         {"002", Mn::Vector3{13.2, 14.3, 15.4}},
+         {"001", Mn::Vector3{12.2, 13.3, 14.4}},
+         {"000", Mn::Vector3{11.2, 12.3, 13.4}}});
 
     SubsetTestMap link_id_10_obj_name(
         {{"subset_id_100_obj_name", subset_id_100_obj_name},
          {"subset_id_101_obj_name", subset_id_101_obj_name}});
 
     MarkersTestMap subset_id_110_obj_name(
-        {{"3", Mn::Vector3{14.3, 15.4, 16.5}},
-         {"2", Mn::Vector3{13.3, 14.4, 15.5}},
-         {"1", Mn::Vector3{12.3, 13.4, 14.5}},
-         {"0", Mn::Vector3{11.3, 12.4, 13.5}}});
+        {{"003", Mn::Vector3{14.3, 15.4, 16.5}},
+         {"002", Mn::Vector3{13.3, 14.4, 15.5}},
+         {"001", Mn::Vector3{12.3, 13.4, 14.5}},
+         {"000", Mn::Vector3{11.3, 12.4, 13.5}}});
 
     MarkersTestMap subset_id_111_obj_name(
-        {{"markers_03", Mn::Vector3{14.4, 15.5, 16.6}},
-         {"markers_02", Mn::Vector3{13.4, 14.5, 15.6}},
-         {"markers_01", Mn::Vector3{12.4, 13.5, 14.6}},
-         {"markers_00", Mn::Vector3{11.4, 12.5, 13.6}}});
+        {{"003", Mn::Vector3{14.4, 15.5, 16.6}},
+         {"002", Mn::Vector3{13.4, 14.5, 15.6}},
+         {"001", Mn::Vector3{12.4, 13.5, 14.6}},
+         {"000", Mn::Vector3{11.4, 12.5, 13.6}}});
 
     SubsetTestMap link_id_11_obj_name(
         {{"subset_id_110_obj_name", subset_id_110_obj_name},
@@ -1906,51 +1910,54 @@ void AttributesConfigsTest::testArticulatedObjectAttrVals(
     // Test marker sets
 
     MarkersTestMap subset_id_000_ao_name(
-        {{"markers_03", Mn::Vector3{14.1, 5.2, 6.3}},
-         {"markers_02", Mn::Vector3{13.1, 4.2, 5.3}},
-         {"markers_01", Mn::Vector3{12.1, 3.2, 4.3}},
-         {"markers_00", Mn::Vector3{11.1, 2.2, 3.3}}});
+        {{"003", Mn::Vector3{14.1, 5.2, 6.3}},
+         {"002", Mn::Vector3{13.1, 4.2, 5.3}},
+         {"001", Mn::Vector3{12.1, 3.2, 4.3}},
+         {"000", Mn::Vector3{11.1, 2.2, 3.3}}});
 
-    MarkersTestMap subset_id_001_ao_name({{"3", Mn::Vector3{14.2, 5.3, 6.4}},
-                                          {"2", Mn::Vector3{13.2, 4.3, 5.4}},
-                                          {"1", Mn::Vector3{12.2, 3.3, 4.4}},
-                                          {"0", Mn::Vector3{11.2, 2.3, 3.4}}});
+    MarkersTestMap subset_id_001_ao_name(
+        {{"003", Mn::Vector3{14.2, 5.3, 6.4}},
+         {"002", Mn::Vector3{13.2, 4.3, 5.4}},
+         {"001", Mn::Vector3{12.2, 3.3, 4.4}},
+         {"000", Mn::Vector3{11.2, 2.3, 3.4}}});
 
     SubsetTestMap link_id_00_ao_name(
         {{"subset_id_000_ao_name", subset_id_000_ao_name},
          {"subset_id_001_ao_name", subset_id_001_ao_name}});
 
-    MarkersTestMap subset_id_010_ao_name({{"3", Mn::Vector3{14.3, 5.4, 6.5}},
-                                          {"2", Mn::Vector3{13.3, 4.4, 5.5}},
-                                          {"1", Mn::Vector3{12.3, 3.4, 4.5}},
-                                          {"0", Mn::Vector3{11.3, 2.4, 3.5}}});
+    MarkersTestMap subset_id_010_ao_name(
+        {{"003", Mn::Vector3{14.3, 5.4, 6.5}},
+         {"002", Mn::Vector3{13.3, 4.4, 5.5}},
+         {"001", Mn::Vector3{12.3, 3.4, 4.5}},
+         {"000", Mn::Vector3{11.3, 2.4, 3.5}}});
 
     MarkersTestMap subset_id_011_ao_name(
-        {{"markers_03", Mn::Vector3{14.4, 5.5, 6.6}},
-         {"markers_02", Mn::Vector3{13.4, 4.5, 5.6}},
-         {"markers_01", Mn::Vector3{12.4, 3.5, 4.6}},
-         {"markers_00", Mn::Vector3{11.4, 2.5, 3.6}}});
+        {{"003", Mn::Vector3{14.4, 5.5, 6.6}},
+         {"002", Mn::Vector3{13.4, 4.5, 5.6}},
+         {"001", Mn::Vector3{12.4, 3.5, 4.6}},
+         {"000", Mn::Vector3{11.4, 2.5, 3.6}}});
 
     SubsetTestMap link_id_01_ao_name(
         {{"subset_id_010_ao_name", subset_id_010_ao_name},
          {"subset_id_011_ao_name", subset_id_011_ao_name}});
 
-    MarkersTestMap subset_id_020_ao_name({{"3", Mn::Vector3{24.3, 5.4, 6.5}},
-                                          {"2", Mn::Vector3{23.3, 4.4, 5.5}},
-                                          {"1", Mn::Vector3{22.3, 3.4, 4.5}},
-                                          {"0", Mn::Vector3{21.3, 2.4, 3.5}}});
+    MarkersTestMap subset_id_020_ao_name(
+        {{"003", Mn::Vector3{24.3, 5.4, 6.5}},
+         {"002", Mn::Vector3{23.3, 4.4, 5.5}},
+         {"001", Mn::Vector3{22.3, 3.4, 4.5}},
+         {"000", Mn::Vector3{21.3, 2.4, 3.5}}});
 
     MarkersTestMap subset_id_021_ao_name(
-        {{"markers_03", Mn::Vector3{24.4, 5.5, 6.6}},
-         {"markers_02", Mn::Vector3{23.4, 4.5, 5.6}},
-         {"markers_01", Mn::Vector3{22.4, 3.5, 4.6}},
-         {"markers_00", Mn::Vector3{21.4, 2.5, 3.6}}});
+        {{"003", Mn::Vector3{24.4, 5.5, 6.6}},
+         {"002", Mn::Vector3{23.4, 4.5, 5.6}},
+         {"001", Mn::Vector3{22.4, 3.5, 4.6}},
+         {"000", Mn::Vector3{21.4, 2.5, 3.6}}});
 
     MarkersTestMap subset_id_022_ao_name(
-        {{"markers_03", Mn::Vector3{224.4, 5.5, 6.6}},
-         {"markers_02", Mn::Vector3{223.4, 4.5, 5.6}},
-         {"markers_01", Mn::Vector3{222.4, 3.5, 4.6}},
-         {"markers_00", Mn::Vector3{221.4, 2.5, 3.6}}});
+        {{"003", Mn::Vector3{224.4, 5.5, 6.6}},
+         {"002", Mn::Vector3{223.4, 4.5, 5.6}},
+         {"001", Mn::Vector3{222.4, 3.5, 4.6}},
+         {"000", Mn::Vector3{221.4, 2.5, 3.6}}});
 
     SubsetTestMap link_id_02_ao_name(
         {{"subset_id_020_ao_name", subset_id_020_ao_name},
@@ -1963,32 +1970,32 @@ void AttributesConfigsTest::testArticulatedObjectAttrVals(
          {"link_id_02_ao_name", link_id_02_ao_name}}};
 
     MarkersTestMap subset_id_100_ao_name(
-        {{"markers_03", Mn::Vector3{114.1, 15.2, 16.3}},
-         {"markers_02", Mn::Vector3{113.1, 14.2, 15.3}},
-         {"markers_01", Mn::Vector3{112.1, 13.2, 14.3}},
-         {"markers_00", Mn::Vector3{111.1, 12.2, 13.3}}});
+        {{"003", Mn::Vector3{114.1, 15.2, 16.3}},
+         {"002", Mn::Vector3{113.1, 14.2, 15.3}},
+         {"001", Mn::Vector3{112.1, 13.2, 14.3}},
+         {"000", Mn::Vector3{111.1, 12.2, 13.3}}});
 
     MarkersTestMap subset_id_101_ao_name(
-        {{"3", Mn::Vector3{114.2, 15.3, 16.4}},
-         {"2", Mn::Vector3{113.2, 14.3, 15.4}},
-         {"1", Mn::Vector3{112.2, 13.3, 14.4}},
-         {"0", Mn::Vector3{111.2, 12.3, 13.4}}});
+        {{"003", Mn::Vector3{114.2, 15.3, 16.4}},
+         {"002", Mn::Vector3{113.2, 14.3, 15.4}},
+         {"001", Mn::Vector3{112.2, 13.3, 14.4}},
+         {"000", Mn::Vector3{111.2, 12.3, 13.4}}});
 
     SubsetTestMap link_id_10_ao_name(
         {{"subset_id_100_ao_name", subset_id_100_ao_name},
          {"subset_id_101_ao_name", subset_id_101_ao_name}});
 
     MarkersTestMap subset_id_110_ao_name(
-        {{"3", Mn::Vector3{114.3, 15.4, 16.5}},
-         {"2", Mn::Vector3{113.3, 14.4, 15.5}},
-         {"1", Mn::Vector3{112.3, 13.4, 14.5}},
-         {"0", Mn::Vector3{111.3, 12.4, 13.5}}});
+        {{"003", Mn::Vector3{114.3, 15.4, 16.5}},
+         {"002", Mn::Vector3{113.3, 14.4, 15.5}},
+         {"001", Mn::Vector3{112.3, 13.4, 14.5}},
+         {"000", Mn::Vector3{111.3, 12.4, 13.5}}});
 
     MarkersTestMap subset_id_111_ao_name(
-        {{"markers_03", Mn::Vector3{114.4, 15.5, 16.6}},
-         {"markers_02", Mn::Vector3{113.4, 14.5, 15.6}},
-         {"markers_01", Mn::Vector3{112.4, 13.5, 14.6}},
-         {"markers_00", Mn::Vector3{111.4, 12.5, 13.6}}});
+        {{"003", Mn::Vector3{114.4, 15.5, 16.6}},
+         {"002", Mn::Vector3{113.4, 14.5, 15.6}},
+         {"001", Mn::Vector3{112.4, 13.5, 14.6}},
+         {"000", Mn::Vector3{111.4, 12.5, 13.6}}});
 
     SubsetTestMap link_id_11_ao_name(
         {{"subset_id_110_ao_name", subset_id_110_ao_name},

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -109,7 +109,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * @param markerSetsHierarchy The hieraarchy the marker sets should follow.
    */
   void testMarkerSetsConfigVals(
-      std::shared_ptr<esp::core::config::Configuration> markerSetsConfig,
+      std::shared_ptr<esp::metadata::attributes::MarkerSets> markerSetsConfig,
       const MarkerSetTestMap&  // markers in link subset
           markerSetsHierarchy);
 
@@ -307,7 +307,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
 }  // AttributesConfigsTest::testUserDefinedConfigVals
 
 void AttributesConfigsTest::testMarkerSetsConfigVals(
-    std::shared_ptr<esp::core::config::Configuration> markerSetsConfig,
+    std::shared_ptr<esp::metadata::attributes::MarkerSets> markerSetsConfig,
     const MarkerSetTestMap&  // markers in link subset
         markerSetsHierarchy) {
   for (const auto& markerSetInfoEntry : markerSetsHierarchy) {

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -32,6 +32,7 @@ using esp::physics::MotionType;
 
 using AttrMgrs::AttributesManager;
 using Attrs::ArticulatedObjectAttributes;
+using Attrs::MarkerSets;
 using Attrs::ObjectAttributes;
 using Attrs::PbrShaderAttributes;
 using Attrs::PhysicsManagerAttributes;
@@ -109,7 +110,7 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * @param markerSetsHierarchy The hieraarchy the marker sets should follow.
    */
   void testMarkerSetsConfigVals(
-      std::shared_ptr<esp::metadata::attributes::MarkerSets> markerSetsConfig,
+      std::shared_ptr<Attrs::MarkerSets> markerSetsConfig,
       const MarkerSetTestMap&  // markers in link subset
           markerSetsHierarchy);
 
@@ -118,31 +119,27 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * loading process is working as expected.
    */
   void testPhysicsAttrVals(
-      std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
-          physMgrAttr);
+      std::shared_ptr<Attrs::PhysicsManagerAttributes> physMgrAttr);
 
   /**
    * @brief This test will verify that the PBR/IBL shader config attributes'
    * managers' JSON loading process is working as expected.
    */
   void testPbrShaderAttrVals(
-      std::shared_ptr<esp::metadata::attributes::PbrShaderAttributes>
-          pbrShaderAttr);
+      std::shared_ptr<Attrs::PbrShaderAttributes> pbrShaderAttr);
   /**
    * @brief This test will verify that the Light Attributes' managers' JSON
    * loading process is working as expected.
    */
   void testLightAttrVals(
-      std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
-          lightLayoutAttr);
+      std::shared_ptr<Attrs::LightLayoutAttributes> lightLayoutAttr);
 
   /**
    * @brief This test will verify that the Scene Instance Attributes' managers'
    * JSON loading process is working as expected.
    */
   void testSceneInstanceAttrVals(
-      std::shared_ptr<esp::metadata::attributes::SceneInstanceAttributes>
-          sceneInstAttr);
+      std::shared_ptr<Attrs::SceneInstanceAttributes> sceneInstAttr);
 
   /**
    * @brief This test will verify that the root-level scene instance user
@@ -155,31 +152,27 @@ struct AttributesConfigsTest : Cr::TestSuite::Tester {
    * loading process is working as expected.
    */
   void testSemanticAttrVals(
-      std::shared_ptr<esp::metadata::attributes::SemanticAttributes>
-          semanticAttr,
+      std::shared_ptr<Attrs::SemanticAttributes> semanticAttr,
       const std::string& assetPath);
   /**
    * @brief This test will verify that the Stage attributes' managers' JSON
    * loading process is working as expected.
    */
-  void testStageAttrVals(
-      std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
-      const std::string& assetPath);
+  void testStageAttrVals(std::shared_ptr<Attrs::StageAttributes> stageAttr,
+                         const std::string& assetPath);
 
   /**
    * @brief This test will verify that the Object attributes' managers' JSON
    * loading process is working as expected.
    */
-  void testObjectAttrVals(
-      std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
-      const std::string& assetPath);
+  void testObjectAttrVals(std::shared_ptr<Attrs::ObjectAttributes> objAttr,
+                          const std::string& assetPath);
   /**
    * @brief This test will verify that the Articulated Object attributes'
    * managers' JSON loading process is working as expected.
    */
   void testArticulatedObjectAttrVals(
-      std::shared_ptr<esp::metadata::attributes::ArticulatedObjectAttributes>
-          artObjAttr,
+      std::shared_ptr<Attrs::ArticulatedObjectAttributes> artObjAttr,
       const std::string& assetPath,
       const std::string& urdfPath);
 
@@ -307,7 +300,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
 }  // AttributesConfigsTest::testUserDefinedConfigVals
 
 void AttributesConfigsTest::testMarkerSetsConfigVals(
-    std::shared_ptr<esp::metadata::attributes::MarkerSets> markerSetsConfig,
+    std::shared_ptr<Attrs::MarkerSets> markerSetsConfig,
     const MarkerSetTestMap&  // markers in link subset
         markerSetsHierarchy) {
   for (const auto& markerSetInfoEntry : markerSetsHierarchy) {
@@ -358,8 +351,7 @@ void AttributesConfigsTest::testMarkerSetsConfigVals(
 /////////////  Begin JSON String-based tests
 
 void AttributesConfigsTest::testPhysicsAttrVals(
-    std::shared_ptr<esp::metadata::attributes::PhysicsManagerAttributes>
-        physMgrAttr) {
+    std::shared_ptr<Attrs::PhysicsManagerAttributes> physMgrAttr) {
   // match values set in test JSON
 
   CORRADE_COMPARE(physMgrAttr->getGravity(), Mn::Vector3(1, 2, 3));
@@ -442,8 +434,7 @@ void AttributesConfigsTest::testPhysicsJSONLoad() {
 }  // AttributesConfigsTest::testPhysicsJSONLoad
 
 void AttributesConfigsTest::testPbrShaderAttrVals(
-    std::shared_ptr<esp::metadata::attributes::PbrShaderAttributes>
-        pbrShaderAttr) {
+    std::shared_ptr<Attrs::PbrShaderAttributes> pbrShaderAttr) {
   CORRADE_VERIFY(!pbrShaderAttr->getEnableDirectLighting());
   CORRADE_VERIFY(!pbrShaderAttr->getEnableIBL());
 
@@ -574,8 +565,7 @@ void AttributesConfigsTest::testPbrShaderAttrJSONLoad() {
 }  // AttributesConfigsTest::testPbrShaderAttrJSONLoad
 
 void AttributesConfigsTest::testLightAttrVals(
-    std::shared_ptr<esp::metadata::attributes::LightLayoutAttributes>
-        lightLayoutAttr) {
+    std::shared_ptr<Attrs::LightLayoutAttributes> lightLayoutAttr) {
   // test light layout attributes-level user config vals
   testUserDefinedConfigVals(lightLayoutAttr->getUserConfiguration(), 4,
                             "light attribs defined string", true, 23, 2.3,
@@ -730,8 +720,7 @@ void AttributesConfigsTest::testSceneInstanceRootUserDefinedAttrVals(
 }  // AttributesConfigsTest::testSceneInstanceRootUserDefinedAttrVals
 
 void AttributesConfigsTest::testSceneInstanceAttrVals(
-    std::shared_ptr<esp::metadata::attributes::SceneInstanceAttributes>
-        sceneAttr) {
+    std::shared_ptr<Attrs::SceneInstanceAttributes> sceneAttr) {
   // match values set in test JSON
   CORRADE_COMPARE(
       static_cast<int>(sceneAttr->getTranslationOrigin()),
@@ -1138,7 +1127,7 @@ void AttributesConfigsTest::testSceneInstanceJSONLoad() {
 
 }  // AttributesConfigsTest::testSceneInstanceJSONLoad
 void AttributesConfigsTest::testSemanticAttrVals(
-    std::shared_ptr<esp::metadata::attributes::SemanticAttributes> semanticAttr,
+    std::shared_ptr<Attrs::SemanticAttributes> semanticAttr,
     const std::string& assetPath) {
   CORRADE_COMPARE(
       semanticAttr->getSemanticDescriptorFilename(),
@@ -1307,7 +1296,7 @@ void AttributesConfigsTest::testSemanticJSONLoad() {
 }  // AttributesConfigsTest::testSemanticJSONLoad
 
 void AttributesConfigsTest::testStageAttrVals(
-    std::shared_ptr<esp::metadata::attributes::StageAttributes> stageAttr,
+    std::shared_ptr<Attrs::StageAttributes> stageAttr,
     const std::string& assetPath) {
   // match values set in test JSON
   CORRADE_COMPARE(stageAttr->getScale(), Mn::Vector3(2, 3, 4));
@@ -1587,7 +1576,7 @@ void AttributesConfigsTest::testStageJSONLoad() {
 }  // AttributesConfigsTest::testStageJSONLoad(
 
 void AttributesConfigsTest::testObjectAttrVals(
-    std::shared_ptr<esp::metadata::attributes::ObjectAttributes> objAttr,
+    std::shared_ptr<Attrs::ObjectAttributes> objAttr,
     const std::string& assetPath) {
   // match values set in test JSON
 
@@ -1872,8 +1861,7 @@ void AttributesConfigsTest::testObjectJSONLoad() {
 }  // AttributesConfigsTest::testObjectJSONLoadTest
 
 void AttributesConfigsTest::testArticulatedObjectAttrVals(
-    std::shared_ptr<esp::metadata::attributes::ArticulatedObjectAttributes>
-        artObjAttr,
+    std::shared_ptr<Attrs::ArticulatedObjectAttributes> artObjAttr,
     const std::string& assetPath,
     const std::string& urdfPath) {
   // match values set in test JSON


### PR DESCRIPTION
## Motivation and Context
This PR expands on the Markersets [support added in this PR](https://github.com/facebookresearch/habitat-sim/pull/2368) to make interaction with Markersets easier.
- Introduces a set of classes (MarkerSets, MarkerSet, LinkMarkerSets ,LinkMarkerSubset) to map convenience functions to a MarkerSets Configuration hierarchy, including python bindings. These functions include querying, accessing and removing nested configurations as well as adding marker points to any marker subset.
- Adds Stage/Object/Articulated Object support for saving the markersets present from the initialization attributes used to create the object.
- Adds functionality to transform a list of points from ao/object local space to global, and vice versa.
- Adds saving of scale as a vector for all constructs (ao's, objects and stages) on their creation.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
