### PR TITLE
Set node object IDs for articulated object links.

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -161,12 +161,16 @@ int BulletPhysicsManager::addArticulatedObjectInternal(
   }
 
   // allocate ids for links
+  ArticulatedLink& rootObject = articulatedObject->getLink(-1);
+  rootObject.node().setBaseObjectId(articulatedObject->getObjectID());
   for (int linkIx = 0; linkIx < articulatedObject->btMultiBody_->getNumLinks();
        ++linkIx) {
     int linkObjectId = allocateObjectID();
     articulatedObject->objectIdToLinkId_[linkObjectId] = linkIx;
     collisionObjToObjIds_->emplace(
         articulatedObject->btMultiBody_->getLinkCollider(linkIx), linkObjectId);
+    ArticulatedLink& linkObject = articulatedObject->getLink(linkIx);
+    linkObject.node().setBaseObjectId(linkObjectId);
   }
 
   // render visual shapes if either no skinned mesh is present or if the config


### PR DESCRIPTION
## Motivation and Context

This change sets the `OBJECT_ID` fields for articulated object nodes.

Notes:
* For gfx-replay use cases, the articulated object link IDs are important. They are used to match gfx-replay instances with real objects.
* For semantic rendering cases, we might want to have a separate field for the root object ID.
* Tests are missing.

## How Has This Been Tested

Tested using gfx-replay (`habitat-sim -> habitat-lab -> Unity`).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
