### PR TITLE
[CI][conda] - Update conda build docker to centos8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,7 +711,7 @@ jobs:
                   /bin/bash -c "source ~/.bashrc && conda activate py39 \
                                 && cd /remote/habitat-sim/ && git config --global --add safe.directory '*' \
                                 && cd /remote/habitat-sim/conda-build \
-                                <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} <</ parameters.CI_TEST >> --hostname "aihabitat-conda-ci-builder-linux" \
+                                <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} --hostname "aihabitat-conda-ci-builder-linux" \ <</ parameters.CI_TEST >>
                                 && python matrix_builder.py \
                                   <<# parameters.CI_TEST >> --ci_test <</ parameters.CI_TEST>> \
                                   <<^ parameters.CI_TEST >> --conda_upload << parameters.NIGHTLY_FLAG >> <</ parameters.CI_TEST >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -708,13 +708,7 @@ jobs:
               docker run -it --ipc=host --rm -v $(pwd)/../../:/remote \
                   <<^ parameters.CI_TEST >> --env << parameters.AIHABITAT_CONDA_CHN_PWD_VAR >> <</ parameters.CI_TEST >> \
                   hsim_condabuild_dcontainer \
-                  /bin/bash -c "source ~/.bashrc && conda activate py39 \
-                                && cd /remote/habitat-sim/ && git config --global --add safe.directory '*' \
-                                && cd /remote/habitat-sim/conda-build \
-                                <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} --hostname "aihabitat-conda-ci-builder-linux" \ <</ parameters.CI_TEST >>
-                                && python matrix_builder.py \
-                                <<# parameters.CI_TEST >>--ci_test <</ parameters.CI_TEST>> \
-                                <<^ parameters.CI_TEST >> --conda_upload << parameters.NIGHTLY_FLAG >> <</ parameters.CI_TEST >>"
+                  /bin/bash -c "source ~/.bashrc && conda activate py39 && cd /remote/habitat-sim/ && git config --global --add safe.directory '*' && cd /remote/habitat-sim/conda-build <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} --hostname "aihabitat-conda-ci-builder-linux" <</ parameters.CI_TEST >> && python matrix_builder.py <<# parameters.CI_TEST >> --ci_test <</ parameters.CI_TEST>> <<^ parameters.CI_TEST >> --conda_upload << parameters.NIGHTLY_FLAG >> <</ parameters.CI_TEST >>"
 
   update_docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -713,8 +713,8 @@ jobs:
                                 && cd /remote/habitat-sim/conda-build \
                                 <<^ parameters.CI_TEST >> && yes | anaconda login --username << parameters.AIHABITAT_CONDA_CHN >> --password \${<< parameters.AIHABITAT_CONDA_CHN_PWD_VAR >>} --hostname "aihabitat-conda-ci-builder-linux" \ <</ parameters.CI_TEST >>
                                 && python matrix_builder.py \
-                                  <<# parameters.CI_TEST >> --ci_test <</ parameters.CI_TEST>> \
-                                  <<^ parameters.CI_TEST >> --conda_upload << parameters.NIGHTLY_FLAG >> <</ parameters.CI_TEST >>"
+                                <<# parameters.CI_TEST >>--ci_test <</ parameters.CI_TEST>> \
+                                <<^ parameters.CI_TEST >> --conda_upload << parameters.NIGHTLY_FLAG >> <</ parameters.CI_TEST >>"
 
   update_docs:
     docker:

--- a/conda-build/Dockerfile
+++ b/conda-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cudagl:10.0-devel-centos7
+FROM nvidia/cudagl:10.1-devel-centos8
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -6,17 +6,18 @@ ENV LANGUAGE en_US.UTF-8
 ARG AIHABITAT_CONDA_CHN
 ARG AIHABITAT_CONDA_CHN_PWD
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
-    yum -y update && yum clean all && \
-    yum -y install ...
+RUN yum-config-manager --enable rhel-server-rhscl-8-rpms
+RUN yum -y --nogpgcheck update
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum -y --nogpgcheck update
 
 RUN yum install -y wget curl perl cmake util-linux xz bzip2 git patch which unzip python3
 RUN yum install -y yum-utils centos-release-scl
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH
+RUN yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran devtoolset-8-binutils
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
 
 RUN yum install -y autoconf aclocal automake make
 RUN yum install -y mesa-libEGL-devel mesa-libGL-devel

--- a/conda-build/Dockerfile
+++ b/conda-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cudagl:10.0-devel-centos7
+FROM nvidia/cudagl:11.4.2-devel-centos8
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -8,10 +8,10 @@ ARG AIHABITAT_CONDA_CHN_PWD
 
 RUN yum install -y wget curl perl cmake util-linux xz bzip2 git patch which unzip python3
 RUN yum install -y yum-utils centos-release-scl
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH
+RUN yum-config-manager --enable rhel-server-rhscl-8-rpms
+RUN yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran devtoolset-8-binutils
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
 
 RUN yum install -y autoconf aclocal automake make
 RUN yum install -y mesa-libEGL-devel mesa-libGL-devel

--- a/conda-build/Dockerfile
+++ b/conda-build/Dockerfile
@@ -6,20 +6,14 @@ ENV LANGUAGE en_US.UTF-8
 ARG AIHABITAT_CONDA_CHN
 ARG AIHABITAT_CONDA_CHN_PWD
 
-RUN yum-config-manager --enable rhel-server-rhscl-8-rpms
-RUN yum -y --nogpgcheck update
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-RUN yum -y --nogpgcheck update
+RUN yum -y --nogpgcheck update --nobest
 
+RUN yum install -y yum-utils
 RUN yum install -y wget curl perl cmake util-linux xz bzip2 git patch which unzip python3
-RUN yum install -y yum-utils centos-release-scl
-RUN yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran devtoolset-8-binutils
-ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
-
-RUN yum install -y autoconf aclocal automake make
+RUN yum install -y autoconf automake make
 RUN yum install -y mesa-libEGL-devel mesa-libGL-devel
 
 # Install patchelf

--- a/conda-build/Dockerfile
+++ b/conda-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cudagl:11.4.2-devel-centos8
+FROM nvidia/cudagl:10.0-devel-centos7
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -6,12 +6,17 @@ ENV LANGUAGE en_US.UTF-8
 ARG AIHABITAT_CONDA_CHN
 ARG AIHABITAT_CONDA_CHN_PWD
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum -y update && yum clean all && \
+    yum -y install ...
+
 RUN yum install -y wget curl perl cmake util-linux xz bzip2 git patch which unzip python3
 RUN yum install -y yum-utils centos-release-scl
-RUN yum-config-manager --enable rhel-server-rhscl-8-rpms
-RUN yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran devtoolset-8-binutils
-ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH
 
 RUN yum install -y autoconf aclocal automake make
 RUN yum install -y mesa-libEGL-devel mesa-libGL-devel


### PR DESCRIPTION
## Motivation and Context

Our current conda build docker for linux is based on a centos 7 image.
centos7 reached end of life (EoL) in June 2024. 
The mirror repos were moved to centos vault causing our current build to fail.

This PR updates the docker to centos 8.

## How Has This Been Tested

CI conda build test passed.

On branch https://github.com/facebookresearch/habitat-sim/tree/alex-07_11-conda_deploy_test_rhel8 I deployed a test linux package which is currently available [here](https://anaconda.org/aihabitat/habitat-sim-test-rhel8/files). I was able to successfully install this package and run tests locally on Fedora 39.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
