### PR TITLE
--[BUGFIX] - Revert markerset subconfig removals; Don't write empty configs to file

### DIFF
--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -606,8 +606,8 @@ void Configuration::writeSubconfigsToJson(io::JsonGenericValue& jsonObj,
   auto cfgIterPair = getSubconfigIterator();
   for (auto& cfgIter = cfgIterPair.first; cfgIter != cfgIterPair.second;
        ++cfgIter) {
-    // only save if subconfig has entries
-    if (cfgIter->second->getNumEntries() > 0) {
+    // only save if subconfig tree has value entries
+    if (cfgIter->second->getConfigTreeNumValues() > 0) {
       // Create Generic value for key, using allocator, to make sure its a copy
       // and lives long enough
       io::JsonGenericValue name{cfgIter->first.c_str(), allocator};

--- a/src/esp/metadata/attributes/MarkerSets.h
+++ b/src/esp/metadata/attributes/MarkerSets.h
@@ -145,11 +145,7 @@ class LinkSet : public esp::core::config::Configuration {
    */
   void setMarkerSetPoints(const std::string& markerSetName,
                           const std::vector<Mn::Vector3>& markerList) {
-    if (markerList.size() == 0) {
-      removeMarkerSet(markerSetName);
-    } else {
-      editMarkerSet(markerSetName)->setAllPoints(markerList);
-    }
+    editMarkerSet(markerSetName)->setAllPoints(markerList);
   }
 
   /**
@@ -325,12 +321,7 @@ class TaskSet : public esp::core::config::Configuration {
   void setLinkMarkerSetPoints(const std::string& linkSetName,
                               const std::string& markerSetName,
                               const std::vector<Mn::Vector3>& markerList) {
-    auto linkSet = editLinkSet(linkSetName);
-    linkSet->setMarkerSetPoints(markerSetName, markerList);
-    // The above may result in the link set being empty. If so remove it.
-    if (linkSet->getNumMarkerSets() == 0) {
-      removeLinkSet(linkSetName);
-    }
+    editLinkSet(linkSetName)->setMarkerSetPoints(markerSetName, markerList);
   }
 
   /**
@@ -345,12 +336,7 @@ class TaskSet : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markers) {
-    auto linkSet = editLinkSet(linkSetName);
-    linkSet->setAllMarkerPoints(markers);
-    // The above may result in the link set being empty. If so remove it.
-    if (linkSet->getNumMarkerSets() == 0) {
-      removeLinkSet(linkSetName);
-    }
+    editLinkSet(linkSetName)->setAllMarkerPoints(markers);
   }
 
   /**
@@ -585,12 +571,8 @@ class MarkerSets : public esp::core::config::Configuration {
                                   const std::string& linkSetName,
                                   const std::string& markerSetName,
                                   const std::vector<Mn::Vector3>& markerList) {
-    auto taskSetPtr = editTaskSet(taskSetName);
-    taskSetPtr->setLinkMarkerSetPoints(linkSetName, markerSetName, markerList);
-    // After this process, the taskset might be empty, if so, delete it.
-    if (taskSetPtr->getNumLinkSets() == 0) {
-      removeTaskSet(taskSetName);
-    }
+    editTaskSet(taskSetName)
+        ->setLinkMarkerSetPoints(linkSetName, markerSetName, markerList);
   }
 
   /**
@@ -607,12 +589,7 @@ class MarkerSets : public esp::core::config::Configuration {
       const std::string& linkSetName,
       const std::unordered_map<std::string, std::vector<Mn::Vector3>>&
           markerMap) {
-    auto taskSetPtr = editTaskSet(taskSetName);
-    taskSetPtr->setLinkSetPoints(linkSetName, markerMap);
-    // After this process, the taskset might be empty, if so, delete it.
-    if (taskSetPtr->getNumLinkSets() == 0) {
-      removeTaskSet(taskSetName);
-    }
+    editTaskSet(taskSetName)->setLinkSetPoints(linkSetName, markerMap);
   }
 
   /**
@@ -631,10 +608,6 @@ class MarkerSets : public esp::core::config::Configuration {
     auto taskSetPtr = editTaskSet(taskSetName);
     for (const auto& markers : markerMap) {
       taskSetPtr->setLinkSetPoints(markers.first, markers.second);
-    }
-    // After this process, the taskset might be empty, if so, delete it.
-    if (taskSetPtr->getNumLinkSets() == 0) {
-      removeTaskSet(taskSetName);
     }
   }
 


### PR DESCRIPTION
Removing the markerset subconfigs when they were empty caused memory corruption in certain rare cases (python variables retaining possession of a removed variable), so [the change introduced in this PR](https://github.com/facebookresearch/habitat-sim/pull/2434) is being reverted; 

Instead, a subconfig with no values in its entire subconfig hierarchy (all of its own subconfigs and so on, instead of just in its own primary map) will not be written to JSON.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests. Also verified with python app that fix works.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
