### PR TITLE
--Configurations : Expand and unify vector/array-backed value handling

### DIFF
--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -633,6 +633,36 @@ io::JsonGenericValue Configuration::writeToJsonObject(
   return jsonObj;
 }  // writeToJsonObject
 
+template <>
+
+std::vector<float> Configuration::getSubconfigValsOfTypeInVector(
+    const std::string& subCfgName) const {
+  const ConfigValType desiredType = configValTypeFor<double>();
+  const auto subCfg = getSubconfigView(subCfgName);
+  const auto& subCfgTags = subCfg->getKeysByType(desiredType, true);
+  std::vector<float> res;
+  res.reserve(subCfgTags.size());
+  for (const auto& tag : subCfgTags) {
+    res.emplace_back(static_cast<float>(subCfg->get<double>(tag)));
+  }
+  return res;
+}  // getSubconfigValsOfTypeInVector float specialization
+
+template <>
+void Configuration::setSubconfigValsOfTypeInVector(
+    const std::string& subCfgName,
+    const std::vector<float>& values) {
+  auto subCfg = editSubconfig<Configuration>(subCfgName);
+  // remove existing values in subconfig of specified type
+  subCfg->removeAllOfType<double>();
+  // add new values, building string key from index in values array of each
+  // value.
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    const std::string& key = Cr::Utility::formatString("{:.03d}", i);
+    subCfg->set(key, values[i]);
+  }
+}  // setSubconfigValsOfTypeInVector float specialization
+
 /**
  * @brief Retrieves a shared pointer to a copy of the subConfig @ref
  * esp::core::config::Configuration that has the passed @p name . This will

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -490,41 +490,36 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
       } else {
         // The array does not match any currently supported magnum
         // objects, so place in indexed subconfig of values.
+        // decrement count by 1 - the recursive subgroup load will count all the
+        // values.
+        --numConfigSettings;
         // create a new subgroup
         std::shared_ptr<core::config::Configuration> subGroupPtr =
-            getSubconfigCopy<core::config::Configuration>(key);
-
-        for (size_t i = 0; i < jsonObj.Size(); ++i) {
-          const std::string subKey =
-              Cr::Utility::formatString("{}_{:.03d}", key, i);
-          numConfigSettings += subGroupPtr->loadOneConfigFromJson(
-              numConfigSettings, subKey, jsonObj[i]);
-        }
-        setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
+            editSubconfig<core::config::Configuration>(key);
+        // load array into subconfig
+        numConfigSettings += subGroupPtr->loadFromJsonArray(jsonObj);
       }
       // value in array is a number of specified length, else it is a string, an
       // object or a nested array
     } else {
+      // decrement count by 1 - the recursive subgroup load will count all the
+      // values.
+      --numConfigSettings;
       // create a new subgroup
       std::shared_ptr<core::config::Configuration> subGroupPtr =
-          getSubconfigCopy<core::config::Configuration>(key);
-
-      for (size_t i = 0; i < jsonObj.Size(); ++i) {
-        const std::string subKey =
-            Cr::Utility::formatString("{}_{:.03d}", key, i);
-        numConfigSettings += subGroupPtr->loadOneConfigFromJson(
-            numConfigSettings, subKey, jsonObj[i]);
-      }
-      setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
+          editSubconfig<core::config::Configuration>(key);
+      // load array into subconfig
+      numConfigSettings += subGroupPtr->loadFromJsonArray(jsonObj);
     }
   } else if (jsonObj.IsObject()) {
     // support nested objects
     // create a new subgroup
+    // decrement count by 1 - the recursive subgroup load will count all the
+    // values.
+    --numConfigSettings;
     std::shared_ptr<core::config::Configuration> subGroupPtr =
-        getSubconfigCopy<core::config::Configuration>(key);
+        editSubconfig<core::config::Configuration>(key);
     numConfigSettings += subGroupPtr->loadFromJson(jsonObj);
-    // save subgroup's subgroup configuration in original config
-    setSubconfigPtr<core::config::Configuration>(key, subGroupPtr);
     //
   } else {
     // TODO support other types?
@@ -535,18 +530,35 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
                      "skipping this key.";
   }
   return numConfigSettings;
-}  // namespace config
+}  // Configuration::loadOneConfigFromJson
+
+int Configuration::loadFromJsonArray(const io::JsonGenericValue& jsonObj) {
+  // Passed config is found to be a json array, so load every value into this
+  // configuration with key as string version of index.
+  int numConfigSettings = 0;
+  for (size_t i = 0; i < jsonObj.Size(); ++i) {
+    const std::string subKey = Cr::Utility::formatString("{:.03d}", i);
+    numConfigSettings =
+        loadOneConfigFromJson(numConfigSettings, subKey, jsonObj[i]);
+  }
+  return numConfigSettings;
+}  // Configuration::loadFromJsonArray
 
 int Configuration::loadFromJson(const io::JsonGenericValue& jsonObj) {
   // count number of valid user config settings found
   int numConfigSettings = 0;
-  for (rapidjson::Value::ConstMemberIterator it = jsonObj.MemberBegin();
-       it != jsonObj.MemberEnd(); ++it) {
-    // for each key, attempt to parse
-    const std::string key{it->name.GetString()};
-
-    numConfigSettings +=
-        loadOneConfigFromJson(numConfigSettings, key, it->value);
+  if (jsonObj.IsArray()) {
+    // load array into this Configuration
+    numConfigSettings = loadFromJsonArray(jsonObj);
+  } else {
+    for (rapidjson::Value::ConstMemberIterator it = jsonObj.MemberBegin();
+         it != jsonObj.MemberEnd(); ++it) {
+      // for each key, attempt to parse
+      const std::string key{it->name.GetString()};
+      // load value and attach it to given key
+      numConfigSettings =
+          loadOneConfigFromJson(numConfigSettings, key, it->value);
+    }
   }
   return numConfigSettings;
 }  // Configuration::loadFromJson

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -1028,6 +1028,7 @@ class Configuration {
     }
     return res;
   }  // getSubconfigValsOfTypeInVector
+
   /**
    * @brief Set all values from vector of passed type into subconfig specified
    * by given tag @p subCfgName as key-value pairs where the key is the index in
@@ -1055,7 +1056,8 @@ class Configuration {
       const std::string& key = Cr::Utility::formatString("{:.03d}", i);
       subCfg->set(key, values[i]);
     }
-  }
+  }  // setSubconfigValsOfTypeInVector
+
   // ==================== load from and save to json =========================
 
   /**
@@ -1254,6 +1256,15 @@ class Configuration {
  */
 MAGNUM_EXPORT Mn::Debug& operator<<(Mn::Debug& debug,
                                     const Configuration& value);
+
+template <>
+std::vector<float> Configuration::getSubconfigValsOfTypeInVector(
+    const std::string& subCfgName) const;
+
+template <>
+void Configuration::setSubconfigValsOfTypeInVector(
+    const std::string& subCfgName,
+    const std::vector<float>& values);
 
 /**
  * @brief Retrieves a shared pointer to a copy of the subConfig @ref

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -1153,20 +1153,6 @@ class Configuration {
 
  protected:
   /**
-   * @brief Process passed json object into this Configuration, using passed
-   * key.
-   *
-   * @param numVals number of values/configs loaded so far
-   * @param key key to use to search @p jsonObj and also to set value or
-   * subconfig within this Configuration.
-   * @return the number of total fields successfully loaded after this
-   * function executes.
-   */
-  int loadOneConfigFromJson(int numVals,
-                            const std::string& key,
-                            const io::JsonGenericValue& jsonObj);
-
-  /**
    * @brief Friend function.  Checks if passed @p key is contained in @p
    * config. Returns the highest level where @p key was found
    * @param config The configuration to search for passed key
@@ -1225,8 +1211,32 @@ class Configuration {
     return result;
   }
 
+ private:
   /**
-   * @brief Map to hold configurations as subgroups
+   * @brief Process passed json object into this Configuration, using passed
+   * key.
+   *
+   * @param numVals number of values/configs loaded so far
+   * @param key key to use to search @p jsonObj and also to set value or
+   * subconfig within this Configuration.
+   * @return the number of total fields successfully loaded after this
+   * function executes.
+   */
+  int loadOneConfigFromJson(int numVals,
+                            const std::string& key,
+                            const io::JsonGenericValue& jsonObj);
+
+  /**
+   * @brief Process passed json array into this Configuration.
+   *
+   * @param jsonObj The json object being treated as an array
+   * @return the number of elements loaded into this configuration from the
+   * source json array.
+   */
+  int loadFromJsonArray(const io::JsonGenericValue& jsonObj);
+
+  /**
+   * @brief Map to hold Configurations as subgroups
    */
   ConfigMapType configMap_{};
 
@@ -1235,6 +1245,7 @@ class Configuration {
    */
   ValueMapType valueMap_{};
 
+ public:
   ESP_SMART_POINTERS(Configuration)
 };  // class Configuration
 

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -431,46 +431,58 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
     set("auto_clamp_joint_limits", auto_clamp_joint_limits);
   }
 
+  void setInitJointPose(const std::vector<float>& _jointPose) {
+    setSubconfigValsOfTypeInVector("initial_joint_pose", _jointPose);
+  }
+
   /**
    * @brief retrieve a mutable reference to this scene attributes joint
    * initial pose map
    */
-  const std::map<std::string, float>& getInitJointPose() const {
-    return initJointPose_;
+  std::vector<float> getInitJointPose() const {
+    return getSubconfigValsOfTypeInVector<float>("initial_joint_pose");
   }
 
-  std::map<std::string, float>& copyIntoInitJointPose() {
-    return initJointPose_;
-  }
-
-  /**
-   * @brief Add a value to this scene attributes joint initial pose map
-   * @param key the location/joint name to place the value
-   * @param val the joint value to set
-   */
-  void addInitJointPoseVal(const std::string& key, float val) {
-    initJointPose_[key] = val;
+  void setInitJointVelocities(const std::vector<float>& _jointPose) {
+    setSubconfigValsOfTypeInVector("initial_joint_velocities", _jointPose);
   }
 
   /**
    * @brief retrieve a mutable reference to this scene attributes joint
-   * initial velocity map
+   * initial pose map
    */
-  const std::map<std::string, float>& getInitJointVelocities() const {
-    return initJointVelocities_;
-  }
-  std::map<std::string, float>& copyIntoInitJointVelocities() {
-    return initJointVelocities_;
+  std::vector<float> getInitJointVelocities() const {
+    return getSubconfigValsOfTypeInVector<float>("initial_joint_velocities");
   }
 
-  /**
-   * @brief Add a value to this scene attributes joint initial velocity map
-   * @param key the location/joint name to place the value
-   * @param val the joint angular velocity value to set
-   */
-  void addInitJointVelocityVal(const std::string& key, float val) {
-    initJointVelocities_[key] = val;
-  }
+  // /**
+  //  * @brief Add a value to this scene attributes joint initial pose map
+  //  * @param key the location/joint name to place the value
+  //  * @param val the joint value to set
+  //  */
+  // void addInitJointPoseVal(const std::string& key, float val) {
+  //   initJointPose_[key] = val;
+  // }
+
+  // /**
+  //  * @brief retrieve a mutable reference to this scene attributes joint
+  //  * initial velocity map
+  //  */
+  // const std::map<std::string, float>& getInitJointVelocities() const {
+  //   return initJointVelocities_;
+  // }
+  // std::map<std::string, float>& copyIntoInitJointVelocities() {
+  //   return initJointVelocities_;
+  // }
+
+  // /**
+  //  * @brief Add a value to this scene attributes joint initial velocity map
+  //  * @param key the location/joint name to place the value
+  //  * @param val the joint angular velocity value to set
+  //  */
+  // void addInitJointVelocityVal(const std::string& key, float val) {
+  //   initJointVelocities_[key] = val;
+  // }
 
  protected:
   friend class esp::metadata::managers::SceneInstanceAttributesManager;
@@ -507,16 +519,6 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
    */
   void writeValuesToJsonInternal(io::JsonGenericValue& jsonObj,
                                  io::JsonAllocator& allocator) const override;
-
-  /**
-   * @brief Map of joint names/idxs to values for initial pose
-   */
-  std::map<std::string, float> initJointPose_;
-
-  /**
-   * @brief Map of joint names/idxs to values for initial velocities
-   */
-  std::map<std::string, float> initJointVelocities_;
 
  public:
   ESP_SMART_POINTERS(SceneAOInstanceAttributes)

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -88,8 +88,7 @@ class SemanticVolumeAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief retrieve a const reference to the vector holding the poly loop
-   * points.
+   * @brief retrieve a vector holding the poly loop point values.
    */
   std::vector<Magnum::Vector3> getPolyLoop() const {
     return getSubconfigValsOfTypeInVector<Magnum::Vector3>("poly_loop");

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -349,58 +349,17 @@ SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON(
       });
 
   // only used for articulated objects
-  // initial joint pose
-  io::JsonGenericValue::ConstMemberIterator jntPoseJSONIter =
-      jCell.FindMember("initial_joint_pose");
-  if (jntPoseJSONIter != jCell.MemberEnd()) {
-    if (jntPoseJSONIter->value.IsArray()) {
-      std::vector<float> poseRes;
-      // read values into vector
-      io::readMember<float>(jCell, "initial_joint_pose", poseRes);
-      int i = 0;
-      for (const float& v : poseRes) {
-        const std::string key = Cr::Utility::formatString("joint_{:.02d}", i++);
-        instanceAttrs->addInitJointPoseVal(key, v);
-      }
+  // parse initial joint pose values, whether defined as an array or a key-value
+  // store in JSON
+  this->parseSubconfigJsonVals("initial_joint_pose", instanceAttrs, jCell);
 
-    } else if (jntPoseJSONIter->value.IsObject()) {
-      // load values into map
-      io::readMember<std::map<std::string, float>>(
-          jCell, "initial_joint_pose", instanceAttrs->copyIntoInitJointPose());
-    } else {
-      ESP_WARNING() << ": Unknown format for "
-                       "initial_joint_pose specified for instance"
-                    << instanceAttrs->getHandle()
-                    << "in Scene Instance File, so no values are set.";
-    }
-  }
   // only used for articulated objects
-  // initial joint velocities
-  io::JsonGenericValue::ConstMemberIterator jntVelJSONIter =
-      jCell.FindMember("initial_joint_velocities");
-  if (jntVelJSONIter != jCell.MemberEnd()) {
-    if (jntVelJSONIter->value.IsArray()) {
-      std::vector<float> poseRes;
-      // read values into vector
-      io::readMember<float>(jCell, "initial_joint_velocities", poseRes);
-      int i = 0;
-      for (const float& v : poseRes) {
-        const std::string key = Cr::Utility::formatString("joint_{:.02d}", i++);
-        instanceAttrs->addInitJointVelocityVal(key, v);
-      }
+  // parse initial joint velocities values, whether defined as an array or a
+  // key-value
+  // store in JSON
+  this->parseSubconfigJsonVals("initial_joint_velocities", instanceAttrs,
+                               jCell);
 
-    } else if (jntVelJSONIter->value.IsObject()) {
-      // load values into map
-      io::readMember<std::map<std::string, float>>(
-          jCell, "initial_joint_velocities",
-          instanceAttrs->copyIntoInitJointVelocities());
-    } else {
-      ESP_WARNING() << ": Unknown format for "
-                       "initial_joint_velocities specified for instance"
-                    << instanceAttrs->getHandle()
-                    << "in Scene Instance File, so no values are set.";
-    }
-  }
   return instanceAttrs;
 
 }  // SceneInstanceAttributesManager::createAOInstanceAttributesFromJSON

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -116,26 +116,11 @@ void SemanticAttributesManager::setSemanticVolumeAttributesFromJson(
       });
 
   //////////////////////
-  // Polyloop points
+  // Polyloop points and user defined
 
-  io::JsonGenericValue::ConstMemberIterator polyLoopJSONIter =
-      jCell.FindMember("poly_loop");
-  if (polyLoopJSONIter != jCell.MemberEnd()) {
-    if (polyLoopJSONIter->value.IsArray()) {
-      std::vector<Mn::Vector3> polyLoop;
-      // read values into vector
-      io::readMember<Mn::Vector3>(jCell, "poly_loop", polyLoop);
-      instanceAttrs->setPolyLoop(polyLoop);
-    } else if (polyLoopJSONIter->value.IsObject()) {
-      auto config = instanceAttrs->editSubconfig<Configuration>("poly_loop");
-      config->loadFromJson(polyLoopJSONIter->value);
-    } else {
-      ESP_WARNING() << ": Unknown format for "
-                       "poly_loop specified for region instance"
-                    << instanceAttrs->getHandle()
-                    << "in Semantic Config File, so no values are set.";
-    }
-  }
+  // parse poly loop points, whether defined as an array or a key-value store in
+  // JSON
+  this->parseSubconfigJsonVals("poly_loop", instanceAttrs, jCell);
 
   // check for user defined attributes
   this->parseUserDefinedJsonVals(instanceAttrs, jCell);

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -248,19 +248,10 @@ BulletArticulatedObject::getCurrentStateInstanceAttr() {
   }
   sceneArtObjInstanceAttr->setAutoClampJointLimits(autoClampJointLimits_);
 
-  const std::vector<float> jointPos = getJointPositions();
-  int i = 0;
-  for (const float& v : jointPos) {
-    const std::string key = Cr::Utility::formatString("joint_{:.02d}", i++);
-    sceneArtObjInstanceAttr->addInitJointPoseVal(key, v);
-  }
+  sceneArtObjInstanceAttr->setInitJointPose(getJointPositions());
 
-  const std::vector<float> jointVels = getJointVelocities();
-  i = 0;
-  for (const float& v : jointVels) {
-    const std::string key = Cr::Utility::formatString("joint_{:.02d}", i++);
-    sceneArtObjInstanceAttr->addInitJointVelocityVal(key, v);
-  }
+  sceneArtObjInstanceAttr->setInitJointVelocities(getJointVelocities());
+
   return sceneArtObjInstanceAttr;
 }  // BulletArticulatedObject::getCurrentStateInstanceAttr
 
@@ -293,16 +284,14 @@ void BulletArticulatedObject::resetStateFromSceneInstanceAttr() {
   std::vector<float> aoJointPose = getJointPositions();
   // get instance-specified initial joint positions
   const auto& initJointPos = sceneObjInstanceAttr->getInitJointPose();
-  // map instance vals into
-  size_t idx = 0;
-  for (const auto& elem : initJointPos) {
-    if (idx >= aoJointPose.size()) {
+  for (size_t i = 0; i < initJointPos.size(); ++i) {
+    if (i >= aoJointPose.size()) {
       ESP_WARNING() << "Attempting to specify more initial joint poses than "
                        "exist in articulated object"
                     << sceneObjInstanceAttr->getHandle() << ", so skipping";
       break;
     }
-    aoJointPose[idx++] = elem.second;
+    aoJointPose[i] = initJointPos[i];
   }
   setJointPositions(aoJointPose);
 
@@ -310,21 +299,18 @@ void BulletArticulatedObject::resetStateFromSceneInstanceAttr() {
   // get array of existing joint vel dofs
   std::vector<float> aoJointVels = getJointVelocities();
   // get instance-specified initial joint velocities
-  const std::map<std::string, float>& initJointVel =
+  std::vector<float> initJointVels =
       sceneObjInstanceAttr->getInitJointVelocities();
-  idx = 0;
-  for (const auto& elem : initJointVel) {
-    if (idx >= aoJointVels.size()) {
+  for (size_t i = 0; i < initJointVels.size(); ++i) {
+    if (i >= aoJointVels.size()) {
       ESP_WARNING()
           << "Attempting to specify more initial joint velocities than "
              "exist in articulated object"
           << sceneObjInstanceAttr->getHandle() << ", so skipping";
       break;
     }
-    aoJointVels[idx++] = elem.second;
+    aoJointVels[i] = initJointVels[i];
   }
-
-  setJointVelocities(aoJointVels);
 
 }  // BulletArticulatedObject::resetStateFromSceneInstanceAttr
 

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -826,23 +826,14 @@ void AttributesConfigsTest::testSceneInstanceAttrVals(
     CORRADE_COMPARE(static_cast<int>(artObjInstance->getMotionType()),
                     static_cast<int>(esp::physics::MotionType::DYNAMIC));
     // verify init join pose
-    const auto& initJointPoseMap = artObjInstance->getInitJointPose();
+    const auto& initJointPoseVec = artObjInstance->getInitJointPose();
     const std::vector<float> jtPoseVals{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
-    int idx = 0;
-    for (std::map<std::string, float>::const_iterator iter =
-             initJointPoseMap.begin();
-         iter != initJointPoseMap.end(); ++iter) {
-      CORRADE_COMPARE(iter->second, jtPoseVals[idx++]);
-    }
+    CORRADE_COMPARE(initJointPoseVec, jtPoseVals);
+
     // verify init joint vels
-    const auto& initJoinVelMap = artObjInstance->getInitJointVelocities();
+    const auto& initJointVelVec = artObjInstance->getInitJointVelocities();
     const std::vector<float> jtVelVals{1.0, 2.1, 3.2, 4.3, 5.4, 6.5, 7.6};
-    idx = 0;
-    for (std::map<std::string, float>::const_iterator iter =
-             initJoinVelMap.begin();
-         iter != initJoinVelMap.end(); ++iter) {
-      CORRADE_COMPARE(iter->second, jtVelVals[idx++]);
-    }
+    CORRADE_COMPARE(initJointVelVec, jtVelVals);
 
     // test test_urdf_template0 ao instance attributes-level user config vals
     testUserDefinedConfigVals(artObjInstance->getUserConfiguration(), 4,

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -283,8 +283,7 @@ void AttributesConfigsTest::testUserDefinedConfigVals(
   // Verify fields
   // ["test_00", "test_01", "test_02", "test_03"],
   for (int i = 0; i < strListSize; ++i) {
-    const std::string subKey =
-        Cr::Utility::formatString("user_str_array_{:.03d}", i);
+    const std::string subKey = Cr::Utility::formatString("{:.03d}", i);
     const std::string fieldVal = Cr::Utility::formatString("test_{:.02d}", i);
 
     CORRADE_COMPARE(userStrListSubconfig->get<std::string>(subKey), fieldVal);


### PR DESCRIPTION
## Motivation and Context
As an extension of [this PR, which](https://github.com/facebookresearch/habitat-sim/pull/2394) provided vector/array-backed support to subconfigurations, and in [preparation for #2382](https://github.com/facebookresearch/habitat-sim/pull/2382) , which brings substantial expansion to the Configuration subsystem capabilities, this PR expands and unifies the handling of vector/array-based configuration fields.  

Now, a json construct that is expected to be either an array or an array-like key-value store (where the keys are string representations of the indices of the subsquent array) will be handled by the same code, and a paradigm of consistency is introduced to provide vector set/get access to configuration-based vector-like constructs. A float specialization is also added for the Configuration set/getSubconfigValsOfTypeInVector so that the stored doubles can be provided as floats to the float-expecting consumer, and the existing attributes that had custom handling for arrays of data now use the same generalized functionality. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
