### PR TITLE
--[BE] - Add utility function to specify whether object is ao or not

### DIFF
--- a/src/esp/bindings/PhysicsObjectBindings.cpp
+++ b/src/esp/bindings/PhysicsObjectBindings.cpp
@@ -191,10 +191,14 @@ void declareBasePhysicsObjectWrapper(py::module& m,
           ("Rotate this " + objType +
            " by passed angle_in_rad around the z-axis in local frame.")
               .c_str())
+      .def_property_readonly("is_articulated", &PhysObjWrapper::isArticulated,
+                             ("Return whether or not this " + objType +
+                              " object is an articulated object or part of one")
+                                 .c_str())
       .def_property_readonly(
           "visual_scene_nodes", &PhysObjWrapper::getVisualSceneNodes,
           ("Get a list of references to the SceneNodes with this " + objType +
-           "' render assets attached. Use this to manipulate this " + objType +
+           "'s render assets attached. Use this to manipulate this " + objType +
            "'s visual state. Changes to these nodes will not affect physics "
            "simulation.")
               .c_str())

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -461,8 +461,8 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
     return getSubconfigValsOfTypeInVector<float>("initial_joint_pose");
   }
 
-  void setInitJointVelocities(const std::vector<float>& _jointPose) {
-    setSubconfigValsOfTypeInVector("initial_joint_velocities", _jointPose);
+  void setInitJointVelocities(const std::vector<float>& _jointVels) {
+    setSubconfigValsOfTypeInVector("initial_joint_velocities", _jointVels);
   }
 
   /**
@@ -472,35 +472,6 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
   std::vector<float> getInitJointVelocities() const {
     return getSubconfigValsOfTypeInVector<float>("initial_joint_velocities");
   }
-
-  // /**
-  //  * @brief Add a value to this scene attributes joint initial pose map
-  //  * @param key the location/joint name to place the value
-  //  * @param val the joint value to set
-  //  */
-  // void addInitJointPoseVal(const std::string& key, float val) {
-  //   initJointPose_[key] = val;
-  // }
-
-  // /**
-  //  * @brief retrieve a mutable reference to this scene attributes joint
-  //  * initial velocity map
-  //  */
-  // const std::map<std::string, float>& getInitJointVelocities() const {
-  //   return initJointVelocities_;
-  // }
-  // std::map<std::string, float>& copyIntoInitJointVelocities() {
-  //   return initJointVelocities_;
-  // }
-
-  // /**
-  //  * @brief Add a value to this scene attributes joint initial velocity map
-  //  * @param key the location/joint name to place the value
-  //  * @param val the joint angular velocity value to set
-  //  */
-  // void addInitJointVelocityVal(const std::string& key, float val) {
-  //   initJointVelocities_[key] = val;
-  // }
 
  protected:
   friend class esp::metadata::managers::SceneInstanceAttributesManager;

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -263,6 +263,9 @@ class ArticulatedLink : public RigidBase {
   std::string linkName = "";
   std::string linkJointName = "";
 
+  /** @brief Return whether or not this object is articulated. */
+  bool isArticulated() const override { return true; }
+
  private:
   /**
    * @brief Finalize the initialization of this link.
@@ -956,7 +959,7 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   std::shared_ptr<const metadata::attributes::SceneAOInstanceAttributes>
   getInitObjectInstanceAttr() const {
     return PhysicsObjectBase::getInitObjectInstanceAttrInternal<
-        const metadata::attributes::SceneAOInstanceAttributes>();
+        metadata::attributes::SceneAOInstanceAttributes>();
   }
 
   /**
@@ -991,7 +994,10 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   getInitializationAttributes() const {
     return PhysicsObjectBase::getInitializationAttributes<
         metadata::attributes::ArticulatedObjectAttributes>();
-  };
+  }
+
+  /** @brief Return whether or not this object is articulated. */
+  bool isArticulated() const override { return true; }
 
  protected:
   /**

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -100,7 +100,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     if (!initializationAttributes_) {
       return nullptr;
     }
-    return T::create(*(static_cast<T*>(initializationAttributes_.get())));
+    return T::create(*(static_cast<const T*>(initializationAttributes_.get())));
   }
 
   /**
@@ -598,6 +598,10 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual Magnum::Vector3 getScale() const { return _creationScale; }
 
+  /** @brief Return whether or not this object is articulated. Override in
+   * ArticulatedObject */
+  virtual bool isArticulated() const { return false; }
+
  protected:
   /** @brief Accessed internally. Get an appropriately cast copy of the @ref
    * metadata::attributes::SceneObjectInstanceAttributes used to place the
@@ -610,7 +614,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     if (!_initObjInstanceAttrs) {
       return nullptr;
     }
-    return T::create(*(static_cast<T*>(_initObjInstanceAttrs.get())));
+    return T::create(*(static_cast<const T*>(_initObjInstanceAttrs.get())));
   }
 
   /**
@@ -700,11 +704,15 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   metadata::attributes::MarkerSets::ptr markerSets_ = nullptr;
 
   /**
-   * @brief Saved attributes when the object was initialized.
+   * @brief Saved template attributes when the object was initialized.
    */
-  metadata::attributes::AbstractAttributes::ptr initializationAttributes_ =
+  metadata::attributes::AbstractAttributes::cptr initializationAttributes_ =
       nullptr;
 
+  /**
+   * @brief Saved reference to this object's instantiating template manager
+   */
+  // metadata::managers::AttributesManager::ptr templateManager_ = nullptr;
   /**
    * @brief Set the object's creation scale
    */

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -284,7 +284,7 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   std::shared_ptr<const metadata::attributes::SceneObjectInstanceAttributes>
   getInitObjectInstanceAttr() const {
     return PhysicsObjectBase::getInitObjectInstanceAttrInternal<
-        const metadata::attributes::SceneObjectInstanceAttributes>();
+        metadata::attributes::SceneObjectInstanceAttributes>();
   }
 
   /**

--- a/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
+++ b/src/esp/physics/bullet/objectWrappers/ManagedBulletRigidObject.h
@@ -60,20 +60,20 @@ class ManagedBulletRigidObject : public esp::physics::ManagedRigidObject {
   //! no bullet version
   double getMargin() const {
     ESP_WARNING() << "This functionally requires Habitat-Sim to be compiled "
-                     "with Bullet enabled..";
+                     "with Bullet enabled.";
 
     return 0.0;
   }  // getMargin
 
   void setMargin(CORRADE_UNUSED const double margin) {
     ESP_WARNING() << "This functionally requires Habitat-Sim to be compiled "
-                     "with Bullet enabled..";
+                     "with Bullet enabled.";
 
   }  // setMass
 
   Magnum::Range3D getCollisionShapeAabb() {
     ESP_WARNING() << "This functionally requires Habitat-Sim to be compiled "
-                     "with Bullet enabled..";
+                     "with Bullet enabled.";
 
     return {};
   }  // getCollisionShapeAabbb

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -346,6 +346,14 @@ class AbstractManagedPhysicsObject
            getPhyObjInfoHeaderInternal();
   }
 
+  /** @brief Return whether or not this object is articulated. */
+  bool isArticulated() const {
+    if (auto sp = this->getObjectReference()) {
+      return sp->isArticulated();
+    }
+    return false;
+  }
+
   /**
    * @brief Retrieve a comma-separated informational string about the contents
    * of this managed object.

--- a/src/tests/PhysicsTest.cpp
+++ b/src/tests/PhysicsTest.cpp
@@ -230,6 +230,8 @@ void PhysicsTest::testJoinCompound() {
       int num_objects = 7;
       for (int o = 0; o < num_objects; ++o) {
         auto objWrapper = rigidObjectManager_->addObjectByHandle(objectFile);
+        // Verify is not an articulated object or part of one
+        CORRADE_VERIFY(!objWrapper->isArticulated());
 
         esp::scene::SceneNode* node = objWrapper->getSceneNode();
 
@@ -364,8 +366,11 @@ void PhysicsTest::testDiscreteContactTest() {
 
     // generate two centered boxes with dimension 2x2x2
     auto objWrapper0 = rigidObjectManager_->addObjectByHandle(objectFile);
+    // Verify is not an articulated object or part of one
+    CORRADE_VERIFY(!objWrapper0->isArticulated());
     auto objWrapper1 = rigidObjectManager_->addObjectByHandle(objectFile);
-
+    // Verify is not an articulated object or part of one
+    CORRADE_VERIFY(!objWrapper1->isArticulated());
     // place them in collision free location (0.1 about ground plane and 0.2
     // apart)
     objWrapper0->setTranslation(Magnum::Vector3{0, 1.1, 0});

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -993,6 +993,8 @@ void SimTest::testArticulatedObjectSkinned() {
 
   CORRADE_COMPARE(aoManager->getNumObjects(), 0);
   auto ao = aoManager->addArticulatedObjectFromURDF(urdfFile);
+  // Verify is an articulated object
+  CORRADE_VERIFY(ao->isArticulated());
   CORRADE_COMPARE(aoManager->getNumObjects(), 1);
 
   CORRADE_COMPARE(ao->getSceneNode()->getSemanticId(), 100);
@@ -1003,14 +1005,19 @@ void SimTest::testArticulatedObjectSkinned() {
   const auto linkIds = ao->getLinkIdsWithBase();
 
   auto linkA = ao->getLink(linkIds[0]);
+  CORRADE_VERIFY(linkA->isArticulated());
   CORRADE_VERIFY(linkA->linkName == "A");
   auto linkB = ao->getLink(linkIds[1]);
+  CORRADE_VERIFY(linkB->isArticulated());
   CORRADE_VERIFY(linkB->linkName == "B");
   auto linkC = ao->getLink(linkIds[2]);
+  CORRADE_VERIFY(linkC->isArticulated());
   CORRADE_VERIFY(linkC->linkName == "C");
   auto linkD = ao->getLink(linkIds[3]);
+  CORRADE_VERIFY(linkD->isArticulated());
   CORRADE_VERIFY(linkD->linkName == "D");
   auto linkE = ao->getLink(linkIds[4]);
+  CORRADE_VERIFY(linkE->isArticulated());
   CORRADE_VERIFY(linkE->linkName == "E");
 
   ao->setTranslation({1.f, -3.f, -6.f});

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -60,6 +60,8 @@ def test_kinematics():
         # get handle for object 0, used to test
         obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
         cheezit_box = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+        # Verify is not articulated
+        assert not cheezit_box.is_articulated
         assert rigid_obj_mgr.get_num_objects() > 0
         assert (
             len(rigid_obj_mgr.get_object_handles()) == rigid_obj_mgr.get_num_objects()
@@ -174,6 +176,8 @@ def test_kinematics_no_physics():
         # get handle for object 0, used to test
         obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
         cheezit_box = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+        # Verify is not articulated
+        assert not cheezit_box.is_articulated
         assert rigid_obj_mgr.get_num_objects() > 0
         assert (
             len(rigid_obj_mgr.get_object_handles()) == rigid_obj_mgr.get_num_objects()
@@ -296,8 +300,11 @@ def test_dynamics():
         # test adding an object to the world
         obj_handle_list = obj_template_mgr.get_template_handles("cheezit")
         cheezit_box1 = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
+        # Verify is not articulated
+        assert not cheezit_box1.is_articulated
         cheezit_box2 = rigid_obj_mgr.add_object_by_template_handle(obj_handle_list[0])
-
+        # Verify is not articulated
+        assert not cheezit_box2.is_articulated
         assert rigid_obj_mgr.get_num_objects() > 0
         assert (
             len(rigid_obj_mgr.get_object_handles()) == rigid_obj_mgr.get_num_objects()
@@ -438,6 +445,8 @@ def test_velocity_control():
             sim.reset()
 
             box_object = rigid_obj_mgr.add_object_by_template_handle(obj_handle)
+            # Verify is not articulated
+            assert not box_object.is_articulated
             vel_control = box_object.velocity_control
 
             if iteration == 0:
@@ -549,6 +558,9 @@ def test_raycast():
             # add a primitive object to the world and test a ray away from the origin
             cube_prim_handle = obj_template_mgr.get_template_handles("cube")[0]
             cube_obj = rigid_obj_mgr.add_object_by_template_handle(cube_prim_handle)
+            # Verify is not articulated
+            assert not cube_obj.is_articulated
+
             cube_obj.translation = [2.0, 0.0, 2.0]
 
             test_ray_1.origin = np.array([0.0, 0, 2.0])
@@ -648,7 +660,11 @@ def test_collision_groups():
 
             cube_prim_handle = obj_template_mgr.get_template_handles("cube")[0]
             cube_obj1 = rigid_obj_mgr.add_object_by_template_handle(cube_prim_handle)
+            # Verify is not articulated
+            assert not cube_obj1.is_articulated
             cube_obj2 = rigid_obj_mgr.add_object_by_template_handle(cube_prim_handle)
+            # Verify is not articulated
+            assert not cube_obj2.is_articulated
             # add a DYNAMIC cube in a contact free state
             cube_obj1.translation = [1.0, 0.0, 4.5]
             assert not cube_obj1.contact_test()
@@ -665,7 +681,8 @@ def test_collision_groups():
             ao = ao_mgr.add_articulated_object_from_urdf(
                 filepath="data/test_assets/urdf/amass_male.urdf"
             )
-
+            # Verify is articulated
+            assert ao.is_articulated
             ao.translation = [1.3, 0.0, 4.6]
             assert ao.contact_test()
             assert cube_obj2.contact_test()
@@ -703,6 +720,8 @@ def test_collision_groups():
             ao2 = ao_mgr.add_articulated_object_from_urdf(
                 filepath="data/test_assets/urdf/amass_male.urdf"
             )
+            # Verify is articulated
+            assert ao2.is_articulated
             ao2.translation = new_translation
             ao2.awake = False
             ao.awake = False
@@ -907,6 +926,8 @@ def test_articulated_object_add_remove():
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
         assert robot
         assert robot.is_alive
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.object_id == habitat_sim.stage_id + 1  # first robot added
 
         # test object id to link mapping
@@ -927,6 +948,8 @@ def test_articulated_object_add_remove():
             filepath=robot_file, global_scale=2.0
         )
         assert robot2
+        # Verify is articulated
+        assert robot2.is_articulated
         assert art_obj_mgr.get_num_objects() == 2
         assert robot2.global_scale == 2.0
 
@@ -938,7 +961,9 @@ def test_articulated_object_add_remove():
 
         # add some more
         for _i in range(5):
-            art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+            tmp_ao = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+            # Verify is articulated
+            assert tmp_ao.is_articulated
         assert art_obj_mgr.get_num_objects() == 6
 
         # remove another
@@ -973,6 +998,8 @@ def test_articulated_object_maintain_link_order():
             filepath=amass_file, maintain_link_order=True
         )
         assert ao
+        # Verify is articulated
+        assert ao.is_articulated
         assert ao.is_alive
 
         amass_urdf_link_order = [
@@ -1030,6 +1057,8 @@ def test_articulated_object_kinematics(test_asset):
 
         # parse URDF and add an ArticulatedObject to the world
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
 
         # NOTE: basic transform properties refer to the root state
@@ -1182,6 +1211,8 @@ def test_articulated_object_dynamics(test_asset):
 
         # parse URDF and add an ArticulatedObject to the world
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
 
         # object should be initialized with dynamics
@@ -1244,6 +1275,8 @@ def test_articulated_object_dynamics(test_asset):
         robot = art_obj_mgr.add_articulated_object_from_urdf(
             filepath=robot_file, fixed_base=True
         )
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.translation == mn.Vector3(0)
         assert robot.motion_type == habitat_sim.physics.MotionType.DYNAMIC
         # perturb the system dynamically
@@ -1259,6 +1292,8 @@ def test_articulated_object_dynamics(test_asset):
         # instance fresh robot with free base
         art_obj_mgr.remove_object_by_id(robot.object_id)
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot.is_articulated
         # put object to sleep
         assert robot.can_sleep
         assert robot.awake
@@ -1270,6 +1305,8 @@ def test_articulated_object_dynamics(test_asset):
 
         # add a new object to drop onto the first, waking it up
         robot2 = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot2.is_articulated
         sim.step_physics(0.5)
         assert robot.awake
         assert robot2.awake
@@ -1298,6 +1335,8 @@ def test_articulated_object_fixed_base_proxy():
         robot = art_obj_mgr.add_articulated_object_from_urdf(
             filepath=robot_file, fixed_base=True
         )
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
 
         # add a test object to the world
@@ -1339,6 +1378,8 @@ def test_articulated_object_damping_joint_motors():
         art_obj_mgr = sim.get_articulated_object_manager()
         # parse URDF and add an ArticulatedObject to the world
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
         # When URDF joint damping is defined, we generate a set of motors automatically
         # get a map of joint motor ids to starting DoF indices
@@ -1415,6 +1456,8 @@ def test_articulated_object_joint_motors(test_asset):
         robot = art_obj_mgr.add_articulated_object_from_urdf(
             filepath=robot_file, fixed_base=True
         )
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
 
         # remove any automatically created motors
@@ -1796,6 +1839,8 @@ def test_rigid_constraints():
         robot = art_obj_mgr.add_articulated_object_from_urdf(
             filepath=robot_file, fixed_base=False
         )
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
         # need motors to stabalize the humanoid
         joint_motor_settings = habitat_sim.physics.JointMotorSettings()
@@ -1945,6 +1990,8 @@ def test_rigid_constraints():
         robot2 = art_obj_mgr.add_articulated_object_from_urdf(
             filepath=robot_file, fixed_base=True
         )
+        # Verify is articulated
+        assert robot2.is_articulated
         robot2.translation = [-0.775, 0.0, 0.0]
         robot2.create_all_motors(joint_motor_settings)
 
@@ -2029,6 +2076,7 @@ def test_bullet_collision_helper():
         cube_prim_handle = obj_template_mgr.get_template_handles("cube")[0]
         rigid_obj_mgr = sim.get_rigid_object_manager()
         cube_obj = rigid_obj_mgr.add_object_by_template_handle(cube_prim_handle)
+        assert not cube_obj.is_articulated
         cube_obj.translation = [2.5, 1.5, 2.5]
 
         sim.step_physics(0.01)
@@ -2065,6 +2113,8 @@ def test_bullet_collision_helper():
 
         # parse URDF and add an ArticulatedObject to the world
         robot = art_obj_mgr.add_articulated_object_from_urdf(filepath=robot_file)
+        # Verify is articulated
+        assert robot.is_articulated
         assert robot.is_alive
 
         robot.translation = mn.Vector3(2.5, 4.0, 2.5)


### PR DESCRIPTION
## Motivation and Context
This small PR exposes a read-only property ("is_articulated") in the python bindings that says whether an object is articulated or not, as an alternative to checking for the object type before attempting to access type-specific functions.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
c++ PhysicsTest.cpp and SimTest.cpp and python test_physics.py have been expanded to test this field, and all tests pass locally.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
