### PR TITLE
--Add Configuration State Flags - Part 2 (Hidden file path fields)

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -312,7 +312,7 @@ bool ResourceManager::loadSemanticScene(
         semanticAttr,
     const std::string& activeSceneName) {
   const std::string ssdFilename =
-      semanticAttr != nullptr ? semanticAttr->getSemanticDescriptorFilename()
+      semanticAttr != nullptr ? semanticAttr->getSemanticDescriptorFullPath()
                               : "";
   semanticScene_ = nullptr;
   if ((ssdFilename != "") || ((semanticAttr != nullptr) &&
@@ -600,11 +600,11 @@ ResourceManager::createStageAssetInfosFromAttributes(
   // create render asset info
   AssetType renderType = stageAttributes->getRenderAssetType();
   AssetInfo renderInfo{
-      renderType,                               // type
-      stageAttributes->getRenderAssetHandle(),  // file path
-      frame,                                    // frame
-      virtualUnitToMeters,                      // virtualUnitToMeters
-      stageAttributes->getForceFlatShading()    // forceFlatShading
+      renderType,                                 // type
+      stageAttributes->getRenderAssetFullPath(),  // file path
+      frame,                                      // frame
+      virtualUnitToMeters,                        // virtualUnitToMeters
+      stageAttributes->getForceFlatShading()      // forceFlatShading
   };
   renderInfo.shaderTypeToUse = stageAttributes->getShaderType();
   std::string debugStr{};
@@ -619,11 +619,11 @@ ResourceManager::createStageAssetInfosFromAttributes(
     // create collision asset info if requested
     AssetType colType = stageAttributes->getCollisionAssetType();
     AssetInfo collisionInfo{
-        colType,                                     // type
-        stageAttributes->getCollisionAssetHandle(),  // file path
-        frame,                                       // frame
-        virtualUnitToMeters,                         // virtualUnitToMeters
-        true                                         // forceFlatShading
+        colType,                                       // type
+        stageAttributes->getCollisionAssetFullPath(),  // file path
+        frame,                                         // frame
+        virtualUnitToMeters,                           // virtualUnitToMeters
+        true                                           // forceFlatShading
     };
     // Only construct debug string if debug logging level is enabled
     if (ESP_LOG_LEVEL_ENABLED(logging::LoggingLevel::Debug)) {
@@ -647,11 +647,11 @@ ResourceManager::createStageAssetInfosFromAttributes(
           stageAttributes->getOrigin());
     }
     AssetInfo semanticInfo{
-        semanticType,                               // type
-        stageAttributes->getSemanticAssetHandle(),  // file path
-        frame,                                      // frame
-        virtualUnitToMeters,                        // virtualUnitToMeters
-        true,                                       // forceFlatShading
+        semanticType,                                 // type
+        stageAttributes->getSemanticAssetFullPath(),  // file path
+        frame,                                        // frame
+        virtualUnitToMeters,                          // virtualUnitToMeters
+        true,                                         // forceFlatShading
         // only split semantic mesh if doing frustum culling
         stageAttributes->getFrustumCulling()  // splitInstanceMesh
     };
@@ -2896,7 +2896,7 @@ bool ResourceManager::instantiateAssetsOnDemand(
   }
 
   // get render asset handle
-  std::string renderAssetHandle = objectAttributes->getRenderAssetHandle();
+  std::string renderAssetHandle = objectAttributes->getRenderAssetFullPath();
   // whether attributes requires lighting
   bool forceFlatShading = objectAttributes->getForceFlatShading();
   bool renderMeshSuccess = false;
@@ -2930,7 +2930,7 @@ bool ResourceManager::instantiateAssetsOnDemand(
   //        Probably just need to check attr->isCollidable()
   if (!objectAttributes->getCollisionAssetIsPrimitive()) {
     const auto collisionAssetHandle =
-        objectAttributes->getCollisionAssetHandle();
+        objectAttributes->getCollisionAssetFullPath();
     if (resourceDict_.count(collisionAssetHandle) == 0) {
       bool collisionMeshSuccess = loadObjectMeshDataFromFile(
           collisionAssetHandle, objectAttributes, "collision",
@@ -3022,7 +3022,7 @@ void ResourceManager::addObjectToDrawables(
     //! Add mesh to rendering stack
 
     const std::string& renderObjectName =
-        ObjectAttributes->getRenderAssetHandle();
+        ObjectAttributes->getRenderAssetFullPath();
 
     RenderAssetInstanceCreationInfo::Flags flags;
     flags |= RenderAssetInstanceCreationInfo::Flag::IsRGBD;

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -452,12 +452,23 @@ void initAttributesBindings(py::module& m) {
           &ArticulatedObjectAttributes::setURDFPath,
           R"(Relative filepath of the URDF file used to create the Articulated Object
           described by this template.)")
+      .def_property_readonly(
+          "urdf_fullpath", &ArticulatedObjectAttributes::getURDFFullPath,
+          R"(Fully qualified filepath of the URDF file used to create the Articulated Object
+          described by this template. This filepath will only be available/accurate
+          after the owning attributes is registered)")
       .def_property(
           "render_asset_handle",
           &ArticulatedObjectAttributes::getRenderAssetHandle,
           &ArticulatedObjectAttributes::setRenderAssetHandle,
           R"(Handle of the asset used to render constructions built from
           this articulated object template.)")
+      .def_property_readonly(
+          "render_asset_fullpath",
+          &ArticulatedObjectAttributes::getRenderAssetFullPath,
+          R"(Fully qualified filepath of the asset used to render constructions built from
+          this template. This filepath will only be available/accurate
+          after the owning attributes is registered)")
       .def_property(
           "semantic_id", &ArticulatedObjectAttributes::getSemanticId,
           &ArticulatedObjectAttributes::setSemanticId,
@@ -572,6 +583,18 @@ void initAttributesBindings(py::module& m) {
           &AbstractObjectAttributes::setCollisionAssetHandle,
           R"(Handle of the asset used to calculate collsions for constructions
           built from this template.)")
+      .def_property_readonly(
+          "render_asset_fullpath",
+          &AbstractObjectAttributes::getRenderAssetFullPath,
+          R"(Fully qualified filepath of the asset used to render constructions built from
+          this template. This filepath will only be available/accurate
+          after the owning attributes is registered)")
+      .def_property_readonly(
+          "collision_asset_fullpath",
+          &AbstractObjectAttributes::getCollisionAssetFullPath,
+          R"(Fully qualified filepath of the asset used to calculate collsions for constructions
+          built from this template. This filepath will only be available/accurate
+          after the owning attributes is registered)")
       .def_property(
           "shader_type", &AbstractObjectAttributes::getShaderType,
           &AbstractObjectAttributes::setShaderType,
@@ -692,6 +715,11 @@ void initAttributesBindings(py::module& m) {
           R"(Handle of the asset used for semantic segmentation of stages
           built from this template.)")
       .def_property_readonly(
+          "semantic_asset_fullpath", &StageAttributes::getSemanticAssetFullPath,
+          R"(Fully qualified filepath of the asset used for semantic segmentation of stages
+          built from this template. This filepath will only be available/accurate after
+          the owning attributes is registered)")
+      .def_property_readonly(
           "semantic_asset_type", &StageAttributes::getSemanticAssetType,
           R"(Type of asset used for collision calculations for constructions
           built from this template.)")
@@ -705,6 +733,11 @@ void initAttributesBindings(py::module& m) {
           &StageAttributes::setSemanticDescriptorFilename,
           R"(Handle for file containing semantic type maps and hierarchy for
           constructions built from this template.)")
+      .def_property_readonly(
+          "house_fq_filename", &StageAttributes::getSemanticDescriptorFullPath,
+          R"(Fully qualified path of file containing semantic type maps and hierarchy for
+          constructions built from this template. This filepath will only be available/accurate
+          after the owning attributes is registered)")
       .def_property(
           "frustum_culling", &StageAttributes::getFrustumCulling,
           &StageAttributes::setFrustumCulling,

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -244,8 +244,7 @@ void declareBaseAttributesManager(py::module& m,
                &MgrClass::getFirstMatchingObjectOrCopyByHandle),
            ("This returns a copy of the first " + attrType +
             " template containing the passed handle substring if any exist, "
-            "and NULL "
-            "if none could be found.")
+            "and NULL if none could be found.")
                .c_str(),
            "handle_substr"_a)
       .def("get_templates_by_handle_substring",
@@ -258,6 +257,12 @@ void declareBaseAttributesManager(py::module& m,
             "on the value of boolean contains.")
                .c_str(),
            "search_str"_a = "", "contains"_a = true)
+      .def("filter_filepaths", &MgrClass::finalizeAttrPathsBeforeRegister,
+           ("This attempts to filter any filenames in the passed " + attrType +
+            " template so that the fields that would be saved to file would "
+            "only contain relative paths.")
+               .c_str(),
+           "attributes"_a)
       .def("save_template_by_handle",
            static_cast<bool (MgrClass::*)(const std::string&, bool) const>(
                &MgrClass::saveManagedObjectToFile),

--- a/src/esp/metadata/MetadataMediator.cpp
+++ b/src/esp/metadata/MetadataMediator.cpp
@@ -507,7 +507,7 @@ MetadataMediator::makeSceneAndReferenceStage(
   // by the ref that the scene attributes will use.
   std::pair<std::string, std::string> navmeshEntry =
       datasetAttr->addNavmeshPathEntry(
-          sceneName, stageAttributes->getNavmeshAssetHandle(), false);
+          sceneName, stageAttributes->getNavmeshAssetFullPath(), false);
   // navmeshEntry holds the navmesh key-value in the dataset to use by this
   // scene instance. NOTE : the key may have changed from what was passed if a
   // collision occurred with same key but different value, so we need to add
@@ -528,8 +528,8 @@ MetadataMediator::makeSceneAndReferenceStage(
   // add a ref to scene instance attributes of SemanticAttributes if any
   // Semantics info is specified in the passed stage stage, giving it an
   // appropriately obvious name.
-  if ((stageAttributes->getSemanticDescriptorFilename() != "") ||
-      (stageAttributes->getSemanticAssetHandle() != "")) {
+  if ((stageAttributes->getSemanticDescriptorFullPath() != "") ||
+      (stageAttributes->getSemanticAssetFullPath() != "")) {
     std::string sceneSemanticAttrHandle =
         datasetAttr->addSemanticSceneDescrPathEntry(sceneName, stageAttributes);
 

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
@@ -45,7 +45,9 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   init("units_to_meters", 1.0);
   init("render_asset", "");
   init("collision_asset", "");
-
+  // initialize these so they exist in Configuration
+  setHidden("__renderAssetFullPath", "");
+  setHidden("__collisionAssetFullPath", "");
   // This specifies that we want to investigate the state of the render and
   // collision handles before we allow this attributes to be registered.
   // Hidden field

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -127,6 +127,25 @@ class AbstractObjectAttributes : public AbstractAttributes {
   }
 
   /**
+   * @brief Sets the fully-qualified filepath for the render asset to be used to
+   * render the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  void setRenderAssetFullPath(const std::string& renderAssetHandle) {
+    setHidden("__renderAssetFullPath", renderAssetHandle);
+    setIsDirty();
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the render asset to be used to
+   * render the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  std::string getRenderAssetFullPath() const {
+    return get<std::string>("__renderAssetFullPath");
+  }
+
+  /**
    * @brief Sets the render asset type, as specified by @ref AssetType.
    * This specification was generally intended for specifying certain criteria
    * such as orientation for the loaded asset based on file name, which was in
@@ -265,7 +284,24 @@ class AbstractObjectAttributes : public AbstractAttributes {
   std::string getCollisionAssetHandle() const {
     return get<std::string>("collision_asset");
   }
+  /**
+   * @brief Sets the fully-qualified filepath for the collision asset to be used
+   * for mesh collision detection for the construct this attributes describes.
+   * This is only used internally and should not be saved to disk.
+   */
+  void setCollisionAssetFullPath(const std::string& collisionAssetHandle) {
+    setHidden("__collisionAssetFullPath", collisionAssetHandle);
+    setIsDirty();
+  }
 
+  /**
+   * @brief Gets the fully-qualified filepath for the collision asset to be used
+   * for mesh collision detection for the construct this attributes describes.
+   * This is only used internally and should not be saved to disk.
+   */
+  std::string getCollisionAssetFullPath() const {
+    return get<std::string>("__collisionAssetFullPath");
+  }
   /**
    * @brief Sets the collision asset type, as specified by @ref AssetType.
    * This specification was generally intended for specifying certain criteria

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
@@ -37,6 +37,11 @@ ArticulatedObjectAttributes::ArticulatedObjectAttributes(
 
   init("uniform_scale", 1.0f);
   init("mass_scale", 1.0);
+
+  // Initialize these so they exist in the configuration
+  setHidden("__urdfFullPath", "");
+  setHidden("__renderAssetFullPath", "");
+
   // set up an existing subgroup for marker_sets attributes
   addOrEditSubgroup<MarkerSets>("marker_sets");
 }  // ArticulatedObjectAttributes ctor

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -29,6 +29,25 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
    * @brief Gets the string name for the Articulated Object URDF relative path
    */
   std::string getURDFPath() const { return get<std::string>("urdf_filepath"); }
+
+  /**
+   * @brief Sets the fully-qualified filepath for for the Articulated Object
+   * URDF to be used to create the articulated object this attributes describes.
+   * This is only used internally and should not be saved to disk.
+   */
+  void setURDFFullPath(const std::string& urdfFilepath) {
+    setHidden("__urdfFullPath", urdfFilepath);
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for for the Articulated Object
+   * URDF to be used to create the articulated object this attributes describes.
+   * This is only used internally and should not be saved to disk.
+   */
+  std::string getURDFFullPath() const {
+    return get<std::string>("__urdfFullPath");
+  }
+
   /**
    * @brief Sets the string name for the render asset relative path
    */
@@ -40,6 +59,24 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
    */
   std::string getRenderAssetHandle() const {
     return get<std::string>("render_asset");
+  }
+
+  /**
+   * @brief Sets the fully-qualified filepath for the render asset to be used to
+   * render the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  void setRenderAssetFullPath(const std::string& renderAssetHandle) {
+    setHidden("__renderAssetFullPath", renderAssetHandle);
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the render asset to be used to
+   * render the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  std::string getRenderAssetFullPath() const {
+    return get<std::string>("__renderAssetFullPath");
   }
 
   /**

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -169,6 +169,8 @@ std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
   if (setSemanticAssetData && semanticAttr->getSemanticAssetHandle().empty()) {
     // asset handle specified, get all stage-specified data
     semanticAttr->setSemanticAssetHandle(stageSemanticAssetFilename);
+    semanticAttr->setSemanticAssetFullPath(
+        stageAttributes->getSemanticAssetFullPath());
     semanticAttr->setSemanticAssetTypeEnum(
         stageAttributes->getSemanticAssetType());
     semanticAttr->setSemanticOrientUp(stageAttributes->getSemanticOrientUp());
@@ -179,6 +181,8 @@ std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
     // scene descriptor filename specified in stage, set in semantic
     // attributes.
     semanticAttr->setSemanticDescriptorFilename(stageSSDFilename);
+    semanticAttr->setSemanticDescriptorFullPath(
+        stageAttributes->getSemanticDescriptorFullPath());
   }
   // Save changes and make sure appropriate filtering happens
   semanticAttributesManager_->registerObject(semanticAttr, semanticHandle);

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -153,11 +153,12 @@ void SceneDatasetAttributes::createSemanticAttribsFromDS(
 std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
     const std::string& semanticHandle,
     const attributes::StageAttributes::ptr& stageAttributes) {
-  const auto ssdFilename = stageAttributes->getSemanticDescriptorFullPath();
-  const auto semanticAssetFilename =
-      stageAttributes->getSemanticAssetFullPath();
-  bool setSemanticAssetData = (semanticAssetFilename != "");
-  bool setSSDFilename = (ssdFilename != "");
+  const auto stageSSDFilename =
+      stageAttributes->getSemanticDescriptorFilename();
+  const auto stageSemanticAssetFilename =
+      stageAttributes->getSemanticAssetHandle();
+  bool setSemanticAssetData = (stageSemanticAssetFilename != "");
+  bool setSSDFilename = (stageSSDFilename != "");
   // create a semantic attributes if DNE with given handle
   this->createSemanticAttribsFromDS(semanticHandle, "Stage Attributes");
 
@@ -165,23 +166,22 @@ std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
   auto semanticAttr =
       semanticAttributesManager_->getObjectByHandle(semanticHandle);
 
-  if (setSemanticAssetData &&
-      semanticAttr->getSemanticAssetFullPath().empty()) {
+  if (setSemanticAssetData && semanticAttr->getSemanticAssetHandle().empty()) {
     // asset handle specified, get all stage-specified data
-    semanticAttr->setSemanticAssetHandle(
-        stageAttributes->getSemanticAssetHandle());
-    semanticAttr->setSemanticAssetFullPath(semanticAssetFilename);
+    semanticAttr->setSemanticAssetHandle(stageSemanticAssetFilename);
     semanticAttr->setSemanticAssetTypeEnum(
         stageAttributes->getSemanticAssetType());
     semanticAttr->setSemanticOrientUp(stageAttributes->getSemanticOrientUp());
     semanticAttr->setSemanticOrientFront(
         stageAttributes->getSemanticOrientFront());
   }
-  if (setSSDFilename && semanticAttr->getSemanticDescriptorFullPath().empty()) {
+  if (setSSDFilename && semanticAttr->getSemanticDescriptorFilename().empty()) {
     // scene descriptor filename specified in stage, set in semantic
     // attributes.
-    semanticAttr->setSemanticDescriptorFilename(ssdFilename);
+    semanticAttr->setSemanticDescriptorFilename(stageSSDFilename);
   }
+  // Save changes and make sure appropriate filtering happens
+  semanticAttributesManager_->registerObject(semanticAttr, semanticHandle);
   return semanticAttr->getHandle();
 }  // SceneDatasetAttributes::addSemanticSceneDescrPathEntry
 
@@ -198,6 +198,8 @@ void SceneDatasetAttributes::setSemanticAttrSSDFilenames(
     auto semanticAttr =
         semanticAttributesManager_->getObjectByHandle(semanticHandle);
     semanticAttr->setSemanticDescriptorFilename(ssdFilename);
+    // Save changes and make sure appropriate filtering happens
+    semanticAttributesManager_->registerObject(semanticAttr, semanticHandle);
   }
 
 }  // SceneDatasetAttributes::setSemanticAttrSSDFilenames

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.cpp
@@ -153,8 +153,9 @@ void SceneDatasetAttributes::createSemanticAttribsFromDS(
 std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
     const std::string& semanticHandle,
     const attributes::StageAttributes::ptr& stageAttributes) {
-  const auto ssdFilename = stageAttributes->getSemanticDescriptorFilename();
-  const auto semanticAssetFilename = stageAttributes->getSemanticAssetHandle();
+  const auto ssdFilename = stageAttributes->getSemanticDescriptorFullPath();
+  const auto semanticAssetFilename =
+      stageAttributes->getSemanticAssetFullPath();
   bool setSemanticAssetData = (semanticAssetFilename != "");
   bool setSSDFilename = (ssdFilename != "");
   // create a semantic attributes if DNE with given handle
@@ -164,16 +165,19 @@ std::string SceneDatasetAttributes::addSemanticSceneDescrPathEntry(
   auto semanticAttr =
       semanticAttributesManager_->getObjectByHandle(semanticHandle);
 
-  if (setSemanticAssetData && semanticAttr->getSemanticAssetHandle().empty()) {
+  if (setSemanticAssetData &&
+      semanticAttr->getSemanticAssetFullPath().empty()) {
     // asset handle specified, get all stage-specified data
-    semanticAttr->setSemanticAssetHandle(semanticAssetFilename);
+    semanticAttr->setSemanticAssetHandle(
+        stageAttributes->getSemanticAssetHandle());
+    semanticAttr->setSemanticAssetFullPath(semanticAssetFilename);
     semanticAttr->setSemanticAssetTypeEnum(
         stageAttributes->getSemanticAssetType());
     semanticAttr->setSemanticOrientUp(stageAttributes->getSemanticOrientUp());
     semanticAttr->setSemanticOrientFront(
         stageAttributes->getSemanticOrientFront());
   }
-  if (setSSDFilename && semanticAttr->getSemanticDescriptorFilename().empty()) {
+  if (setSSDFilename && semanticAttr->getSemanticDescriptorFullPath().empty()) {
     // scene descriptor filename specified in stage, set in semantic
     // attributes.
     semanticAttr->setSemanticDescriptorFilename(ssdFilename);

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -63,8 +63,11 @@ void SemanticVolumeAttributes::writeValuesToJson(
 // SemanticAttributes
 SemanticAttributes::SemanticAttributes(const std::string& handle)
     : AbstractAttributes("SemanticAttributes", handle) {
+  // set empty defaults for handles
   init("semantic_descriptor_filename", "");
+  setHidden("__semanticDescriptorFullPath", "");
   init("semantic_asset", "");
+  setHidden("__semanticAssetFullPath", "");
   init("semantic_up", Mn::Vector3{0.0, 1.0, 0.0});
   init("semantic_front", Mn::Vector3{0.0, 0.0, -1.0});
   init("use_semantic_frame", false);

--- a/src/esp/metadata/attributes/SemanticAttributes.cpp
+++ b/src/esp/metadata/attributes/SemanticAttributes.cpp
@@ -181,7 +181,7 @@ std::string SemanticAttributes::getObjectInfoInternal() const {
   // std::string res = "";
   // TODO do this for any SemanticAttributes level values
   std::string res = Cr::Utility::formatString(
-      "\nSemantic Scene Descriptor Filename,Semantic Mesh Assset,\n{},{}\n",
+      "\nSemantic Scene Descriptor Filename,Semantic Mesh Asset,\n{},{}\n",
       getSemanticDescriptorFilename(), getSemanticAssetHandle());
 
   int iter = 0;

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -179,35 +179,76 @@ class SemanticAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Set the filename to the text file that describes the hierharchy of
-   * semantic information embedded in the Semantic Asset mesh.  May be
-   * overridden by value specified in Scene Instance Attributes.
+   * @brief Set the relative filename to the text file that describes the
+   * hierharchy of semantic information embedded in the Semantic Asset mesh. May
+   * be overridden by value specified in Scene Instance Attributes.
    */
   void setSemanticDescriptorFilename(
       const std::string& semantic_descriptor_filename) {
     set("semantic_descriptor_filename", semantic_descriptor_filename);
   }
   /**
-   * @brief Get the filename to the text file that describes the hierharchy of
-   * semantic information embedded in the Semantic Asset mesh.  May be
-   * overridden by value specified in Scene Instance Attributes.
+   * @brief Get the relative filename to the text file that describes the
+   * hierharchy of semantic information embedded in the Semantic Asset mesh. May
+   * be overridden by value specified in Scene Instance Attributes.
    */
   std::string getSemanticDescriptorFilename() const {
     return get<std::string>("semantic_descriptor_filename");
   }
 
   /**
-   * @brief Set the Filename to the semantic texture mesh, if one exists.
+   * @brief Sets the fully-qualified filename to the text file that describes
+   * the hierharchy of semantic information embedded in the Semantic Asset mesh.
+   * May be overridden by value specified in Scene Instance Attributes. This is
+   * only used internally and should not be saved to disk.
+   */
+  void setSemanticDescriptorFullPath(
+      const std::string& semanticDescriptorHandle) {
+    setHidden("__semanticDescriptorFullPath", semanticDescriptorHandle);
+  }
+
+  /**
+   * @brief Gets the fully-qualified filename to the text file that describes
+   * the hierharchy of semantic information embedded in the Semantic Asset mesh.
+   * May be overridden by value specified in Scene Instance Attributes. This is
+   * only used internally and should not be saved to disk.
+   */
+  std::string getSemanticDescriptorFullPath() const {
+    return get<std::string>("__semanticDescriptorFullPath");
+  }
+
+  /**
+   * @brief Set the retlative Filename to the semantic texture mesh, if one
+   * exists.
    */
   void setSemanticAssetHandle(const std::string& semanticAssetHandle) {
     set("semantic_asset", semanticAssetHandle);
   }
 
   /**
-   * @brief Get the Filename to the semantic texture mesh, if one exists.
+   * @brief Get the relative Filename to the semantic texture mesh, if one
+   * exists.
    */
   std::string getSemanticAssetHandle() const {
     return get<std::string>("semantic_asset");
+  }
+
+  /**
+   * @brief Sets the fully-qualified filepath for the semantic asset to be used
+   * to render the semantics for the stage this attributes describes. This is
+   * only used internally and should not be saved to disk.
+   */
+  void setSemanticAssetFullPath(const std::string& semanticAssetHandle) {
+    setHidden("__semanticAssetFullPath", semanticAssetHandle);
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the semantic asset to be used
+   * to render the semantics for the stage this attributes describes. This is
+   * only used internally and should not be saved to disk.
+   */
+  std::string getSemanticAssetFullPath() const {
+    return get<std::string>("__semanticAssetFullPath");
   }
 
   /**

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -218,7 +218,7 @@ class SemanticAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Set the retlative Filename to the semantic texture mesh, if one
+   * @brief Set the relative Filename to the semantic texture mesh, if one
    * exists.
    */
   void setSemanticAssetHandle(const std::string& semanticAssetHandle) {

--- a/src/esp/metadata/attributes/StageAttributes.cpp
+++ b/src/esp/metadata/attributes/StageAttributes.cpp
@@ -28,8 +28,12 @@ StageAttributes::StageAttributes(const std::string& handle)
   initSemanticAssetTypeEnum(AssetType::InstanceMesh);
   // set empty defaults for handles
   init("nav_asset", "");
+  setHidden("__navmeshAssetFullPath", "");
   init("semantic_asset", "");
+  setHidden("__semanticAssetFullPath", "");
   init("semantic_descriptor_filename", "");
+  setHidden("__semanticDescriptorFullPath", "");
+
 }  // StageAttributes ctor
 
 void StageAttributes::writeValuesToJsonInternal(

--- a/src/esp/metadata/attributes/StageAttributes.h
+++ b/src/esp/metadata/attributes/StageAttributes.h
@@ -92,12 +92,65 @@ class StageAttributes : public AbstractObjectAttributes {
   std::string getSemanticDescriptorFilename() const {
     return get<std::string>("semantic_descriptor_filename");
   }
+
+  /**
+   * @brief Sets the fully-qualified filepath for the semantic asset to be used
+   * to semantic the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  void setSemanticDescriptorFullPath(
+      const std::string& semanticDescriptorHandle) {
+    setHidden("__semanticDescriptorFullPath", semanticDescriptorHandle);
+    setIsDirty();
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the semantic asset to be used
+   * to semantic the construct this attributes describes. This is only used
+   * internally and should not be saved to disk.
+   */
+  std::string getSemanticDescriptorFullPath() const {
+    return get<std::string>("__semanticDescriptorFullPath");
+  }
+
+  /**
+   * @brief Sets the relative path/filename for the semantic asset to be used to
+   * render the semantics for the stage this attributes describes. This is
+   * relative to the on-disk location of the file responsible for this
+   * configuration.
+   */
   void setSemanticAssetHandle(const std::string& semanticAssetHandle) {
     set("semantic_asset", semanticAssetHandle);
     setIsDirty();
   }
+
+  /**
+   * @brief Gets the relative path/filename for the semantic asset to be used to
+   * render the semantics for the stage this attributes describes. This is
+   * relative to the on-disk location of the file responsible for this
+   * configuration.
+   */
   std::string getSemanticAssetHandle() const {
     return get<std::string>("semantic_asset");
+  }
+
+  /**
+   * @brief Sets the fully-qualified filepath for the semantic asset to be used
+   * to render the semantics for the stage this attributes describes. This is
+   * only used internally and should not be saved to disk.
+   */
+  void setSemanticAssetFullPath(const std::string& semanticAssetHandle) {
+    setHidden("__semanticAssetFullPath", semanticAssetHandle);
+    setIsDirty();
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the semantic asset to be used
+   * to render the semantics for the stage this attributes describes. This is
+   * only used internally and should not be saved to disk.
+   */
+  std::string getSemanticAssetFullPath() const {
+    return get<std::string>("__semanticAssetFullPath");
   }
 
   /**
@@ -249,6 +302,25 @@ class StageAttributes : public AbstractObjectAttributes {
   }
   std::string getNavmeshAssetHandle() const {
     return get<std::string>("nav_asset");
+  }
+
+  /**
+   * @brief Sets the fully-qualified filepath for the navmesh asset to be used
+   * with the stage this attributes describes. This is only used internally and
+   * should not be saved to disk.
+   */
+  void setNavmeshAssetFullPath(const std::string& navmeshAssetHandle) {
+    setHidden("__navmeshAssetFullPath", navmeshAssetHandle);
+    setIsDirty();
+  }
+
+  /**
+   * @brief Gets the fully-qualified filepath for the navmesh asset to be used
+   * with the stage this attributes describes. This is only used internally and
+   * should not be saved to disk.
+   */
+  std::string getNavmeshAssetFullPath() const {
+    return get<std::string>("__navmeshAssetFullPath");
   }
 
   /**

--- a/src/esp/metadata/managers/AOAttributesManager.cpp
+++ b/src/esp/metadata/managers/AOAttributesManager.cpp
@@ -203,16 +203,20 @@ AOAttributesManager::preRegisterObjectFinalize(
         << "`, but this file cannot be found, so registration is aborted.";
     return core::managedContainers::ManagedObjectPreregistration::Failed;
   }
-
+  const std::string renderAssetHandle =
+      AOAttributesTemplate->getRenderAssetHandle();
   // Furthermore, if 'skin' is specified as render_mode and no skin is
   // specified or the specified skin cannot be found, the registration should
   // also fail and the template should not be registered.
-  bool useSkinRenderMode = AOAttributesTemplate->getRenderMode() ==
-                           attributes::ArticulatedObjectRenderMode::Skin;
+  bool useSkinRenderMode =
+      (AOAttributesTemplate->getRenderMode() ==
+       attributes::ArticulatedObjectRenderMode::Skin) ||
+      ((AOAttributesTemplate->getRenderMode() ==
+        attributes::ArticulatedObjectRenderMode::Default) &&
+       (!renderAssetHandle.empty()));
   if (useSkinRenderMode) {
-    // if 'skin' render mode is specified as render mode
-    const std::string renderAssetHandle =
-        AOAttributesTemplate->getRenderAssetHandle();
+    // if 'skin' render mode is specified as render mode or default and a skin
+    // is specified
 
     const std::string renderAssetFullPath =
         AOAttributesTemplate->getRenderAssetFullPath();
@@ -268,21 +272,18 @@ void AOAttributesManager::finalizeAttrPathsBeforeRegister(
         AOAttributesTemplate->setURDFFullPath(urdfAsset);
       });
 
-  bool useSkinRenderMode = AOAttributesTemplate->getRenderMode() ==
-                           attributes::ArticulatedObjectRenderMode::Skin;
-  if (useSkinRenderMode) {
-    // Render asset filename filter out path and set internal reference to
-    // full filepath
-    this->filterAttribsFilenames(
-        AOAttributesTemplate, AOAttributesTemplate->getRenderAssetHandle(),
-        AOAttributesTemplate->getRenderAssetFullPath(),
-        [AOAttributesTemplate](const std::string& renderAsset) {
-          AOAttributesTemplate->setRenderAssetHandle(renderAsset);
-        },
-        [AOAttributesTemplate](const std::string& renderAsset) {
-          AOAttributesTemplate->setRenderAssetFullPath(renderAsset);
-        });
-  }
+  // Render asset filename filter out path and set internal reference to
+  // full filepath
+  this->filterAttribsFilenames(
+      AOAttributesTemplate, AOAttributesTemplate->getRenderAssetHandle(),
+      AOAttributesTemplate->getRenderAssetFullPath(),
+      [AOAttributesTemplate](const std::string& renderAsset) {
+        AOAttributesTemplate->setRenderAssetHandle(renderAsset);
+      },
+      [AOAttributesTemplate](const std::string& renderAsset) {
+        AOAttributesTemplate->setRenderAssetFullPath(renderAsset);
+      });
+
 }  // AOAttributesManager::finalizeAttrPathsBeforeRegister
 
 std::map<std::string, std::string>

--- a/src/esp/metadata/managers/AOAttributesManager.h
+++ b/src/esp/metadata/managers/AOAttributesManager.h
@@ -73,6 +73,17 @@ class AOAttributesManager
    */
   std::map<std::string, std::string> getArticulatedObjectModelFilenames() const;
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::ArticulatedObjectAttributes::ptr& attributes)
+      const override;
+
  protected:
   /**
    * @brief Parse Marker_sets object in json, if present.

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -150,7 +150,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
    * @param handle String name of primitive asset attributes desired
    * @return whether handle exists or not in asset attributes library
    */
-  bool isValidPrimitiveAttributes(const std::string& handle) {
+  bool isValidPrimitiveAttributes(const std::string& handle) const {
     return assetAttributesMgr_->getObjectLibHasHandle(handle);
   }
 

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -568,7 +568,7 @@ class AssetAttributesManager
   }  // AssetAttributeManager::createPrimAttributes
 
   /**
-   * @brief Any Assset-attributes-specific resetting that needs to happen on
+   * @brief Any Asset-attributes-specific resetting that needs to happen on
    * reset.
    */
   void resetFinalize() override {

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -127,6 +127,17 @@ class AssetAttributesManager
       const io::JsonGenericValue& jsonConfig) override;
 
   /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      CORRADE_UNUSED const attributes::AbstractPrimitiveAttributes::ptr&
+          attributes) const override {}
+
+  /**
    * @brief Method to take an existing attributes and set its values from passed
    * json config file.
    * @param attribs (out) an existing attributes to be modified.

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -756,7 +756,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
     if (relPathNameExists) {
       // Get new path relative to attrFilepath
       const std::string newRelFilepath =
-          io::getPathRealtiveToAbsPath(curRelativePathName, attrFilepath);
+          io::getPathRelativeToAbsPath(curRelativePathName, attrFilepath);
       // save the new relative filepath
       relPathSetter(newRelFilepath);
       Cr::Utility::formatInto(dispString, dispString.size(),

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -729,6 +729,13 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   // Initialize potentially empty fields
   relPathSetter(curRelativePathName);
   fqPathSetter(curFullyQualifiedPathName);
+  // Check if expected relative filepath is accessible on disk (therefore is
+  // fully qualified)
+  bool relPathNameExists = CrPath::exists(curRelativePathName);
+  if (relPathNameExists) {
+    // Set the fully qualified value to be the found curRelPathName
+    fqPathSetter(curRelativePathName);
+  }
 
   // Get the attributes filepath that our desired filepath should be
   // relative to
@@ -746,9 +753,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
 
     // Check if expected relative filepath is accessible on disk (therefore is
     // fully qualified)
-    if (CrPath::exists(curRelativePathName)) {
-      // Set the fully qualified value to be the found curRelPathName
-      fqPathSetter(curRelativePathName);
+    if (relPathNameExists) {
       // Get new path relative to attrFilepath
       const std::string newRelFilepath =
           io::getPathRealtiveToAbsPath(curRelativePathName, attrFilepath);

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -714,8 +714,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
 
   std::string dispString = Cr::Utility::formatString(
       "AttrHandle `{}` class :`{}`|curRelPathName `{}`|curFQPathName "
-      ":`{}`|nonEmptyRel "
-      "`{}`|nonEmptyFQ :`{}`",
+      ":`{}`|nonEmptyRel proposal :`{}`|nonEmptyFQ proposal :`{}`",
       attributes->getHandle(), attributes->getClassKey(), curRelPathName,
       curFQPathName, curRelativePathName, curFullyQualifiedPathName);
 
@@ -749,7 +748,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   // verify attributes filepath exists
   if (CrPath::isDirectory(attrFilepath)) {
     Cr::Utility::formatInto(dispString, dispString.size(),
-                            "|attr Filepath `{}`", attrFilepath);
+                            "|attributes Filepath :`{}`", attrFilepath);
 
     // Check if expected relative filepath is accessible on disk (therefore is
     // fully qualified)
@@ -760,14 +759,15 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
       // save the new relative filepath
       relPathSetter(newRelFilepath);
       Cr::Utility::formatInto(dispString, dispString.size(),
-                              "|curRelPathName is FOUND/FQ|newRelFP `{}`",
+                              "|curRelPathName is FOUND/FQ|newRelFP :`{}`",
                               newRelFilepath);
     }
 
   }  // if attributes dir is set properly
   else {
     Cr::Utility::formatInto(dispString, dispString.size(),
-                            "|NON-EXISTING FILEPATH `{}` ", attrFilepath);
+                            "|FILEPATH DOES NOT EXIST IN SYSTEM :`{}` ",
+                            attrFilepath);
   }
 
   ESP_VERY_VERBOSE() << dispString;

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -266,6 +266,8 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
    * @param jsonTag The field to look for. If present expected to hold a string
    * @param mapName String map name, to be displayed if the value found in json
    * is not found in @p mapToUse
+   * @param saveUnspecified Whether to save the 'unspecified' string in value
+   * setter if no value is specified in json.
    * @param mapToUse String-keyed map of enum values supported for the field
    * that corresponds to @p jsonTag. See attributes::AttributesEnumMaps.h/cpp.
    * @param valueSetter The config function to use to set the value

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -721,8 +721,8 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
 
   // If both relative and fully qualified paths are empty,
   if (curRelativePathName.empty() && curFullyQualifiedPathName.empty()) {
-    ESP_ERROR() << "BOTH RELATIVE AND FQ PATHS ARE EMPTY Skipping: "
-                << dispString;
+    ESP_VERY_VERBOSE() << "BOTH RELATIVE AND FQ PATHS ARE EMPTY Skipping: "
+                       << dispString;
     return;
   }
 
@@ -741,7 +741,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   // relative to
   const std::string attrFilepath = attributes->getFileDirectory();
   if (attrFilepath.empty()) {
-    ESP_ERROR() << "EMPTY FILEPATH Skipping : " << dispString;
+    ESP_VERY_VERBOSE() << "EMPTY FILEPATH Skipping : " << dispString;
     // if filepath is empty, do nothing.
     return;
   }
@@ -762,20 +762,6 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
       Cr::Utility::formatInto(dispString, dispString.size(),
                               "|curRelPathName is FOUND/FQ|newRelFP `{}`",
                               newRelFilepath);
-    } else if (curRelativePathName.empty()) {
-      Cr::Utility::formatInto(dispString, dispString.size(),
-                              "|!!! curRelPathName is empty");
-    } else {
-      // Current relative filepath cannot be found and is not empty, so assume
-      // it is already appropriately formatted
-    }
-
-    if (CrPath::exists(curFullyQualifiedPathName)) {
-      // Current fully qualified pathname is found
-      Cr::Utility::formatInto(dispString, dispString.size(),
-                              "|curFQPathName is FOUND/FQ");
-
-      // TODO : Populate relPathName with relative path pathname?
     }
 
   }  // if attributes dir is set properly
@@ -784,7 +770,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
                             "|NON-EXISTING FILEPATH `{}` ", attrFilepath);
   }
 
-  ESP_ERROR() << "\n" << dispString << "\n";
+  ESP_VERY_VERBOSE() << dispString;
 }  // filterAttribsFilenames
 
 template <class T, ManagedObjectAccess Access>

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -710,7 +710,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   const std::string curFullyQualifiedPathName =
       (curFQPathName.empty() ? curRelPathName : curFQPathName);
   const std::string curRelativePathName =
-      (curRelPathName.empty() ? curFQPathName : curRelPathName);
+      (curRelPathName.empty() ? curFullyQualifiedPathName : curRelPathName);
 
   std::string dispString = Cr::Utility::formatString(
       "AttrHandle `{}` class :`{}`|curRelPathName `{}`|curFQPathName "
@@ -719,9 +719,11 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
       attributes->getHandle(), attributes->getClassKey(), curRelPathName,
       curFQPathName, curRelativePathName, curFullyQualifiedPathName);
 
+  // If both relative and fully qualified paths are empty,
   if (curRelativePathName.empty() && curFullyQualifiedPathName.empty()) {
     ESP_ERROR() << "BOTH RELATIVE AND FQ PATHS ARE EMPTY Skipping: "
-                << dispString << "\n";
+                << dispString;
+    return;
   }
 
   // Initialize potentially empty fields
@@ -732,7 +734,7 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   // relative to
   const std::string attrFilepath = attributes->getFileDirectory();
   if (attrFilepath.empty()) {
-    ESP_ERROR() << "EMPTY FILEPATH Skipping : " << dispString << "\n";
+    ESP_ERROR() << "EMPTY FILEPATH Skipping : " << dispString;
     // if filepath is empty, do nothing.
     return;
   }
@@ -742,7 +744,6 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
     Cr::Utility::formatInto(dispString, dispString.size(),
                             "|attr Filepath `{}`", attrFilepath);
 
-    auto len = attrFilepath.length();
     // Check if expected relative filepath is accessible on disk (therefore is
     // fully qualified)
     if (CrPath::exists(curRelativePathName)) {

--- a/src/esp/metadata/managers/AttributesManagerBase.h
+++ b/src/esp/metadata/managers/AttributesManagerBase.h
@@ -249,8 +249,8 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
  protected:
   /**
    * @brief Called internally right before attribute registration. Filepaths
-   * in the json configs for Habitat Datasets are specified relative to the
-   * location of the config in the file hierarchy. As the config is loaded,
+   * in the json configs for Habitat SceneDatasets are specified relative to
+   * the location of the config in the file hierarchy. As the config is loaded,
    * these filepaths will be fully qualified with absolute paths so that they
    * can be easily found and consumed on command. However, saving fully
    * qualified filepaths to JSON configs is undesirable.
@@ -264,7 +264,7 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
    *
    *
    * It is assumed that what is passed to this function always referneces a
-   * filepath, so if, for example, this is called on a render asseet filepath,
+   * filepath, so if, for example, this is called on a render asset filepath,
    * it is assumed that that filepath does not reference a primitive
    * (non-file-based) asset.
    *

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -80,6 +80,17 @@ class LightLayoutAttributesManager
   gfx::LightSetup createLightSetupFromAttributes(
       const std::string& lightConfigName);
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      CORRADE_UNUSED const attributes::LightLayoutAttributes::ptr& attributes)
+      const override {}
+
  protected:
   /**
    * @brief Used Internally.  Create and configure newly-created attributes

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -315,26 +315,41 @@ void ObjectAttributesManager::finalizeAttrPathsBeforeRegister(
   //     << objectTemplate->getFileDirectory() << "`";
   // Render asset filename filter out path and set internal reference to full
   // filepaath
-  this->filterAttribsFilenames(
-      objectTemplate, objectTemplate->getRenderAssetHandle(),
-      objectTemplate->getRenderAssetFullPath(),
-      [objectTemplate](const std::string& renderAsset) {
-        objectTemplate->setRenderAssetHandle(renderAsset);
-      },
-      [objectTemplate](const std::string& renderAsset) {
-        objectTemplate->setRenderAssetFullPath(renderAsset);
-      });
+  // Render asset filename filter out path and set internal reference to full
+  // filepath
+  const std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
+  if (!this->isValidPrimitiveAttributes(renderAssetHandle)) {
+    this->filterAttribsFilenames(
+        objectTemplate, renderAssetHandle,
+        objectTemplate->getRenderAssetFullPath(),
+        [objectTemplate](const std::string& renderAsset) {
+          objectTemplate->setRenderAssetHandle(renderAsset);
+        },
+        [objectTemplate](const std::string& renderAsset) {
+          objectTemplate->setRenderAssetFullPath(renderAsset);
+        });
+  } else {
+    // If handle refs a prim then just copy it over to full path
+    objectTemplate->setRenderAssetFullPath(renderAssetHandle);
+  }
   // Collision asset filename filter out path and set internal reference to
   // full filepaath
-  this->filterAttribsFilenames(
-      objectTemplate, objectTemplate->getCollisionAssetHandle(),
-      objectTemplate->getCollisionAssetFullPath(),
-      [objectTemplate](const std::string& colHndl) {
-        objectTemplate->setCollisionAssetHandle(colHndl);
-      },
-      [objectTemplate](const std::string& colHndl) {
-        objectTemplate->setCollisionAssetFullPath(colHndl);
-      });
+  const std::string collisionAssetHandle =
+      objectTemplate->getCollisionAssetHandle();
+  if (!this->isValidPrimitiveAttributes(collisionAssetHandle)) {
+    this->filterAttribsFilenames(
+        objectTemplate, collisionAssetHandle,
+        objectTemplate->getCollisionAssetFullPath(),
+        [objectTemplate](const std::string& colHndl) {
+          objectTemplate->setCollisionAssetHandle(colHndl);
+        },
+        [objectTemplate](const std::string& colHndl) {
+          objectTemplate->setCollisionAssetFullPath(colHndl);
+        });
+  } else {
+    // If handle refs a prim then just copy it over to full path
+    objectTemplate->setCollisionAssetFullPath(collisionAssetHandle);
+  }
 
   // ESP_ERROR(Mn::Debug::Flag::NoSpace)
   //     << "AFTER Obj `" << objectTemplateHandle << "`: Render fn `"

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -299,9 +299,7 @@ ObjectAttributesManager::preRegisterObjectFinalize(
   }
   // filter all paths properly so that the handles don't have filepaths and the
   // accessors are hidden fields
-  if (!objectTemplate->getRenderAssetIsPrimitive()) {
-    this->finalizeAttrPathsBeforeRegister(objectTemplate);
-  }
+  this->finalizeAttrPathsBeforeRegister(objectTemplate);
   // Clear dirty flag from when asset handles are changed
   objectTemplate->setIsClean();
 

--- a/src/esp/metadata/managers/ObjectAttributesManager.cpp
+++ b/src/esp/metadata/managers/ObjectAttributesManager.cpp
@@ -308,13 +308,11 @@ ObjectAttributesManager::preRegisterObjectFinalize(
 
 void ObjectAttributesManager::finalizeAttrPathsBeforeRegister(
     const attributes::ObjectAttributes::ptr& objectTemplate) const {
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "BEFORE Obj `" << objectTemplateHandle << "`: Render fn `"
-  //     << objectTemplate->getRenderAssetHandle() << "`| Collision fn `"
-  //     << objectTemplate->getCollisionAssetHandle() << "`| file dir `"
-  //     << objectTemplate->getFileDirectory() << "`";
-  // Render asset filename filter out path and set internal reference to full
-  // filepaath
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "BEFORE Obj `" << objectTemplate->getHandle() << "`: Render fn `"
+      << objectTemplate->getRenderAssetHandle() << "`| Collision fn `"
+      << objectTemplate->getCollisionAssetHandle() << "`| file dir `"
+      << objectTemplate->getFileDirectory() << "`";
   // Render asset filename filter out path and set internal reference to full
   // filepath
   const std::string renderAssetHandle = objectTemplate->getRenderAssetHandle();
@@ -351,12 +349,12 @@ void ObjectAttributesManager::finalizeAttrPathsBeforeRegister(
     objectTemplate->setCollisionAssetFullPath(collisionAssetHandle);
   }
 
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "AFTER Obj `" << objectTemplateHandle << "`: Render fn `"
-  //     << objectTemplate->getRenderAssetHandle() << "`| Collision fn `"
-  //     << objectTemplate->getCollisionAssetHandle() << "`| file dir `"
-  //     << objectTemplate->getFileDirectory() << "`";
-}
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "AFTER Obj `" << objectTemplate->getHandle() << "`: Render fn `"
+      << objectTemplate->getRenderAssetHandle() << "`| Collision fn `"
+      << objectTemplate->getCollisionAssetHandle() << "`| file dir `"
+      << objectTemplate->getFileDirectory() << "`";
+}  // ObjectAttributesManager::finalizeAttrPathsBeforeRegister
 
 void ObjectAttributesManager::postRegisterObjectHandling(
     int objectTemplateID,

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -226,6 +226,16 @@ class ObjectAttributesManager
       bool forceRegistration) override;
 
   /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::ObjectAttributes::ptr& attributes) const override;
+
+  /**
    * @brief This method will perform any final manager-related handling after
    * successfully registering an object.
    *

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -145,6 +145,16 @@ class ObjectAttributesManager
         physicsSynthObjTmpltLibByID_, subStr, contains, sorted);
   }
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::ObjectAttributes::ptr& attributes) const override;
+
   // ======== End File-based and primitive-based partition functions ========
 
  protected:
@@ -224,16 +234,6 @@ class ObjectAttributesManager
       attributes::ObjectAttributes::ptr attributesTemplate,
       const std::string& attributesTemplateHandle,
       bool forceRegistration) override;
-
-  /**
-   * @brief This function will be called to finalize attributes' paths before
-   * registration, moving fully qualified paths to the appropriate hidden
-   * attribute fields. This can also be called without registration to make sure
-   * the paths specified in an attributes are properly configured.
-   * @param attributes The attributes to be filtered.
-   */
-  void finalizeAttrPathsBeforeRegister(
-      const attributes::ObjectAttributes::ptr& attributes) const override;
 
   /**
    * @brief This method will perform any final manager-related handling after

--- a/src/esp/metadata/managers/PbrShaderAttributesManager.h
+++ b/src/esp/metadata/managers/PbrShaderAttributesManager.h
@@ -95,6 +95,20 @@ class PbrShaderAttributesManager
     }
   }  // PbrShaderAttributesManager::setAllDirectLightsEnabled
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   *
+   * TODO : If/When we begin treating IBL filepaths like we do other paths, this
+   * will need to be implemented.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      CORRADE_UNUSED const attributes::PbrShaderAttributes::ptr& attributes)
+      const override{};
+
  protected:
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -63,6 +63,17 @@ class PhysicsAttributesManager
   void setValsFromJSONDoc(attributes::PhysicsManagerAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      CORRADE_UNUSED const attributes::PhysicsManagerAttributes::ptr&
+          attributes) const override {}
+
  protected:
   /**
    * @brief Used Internally.  Create and configure newly-created attributes with

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -262,7 +262,7 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
                 (key == "configs")) {
               // These keys have been processed already
               continue;
-            }  // if has configs cell
+            }  // if has paths, default_attributes or configs cell
             else {
               if (it->value.IsString()) {
                 strKeyMap->emplace(key, it->value.GetString());
@@ -275,7 +275,6 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
               }
             }
           }  // for each sub-cell within main cell
-
         } else {
           // No map was passed - only applicable for
           // semantic_scene_descriptor_instances
@@ -284,10 +283,10 @@ void SceneDatasetAttributesManager::readDatasetJSONCell(
                 << "Unable to load semantic scene map due to destination "
                    "map being null.";
           }
-        }
-      }  // process unexpected member tags
-    }    // if cell is an object
-  }      // if cell exists
+        }  // map passed to this function
+      }    // process unexpected member tags
+    }      // if cell is an object
+  }        // if cell exists
 }  // SceneDatasetAttributesManager::readDatasetJSONCell
 
 void SceneDatasetAttributesManager::validateMap(
@@ -297,17 +296,18 @@ void SceneDatasetAttributesManager::validateMap(
   // now verify that all entries in map exist.  If not replace entry with
   // dsDir-prepended entry
   for (std::pair<const std::string, std::string>& entry : map) {
+    const std::string key = entry.first;
     const std::string loc = entry.second;
     if (!Cr::Utility::Path::exists(loc)) {
       std::string newLoc = Cr::Utility::Path::join(dsDir, loc);
       if (!Cr::Utility::Path::exists(newLoc)) {
         ESP_ERROR(Mn::Debug::Flag::NoSpace)
-            << "`" << tag << "` Value : `" << loc
+            << "`" << tag << "` Key : `" << key << "` Value : `" << loc
             << "` not found on disk as absolute path or relative to `" << dsDir
             << "`";
       } else {
         // replace value with dataset-augmented absolute path
-        map[entry.first] = newLoc;
+        map[key] = newLoc;
       }
     }  // loc does not exist
   }    // for each loc

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -93,6 +93,17 @@ class SceneDatasetAttributesManager
     }
   }  // SceneDatasetAttributesManager::setDefaultPbrShaderAttributesHandle
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::SceneDatasetAttributes::ptr& attributes)
+      const override {}
+
  protected:
   /**
    * @brief This will validate a loaded dataset map with file location values

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.h
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.h
@@ -100,6 +100,17 @@ class SceneInstanceAttributesManager
     return attributes::SceneAOInstanceAttributes::create(handle);
   }
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      CORRADE_UNUSED const attributes::SceneInstanceAttributes::ptr& attributes)
+      const override {}
+
  protected:
   /**
    * @brief Gets the name/key value of the appropriate enum corresponding to the

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -233,14 +233,13 @@ SemanticAttributesManager::preRegisterObjectFinalize(
 void SemanticAttributesManager::finalizeAttrPathsBeforeRegister(
     const attributes::SemanticAttributes::ptr& semanticAttributes) const {
   // filter filepaths of full path qualifiers
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "BEFORE : Semantic Attr `" << semanticAttributes->getHandle()
-  //     << "`| semantic asset fn `"
-  //     << semanticAttributes->getSemanticAssetHandle()
-  //     << "`| semantic descriptor fn `"
-  //     << semanticAttributes->getSemanticDescriptorFilename()
-  //     << "`| file directory `" << semanticAttributes->getFileDirectory() <<
-  //     "`";
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "BEFORE : Semantic Attr `" << semanticAttributes->getHandle()
+      << "`| semantic asset fn `"
+      << semanticAttributes->getSemanticAssetHandle()
+      << "`| semantic descriptor fn `"
+      << semanticAttributes->getSemanticDescriptorFilename()
+      << "`| file directory `" << semanticAttributes->getFileDirectory() << "`";
   // Semantic asset filename
   this->filterAttribsFilenames(
       semanticAttributes, semanticAttributes->getSemanticAssetHandle(),
@@ -262,14 +261,13 @@ void SemanticAttributesManager::finalizeAttrPathsBeforeRegister(
         semanticAttributes->setSemanticDescriptorFullPath(semanticAsset);
       });
 
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "AFTER : Semantic Attr `" << semanticAttributes->getHandle()
-  //     << "`| semantic asset fn `"
-  //     << semanticAttributes->getSemanticAssetHandle()
-  //     << "`| semantic descriptor fn `"
-  //     << semanticAttributes->getSemanticDescriptorFilename()
-  //     << "`| file directory `" << semanticAttributes->getFileDirectory() <<
-  //     "`";
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "AFTER : Semantic Attr `" << semanticAttributes->getHandle()
+      << "`| semantic asset fn `"
+      << semanticAttributes->getSemanticAssetHandle()
+      << "`| semantic descriptor fn `"
+      << semanticAttributes->getSemanticDescriptorFilename()
+      << "`| file directory `" << semanticAttributes->getFileDirectory() << "`";
 
 }  // SemanticAttributesManager::finalizeAttrPathsBeforeRegister
 

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -221,7 +221,7 @@ void SemanticAttributesManager::setValsFromJSONDoc(
 core::managedContainers::ManagedObjectPreregistration
 SemanticAttributesManager::preRegisterObjectFinalize(
     attributes::SemanticAttributes::ptr semanticAttributes,
-    const std::string& semanticAttrHandle,
+    CORRADE_UNUSED const std::string& semanticAttrHandle,
     CORRADE_UNUSED bool forceRegistration) {
   // filter all paths properly so that the handles don't have filepaths and the
   // accessors are hidden fields
@@ -234,13 +234,13 @@ void SemanticAttributesManager::finalizeAttrPathsBeforeRegister(
     const attributes::SemanticAttributes::ptr& semanticAttributes) const {
   // filter filepaths of full path qualifiers
   // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "BEFORE : Semantic Attr `" << semanticAttrHandle
+  //     << "BEFORE : Semantic Attr `" << semanticAttributes->getHandle()
   //     << "`| semantic asset fn `"
   //     << semanticAttributes->getSemanticAssetHandle()
   //     << "`| semantic descriptor fn `"
   //     << semanticAttributes->getSemanticDescriptorFilename()
-  //     << "`| file dir `"
-  //     << semanticAttributes->getFileDirectory() << "`";
+  //     << "`| file directory `" << semanticAttributes->getFileDirectory() <<
+  //     "`";
   // Semantic asset filename
   this->filterAttribsFilenames(
       semanticAttributes, semanticAttributes->getSemanticAssetHandle(),
@@ -263,14 +263,13 @@ void SemanticAttributesManager::finalizeAttrPathsBeforeRegister(
       });
 
   // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "AFTER : Semantic Attr `" << semanticAttrHandle
+  //     << "AFTER : Semantic Attr `" << semanticAttributes->getHandle()
   //     << "`| semantic asset fn `"
   //     << semanticAttributes->getSemanticAssetHandle()
   //     << "`| semantic descriptor fn `"
   //     << semanticAttributes->getSemanticDescriptorFilename()
-  //     << "`| file dir `"
-  //     << semanticAttributes->getFileDirectory() << "`";
-  // No pre-registration conditioning performed
+  //     << "`| file directory `" << semanticAttributes->getFileDirectory() <<
+  //     "`";
 
 }  // SemanticAttributesManager::finalizeAttrPathsBeforeRegister
 

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -218,6 +218,47 @@ void SemanticAttributesManager::setValsFromJSONDoc(
 
 }  // SemanticAttributesManager::setValsFromJSONDoc
 
+core::managedContainers::ManagedObjectPreregistration
+SemanticAttributesManager::preRegisterObjectFinalize(
+    attributes::SemanticAttributes::ptr semanticAttributes,
+    const std::string& semanticAttrHandle,
+    CORRADE_UNUSED bool forceRegistration) {
+  // filter filepaths of full path qualifiers
+  // Semantic asset filename
+  this->filterAttribsFilenames(
+      semanticAttributes,
+      [semanticAttributes](void) -> std::string {
+        return semanticAttributes->getSemanticAssetHandle();
+      },
+      [semanticAttributes](const std::string& semanticAsset) {
+        semanticAttributes->setSemanticAssetHandle(semanticAsset);
+      },
+      [semanticAttributes](const std::string& semanticAsset) {
+        semanticAttributes->setSemanticAssetFullPath(semanticAsset);
+      });
+  // Semantic descriptor filename
+  this->filterAttribsFilenames(
+      semanticAttributes,
+      [semanticAttributes](void) -> std::string {
+        return semanticAttributes->getSemanticDescriptorFilename();
+      },
+      [semanticAttributes](const std::string& semanticAsset) {
+        semanticAttributes->setSemanticDescriptorFilename(semanticAsset);
+      },
+      [semanticAttributes](const std::string& semanticAsset) {
+        semanticAttributes->setSemanticDescriptorFullPath(semanticAsset);
+      });
+
+  ESP_ERROR(Mn::Debug::Flag::NoSpace)
+      << "Semantic Attr `" << semanticAttrHandle << "`| semantic asset fn `"
+      << semanticAttributes->getSemanticAssetHandle()
+      << "`| semantic descriptor fn `"
+      << semanticAttributes->getSemanticDescriptorFilename() << "`| file dir `"
+      << semanticAttributes->getFileDirectory() << "`";
+  // No pre-registration conditioning performed
+  return core::managedContainers::ManagedObjectPreregistration::Success;
+}
+
 }  // namespace managers
 }  // namespace metadata
 }  // namespace esp

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -223,13 +223,28 @@ SemanticAttributesManager::preRegisterObjectFinalize(
     attributes::SemanticAttributes::ptr semanticAttributes,
     const std::string& semanticAttrHandle,
     CORRADE_UNUSED bool forceRegistration) {
+  // filter all paths properly so that the handles don't have filepaths and the
+  // accessors are hidden fields
+  this->finalizeAttrPathsBeforeRegister(semanticAttributes);
+
+  return core::managedContainers::ManagedObjectPreregistration::Success;
+}  // SemanticAttributesManager::preRegisterObjectFinalize
+
+void SemanticAttributesManager::finalizeAttrPathsBeforeRegister(
+    const attributes::SemanticAttributes::ptr& semanticAttributes) const {
   // filter filepaths of full path qualifiers
+  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
+  //     << "BEFORE : Semantic Attr `" << semanticAttrHandle
+  //     << "`| semantic asset fn `"
+  //     << semanticAttributes->getSemanticAssetHandle()
+  //     << "`| semantic descriptor fn `"
+  //     << semanticAttributes->getSemanticDescriptorFilename()
+  //     << "`| file dir `"
+  //     << semanticAttributes->getFileDirectory() << "`";
   // Semantic asset filename
   this->filterAttribsFilenames(
-      semanticAttributes,
-      [semanticAttributes](void) -> std::string {
-        return semanticAttributes->getSemanticAssetHandle();
-      },
+      semanticAttributes, semanticAttributes->getSemanticAssetHandle(),
+      semanticAttributes->getSemanticAssetFullPath(),
       [semanticAttributes](const std::string& semanticAsset) {
         semanticAttributes->setSemanticAssetHandle(semanticAsset);
       },
@@ -238,10 +253,8 @@ SemanticAttributesManager::preRegisterObjectFinalize(
       });
   // Semantic descriptor filename
   this->filterAttribsFilenames(
-      semanticAttributes,
-      [semanticAttributes](void) -> std::string {
-        return semanticAttributes->getSemanticDescriptorFilename();
-      },
+      semanticAttributes, semanticAttributes->getSemanticDescriptorFilename(),
+      semanticAttributes->getSemanticDescriptorFullPath(),
       [semanticAttributes](const std::string& semanticAsset) {
         semanticAttributes->setSemanticDescriptorFilename(semanticAsset);
       },
@@ -249,15 +262,17 @@ SemanticAttributesManager::preRegisterObjectFinalize(
         semanticAttributes->setSemanticDescriptorFullPath(semanticAsset);
       });
 
-  ESP_ERROR(Mn::Debug::Flag::NoSpace)
-      << "Semantic Attr `" << semanticAttrHandle << "`| semantic asset fn `"
-      << semanticAttributes->getSemanticAssetHandle()
-      << "`| semantic descriptor fn `"
-      << semanticAttributes->getSemanticDescriptorFilename() << "`| file dir `"
-      << semanticAttributes->getFileDirectory() << "`";
+  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
+  //     << "AFTER : Semantic Attr `" << semanticAttrHandle
+  //     << "`| semantic asset fn `"
+  //     << semanticAttributes->getSemanticAssetHandle()
+  //     << "`| semantic descriptor fn `"
+  //     << semanticAttributes->getSemanticDescriptorFilename()
+  //     << "`| file dir `"
+  //     << semanticAttributes->getFileDirectory() << "`";
   // No pre-registration conditioning performed
-  return core::managedContainers::ManagedObjectPreregistration::Success;
-}
+
+}  // SemanticAttributesManager::finalizeAttrPathsBeforeRegister
 
 }  // namespace managers
 }  // namespace metadata

--- a/src/esp/metadata/managers/SemanticAttributesManager.h
+++ b/src/esp/metadata/managers/SemanticAttributesManager.h
@@ -124,11 +124,9 @@ class SemanticAttributesManager
       CORRADE_UNUSED const std::string& templateHandle) override {}
 
   /**
-   * @brief Not required for this manager.
-   *
-   * This method will perform any essential updating to the managed object
-   * before registration is performed. If this updating fails, registration will
-   * also fail.
+   * @brief This method will perform any essential updating to the managed
+   * object before registration is performed. If this updating fails,
+   * registration will also fail.
    * @param object the managed object to be registered
    * @param objectHandle the name to register the managed object with.
    * Expected to be valid.
@@ -138,13 +136,9 @@ class SemanticAttributesManager
    * register the object if it has.
    */
   core::managedContainers::ManagedObjectPreregistration
-  preRegisterObjectFinalize(
-      CORRADE_UNUSED attributes::SemanticAttributes::ptr object,
-      CORRADE_UNUSED const std::string& objectHandle,
-      CORRADE_UNUSED bool forceRegistration) override {
-    // No pre-registration conditioning performed
-    return core::managedContainers::ManagedObjectPreregistration::Success;
-  }
+  preRegisterObjectFinalize(attributes::SemanticAttributes::ptr object,
+                            const std::string& objectHandle,
+                            CORRADE_UNUSED bool forceRegistration) override;
 
   /**
    * @brief Not required for this manager.

--- a/src/esp/metadata/managers/SemanticAttributesManager.h
+++ b/src/esp/metadata/managers/SemanticAttributesManager.h
@@ -70,6 +70,16 @@ class SemanticAttributesManager
     return attributes::SemanticVolumeAttributes::create(handle);
   }
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::SemanticAttributes::ptr& attributes) const override;
+
  protected:
   /**
    * @brief Used Internally.  Create a @ref

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -285,14 +285,14 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
     // set default origin and orientation values based on file name
     // from AssetInfo::fromPath
     // set defaults for passed render asset handles
-    StageAttributesManager::setDefaultAssetNameBasedAttributes(
+    this->setDefaultAssetNameBasedAttributes(
         newAttributes, createNewAttributes,
         newAttributes->getRenderAssetHandle(), [newAttributes](auto&& PH1) {
           newAttributes->initRenderAssetTypeEnum(
               std::forward<decltype(PH1)>(PH1));
         });
     // set defaults for passed collision asset handles
-    StageAttributesManager::setDefaultAssetNameBasedAttributes(
+    this->setDefaultAssetNameBasedAttributes(
         newAttributes, false, newAttributes->getCollisionAssetHandle(),
         [newAttributes](auto&& PH1) {
           newAttributes->initCollisionAssetTypeEnum(
@@ -300,7 +300,7 @@ StageAttributes::ptr StageAttributesManager::initNewObjectInternal(
         });
 
     // set defaults for passed semantic asset handles
-    StageAttributesManager::setDefaultAssetNameBasedAttributes(
+    this->setDefaultAssetNameBasedAttributes(
         newAttributes, false, newAttributes->getSemanticAssetHandle(),
         [newAttributes](auto&& PH1) {
           newAttributes->initSemanticAssetTypeEnum(
@@ -404,9 +404,6 @@ void StageAttributesManager::setValsFromJSONDoc(
   // populate specified semantic file name if specified in json - defaults
   // are overridden only if specified in json.
 
-  std::string navmeshFName = "";
-  std::string semanticSceneDescriptor = "";
-
   // populate semantic mesh type if present
   std::string semanticFName = stageAttributes->getSemanticAssetHandle();
   semanticFName = this->setJSONAssetHandleAndType(
@@ -422,6 +419,7 @@ void StageAttributesManager::setValsFromJSONDoc(
   // instance
   stageAttributes->initSemanticAssetTypeEnum(AssetType::InstanceMesh);
 
+  std::string navmeshFName = "";
   if (io::readMember<std::string>(jsonConfig, "nav_asset", navmeshFName)) {
     // if "nav mesh" is specified in stage json set value (override default).
     // navmesh filename might already be fully qualified; if not, might just be
@@ -433,6 +431,7 @@ void StageAttributesManager::setValsFromJSONDoc(
     stageAttributes->setNavmeshAssetHandle(navmeshFName);
   }
 
+  std::string semanticSceneDescriptor = "";
   if (io::readMember<std::string>(jsonConfig, "semantic_descriptor_filename",
                                   semanticSceneDescriptor)) {
     // if "semantic_descriptor_filename" is specified in stage json, set value

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -484,26 +484,39 @@ void StageAttributesManager::finalizeAttrPathsBeforeRegister(
 
   // Render asset filename filter out path and set internal reference to full
   // filepath
-  this->filterAttribsFilenames(
-      stageAttributes, stageAttributes->getRenderAssetHandle(),
-      stageAttributes->getRenderAssetFullPath(),
-      [stageAttributes](const std::string& renderAsset) {
-        stageAttributes->setRenderAssetHandle(renderAsset);
-      },
-      [stageAttributes](const std::string& renderAsset) {
-        stageAttributes->setRenderAssetFullPath(renderAsset);
-      });
+  const std::string renderAssetHandle = stageAttributes->getRenderAssetHandle();
+  if (!this->isValidPrimitiveAttributes(renderAssetHandle)) {
+    this->filterAttribsFilenames(
+        stageAttributes, renderAssetHandle,
+        stageAttributes->getRenderAssetFullPath(),
+        [stageAttributes](const std::string& renderAsset) {
+          stageAttributes->setRenderAssetHandle(renderAsset);
+        },
+        [stageAttributes](const std::string& renderAsset) {
+          stageAttributes->setRenderAssetFullPath(renderAsset);
+        });
+  } else {
+    // If handle refs a prim then just copy it over to full path
+    stageAttributes->setRenderAssetFullPath(renderAssetHandle);
+  }
   // Collision asset filename filter out path and set internal reference to
   // full filepaath
-  this->filterAttribsFilenames(
-      stageAttributes, stageAttributes->getCollisionAssetHandle(),
-      stageAttributes->getCollisionAssetFullPath(),
-      [stageAttributes](const std::string& colHndl) {
-        stageAttributes->setCollisionAssetHandle(colHndl);
-      },
-      [stageAttributes](const std::string& colHndl) {
-        stageAttributes->setCollisionAssetFullPath(colHndl);
-      });
+  const std::string collisionAssetHandle =
+      stageAttributes->getCollisionAssetHandle();
+  if (!this->isValidPrimitiveAttributes(collisionAssetHandle)) {
+    this->filterAttribsFilenames(
+        stageAttributes, collisionAssetHandle,
+        stageAttributes->getCollisionAssetFullPath(),
+        [stageAttributes](const std::string& colHndl) {
+          stageAttributes->setCollisionAssetHandle(colHndl);
+        },
+        [stageAttributes](const std::string& colHndl) {
+          stageAttributes->setCollisionAssetFullPath(colHndl);
+        });
+  } else {
+    // If handle refs a prim then just copy it over to full path
+    stageAttributes->setCollisionAssetFullPath(collisionAssetHandle);
+  }
   // filter filepaths of full path qualifiers
   // Navmesh asset filename
   this->filterAttribsFilenames(

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -457,7 +457,9 @@ StageAttributesManager::preRegisterObjectFinalize(
   }
   // filter all paths properly so that the handles don't have filepaths and the
   // accessors are hidden fields
-  this->finalizeAttrPathsBeforeRegister(stageAttributes);
+  if (!stageIsNone) {
+    this->finalizeAttrPathsBeforeRegister(stageAttributes);
+  }
 
   stageAttributes->setIsClean();
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -441,25 +441,25 @@ StageAttributesManager::preRegisterObjectFinalize(
     stageAttributes->setCollisionAssetFullPath("NONE");
   } else {
     // Else, means no collision data specified, use specified render data
-    ESP_DEBUG()
-        << "Collision asset template handle :" << collisionAssetHandle
-        << "specified in stage template with handle :" << stageAttributesHandle
-        << "does not correspond to any existing file or primitive render "
-           "asset.  Overriding with given render asset handle :"
-        << renderAssetHandle << ".";
+    ESP_DEBUG(Mn::Debug::Flag::NoSpace)
+        << "Collision asset template handle : `" << collisionAssetHandle
+        << "` specified in stage template with handle : `"
+        << stageAttributesHandle
+        << "` does not correspond to any existing file or known primitive "
+           "asset. Overriding with given render asset handle : `"
+        << renderAssetHandle << "`.";
 
     stageAttributes->setCollisionAssetHandle(
-        stageAttributes->getCollisionAssetHandle());
+        stageAttributes->getRenderAssetHandle());
     stageAttributes->setCollisionAssetFullPath(
-        stageAttributes->getCollisionAssetFullPath());
+        stageAttributes->getRenderAssetFullPath());
     stageAttributes->setCollisionAssetIsPrimitive(
         stageAttributes->getRenderAssetIsPrimitive());
   }
   // filter all paths properly so that the handles don't have filepaths and the
   // accessors are hidden fields
-  if (!stageIsNone) {
-    this->finalizeAttrPathsBeforeRegister(stageAttributes);
-  }
+
+  this->finalizeAttrPathsBeforeRegister(stageAttributes);
 
   stageAttributes->setIsClean();
 

--- a/src/esp/metadata/managers/StageAttributesManager.cpp
+++ b/src/esp/metadata/managers/StageAttributesManager.cpp
@@ -469,18 +469,17 @@ StageAttributesManager::preRegisterObjectFinalize(
 
 void StageAttributesManager::finalizeAttrPathsBeforeRegister(
     const attributes::StageAttributes::ptr& stageAttributes) const {
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "BEFORE : Stage `" << stageAttributesHandle << "`: Render rel `"
-  //     << stageAttributes->getRenderAssetHandle() << "`: Render FQ `"
-  //     << stageAttributes->getRenderAssetFullPath() << "`| Collision rel `"
-  //     << stageAttributes->getCollisionAssetHandle() << "`| Collision FQ `"
-  //     << stageAttributes->getCollisionAssetFullPath() << "`| navmesh rel `"
-  //     << stageAttributes->getNavmeshAssetHandle()
-  //     << "`| semantic asset rel `"
-  //     << stageAttributes->getSemanticAssetHandle()
-  //     << "`| semantic descriptor rel `"
-  //     << stageAttributes->getSemanticDescriptorFilename() << "`| file dir `"
-  //     << stageAttributes->getFileDirectory() << "`";
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "BEFORE : Stage `" << stageAttributes->getHandle() << "`: Render rel `"
+      << stageAttributes->getRenderAssetHandle() << "`: Render FQ `"
+      << stageAttributes->getRenderAssetFullPath() << "`| Collision rel `"
+      << stageAttributes->getCollisionAssetHandle() << "`| Collision FQ `"
+      << stageAttributes->getCollisionAssetFullPath() << "`| navmesh rel `"
+      << stageAttributes->getNavmeshAssetHandle() << "`| semantic asset rel `"
+      << stageAttributes->getSemanticAssetHandle()
+      << "`| semantic descriptor rel `"
+      << stageAttributes->getSemanticDescriptorFilename() << "`| file dir `"
+      << stageAttributes->getFileDirectory() << "`";
 
   // Render asset filename filter out path and set internal reference to full
   // filepath
@@ -549,18 +548,17 @@ void StageAttributesManager::finalizeAttrPathsBeforeRegister(
         stageAttributes->setSemanticDescriptorFullPath(ssd);
       });
 
-  // ESP_ERROR(Mn::Debug::Flag::NoSpace)
-  //     << "AFTER : Stage `" << stageAttributesHandle << "`: Render rel `"
-  //     << stageAttributes->getRenderAssetHandle() << "`: Render FQ `"
-  //     << stageAttributes->getRenderAssetFullPath() << "`| Collision rel `"
-  //     << stageAttributes->getCollisionAssetHandle() << "`| Collision FQ `"
-  //     << stageAttributes->getCollisionAssetFullPath() << "`| navmesh rel `"
-  //     << stageAttributes->getNavmeshAssetHandle()
-  //     << "`| semantic asset rel `"
-  //     << stageAttributes->getSemanticAssetHandle()
-  //     << "`| semantic descriptor rel `"
-  //     << stageAttributes->getSemanticDescriptorFilename() << "`| file dir `"
-  //     << stageAttributes->getFileDirectory() << "`";
+  ESP_VERY_VERBOSE(Mn::Debug::Flag::NoSpace)
+      << "AFTER : Stage `" << stageAttributes->getHandle() << "`: Render rel `"
+      << stageAttributes->getRenderAssetHandle() << "`: Render FQ `"
+      << stageAttributes->getRenderAssetFullPath() << "`| Collision rel `"
+      << stageAttributes->getCollisionAssetHandle() << "`| Collision FQ `"
+      << stageAttributes->getCollisionAssetFullPath() << "`| navmesh rel `"
+      << stageAttributes->getNavmeshAssetHandle() << "`| semantic asset rel `"
+      << stageAttributes->getSemanticAssetHandle()
+      << "`| semantic descriptor rel `"
+      << stageAttributes->getSemanticDescriptorFilename() << "`| file dir `"
+      << stageAttributes->getFileDirectory() << "`";
 
   // Clear dirty flag from when asset handles are changed
 }

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -154,6 +154,16 @@ class StageAttributesManager
       bool forceRegistration) override;
 
   /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::StageAttributes::ptr& attributes) const override;
+
+  /**
    * @brief Not required for this manager.
    *
    * This method will perform any final manager-related handling after

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -79,6 +79,16 @@ class StageAttributesManager
   void setValsFromJSONDoc(attributes::StageAttributes::ptr attribs,
                           const io::JsonGenericValue& jsonConfig) override;
 
+  /**
+   * @brief This function will be called to finalize attributes' paths before
+   * registration, moving fully qualified paths to the appropriate hidden
+   * attribute fields. This can also be called without registration to make sure
+   * the paths specified in an attributes are properly configured.
+   * @param attributes The attributes to be filtered.
+   */
+  void finalizeAttrPathsBeforeRegister(
+      const attributes::StageAttributes::ptr& attributes) const override;
+
  protected:
   /**
    * @brief Create and save default primitive asset-based object templates,
@@ -152,16 +162,6 @@ class StageAttributesManager
       attributes::StageAttributes::ptr StageAttributesTemplate,
       const std::string& StageAttributesHandle,
       bool forceRegistration) override;
-
-  /**
-   * @brief This function will be called to finalize attributes' paths before
-   * registration, moving fully qualified paths to the appropriate hidden
-   * attribute fields. This can also be called without registration to make sure
-   * the paths specified in an attributes are properly configured.
-   * @param attributes The attributes to be filtered.
-   */
-  void finalizeAttrPathsBeforeRegister(
-      const attributes::StageAttributes::ptr& attributes) const override;
 
   /**
    * @brief Not required for this manager.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -126,7 +126,7 @@ int BulletPhysicsManager::addArticulatedObjectInternal(
     // acquire context if available
     simulator_->getRenderGLContext();
   }
-  const std::string urdfFilepath = artObjAttributes->getURDFPath();
+  const std::string urdfFilepath = artObjAttributes->getURDFFullPath();
   // Load model and set active
   ESP_CHECK(urdfImporter_->loadURDF(urdfFilepath, forceReload),
             "failed to parse/load URDF file" << urdfFilepath);
@@ -155,7 +155,7 @@ int BulletPhysicsManager::addArticulatedObjectInternal(
   auto model = u2b->getModel();
 
   // if the AO attributes specifies a render asset, load and link it
-  const auto renderAssetPath = artObjAttributes->getRenderAssetHandle();
+  const auto renderAssetPath = artObjAttributes->getRenderAssetFullPath();
   if (renderAssetPath != "") {
     instantiateSkinnedModel(articulatedObject, artObjAttributes,
                             renderAssetPath, objectNode, drawables, lightSetup);

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -97,7 +97,8 @@ bool BulletRigidObject::constructCollisionShape() {
   auto initAttr = PhysicsObjectBase::getInitializationAttributes<
       metadata::attributes::ObjectAttributes>();
   // collision mesh/asset handle
-  const std::string collisionAssetHandle = initAttr->getCollisionAssetHandle();
+  const std::string collisionAssetHandle =
+      initAttr->getCollisionAssetFullPath();
 
   if (!initAttr->getUseMeshCollision()) {
     // if using prim collider get appropriate bullet collision primitive

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -70,7 +70,7 @@ void BulletRigidStage::constructAndAddCollisionObjects() {
     auto initAttr = PhysicsObjectBase::getInitializationAttributes<
         metadata::attributes::StageAttributes>();
     // construct the objects first time
-    const auto collisionAssetHandle = initAttr->getCollisionAssetHandle();
+    const auto collisionAssetHandle = initAttr->getCollisionAssetFullPath();
 
     const std::vector<assets::CollisionMeshData>& meshGroup =
         resMgr_.getCollisionMesh(collisionAssetHandle);

--- a/src/esp/scene/SemanticScene.cpp
+++ b/src/esp/scene/SemanticScene.cpp
@@ -26,7 +26,7 @@ namespace scene {
 bool SemanticScene::
     loadSemanticSceneDescriptor(const std::shared_ptr<metadata::attributes::SemanticAttributes>& semanticAttr, SemanticScene& scene, const quatf& rotation /* = quatf::FromTwoVectors(-vec3f::UnitZ(), geo::ESP_GRAVITY) */) {
   const std::string ssdFileName =
-      semanticAttr != nullptr ? semanticAttr->getSemanticDescriptorFilename()
+      semanticAttr != nullptr ? semanticAttr->getSemanticDescriptorFullPath()
                               : "";
 
   bool loadSuccess = false;

--- a/src/esp/scene/SemanticScene.h
+++ b/src/esp/scene/SemanticScene.h
@@ -326,8 +326,8 @@ class SemanticScene {
                               const std::string& srcFunc) {
     if (!Cr::Utility::Path::exists(filename)) {
       ESP_WARNING(Mn::Debug::Flag::NoSpace)
-          << "::" << srcFunc << ": File" << filename
-          << "does not exist.  Aborting load.";
+          << "::" << srcFunc << ": File `" << filename
+          << "` does not exist.  Aborting load.";
       return false;
     }
     return true;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -498,16 +498,20 @@ bool Simulator::instanceStageForSceneAttributes(
   // SemanticAttributes
   if (semanticAttr != nullptr) {
     const std::string semanticAttrSSDName =
-        semanticAttr->getSemanticDescriptorFilename();
+        semanticAttr->getSemanticDescriptorFullPath();
     const std::string semanticAttrAssetName =
-        semanticAttr->getSemanticAssetHandle();
+        semanticAttr->getSemanticAssetFullPath();
     // - Set stage semantic values if appropriate - this overrides whatever is
     // specified previoussly in stage attributes.
     if (semanticAttrSSDName != "") {
-      stageAttributes->setSemanticDescriptorFilename(semanticAttrSSDName);
+      stageAttributes->setSemanticDescriptorFilename(
+          semanticAttr->getSemanticDescriptorFilename());
+      stageAttributes->setSemanticDescriptorFullPath(semanticAttrSSDName);
     }
     if (semanticAttrAssetName != "") {
-      stageAttributes->setSemanticAssetHandle(semanticAttrAssetName);
+      stageAttributes->setSemanticAssetHandle(
+          semanticAttr->getSemanticAssetHandle());
+      stageAttributes->setSemanticAssetFullPath(semanticAttrAssetName);
       stageAttributes->setSemanticAssetTypeEnum(
           semanticAttr->getSemanticAssetType());
       if (semanticAttr->getSemanticOrientFront() !=
@@ -534,9 +538,9 @@ bool Simulator::instanceStageForSceneAttributes(
   std::vector<int> tempIDs{activeSceneID_, activeSemanticSceneID_};
   ESP_DEBUG() << "Start to load stage named :" << stageAttributes->getHandle()
               << "with render asset :"
-              << stageAttributes->getRenderAssetHandle()
+              << stageAttributes->getRenderAssetFullPath()
               << "and collision asset :"
-              << stageAttributes->getCollisionAssetHandle();
+              << stageAttributes->getCollisionAssetFullPath();
 
   // Load stage
   bool loadSuccess = resourceManager_->loadStage(
@@ -883,7 +887,7 @@ assets::MeshData::ptr Simulator::getJoinedMesh(
   auto stageInitAttrs = physicsManager_->getStageInitAttributes();
   if (stageInitAttrs != nullptr) {
     joinedMesh = resourceManager_->createJoinedCollisionMesh(
-        stageInitAttrs->getRenderAssetHandle());
+        stageInitAttrs->getRenderAssetFullPath());
   }
 
   // add STATIC collision objects
@@ -915,9 +919,9 @@ assets::MeshData::ptr Simulator::getJoinedMesh(
         objectTransform.scale(Magnum::EigenIntegration::cast<vec3f>(
             initializationTemplate->getScale()));
         std::string meshHandle =
-            initializationTemplate->getCollisionAssetHandle();
+            initializationTemplate->getCollisionAssetFullPath();
         if (meshHandle.empty()) {
-          meshHandle = initializationTemplate->getRenderAssetHandle();
+          meshHandle = initializationTemplate->getRenderAssetFullPath();
         }
         meshComponentStates[meshHandle].push_back(objectTransform);
       }
@@ -981,7 +985,7 @@ assets::MeshData::ptr Simulator::getJoinedSemanticMesh(
   auto stageInitAttrs = physicsManager_->getStageInitAttributes();
   if (stageInitAttrs != nullptr) {
     joinedSemanticMesh = resourceManager_->createJoinedSemanticCollisionMesh(
-        objectIds, stageInitAttrs->getSemanticAssetHandle());
+        objectIds, stageInitAttrs->getSemanticAssetFullPath());
   }
 
   return joinedSemanticMesh;

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -498,20 +498,20 @@ bool Simulator::instanceStageForSceneAttributes(
   // SemanticAttributes
   if (semanticAttr != nullptr) {
     const std::string semanticAttrSSDName =
-        semanticAttr->getSemanticDescriptorFullPath();
+        semanticAttr->getSemanticDescriptorFilename();
     const std::string semanticAttrAssetName =
-        semanticAttr->getSemanticAssetFullPath();
+        semanticAttr->getSemanticAssetHandle();
     // - Set stage semantic values if appropriate - this overrides whatever is
     // specified previoussly in stage attributes.
     if (semanticAttrSSDName != "") {
-      stageAttributes->setSemanticDescriptorFilename(
-          semanticAttr->getSemanticDescriptorFilename());
-      stageAttributes->setSemanticDescriptorFullPath(semanticAttrSSDName);
+      stageAttributes->setSemanticDescriptorFilename(semanticAttrSSDName);
+      stageAttributes->setSemanticDescriptorFullPath(
+          semanticAttr->getSemanticDescriptorFullPath());
     }
     if (semanticAttrAssetName != "") {
-      stageAttributes->setSemanticAssetHandle(
-          semanticAttr->getSemanticAssetHandle());
-      stageAttributes->setSemanticAssetFullPath(semanticAttrAssetName);
+      stageAttributes->setSemanticAssetHandle(semanticAttrAssetName);
+      stageAttributes->setSemanticAssetFullPath(
+          semanticAttr->getSemanticAssetFullPath());
       stageAttributes->setSemanticAssetTypeEnum(
           semanticAttr->getSemanticAssetType());
       if (semanticAttr->getSemanticOrientFront() !=
@@ -525,6 +525,8 @@ bool Simulator::instanceStageForSceneAttributes(
             semanticAttr->getSemanticOrientUp());
       }
     }
+    metadataMediator_->getStageAttributesManager()
+        ->finalizeAttrPathsBeforeRegister(stageAttributes);
   }
 
   // set visibility if explicitly specified in stage instance configs

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -1134,11 +1134,11 @@ void AttributesConfigsTest::testSemanticAttrVals(
     std::shared_ptr<Attrs::SemanticAttributes> semanticAttr,
     const std::string& assetPath) {
   CORRADE_COMPARE(
-      semanticAttr->getSemanticDescriptorFilename(),
+      semanticAttr->getSemanticDescriptorFullPath(),
       Cr::Utility::Path::join(assetPath, "test_semantic_lexicon.json"));
 
   CORRADE_COMPARE(
-      semanticAttr->getSemanticAssetHandle(),
+      semanticAttr->getSemanticAssetFullPath(),
       Cr::Utility::Path::join(assetPath, "test_semantic_asset.glb"));
 
   // verify regions
@@ -1319,8 +1319,8 @@ void AttributesConfigsTest::testStageAttrVals(
                   Mn::Vector3(2.0, 0.0, 0.0));
   CORRADE_COMPARE(stageAttr->getSemanticOrientUp(), Mn::Vector3(0.0, 2.0, 0.0));
 
-  CORRADE_COMPARE(stageAttr->getRenderAssetHandle(), assetPath);
-  CORRADE_COMPARE(stageAttr->getCollisionAssetHandle(), assetPath);
+  CORRADE_COMPARE(stageAttr->getRenderAssetFullPath(), assetPath);
+  CORRADE_COMPARE(stageAttr->getCollisionAssetFullPath(), assetPath);
   CORRADE_VERIFY(!stageAttr->getIsCollidable());
   // stage-specific attributes
   CORRADE_COMPARE(stageAttr->getOrigin(), Mn::Vector3(1, 2, 3));
@@ -1330,8 +1330,8 @@ void AttributesConfigsTest::testStageAttrVals(
   // make sure that is not default value "flat"
   CORRADE_COMPARE(static_cast<int>(stageAttr->getShaderType()),
                   static_cast<int>(Attrs::ObjectInstanceShaderType::Material));
-  CORRADE_COMPARE(stageAttr->getSemanticAssetHandle(), assetPath);
-  CORRADE_COMPARE(stageAttr->getNavmeshAssetHandle(), assetPath);
+  CORRADE_COMPARE(stageAttr->getSemanticAssetFullPath(), assetPath);
+  CORRADE_COMPARE(stageAttr->getNavmeshAssetFullPath(), assetPath);
   // test stage attributes-level user config vals
   testUserDefinedConfigVals(
       stageAttr->getUserConfiguration(), 4, "stage defined string", false, 3,
@@ -1592,8 +1592,8 @@ void AttributesConfigsTest::testObjectAttrVals(
   CORRADE_COMPARE(objAttr->getUnitsToMeters(), 1.1);
   CORRADE_COMPARE(objAttr->getOrientUp(), Mn::Vector3(2.1, 0, 0));
   CORRADE_COMPARE(objAttr->getOrientFront(), Mn::Vector3(0, 2.1, 0));
-  CORRADE_COMPARE(objAttr->getRenderAssetHandle(), assetPath);
-  CORRADE_COMPARE(objAttr->getCollisionAssetHandle(), assetPath);
+  CORRADE_COMPARE(objAttr->getRenderAssetFullPath(), assetPath);
+  CORRADE_COMPARE(objAttr->getCollisionAssetFullPath(), assetPath);
   CORRADE_VERIFY(!objAttr->getIsCollidable());
   CORRADE_COMPARE(objAttr->getSemanticId(), 7);
   // object-specific attributes
@@ -1869,8 +1869,8 @@ void AttributesConfigsTest::testArticulatedObjectAttrVals(
     const std::string& assetPath,
     const std::string& urdfPath) {
   // match values set in test JSON
-  CORRADE_COMPARE(artObjAttr->getURDFPath(), urdfPath);
-  CORRADE_COMPARE(artObjAttr->getRenderAssetHandle(), assetPath);
+  CORRADE_COMPARE(artObjAttr->getURDFFullPath(), urdfPath);
+  CORRADE_COMPARE(artObjAttr->getRenderAssetFullPath(), assetPath);
   CORRADE_COMPARE(artObjAttr->getSemanticId(), 100);
 
   CORRADE_COMPARE(static_cast<int>(artObjAttr->getBaseType()),

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -928,7 +928,7 @@ void AttributesManagersTest::testPrimitiveAssetAttributes() {
     // test that a new template can be created from the specified handles
     testAssetAttributesTemplateCreateFromHandle(uvSphereWireframeHandle);
   }
-}  // AttributesManagersTest::AsssetAttributesManagerGetAndModify test
+}  // AttributesManagersTest::AssetAttributesManagerGetAndModify test
 
 void AttributesManagersTest::testPrimitiveBasedObjectAttributes() {
   // get all handles of templates for primitive-based render objects

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -113,7 +113,7 @@ void MetadataMediatorTest::testDataset0() {
     // verify that all attributes' names are the same as the render handles
     // (which were the original files)
     CORRADE_COMPARE(glbStageAttr->getHandle(),
-                    glbStageAttr->getRenderAssetHandle());
+                    glbStageAttr->getRenderAssetFullPath());
   }
 
   // get list of matching handles for base - should always only be 1
@@ -124,7 +124,7 @@ void MetadataMediatorTest::testDataset0() {
   auto stageAttr =
       stageAttributesMgr->getObjectCopyByHandle(stageAttrHandles[0]);
   // get render asset handle for later comparison
-  auto renderAssetHandle = stageAttr->getRenderAssetHandle();
+  auto renderAssetHandle = stageAttr->getRenderAssetFullPath();
   // verify existence
   CORRADE_VERIFY(stageAttr);
   // verify set to values in file
@@ -161,7 +161,7 @@ void MetadataMediatorTest::testDataset0() {
   // verify existence
   CORRADE_VERIFY(stageAttr);
   // verify set to values in dataset_config file
-  auto newRenderAssetHandle = stageAttr->getRenderAssetHandle();
+  auto newRenderAssetHandle = stageAttr->getRenderAssetFullPath();
   // verify same renderasset handle to loaded stage attributes
   CORRADE_COMPARE(renderAssetHandle, newRenderAssetHandle);
   // verify values set correctly
@@ -246,7 +246,7 @@ void MetadataMediatorTest::testDataset0() {
   // verify existence
   CORRADE_VERIFY(objAttr);
   // verify set to values in dataset_config file
-  newRenderAssetHandle = objAttr->getRenderAssetHandle();
+  newRenderAssetHandle = objAttr->getRenderAssetFullPath();
   // verify same renderasset handle to loaded stage attributes
   CORRADE_VERIFY(newRenderAssetHandle.find("dataset_test_object3.glb") !=
                  std::string::npos);
@@ -445,12 +445,12 @@ void MetadataMediatorTest::testDataset0() {
   const auto semanticAttr1 =
       semanticMgr->getObjectCopyByHandle("semantic_descriptor_path1");
 
-  CORRADE_COMPARE(semanticAttr1->getSemanticDescriptorFilename(),
+  CORRADE_COMPARE(semanticAttr1->getSemanticDescriptorFullPath(),
                   "test_semantic_descriptor_path1");
 
   const auto semanticAttr2 =
       semanticMgr->getObjectCopyByHandle("semantic_descriptor_path2");
-  CORRADE_COMPARE(semanticAttr2->getSemanticDescriptorFilename(),
+  CORRADE_COMPARE(semanticAttr2->getSemanticDescriptorFullPath(),
                   "test_semantic_descriptor_path2");
 
   // end test LoadSemanticScene

--- a/src/tests/Mp3dTest.cpp
+++ b/src/tests/Mp3dTest.cpp
@@ -36,6 +36,8 @@ void Mp3dTest::testLoad() {
   auto mp3dAttr =
       esp::metadata::attributes::SemanticAttributes::create("mp3dTestAttrs");
   mp3dAttr->setSemanticDescriptorFilename(filename);
+  mp3dAttr->setSemanticDescriptorFullPath(filename);
+
   esp::scene::SemanticScene house;
   const esp::quatf alignGravity =
       esp::quatf::FromTwoVectors(-esp::vec3f::UnitZ(), esp::geo::ESP_GRAVITY);

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -586,7 +586,7 @@ void SimTest::loadingObjectTemplates() {
   CORRADE_COMPARE(templateIndex2, templateIndex);
   ObjectAttributes::ptr newTemplate2 =
       objectAttribsMgr->getObjectCopyByHandle(boxPath);
-  CORRADE_COMPARE(newTemplate2->getRenderAssetHandle(), chairPath);
+  CORRADE_COMPARE(newTemplate2->getRenderAssetFullPath(), chairPath);
 }
 
 void SimTest::buildingPrimAssetObjectTemplates() {

--- a/tests/test_attributes_managers.py
+++ b/tests/test_attributes_managers.py
@@ -307,7 +307,7 @@ def test_stage_attributes_managers():
         assert template0.gravity == mn.Vector3(0.0, -9.8, 0.0)
 
         # verify creating new template
-        perform_add_blank_template_test(stage_mgr, template0.render_asset_handle)
+        perform_add_blank_template_test(stage_mgr, template0.render_asset_fullpath)
 
 
 def test_object_attributes_managers():
@@ -323,7 +323,7 @@ def test_object_attributes_managers():
         template0, _ = perform_general_tests(obj_mgr, rand_obj_handle)
 
         # verify creating new template
-        perform_add_blank_template_test(obj_mgr, template0.render_asset_handle)
+        perform_add_blank_template_test(obj_mgr, template0.render_asset_fullpath)
 
 
 def perform_asset_attrib_mgr_tests(attr_mgr, default_attribs, legalVal, illegalVal):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -250,8 +250,10 @@ def test_object_template_editing():
             assert obj.object_id != habitat_sim.stage_id
 
             # test getting initialization templates
+            # NOTE : After template is registered, the read-only 'render_asset_fullpath'
+            # field holds the fully qualified path
             stage_init_template = sim.get_stage_initialization_template()
-            assert stage_init_template.render_asset_handle == cfg_settings["scene"]
+            assert stage_init_template.render_asset_fullpath == cfg_settings["scene"]
 
             obj_init_template = obj.creation_attributes
             assert obj_init_template.render_asset_handle.endswith("sphere.glb")


### PR DESCRIPTION
## Motivation and Context
This PR is the 2nd of 2 PRs started with [this PR](https://github.com/facebookresearch/habitat-sim/pull/2396) that add state-based support to ConfigValues.  This PR is primarily concerned with implementing hidden/internal configuration fields intended to be used for data that is only locally relevant, such as fully-qualified file paths. 

We do not want file names saved to json that embed absolute path data, so we need to keep a version of the path data that remains relative to the location of the JSON config file while we also want to have an easily consumed absolute path to the assets in question.  Using the hidden field feature, paths can be saved in the configs as they are loaded, or otherwise relative to the dataset config directory, while they can be accessed internally fully qualified.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
