### PR TITLE
--Configuration : Add ability to handle vectors of fields within subconfigs

### DIFF
--- a/src/esp/metadata/attributes/AttributesBase.h
+++ b/src/esp/metadata/attributes/AttributesBase.h
@@ -103,9 +103,12 @@ class AbstractAttributes
   }
 
   /**
-   *  @brief Unique ID referencing attributes
+   *  @brief Set the unique ID referencing attributes
    */
   void setID(int ID) override { set("ID", ID); }
+  /**
+   *  @brief Get the unique ID referencing attributes
+   */
   int getID() const override { return get<int>("ID"); }
 
   /**

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -34,29 +34,14 @@ class MarkerSet : public esp::core::config::Configuration {
    * @brief Returns a list of all the marker points in this MarkerSet
    */
   std::vector<Mn::Vector3> getAllPoints() const {
-    const auto markersPtr = getSubconfigView("markers");
-    // Get all vector3 keys from subconfig in sorted vector
-    std::vector<std::string> markerTags = markersPtr->getKeysByType(
-        esp::core::config::ConfigValType::MagnumVec3, true);
-    std::vector<Mn::Vector3> res;
-    res.reserve(markerTags.size());
-    for (const auto& tag : markerTags) {
-      res.emplace_back(markersPtr->get<Mn::Vector3>(tag));
-    }
-    return res;
+    return getSubconfigValsOfTypeInVector<Mn::Vector3>("markers");
   }
 
   /**
    * @brief Set the list of all the marker points for this MarkerSet
    */
   void setAllPoints(const std::vector<Mn::Vector3>& markers) {
-    auto markersPtr = editSubconfig<Configuration>("markers");
-    // Remove all existing marker points
-    markersPtr->_clearAllValues();
-    for (std::size_t i = 0; i < markers.size(); ++i) {
-      const std::string& key = Cr::Utility::formatString("{:.03d}", i);
-      markersPtr->set(key, markers[i]);
-    }
+    setSubconfigValsOfTypeInVector("markers", markers);
   }
 
   /**

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -56,11 +56,6 @@ void SemanticVolumeAttributes::writeValuesToJson(
   writeValueToJson("extrusion_height", jsonObj, allocator);
   writeValueToJson("min_bounds", jsonObj, allocator);
   writeValueToJson("max_bounds", jsonObj, allocator);
-  // write out poly loop point array.
-  const auto& polyLoop = getPolyLoop();
-  if (!polyLoop.empty()) {
-    io::addMember(jsonObj, "poly_loop", polyLoop, allocator);
-  }
 
 }  // SemanticVolumeAttributes::writeValuesToJson
 

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -21,13 +21,13 @@ SemanticVolumeAttributes::SemanticVolumeAttributes(const std::string& handle)
 std::string SemanticVolumeAttributes::getObjectInfoHeaderInternal() const {
   std::string res =
       "Name,Label,Floor Height,Extrusion Height,Min Bounds,Max Bounds,";
-  int iter = 0;
-  for (const auto& it : polyLoop_) {
+  const auto& polyLoop = getPolyLoop();
+  for (int iter = 0; iter < polyLoop.size(); ++iter) {
     Cr::Utility::formatInto(res, res.size(), "Poly Vert {} XYZ,",
-                            std::to_string(iter++));
+                            std::to_string(iter));
   }
   return res;
-}
+}  // namespace attributes
 
 std::string SemanticVolumeAttributes::getObjectInfoInternal() const {
   std::string res = Cr::Utility::formatString(
@@ -35,7 +35,8 @@ std::string SemanticVolumeAttributes::getObjectInfoInternal() const {
       getAsString("floor_height"), getAsString("extrusion_height"),
       getAsString("min_bounds"), getAsString("max_bounds"));
   Cr::Utility::formatInto(res, res.size(), "[");
-  for (const Magnum::Vector3& pt : polyLoop_) {
+  const auto& polyLoop = getPolyLoop();
+  for (const auto& pt : polyLoop) {
     Cr::Utility::formatInto(res, res.size(), "[{} {} {}],", pt.x(), pt.y(),
                             pt.z());
   }
@@ -56,8 +57,9 @@ void SemanticVolumeAttributes::writeValuesToJson(
   writeValueToJson("min_bounds", jsonObj, allocator);
   writeValueToJson("max_bounds", jsonObj, allocator);
   // write out poly loop point array.
-  if (!polyLoop_.empty()) {
-    io::addMember(jsonObj, "poly_loop", polyLoop_, allocator);
+  const auto& polyLoop = getPolyLoop();
+  if (!polyLoop.empty()) {
+    io::addMember(jsonObj, "poly_loop", polyLoop, allocator);
   }
 
 }  // SemanticVolumeAttributes::writeValuesToJson

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -87,18 +87,18 @@ class SemanticVolumeAttributes : public AbstractAttributes {
     set("max_bounds", _max_bounds);
   }
 
-  ////  TODO : Replace vector with configuration?
-
   /**
    * @brief retrieve a const reference to the vector holding the poly loop
    * points.
    */
-  const std::vector<Magnum::Vector3>& getPolyLoop() const { return polyLoop_; }
+  std::vector<Magnum::Vector3> getPolyLoop() const {
+    return getSubconfigValsOfTypeInVector<Magnum::Vector3>("poly_loop");
+  }
   /**
    * @brief Set the vector holding the poly loop points.
    */
-  void setPolyLoop(std::vector<Magnum::Vector3> _polyLoop) {
-    polyLoop_ = std::move(_polyLoop);
+  void setPolyLoop(const std::vector<Magnum::Vector3>& _polyLoop) {
+    setSubconfigValsOfTypeInVector("poly_loop", _polyLoop);
   }
 
   /**
@@ -121,12 +121,6 @@ class SemanticVolumeAttributes : public AbstractAttributes {
    * of this managed object.
    */
   std::string getObjectInfoInternal() const override;
-
-  /**
-   * @brief Vector of points making up the poly loop that describes the
-   * extrusion base.
-   */
-  std::vector<Magnum::Vector3> polyLoop_{};
 
  public:
   ESP_SMART_POINTERS(SemanticVolumeAttributes)

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -282,7 +282,7 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
   /**
    * @brief Set a filename attribute to hold the appropriate data if the
    * existing attribute's given path contains the sentinel tag value defined at
-   * @ref esp::metadata::CONFIG_NAME_AS_ASSET_FILENAME. This will be called from
+   * @ref esp::metadata::CONFIG_NAME_AS_ASSET_FILENAME. This will be specified in
    * the Scene Dataset configuration file in the "default_attributes" tag for
    * any attributes which consume file names to specify that the name specified
    * as the instanced attributes should also be used to build the name of the
@@ -297,7 +297,9 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
    *
    * This will only be called from the specified manager's initNewObjectInternal
    * function, where the attributes is initially built from a default attributes
-   * (if such an attributes exists).
+   * (if such an attributes exists), since it is only within the default
+   * attributes that the tag in question would be specified.
+   *
    * @param attributes The AbstractAttributes being worked with.
    * @param srcAssetFilename The given asset's stored filename to be queried for
    * the specified tag. If the tag exists, replace it with the simplified handle

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -126,7 +126,9 @@ void SemanticAttributesManager::setSemanticVolumeAttributesFromJson(
       // read values into vector
       io::readMember<Mn::Vector3>(jCell, "poly_loop", polyLoop);
       instanceAttrs->setPolyLoop(polyLoop);
-
+    } else if (polyLoopJSONIter->value.IsObject()) {
+      auto config = instanceAttrs->editSubconfig<Configuration>("poly_loop");
+      config->loadFromJson(polyLoopJSONIter->value);
     } else {
       ESP_WARNING() << ": Unknown format for "
                        "poly_loop specified for region instance"

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -167,8 +167,7 @@ bool SemanticScene::
         const Mn::Vector3 max = regionInstance->getMaxBounds();
         regionPtr->setBBox(min, max);
         // Set polyloop points and precalc polyloop edge vectors
-        const std::vector<Mn::Vector3>& loopPoints =
-            regionInstance->getPolyLoop();
+        const auto loopPoints = regionInstance->getPolyLoop();
 
         std::size_t numPts = loopPoints.size();
         regionPtr->polyLoopPoints_ = std::vector<Mn::Vector2>(numPts);


### PR DESCRIPTION
## Motivation and Context
This PR takes the support for vectors of points introduced with MarkerSets, promotes it to the underlying Configuration and expands it to be vectors of any type.  In a nutshell a vector of data can be stored in a subconfig by having the key be a string rep of the index in the vector referencing the value.  

This obviates the need for local vectors to implementers of the Configuration class, such as SemanticAttributes, which stored the polyloop of points in a vector member varaiable. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
