### PR TITLE
--Convenience functions for accessing markers in local and world space

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -207,8 +207,19 @@ void declareBasePhysicsObjectWrapper(py::module& m,
       .def_property_readonly(
           "marker_sets", &PhysObjWrapper::getMarkerSets,
           py::return_value_policy::reference_internal,
-          ("The MarkerSets defined for " + objType + " this object.").c_str())
-
+          ("The MarkerSets defined for this " + objType + ".").c_str())
+      .def("marker_points_local", &PhysObjWrapper::getMarkerPointsLocal,
+           ("A nested dict structure holding all the marker"
+            "points defined for this this " +
+            objType +
+            " in object-local space. Same result as "
+            "<obj>.marker_sets.get_all_marker_points.")
+               .c_str())
+      .def("marker_points_global", &PhysObjWrapper::getMarkerPointsGlobal,
+           ("A nested dict structure holding all the marker"
+            "points defined for this this " +
+            objType + " transformed to world space.")
+               .c_str())
       .def_property_readonly(
           "csv_info", &PhysObjWrapper::getObjectInfo,
           ("Comma-separated informational string describing this " + objType +
@@ -663,8 +674,8 @@ void initPhysicsObjectBindings(py::module& m) {
 
   // create bindings for ArticulatedObjects
   // physics object base instance for articulated object
-  declareBasePhysicsObjectWrapper<ArticulatedObject>(m, "Articulated Object",
-                                                     "ArticulatedObject");
+  declareBasePhysicsObjectWrapper<ArticulatedObject>(
+      m, "Articulated Object", "ManagedArticulatedObject");
 
   // ==== ManagedArticulatedObject ====
   declareArticulatedObjectWrapper(m, "Articulated Object",

--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -210,14 +210,14 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           ("The MarkerSets defined for this " + objType + ".").c_str())
       .def("marker_points_local", &PhysObjWrapper::getMarkerPointsLocal,
            ("A nested dict structure holding all the marker"
-            "points defined for this this " +
+            "points defined for this " +
             objType +
             " in object-local space. Same result as "
             "<obj>.marker_sets.get_all_marker_points.")
                .c_str())
       .def("marker_points_global", &PhysObjWrapper::getMarkerPointsGlobal,
            ("A nested dict structure holding all the marker"
-            "points defined for this this " +
+            "points defined for this " +
             objType + " transformed to world space.")
                .c_str())
       .def_property_readonly(

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -203,6 +203,40 @@ class AbstractManagedPhysicsObject
     return {};
   }
 
+  /**
+   * @brief Retrieves the hierarchical map-of-map-of-maps containing
+   * the @ref MarkerSets constituent marker points, in local space
+   * (which is the space they are given in).
+   */
+  std::unordered_map<
+      std::string,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
+  getMarkerPointsLocal() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getMarkerPointsLocal();
+    }
+    return {};
+  }
+
+  /**
+   * @brief Retrieves the hierarchical map-of-map-of-maps containing
+   * the @ref MarkerSets constituent marker points, in local space
+   * (which is the space they are given in).
+   */
+  std::unordered_map<
+      std::string,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<Mn::Vector3>>>>
+  getMarkerPointsGlobal() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->getMarkerPointsGlobal();
+    }
+    return {};
+  }
+
   Magnum::Quaternion getRotation() const {
     if (auto sp = this->getObjectReference()) {
       return sp->getRotation();


### PR DESCRIPTION
## Motivation and Context
This PR adds a few convenience functions and bindings to provide quick access to the nested dictionary structure of marker points in both object local and world space.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
