### PR TITLE
--Properly initialize std::vector member variable to be correct size

### DIFF
--- a/src/esp/scene/SceneNode.cpp
+++ b/src/esp/scene/SceneNode.cpp
@@ -18,7 +18,9 @@ namespace scene {
 SceneNode::SceneNode()
     : Mn::SceneGraph::AbstractFeature3D{*this},
       nodeSensorSuite_(new esp::sensor::SensorSuite(*this)),
-      subtreeSensorSuite_(new esp::sensor::SensorSuite(*this)) {
+      subtreeSensorSuite_(new esp::sensor::SensorSuite(*this)),
+      semanticIDs_(static_cast<int>(SceneNodeSemanticDataIDX::NUM_SEMANTIC_IDS),
+                   0) {
   setCachedTransformations(Mn::SceneGraph::CachedTransformation::Absolute);
   absoluteTransformation_ = absoluteTransformation();
   // Once created, nodeSensorSuite_ and subtreeSensorSuite_ are features owned

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -353,8 +353,7 @@ class SceneNode : public MagnumObject,
 
   //! The semantic category of this node. Used to render attached Drawables with
   //! Semantic sensor when no perVertexObjectIds are present.
-  std::vector<int> semanticIDs_{
-      static_cast<int>(SceneNodeSemanticDataIDX::NUM_SEMANTIC_IDS), 0};
+  std::vector<int> semanticIDs_;
 };  // namespace scene
 
 // Traversal Helpers


### PR DESCRIPTION
## Motivation and Context
This bugfix fixes the incorrect initialization of the SceneNode semanticIDs_ vector which was causing a heap corruption.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Local c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
