### PR TITLE
--Bugfix : Expand absolute-to-relative filepath mapping rigor

### DIFF
--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -78,14 +78,14 @@ std::string getPathRelativeToAbsPath(const std::string& toRelPath,
 
     ++absIter;
   }
-  std::string scratch = "";
-  // build relative path in scratch
+  // Relative tail of path
+  std::string relTail = "";
   while (relIter != relDirs.cend()) {
     if (*relIter == *relDirs.crbegin()) {
-      Cr::Utility::formatInto(result, result.size(), "{}{}", scratch,
+      Cr::Utility::formatInto(result, result.size(), "{}{}", relTail,
                               *relDirs.crbegin());
     } else {
-      Cr::Utility::formatInto(scratch, scratch.size(), "{}{}", *relIter, delim);
+      Cr::Utility::formatInto(relTail, relTail.size(), "{}{}", *relIter, delim);
     }
     ++relIter;
   }

--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -65,8 +65,8 @@ std::string getPathRelativeToAbsPath(const std::string& toRelPath,
   auto relIter = relDirs.cbegin();
 
   // find where both paths diverge - skip shared path components
-  while (*relIter == *absIter && absIter != absDirs.cend() &&
-         relIter != relDirs.cend()) {
+  while (absIter != absDirs.cend() && relIter != relDirs.cend() &&
+         *relIter == *absIter) {
     ++relIter;
     ++absIter;
   }

--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -52,9 +52,11 @@ std::string getPathRelativeToAbsPath(const std::string& toRelPath,
   const char* delim = "/";
 
   std::vector<std::string> absDirs =
-                               Cr::Utility::String::split(absPath, delim[0]),
+                               Cr::Utility::String::splitWithoutEmptyParts(
+                                   absPath, delim[0]),
                            relDirs =
-                               Cr::Utility::String::split(toRelPath, delim[0]);
+                               Cr::Utility::String::splitWithoutEmptyParts(
+                                   toRelPath, delim[0]);
   auto absIter = absDirs.cbegin();
   auto relIter = relDirs.cbegin();
 
@@ -66,11 +68,10 @@ std::string getPathRelativeToAbsPath(const std::string& toRelPath,
   }
 
   // Add back-path components for each directory in abspath not found in
-  // toRelPaath
+  // toRelPath
   while (absIter != absDirs.cend()) {
-    if (*absIter != *absDirs.crbegin()) {
-      Cr::Utility::formatInto(result, result.size(), "..{}", delim);
-    }
+    Cr::Utility::formatInto(result, result.size(), "..{}", delim);
+
     ++absIter;
   }
   std::string scratch = "";

--- a/src/esp/io/Io.cpp
+++ b/src/esp/io/Io.cpp
@@ -47,7 +47,11 @@ std::string normalizePath(const std::string& srcPath) {
 }  // normalizePath
 
 std::string getPathRelativeToAbsPath(const std::string& toRelPath,
-                                     const std::string& absPath) {
+                                     const std::string& absPathArg) {
+  // Check if absPath is a path or filename - only use the path if it is a
+  // filenaame
+  const std::string absPath = Cr::Utility::Path::split(absPathArg).first();
+
   std::string result = "";
   const char* delim = "/";
 

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -141,7 +141,7 @@ void IOTest::testEllipsisFilter() {
 void IOTest::absToRelativePathConverison() {
   // Test conversion of an absolute path to a path relative to another path.
   // Path to be relative to
-  const std::string absPathTarget = "/aa/bb/cc/dd/ee/ff/gg/";
+  std::string absPathTarget = "/aa/bb/cc/dd/ee/ff/gg/";
 
   // Path to convert
   std::string absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/";
@@ -156,6 +156,36 @@ void IOTest::absToRelativePathConverison() {
       esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
 
   CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/");
+
+  absPathToConvert = "/aa/bb/cc/dd/ee/ff/gg/test.xyz";
+  relPathToBaseTarget =
+      esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
+
+  CORRADE_COMPARE(relPathToBaseTarget, "test.xyz");
+
+  // Test conversion of an absolute path to a path relative to another path.
+  // Path to be relative to
+  absPathTarget = "aa/bb/cc/dd/ee/ff/gg/";
+
+  // Path to convert
+  absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/";
+  // Result of conversion
+  relPathToBaseTarget =
+      esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
+
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../xx/yy/zz/");
+
+  absPathToConvert = "/aa/bb/cc/../dd/xx/yy/zz/";
+  relPathToBaseTarget =
+      esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
+
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/");
+
+  absPathToConvert = "/aa/bb/cc/dd/ee/ff/gg/test.xyz";
+  relPathToBaseTarget =
+      esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
+
+  CORRADE_COMPARE(relPathToBaseTarget, "test.xyz");
 
 }  // IOTest::absToRelativePathConverison
 

--- a/src/tests/IOTest.cpp
+++ b/src/tests/IOTest.cpp
@@ -143,19 +143,19 @@ void IOTest::absToRelativePathConverison() {
   // Path to be relative to
   std::string absPathTarget = "/aa/bb/cc/dd/ee/ff/gg/";
 
-  // Path to convert
-  std::string absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/";
+  // Filepath to convert
+  std::string absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/test.txt";
   // Result of conversion
   std::string relPathToBaseTarget =
       esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
 
-  CORRADE_COMPARE(relPathToBaseTarget, "../../../xx/yy/zz/");
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../xx/yy/zz/test.txt");
 
-  absPathToConvert = "/aa/bb/cc/../dd/xx/yy/zz/";
+  absPathToConvert = "/aa/bb/cc/../dd/xx/yy/zz/test.txt";
   relPathToBaseTarget =
       esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
 
-  CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/");
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/test.txt");
 
   absPathToConvert = "/aa/bb/cc/dd/ee/ff/gg/test.xyz";
   relPathToBaseTarget =
@@ -168,18 +168,18 @@ void IOTest::absToRelativePathConverison() {
   absPathTarget = "aa/bb/cc/dd/ee/ff/gg/";
 
   // Path to convert
-  absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/";
+  absPathToConvert = "/aa/bb/cc/dd/xx/yy/zz/test.txt";
   // Result of conversion
   relPathToBaseTarget =
       esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
 
-  CORRADE_COMPARE(relPathToBaseTarget, "../../../xx/yy/zz/");
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../xx/yy/zz/test.txt");
 
-  absPathToConvert = "/aa/bb/cc/../dd/xx/yy/zz/";
+  absPathToConvert = "/aa/bb/cc/../dd/xx/yy/zz/test.txt";
   relPathToBaseTarget =
       esp::io::getPathRelativeToAbsPath(absPathToConvert, absPathTarget);
 
-  CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/");
+  CORRADE_COMPARE(relPathToBaseTarget, "../../../../../dd/xx/yy/zz/test.txt");
 
   absPathToConvert = "/aa/bb/cc/dd/ee/ff/gg/test.xyz";
   relPathToBaseTarget =


### PR DESCRIPTION
## Motivation and Context
This PR addresses some edge case situations that might arise when absolute filepaths are made relative to other paths.

It also substantially expands the tests of this functionality.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
