### PR TITLE
Avoid setting CUDA device when there is no GPU.

### DIFF
--- a/src/esp/gfx/WindowlessContext.cpp
+++ b/src/esp/gfx/WindowlessContext.cpp
@@ -42,7 +42,9 @@ struct WindowlessContext::Impl {
 
 #if defined(CORRADE_TARGET_UNIX) && !defined(CORRADE_TARGET_APPLE)
 #ifdef MAGNUM_TARGET_EGL
-    config.setCudaDevice(device);
+    if (device != -1) {
+      config.setCudaDevice(device);
+    }
 #else  // NO MAGNUM_TARGET_EGL
     if (device != 0)
       Mn::Fatal{} << "GLX context does not support multiple GPUs. Please "

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -164,3 +164,17 @@ def test_empty_scene(sensor_type):
         habitat_sim.Configuration(backend_cfg, [agent_cfg])
     ) as sim:
         _ = sim.get_sensor_observations()
+
+def test_empty_scene_no_device(sensor_type):
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.scene_id = "NONE"
+    backend_cfg.gpu_device_id = -1
+
+    agent_cfg = habitat_sim.AgentConfiguration()
+    agent_cfg.sensor_specifications = [habitat_sim.CameraSensorSpec()]
+    agent_cfg.sensor_specifications[-1].sensor_type = sensor_type
+
+    with habitat_sim.Simulator(
+        habitat_sim.Configuration(backend_cfg, [agent_cfg])
+    ) as sim:
+        _ = sim.get_sensor_observations()        

--- a/tests/test_gfx.py
+++ b/tests/test_gfx.py
@@ -165,6 +165,15 @@ def test_empty_scene(sensor_type):
     ) as sim:
         _ = sim.get_sensor_observations()
 
+
+@pytest.mark.parametrize(
+    "sensor_type",
+    [
+        habitat_sim.SensorType.COLOR,
+        habitat_sim.SensorType.DEPTH,
+        habitat_sim.SensorType.SEMANTIC,
+    ],
+)
 def test_empty_scene_no_device(sensor_type):
     backend_cfg = habitat_sim.SimulatorConfiguration()
     backend_cfg.scene_id = "NONE"
@@ -177,4 +186,4 @@ def test_empty_scene_no_device(sensor_type):
     with habitat_sim.Simulator(
         habitat_sim.Configuration(backend_cfg, [agent_cfg])
     ) as sim:
-        _ = sim.get_sensor_observations()        
+        _ = sim.get_sensor_observations()


### PR DESCRIPTION
## Motivation and Context

This change omits `setCudaDevice` when `gpu_device_id == -1`.

Hydra override:
```
habitat.simulator.habitat_sim_v0.gpu_device_id=-1
```

Source: https://github.com/facebookresearch/habitat-sim/commit/a26f3accbce93caa0cecf9841b3f2217b96c002d

## How Has This Been Tested

Tested on cpu-only AWS servers.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
