### PR TITLE
--[BugFix] - Handle transformations of points assigned to an AO's baselink

### DIFF
--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -556,7 +556,7 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
         const std::string linkName = linkEntry.first;
         int linkId = getLinkIdFromName(linkName);
         // locally access the unique pointer's payload
-        const esp::physics::ArticulatedLink* aoLink;
+        const esp::physics::ArticulatedLink* aoLink = nullptr;
         if (linkId == -1) {
           aoLink = baseLink_.get();
         } else {

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -555,19 +555,25 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
       for (const auto& linkEntry : taskEntry.second) {
         const std::string linkName = linkEntry.first;
         int linkId = getLinkIdFromName(linkName);
-        auto linkIter = links_.find(linkId);
-        ESP_CHECK(
-            linkIter != links_.end(),
-            "ArticulatedObject::getMarkerPointsGlobal - no link found with "
-            "linkId ="
-                << linkId);
+        // locally access the unique pointer's payload
+        const esp::physics::ArticulatedLink* aoLink;
+        if (linkId == -1) {
+          aoLink = baseLink_.get();
+        } else {
+          auto linkIter = links_.find(linkId);
+          ESP_CHECK(
+              linkIter != links_.end(),
+              "ArticulatedObject::getMarkerPointsGlobal - no link found with "
+              "linkId ="
+                  << linkId);
+          aoLink = linkIter->second.get();
+        }
         std::unordered_map<std::string, std::vector<Mn::Vector3>> perLinkMap;
         // for each set in link
         for (const auto& markersEntry : linkEntry.second) {
           const std::string markersName = markersEntry.first;
           perLinkMap[markersName] =
-              linkIter->second->transformLocalPointsToWorld(markersEntry.second,
-                                                            linkId);
+              aoLink->transformLocalPointsToWorld(markersEntry.second, linkId);
         }
         perTaskMap[linkName] = perLinkMap;
       }

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -493,7 +493,10 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    */
   std::vector<Mn::Vector3> transformLocalPointsToWorld(
       const std::vector<Mn::Vector3>& points,
-      int linkId) const override {
+      int linkId = -1) const override {
+    if (linkId == -1) {
+      return this->baseLink_->transformLocalPointsToWorld(points, -1);
+    }
     auto linkIter = links_.find(linkId);
     ESP_CHECK(linkIter != links_.end(),
               "ArticulatedObject::getLinkVisualSceneNodes - no link found with "
@@ -511,7 +514,10 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
    */
   std::vector<Mn::Vector3> transformWorldPointsToLocal(
       const std::vector<Mn::Vector3>& points,
-      int linkId) const override {
+      int linkId = -1) const override {
+    if (linkId == -1) {
+      return this->baseLink_->transformWorldPointsToLocal(points, -1);
+    }
     auto linkIter = links_.find(linkId);
     ESP_CHECK(linkIter != links_.end(),
               "ArticulatedObject::getLinkVisualSceneNodes - no link found with "

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -233,7 +233,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     std::vector<Mn::Vector3> wsPoints;
     wsPoints.reserve(points.size());
     Mn::Vector3 objScale = getScale();
-    Mn::Matrix4 worldTransform = getTransformation();
+    Mn::Matrix4 worldTransform = node().absoluteTransformation();
     for (const auto& lsPoint : points) {
       wsPoints.emplace_back(worldTransform.transformPoint(lsPoint * objScale));
     }
@@ -253,7 +253,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     std::vector<Mn::Vector3> lsPoints;
     lsPoints.reserve(points.size());
     Mn::Vector3 objScale = getScale();
-    Mn::Matrix4 worldTransform = getTransformation();
+    Mn::Matrix4 worldTransform = node().absoluteTransformation();
     for (const auto& wsPoint : points) {
       lsPoints.emplace_back(worldTransform.inverted().transformPoint(wsPoint) /
                             objScale);

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -229,7 +229,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual std::vector<Mn::Vector3> transformLocalPointsToWorld(
       const std::vector<Mn::Vector3>& points,
-      CORRADE_UNUSED int linkID) const {
+      CORRADE_UNUSED int linkID = -1) const {
     std::vector<Mn::Vector3> wsPoints;
     wsPoints.reserve(points.size());
     Mn::Vector3 objScale = getScale();
@@ -249,7 +249,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   virtual std::vector<Mn::Vector3> transformWorldPointsToLocal(
       const std::vector<Mn::Vector3>& points,
-      CORRADE_UNUSED int linkID) const {
+      CORRADE_UNUSED int linkID = -1) const {
     std::vector<Mn::Vector3> lsPoints;
     lsPoints.reserve(points.size());
     Mn::Vector3 objScale = getScale();


### PR DESCRIPTION
## Motivation and Context
This PR will properly handle transformations of points assigned to the baseLink of an ArticulatedObject between local and world space. It will also accommodate transforming baseLink-assigned marker points to world space if any should exist.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally C++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
