### PR TITLE
Add instance metadata to gfx-replay.

### DIFF
--- a/src/esp/gfx/replay/Keyframe.h
+++ b/src/esp/gfx/replay/Keyframe.h
@@ -31,11 +31,21 @@ struct Transform {
  */
 struct RenderAssetInstanceState {
   Transform absTransform;  // localToWorld
-  // note we currently only support semanticId per instance, not per drawable
-  int semanticId = ID_UNDEFINED;
   // note we don't currently support runtime changes to lightSetupKey
   bool operator==(const RenderAssetInstanceState& rhs) const {
-    return absTransform == rhs.absTransform && semanticId == rhs.semanticId;
+    return absTransform == rhs.absTransform;
+  }
+};
+
+/**
+ * @brief Metadata associated with an instance.
+ */
+struct InstanceMetadata {
+  int objectId = ID_UNDEFINED;
+  int semanticId = ID_UNDEFINED;
+
+  bool operator==(const InstanceMetadata& rhs) const {
+    return objectId == rhs.objectId && semanticId == rhs.semanticId;
   }
 };
 
@@ -67,6 +77,7 @@ struct Keyframe {
                         esp::assets::RenderAssetInstanceCreationInfo>>
       creations;
   std::vector<RenderAssetInstanceKey> deletions;
+  std::vector<std::pair<RenderAssetInstanceKey, InstanceMetadata>> metadata;
   std::vector<std::pair<RenderAssetInstanceKey, RenderAssetInstanceState>>
       stateUpdates;
   std::vector<RigUpdate> rigUpdates;

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -112,13 +112,14 @@ class AbstractPlayerImplementation {
   virtual Mn::Matrix4 hackGetNodeTransform(NodeHandle node) const = 0;
 
   /**
-   * @brief Set node semantic ID
+   * @brief Set node metadata.
    *
    * The @p handle is expected to be returned from an earlier call to
    * @ref loadAndCreateRenderAssetInstance() on the same instance. Default
    * implementation does nothing.
    */
-  virtual void setNodeSemanticId(NodeHandle node, unsigned id);
+  virtual void setNodeMetadata(NodeHandle node,
+                               const InstanceMetadata& metadata);
 
   /**
    * @brief Change light setup
@@ -176,7 +177,8 @@ class AbstractSceneGraphPlayerImplementation
 
   Mn::Matrix4 hackGetNodeTransform(NodeHandle node) const override;
 
-  void setNodeSemanticId(NodeHandle node, unsigned id) override;
+  void setNodeMetadata(NodeHandle node,
+                       const InstanceMetadata& metadata) override;
 };
 
 /**

--- a/src/esp/gfx/replay/Player.h
+++ b/src/esp/gfx/replay/Player.h
@@ -18,6 +18,11 @@ namespace replay {
 
 class Player;
 
+struct CreationRecord {
+  assets::RenderAssetInstanceCreationInfo creationInfo;
+  InstanceMetadata metadata;
+};
+
 /**
 @brief Node handle
 
@@ -306,9 +311,7 @@ class Player {
   std::vector<Keyframe> keyframes_;
   std::unordered_map<std::string, esp::assets::AssetInfo> assetInfos_;
   std::unordered_map<RenderAssetInstanceKey, NodeHandle> createdInstances_;
-  std::unordered_map<RenderAssetInstanceKey,
-                     assets::RenderAssetInstanceCreationInfo>
-      creationInfos_;
+  std::unordered_map<RenderAssetInstanceKey, CreationRecord> creationRecords_;
   std::unordered_map<RenderAssetInstanceKey, Mn::Matrix4> latestTransformCache_;
   std::set<std::string> failedFilepaths_;
 

--- a/src/esp/gfx/replay/Recorder.cpp
+++ b/src/esp/gfx/replay/Recorder.cpp
@@ -76,6 +76,9 @@ void Recorder::onCreateRenderAssetInstance(
   RenderAssetInstanceKey instanceKey = getNewInstanceKey();
   getKeyframe().creations.emplace_back(instanceKey, creation);
 
+  InstanceMetadata metadata{node->getBaseObjectId(), node->getSemanticId()};
+  getKeyframe().metadata.emplace_back(instanceKey, metadata);
+
   // Constructing NodeDeletionHelper here is equivalent to calling
   // node->addFeature. We keep a pointer to deletionHelper so we can delete it
   // manually later if necessary.
@@ -214,7 +217,7 @@ RenderAssetInstanceState Recorder::getInstanceState(
     const scene::SceneNode* node) {
   const auto absTransformMat = node->absoluteTransformation();
   const auto transform = ::createReplayTransform(absTransformMat);
-  return RenderAssetInstanceState{transform, node->getSemanticId()};
+  return RenderAssetInstanceState{transform};
 }
 
 void Recorder::updateStates() {

--- a/src/esp/gfx/replay/Recorder.h
+++ b/src/esp/gfx/replay/Recorder.h
@@ -185,6 +185,7 @@ class Recorder {
     scene::SceneNode* node = nullptr;
     RenderAssetInstanceKey instanceKey = ID_UNDEFINED;
     Corrade::Containers::Optional<RenderAssetInstanceState> recentState;
+    Corrade::Containers::Optional<InstanceMetadata> metadata;
     NodeDeletionHelper* deletionHelper = nullptr;
     int rigId = ID_UNDEFINED;
   };
@@ -198,6 +199,7 @@ class Recorder {
   RenderAssetInstanceKey getNewInstanceKey();
   int findInstance(const scene::SceneNode* queryNode);
   RenderAssetInstanceState getInstanceState(const scene::SceneNode* node);
+  InstanceMetadata getInstanceMetadata(const scene::SceneNode* node);
   void updateStates();
   void updateInstanceStates();
   void updateRigInstanceStates();

--- a/src/esp/io/JsonEspTypes.cpp
+++ b/src/esp/io/JsonEspTypes.cpp
@@ -36,6 +36,8 @@ JsonGenericValue toJsonValue(const gfx::replay::Keyframe& keyframe,
     io::addMember(obj, "creations", creationsArray, allocator);
   }
 
+  io::addMember(obj, "metadata", keyframe.metadata, allocator);
+
   io::addMember(obj, "deletions", keyframe.deletions, allocator);
 
   if (!keyframe.stateUpdates.empty()) {
@@ -115,6 +117,8 @@ bool fromJsonValue(const JsonGenericValue& obj,
       keyframe.creations.emplace_back(std::move(pair));
     }
   }
+
+  io::readMember(obj, "metadata", keyframe.metadata);
 
   io::readMember(obj, "deletions", keyframe.deletions);
 

--- a/src/esp/io/JsonEspTypes.cpp
+++ b/src/esp/io/JsonEspTypes.cpp
@@ -36,8 +36,6 @@ JsonGenericValue toJsonValue(const gfx::replay::Keyframe& keyframe,
     io::addMember(obj, "creations", creationsArray, allocator);
   }
 
-  io::addMember(obj, "metadata", keyframe.metadata, allocator);
-
   io::addMember(obj, "deletions", keyframe.deletions, allocator);
 
   if (!keyframe.stateUpdates.empty()) {
@@ -49,6 +47,17 @@ JsonGenericValue toJsonValue(const gfx::replay::Keyframe& keyframe,
       stateUpdatesArray.PushBack(stateObj, allocator);
     }
     io::addMember(obj, "stateUpdates", stateUpdatesArray, allocator);
+  }
+
+  if (!keyframe.metadata.empty()) {
+    JsonGenericValue metadataArray(rapidjson::kArrayType);
+    for (const auto& pair : keyframe.metadata) {
+      JsonGenericValue metadataObj(rapidjson::kObjectType);
+      io::addMember(metadataObj, "instanceKey", pair.first, allocator);
+      io::addMember(metadataObj, "metadata", pair.second, allocator);
+      metadataArray.PushBack(metadataObj, allocator);
+    }
+    io::addMember(obj, "metadata", metadataArray, allocator);
   }
 
   if (!keyframe.rigUpdates.empty()) {
@@ -118,8 +127,6 @@ bool fromJsonValue(const JsonGenericValue& obj,
     }
   }
 
-  io::readMember(obj, "metadata", keyframe.metadata);
-
   io::readMember(obj, "deletions", keyframe.deletions);
 
   itr = obj.FindMember("stateUpdates");
@@ -133,6 +140,20 @@ bool fromJsonValue(const JsonGenericValue& obj,
       io::readMember(stateObj, "instanceKey", pair.first);
       io::readMember(stateObj, "state", pair.second);
       keyframe.stateUpdates.emplace_back(std::move(pair));
+    }
+  }
+
+  itr = obj.FindMember("metadata");
+  if (itr != obj.MemberEnd()) {
+    const JsonGenericValue& metadataArray = itr->value;
+    keyframe.metadata.reserve(metadataArray.Size());
+    for (const auto& metadataObj : metadataArray.GetArray()) {
+      std::pair<gfx::replay::RenderAssetInstanceKey,
+                gfx::replay::InstanceMetadata>
+          pair;
+      io::readMember(metadataObj, "instanceKey", pair.first);
+      io::readMember(metadataObj, "metadata", pair.second);
+      keyframe.metadata.emplace_back(std::move(pair));
     }
   }
 

--- a/src/esp/io/JsonEspTypes.h
+++ b/src/esp/io/JsonEspTypes.h
@@ -140,6 +140,22 @@ inline bool fromJsonValue(const JsonGenericValue& obj,
   return true;
 }
 
+inline JsonGenericValue toJsonValue(const esp::gfx::replay::InstanceMetadata& x,
+                                    JsonAllocator& allocator) {
+  JsonGenericValue obj(rapidjson::kObjectType);
+  addMember(obj, "objectId", x.objectId, allocator);
+  addMember(obj, "semanticId", x.semanticId, allocator);
+  return obj;
+}
+
+inline bool fromJsonValue(const JsonGenericValue& obj,
+                          esp::gfx::replay::InstanceMetadata& x) {
+  bool success = true;
+  success &= readMember(obj, "objectId", x.objectId);
+  success &= readMember(obj, "semanticId", x.semanticId);
+  return success;
+}
+
 inline JsonGenericValue toJsonValue(const esp::gfx::replay::Transform& x,
                                     JsonAllocator& allocator) {
   JsonGenericValue obj(rapidjson::kObjectType);
@@ -161,14 +177,12 @@ inline JsonGenericValue toJsonValue(
     JsonAllocator& allocator) {
   JsonGenericValue obj(rapidjson::kObjectType);
   addMember(obj, "absTransform", x.absTransform, allocator);
-  addMember(obj, "semanticId", x.semanticId, allocator);
   return obj;
 }
 
 inline bool fromJsonValue(const JsonGenericValue& obj,
                           esp::gfx::replay::RenderAssetInstanceState& x) {
   readMember(obj, "absTransform", x.absTransform);
-  readMember(obj, "semanticId", x.semanticId);
   return true;
 }
 

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -125,13 +125,14 @@ void GfxReplayTest::testRecorder() {
   info2.overridePhongMaterial->ambientColor = Mn::Color4(0.1, 0.2, 0.3, 0.4);
   info2.overridePhongMaterial->diffuseColor = Mn::Color4(0.2, 0.3, 0.4, 0.5);
   info2.overridePhongMaterial->specularColor = Mn::Color4(0.3, 0.4, 0.5, 0.6);
+  node->setSemanticId(7);
+  node->setBaseObjectId(9);
 
   esp::gfx::replay::Recorder recorder;
   recorder.onLoadRenderAsset(info);
   recorder.onCreateRenderAssetInstance(node, creation);
   recorder.saveKeyframe();
   node->setTranslation(Mn::Vector3(1.f, 2.f, 3.f));
-  node->setSemanticId(7);
 
   // add the new override AssetInfo after 1st keyframe
   auto* node2 = resourceManager.loadAndCreateRenderAssetInstance(
@@ -162,13 +163,14 @@ void GfxReplayTest::testRecorder() {
   esp::gfx::replay::RenderAssetInstanceKey instanceKey =
       keyframes[0].creations[0].first;
   CORRADE_COMPARE(keyframes[0].stateUpdates[0].first, instanceKey);
+  CORRADE_COMPARE(keyframes[0].metadata[0].second.semanticId, 7);
+  CORRADE_COMPARE(keyframes[0].metadata[0].second.objectId, 9);
 
   // verify frame #1 has an updated state for node and state for new node2
   CORRADE_COMPARE(keyframes[1].stateUpdates.size(), 2);
   // verify frame #1 has our translation and semantic Id
   CORRADE_COMPARE(keyframes[1].stateUpdates[0].second.absTransform.translation,
                   Mn::Vector3(1.f, 2.f, 3.f));
-  CORRADE_COMPARE(keyframes[1].stateUpdates[0].second.semanticId, 7);
 
   // verify override material AssetInfo is loaded correctly
   CORRADE_COMPARE(keyframes[1].loads.size(), 1);
@@ -256,6 +258,8 @@ void GfxReplayTest::testPlayer() {
   flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
   esp::assets::RenderAssetInstanceCreationInfo creation(
       boxFile, Corrade::Containers::NullOpt, flags, lightSetupKey);
+  constexpr int semanticId = 11;
+  constexpr int objectId = 22;
 
   /*
   // Keyframe struct shown here for reference
@@ -276,14 +280,23 @@ void GfxReplayTest::testPlayer() {
   keyframes.emplace_back(esp::gfx::replay::Keyframe{
       {info}, {}, {{instanceKey, creation}}, {}, {}, {}, {}});
 
-  constexpr int semanticId = 4;
+  esp::gfx::replay::InstanceMetadata instanceMetadata{};
+  instanceMetadata.objectId = objectId;
+  instanceMetadata.semanticId = semanticId;
+
   esp::gfx::replay::RenderAssetInstanceState stateUpdate{
-      {Mn::Vector3(1.f, 2.f, 3.f), Mn::Quaternion(Mn::Math::IdentityInit)},
-      semanticId};
+      {Mn::Vector3(1.f, 2.f, 3.f), Mn::Quaternion(Mn::Math::IdentityInit)}};
 
   // keyframe #1: a state update
-  keyframes.emplace_back(esp::gfx::replay::Keyframe{
-      {}, {}, {}, {}, {{instanceKey, stateUpdate}}, {}, {}});
+  keyframes.emplace_back(
+      esp::gfx::replay::Keyframe{{},
+                                 {},
+                                 {},
+                                 {},
+                                 {{instanceKey, instanceMetadata}},
+                                 {{instanceKey, stateUpdate}},
+                                 {},
+                                 {}});
 
   // keyframe #2: delete instance
   keyframes.emplace_back(
@@ -292,6 +305,7 @@ void GfxReplayTest::testPlayer() {
   // keyframe #3: include a user transform
   keyframes.emplace_back(
       esp::gfx::replay::Keyframe{{},
+                                 {},
                                  {},
                                  {},
                                  {},
@@ -336,6 +350,7 @@ void GfxReplayTest::testPlayer() {
         CORRADE_COMPARE(instanceNode->translation(),
                         Mn::Vector3(1.f, 2.f, 3.f));
         CORRADE_COMPARE(instanceNode->getSemanticId(), semanticId);
+        CORRADE_COMPARE(instanceNode->getBaseObjectId(), objectId);
       } else {  // if rootNode had children originally, then stateUpdate was
                 // applied to a sibling of the lastRootChild
         // get the lastRootChild before the stateUpdate
@@ -351,6 +366,7 @@ void GfxReplayTest::testPlayer() {
         CORRADE_COMPARE(instanceNode->translation(),
                         Mn::Vector3(1.f, 2.f, 3.f));
         CORRADE_COMPARE(instanceNode->getSemanticId(), semanticId);
+        CORRADE_COMPARE(instanceNode->getBaseObjectId(), objectId);
       }
     } else if (keyframeIndex == 2) {
       // assert that no new nodes were created

--- a/src/tests/GfxReplayTest.cpp
+++ b/src/tests/GfxReplayTest.cpp
@@ -132,6 +132,8 @@ void GfxReplayTest::testRecorder() {
   recorder.onLoadRenderAsset(info);
   recorder.onCreateRenderAssetInstance(node, creation);
   recorder.saveKeyframe();
+
+  node->setSemanticId(5);
   node->setTranslation(Mn::Vector3(1.f, 2.f, 3.f));
 
   // add the new override AssetInfo after 1st keyframe
@@ -163,14 +165,17 @@ void GfxReplayTest::testRecorder() {
   esp::gfx::replay::RenderAssetInstanceKey instanceKey =
       keyframes[0].creations[0].first;
   CORRADE_COMPARE(keyframes[0].stateUpdates[0].first, instanceKey);
+  CORRADE_COMPARE(keyframes[0].metadata.size(), 1);
   CORRADE_COMPARE(keyframes[0].metadata[0].second.semanticId, 7);
   CORRADE_COMPARE(keyframes[0].metadata[0].second.objectId, 9);
 
   // verify frame #1 has an updated state for node and state for new node2
   CORRADE_COMPARE(keyframes[1].stateUpdates.size(), 2);
+  CORRADE_COMPARE(keyframes[1].metadata.size(), 2);
   // verify frame #1 has our translation and semantic Id
   CORRADE_COMPARE(keyframes[1].stateUpdates[0].second.absTransform.translation,
                   Mn::Vector3(1.f, 2.f, 3.f));
+  CORRADE_COMPARE(keyframes[1].metadata[0].second.semanticId, 5);
 
   // verify override material AssetInfo is loaded correctly
   CORRADE_COMPARE(keyframes[1].loads.size(), 1);

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -437,7 +437,7 @@ void IOTest::testJsonEspTypes() {
         {Magnum::Vector3(1.f, 2.f, 3.f),
          Magnum::Quaternion::rotation(Magnum::Rad{1.f},
                                       Magnum::Vector3(0.f, 1.f, 0.f))},
-        4};
+    };
     esp::io::addMember(d, "state", state, allocator);
     // read and compare RenderAssetInstanceState
     esp::gfx::replay::RenderAssetInstanceState state2;


### PR DESCRIPTION
## Motivation and Context

This changeset adds an `InstanceMetadata` entry to `gfx-replay` keyframes so that this information can be made available to external players.

This information can be used to do commands on `gfx-replay` instances based on real simulation IDs, for example:
* Hiding an agent.
* Highlighting an object's mesh.
* Tooling.
* ...

## How Has This Been Tested

* Added test.
* Tested in Unity gfx-replay client.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
