### PR TITLE
--[BUGFIX] - Properly set instance user config from base passed base config.

### DIFF
--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -45,6 +45,12 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     const std::string& handle,
     const std::shared_ptr<AbstractObjectAttributes>& baseObjAttribs)
     : SceneObjectInstanceAttributes(handle) {
+  // This constructor is for internally generated SceneObjectInstanceAttributes,
+  // to correspond to an object that is being created programmatically and saved
+  // to a scene instance.
+  // Handle is set via init in base class, which would not be written out to
+  // file if we did not explicitly set it.
+  setHandle(handle);
   // set appropriate fields from abstract object attributes
   // Not initialize, since these are not default values
   set("shader_type", getShaderTypeName(baseObjAttribs->getShaderType()));
@@ -182,9 +188,13 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
 SceneAOInstanceAttributes::SceneAOInstanceAttributes(
     const std::string& handle,
     const std::shared_ptr<ArticulatedObjectAttributes>& aObjAttribs)
-    : SceneObjectInstanceAttributes(handle, "SceneAOInstanceAttributes") {
-  // initialize default auto clamp values (only used for articulated object)
-  init("auto_clamp_joint_limits", false);
+    : SceneAOInstanceAttributes(handle) {
+  // This constructor is for internally generated SceneAOInstanceAttributes, to
+  // correspond to an object that is being created programmatically and saved to
+  // a scene instance.
+  // Handle is set via init in base class, which would not be written out to
+  // file if we did not explicitly set it.
+  setHandle(handle);
 
   // Should not initialize these values but set them, since these are not
   // default values, but from an existing AO attributes.

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -50,10 +50,12 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   set("shader_type", getShaderTypeName(baseObjAttribs->getShaderType()));
   // set to match attributes setting
   set("is_instance_visible", (baseObjAttribs->getIsVisible() ? 1 : 0));
+
   // set nonuniform scale to match attributes scale
   setNonUniformScale(baseObjAttribs->getScale());
   // Prepopulate user config to match baseObjAttribs' user config.
-  overwriteWithConfig(baseObjAttribs->getUserConfiguration());
+  editUserConfiguration()->overwriteWithConfig(
+      baseObjAttribs->getUserConfiguration());
 }
 
 std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
@@ -197,10 +199,10 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(
   setLinkOrder(getAOLinkOrderName(aObjAttribs->getLinkOrder()));
   // Set render mode to use aObjAttribs value
   setRenderMode(getAORenderModeName(aObjAttribs->getRenderMode()));
-  // set appropriate values to match values in aObjAttribs
-  setMassScale(aObjAttribs->getMassScale());
+
   // Prepopulate user config to match attribs' user config.
-  overwriteWithConfig(aObjAttribs->getUserConfiguration());
+  editUserConfiguration()->overwriteWithConfig(
+      aObjAttribs->getUserConfiguration());
   editSubconfig<Configuration>("initial_joint_pose");
   editSubconfig<Configuration>("initial_joint_velocities");
 }

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -225,6 +225,24 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   void writeValuesToJson(io::JsonGenericValue& jsonObj,
                          io::JsonAllocator& allocator) const override;
 
+  /**
+   * @brief Retrieve a comma-separated string holding the header values for the
+   * info returned for this managed object.
+   */
+  std::string getObjectInfoHeader() const override {
+    return Cr::Utility::formatString("Template Name, ID, {}",
+                                     getObjectInfoHeaderInternal());
+  }
+
+  /**
+   * @brief Retrieve a comma-separated informational string about the contents
+   * of this managed object.
+   */
+  std::string getObjectInfo() const override {
+    return Cr::Utility::formatString(
+        "{},{},{}", getHandle(), getAsString("__ID"), getObjectInfoInternal());
+  }
+
  protected:
   friend class esp::metadata::managers::SceneInstanceAttributesManager;
   /**

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -202,10 +202,14 @@ int PhysicsManager::addObjectAndSaveAttributes(
   }
 
   if (objInstAttributes == nullptr) {
-    // Create objInstAttributes and populate with start values from
-    objInstAttributes = resourceManager_.getSceneInstanceAttributesManager()
-                            ->createEmptyInstanceAttributes(
-                                objAttributes->getHandle(), objAttributes);
+    // Create objInstAttributes and populate with start values from config
+    // attributes.
+    // Use simplified handle to reference attributes
+    // TODO : probably need something more specific eventually
+    objInstAttributes =
+        resourceManager_.getSceneInstanceAttributesManager()
+            ->createEmptyInstanceAttributes(
+                objAttributes->getSimplifiedHandle(), objAttributes);
   }
 
   // create and add object using provided object attributes
@@ -528,10 +532,14 @@ int PhysicsManager::addArticulatedObjectAndSaveAttributes(
     return ID_UNDEFINED;
   }
   if (aObjInstAttributes == nullptr) {
+    // Create aObjInstAttributes and populate with start values from config
+    // attributes.
+    // Use simplified handle to reference attributes
+    // TODO : probably need something more specific eventually
     aObjInstAttributes =
         resourceManager_.getSceneInstanceAttributesManager()
-            ->createEmptyAOInstanceAttributes(artObjAttributes->getHandle(),
-                                              artObjAttributes);
+            ->createEmptyAOInstanceAttributes(
+                artObjAttributes->getSimplifiedHandle(), artObjAttributes);
     // TODO do we need to save this to curSceneInstanceAttributes responsible
     // for this scene?
   }


### PR DESCRIPTION
## Motivation and Context
This PR properly copies the user defined attributes from a base config to an instance config's user-defined subconfig, instead of in the subconfig's base level.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Local c++ and python tests
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
