### PR TITLE
[CI] - Disable new clone protection for git lfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,7 +402,7 @@ jobs:
           command: |
               # Disable clone protection for git lfs
               export GIT_CLONE_PROTECTION_ACTIVE=false
-              
+
               sudo apt install git-lfs
               git --version
               git-lfs --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,9 @@ jobs:
       - run: &download_test_data
           name: Download test data
           command: |
+              # Disable clone protection for git lfs
+              export GIT_CLONE_PROTECTION_ACTIVE=false
+              
               sudo apt install git-lfs
               git --version
               git-lfs --version


### PR DESCRIPTION
## Motivation and Context

Git LFS was broken on CI by new security measures https://github.com/git-lfs/git-lfs/issues/5749

This PR disables the clone protections for pulling data from our HF repos.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
