### PR TITLE
[CI] - add lab ci asset downloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
               conda install -y gitpython git-lfs
               cd habitat-sim
               git lfs install
-              python src_python/habitat_sim/utils/datasets_download.py --uids ci_test_assets --replace --data-path data/ --no-prune
+              python src_python/habitat_sim/utils/datasets_download.py --uids ci_test_assets ycb rearrange_dataset_v2 --replace --data-path data/ --no-prune
               ls -la data/scene_datasets/habitat-test-scenes/
 
       - run:


### PR DESCRIPTION
## Motivation and Context

This PR adds ycb and rearrange_v2 data downloads to support removal of auto-downloader from lab tests in https://github.com/facebookresearch/habitat-lab/pull/1962

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
