### PR TITLE
--[Bugfix] - Compute AO cumulative bbox on creation unconditionally.

### DIFF
--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -997,6 +997,16 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
         metadata::attributes::ArticulatedObjectAttributes>();
   }
 
+  /**
+   * @brief Compute the cumulative bbox for this AO
+   */
+  void computeAOCumulativeBB() {
+    baseLink_->node().computeCumulativeBB();
+    for (const auto& link : links_) {
+      link.second->node().computeCumulativeBB();
+    }
+  }
+
  protected:
   /**
    * @brief Used to synchronize simulator's notion of the object state

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -200,10 +200,12 @@ int BulletPhysicsManager::addArticulatedObjectInternal(
             "BulletPhysicsManager::addArticulatedObject(): Failed to "
             "instance render asset (attachGeometry) for link"
                 << urdfLinkIx << ".");
-        linkObject.node().computeCumulativeBB();
       }
     }
   }
+
+  // Compute the cumulative bbox for the links in the ao.
+  articulatedObject->computeAOCumulativeBB();
 
   // clear the cache
   u2b->cache = nullptr;


### PR DESCRIPTION
## Motivation and Context
We've been computing AO bboxes during creation only if they were specified to use visuals based on link shapes.  This PR changes this to always compute cumulative bboxes for loaded AOs.  This was not a problem before due to simulator::reconfigure calling reset() which would recompute the cumulative bbox on the scene root node, which would hit the AOs as well, but any AOs that were loaded after reconfigure would be missed.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local C++ and Python tests pass.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
