### PR TITLE
--[BE] - Remove deprecated Sim-level contact test

### DIFF
--- a/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
+++ b/examples/tutorials/nb_python/ECCV_2020_Interactivity.py
@@ -320,7 +320,7 @@ def sample_object_state(
             )
 
         # test for penetration with the environment
-        if not sim.contact_test(obj.object_id):
+        if not obj.contact_test():
             valid_placement = True
 
     if not valid_placement:

--- a/examples/tutorials/notebooks/ECCV_2020_Interactivity.ipynb
+++ b/examples/tutorials/notebooks/ECCV_2020_Interactivity.ipynb
@@ -319,7 +319,7 @@
     "            )\n",
     "\n",
     "        # test for penetration with the environment\n",
-    "        if not sim.contact_test(obj.object_id):\n",
+    "        if not obj.contact_test():\n",
     "            valid_placement = True\n",
     "\n",
     "    if not valid_placement:\n",

--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -239,9 +239,6 @@ void initSimBindings(py::module& m) {
            "collidable"_a,
            R"(Set whether or not the static stage is collidable.)")
       .def(
-          "contact_test", &Simulator::contactTest, "object_id"_a,
-          R"(DEPRECATED AND WILL BE REMOVED IN HABITAT-SIM 2.0. Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
-      .def(
           "get_physics_num_active_contact_points",
           &Simulator::getPhysicsNumActiveContactPoints,
           R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -679,31 +679,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       CORRADE_UNUSED const Magnum::Matrix4& projTrans) const {}
 
   /**
-   * @brief Check whether an object is in contact with any other objects or the
-   * scene.
-   *
-   * @param physObjectID The object ID and key identifying the object in @ref
-   * PhysicsManager::existingObjects_.
-   * @return Whether or not the object is in contact with any other collision
-   * enabled objects.
-   */
-  virtual bool contactTest(const int physObjectID) {
-    const auto existingObjsIter = existingObjects_.find(physObjectID);
-    bool existingObjFound = (existingObjsIter != existingObjects_.end());
-    const auto existingArtObjsIter =
-        existingArticulatedObjects_.find(physObjectID);
-    CORRADE_INTERNAL_ASSERT(
-        existingObjFound ||
-        (existingArtObjsIter != existingArticulatedObjects_.end()));
-    if (existingObjFound) {
-      return existingObjsIter->second->contactTest();
-    } else {
-      return existingArtObjsIter->second->contactTest();
-    }
-    return false;
-  }
-
-  /**
    * @brief Perform discrete collision detection for the scene with the derived
    * PhysicsManager implementation. Not implemented for default @ref
    * PhysicsManager. See @ref BulletPhysicsManager.

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -309,21 +309,6 @@ class Simulator {
   }
 
   /**
-   * @brief Discrete collision check for contact between an object and the
-   * collision world.
-   * @param objectId The object ID and key identifying the object in @ref
-   * esp::physics::PhysicsManager::existingObjects_.
-   * @return Whether or not the object is in contact with any other collision
-   * enabled objects.
-   */
-  bool contactTest(int objectID) {
-    if (sceneHasPhysics()) {
-      return physicsManager_->contactTest(objectID);
-    }
-    return false;
-  }
-
-  /**
    * @brief Perform discrete collision detection for the scene.
    */
   void performDiscreteCollisionDetection() {


### PR DESCRIPTION
## Motivation and Context
The sim/physics manager version of contact test has been deprecated since before Habitat 2.0 was released, and should have been removed then. This PR removes it.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
