### PR TITLE
datasets_download try/catching the git-lfs prune for versions that do not support -f

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -594,7 +594,13 @@ def clone_repo_source(
 
         # prune the repo to reduce wasted memory consumption
         prune_command = "git lfs prune -f --recent"
-        subprocess.check_call(shlex.split(prune_command), cwd=version_dir)
+        try:
+            subprocess.check_call(shlex.split(prune_command), cwd=version_dir)
+        except subprocess.CalledProcessError as e:
+            # a response of status code 127 suggests a git-lfs version that does not support the -f flag 
+            if "status 127" in e:
+                prune_command = "git lfs prune --recent"
+                subprocess.check_call(shlex.split(prune_command), cwd=version_dir)
 
 
 def checkout_repo_tag(repo: Repo, version_dir: str, tag: str):


### PR DESCRIPTION
This commit adds a try/catch around the `git lfs prune -f --recent` call to re-run the command without the `-f` switch. While users can specify `--no-prune` in the data loader command, that workaround should not be necessary.

## Motivation and Context

Some common git-lfs versions (e.g., 2.9.2 which Ubuntu 20.04 runs) do not support the -f flag on `git lfs prune`. This change wraps the `git lfs prune -f --recent` call in a try/catch for compatibility and a simpler user experience. Issue #2172 asks about this.

## How Has This Been Tested

I tested loading a dataset using git-lfs version 2.9.2, which previously broke due to the assumed `-f` switch. I used the command:

`python -m habitat_sim.utils.datasets_download --uids rearrange_task_assets --data-path data`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
