### PR TITLE
--[WIP]-Deduplicate Subconfigurations

### DIFF
--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -181,7 +181,9 @@ void initConfigBindings(py::module& m) {
            R"(Save a subconfiguration with the given name.)", "name"_a,
            "subconfig"_a)
       .def(
-          "has_subconfig", &Configuration::hasSubconfig,
+          "has_subconfig",
+          static_cast<bool (Configuration::*)(const std::string&) const>(
+              &Configuration::hasSubconfig),
           R"(Returns true if specified key references an existing subconfiguration within this configuration.)")
       .def(
           "remove_subconfig", &Configuration::removeSubconfig,

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -652,7 +652,7 @@ class ConfigValue {
   friend bool operator!=(const ConfigValue& a, const ConfigValue& b);
 
   ESP_SMART_POINTERS(ConfigValue)
-};  // namespace config
+};  // class ConfigValue
 
 /**
  * @brief provide debug stream support for @ref ConfigValue
@@ -1218,6 +1218,25 @@ class Configuration {
   }
 
   /**
+   * @brief return if passed @p subConfig exists in this Configuration's
+   * subconfig map. Does not compare hidden ConfigValues.
+   */
+  template <typename T>
+  bool hasSubconfig(const std::shared_ptr<T>& subConfig) const {
+    static_assert(std::is_base_of<Configuration, T>::value,
+                  "Configuration : Desired subconfig must be derived from "
+                  "core::config::Configuration");
+    auto cfgIterPair = getSubconfigIterator();
+    for (auto& cfgIter = cfgIterPair.first; cfgIter != cfgIterPair.second;
+         ++cfgIter) {
+      if (*(cfgIter->second) == *subConfig) {
+        return true;
+      }
+    }
+    return false;
+  }  // hasSubconfig
+
+  /**
    * @brief Templated subconfig copy getter. Retrieves a shared pointer to a
    * copy of the subConfig @ref esp::core::config::Configuration that has the
    * passed @p cfgName .
@@ -1661,6 +1680,15 @@ class Configuration {
   ValueMapType valueMap_{};
 
  public:
+  /**
+   * @brief Comparison - Ignores ConfigValues specified as hidden
+   */
+  friend bool operator==(const Configuration& a, const Configuration& b);
+  /**
+   * @brief Inequality Comparison - Ignores ConfigValues specified as hidden
+   */
+  friend bool operator!=(const Configuration& a, const Configuration& b);
+
   ESP_SMART_POINTERS(Configuration)
 };  // class Configuration
 

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -252,7 +252,7 @@ class LightLayoutAttributes : public AbstractAttributes {
    */
   void addLightInstance(LightInstanceAttributes::ptr _lightInstance) {
     this->setSubAttributesInternal<LightInstanceAttributes>(
-        _lightInstance, availableLightIDs_, lightInstConfig_, "");
+        _lightInstance, availableLightIDs_, lightInstConfig_, "", false);
   }
 
   /**

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -626,11 +626,21 @@ class SceneInstanceAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Add an object instance attributes to this scene instance.
+   * @brief Add an object instance attributes to this scene instance. Returns
+   * false if not added due to a duplicate to @p _objInstance found in
+   * @p objInstConfig_ during uniqueness validation.
+   * @param _objInstance The object instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _objInstance .
+   * Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _objInstance was added due to a duplicate being
+   * found.
    */
-  void addObjectInstanceAttrs(SceneObjectInstanceAttributes::ptr _objInstance) {
-    setSubAttributesInternal<SceneObjectInstanceAttributes>(
-        _objInstance, availableObjInstIDs_, objInstConfig_, "obj_inst_");
+  bool addObjectInstanceAttrs(SceneObjectInstanceAttributes::ptr _objInstance,
+                              bool _validateUnique) {
+    return setSubAttributesInternal<SceneObjectInstanceAttributes>(
+        _objInstance, availableObjInstIDs_, objInstConfig_, "obj_inst_",
+        _validateUnique);
   }
 
   /**
@@ -657,13 +667,21 @@ class SceneInstanceAttributes : public AbstractAttributes {
 
   /**
    * @brief Add an articulated object instance's attributes to this scene
-   * instance.
+   * instance. Returns false if not added due to a duplicate to
+   * @p _artObjInstance found in @p artObjInstConfig_ .
+   * @param _artObjInstance The object instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _objInstance .
+   * Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _objInstance was added due to a duplicate being
+   * found.
    */
-  void addArticulatedObjectInstanceAttrs(
-      SceneAOInstanceAttributes::ptr _artObjInstance) {
-    setSubAttributesInternal<SceneAOInstanceAttributes>(
+  bool addArticulatedObjectInstanceAttrs(
+      SceneAOInstanceAttributes::ptr _artObjInstance,
+      bool _validateUnique) {
+    return setSubAttributesInternal<SceneAOInstanceAttributes>(
         _artObjInstance, availableArtObjInstIDs_, artObjInstConfig_,
-        "art_obj_inst_");
+        "art_obj_inst_", _validateUnique);
   }
 
   /**

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -372,12 +372,21 @@ class SemanticAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Add an object instance attributes to this scene instance.
+   * @brief Add an object instance attributes to this scene instance.  Returns
+   * false if not added due to a duplicate to @p _regionInstance found in
+   * @p regionAnnotationConfig_ .
+   * @param _regionInstance The region instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _regionInstance
+   * . Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _regionInstance was added due to a duplicate
+   * being found.
    */
-  void addRegionInstanceAttrs(SemanticVolumeAttributes::ptr _regionInstance) {
-    setSubAttributesInternal<SemanticVolumeAttributes>(
+  bool addRegionInstanceAttrs(SemanticVolumeAttributes::ptr _regionInstance,
+                              bool _validateUnique) {
+    return setSubAttributesInternal<SemanticVolumeAttributes>(
         _regionInstance, availableRegionInstIDs_, regionAnnotationConfig_,
-        "region_desc_");
+        "region_desc_", _validateUnique);
   }
 
   /**

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -112,6 +112,13 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
     }
   }
 
+  // TODO set this via configuration value - should only be called when
+  // explicitly filtering dataset
+  bool validateUniqueness = true;
+
+  // Only resave if instance attributes' attempt to be added reveals duplicate
+  // attributes
+  bool resaveAttributes = false;
   // Check for object instances existence
   io::JsonGenericValue::ConstMemberIterator objJSONIter =
       jsonConfig.FindMember("object_instances");
@@ -122,8 +129,12 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
       for (rapidjson::SizeType i = 0; i < objectArray.Size(); ++i) {
         const auto& objCell = objectArray[i];
         if (objCell.IsObject()) {
-          attribs->addObjectInstanceAttrs(
-              createInstanceAttributesFromJSON(objCell));
+          // Resave if attributes not added due to being already found in the
+          // subconfiguration
+          resaveAttributes = !attribs->addObjectInstanceAttrs(
+                                 createInstanceAttributesFromJSON(objCell),
+                                 validateUniqueness) ||
+                             resaveAttributes;
         } else {
           ESP_WARNING(Mn::Debug::Flag::NoSpace)
               << "Object instance issue in Scene Instance `" << attribsDispName
@@ -133,9 +144,9 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
         }
       }
     } else {
-      // object_instances tag exists but is not an array. should warn (perhaps
-      // error?)
-      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+      // object_instances tag exists but is not an array; gives error message.
+      // (Perhaps should fail?)
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
           << "Object instances issue in Scene Instance `" << attribsDispName
           << "`: JSON cell `object_instances` is not a valid JSON "
              "array, so no object instances loaded.";
@@ -160,8 +171,12 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
         const auto& artObjCell = articulatedObjArray[i];
 
         if (artObjCell.IsObject()) {
-          attribs->addArticulatedObjectInstanceAttrs(
-              createAOInstanceAttributesFromJSON(artObjCell));
+          // Resave if attributes not added due to being already found in the
+          // subconfiguration
+          resaveAttributes = !attribs->addArticulatedObjectInstanceAttrs(
+                                 createAOInstanceAttributesFromJSON(artObjCell),
+                                 validateUniqueness) ||
+                             resaveAttributes;
         } else {
           ESP_WARNING(Mn::Debug::Flag::NoSpace)
               << "Articulated Object specification error in Scene Instance `"
@@ -171,9 +186,9 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
         }
       }
     } else {
-      // articulated_object_instances tag exists but is not an array. should
-      // warn (perhaps error?)
-      ESP_WARNING(Mn::Debug::Flag::NoSpace)
+      // articulated_object_instances tag exists but is not an array; gives
+      // error message. (Perhaps should fail?)
+      ESP_ERROR(Mn::Debug::Flag::NoSpace)
           << "Articulated Object instances issue in Scene "
              "InstanceScene Instance `"
           << attribsDispName
@@ -282,6 +297,10 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
   }
   // check for user defined attributes
   this->parseUserDefinedJsonVals(attribs, jsonConfig);
+
+  if (resaveAttributes) {
+    // TODO Resave this attributes due to duplicate entries being filtered out
+  }
 
 }  // SceneInstanceAttributesManager::setValsFromJSONDoc
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -672,16 +672,20 @@ void PhysicsManager::buildCurrentStateSceneAttributes(
   sceneInstanceAttrs->clearObjectInstances();
   // get each object's current state as a SceneObjectInstanceAttributes
   for (const auto& item : existingObjects_) {
+    // Will not add an object instance attributes that is found to be identical
+    // to an already existing attributes (not counting hidden fields)
     sceneInstanceAttrs->addObjectInstanceAttrs(
-        item.second->getCurrentStateInstanceAttr());
+        item.second->getCurrentStateInstanceAttr(), true);
   }
   // 3. Clear existing Articulated object instances, and set new ones reflecting
   // current state
   sceneInstanceAttrs->clearArticulatedObjectInstances();
   // get each articulated object's current state as a SceneAOInstanceAttributes
   for (const auto& item : existingArticulatedObjects_) {
+    // Will not add an ao instance attributes that is found to be identical to
+    // an already existing attributes (not counting hidden fields)
     sceneInstanceAttrs->addArticulatedObjectInstanceAttrs(
-        item.second->getCurrentStateInstanceAttr());
+        item.second->getCurrentStateInstanceAttr(), true);
   }
 
 }  // PhysicsManager::buildCurrentStateSceneAttributes


### PR DESCRIPTION
## Motivation and Context
This PR introduces conditional de-duplication of any loaded subconfiguration, such as Object Instances from the Scene Instance configuration file.  If two object instances are loaded that have identical data then the second and subsequent duplicate will not be saved as part of the internal representation of the scene instance.  

This will also prevent two identical SceneObjectInstanceAttributes or SceneAOInstanceAttributes from being saved when a 
SceneInstanceAttributes is being created for manual save to disk.

Still needed : 
 - Config field to control dedup-on-dataset load to minimize comparison overhead
 - Tests

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
