### PR TITLE
--[BUGFIX] Make sure empty Markerset subconfigs are removed when appropriate

### DIFF
--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -26,7 +26,12 @@ class MarkerSet : public esp::core::config::Configuration {
   /**
    * @brief Returns the number of existing marker points in this MarkerSet.
    */
-  int getNumPoints() const {
+  int getNumPoints() {
+    // the 'markers' subconfig may not exist due to how the MarkerSet hierarchy
+    // is loaded from JSON.
+    if (!hasSubconfig("markers")) {
+      return 0;
+    }
     return getSubconfigView("markers")->getNumValues();
   }
 
@@ -34,6 +39,11 @@ class MarkerSet : public esp::core::config::Configuration {
    * @brief Returns a list of all the marker points in this MarkerSet
    */
   std::vector<Mn::Vector3> getAllPoints() const {
+    // the 'markers' subconfig may not exist due to how the MarkerSet hierarchy
+    // is loaded from JSON.
+    if (!hasSubconfig("markers")) {
+      return {};
+    }
     return getSubconfigValsOfTypeInVector<Mn::Vector3>("markers");
   }
 
@@ -51,6 +61,7 @@ class MarkerSet : public esp::core::config::Configuration {
    */
   int rekeyAllMarkers() { return rekeySubconfigValues("markers"); }
 
+ public:
   ESP_SMART_POINTERS(MarkerSet)
 };  // class MarkerSet
 

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -134,7 +134,11 @@ class LinkSet : public esp::core::config::Configuration {
    */
   void setMarkerSetPoints(const std::string& markerSetName,
                           const std::vector<Mn::Vector3>& markerList) {
-    editMarkerSet(markerSetName)->setAllPoints(markerList);
+    if (markerList.size() == 0) {
+      removeMarkerSet(markerSetName);
+    } else {
+      editMarkerSet(markerSetName)->setAllPoints(markerList);
+    }
   }
 
   /**
@@ -310,7 +314,12 @@ class TaskSet : public esp::core::config::Configuration {
   void setLinkMarkerSetPoints(const std::string& linkSetName,
                               const std::string& markerSetName,
                               const std::vector<Mn::Vector3>& markerList) {
-    editLinkSet(linkSetName)->setMarkerSetPoints(markerSetName, markerList);
+    auto linkSet = editLinkSet(linkSetName);
+    linkSet->setMarkerSetPoints(markerSetName, markerList);
+    // The above may result in the link set being empty. If so remove it.
+    if (linkSet->getNumMarkerSets() == 0) {
+      removeLinkSet(linkSetName);
+    }
   }
 
   /**
@@ -325,7 +334,12 @@ class TaskSet : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markers) {
-    editLinkSet(linkSetName)->setAllMarkerPoints(markers);
+    auto linkSet = editLinkSet(linkSetName);
+    linkSet->setAllMarkerPoints(markers);
+    // The above may result in the link set being empty. If so remove it.
+    if (linkSet->getNumMarkerSets() == 0) {
+      removeLinkSet(linkSetName);
+    }
   }
 
   /**
@@ -542,7 +556,6 @@ class MarkerSets : public esp::core::config::Configuration {
    * @param linkSetName the name of the LinkSet within @p taskSetName
    * @param markerSetName the name of the MarkerSet within @p linkSetName
    */
-
   void initTaskLinkMarkerSet(const std::string& taskSetName,
                              const std::string& linkSetName,
                              const std::string& markerSetName) {
@@ -561,8 +574,12 @@ class MarkerSets : public esp::core::config::Configuration {
                                   const std::string& linkSetName,
                                   const std::string& markerSetName,
                                   const std::vector<Mn::Vector3>& markerList) {
-    editTaskSet(taskSetName)
-        ->setLinkMarkerSetPoints(linkSetName, markerSetName, markerList);
+    auto taskSetPtr = editTaskSet(taskSetName);
+    taskSetPtr->setLinkMarkerSetPoints(linkSetName, markerSetName, markerList);
+    // After this process, the taskset might be empty, if so, delete it.
+    if (taskSetPtr->getNumLinkSets() == 0) {
+      removeTaskSet(taskSetName);
+    }
   }
 
   /**
@@ -579,7 +596,12 @@ class MarkerSets : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markerMap) {
-    editTaskSet(taskSetName)->setLinkSetPoints(linkSetName, markerMap);
+    auto taskSetPtr = editTaskSet(taskSetName);
+    taskSetPtr->setLinkSetPoints(linkSetName, markerMap);
+    // After this process, the taskset might be empty, if so, delete it.
+    if (taskSetPtr->getNumLinkSets() == 0) {
+      removeTaskSet(taskSetName);
+    }
   }
 
   /**
@@ -595,7 +617,14 @@ class MarkerSets : public esp::core::config::Configuration {
           std::string,
           std::unordered_map<std::string, std::vector<Mn::Vector3>>>&
           markerMap) {
-    editTaskSet(taskSetName)->setAllMarkerPoints(markerMap);
+    auto taskSetPtr = editTaskSet(taskSetName);
+    for (const auto& markers : markerMap) {
+      taskSetPtr->setLinkSetPoints(markers.first, markers.second);
+    }
+    // After this process, the taskset might be empty, if so, delete it.
+    if (taskSetPtr->getNumLinkSets() == 0) {
+      removeTaskSet(taskSetName);
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation and Context

If all the markers in a markerset are removed, the markerset should also be removed. This should apply to all levels of the hierarchy, so that empty (sub)objects are not written to JSON on save.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Locally c++ and python tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
