### PR TITLE
[data] update dataset_downloader.py with replica_cad rearrange dataset v2

### DIFF
--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -200,9 +200,9 @@ def initialize_test_data_sources(data_path):
             "link": data_path + "datasets/rearrange_pick/replica_cad/v0",
             "version": "1.0",
         },
-        "rearrange_dataset_v1": {
-            "source": "https://dl.fbaipublicfiles.com/habitat/data/datasets/replica_cad/v1.zip",
-            "package_name": "v1.zip",
+        "rearrange_dataset_v2": {
+            "source": "https://dl.fbaipublicfiles.com/habitat/data/datasets/replica_cad/v2.zip",
+            "package_name": "v2.zip",
             "link": data_path + "datasets/replica_cad/rearrange",
             "version": "1.0",
         },
@@ -357,7 +357,7 @@ def initialize_test_data_sources(data_path):
             "hab_fetch",
             "ycb",
             "rearrange_pick_dataset_v0",
-            "rearrange_dataset_v1",
+            "rearrange_dataset_v2",
         ],
         "hm3d_example": [
             "hm3d_example_habitat",


### PR DESCRIPTION
## Motivation and Context

Updates the replica_cad rearrange dataset links for v2.

V2 remaps all entries in `RearrangeEpisode.name_to_receptacle` dict to correctly reference the `Receptacle.unique_name` instead of `Receptacle.name`.

Also removes all v0 pickle files from the dataset.

## How Has This Been Tested

CI?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
