### PR TITLE
--[BE] - Duplicate existing rigid or articulated object

### DIFF
--- a/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
+++ b/src/esp/bindings/PhysicsWrapperManagerBindings.cpp
@@ -234,6 +234,16 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
           Optionally attach the object to an existing SceneNode and assign its initial
           LightSetup key. Returns a reference to the created object.)")
       .def(
+          "duplicate_object_by_id",
+#ifdef ESP_BUILD_WITH_BULLET
+          &RigidObjectManager::copyBulletObjectByID,
+#else
+          &RigidObjectManager::copyObjectByID,
+#endif
+          "object_id"_a,
+          R"(Duplicate an existing rigid object referenced by its ID and add it into the scene.
+          Returns a reference to the created object.)")
+      .def(
           "add_object_by_template_handle",
 #ifdef ESP_BUILD_WITH_BULLET
           &RigidObjectManager::addBulletObjectByHandle,
@@ -300,7 +310,16 @@ void initPhysicsWrapperManagerBindings(pybind11::module& m) {
           R"(Instance an articulated object into the scene via a template referenced by its ID.
           Optionally force the articulated object's model to be reloaded from disk and assign its initial
           LightSetup key. Returns a reference to the created object.)")
-
+      .def(
+          "duplicate_articulated_object_by_id",
+#ifdef ESP_BUILD_WITH_BULLET
+          &ArticulatedObjectManager::copyBulletArticulatedObjectByID,
+#else
+          &ArticulatedObjectManager::copyArticulatedObjectByID,
+#endif
+          "ao_object_id"_a,
+          R"(Duplicate an existing articulated object referenced by its ID and add it into the scene.
+          Returns a reference to the created object.)")
       .def(
           "add_articulated_object_from_urdf",
 #ifdef ESP_BUILD_WITH_BULLET

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -146,7 +146,9 @@ class ArticulatedLink : public RigidBase {
                   0,  // TODO: pass an actual object ID. This is currently
                       // assigned AFTER creation.
                   resMgr),
-        mbIndex_(index) {}
+        mbIndex_(index) {
+    setIsArticulated(true);
+  }
 
   ~ArticulatedLink() override = default;
 
@@ -263,9 +265,6 @@ class ArticulatedLink : public RigidBase {
   std::string linkName = "";
   std::string linkJointName = "";
 
-  /** @brief Return whether or not this object is articulated. */
-  bool isArticulated() const override { return true; }
-
  private:
   /**
    * @brief Finalize the initialization of this link.
@@ -301,7 +300,9 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
   ArticulatedObject(scene::SceneNode* rootNode,
                     assets::ResourceManager& resMgr,
                     int objectId)
-      : PhysicsObjectBase(rootNode, objectId, resMgr){};
+      : PhysicsObjectBase(rootNode, objectId, resMgr) {
+    setIsArticulated(true);
+  }
 
   ~ArticulatedObject() override {
     // clear links and delete their SceneNodes
@@ -995,9 +996,6 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
     return PhysicsObjectBase::getInitializationAttributes<
         metadata::attributes::ArticulatedObjectAttributes>();
   }
-
-  /** @brief Return whether or not this object is articulated. */
-  bool isArticulated() const override { return true; }
 
  protected:
   /**

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -123,11 +123,27 @@ int PhysicsManager::addObject(int attributesID,
 int PhysicsManager::addObjectInstance(
     const esp::metadata::attributes::SceneObjectInstanceAttributes::cptr&
         objInstAttributes,
-    const std::string& attributesHandle,
     bool defaultCOMCorrection,
     DrawableGroup* drawables,
     scene::SceneNode* attachmentNode,
     const std::string& lightSetup) {
+  // Template attributes handle from instance
+  const std::string objAttrHandle = objInstAttributes->getHandle();
+  // Get full object template attributes handle
+  const std::string attributesHandle =
+      resourceManager_.getObjectAttributesManager()->getFullAttrNameFromStr(
+          objAttrHandle);
+
+  // make sure full handle is not empty, meaning template is not found in
+  // manager
+  ESP_CHECK(!attributesHandle.empty(),
+            Cr::Utility::formatString(
+                "PhysicsManager::addObjectInstance() : Attempt to "
+                "load object instance specified in current scene instance "
+                ":{} failed due to object instance configuration handle '{}' "
+                "being empty or unknown. Aborting",
+                simulator_->getActiveSceneDatasetName(), objAttrHandle));
+
   // Get ObjectAttributes
   auto objAttributes =
       resourceManager_.getObjectAttributesManager()->getObjectCopyByHandle(
@@ -136,8 +152,7 @@ int PhysicsManager::addObjectInstance(
   if (!objAttributes) {
     ESP_ERROR(Mn::Debug::Flag::NoSpace)
         << "Missing/improperly configured ObjectAttributes '"
-        << attributesHandle << "', whose handle contains '"
-        << objInstAttributes->getHandle()
+        << attributesHandle << "', whose handle contains '" << objAttrHandle
         << "' as specified in object instance attributes, so addObjectInstance "
            "aborted.";
     return ID_UNDEFINED;
@@ -183,6 +198,32 @@ int PhysicsManager::addObjectInstance(
                                     objInstAttributes);
 
 }  // PhysicsManager::addObjectInstance
+
+int PhysicsManager::cloneExistingObject(int objectID) {
+  // Retrieve object by ID
+  const auto existingObjIter = existingObjects_.find(objectID);
+  // Verify object id exists and is a rigid object
+  if (existingObjIter == existingObjects_.end()) {
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Object cloning failed due to unknown existing object ID `"
+        << objectID << "`. Aborting";
+    return ID_UNDEFINED;
+  }
+  auto objPtr = existingObjIter->second;
+  // Get object instance attributes copy
+  esp::metadata::attributes::SceneObjectInstanceAttributes::cptr objInstAttrs =
+      objPtr->getInitObjectInstanceAttr();
+  // Create object instance
+  int newObjID = addObjectInstance(objInstAttrs, objPtr->getIsCOMCorreected(),
+                                   &simulator_->getDrawableGroup(), nullptr,
+                                   simulator_->getCurrentLightSetupKey());
+
+  // Update new object's values if necessary
+  // auto newObject = existingObjects_.find(newObjID);
+
+  return newObjID;
+
+}  // PhysicsManager::cloneExistingObject
 
 int PhysicsManager::addObjectAndSaveAttributes(
     const esp::metadata::attributes::ObjectAttributes::ptr& objAttributes,
@@ -434,9 +475,26 @@ int PhysicsManager::addArticulatedObjectInstance(
     const std::shared_ptr<
         const esp::metadata::attributes::SceneAOInstanceAttributes>&
         aObjInstAttributes,
-    const std::string& artObjAttrHandle,
     DrawableGroup* drawables,
     const std::string& lightSetup) {
+  // AO template attributes handle from articulated object instance
+  const std::string artObjHandle = aObjInstAttributes->getHandle();
+
+  // Get model file name from handle
+  const std::string artObjAttrHandle =
+      resourceManager_.getAOAttributesManager()->getFullAttrNameFromStr(
+          artObjHandle);
+
+  // make sure full handle is not empty
+  ESP_CHECK(
+      !artObjAttrHandle.empty(),
+      Cr::Utility::formatString(
+          "PhysicsManager::addArticulatedObjectInstance() : "
+          "Attempt to load articulated object instance specified in "
+          "current scene instance :{} failed due to AO instance "
+          "configuration file handle '{}' being empty or unknown. Aborting",
+          simulator_->getActiveSceneDatasetName(), artObjHandle));
+
   // Get ArticulatedObjectAttributes
   auto artObjAttributes =
       resourceManager_.getAOAttributesManager()->getObjectCopyByHandle(
@@ -509,6 +567,33 @@ int PhysicsManager::addArticulatedObjectInstance(
       artObjAttributes, drawables, false, lightSetup, aObjInstAttributes);
 
 }  // PhysicsManager::addArticulatedObjectInstance
+
+int PhysicsManager::cloneExistingArticulatedObject(int aObjectID) {
+  // Retrieve object by ID
+  const auto existingAOIter = existingArticulatedObjects_.find(aObjectID);
+  // Verify object id exists and is a rigid object
+  if (existingAOIter == existingArticulatedObjects_.end()) {
+    ESP_ERROR(Mn::Debug::Flag::NoSpace)
+        << "Articulated Object cloning failed due to unknown existing "
+           "articulated object ID `"
+        << aObjectID << "`. Aborting";
+    return ID_UNDEFINED;
+  }
+  auto aObjPtr = existingAOIter->second;
+  // Get object instance attributes copy
+  esp::metadata::attributes::SceneAOInstanceAttributes::cptr artObjInstAttrs =
+      aObjPtr->getInitObjectInstanceAttr();
+  // Create object instance
+  int newArtObjID = addArticulatedObjectInstance(
+      artObjInstAttrs, &simulator_->getDrawableGroup(),
+      simulator_->getCurrentLightSetupKey());
+
+  // Update new object's values if necessary
+  // auto newArtObj = existingArticulatedObjects_.find(newArtObjID);
+
+  return newArtObjID;
+
+}  // PhysicsManager::cloneExistingArticulatedObject
 
 int PhysicsManager::addArticulatedObjectAndSaveAttributes(
     const esp::metadata::attributes::ArticulatedObjectAttributes::ptr&

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -214,7 +214,7 @@ int PhysicsManager::cloneExistingObject(int objectID) {
   esp::metadata::attributes::SceneObjectInstanceAttributes::cptr objInstAttrs =
       objPtr->getInitObjectInstanceAttr();
   // Create object instance
-  int newObjID = addObjectInstance(objInstAttrs, objPtr->getIsCOMCorreected(),
+  int newObjID = addObjectInstance(objInstAttrs, objPtr->isCOMCorrected(),
                                    &simulator_->getDrawableGroup(), nullptr,
                                    simulator_->getCurrentLightSetupKey());
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -296,8 +296,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * esp::metadata::attributes::SceneObjectInstanceAttributes file.
    * @param objInstAttributes The attributes that describe the desired state to
    * set this object.
-   * @param attributesHandle The handle of the object attributes used as the key
-   * to query @ref esp::metadata::managers::ObjectAttributesManager.
    * @param defaultCOMCorrection The default value of whether COM-based
    * translation correction needs to occur.
    * @param drawables Reference to the scene graph drawables group to enable
@@ -313,11 +311,21 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   int addObjectInstance(
       const esp::metadata::attributes::SceneObjectInstanceAttributes::cptr&
           objInstAttributes,
-      const std::string& attributesHandle,
       bool defaultCOMCorrection = false,
       DrawableGroup* drawables = nullptr,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Duplicate an existing rigid using its @ref
+   * esp::metadata::attributes::SceneObjectInstanceAttributes template.
+   * @param objectID The ID of the existing @ref RigidObject we wish to duplicate.
+   * @return The instanced @ref RigidObject 's ID, mapping to the rigid
+   * object in @ref PhysicsManager::existingObjects_ if successful, or
+   * @ref esp::ID_UNDEFINED. These values come from the same pool used
+   * by articulated objects.
+   */
+  int cloneExistingObject(int objectID);
 
   /** @brief Instance a physical object from an object properties template in
    * the @ref esp::metadata::managers::ObjectAttributesManager.  This method
@@ -405,12 +413,9 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
 
   /**
    * @brief Instance and place an @ref ArticulatedObject from a @ref
-   * esp::metadata::attributes::SceneAOInstanceAttributes file.
+   * esp::metadata::attributes::SceneAOInstanceAttributes template.
    * @param aObjInstAttributes The attributes that describe the desired initial
    * state to set for this articulated object.
-   * @param attributesHandle The handle of the @ref ArticulatedObject attributes
-   * used as the key to query @ref esp::metadata::managers::AOAttributesManager
-   * for the attributes.
    * @param drawables Reference to the scene graph drawables group to enable
    * rendering of the newly initialized object. If nullptr, will attempt to
    * query Simulator to retrieve a group.
@@ -424,9 +429,19 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       const std::shared_ptr<
           const esp::metadata::attributes::SceneAOInstanceAttributes>&
           aObjInstAttributes,
-      const std::string& attributesHandle,
       DrawableGroup* drawables = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
+
+  /**
+   * @brief Duplicate an existing @ref ArticulatedObject using its @ref
+   * esp::metadata::attributes::SceneAOInstanceAttributes template.
+   * @param aObjectID The ID of the existing @ref ArticulatedObject we wish to duplicate.
+   * @return The instanced @ref ArticulatedObject 's ID, mapping to the articulated
+   * object in @ref PhysicsManager::existingObjects_ if successful, or
+   * @ref esp::ID_UNDEFINED. These values come from the same pool used
+   * by rigid objects.
+   */
+  int cloneExistingArticulatedObject(int aObjectID);
 
   /**
    * @brief Instance an @ref ArticulatedObject from an

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -600,9 +600,11 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   /** @brief Return whether or not this object is articulated. Override in
    * ArticulatedObject */
-  virtual bool isArticulated() const { return false; }
+  bool isArticulated() const { return _isArticulated; }
 
  protected:
+  void setIsArticulated(bool isArticulated) { _isArticulated = isArticulated; }
+
   /** @brief Accessed internally. Get an appropriately cast copy of the @ref
    * metadata::attributes::SceneObjectInstanceAttributes used to place the
    * object within the scene.
@@ -710,10 +712,6 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
       nullptr;
 
   /**
-   * @brief Saved reference to this object's instantiating template manager
-   */
-  // metadata::managers::AttributesManager::ptr templateManager_ = nullptr;
-  /**
    * @brief Set the object's creation scale
    */
   void setScale(const Magnum::Vector3& creationScale) {
@@ -732,6 +730,12 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * @brief The scale applied to this object on creation
    */
   Mn::Vector3 _creationScale{1.0f, 1.0f, 1.0f};
+
+  /**
+   * @brief Whether or not this is an articulated object. Set to true in
+   * articulated object constructors.
+   */
+  bool _isArticulated = false;
 
  public:
   ESP_SMART_POINTERS(PhysicsObjectBase)

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -163,6 +163,7 @@ class RigidObject : public RigidBase {
   void setIsCOMCorrected(bool _isCOMCorrected) {
     isCOMCorrected_ = _isCOMCorrected;
   }
+  bool getIsCOMCorreected() const { return isCOMCorrected_; }
 
   /**
    * @brief Reverses the COM correction transformation for objects that require

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -163,7 +163,7 @@ class RigidObject : public RigidBase {
   void setIsCOMCorrected(bool _isCOMCorrected) {
     isCOMCorrected_ = _isCOMCorrected;
   }
-  bool getIsCOMCorreected() const { return isCOMCorrected_; }
+  bool isCOMCorrected() const { return isCOMCorrected_; }
 
   /**
    * @brief Reverses the COM correction transformation for objects that require

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.cpp
@@ -74,5 +74,14 @@ ArticulatedObjectManager::addArticulatedObjectByID(
   return nullptr;
 }
 
+std::shared_ptr<ManagedArticulatedObject>
+ArticulatedObjectManager::copyArticulatedObjectByID(int aObjectID) {
+  if (auto physMgr = this->getPhysicsManager()) {
+    int newAObjID = physMgr->cloneExistingArticulatedObject(aObjectID);
+    return this->getObjectCopyByID(newAObjID);
+  }
+  return nullptr;
+}  // ArticulatedObjectManager::copyArticulatedObjectByID
+
 }  // namespace physics
 }  // namespace esp

--- a/src/esp/physics/objectManagers/ArticulatedObjectManager.h
+++ b/src/esp/physics/objectManagers/ArticulatedObjectManager.h
@@ -199,6 +199,37 @@ class ArticulatedObjectManager
     return objPtr;
   }
 
+  /**
+   * @brief Duplicate an existing @ref ArticulatedObject referenced by the
+   * given @p aObjectID .
+   *
+   * @param aObjectID The ID of the @ref ArticulatedObject to duplicate
+   * @return A shared pointer to the instanced @ref ArticulatedObject 's wrapper .
+   */
+  std::shared_ptr<ManagedArticulatedObject> copyArticulatedObjectByID(
+      int aObjectID);
+
+  /**
+   * @brief Cast to BulletArticulatedObject version.
+   * Duplicate an existing @ref ArticulatedObject referenced by the
+   * given @p aObjectID .
+   *
+   * @param aObjectID The ID of the @ref ArticulatedObject to duplicate
+   * @return A shared pointer to the instanced @ref ArticulatedObject .
+   */
+  std::shared_ptr<ManagedArticulatedObject> copyBulletArticulatedObjectByID(
+      int aObjectID) {
+    std::shared_ptr<ManagedArticulatedObject> aObjPtr =
+        copyArticulatedObjectByID(aObjectID);
+
+    if (std::shared_ptr<ManagedBulletArticulatedObject> castObjPtr =
+            std::dynamic_pointer_cast<ManagedBulletArticulatedObject>(
+                aObjPtr)) {
+      return castObjPtr;
+    }
+    return aObjPtr;
+  }
+
  protected:
   /**
    * @brief This method will remove articulated objects from physics manager.

--- a/src/esp/physics/objectManagers/RigidObjectManager.cpp
+++ b/src/esp/physics/objectManagers/RigidObjectManager.cpp
@@ -51,6 +51,16 @@ std::shared_ptr<ManagedRigidObject> RigidObjectManager::addObjectByID(
   }
 }  // RigidObjectManager::addObject
 
+std::shared_ptr<ManagedRigidObject> RigidObjectManager::copyObjectByID(
+    int objectID) {
+  if (auto physMgr = this->getPhysicsManager()) {
+    int newObjID = physMgr->cloneExistingObject(objectID);
+    return this->getObjectCopyByID(newObjID);
+  } else {
+    return nullptr;
+  }
+}  // RigidObjectManager::copyObjectByID
+
 std::shared_ptr<ManagedRigidObject> RigidObjectManager::removePhysObjectByID(
     int objectID,
     bool deleteObjectNode,

--- a/src/esp/physics/objectManagers/RigidObjectManager.h
+++ b/src/esp/physics/objectManagers/RigidObjectManager.h
@@ -96,6 +96,31 @@ class RigidObjectManager
     return objPtr;
   }
 
+  /** @brief Duplicate an existing @ref RigidObject referenced by the
+   * given @p objectID .
+   * @param objectID The ID of the object to duplicate.
+   * @return A shared pointer to the newly instanced @ref RigidObject 's wrapper .
+   */
+  std::shared_ptr<ManagedRigidObject> copyObjectByID(int objectID);
+
+  /**
+   * @brief Templated version of copyObjectByID. Will cast result to
+   * appropriate dynamics library wrapper.
+   * @param attributesID The ID of the object's template in @ref
+   * esp::metadata::managers::ObjectAttributesManager
+   * @param attachmentNode If supplied, attach the new physical object to an
+   * existing SceneNode.
+   * @return a copy of the instanced object, appropriately cast, or nullptr.
+   */
+  std::shared_ptr<ManagedRigidObject> copyBulletObjectByID(int objectID) {
+    std::shared_ptr<ManagedRigidObject> objPtr = copyObjectByID(objectID);
+    if (std::shared_ptr<ManagedBulletRigidObject> castObjPtr =
+            std::dynamic_pointer_cast<ManagedBulletRigidObject>(objPtr)) {
+      return castObjPtr;
+    }
+    return objPtr;
+  }
+
   /**
    * @brief Overload of standard @ref
    * esp::core::managedContainers::ManagedContainer::removeObjectByID to allow

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -634,20 +634,10 @@ bool Simulator::instanceObjectsForSceneAttributes(
             "due to object instance configuration not being found. Aborting",
             config_.activeSceneName));
 
-    const std::string objAttrFullHandle =
-        metadataMediator_->getObjAttrFullHandle(objInst->getHandle());
-    // make sure full handle is not empty
-    ESP_CHECK(!objAttrFullHandle.empty(),
-              Cr::Utility::formatString(
-                  "Simulator::instanceObjectsForSceneAttributes() : Attempt to "
-                  "load object instance specified in current scene instance "
-                  ":{} failed due to object instance configuration handle '{}' "
-                  "being empty or unknown. Aborting",
-                  config_.activeSceneName, objInst->getHandle()));
     // objID =
-    physicsManager_->addObjectInstance(
-        objInst, objAttrFullHandle, defaultCOMCorrection, &getDrawableGroup(),
-        attachmentNode, config_.sceneLightSetupKey);
+    physicsManager_->addObjectInstance(objInst, defaultCOMCorrection,
+                                       &getDrawableGroup(), attachmentNode,
+                                       config_.sceneLightSetupKey);
   }  // for each object attributes
   return true;
 }  // Simulator::instanceObjectsForSceneAttributes()
@@ -672,26 +662,10 @@ bool Simulator::instanceArticulatedObjectsForSceneAttributes(
                   "AO instance configuration not being found. Aborting",
                   config_.activeSceneName));
 
-    // get model file name
-    const std::string artObjAttrHandle =
-        metadataMediator_->getArticulatedObjModelFullHandle(
-            artObjInst->getHandle());
-
-    // make sure full handle is not empty
-    ESP_CHECK(
-        !artObjAttrHandle.empty(),
-        Cr::Utility::formatString(
-            "Simulator::instanceArticulatedObjectsForSceneAttributes() : "
-            "Attempt to load articulated object instance specified in "
-            "current scene instance :{} failed due to AO instance "
-            "configuration file handle '{}' being empty or unknown. Aborting",
-            config_.activeSceneName, artObjInst->getHandle()));
-
     // create articulated object
     // aoID =
-    physicsManager_->addArticulatedObjectInstance(artObjInst, artObjAttrHandle,
-                                                  &getDrawableGroup(),
-                                                  config_.sceneLightSetupKey);
+    physicsManager_->addArticulatedObjectInstance(
+        artObjInst, &getDrawableGroup(), config_.sceneLightSetupKey);
   }  // for each articulated object instance
   return true;
 }  // Simulator::instanceArticulatedObjectsForSceneAttributes

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -711,6 +711,13 @@ class Simulator {
   }
 
   /**
+   * @brief retrieve Current lightsetup key
+   */
+  std::string getCurrentLightSetupKey() const {
+    return config_.sceneLightSetupKey;
+  }
+
+  /**
    * @brief Register a @ref gfx::LightSetup with a key name.
    *
    * If this name already exists, the @ref gfx::LightSetup is updated and all


### PR DESCRIPTION
## Motivation and Context
This function enables the easy and accurate duplication of existing rigid and articulated objects. If an object has been instantiated by an scene object/ao instance attributes, that object's state will be impacted by both its creation template and the instance attributes, which can be arcane. Instead of attempting to duplicate this process externally, the instance attributes and config template are accessed internally for the existing object and used to recreate another just like it.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally existing c++ and python tests pass. Tests to be added to verify duplication process.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
