### PR TITLE
[bugfix] - reorder Configuration setter bindings 

### DIFF
--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -105,6 +105,13 @@ void initConfigBindings(py::module& m) {
           "key"_a, "value"_a)
       .def(
           "set",
+          [](Configuration& self, const std::string& key, const bool val) {
+            self.set(key, val);
+          },
+          R"(Set the value specified by given string key to be specified boolean value)",
+          "key"_a, "value"_a)
+      .def(
+          "set",
           [](Configuration& self, const std::string& key, const int val) {
             self.set(key, val);
           },
@@ -116,13 +123,6 @@ void initConfigBindings(py::module& m) {
             self.set(key, val);
           },
           R"(Set the value specified by given string key to be specified double value)",
-          "key"_a, "value"_a)
-      .def(
-          "set",
-          [](Configuration& self, const std::string& key, const bool val) {
-            self.set(key, val);
-          },
-          R"(Set the value specified by given string key to be specified boolean value)",
           "key"_a, "value"_a)
       .def(
           "set",

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -30,8 +30,9 @@ def test_core_configuration():
     config.remove("test")
     assert not config.has_value("test")
 
-    config.set("bool", np.array(True))
+    config.set("bool", True)
     assert config.get("bool") == True
+    assert type(config.get("bool")) == bool
 
     config.set("integer", 3)
     assert config.get("integer") == 3


### PR DESCRIPTION
## Motivation and Context

Python seems to treat bindings as a dict or list and searches for the first matching override for a bound function. Python treats Bool as a subclass of Integer, so set(key, Bool) in Configuration was writing integers. Re-ordering the bindings fixes this.

## How Has This Been Tested

Local testing and new python test case

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
