### PR TITLE
Simulator.reset should change default_lighting_key to point to scene instance lighting setup

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -680,7 +680,13 @@ void Simulator::reset() {
     agent->reset();
   }
   getActiveSceneGraph().getRootNode().computeCumulativeBB();
-  resourceManager_->setLightSetup(gfx::getDefaultLights());
+  // set the default light key to reference the scene's light setup
+  auto initSceneInstanceAttr =
+      metadataMediator_->getSceneInstanceAttributesManager()
+          ->getObjectCopyByHandle(curSceneInstanceAttributes_->getHandle());
+  auto sceneLightSetup = resourceManager_->getLightSetup(
+      initSceneInstanceAttr->getLightingHandle());
+  resourceManager_->setLightSetup(*sceneLightSetup);
 }  // Simulator::reset()
 
 metadata::attributes::SceneInstanceAttributes::ptr


### PR DESCRIPTION
## Motivation and Context

Moved this change from https://github.com/facebookresearch/habitat-sim/pull/2451 for closer evaluation in isolation and unit test updates.

## How Has This Been Tested

CI
TODO: requires changes to unit test GT images.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
