### PR TITLE
--[WIP][Bugfix]- Address remaining issues with bindings stubgen

### DIFF
--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -176,7 +176,7 @@ void initAttributesBindings(py::module& m) {
       .value("LINK_VISUALS",
              metadata::attributes::ArticulatedObjectRenderMode::LinkVisuals,
              "Render the Articulated Object using urdf-defined "
-             "meshes/primitives to respresent each link.")
+             "meshes/primitives to represent each link.")
       .value("NONE", metadata::attributes::ArticulatedObjectRenderMode::None,
              "Do not render the Articulated Object.")
       .value("BOTH", metadata::attributes::ArticulatedObjectRenderMode::Both,
@@ -1045,7 +1045,7 @@ void initAttributesBindings(py::module& m) {
           R"(Whether or not the asset described by this attributes supports texture-based semantics)")
       .def_property_readonly(
           "num_regions", &SemanticAttributes::getNumRegionInstances,
-          R"(The nmumber of semantic regions defined by this Semantic Attributes.)");
+          R"(The number of semantic regions defined by this Semantic Attributes.)");
 
   // ==== StageAttributes ====
   py::class_<StageAttributes, AbstractObjectAttributes, StageAttributes::ptr>(

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -520,7 +520,7 @@ void initAttributesManagersBindings(py::module& m) {
              AttributesManager<PbrShaderAttributes, ManagedObjectAccess::Copy>,
              PbrShaderAttributesManager::ptr>(
       m, "PbrShaderAttributesManager",
-      R"(Manages PbrShaderAttributess which define PBR shader calculation control values, such as
+      R"(Manages PbrShaderAttributes which define PBR shader calculation control values, such as
       enabling IBL or specifying direct and indirect lighting balance. Can import .pbr_config.json files.)");
 
   // ==== Semantic Attributes Template manager ====

--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -240,41 +240,43 @@ void initGfxBindings(
       m, "DebugLineRender")
       .def(
           "set_line_width", &DebugLineRender::setLineWidth,
-          R"(Set global line width for all lines rendered by DebugLineRender.)")
+          R"(Set global line width for all lines rendered by DebugLineRender.)",
+          "width"_a)
       .def(
           "push_transform", &DebugLineRender::pushTransform,
-          R"(Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped. Must be paired with popTransform().)")
+          R"(Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped. Must be paired with popTransform().)",
+          "transform"_a)
       .def("pop_transform", &DebugLineRender::popTransform,
            R"(See push_transform.)")
       .def("draw_box", &DebugLineRender::drawBox,
            R"(Draw a box in world-space or local-space (see pushTransform).)")
       .def(
-          "draw_circle", &DebugLineRender::drawCircle, "translation"_a,
-          "radius"_a, "color"_a, "num_segments"_a = 24,
-          "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0},
-          R"(Draw a circle in world-space or local-space (see pushTransform). The circle is an approximation; see numSegments.)")
-      .def(
-          "draw_transformed_line",
-          py::overload_cast<const Magnum::Vector3&, const Magnum::Vector3&,
-                            const Magnum::Color4&, const Magnum::Color4&>(
-              &DebugLineRender::drawTransformedLine),
-          "from"_a, "to"_a, "from_color"_a, "to_color"_a,
-          R"(Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.)")
+          "draw_circle", &DebugLineRender::drawCircle,
+          R"(Draw a circle in world-space or local-space (see pushTransform). The circle is an approximation; see numSegments.)",
+          "translation"_a, "radius"_a, "color"_a, "num_segments"_a = 24,
+          "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0})
       .def(
           "draw_transformed_line",
           py::overload_cast<const Magnum::Vector3&, const Magnum::Vector3&,
                             const Magnum::Color4&>(
               &DebugLineRender::drawTransformedLine),
-          "from"_a, "to"_a, "color"_a,
-          R"(Draw a line segment in world-space or local-space (see pushTransform).)")
+          R"(Draw a line segment in world-space or local-space (see pushTransform).)",
+          "fromPt"_a, "toPt"_a, "color"_a)
+      .def(
+          "draw_transformed_line",
+          py::overload_cast<const Magnum::Vector3&, const Magnum::Vector3&,
+                            const Magnum::Color4&, const Magnum::Color4&>(
+              &DebugLineRender::drawTransformedLine),
+          R"(Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.)",
+          "fromPt"_a, "toPt"_a, "from_color"_a, "to_color"_a)
       .def(
           "draw_path_with_endpoint_circles",
           py::overload_cast<const std::vector<Magnum::Vector3>&, float,
                             const Magnum::Color4&, int, const Magnum::Vector3&>(
               &DebugLineRender::drawPathWithEndpointCircles),
+          R"(Draw a sequence of line segments with circles at the two endpoints. In world-space or local-space (see pushTransform).)",
           "points"_a, "radius"_a, "color"_a, "num_segments"_a = 24,
-          "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0},
-          R"(Draw a sequence of line segments with circles at the two endpoints. In world-space or local-space (see pushTransform).)");
+          "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0});
 
   m.attr("DEFAULT_LIGHTING_KEY") = DEFAULT_LIGHTING_KEY;
   m.attr("NO_LIGHT_KEY") = NO_LIGHT_KEY;

--- a/src/esp/bindings/PhysicsBindings.cpp
+++ b/src/esp/bindings/PhysicsBindings.cpp
@@ -209,7 +209,7 @@ void initPhysicsBindings(py::module& m) {
       .value("UserGroup7", CollisionGroup::UserGroup7)
       .value("UserGroup8", CollisionGroup::UserGroup8)
       .value("UserGroup9", CollisionGroup::UserGroup9)
-      .value("None", CollisionGroup{});
+      .value("NoneGroup", CollisionGroup{});
   pybindEnumOperators(collisionGroups);
 
   // ==== class object CollisionGroupHelper ====

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -179,11 +179,16 @@ void initSceneBindings(
       .def("index", &LoopRegionCategory::index, "mapping"_a = "")
       .def("name", &LoopRegionCategory::name, "mapping"_a = "");
 
-  // These two are (cyclically) referenced by multiple classes below, define
+  // These are (cyclically) referenced by multiple classes below, define
   // the classes first so pybind has the type definition available when binding
   // functions
   py::class_<SemanticObject, SemanticObject::ptr> semanticObject(
       m, "SemanticObject");
+  py::class_<CCSemanticObject, SemanticObject, CCSemanticObject::ptr>
+      ccSemanticObject(
+          m, "CCSemanticObject",
+          "This class exists to facilitate semantic object data access for "
+          "bboxes derived from connected component analysis.");
   py::class_<SemanticRegion, SemanticRegion::ptr> semanticRegion(
       m, "SemanticRegion");
 
@@ -233,6 +238,15 @@ void initSceneBindings(
       .def_property_readonly("aabb", &SemanticObject::aabb)
       .def_property_readonly("obb", &SemanticObject::obb)
       .def_property_readonly("category", &SemanticObject::category);
+
+  // ==== CCSemanticObject =====
+  ccSemanticObject
+      .def_property_readonly("num_src_verts", &CCSemanticObject::getNumSrcVerts,
+                             "The number of vertices in the connected "
+                             "component making up this semantic object.")
+      .def_property_readonly("vert_set", &CCSemanticObject::getVertSet,
+                             "A set of the vertices in the connected component "
+                             "making up this semantic object.");
 
   // ==== SemanticScene ====
   py::class_<SemanticScene, SemanticScene::ptr>(m, "SemanticScene")

--- a/src/esp/metadata/attributes/AttributesEnumMaps.h
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.h
@@ -128,7 +128,7 @@ enum class ArticulatedObjectRenderMode {
   Skin,
   /**
    * @brief Render the Articulated Object using urdf-defined meshes/primitives
-   * to respresent each link.
+   * to represent each link.
    */
   LinkVisuals,
   /**

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -316,7 +316,7 @@ class LightLayoutAttributes : public AbstractAttributes {
   std::shared_ptr<Configuration> lightInstConfig_{};
 
   /**
-   * @brief Deque holding all released IDs to consume for @ref LightInstanceAttributess when
+   * @brief Deque holding all released IDs to consume for @ref LightInstanceAttributes when
    * one is deleted, before using size of lightInstances_ container.
    */
   std::deque<int> availableLightIDs_;

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -76,7 +76,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
   void setAssetAttributesManager(
       AssetAttributesManager::cptr assetAttributesMgr) {
     assetAttributesMgr_ = std::move(assetAttributesMgr);
-    // Create default primitive-based object attributess
+    // Create default primitive-based object attributes
     createDefaultPrimBasedAttributesTemplates();
   }
 


### PR DESCRIPTION
## Motivation and Context
This PR fixes some issues that were [missed in the previous PR](https://github.com/facebookresearch/habitat-sim/pull/2430), which manifest when pybind11 stubs are being generated (see [here](https://github.com/facebookresearch/habitat-sim/pull/2415) ). 

Until all such issues are fixed, adding pybind11-stubgen to the build process will generate a stub file that will fail mypy precommit. In other words, no python source code changes or additions will be able to be committed to the repo with the erroneous stub file.

- Cannot have argument names in a method that are python reserved words.
- Same applies for enums.  All enums should be all caps in python, so that's an essential refactor that needs to happen which would obviate this issue.
- All types accessed by the bindings, either as args or return values, need to have pybind equivalents defined or else the generated stub file will have ellipses in the typing statements that cause syntax errors when mypy is executed.

Also, some missed spelling errors are corrected.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally tests pass; also testing with mypy execution on a modified python file.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
