### PR TITLE
--Move AssetType enum class attributes namespace

### DIFF
--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -12,13 +12,13 @@ namespace assets {
 
 AssetInfo AssetInfo::fromPath(const std::string& path) {
   using Corrade::Utility::String::endsWith;
-  AssetInfo info{AssetType::UNKNOWN, path};
+  AssetInfo info{metadata::attributes::AssetType::UNKNOWN, path};
 
   if (endsWith(path, "_semantic.ply")) {
-    info.type = AssetType::INSTANCE_MESH;
+    info.type = metadata::attributes::AssetType::INSTANCE_MESH;
   } else if (endsWith(path, ".glb")) {
     // assumes MP3D glb with gravity = -Z
-    info.type = AssetType::MP3D_MESH;
+    info.type = metadata::attributes::AssetType::MP3D_MESH;
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
     info.frame = geo::CoordinateFrame(geo::ESP_BACK, geo::ESP_UP);

--- a/src/esp/assets/Asset.cpp
+++ b/src/esp/assets/Asset.cpp
@@ -12,13 +12,13 @@ namespace assets {
 
 AssetInfo AssetInfo::fromPath(const std::string& path) {
   using Corrade::Utility::String::endsWith;
-  AssetInfo info{metadata::attributes::AssetType::UNKNOWN, path};
+  AssetInfo info{metadata::attributes::AssetType::Unknown, path};
 
   if (endsWith(path, "_semantic.ply")) {
-    info.type = metadata::attributes::AssetType::INSTANCE_MESH;
+    info.type = metadata::attributes::AssetType::InstanceMesh;
   } else if (endsWith(path, ".glb")) {
     // assumes MP3D glb with gravity = -Z
-    info.type = metadata::attributes::AssetType::MP3D_MESH;
+    info.type = metadata::attributes::AssetType::Mp3dMesh;
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
     info.frame = geo::CoordinateFrame(geo::ESP_BACK, geo::ESP_UP);

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -50,7 +50,7 @@ struct AssetInfo {
    * @brief The type of the asset
    */
   metadata::attributes::AssetType type =
-      metadata::attributes::AssetType::UNKNOWN;
+      metadata::attributes::AssetType::Unknown;
   /**
    * @brief The path to the asset's source on disk
    */
@@ -71,7 +71,7 @@ struct AssetInfo {
   /**
    * @brief Whether supported semantic meshes should be split
    */
-  bool splitInstanceMesh = true;  // only applies to AssetType::INSTANCE_MESH
+  bool splitInstanceMesh = true;  // only applies to AssetType::InstanceMesh
 
   /**
    * @brief if set, override the asset material with a procedural Phong material

--- a/src/esp/assets/Asset.h
+++ b/src/esp/assets/Asset.h
@@ -16,24 +16,6 @@ namespace esp {
 namespace assets {
 
 /**
- * @brief Supported Asset types
- */
-enum class AssetType {
-  UNKNOWN,
-  MP3D_MESH,
-  INSTANCE_MESH,
-  UNKNOWN2,
-  NAVMESH,
-  PRIMITIVE,
-};
-
-/**
- * @brief loading an asset info with filepath == EMPTY_SCENE creates a scene
- * graph with no scene mesh (ie. an empty scene)
- */
-constexpr char EMPTY_SCENE[] = "NONE";
-
-/**
  * @brief stores basic Phong compatible color properties for procedural override
  * material construction
  */
@@ -67,11 +49,12 @@ struct AssetInfo {
   /**
    * @brief The type of the asset
    */
-  AssetType type = AssetType::UNKNOWN;
+  metadata::attributes::AssetType type =
+      metadata::attributes::AssetType::UNKNOWN;
   /**
    * @brief The path to the asset's source on disk
    */
-  std::string filepath = EMPTY_SCENE;  // empty scene
+  std::string filepath = esp::EMPTY_SCENE;  // empty scene
   /**
    * The @ref esp::geo::CoordinateFrame describing the default orientation of the asset
    */

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -97,6 +97,7 @@ namespace esp {
 
 using metadata::attributes::AbstractObjectAttributes;
 using metadata::attributes::ArticulatedObjectAttributes;
+using metadata::attributes::AssetType;
 using metadata::attributes::CubePrimitiveAttributes;
 using metadata::attributes::ObjectAttributes;
 using metadata::attributes::ObjectInstanceShaderType;

--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -557,14 +557,14 @@ bool ResourceManager::buildMeshGroups(
   if (colMeshGroupIter == collisionMeshGroups_.end()) {
     //! Collect collision mesh group
     bool colMeshGroupSuccess = false;
-    if ((info.type == AssetType::INSTANCE_MESH) && !info.hasSemanticTextures) {
+    if ((info.type == AssetType::InstanceMesh) && !info.hasSemanticTextures) {
       // PLY Semantic mesh
       colMeshGroupSuccess =
           buildStageCollisionMeshGroup<GenericSemanticMeshData>(info.filepath,
                                                                 meshGroup);
-    } else if ((info.type == AssetType::MP3D_MESH ||
-                info.type == AssetType::UNKNOWN) ||
-               ((info.type == AssetType::INSTANCE_MESH) &&
+    } else if ((info.type == AssetType::Mp3dMesh ||
+                info.type == AssetType::Unknown) ||
+               ((info.type == AssetType::InstanceMesh) &&
                 info.hasSemanticTextures)) {
       // GLB Mesh
       colMeshGroupSuccess = buildStageCollisionMeshGroup<GenericMeshData>(
@@ -810,12 +810,12 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
     AssetInfo defaultInfo(info);
     defaultInfo.overridePhongMaterial = Cr::Containers::NullOpt;
 
-    if (info.type == AssetType::PRIMITIVE) {
+    if (info.type == AssetType::Primitive) {
       ESP_DEBUG(Mn::Debug::Flag::NoSpace)
           << "Building Prim named `" << info.filepath << "`.";
       buildPrimitiveAssetData(info.filepath);
       meshSuccess = true;
-    } else if (info.type == AssetType::INSTANCE_MESH) {
+    } else if (info.type == AssetType::InstanceMesh) {
       ESP_DEBUG(Mn::Debug::Flag::NoSpace)
           << "Loading Semantic Mesh asset named `" << info.filepath << "`.";
       meshSuccess = loadSemanticRenderAsset(defaultInfo);
@@ -830,7 +830,7 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
 
     if (meshSuccess) {
       // create and register the collisionMeshGroups
-      if (info.type != AssetType::PRIMITIVE) {
+      if (info.type != AssetType::Primitive) {
         std::vector<CollisionMeshData> meshGroup;
         CORRADE_ASSERT(buildMeshGroups(defaultInfo, meshGroup),
                        "Failed to construct collisionMeshGroups for asset"
@@ -872,7 +872,7 @@ bool ResourceManager::loadRenderAsset(const AssetInfo& info) {
           node->materialID = materialId;
         }
       }
-      if (info.type != AssetType::PRIMITIVE) {
+      if (info.type != AssetType::Primitive) {
         // clone the collision data
         collisionMeshGroups_.emplace(modifiedAssetName,
                                      collisionMeshGroups_.at(info.filepath));
@@ -906,13 +906,13 @@ scene::SceneNode* ResourceManager::createRenderAssetInstance(
 
   const auto& info = loadedAssetData.assetInfo;
   scene::SceneNode* newNode = nullptr;
-  if (info.type == AssetType::INSTANCE_MESH) {
+  if (info.type == AssetType::InstanceMesh) {
     CORRADE_ASSERT(!visNodeCache,
                    "createRenderAssetInstanceVertSemantic doesn't support this",
                    nullptr);
     newNode = createSemanticRenderAssetInstance(creation, parent, drawables);
   } else if (isRenderAssetGeneral(info.type) ||
-             info.type == AssetType::PRIMITIVE) {
+             info.type == AssetType::Primitive) {
     newNode = createRenderAssetInstanceGeneralPrimitive(
         creation, parent, drawables, visNodeCache);
   } else {
@@ -1015,7 +1015,7 @@ bool ResourceManager::loadObjectMeshDataFromFile(
     const bool forceFlatShading) {
   bool success = false;
   if (!filename.empty()) {
-    AssetInfo meshInfo{AssetType::UNKNOWN, filename};
+    AssetInfo meshInfo{AssetType::Unknown, filename};
     meshInfo.forceFlatShading = forceFlatShading;
     meshInfo.shaderTypeToUse = objectAttributes->getShaderType();
     meshInfo.frame = buildFrameFromAttributes(
@@ -1208,7 +1208,7 @@ void ResourceManager::buildPrimitiveAssetData(
   }
 
   // make assetInfo
-  AssetInfo info{AssetType::PRIMITIVE};
+  AssetInfo info{AssetType::Primitive};
   info.forceFlatShading = false;
 
   // make MeshMetaData
@@ -1351,7 +1351,7 @@ ResourceManager::flattenImportedMeshAndBuildSemantic(Importer& fileImporter,
 }  // ResourceManager::loadAndFlattenImportedMeshData
 
 bool ResourceManager::loadRenderAssetSemantic(const AssetInfo& info) {
-  CORRADE_INTERNAL_ASSERT(info.type == AssetType::INSTANCE_MESH);
+  CORRADE_INTERNAL_ASSERT(info.type == AssetType::InstanceMesh);
 
   const std::string& filename = info.filepath;
 
@@ -1531,7 +1531,7 @@ bool ResourceManager::loadRenderAssetGeneral(const AssetInfo& info) {
   // w/texture annotations
   CORRADE_INTERNAL_ASSERT(
       isRenderAssetGeneral(info.type) ||
-      ((info.type == AssetType::INSTANCE_MESH) && info.hasSemanticTextures));
+      ((info.type == AssetType::InstanceMesh) && info.hasSemanticTextures));
 
   const std::string& filename = info.filepath;
   CORRADE_INTERNAL_ASSERT(resourceDict_.count(filename) == 0);
@@ -1765,7 +1765,7 @@ bool ResourceManager::buildTrajectoryVisualization(
   ESP_VERY_VERBOSE() << "Successfully returned from trajectoryTubeSolid";
 
   // make assetInfo
-  AssetInfo info{AssetType::PRIMITIVE};
+  AssetInfo info{AssetType::Primitive};
   info.forceFlatShading = false;
   // set up primitive mesh
   // make  primitive mesh structure

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -86,6 +86,10 @@ struct CollisionMeshData;
 class GenericSemanticMeshData;
 struct MeshData;
 struct RenderAssetInstanceCreationInfo;
+
+// used to continue outdated support of "file extension as object type"
+using metadata::attributes::AssetType;
+
 // used for shadertype specification
 using metadata::attributes::ObjectInstanceShaderType;
 

--- a/src/esp/assets/ResourceManager.h
+++ b/src/esp/assets/ResourceManager.h
@@ -798,7 +798,7 @@ class ResourceManager {
    * @return Whether it is a General
    */
   inline bool isRenderAssetGeneral(AssetType type) {
-    return type == AssetType::MP3D_MESH || type == AssetType::UNKNOWN;
+    return type == AssetType::Mp3dMesh || type == AssetType::Unknown;
   }
 
   /**

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -101,6 +101,12 @@ constexpr int RIGID_STAGE_ID = 0;
 static const double NO_TIME = 0.0;
 
 /**
+ * @brief loading an asset info with filepath == EMPTY_SCENE creates a scene
+ * graph with no scene mesh (ie. an empty scene)
+ */
+constexpr char EMPTY_SCENE[] = "NONE";
+
+/**
  * @brief The @ref esp::gfx::ShaderManager key for @ref esp::gfx::LightInfo
  * which has no lights
  */

--- a/src/esp/metadata/attributes/AttributesBase.cpp
+++ b/src/esp/metadata/attributes/AttributesBase.cpp
@@ -9,24 +9,6 @@ namespace esp {
 namespace metadata {
 namespace attributes {
 
-// All keys must be lowercase
-const std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap = {
-    {"unknown", esp::assets::AssetType::UNKNOWN},
-    {"mp3d", esp::assets::AssetType::MP3D_MESH},
-    {"semantic", esp::assets::AssetType::INSTANCE_MESH},
-    {"navmesh", esp::assets::AssetType::NAVMESH},
-};
-
-std::string getMeshTypeName(esp::assets::AssetType meshTypeEnum) {
-  // Must always be valid value
-  for (const auto& it : AssetTypeNamesMap) {
-    if (it.second == meshTypeEnum) {
-      return it.first;
-    }
-  }
-  return "unknown";
-}
-
 AbstractAttributes::AbstractAttributes(const std::string& attributesClassKey,
                                        const std::string& handle)
     : Configuration() {

--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -12,9 +12,6 @@
 #include "esp/core/managedContainers/AbstractFileBasedManagedObject.h"
 
 namespace esp {
-namespace asset {
-enum class AssetType;
-}
 namespace metadata {
 /**
  * @brief A tag to search for in the default_attributes section of the Scene
@@ -26,20 +23,6 @@ constexpr char CONFIG_NAME_AS_ASSET_FILENAME[] =
     "%%CONFIG_NAME_AS_ASSET_FILENAME%%";
 
 namespace attributes {
-
-/**
- * @brief Constant static map to provide mappings from string tags to
- * @ref esp::assets::AssetType values.  This will be used to map values
- * set in json for mesh type to @ref esp::assets::AssetType.  Keys must
- * be lowercase.
- */
-const extern std::map<std::string, esp::assets::AssetType> AssetTypeNamesMap;
-
-/**
- * @brief Get a string name representing the specified @ref
- * esp::assets::AssetType enum value.
- */
-std::string getMeshTypeName(esp::assets::AssetType meshTypeEnum);
 
 /**
  * @brief Base class for all implemented attributes.  Inherits from @ref

--- a/src/esp/metadata/attributes/AttributesEnumMaps.cpp
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.cpp
@@ -10,6 +10,23 @@ namespace metadata {
 namespace attributes {
 
 // All keys must be lowercase
+const std::map<std::string, AssetType> AssetTypeNamesMap = {
+    {"unknown", AssetType::UNKNOWN},
+    {"mp3d", AssetType::MP3D_MESH},
+    {"semantic", AssetType::INSTANCE_MESH},
+    {"navmesh", AssetType::NAVMESH},
+};
+
+std::string getMeshTypeName(AssetType meshTypeEnum) {
+  // Must always be valid value
+  for (const auto& it : AssetTypeNamesMap) {
+    if (it.second == meshTypeEnum) {
+      return it.first;
+    }
+  }
+  return "unknown";
+}
+
 const std::map<std::string, esp::gfx::LightType> LightTypeNamesMap = {
     {"point", esp::gfx::LightType::Point},
     {"directional", esp::gfx::LightType::Directional},

--- a/src/esp/metadata/attributes/AttributesEnumMaps.cpp
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.cpp
@@ -11,13 +11,20 @@ namespace attributes {
 
 // All keys must be lowercase
 const std::map<std::string, AssetType> AssetTypeNamesMap = {
-    {"unknown", AssetType::UNKNOWN},
-    {"mp3d", AssetType::MP3D_MESH},
-    {"semantic", AssetType::INSTANCE_MESH},
-    {"navmesh", AssetType::NAVMESH},
-};
+    {"unknown", AssetType::Unknown},
+    {"mp3d", AssetType::Mp3dMesh},
+    {"semantic", AssetType::InstanceMesh},
+    {"navmesh", AssetType::Navmesh},
+    {"primitive", AssetType::Primitive}};
 
 std::string getMeshTypeName(AssetType meshTypeEnum) {
+  // this verifies that enum value being checked is supported by string-keyed
+  // map. The values below should be the minimum and maximum enums supported by
+  // AssetTypeNamesMap
+  if (meshTypeEnum <= AssetType::Unknown ||
+      meshTypeEnum >= AssetType::EndAssetType) {
+    return "unknown";
+  }
   // Must always be valid value
   for (const auto& it : AssetTypeNamesMap) {
     if (it.second == meshTypeEnum) {

--- a/src/esp/metadata/attributes/AttributesEnumMaps.h
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.h
@@ -8,14 +8,23 @@
 #include "esp/core/Esp.h"
 #include "esp/gfx/LightSetup.h"
 namespace esp {
-namespace asset {
-enum class AssetType;
-}
 namespace physics {
 enum class MotionType;
 }
 namespace metadata {
 namespace attributes {
+
+/**
+ * @brief Supported Asset types
+ */
+enum class AssetType {
+  UNKNOWN,
+  MP3D_MESH,
+  INSTANCE_MESH,
+  UNKNOWN2,
+  NAVMESH,
+  PRIMITIVE,
+};
 
 /**
  * @brief This enum class defines possible options for the type of joint that
@@ -207,6 +216,20 @@ enum class SceneInstanceTranslationOrigin {
    */
   EndTransOrigin,
 };
+
+/**
+ * @brief Constant static map to provide mappings from string tags to
+ * @ref AssetType values.  This will be used to map values
+ * set in json for mesh type to @ref AssetType.  Keys must
+ * be lowercase.
+ */
+const extern std::map<std::string, AssetType> AssetTypeNamesMap;
+
+/**
+ * @brief Get a string name representing the specified @ref
+ * AssetType enum value.
+ */
+std::string getMeshTypeName(AssetType meshTypeEnum);
 
 /**
  * @brief Constant map to provide mappings from string tags to @ref

--- a/src/esp/metadata/attributes/AttributesEnumMaps.h
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.h
@@ -18,12 +18,12 @@ namespace attributes {
  * @brief Supported Asset types
  */
 enum class AssetType {
-  UNKNOWN,
-  MP3D_MESH,
-  INSTANCE_MESH,
-  UNKNOWN2,
-  NAVMESH,
-  PRIMITIVE,
+  Unknown,
+  Mp3dMesh,
+  InstanceMesh,
+  Navmesh,
+  Primitive,
+  EndAssetType,
 };
 
 /**

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -74,8 +74,8 @@ SemanticAttributes::SemanticAttributes(const std::string& handle)
   // setting default for semantic assets having semantically painted textures to
   // false
   setHasSemanticTextures(false);
-  // 4 corresponds to esp::assets::AssetType::INSTANCE_MESH
-  setSemanticAssetType(static_cast<int>(esp::assets::AssetType::INSTANCE_MESH));
+  // 4 corresponds to AssetType::INSTANCE_MESH
+  setSemanticAssetType(static_cast<int>(AssetType::INSTANCE_MESH));
   // get refs to internal subconfigs for semantic region attributes
   regionAnnotationConfig_ = editSubconfig<Configuration>("region_annotations");
 }  // SemanticAttributes ctor

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -74,8 +74,8 @@ SemanticAttributes::SemanticAttributes(const std::string& handle)
   // setting default for semantic assets having semantically painted textures to
   // false
   setHasSemanticTextures(false);
-  // 4 corresponds to AssetType::INSTANCE_MESH
-  setSemanticAssetType(static_cast<int>(AssetType::INSTANCE_MESH));
+  // 4 corresponds to AssetType::InstanceMesh
+  setSemanticAssetType(static_cast<int>(AssetType::InstanceMesh));
   // get refs to internal subconfigs for semantic region attributes
   regionAnnotationConfig_ = editSubconfig<Configuration>("region_annotations");
 }  // SemanticAttributes ctor

--- a/src/esp/metadata/attributes/StageAttributes.cpp
+++ b/src/esp/metadata/attributes/StageAttributes.cpp
@@ -25,10 +25,10 @@ StageAttributes::StageAttributes(const std::string& handle)
   setShaderType(getShaderTypeName(ObjectInstanceShaderType::Material));
   // TODO remove this once ShaderType support is complete
   setForceFlatShading(true);
-  // 0 corresponds to esp::assets::AssetType::UNKNOWN->treated as general mesh
-  setCollisionAssetType(static_cast<int>(esp::assets::AssetType::UNKNOWN));
-  // 4 corresponds to esp::assets::AssetType::INSTANCE_MESH
-  setSemanticAssetType(static_cast<int>(esp::assets::AssetType::INSTANCE_MESH));
+  // 0 corresponds to AssetType::UNKNOWN->treated as general mesh
+  setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
+  // 4 corresponds to AssetType::INSTANCE_MESH
+  setSemanticAssetType(static_cast<int>(AssetType::INSTANCE_MESH));
   // set empty defaults for handles
   set("nav_asset", "");
   set("semantic_asset", "");

--- a/src/esp/metadata/attributes/StageAttributes.cpp
+++ b/src/esp/metadata/attributes/StageAttributes.cpp
@@ -25,10 +25,10 @@ StageAttributes::StageAttributes(const std::string& handle)
   setShaderType(getShaderTypeName(ObjectInstanceShaderType::Material));
   // TODO remove this once ShaderType support is complete
   setForceFlatShading(true);
-  // 0 corresponds to AssetType::UNKNOWN->treated as general mesh
-  setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
-  // 4 corresponds to AssetType::INSTANCE_MESH
-  setSemanticAssetType(static_cast<int>(AssetType::INSTANCE_MESH));
+  // 0 corresponds to AssetType::Unknown->treated as general mesh
+  setCollisionAssetType(static_cast<int>(AssetType::Unknown));
+  // 4 corresponds to AssetType::InstanceMesh
+  setSemanticAssetType(static_cast<int>(AssetType::InstanceMesh));
   // set empty defaults for handles
   set("nav_asset", "");
   set("semantic_asset", "");

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -18,6 +18,7 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace metadata {
+using attributes::AssetType;
 namespace managers {
 
 /**
@@ -350,14 +351,12 @@ auto AbstractObjectAttributesManager<T, Access>::
   auto colAssetHandle = attributes->getCollisionAssetHandle();
   if (this->isValidPrimitiveAttributes(colAssetHandle)) {
     // value is valid primitive, and value is different than existing value
-    attributes->setCollisionAssetType(
-        static_cast<int>(esp::assets::AssetType::PRIMITIVE));
+    attributes->setCollisionAssetType(static_cast<int>(AssetType::PRIMITIVE));
     attributes->setUseMeshCollision(false);
   } else {
     // TODO eventually remove this, but currently non-prim collision mesh must
     // be UNKNOWN
-    attributes->setCollisionAssetType(
-        static_cast<int>(esp::assets::AssetType::UNKNOWN));
+    attributes->setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
     attributes->setUseMeshCollision(true);
   }
 
@@ -389,7 +388,7 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
   // Map a json string value to its corresponding AssetType if found and cast to
   // int, based on AbstractObjectAttributes::AssetTypeNamesMap mappings.
   // Casts an int of the esp::AssetType enum value if found and understood,
-  // 0 (esp::assets::AssetType::UNKNOWN) if found but not understood, and
+  // 0 (AssetType::UNKNOWN) if found but not understood, and
   //-1 if tag is not found in json.
   int typeVal = -1;
   std::string tmpVal = "";
@@ -408,7 +407,7 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
           << "` does not map to a valid "
              "AbstractObjectAttributes::AssetTypeNamesMap value, so "
              "defaulting mesh type to AssetType::UNKNOWN.";
-      typeVal = static_cast<int>(esp::assets::AssetType::UNKNOWN);
+      typeVal = static_cast<int>(AssetType::UNKNOWN);
     }
     // value found so override current value, otherwise do not.
     meshTypeSetter(typeVal);

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -351,12 +351,12 @@ auto AbstractObjectAttributesManager<T, Access>::
   auto colAssetHandle = attributes->getCollisionAssetHandle();
   if (this->isValidPrimitiveAttributes(colAssetHandle)) {
     // value is valid primitive, and value is different than existing value
-    attributes->setCollisionAssetType(static_cast<int>(AssetType::PRIMITIVE));
+    attributes->setCollisionAssetType(static_cast<int>(AssetType::Primitive));
     attributes->setUseMeshCollision(false);
   } else {
     // TODO eventually remove this, but currently non-prim collision mesh must
     // be UNKNOWN
-    attributes->setCollisionAssetType(static_cast<int>(AssetType::UNKNOWN));
+    attributes->setCollisionAssetType(static_cast<int>(AssetType::Unknown));
     attributes->setUseMeshCollision(true);
   }
 
@@ -388,7 +388,7 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
   // Map a json string value to its corresponding AssetType if found and cast to
   // int, based on AbstractObjectAttributes::AssetTypeNamesMap mappings.
   // Casts an int of the esp::AssetType enum value if found and understood,
-  // 0 (AssetType::UNKNOWN) if found but not understood, and
+  // 0 (AssetType::Unknown) if found but not understood, and
   //-1 if tag is not found in json.
   int typeVal = -1;
   std::string tmpVal = "";
@@ -406,8 +406,8 @@ AbstractObjectAttributesManager<T, Access>::setJSONAssetHandleAndType(
           << "> : Value in json @ tag :" << jsonMeshTypeTag << ": `" << tmpVal
           << "` does not map to a valid "
              "AbstractObjectAttributes::AssetTypeNamesMap value, so "
-             "defaulting mesh type to AssetType::UNKNOWN.";
-      typeVal = static_cast<int>(AssetType::UNKNOWN);
+             "defaulting mesh type to AssetType::Unknown.";
+      typeVal = static_cast<int>(AssetType::Unknown);
     }
     // value found so override current value, otherwise do not.
     meshTypeSetter(typeVal);

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -16,11 +16,10 @@ namespace Cr = Corrade;
 
 namespace esp {
 
-using assets::AssetType;
-
 namespace metadata {
 
 using attributes::AbstractObjectAttributes;
+using attributes::AssetType;
 using attributes::ObjectAttributes;
 namespace managers {
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -45,7 +45,7 @@ ObjectAttributesManager::createPrimBasedAttributesTemplate(
   primObjectAttributes->setScale({0.1, 0.1, 0.1});
 
   // set render mesh handle
-  int primType = static_cast<int>(AssetType::PRIMITIVE);
+  int primType = static_cast<int>(AssetType::Primitive);
   primObjectAttributes->setRenderAssetType(primType);
   // set collision mesh/primitive handle and default for primitives to not use
   // mesh collisions
@@ -198,10 +198,10 @@ void ObjectAttributesManager::setDefaultAssetNameBasedAttributes(
     const std::function<void(int)>& assetTypeSetter) {
   if (this->isValidPrimitiveAttributes(meshHandle)) {
     // value is valid primitive, and value is different than existing value
-    assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
+    assetTypeSetter(static_cast<int>(AssetType::Primitive));
   } else {
     // use unknown for object mesh types of non-primitives
-    assetTypeSetter(static_cast<int>(AssetType::UNKNOWN));
+    assetTypeSetter(static_cast<int>(AssetType::Unknown));
   }
   if (setFrame) {
     attributes->setOrientUp({0, 1, 0});

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -15,7 +15,6 @@
 #include "esp/io/Json.h"
 
 namespace esp {
-using assets::AssetType;
 using core::managedContainers::ManagedObjectAccess;
 
 namespace metadata {

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -76,7 +76,7 @@ StageAttributesManager::preRegisterObjectFinalize(
     stageAttributes->setRenderAssetIsPrimitive(false);
   } else if (std::string::npos != stageAttributesHandle.find("NONE")) {
     // Render asset handle will be NONE as well - force type to be unknown
-    stageAttributes->setRenderAssetType(static_cast<int>(AssetType::UNKNOWN));
+    stageAttributes->setRenderAssetType(static_cast<int>(AssetType::Unknown));
     stageAttributes->setRenderAssetIsPrimitive(false);
   } else if (forceRegistration) {
     ESP_WARNING()
@@ -107,7 +107,7 @@ StageAttributesManager::preRegisterObjectFinalize(
   } else if (std::string::npos != stageAttributesHandle.find("NONE")) {
     // Collision asset handle will be NONE as well - force type to be unknown
     stageAttributes->setCollisionAssetType(
-        static_cast<int>(AssetType::UNKNOWN));
+        static_cast<int>(AssetType::Unknown));
     stageAttributes->setCollisionAssetIsPrimitive(false);
   } else {
     // Else, means no collision data specified, use specified render data
@@ -147,7 +147,7 @@ StageAttributes::ptr StageAttributesManager::createPrimBasedAttributesTemplate(
   stageAttributes->setMargin(0.0);
 
   // set render mesh handle
-  int primType = static_cast<int>(AssetType::PRIMITIVE);
+  int primType = static_cast<int>(AssetType::Primitive);
   stageAttributes->setRenderAssetType(primType);
   // set collision mesh/primitive handle and default for primitives to not use
   // mesh collisions
@@ -307,7 +307,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
     // TODO : get rid of this once the hardcoded mesh-type handling is removed,
     // but for now force all semantic assets to be instance_mesh
     newAttributes->setSemanticAssetType(
-        static_cast<int>(AssetType::INSTANCE_MESH));
+        static_cast<int>(AssetType::InstanceMesh));
   }
   // set default physical quantities specified in physics manager attributes
   if (physicsAttributesManager_->getObjectLibHasHandle(
@@ -339,18 +339,18 @@ void StageAttributesManager::setDefaultAssetNameBasedAttributes(
   up = up1;
   fwd = fwd1;
   if (endsWith(fileName, "_semantic.ply")) {
-    assetTypeSetter(static_cast<int>(AssetType::INSTANCE_MESH));
+    assetTypeSetter(static_cast<int>(AssetType::InstanceMesh));
   } else if (endsWith(fileName, ".glb")) {
     // assumes MP3D glb with gravity = -Z
-    assetTypeSetter(static_cast<int>(AssetType::MP3D_MESH));
+    assetTypeSetter(static_cast<int>(AssetType::Mp3dMesh));
     // Create a coordinate for the mesh by rotating the default ESP
     // coordinate frame to -Z gravity
     up = up2;
     fwd = fwd2;
   } else if (StageAttributesManager::isValidPrimitiveAttributes(fileName)) {
-    assetTypeSetter(static_cast<int>(AssetType::PRIMITIVE));
+    assetTypeSetter(static_cast<int>(AssetType::Primitive));
   } else {
-    assetTypeSetter(static_cast<int>(AssetType::UNKNOWN));
+    assetTypeSetter(static_cast<int>(AssetType::Unknown));
   }
   if (setFrame) {
     attributes->setOrientUp(up);
@@ -419,7 +419,7 @@ void StageAttributesManager::setValsFromJSONDoc(
   // TODO eventually remove this, but currently semantic mesh must be
   // instance
   stageAttributes->setSemanticAssetType(
-      static_cast<int>(AssetType::INSTANCE_MESH));
+      static_cast<int>(AssetType::InstanceMesh));
 
   if (io::readMember<std::string>(jsonConfig, "nav_asset", navmeshFName)) {
     // if "nav mesh" is specified in stage json set value (override default).

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -11,9 +11,6 @@
 #include "PhysicsAttributesManager.h"
 
 namespace esp {
-namespace assets {
-enum class AssetType;
-}  // namespace assets
 namespace metadata {
 namespace managers {
 

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -16,6 +16,7 @@
 namespace Mn = Magnum;
 
 namespace esp {
+using metadata::attributes::AssetType;
 namespace physics {
 
 bool URDFImporter::loadURDF(const std::string& urdfFilepath, bool forceReload) {
@@ -257,7 +258,7 @@ void URDFImporter::importURDFAssets(
     for (auto& collision : link->m_collisionArray) {
       if (collision.m_geometry.m_type == metadata::URDF::GEOM_MESH) {
         // pre-load the mesh asset for its collision shape
-        assets::AssetInfo meshAsset{assets::AssetType::UNKNOWN,
+        assets::AssetInfo meshAsset{AssetType::UNKNOWN,
                                     collision.m_geometry.m_meshFileName};
         CORRADE_ASSERT(resourceManager_.loadRenderAsset(meshAsset),
                        "Failed to load URDF ("
@@ -268,7 +269,7 @@ void URDFImporter::importURDFAssets(
     // pre-load visual meshes and primitive asset variations and cache the
     // handle
     for (auto& visual : link->m_visualArray) {
-      assets::AssetInfo visualMeshInfo{assets::AssetType::UNKNOWN};
+      assets::AssetInfo visualMeshInfo{AssetType::UNKNOWN};
       visualMeshInfo.forceFlatShading = false;
 
       std::shared_ptr<metadata::URDF::Material> material =
@@ -284,7 +285,7 @@ void URDFImporter::importURDFAssets(
       }
       switch (visual.m_geometry.m_type) {
         case metadata::URDF::GEOM_CAPSULE: {
-          visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::PRIMITIVE;
           auto assetMgr = resourceManager_.getAssetAttributesManager();
           auto capTemplate = assetMgr->getDefaultCapsuleTemplate(false);
           // proportions as suggested on magnum docs
@@ -295,17 +296,17 @@ void URDFImporter::importURDFAssets(
           visual.m_geometry.m_meshFileName = capTemplate->getHandle();
         } break;
         case metadata::URDF::GEOM_CYLINDER:
-          visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::PRIMITIVE;
           visualMeshInfo.filepath =
               "cylinderSolid_rings_1_segments_12_halfLen_1_useTexCoords_false_"
               "useTangents_false_capEnds_true";
           break;
         case metadata::URDF::GEOM_BOX:
-          visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::PRIMITIVE;
           visualMeshInfo.filepath = "cubeSolid";
           break;
         case metadata::URDF::GEOM_SPHERE:
-          visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::PRIMITIVE;
           visualMeshInfo.filepath = "icosphereSolid_subdivs_1";
           break;
         case metadata::URDF::GEOM_MESH:

--- a/src/esp/physics/URDFImporter.cpp
+++ b/src/esp/physics/URDFImporter.cpp
@@ -258,7 +258,7 @@ void URDFImporter::importURDFAssets(
     for (auto& collision : link->m_collisionArray) {
       if (collision.m_geometry.m_type == metadata::URDF::GEOM_MESH) {
         // pre-load the mesh asset for its collision shape
-        assets::AssetInfo meshAsset{AssetType::UNKNOWN,
+        assets::AssetInfo meshAsset{AssetType::Unknown,
                                     collision.m_geometry.m_meshFileName};
         CORRADE_ASSERT(resourceManager_.loadRenderAsset(meshAsset),
                        "Failed to load URDF ("
@@ -269,7 +269,7 @@ void URDFImporter::importURDFAssets(
     // pre-load visual meshes and primitive asset variations and cache the
     // handle
     for (auto& visual : link->m_visualArray) {
-      assets::AssetInfo visualMeshInfo{AssetType::UNKNOWN};
+      assets::AssetInfo visualMeshInfo{AssetType::Unknown};
       visualMeshInfo.forceFlatShading = false;
 
       std::shared_ptr<metadata::URDF::Material> material =
@@ -285,7 +285,7 @@ void URDFImporter::importURDFAssets(
       }
       switch (visual.m_geometry.m_type) {
         case metadata::URDF::GEOM_CAPSULE: {
-          visualMeshInfo.type = AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::Primitive;
           auto assetMgr = resourceManager_.getAssetAttributesManager();
           auto capTemplate = assetMgr->getDefaultCapsuleTemplate(false);
           // proportions as suggested on magnum docs
@@ -296,17 +296,17 @@ void URDFImporter::importURDFAssets(
           visual.m_geometry.m_meshFileName = capTemplate->getHandle();
         } break;
         case metadata::URDF::GEOM_CYLINDER:
-          visualMeshInfo.type = AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::Primitive;
           visualMeshInfo.filepath =
               "cylinderSolid_rings_1_segments_12_halfLen_1_useTexCoords_false_"
               "useTangents_false_capEnds_true";
           break;
         case metadata::URDF::GEOM_BOX:
-          visualMeshInfo.type = AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::Primitive;
           visualMeshInfo.filepath = "cubeSolid";
           break;
         case metadata::URDF::GEOM_SPHERE:
-          visualMeshInfo.type = AssetType::PRIMITIVE;
+          visualMeshInfo.type = AssetType::Primitive;
           visualMeshInfo.filepath = "icosphereSolid_subdivs_1";
           break;
         case metadata::URDF::GEOM_MESH:

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -22,6 +22,7 @@
 #include "esp/sim/Simulator.h"
 
 namespace esp {
+using metadata::attributes::AssetType;
 namespace physics {
 
 BulletPhysicsManager::BulletPhysicsManager(
@@ -273,7 +274,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
         visual.m_linkLocalFrame);
 
     // prep the AssetInfo, overwrite the filepath later
-    assets::AssetInfo visualMeshInfo{assets::AssetType::UNKNOWN};
+    assets::AssetInfo visualMeshInfo{AssetType::UNKNOWN};
     visualMeshInfo.forceFlatShading = forceFlatShading;
 
     // create a modified asset if necessary for material override
@@ -292,7 +293,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
     auto scale = Mn::Vector3{1.0f, 1.0f, 1.0f};
     switch (visual.m_geometry.m_type) {
       case metadata::URDF::GEOM_CAPSULE:
-        visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::PRIMITIVE;
         // should be registered and cached already
         visualMeshInfo.filepath = visual.m_geometry.m_meshFileName;
         // scale by radius as suggested by magnum docs
@@ -303,7 +304,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
             Mn::Matrix4::rotationX(Mn::Rad(M_PI_2)));
         break;
       case metadata::URDF::GEOM_CYLINDER:
-        visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::PRIMITIVE;
         // the default created primitive handle for the cylinder with radius 1
         // and length 2
         visualMeshInfo.filepath =
@@ -318,12 +319,12 @@ bool BulletPhysicsManager::attachLinkGeometry(
             Mn::Matrix4::rotationX(Mn::Rad(M_PI_2)));
         break;
       case metadata::URDF::GEOM_BOX:
-        visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::PRIMITIVE;
         visualMeshInfo.filepath = "cubeSolid";
         scale = visual.m_geometry.m_boxSize * 0.5;
         break;
       case metadata::URDF::GEOM_SPHERE: {
-        visualMeshInfo.type = esp::assets::AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::PRIMITIVE;
         // default sphere prim is already constructed w/ radius 1
         visualMeshInfo.filepath = "icosphereSolid_subdivs_1";
         scale = Mn::Vector3(visual.m_geometry.m_sphereRadius);

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -274,7 +274,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
         visual.m_linkLocalFrame);
 
     // prep the AssetInfo, overwrite the filepath later
-    assets::AssetInfo visualMeshInfo{AssetType::UNKNOWN};
+    assets::AssetInfo visualMeshInfo{AssetType::Unknown};
     visualMeshInfo.forceFlatShading = forceFlatShading;
 
     // create a modified asset if necessary for material override
@@ -293,7 +293,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
     auto scale = Mn::Vector3{1.0f, 1.0f, 1.0f};
     switch (visual.m_geometry.m_type) {
       case metadata::URDF::GEOM_CAPSULE:
-        visualMeshInfo.type = AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::Primitive;
         // should be registered and cached already
         visualMeshInfo.filepath = visual.m_geometry.m_meshFileName;
         // scale by radius as suggested by magnum docs
@@ -304,7 +304,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
             Mn::Matrix4::rotationX(Mn::Rad(M_PI_2)));
         break;
       case metadata::URDF::GEOM_CYLINDER:
-        visualMeshInfo.type = AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::Primitive;
         // the default created primitive handle for the cylinder with radius 1
         // and length 2
         visualMeshInfo.filepath =
@@ -319,12 +319,12 @@ bool BulletPhysicsManager::attachLinkGeometry(
             Mn::Matrix4::rotationX(Mn::Rad(M_PI_2)));
         break;
       case metadata::URDF::GEOM_BOX:
-        visualMeshInfo.type = AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::Primitive;
         visualMeshInfo.filepath = "cubeSolid";
         scale = visual.m_geometry.m_boxSize * 0.5;
         break;
       case metadata::URDF::GEOM_SPHERE: {
-        visualMeshInfo.type = AssetType::PRIMITIVE;
+        visualMeshInfo.type = AssetType::Primitive;
         // default sphere prim is already constructed w/ radius 1
         visualMeshInfo.filepath = "icosphereSolid_subdivs_1";
         scale = Mn::Vector3(visual.m_geometry.m_sphereRadius);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -39,7 +39,7 @@ namespace Cr = Corrade;
 
 namespace esp {
 namespace sim {
-
+using metadata::attributes::AssetType;
 using metadata::attributes::PhysicsManagerAttributes;
 using metadata::attributes::SceneAOInstanceAttributes;
 using metadata::attributes::SceneObjectInstanceAttributes;
@@ -582,12 +582,12 @@ bool Simulator::instanceStageForSceneAttributes(
         (activeSemanticSceneID_ != activeSceneID_)) {
       sceneID_.push_back(activeSemanticSceneID_);
     } else {  // activeSemanticSceneID_ == activeSceneID_;
-      assets::AssetType stageType =
-          static_cast<assets::AssetType>(stageAttributes->getRenderAssetType());
+      AssetType stageType =
+          static_cast<AssetType>(stageAttributes->getRenderAssetType());
       // instance meshes contain their semantic annotations
       // empty scene has none to worry about
-      if (!(stageType == assets::AssetType::INSTANCE_MESH ||
-            stageAttributesHandle == assets::EMPTY_SCENE)) {
+      if (!(stageType == AssetType::INSTANCE_MESH ||
+            stageAttributesHandle == esp::EMPTY_SCENE)) {
         semanticSceneMeshLoaded_ = false;
         // TODO: programmatic generation of semantic meshes when no
         // annotations are provided.

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -586,7 +586,7 @@ bool Simulator::instanceStageForSceneAttributes(
           static_cast<AssetType>(stageAttributes->getRenderAssetType());
       // instance meshes contain their semantic annotations
       // empty scene has none to worry about
-      if (!(stageType == AssetType::INSTANCE_MESH ||
+      if (!(stageType == AssetType::InstanceMesh ||
             stageAttributesHandle == esp::EMPTY_SCENE)) {
         semanticSceneMeshLoaded_ = false;
         // TODO: programmatic generation of semantic meshes when no

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -388,7 +388,7 @@ void IOTest::testJsonEspTypes() {
   {
     // AssetInfo
     esp::assets::AssetInfo assetInfo{
-        AssetType::MP3D_MESH,
+        AssetType::Mp3dMesh,
         "test_filepath2",
         esp::geo::CoordinateFrame(esp::vec3f(1.f, 0.f, 0.f),
                                   esp::vec3f(0.f, 0.f, 1.f),

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -20,6 +20,7 @@
 namespace Cr = Corrade;
 
 using esp::metadata::attributes::ArticulatedObjectAttributes;
+using esp::metadata::attributes::AssetType;
 using esp::metadata::attributes::ObjectAttributes;
 namespace {
 const std::string dataDir = Corrade::Utility::Path::join(SCENE_DATASETS, "../");
@@ -387,7 +388,7 @@ void IOTest::testJsonEspTypes() {
   {
     // AssetInfo
     esp::assets::AssetInfo assetInfo{
-        esp::assets::AssetType::MP3D_MESH,
+        AssetType::MP3D_MESH,
         "test_filepath2",
         esp::geo::CoordinateFrame(esp::vec3f(1.f, 0.f, 0.f),
                                   esp::vec3f(0.f, 0.f, 1.f),

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -969,7 +969,7 @@ void SimTest::getRuntimePerfStats() {
 
   SimulatorConfiguration simConfig =
       simulator->getMetadataMediator()->getSimulatorConfiguration();
-  simConfig.activeSceneName = esp::assets::EMPTY_SCENE;
+  simConfig.activeSceneName = esp::EMPTY_SCENE;
   simulator->reconfigure(simConfig);
 
   statValues = simulator->getRuntimePerfStatValues();

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -45,7 +45,7 @@ MeshData SceneLoader::load(const AssetInfo& info) {
     return mesh;
   }
 
-  if (info.type == metadata::attributes::AssetType::INSTANCE_MESH) {
+  if (info.type == metadata::attributes::AssetType::InstanceMesh) {
     Cr::Containers::Pointer<Importer> importer;
     CORRADE_INTERNAL_ASSERT_OUTPUT(
         importer = importerManager_.loadAndInstantiate("StanfordImporter"));

--- a/src/utils/datatool/SceneLoader.cpp
+++ b/src/utils/datatool/SceneLoader.cpp
@@ -15,6 +15,7 @@
 #include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"
+#include "esp/metadata/attributes/AttributesEnumMaps.h"
 
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
@@ -44,7 +45,7 @@ MeshData SceneLoader::load(const AssetInfo& info) {
     return mesh;
   }
 
-  if (info.type == AssetType::INSTANCE_MESH) {
+  if (info.type == metadata::attributes::AssetType::INSTANCE_MESH) {
     Cr::Containers::Pointer<Importer> importer;
     CORRADE_INTERNAL_ASSERT_OUTPUT(
         importer = importerManager_.loadAndInstantiate("StanfordImporter"));


### PR DESCRIPTION
## Motivation and Context

This PR moves the AssetType enum from the asset namespace to the metadata::attributes namespace where it can reside with the other metadata-related enum classes in AttributesEnumMaps.  This is primarily for consistency but also to facilitate interactions with the enum-backed data in the Attributes that consume it.

The PR also moves the EMPTY_SCENE definition to Esp.h from Asset.h, in an effort to also maintain consistency in where our system-wide consts are stored.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
