### PR TITLE
[CI] fix pip install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -761,17 +761,7 @@ workflows:
   version: 2
   install_and_test:
     jobs:
-      - python_lint
-      - js_lint
-      - lab_build_habitat
-      - build_conda_osx:
-         CI_TEST: true
       - test_pip_build
-      - install_and_test_ubuntu
-      - pre-commit
-      - build_conda_binaries:
-          CI_TEST: true
-      - clang_tidy
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,8 @@ jobs:
       - run:
           name: pip install
           command: |
-            cd /opt/circleci/.pyenv/plugins/python-build/../.. && git fetch --tags && git checkout v2.3.15 && cd -
+            cd /opt/circleci/.pyenv/plugins/python-build/../.. && git fetch --tags && git checkout v2.3.15
+            cd /home/circleci/project
             pyenv install 3.9.16
             pyenv global 3.9.16
             ls -la

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,7 @@ jobs:
             cd /opt/circleci/.pyenv/plugins/python-build/../.. && git fetch --tags && git checkout v2.3.15 && cd -
             pyenv install 3.9.16
             pyenv global 3.9.16
+            ls -la
             python3 -m pip install -U pip
             python3 -m pip install . -v
             cd ../ && python3 -c "import habitat_sim"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -761,7 +761,17 @@ workflows:
   version: 2
   install_and_test:
     jobs:
+      - python_lint
+      - js_lint
+      - lab_build_habitat
+      - build_conda_osx:
+         CI_TEST: true
       - test_pip_build
+      - install_and_test_ubuntu
+      - pre-commit
+      - build_conda_binaries:
+          CI_TEST: true
+      - clang_tidy
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,11 +379,9 @@ jobs:
       - run:
           name: pip install
           command: |
-            cd /opt/circleci/.pyenv/plugins/python-build/../.. && git fetch --tags && git checkout v2.3.15
             cd /home/circleci/project
             pyenv install 3.9.16
             pyenv global 3.9.16
-            ls -la
             python3 -m pip install -U pip
             python3 -m pip install . -v
             cd ../ && python3 -c "import habitat_sim"


### PR DESCRIPTION
## Motivation and Context
Fixes the current emergent CI issue with pip install.

Not sure of exact details, but it appears the behavior or routing of `cd -` resulted in pip installation targeting the root directory '/home/circleci` instead of the expected `/home/circleci/project` directory containing the cloned repo.

Emergent permission issues in  `/opt/circleci/.pyenv/` suspected of being part of the problem.

Empirical solution was to skip the initial setup and route directly to project/ directory for pip installation.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
