### PR TITLE
--[BE] - Refactor/cleanup attributes and attributes managers

### DIFF
--- a/docs/pages/attributesJSON.rst
+++ b/docs/pages/attributesJSON.rst
@@ -69,7 +69,7 @@ Stages, Objects, Lights, and Scenes can be linked from .json, created directly f
                 - If provided, creates a duplicate of the linked *_config.json*
             - "template_handle"
                 - string
-                - Handle/name for the new *Attributes*. Used to reference it within its *AttributesManager*.
+                - Handle/name for the new *Attributes*. Used to reference it within its *AbstractAttributesManager*.
             -  "attributes"
                 - JSON object
                 - Attribute configuration to override defaults or copied values.

--- a/src/esp/bindings/AttributesBindings.cpp
+++ b/src/esp/bindings/AttributesBindings.cpp
@@ -7,9 +7,9 @@
 #include <Magnum/PythonBindings.h>
 
 #include "esp/core/managedContainers/AbstractManagedObject.h"
+#include "esp/metadata/attributes/AbstractAttributes.h"
 #include "esp/metadata/attributes/AbstractObjectAttributes.h"
 #include "esp/metadata/attributes/ArticulatedObjectAttributes.h"
-#include "esp/metadata/attributes/AttributesBase.h"
 #include "esp/metadata/attributes/AttributesEnumMaps.h"
 #include "esp/metadata/attributes/LightLayoutAttributes.h"
 #include "esp/metadata/attributes/MarkerSets.h"

--- a/src/esp/bindings/AttributesManagersBindings.cpp
+++ b/src/esp/bindings/AttributesManagersBindings.cpp
@@ -15,8 +15,8 @@
 #include "esp/metadata/attributes/StageAttributes.h"
 
 #include "esp/metadata/managers/AOAttributesManager.h"
+#include "esp/metadata/managers/AbstractAttributesManager.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
 #include "esp/metadata/managers/LightLayoutAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PbrShaderAttributesManager.h"
@@ -56,13 +56,14 @@ template <class T, ManagedObjectAccess Access>
 void declareBaseAttributesManager(py::module& m,
                                   const std::string& attrType,
                                   const std::string& classStrPrefix) {
-  using MgrClass = AttributesManager<T, Access>;
+  using MgrClass = AbstractAttributesManager<T, Access>;
   using AttribsPtr = std::shared_ptr<T>;
   // Most, but not all, of these methods are from ManagedContainer class
-  // template.  However, we use AttributesManager as the base class because we
-  // wish to have appropriate (attributes-related) argument nomenclature and
-  // documentation.
-  std::string pyclass_name = classStrPrefix + std::string("AttributesManager");
+  // template.  However, we use AbstractAttributesManager as the base class
+  // because we wish to have appropriate (attributes-related) argument
+  // nomenclature and documentation.
+  std::string pyclass_name =
+      classStrPrefix + std::string("AbstractAttributesManager");
   py::class_<MgrClass, std::shared_ptr<MgrClass>>(m, pyclass_name.c_str())
       .def("get_template_handle_by_id", &MgrClass::getObjectHandleByID,
            ("Returns string handle for the " + attrType +
@@ -332,10 +333,10 @@ void initAttributesManagersBindings(py::module& m) {
   declareBaseAttributesManager<AbstractPrimitiveAttributes,
                                ManagedObjectAccess::Copy>(m, "Primitive Asset",
                                                           "BaseAsset");
-  py::class_<
-      AssetAttributesManager,
-      AttributesManager<AbstractPrimitiveAttributes, ManagedObjectAccess::Copy>,
-      AssetAttributesManager::ptr>(
+  py::class_<AssetAttributesManager,
+             AbstractAttributesManager<AbstractPrimitiveAttributes,
+                                       ManagedObjectAccess::Copy>,
+             AssetAttributesManager::ptr>(
       m, "AssetAttributesManager",
       R"(Manages PrimtiveAttributes objects which define parameters for constructing primitive mesh shapes such as cubes, capsules, cylinders, and cones.)")
       // AssetAttributesMangaer-specific bindings
@@ -420,20 +421,21 @@ void initAttributesManagersBindings(py::module& m) {
                                ManagedObjectAccess::Copy>(
       m, "LightLayoutAttributes", "BaseLightLayout");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<
-      LightLayoutAttributesManager,
-      AttributesManager<LightLayoutAttributes, ManagedObjectAccess::Copy>,
-      LightLayoutAttributesManager::ptr>(m, "LightLayoutAttributesManager");
+  py::class_<LightLayoutAttributesManager,
+             AbstractAttributesManager<LightLayoutAttributes,
+                                       ManagedObjectAccess::Copy>,
+             LightLayoutAttributesManager::ptr>(m,
+                                                "LightLayoutAttributesManager");
 
   // ==== Articulated Object Attributes Template manager ====
   declareBaseAttributesManager<ArticulatedObjectAttributes,
                                ManagedObjectAccess::Copy>(
       m, "ArticulatedObjectAttributes", "BaseArticulatedObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<
-      AOAttributesManager,
-      AttributesManager<ArticulatedObjectAttributes, ManagedObjectAccess::Copy>,
-      AOAttributesManager::ptr>(
+  py::class_<AOAttributesManager,
+             AbstractAttributesManager<ArticulatedObjectAttributes,
+                                       ManagedObjectAccess::Copy>,
+             AOAttributesManager::ptr>(
       m, "AOAttributesManager",
       R"(Manages ArticulatedObjectAttributes which define Habitat-specific metadata for articulated objects
       (i.e. render asset or semantic ID), in addition to data held in defining URDF file, pre-instantiation.
@@ -443,9 +445,10 @@ void initAttributesManagersBindings(py::module& m) {
   declareBaseAttributesManager<ObjectAttributes, ManagedObjectAccess::Copy>(
       m, "ObjectAttributes", "BaseObject");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<ObjectAttributesManager,
-             AttributesManager<ObjectAttributes, ManagedObjectAccess::Copy>,
-             ObjectAttributesManager::ptr>(
+  py::class_<
+      ObjectAttributesManager,
+      AbstractAttributesManager<ObjectAttributes, ManagedObjectAccess::Copy>,
+      ObjectAttributesManager::ptr>(
       m, "ObjectAttributesManager",
       R"(Manages ObjectAttributes which define metadata for rigid objects pre-instantiation.
       Can import .object_config.json files.)")
@@ -504,10 +507,10 @@ void initAttributesManagersBindings(py::module& m) {
                                ManagedObjectAccess::Copy>(
       m, "PhysicsAttributes", "BasePhysics");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<
-      PhysicsAttributesManager,
-      AttributesManager<PhysicsManagerAttributes, ManagedObjectAccess::Copy>,
-      PhysicsAttributesManager::ptr>(
+  py::class_<PhysicsAttributesManager,
+             AbstractAttributesManager<PhysicsManagerAttributes,
+                                       ManagedObjectAccess::Copy>,
+             PhysicsAttributesManager::ptr>(
       m, "PhysicsAttributesManager",
       R"(Manages PhysicsManagerAttributes which define global Simulation parameters
       such as timestep. Can import .physics_config.json files.)");
@@ -516,9 +519,10 @@ void initAttributesManagersBindings(py::module& m) {
   declareBaseAttributesManager<PbrShaderAttributes, ManagedObjectAccess::Copy>(
       m, "PbrShaderAttributes", "BasePbrConfig");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<PbrShaderAttributesManager,
-             AttributesManager<PbrShaderAttributes, ManagedObjectAccess::Copy>,
-             PbrShaderAttributesManager::ptr>(
+  py::class_<
+      PbrShaderAttributesManager,
+      AbstractAttributesManager<PbrShaderAttributes, ManagedObjectAccess::Copy>,
+      PbrShaderAttributesManager::ptr>(
       m, "PbrShaderAttributesManager",
       R"(Manages PbrShaderAttributes which define PBR shader calculation control values, such as
       enabling IBL or specifying direct and indirect lighting balance. Can import .pbr_config.json files.)");
@@ -527,9 +531,10 @@ void initAttributesManagersBindings(py::module& m) {
   declareBaseAttributesManager<SemanticAttributes, ManagedObjectAccess::Copy>(
       m, "SemanticAttributes", "BaseSemantic");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<SemanticAttributesManager,
-             AttributesManager<SemanticAttributes, ManagedObjectAccess::Copy>,
-             SemanticAttributesManager::ptr>(
+  py::class_<
+      SemanticAttributesManager,
+      AbstractAttributesManager<SemanticAttributes, ManagedObjectAccess::Copy>,
+      SemanticAttributesManager::ptr>(
       m, "SemanticAttributesManager",
       R"(Manages SemanticAttributes which define semantic mappings and files applicable to a scene instance,
       such as semantic screen descriptor files and semantic regions. Can import .semantic_config.json files.)");
@@ -538,9 +543,10 @@ void initAttributesManagersBindings(py::module& m) {
   declareBaseAttributesManager<StageAttributes, ManagedObjectAccess::Copy>(
       m, "StageAttributes", "BaseStage");
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<StageAttributesManager,
-             AttributesManager<StageAttributes, ManagedObjectAccess::Copy>,
-             StageAttributesManager::ptr>(
+  py::class_<
+      StageAttributesManager,
+      AbstractAttributesManager<StageAttributes, ManagedObjectAccess::Copy>,
+      StageAttributesManager::ptr>(
       m, "StageAttributesManager",
       R"(Manages StageAttributes which define metadata for stages (i.e. static background mesh such
       as architectural elements) pre-instantiation. Can import .stage_config.json files.)");

--- a/src/esp/bindings/ConfigBindings.cpp
+++ b/src/esp/bindings/ConfigBindings.cpp
@@ -181,7 +181,9 @@ void initConfigBindings(py::module& m) {
            R"(Save a subconfiguration with the given name.)", "name"_a,
            "subconfig"_a)
       .def(
-          "has_subconfig", &Configuration::hasSubconfig,
+          "has_subconfig",
+          static_cast<bool (Configuration::*)(const std::string&) const>(
+              &Configuration::hasSubconfig),
           R"(Returns true if specified key references an existing subconfiguration within this configuration.)")
       .def(
           "remove_subconfig", &Configuration::removeSubconfig,

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -652,7 +652,7 @@ class ConfigValue {
   friend bool operator!=(const ConfigValue& a, const ConfigValue& b);
 
   ESP_SMART_POINTERS(ConfigValue)
-};  // namespace config
+};  // class ConfigValue
 
 /**
  * @brief provide debug stream support for @ref ConfigValue
@@ -1218,6 +1218,25 @@ class Configuration {
   }
 
   /**
+   * @brief return if passed @p subConfig exists in this Configuration's
+   * subconfig map. Does not compare hidden ConfigValues.
+   */
+  template <typename T>
+  bool hasSubconfig(const std::shared_ptr<T>& subConfig) const {
+    static_assert(std::is_base_of<Configuration, T>::value,
+                  "Configuration : Desired subconfig must be derived from "
+                  "core::config::Configuration");
+    auto cfgIterPair = getSubconfigIterator();
+    for (auto& cfgIter = cfgIterPair.first; cfgIter != cfgIterPair.second;
+         ++cfgIter) {
+      if (*(cfgIter->second) == *subConfig) {
+        return true;
+      }
+    }
+    return false;
+  }  // hasSubconfig
+
+  /**
    * @brief Templated subconfig copy getter. Retrieves a shared pointer to a
    * copy of the subConfig @ref esp::core::config::Configuration that has the
    * passed @p cfgName .
@@ -1661,6 +1680,15 @@ class Configuration {
   ValueMapType valueMap_{};
 
  public:
+  /**
+   * @brief Comparison - Ignores ConfigValues specified as hidden
+   */
+  friend bool operator==(const Configuration& a, const Configuration& b);
+  /**
+   * @brief Inequality Comparison - Ignores ConfigValues specified as hidden
+   */
+  friend bool operator!=(const Configuration& a, const Configuration& b);
+
   ESP_SMART_POINTERS(Configuration)
 };  // class Configuration
 

--- a/src/esp/core/managedContainers/ManagedContainer.h
+++ b/src/esp/core/managedContainers/ManagedContainer.h
@@ -734,18 +734,15 @@ class ManagedContainer : public ManagedContainerBase {
         (status == ManagedObjectPreregistration::Success_Use_Object_Handle
              ? object->getHandle()
              : objectHandle);
-    // adds template to library, and returns either the ID of the existing
-    // template referenced by stageAttributesHandle, or the next available
-    // ID if not found.
+    // adds template to library, and returns the ID of the existing template
+    // referenced by handleToUse
     int objectID = this->addObjectToLibrary(std::move(object), handleToUse);
     // If registration succeeded then perform post-registration handling
     if (objectID != ID_UNDEFINED) {
       // post registration manager-specific processing.
-      postRegisterObjectHandling(objectID, objectHandle);
+      postRegisterObjectHandling(objectID, handleToUse);
     }
-
     return objectID;
-
   }  // registerObjectInternal
 
   /**

--- a/src/esp/metadata/CMakeLists.txt
+++ b/src/esp/metadata/CMakeLists.txt
@@ -4,8 +4,8 @@
 
 set(
   metadata_SOURCES
-  attributes/AttributesBase.h
-  attributes/AttributesBase.cpp
+  attributes/AbstractAttributes.h
+  attributes/AbstractAttributes.cpp
   attributes/AttributesEnumMaps.h
   attributes/AttributesEnumMaps.cpp
   attributes/AbstractObjectAttributes.h
@@ -31,7 +31,7 @@ set(
   attributes/SemanticAttributes.cpp
   attributes/StageAttributes.h
   attributes/StageAttributes.cpp
-  managers/AttributesManagerBase.h
+  managers/AbstractAttributesManager.h
   managers/AbstractObjectAttributesManager.h
   managers/AOAttributesManager.h
   managers/AOAttributesManager.cpp

--- a/src/esp/metadata/attributes/AbstractAttributes.cpp
+++ b/src/esp/metadata/attributes/AbstractAttributes.cpp
@@ -2,7 +2,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 #include "esp/physics/PhysicsObjectBase.h"
 namespace esp {
 

--- a/src/esp/metadata/attributes/AbstractAttributes.h
+++ b/src/esp/metadata/attributes/AbstractAttributes.h
@@ -2,8 +2,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
-#define ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
+#ifndef ESP_METADATA_ATTRIBUTES_ABSTRACTATTRIBUTES_H_
+#define ESP_METADATA_ATTRIBUTES_ABSTRACTATTRIBUTES_H_
 
 #include <Corrade/Utility/Path.h>
 #include <deque>
@@ -177,7 +177,7 @@ class AbstractAttributes
   using Configuration::set;
 
   /**
-   * @brief return a vector of shared pointers to const @ref AttributesBase
+   * @brief return a vector of shared pointers to const @ref AbstractAttributes
    * sub-configurations.
    * @param subAttrConfig The subconfiguration from which to aquire the
    * subconfigs.
@@ -229,7 +229,7 @@ class AbstractAttributes
   }
 
   /**
-   * @brief Returns a shared pointer to the named @ref AttributesBase
+   * @brief Returns a shared pointer to the named @ref AbstractAttributes
    * sub-configurations member of the passed @p subAttrConfig.
    */
   template <class T>
@@ -239,9 +239,9 @@ class AbstractAttributes
 
   /**
    * @brief Removes and returns a shared pointer to the named @ref
-   * AttributesBase sub-configurations member of the passed @p subAttrConfig.
-   * The object's ID is freed as part of this process, to be used by other
-   * objects.
+   * AbstractAttributes sub-configurations member of the passed @p
+   * subAttrConfig. The object's ID is freed as part of this process, to be used
+   * by other objects.
    * @tparam The desired type of the removed Configuration
    * @param name The name of the object to remove.
    * @param availableIDs A deque of the IDs that this configuration has
@@ -457,4 +457,4 @@ void AbstractAttributes::copySubconfigIntoMe(
 }  // namespace metadata
 }  // namespace esp
 
-#endif  // ESP_METADATA_ATTRIBUTES_ATTRIBUTESBASE_H_
+#endif  // ESP_METADATA_ATTRIBUTES_ABSTRACTATTRIBUTES_H_

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_ABSTRACTOBJECTATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_ABSTRACTOBJECTATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 #include "MarkerSets.h"
 
 namespace esp {

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_ARTICULATEDOBJECTATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_ARTICULATEDOBJECTATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 #include "MarkerSets.h"
 
 namespace esp {

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -252,7 +252,7 @@ class LightLayoutAttributes : public AbstractAttributes {
    */
   void addLightInstance(LightInstanceAttributes::ptr _lightInstance) {
     this->setSubAttributesInternal<LightInstanceAttributes>(
-        _lightInstance, availableLightIDs_, lightInstConfig_, "");
+        _lightInstance, availableLightIDs_, lightInstConfig_, "", false);
   }
 
   /**

--- a/src/esp/metadata/attributes/LightLayoutAttributes.h
+++ b/src/esp/metadata/attributes/LightLayoutAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_LIGHTLAYOUTATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_LIGHTLAYOUTATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 #include "esp/gfx/LightSetup.h"
 
 namespace esp {

--- a/src/esp/metadata/attributes/PbrShaderAttributes.h
+++ b/src/esp/metadata/attributes/PbrShaderAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_PBRSHADERATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_PBRSHADERATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 namespace esp {
 namespace metadata {

--- a/src/esp/metadata/attributes/PhysicsManagerAttributes.h
+++ b/src/esp/metadata/attributes/PhysicsManagerAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_PHYSICSMANAGERATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_PHYSICSMANAGERATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 namespace esp {
 namespace metadata {

--- a/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
+++ b/src/esp/metadata/attributes/PrimitiveAssetAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_PRIMITIVEASSETATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_PRIMITIVEASSETATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 namespace esp {
 namespace metadata {

--- a/src/esp/metadata/attributes/SceneDatasetAttributes.h
+++ b/src/esp/metadata/attributes/SceneDatasetAttributes.h
@@ -10,7 +10,7 @@
  * relevant data and configurations for a specific dataset.
  */
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 #include "esp/metadata/managers/AOAttributesManager.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
@@ -35,6 +35,7 @@ class SceneDatasetAttributes : public AbstractAttributes {
     // These are to clear any external refs persisting after this scene dataset
     // is deleted.  Accessing these refs should result in errors instead of
     // leaks/undefined behavior.
+    artObjAttributesManager_ = nullptr;
     assetAttributesManager_ = nullptr;
     lightLayoutAttributesManager_ = nullptr;
     objectAttributesManager_ = nullptr;
@@ -42,7 +43,14 @@ class SceneDatasetAttributes : public AbstractAttributes {
     semanticAttributesManager_ = nullptr;
     stageAttributesManager_ = nullptr;
     navmeshMap_.clear();
-    semanticAttributesManager_ = nullptr;
+  }
+
+  /**
+   * @brief Return manager for construction and access to articulated object
+   * attributes.
+   */
+  const managers::AOAttributesManager::ptr& getAOAttributesManager() const {
+    return artObjAttributesManager_;
   }
 
   /**
@@ -54,26 +62,19 @@ class SceneDatasetAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Return manager for construction and access to object attributes.
-   */
-  const managers::ObjectAttributesManager::ptr& getObjectAttributesManager()
-      const {
-    return objectAttributesManager_;
-  }
-  /**
-   * @brief Return manager for construction and access to articulated object
-   * attributes.
-   */
-  const managers::AOAttributesManager::ptr& getAOAttributesManager() const {
-    return artObjAttributesManager_;
-  }
-
-  /**
    * @brief Return manager for construction and access to light attributes.
    */
   const managers::LightLayoutAttributesManager::ptr&
   getLightLayoutAttributesManager() const {
     return lightLayoutAttributesManager_;
+  }
+
+  /**
+   * @brief Return manager for construction and access to object attributes.
+   */
+  const managers::ObjectAttributesManager::ptr& getObjectAttributesManager()
+      const {
+    return objectAttributesManager_;
   }
 
   /**
@@ -446,6 +447,12 @@ class SceneDatasetAttributes : public AbstractAttributes {
       const std::string& descString);
 
   /**
+   * @brief Manages all construction and access to articulated object attributes
+   * from this dataset.
+   */
+  managers::AOAttributesManager::ptr artObjAttributesManager_ = nullptr;
+
+  /**
    * @brief Reference to AssetAttributesManager to give access to primitive
    * attributes for object construction
    */
@@ -463,12 +470,6 @@ class SceneDatasetAttributes : public AbstractAttributes {
    * dataset.
    */
   managers::ObjectAttributesManager::ptr objectAttributesManager_ = nullptr;
-
-  /**
-   * @brief Manages all construction and access to articulated object attributes
-   * from this dataset.
-   */
-  managers::AOAttributesManager::ptr artObjAttributesManager_ = nullptr;
 
   /**
    * @brief Manages all construction and access to @ref metadata::attributes::SceneInstanceAttributes

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -626,11 +626,21 @@ class SceneInstanceAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Add an object instance attributes to this scene instance.
+   * @brief Add an object instance attributes to this scene instance. Returns
+   * false if not added due to a duplicate to @p _objInstance found in
+   * @p objInstConfig_ during uniqueness validation.
+   * @param _objInstance The object instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _objInstance .
+   * Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _objInstance was added due to a duplicate being
+   * found.
    */
-  void addObjectInstanceAttrs(SceneObjectInstanceAttributes::ptr _objInstance) {
-    setSubAttributesInternal<SceneObjectInstanceAttributes>(
-        _objInstance, availableObjInstIDs_, objInstConfig_, "obj_inst_");
+  bool addObjectInstanceAttrs(SceneObjectInstanceAttributes::ptr _objInstance,
+                              bool _validateUnique) {
+    return setSubAttributesInternal<SceneObjectInstanceAttributes>(
+        _objInstance, availableObjInstIDs_, objInstConfig_, "obj_inst_",
+        _validateUnique);
   }
 
   /**
@@ -657,13 +667,21 @@ class SceneInstanceAttributes : public AbstractAttributes {
 
   /**
    * @brief Add an articulated object instance's attributes to this scene
-   * instance.
+   * instance. Returns false if not added due to a duplicate to
+   * @p _artObjInstance found in @p artObjInstConfig_ .
+   * @param _artObjInstance The object instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _objInstance .
+   * Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _objInstance was added due to a duplicate being
+   * found.
    */
-  void addArticulatedObjectInstanceAttrs(
-      SceneAOInstanceAttributes::ptr _artObjInstance) {
-    setSubAttributesInternal<SceneAOInstanceAttributes>(
+  bool addArticulatedObjectInstanceAttrs(
+      SceneAOInstanceAttributes::ptr _artObjInstance,
+      bool _validateUnique) {
+    return setSubAttributesInternal<SceneAOInstanceAttributes>(
         _artObjInstance, availableArtObjInstIDs_, artObjInstConfig_,
-        "art_obj_inst_");
+        "art_obj_inst_", _validateUnique);
   }
 
   /**

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -8,7 +8,7 @@
 #include <deque>
 #include <utility>
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 namespace esp {
 namespace physics {

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_ATTRIBUTES_SEMANTICATTRIBUTES_H_
 #define ESP_METADATA_ATTRIBUTES_SEMANTICATTRIBUTES_H_
 
-#include "AttributesBase.h"
+#include "AbstractAttributes.h"
 
 namespace esp {
 namespace metadata {

--- a/src/esp/metadata/attributes/SemanticAttributes.h
+++ b/src/esp/metadata/attributes/SemanticAttributes.h
@@ -372,12 +372,21 @@ class SemanticAttributes : public AbstractAttributes {
   }
 
   /**
-   * @brief Add an object instance attributes to this scene instance.
+   * @brief Add an object instance attributes to this scene instance.  Returns
+   * false if not added due to a duplicate to @p _regionInstance found in
+   * @p regionAnnotationConfig_ .
+   * @param _regionInstance The region instance to add to the owning
+   * subconfiguration.
+   * @param _validateUnique Whether to validate uniqueness of @p _regionInstance
+   * . Note : hidden fields are ignored for this validation.
+   * @return Whether or not @p _regionInstance was added due to a duplicate
+   * being found.
    */
-  void addRegionInstanceAttrs(SemanticVolumeAttributes::ptr _regionInstance) {
-    setSubAttributesInternal<SemanticVolumeAttributes>(
+  bool addRegionInstanceAttrs(SemanticVolumeAttributes::ptr _regionInstance,
+                              bool _validateUnique) {
+    return setSubAttributesInternal<SemanticVolumeAttributes>(
         _regionInstance, availableRegionInstIDs_, regionAnnotationConfig_,
-        "region_desc_");
+        "region_desc_", _validateUnique);
   }
 
   /**

--- a/src/esp/metadata/managers/AOAttributesManager.cpp
+++ b/src/esp/metadata/managers/AOAttributesManager.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "AOAttributesManager.h"
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 namespace Cr = Corrade;
 namespace esp {

--- a/src/esp/metadata/managers/AOAttributesManager.h
+++ b/src/esp/metadata/managers/AOAttributesManager.h
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/metadata/attributes/ArticulatedObjectAttributes.h"
 
@@ -20,14 +20,13 @@ using core::managedContainers::ManagedFileBasedContainer;
 using core::managedContainers::ManagedObjectAccess;
 
 class AOAttributesManager
-    : public AttributesManager<attributes::ArticulatedObjectAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::ArticulatedObjectAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   AOAttributesManager()
-      : AttributesManager<
-            attributes::ArticulatedObjectAttributes,
-            ManagedObjectAccess::Copy>::AttributesManager("Articulated Object",
-                                                          "ao_config.json") {
+      : AbstractAttributesManager<attributes::ArticulatedObjectAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("Articulated Object", "ao_config.json") {
     this->copyConstructorMap_["ArticulatedObjectAttributes"] =
         &AOAttributesManager::createObjectCopy<
             attributes::ArticulatedObjectAttributes>;
@@ -125,8 +124,8 @@ class AOAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/AbstractAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractAttributesManager.h
@@ -2,14 +2,14 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#ifndef ESP_METADATA_MANAGERS_ATTRIBUTESMANAGERBASE_H_
-#define ESP_METADATA_MANAGERS_ATTRIBUTESMANAGERBASE_H_
+#ifndef ESP_METADATA_MANAGERS_ABSTRACTATTRIBUTESMANAGER_H_
+#define ESP_METADATA_MANAGERS_ABSTRACTATTRIBUTESMANAGER_H_
 
 /** @file
- * @brief Class Template @ref esp::metadata::managers::AttributesManager
+ * @brief Class Template @ref esp::metadata::managers::AbstractAttributesManager
  */
 
-#include "esp/metadata/attributes/AttributesBase.h"
+#include "esp/metadata/attributes/AbstractAttributes.h"
 
 #include "esp/core/managedContainers/ManagedFileBasedContainer.h"
 #include "esp/io/Io.h"
@@ -42,11 +42,12 @@ using core::managedContainers::ManagedObjectAccess;
  * themselves.
  */
 template <class T, ManagedObjectAccess Access>
-class AttributesManager : public ManagedFileBasedContainer<T, Access> {
+class AbstractAttributesManager : public ManagedFileBasedContainer<T, Access> {
  public:
-  static_assert(std::is_base_of<attributes::AbstractAttributes, T>::value,
-                "AttributesManager :: Managed object type must be derived from "
-                "AbstractAttributes");
+  static_assert(
+      std::is_base_of<attributes::AbstractAttributes, T>::value,
+      "AbstractAttributesManager :: Managed object type must be derived from "
+      "AbstractAttributes");
 
   typedef std::shared_ptr<T> AttribsPtr;
 
@@ -59,11 +60,12 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
    * the managed type of attributes (i.e. "stage_config.json" for configurations
    * describing stages).
    */
-  AttributesManager(const std::string& attrType, const std::string& JSONTypeExt)
+  AbstractAttributesManager(const std::string& attrType,
+                            const std::string& JSONTypeExt)
       : ManagedFileBasedContainer<T, Access>::ManagedFileBasedContainer(
             attrType,
             JSONTypeExt) {}
-  ~AttributesManager() override = default;
+  ~AbstractAttributesManager() override = default;
 
   /**
    * @brief Load all file-based templates given string list of template file
@@ -174,7 +176,7 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
     // set the values for this attributes from the json config.
     this->setValsFromJSONDoc(attributes, jsonConfig);
     return attributes;
-  }  // AttributesManager<T, Access>::buildObjectFromJSONDoc
+  }  // AbstractAttributesManager<T, Access>::buildObjectFromJSONDoc
 
   /**
    * @brief Method to take an existing attributes and set its values from passed
@@ -197,7 +199,7 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
       const attributes::AbstractAttributes::ptr& attribs,
       const io::JsonGenericValue& jsonConfig) const {
     return this->parseSubconfigJsonVals("user_defined", attribs, jsonConfig);
-  }  // AttributesManager<T, Access>::parseUserDefinedJsonVals
+  }  // AbstractAttributesManager<T, Access>::parseUserDefinedJsonVals
 
   /**
    * @brief This function takes the passed json block @p jsonConfig, looks for
@@ -395,14 +397,15 @@ class AttributesManager : public ManagedFileBasedContainer<T, Access> {
       const std::function<void(const std::string&)>& handleSetter);
 
  public:
-  ESP_SMART_POINTERS(AttributesManager<T, Access>)
+  ESP_SMART_POINTERS(AbstractAttributesManager<T, Access>)
 
-};  // class AttributesManager
+};  // class AbstractAttributesManager
 
 /////////////////////////////
 // Class Template Method Definitions
 template <class T, ManagedObjectAccess Access>
-std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
+std::vector<int>
+AbstractAttributesManager<T, Access>::loadAllFileBasedTemplates(
     const std::vector<std::string>& paths,
     bool saveAsDefaults) {
   std::vector<int> templateIndices(paths.size(), ID_UNDEFINED);
@@ -431,10 +434,11 @@ std::vector<int> AttributesManager<T, Access>::loadAllFileBasedTemplates(
       << "<" << this->objectType_
       << "> : Loaded file-based templates: " << std::to_string(paths.size());
   return templateIndices;
-}  // AttributesManager<T, Access>::loadAllObjectTemplates
+}  // AbstractAttributesManager<T, Access>::loadAllObjectTemplates
 
 template <class T, ManagedObjectAccess Access>
-std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
+std::vector<int>
+AbstractAttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
     const std::string& path,
     const std::string& extType,
     bool saveAsDefaults) {
@@ -480,10 +484,10 @@ std::vector<int> AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt(
   templateIndices = this->loadAllFileBasedTemplates(paths, saveAsDefaults);
 
   return templateIndices;
-}  // AttributesManager<T, Access>::loadAllTemplatesFromPathAndExt
+}  // AbstractAttributesManager<T, Access>::loadAllTemplatesFromPathAndExt
 
 template <class T, ManagedObjectAccess Access>
-void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
+void AbstractAttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
     const std::string& configDir,
     const std::string& extType,
     const io::JsonGenericValue& filePaths) {
@@ -533,10 +537,10 @@ void AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad(
       << "<" << this->objectType_ << "> : " << std::to_string(filePaths.Size())
       << " paths specified in JSON doc for " << this->objectType_
       << " configuration files.";
-}  // AttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
+}  // AbstractAttributesManager<T, Access>::buildAttrSrcPathsFromJSONAndLoad
 
 template <class T, ManagedObjectAccess Access>
-auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
+auto AbstractAttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     const std::string& filename,
     std::string& msg,
     bool registerObj) -> AttribsPtr {
@@ -581,10 +585,10 @@ auto AttributesManager<T, Access>::createFromJsonOrDefaultInternal(
     }
   }
   return attrs;
-}  // AttributesManager<T, Access>::createFromJsonFileOrDefaultInternal
+}  // AbstractAttributesManager<T, Access>::createFromJsonFileOrDefaultInternal
 
 template <class T, ManagedObjectAccess Access>
-bool AttributesManager<T, Access>::parseSubconfigJsonVals(
+bool AbstractAttributesManager<T, Access>::parseSubconfigJsonVals(
     const std::string& subGroupName,
     const attributes::AbstractAttributes::ptr& attribs,
     const io::JsonGenericValue& jsonConfig) const {
@@ -617,10 +621,10 @@ bool AttributesManager<T, Access>::parseSubconfigJsonVals(
     }
   }  // if has requested tag
   return false;
-}  // AttributesManager<T, Access>::parseSubconfigJsonVals
+}  // AbstractAttributesManager<T, Access>::parseSubconfigJsonVals
 
 template <class T, ManagedObjectAccess Access>
-bool AttributesManager<T, Access>::setFilenameFromDefaultTag(
+bool AbstractAttributesManager<T, Access>::setFilenameFromDefaultTag(
     const AttribsPtr& attributes,
     const std::string& srcAssetFilename,
     const std::function<void(const std::string&)>& filenameSetter) {
@@ -671,10 +675,10 @@ bool AttributesManager<T, Access>::setFilenameFromDefaultTag(
   // No file exists with passed name, either as relative path or as
   // wild-card-equipped relative path
   return false;
-}  // AttributesManager<T, Access>::setFilenameFromDefaultTag
+}  // AbstractAttributesManager<T, Access>::setFilenameFromDefaultTag
 
 template <class T, ManagedObjectAccess Access>
-bool AttributesManager<T, Access>::setAttributesHandleFromDefaultTag(
+bool AbstractAttributesManager<T, Access>::setAttributesHandleFromDefaultTag(
     const AttribsPtr& attributes,
     const std::string& srcAssetHandle,
     const std::function<void(const std::string&)>& handleSetter) {
@@ -698,10 +702,10 @@ bool AttributesManager<T, Access>::setAttributesHandleFromDefaultTag(
     return true;
   }
   return false;
-}  // AttributesManager<T, Access>::setAttributesHandleFromDefaultTag
+}  // AbstractAttributesManager<T, Access>::setAttributesHandleFromDefaultTag
 
 template <class T, ManagedObjectAccess Access>
-void AttributesManager<T, Access>::filterAttribsFilenames(
+void AbstractAttributesManager<T, Access>::filterAttribsFilenames(
     const AttribsPtr& attributes,
     const std::string& curRelPathName,
     const std::string& curFQPathName,
@@ -792,11 +796,11 @@ void AttributesManager<T, Access>::filterAttribsFilenames(
   }
 
   ESP_VERY_VERBOSE() << dispString;
-}  // AttributesManager<T, Access>::filterAttribsFilenames
+}  // AbstractAttributesManager<T, Access>::filterAttribsFilenames
 
 template <class T, ManagedObjectAccess Access>
 template <class M>
-void AttributesManager<T, Access>::setEnumStringFromJsonDoc(
+void AbstractAttributesManager<T, Access>::setEnumStringFromJsonDoc(
     const io::JsonGenericValue& jsonConfig,
     const char* jsonTag,
     const std::string& mapName,
@@ -828,9 +832,9 @@ void AttributesManager<T, Access>::setEnumStringFromJsonDoc(
       valueSetter("unspecified");
     }
   }
-}  // AttributesManager<T, Access>::setEnumStringFromJsonDoc
+}  // AbstractAttributesManager<T, Access>::setEnumStringFromJsonDoc
 
 }  // namespace managers
 }  // namespace metadata
 }  // namespace esp
-#endif  // ESP_METADATA_MANAGERS_ATTRIBUTESMANAGERBASE_H_
+#endif  // ESP_METADATA_MANAGERS_ABSTRACTATTRIBUTESMANAGER_H_

--- a/src/esp/metadata/managers/AbstractObjectAttributesManager.h
+++ b/src/esp/metadata/managers/AbstractObjectAttributesManager.h
@@ -11,8 +11,8 @@
  */
 
 #include "esp/metadata/attributes/AbstractObjectAttributes.h"
+#include "esp/metadata/managers/AbstractAttributesManager.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
 
 namespace Cr = Corrade;
 
@@ -29,7 +29,8 @@ namespace managers {
  * esp::metadata::attributes::AbstractObjectAttributes.
  */
 template <class T, ManagedObjectAccess Access>
-class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
+class AbstractObjectAttributesManager
+    : public AbstractAttributesManager<T, Access> {
  public:
   static_assert(std::is_base_of<attributes::AbstractObjectAttributes, T>::value,
                 "AbstractObjectAttributesManager :: Managed object type must "
@@ -39,7 +40,7 @@ class AbstractObjectAttributesManager : public AttributesManager<T, Access> {
 
   AbstractObjectAttributesManager(const std::string& attrType,
                                   const std::string& JSONTypeExt)
-      : AttributesManager<T, Access>::AttributesManager(
+      : AbstractAttributesManager<T, Access>::AbstractAttributesManager(
             (attrType + " Template"),
             JSONTypeExt) {}
   ~AbstractObjectAttributesManager() override = default;

--- a/src/esp/metadata/managers/AssetAttributesManager.cpp
+++ b/src/esp/metadata/managers/AssetAttributesManager.cpp
@@ -7,8 +7,8 @@
 
 #include <utility>
 
+#include "AbstractAttributesManager.h"
 #include "AssetAttributesManager.h"
-#include "AttributesManagerBase.h"
 
 namespace esp {
 namespace metadata {
@@ -40,10 +40,9 @@ const std::map<PrimObjTypes, const char*>
         {PrimObjTypes::END_PRIM_OBJ_TYPES, "NONE DEFINED"}};
 
 AssetAttributesManager::AssetAttributesManager()
-    : AttributesManager<
-          attributes::AbstractPrimitiveAttributes,
-          ManagedObjectAccess::Copy>::AttributesManager("Primitive Asset",
-                                                        "prim_config.json") {
+    : AbstractAttributesManager<attributes::AbstractPrimitiveAttributes,
+                                ManagedObjectAccess::Copy>::
+          AbstractAttributesManager("Primitive Asset", "prim_config.json") {
   // function pointers to asset attributes constructors
   primTypeConstructorMap_["capsule3DSolid"] =
       &AssetAttributesManager::createPrimAttributes<

--- a/src/esp/metadata/managers/AssetAttributesManager.h
+++ b/src/esp/metadata/managers/AssetAttributesManager.h
@@ -11,7 +11,7 @@
  * primitives.
  */
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 #include "esp/metadata/attributes/PrimitiveAssetAttributes.h"
 
 namespace esp {
@@ -77,8 +77,8 @@ enum class PrimObjTypes : uint32_t {
 namespace managers {
 
 class AssetAttributesManager
-    : public AttributesManager<attributes::AbstractPrimitiveAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::AbstractPrimitiveAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   /**
    * @brief Constant Map holding names of all Magnum 3D primitive classes
@@ -458,8 +458,8 @@ class AssetAttributesManager
  protected:
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *
@@ -488,7 +488,7 @@ class AssetAttributesManager
       return false;
     }
     return true;
-  }  // AttributesManager::verifyTemplateHandle
+  }  // AbstractAttributesManager::verifyTemplateHandle
 
   /**
    * @brief This method will perform any essential updating to the managed

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.cpp
@@ -246,7 +246,7 @@ void LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc(
           });
     }
   }  // if JSON object 'spot' present
-}  // LightLayoutAttributesManager::setValsFromJSONDoc
+}  // LightLayoutAttributesManager::setLightInstanceValsFromJSONDoc
 
 LightLayoutAttributes::ptr LightLayoutAttributesManager::initNewObjectInternal(
     const std::string& handleName,

--- a/src/esp/metadata/managers/LightLayoutAttributesManager.h
+++ b/src/esp/metadata/managers/LightLayoutAttributesManager.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_MANAGERS_LIGHTATTRIBUTEMANAGER_H_
 #define ESP_METADATA_MANAGERS_LIGHTATTRIBUTEMANAGER_H_
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/gfx/LightSetup.h"
 #include "esp/metadata/attributes/LightLayoutAttributes.h"
@@ -17,13 +17,14 @@ namespace metadata {
 namespace managers {
 
 class LightLayoutAttributesManager
-    : public AttributesManager<attributes::LightLayoutAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::LightLayoutAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   LightLayoutAttributesManager()
-      : AttributesManager<attributes::LightLayoutAttributes,
-                          ManagedObjectAccess::Copy>::
-            AttributesManager("Lighting Layout", "lighting_config.json") {
+      : AbstractAttributesManager<attributes::LightLayoutAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("Lighting Layout",
+                                      "lighting_config.json") {
     // build this manager's copy constructor map
     this->copyConstructorMap_["LightLayoutAttributes"] =
         &LightLayoutAttributesManager::createObjectCopy<
@@ -109,7 +110,8 @@ class LightLayoutAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal.  This should only be
+   * AbstractAttributesManager-specific upon template removal.  This should only
+   * be
    * called from @ref esp::core::managedContainers::ManagedContainerBase.
    *
    * @param templateID the ID of the template to remove

--- a/src/esp/metadata/managers/ObjectAttributesManager.h
+++ b/src/esp/metadata/managers/ObjectAttributesManager.h
@@ -200,8 +200,8 @@ class ObjectAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/PbrShaderAttributesManager.cpp
+++ b/src/esp/metadata/managers/PbrShaderAttributesManager.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "PbrShaderAttributesManager.h"
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/io/Json.h"
 

--- a/src/esp/metadata/managers/PbrShaderAttributesManager.h
+++ b/src/esp/metadata/managers/PbrShaderAttributesManager.h
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/gfx/configure.h"
 #include "esp/metadata/attributes/PbrShaderAttributes.h"
@@ -19,14 +19,13 @@ namespace metadata {
 namespace managers {
 
 class PbrShaderAttributesManager
-    : public AttributesManager<attributes::PbrShaderAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::PbrShaderAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   PbrShaderAttributesManager()
-      : AttributesManager<
-            attributes::PbrShaderAttributes,
-            ManagedObjectAccess::Copy>::AttributesManager("PBR Rendering",
-                                                          "pbr_config.json") {
+      : AbstractAttributesManager<attributes::PbrShaderAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("PBR Rendering", "pbr_config.json") {
     this->copyConstructorMap_["PbrShaderAttributes"] =
         &PbrShaderAttributesManager::createObjectCopy<
             attributes::PbrShaderAttributes>;
@@ -127,8 +126,8 @@ class PbrShaderAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/PhysicsAttributesManager.cpp
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "PhysicsAttributesManager.h"
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/io/Json.h"
 

--- a/src/esp/metadata/managers/PhysicsAttributesManager.h
+++ b/src/esp/metadata/managers/PhysicsAttributesManager.h
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/metadata/attributes/PhysicsManagerAttributes.h"
 #include "esp/physics/configure.h"
@@ -19,13 +19,14 @@ namespace metadata {
 namespace managers {
 
 class PhysicsAttributesManager
-    : public AttributesManager<attributes::PhysicsManagerAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::PhysicsManagerAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   PhysicsAttributesManager()
-      : AttributesManager<attributes::PhysicsManagerAttributes,
-                          ManagedObjectAccess::Copy>::
-            AttributesManager("Physics Manager", "physics_config.json") {
+      : AbstractAttributesManager<attributes::PhysicsManagerAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("Physics Manager",
+                                      "physics_config.json") {
     this->copyConstructorMap_["PhysicsManagerAttributes"] =
         &PhysicsAttributesManager::createObjectCopy<
             attributes::PhysicsManagerAttributes>;
@@ -100,8 +101,8 @@ class PhysicsAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.cpp
@@ -18,8 +18,9 @@ namespace managers {
 SceneDatasetAttributesManager::SceneDatasetAttributesManager(
     PhysicsAttributesManager::ptr physicsAttributesMgr,
     PbrShaderAttributesManager::ptr pbrShaderAttributesMgr)
-    : AttributesManager<SceneDatasetAttributes, ManagedObjectAccess::Share>::
-          AttributesManager("Dataset", "scene_dataset_config.json"),
+    : AbstractAttributesManager<SceneDatasetAttributes,
+                                ManagedObjectAccess::Share>::
+          AbstractAttributesManager("Dataset", "scene_dataset_config.json"),
       physicsAttributesManager_(std::move(physicsAttributesMgr)),
       pbrShaderAttributesManager_(std::move(pbrShaderAttributesMgr)) {
   // build this manager's copy ctor map

--- a/src/esp/metadata/managers/SceneDatasetAttributesManager.h
+++ b/src/esp/metadata/managers/SceneDatasetAttributesManager.h
@@ -10,15 +10,15 @@
 #include "PbrShaderAttributesManager.h"
 #include "PhysicsAttributesManager.h"
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 #include "esp/metadata/attributes/SceneDatasetAttributes.h"
 
 namespace esp {
 namespace metadata {
 namespace managers {
 class SceneDatasetAttributesManager
-    : public AttributesManager<attributes::SceneDatasetAttributes,
-                               ManagedObjectAccess::Share> {
+    : public AbstractAttributesManager<attributes::SceneDatasetAttributes,
+                                       ManagedObjectAccess::Share> {
  public:
   explicit SceneDatasetAttributesManager(
       PhysicsAttributesManager::ptr physicsAttributesMgr,
@@ -121,7 +121,7 @@ class SceneDatasetAttributesManager
   /**
    * @brief Verify a particular subcell exists within the
    * dataset_config.JSON file, and if so, handle reading the possible JSON
-   * sub-cells it might hold, using the passed attributesManager for the
+   * sub-cells it might hold, using the passed AbstractAttributesManager for the
    * dataset being processed.
    * @tparam the type of the attributes manager.
    * @param dsDir The root directory of the dataset attributes being built.
@@ -173,8 +173,8 @@ class SceneDatasetAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -111,7 +111,8 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
                     << "` so no Stage can be created for this Scene.");
     }
   }
-
+  // TODO : drive by diagnostics when implemented
+  bool validateUnique = false;
   // Check for object instances existence
   io::JsonGenericValue::ConstMemberIterator objJSONIter =
       jsonConfig.FindMember("object_instances");
@@ -123,7 +124,7 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
         const auto& objCell = objectArray[i];
         if (objCell.IsObject()) {
           attribs->addObjectInstanceAttrs(
-              createInstanceAttributesFromJSON(objCell));
+              createInstanceAttributesFromJSON(objCell), validateUnique);
         } else {
           ESP_WARNING(Mn::Debug::Flag::NoSpace)
               << "Object instance issue in Scene Instance `" << attribsDispName
@@ -161,7 +162,7 @@ void SceneInstanceAttributesManager::setValsFromJSONDoc(
 
         if (artObjCell.IsObject()) {
           attribs->addArticulatedObjectInstanceAttrs(
-              createAOInstanceAttributesFromJSON(artObjCell));
+              createAOInstanceAttributesFromJSON(artObjCell), validateUnique);
         } else {
           ESP_WARNING(Mn::Debug::Flag::NoSpace)
               << "Articulated Object specification error in Scene Instance `"

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.h
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.h
@@ -5,7 +5,7 @@
 #ifndef ESP_METADATA_MANAGERS_SCENEINSTANCEATTRIBUTEMANAGER_H_
 #define ESP_METADATA_MANAGERS_SCENEINSTANCEATTRIBUTEMANAGER_H_
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 #include "esp/metadata/attributes/SceneInstanceAttributes.h"
 
 namespace esp {
@@ -15,13 +15,13 @@ namespace managers {
 using esp::core::managedContainers::ManagedObjectAccess;
 
 class SceneInstanceAttributesManager
-    : public AttributesManager<attributes::SceneInstanceAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::SceneInstanceAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   SceneInstanceAttributesManager()
-      : AttributesManager<attributes::SceneInstanceAttributes,
-                          ManagedObjectAccess::Copy>::
-            AttributesManager("Scene Instance", "scene_instance.json") {
+      : AbstractAttributesManager<attributes::SceneInstanceAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("Scene Instance", "scene_instance.json") {
     // build this manager's copy constructor map
     this->copyConstructorMap_["SceneInstanceAttributes"] =
         &SceneInstanceAttributesManager::createObjectCopy<
@@ -176,8 +176,8 @@ class SceneInstanceAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -194,7 +194,8 @@ void SemanticAttributesManager::setValsFromJSONDoc(
     }
     semanticAttribs->setSemanticDescriptorFilename(semanticSceneDescriptor);
   }
-
+  // TODO : drive by diagnostics when implemented
+  bool validateUnique = false;
   // Check for region instances existence
   io::JsonGenericValue::ConstMemberIterator regionJSONIter =
       jsonConfig.FindMember("region_annotations");
@@ -206,7 +207,7 @@ void SemanticAttributesManager::setValsFromJSONDoc(
         const auto& regionCell = regionArray[i];
         if (regionCell.IsObject()) {
           semanticAttribs->addRegionInstanceAttrs(
-              createRegionAttributesFromJSON(regionCell));
+              createRegionAttributesFromJSON(regionCell), validateUnique);
         } else {
           ESP_WARNING(Mn::Debug::Flag::NoSpace)
               << "Region instance issue in Semantic Configuration `"

--- a/src/esp/metadata/managers/SemanticAttributesManager.cpp
+++ b/src/esp/metadata/managers/SemanticAttributesManager.cpp
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "SemanticAttributesManager.h"
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/io/Json.h"
 

--- a/src/esp/metadata/managers/SemanticAttributesManager.h
+++ b/src/esp/metadata/managers/SemanticAttributesManager.h
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "AttributesManagerBase.h"
+#include "AbstractAttributesManager.h"
 
 #include "esp/metadata/attributes/SemanticAttributes.h"
 
@@ -18,13 +18,14 @@ namespace metadata {
 namespace managers {
 
 class SemanticAttributesManager
-    : public AttributesManager<attributes::SemanticAttributes,
-                               ManagedObjectAccess::Copy> {
+    : public AbstractAttributesManager<attributes::SemanticAttributes,
+                                       ManagedObjectAccess::Copy> {
  public:
   SemanticAttributesManager()
-      : AttributesManager<attributes::SemanticAttributes,
-                          ManagedObjectAccess::Copy>::
-            AttributesManager("Semantic Attributes", "semantic_config.json") {
+      : AbstractAttributesManager<attributes::SemanticAttributes,
+                                  ManagedObjectAccess::Copy>::
+            AbstractAttributesManager("Semantic Attributes",
+                                      "semantic_config.json") {
     this->copyConstructorMap_["SemanticAttributes"] =
         &SemanticAttributesManager::createObjectCopy<
             attributes::SemanticAttributes>;
@@ -121,8 +122,8 @@ class SemanticAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called @ref
    * esp::core::ManagedContainerBase.
    *

--- a/src/esp/metadata/managers/StageAttributesManager.h
+++ b/src/esp/metadata/managers/StageAttributesManager.h
@@ -131,8 +131,8 @@ class StageAttributesManager
 
   /**
    * @brief This method will perform any necessary updating that is
-   * attributesManager-specific upon template removal, such as removing a
-   * specific template handle from the list of file-based template handles in
+   * AbstractAttributesManager-specific upon template removal, such as removing
+   * a specific template handle from the list of file-based template handles in
    * ObjectAttributesManager.  This should only be called internally from @ref
    * esp::core::managedContainers::ManagedContainerBase.
    *

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -670,10 +670,14 @@ void PhysicsManager::buildCurrentStateSceneAttributes(
   // 2. Clear existing object instances, and set new ones reflecting current
   // state
   sceneInstanceAttrs->clearObjectInstances();
+
+  // TODO : drive by diagnostics when implemented
+  bool validateUnique = false;
+
   // get each object's current state as a SceneObjectInstanceAttributes
   for (const auto& item : existingObjects_) {
     sceneInstanceAttrs->addObjectInstanceAttrs(
-        item.second->getCurrentStateInstanceAttr());
+        item.second->getCurrentStateInstanceAttr(), validateUnique);
   }
   // 3. Clear existing Articulated object instances, and set new ones reflecting
   // current state
@@ -681,7 +685,7 @@ void PhysicsManager::buildCurrentStateSceneAttributes(
   // get each articulated object's current state as a SceneAOInstanceAttributes
   for (const auto& item : existingArticulatedObjects_) {
     sceneInstanceAttrs->addArticulatedObjectInstanceAttrs(
-        item.second->getCurrentStateInstanceAttr());
+        item.second->getCurrentStateInstanceAttr(), validateUnique);
   }
 
 }  // PhysicsManager::buildCurrentStateSceneAttributes

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -9,8 +9,8 @@
 #include "esp/assets/BaseMesh.h"
 #include "esp/assets/GenericSemanticMeshData.h"
 #include "esp/core/Esp.h"
+#include "esp/metadata/attributes/AbstractAttributes.h"
 #include "esp/metadata/attributes/AbstractObjectAttributes.h"
-#include "esp/metadata/attributes/AttributesBase.h"
 #include "esp/physics/PhysicsObjectBase.h"
 
 /** @file

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -24,7 +24,7 @@
 #include "esp/gfx/replay/Recorder.h"
 #include "esp/gfx/replay/ReplayManager.h"
 #include "esp/metadata/MetadataMediator.h"
-#include "esp/metadata/attributes/AttributesBase.h"
+#include "esp/metadata/attributes/AbstractAttributes.h"
 #include "esp/nav/PathFinder.h"
 #include "esp/physics/PhysicsManager.h"
 #include "esp/physics/bullet/BulletCollisionHelper.h"

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -705,6 +705,8 @@ Simulator::buildCurrentStateSceneAttributes() const {
   // current scene setup - stage instance, object instances and articulated
   // object instances
   physicsManager_->buildCurrentStateSceneAttributes(initSceneInstanceAttr);
+  // NOTE This copy now is different from the registered original in the
+  // SceneInstanceAttributesManager.
 
   // 3. Return the copy
   return initSceneInstanceAttr;

--- a/src/tests/AttributesConfigsTest.cpp
+++ b/src/tests/AttributesConfigsTest.cpp
@@ -8,7 +8,7 @@
 
 #include "esp/metadata/MetadataMediator.h"
 #include "esp/metadata/managers/AOAttributesManager.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
+#include "esp/metadata/managers/AbstractAttributesManager.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PbrShaderAttributesManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
@@ -30,7 +30,7 @@ using esp::metadata::PrimObjTypes;
 
 using esp::physics::MotionType;
 
-using AttrMgrs::AttributesManager;
+using AttrMgrs::AbstractAttributesManager;
 using Attrs::ArticulatedObjectAttributes;
 using Attrs::MarkerSets;
 using Attrs::ObjectAttributes;

--- a/src/tests/AttributesManagersTest.cpp
+++ b/src/tests/AttributesManagersTest.cpp
@@ -8,8 +8,8 @@
 
 #include "esp/metadata/MetadataMediator.h"
 #include "esp/metadata/managers/AOAttributesManager.h"
+#include "esp/metadata/managers/AbstractAttributesManager.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PbrShaderAttributesManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
@@ -28,7 +28,7 @@ using esp::metadata::PrimObjTypes;
 
 using esp::physics::MotionType;
 
-using AttrMgrs::AttributesManager;
+using AttrMgrs::AbstractAttributesManager;
 using Attrs::AbstractPrimitiveAttributes;
 using Attrs::ArticulatedObjectAttributes;
 using Attrs::CapsulePrimitiveAttributes;
@@ -155,10 +155,10 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for PhysicsManagerAttributes.
+   * Attributes via the AbstractAttributesManager for PhysicsManagerAttributes.
    * These tests should be consistent with most types of future
-   * attributes managers specializing the AttributesManager class template that
-   * follow the same expected behavior paths as extent
+   * attributes managers specializing the AbstractAttributesManager class
+   * template that follow the same expected behavior paths as extent
    * attributes/attributesManagers.  Note : PrimitiveAssetAttributes exhibit
    * slightly different behavior and need their own tests.
    */
@@ -166,54 +166,55 @@ struct AttributesManagersTest : Cr::TestSuite::Tester {
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for PbrShaderAttributes. These
+   * Attributes via the AbstractAttributesManager for PbrShaderAttributes. These
    * tests should be consistent with most types of future attributes managers
-   * specializing the AttributesManager class template that follow the same
-   * expected behavior paths as extent attributes/attributesManagers.
+   * specializing the AbstractAttributesManager class template that follow the
+   * same expected behavior paths as extent attributes/attributesManagers.
    */
   void testPbrShaderAttributesManagersCreate();
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for StageAttributes. These
+   * Attributes via the AbstractAttributesManager for StageAttributes. These
    * tests should be consistent with most types of future attributes managers
-   * specializing the AttributesManager class template that follow the same
-   * expected behavior paths as extent attributes/attributesManagers.
+   * specializing the AbstractAttributesManager class template that follow the
+   * same expected behavior paths as extent attributes/attributesManagers.
    */
   void testStageAttributesManagersCreate();
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for SemanticAttributes. These
+   * Attributes via the AbstractAttributesManager for SemanticAttributes. These
    * tests should be consistent with most types of future attributes managers
-   * specializing the AttributesManager class template that follow the same
-   * expected behavior paths as extent attributes/attributesManagers.
+   * specializing the AbstractAttributesManager class template that follow the
+   * same expected behavior paths as extent attributes/attributesManagers.
    */
   void testSemanticAttributesManagersCreate();
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for ArticulatedObjectAttributes. These
-   * tests should be consistent with most types of future attributes managers
-   * specializing the AttributesManager class template that follow the same
-   * expected behavior paths as extent attributes/attributesManagers.
+   * Attributes via the AbstractAttributesManager for
+   * ArticulatedObjectAttributes. These tests should be consistent with most
+   * types of future attributes managers specializing the
+   * AbstractAttributesManager class template that follow the same expected
+   * behavior paths as extent attributes/attributesManagers.
    */
 
   void testArticulatedObjectAttributesManagersCreate();
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for ObjectAttributes. These
+   * Attributes via the AbstractAttributesManager for ObjectAttributes. These
    * tests should be consistent with most types of future attributes managers
-   * specializing the AttributesManager class template that follow the same
-   * expected behavior paths as extent attributes/attributesManagers.  Note :
-   * PrimitiveAssetAttributes exhibit slightly different behavior and need their
-   * own tests.
+   * specializing the AbstractAttributesManager class template that follow the
+   * same expected behavior paths as extent attributes/attributesManagers.  Note
+   * : PrimitiveAssetAttributes exhibit slightly different behavior and need
+   * their own tests.
    */
   void testObjectAttributesManagersCreate();
 
   /**
    * @brief This test will test creating, modifying, registering and deleting
-   * Attributes via the AttributesManager for LightLayoutsAttributes
+   * Attributes via the AbstractAttributesManager for LightLayoutsAttributes
    */
   void testLightLayoutAttributesManager();
 

--- a/src/tests/MetadataMediatorTest.cpp
+++ b/src/tests/MetadataMediatorTest.cpp
@@ -5,8 +5,8 @@
 #include <Corrade/TestSuite/Compare/Numeric.h>
 #include <Corrade/TestSuite/Tester.h>
 #include "esp/metadata/MetadataMediator.h"
+#include "esp/metadata/managers/AbstractAttributesManager.h"
 #include "esp/metadata/managers/AssetAttributesManager.h"
-#include "esp/metadata/managers/AttributesManagerBase.h"
 #include "esp/metadata/managers/ObjectAttributesManager.h"
 #include "esp/metadata/managers/PhysicsAttributesManager.h"
 #include "esp/metadata/managers/StageAttributesManager.h"

--- a/src/tests/ResourceManagerTest.cpp
+++ b/src/tests/ResourceManagerTest.cpp
@@ -19,7 +19,7 @@
 #include "esp/gfx/Renderer.h"
 #include "esp/gfx/WindowlessContext.h"
 #include "esp/metadata/MetadataMediator.h"
-#include "esp/metadata/attributes/AttributesBase.h"
+#include "esp/metadata/attributes/AbstractAttributes.h"
 #include "esp/scene/SceneManager.h"
 
 #include "configure.h"

--- a/src_python/habitat_sim/attributes_managers.py
+++ b/src_python/habitat_sim/attributes_managers.py
@@ -3,7 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Each AttributesManager acts as a library of Attributes objects of a specific type, governing access and supporting import from config files.
+Each AbstractAttributesManager acts as a library of Attributes objects of a specific type, governing access and supporting import from config files.
 
 Notes: SceneDataset and SceneInstance managers can be accessed from MetadataMediator and Simulator APIs, but are not publicly exposed.
 """


### PR DESCRIPTION
## Motivation and Context
This PR addresses a few things that I've wanted to take care of for a while, as well as a little bit of groundwork for future PRs. All of these changes are transparent and should have no impact on current Sim execution.

 - Rename the base classes for the attributes and the managers to be more in line with naming conventions elsewhere in the code base.
 - Add a Configuration comparison override. 
 - Add the ability to check for duplicate Configurations before adding them as Subconfigs on demand.
 - Address a rare edge-case issue during attributes registration where the name that the attributes is saved with can potentially not be the name that is passed to the (child-class-specific) post-registration processing.
  
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally C++ and python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
