### PR TITLE
[doc] - fixes docstring format for get_weighted_regions_for_point 

### DIFF
--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -286,9 +286,7 @@ void initSceneBindings(
            &SemanticScene::getWeightedRegionsForPoint,
            R"("Find all SemanticRegions which contain the point and return a
               sorted list of tuple pairs of the region index and a score of that
-              region, derived as
-                    1 - (region_area/ttl_region_area)
-              where ttl_region_area is the area of all the regions containing
+              region, derived as 1 - (region_area/ttl_region_area) where ttl_region_area is the area of all the regions containing
               the point, so that smaller regions are weighted higher. If only
               one region contains the passed point, its weight will be 1.)",
            "point"_a)


### PR DESCRIPTION
## Motivation and Context

docstring wasn't rendering with the newlines

## How Has This Been Tested

tested with local doc build

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
