### PR TITLE
Add stubs to python bindings to provide typing information.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ numba
 numpy==1.26.4
 numpy-quaternion
 pillow
+pybind11-stubgen
 scipy>=1.10.1
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -264,6 +264,16 @@ class CMakeBuild(build_ext):
         for ext in self.extensions:
             self.build_extension(ext)
 
+        # Build stubs for 'habitat_sim_bindings' to provide type information.
+        subprocess.run(
+            [
+                "pybind11-stubgen",
+                "habitat_sim._ext.habitat_sim_bindings",
+                "-o",
+                "src_python",
+            ]
+        )
+
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
 
@@ -450,21 +460,28 @@ if __name__ == "__main__":
     setup(
         name="habitat_sim",
         version=habitat_sim.__version__,
-        author="FAIR A-STAR",
+        author="Meta",
         description="A high performance simulator for training embodied agents",
         long_description="",
         packages=find_packages(where="src_python"),
         package_dir={"": "src_python"},
         install_requires=requirements,
         tests_require=["hypothesis", "pytest-benchmark", "pytest"],
+        setup_requires=["pybind11-stubgen"],
         python_requires=">=3.9",
         # add extension module
         ext_modules=[CMakeExtension("habitat_sim._ext.habitat_sim_bindings", "src")],
         # add custom build_ext command
-        cmdclass=dict(build_ext=CMakeBuild),
+        cmdclass={
+            "build_ext": CMakeBuild,
+        },
         zip_safe=False,
         include_package_data=True,
+        package_data={
+            "habitat_sim": ["py.typed", "**/*.pyi"],
+        },
     )
+
     pymagnum_build_dir = osp.join(
         _cmake_build_dir, "deps", "magnum-bindings", "src", "python"
     )


### PR DESCRIPTION
## Motivation and Context

This changeset adds stubs to python bindings to provide typing information.
Stub generation depends on `pybind11-stubgen`.

https://github.com/facebookresearch/habitat-sim/assets/110583667/86593700-7896-4dc5-9ca7-a6d077beaad9

**Note that this is WIP. Stub contains some errors, but mostly work.**

## How Has This Been Tested

Tested by importing `habitat_sim` in an external Python file.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
