### PR TITLE
[bugfix] - raycast buffer distance

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -296,6 +296,7 @@ void initSimBindings(py::module& m) {
           R"(Perform discrete collision detection for the scene. Physics must be enabled. Warning: may break simulation determinism.)")
       .def(
           "cast_ray", &Simulator::castRay, "ray"_a, "max_distance"_a = 100.0,
+          "buffer_distance"_a = 0.08,
           R"(Cast a ray into the collidable scene and return hit results. Physics must be enabled. max_distance in units of ray length.)")
       .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
            "object_id"_a,

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -792,10 +792,14 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * distances will be in units of ray length.
    * @param maxDistance The maximum distance along the ray direction to
    * search. In units of ray length.
+   * @param bufferDistance The casts the ray from this distance behind the
+   * origin in the inverted ray direction to avoid errors related to casting
+   * rays inside a collision shape's margin.
    * @return The raycast results sorted by distance.
    */
   virtual RaycastResults castRay(const esp::geo::Ray& ray,
-                                 CORRADE_UNUSED double maxDistance = 100.0) {
+                                 CORRADE_UNUSED double maxDistance = 100.0,
+                                 CORRADE_UNUSED double bufferDistance = 0.08) {
     ESP_ERROR() << "Not implemented in base PhysicsManager. Install with "
                    "--bullet to use this feature.";
     RaycastResults results;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -484,7 +484,8 @@ void BulletPhysicsManager::debugDraw(const Magnum::Matrix4& projTrans) const {
 }
 
 RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
-                                             double maxDistance) {
+                                             double maxDistance,
+                                             double bufferDistance) {
   RaycastResults results;
   results.ray = ray;
   double rayLength = static_cast<double>(ray.direction.length());
@@ -492,7 +493,7 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
     ESP_ERROR() << "Cannot cast ray with zero length, aborting.";
     return results;
   }
-  btVector3 from(ray.origin);
+  btVector3 from(ray.origin - (ray.direction / rayLength) * bufferDistance);
   btVector3 to(ray.origin + ray.direction * maxDistance);
 
   btCollisionWorld::AllHitsRayResultCallback allResults(from, to);
@@ -505,7 +506,13 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
     hit.normal = Magnum::Vector3{allResults.m_hitNormalWorld[i]};
     hit.point = Magnum::Vector3{allResults.m_hitPointWorld[i]};
     hit.rayDistance =
-        (static_cast<double>(allResults.m_hitFractions[i]) * maxDistance);
+        (static_cast<double>(allResults.m_hitFractions[i]) * maxDistance) -
+        bufferDistance;
+    if (hit.rayDistance < 0) {
+      // We cast the the ray from bufferDistance behind the origin, so we'll
+      // throw away hits in the intermediate space.
+      continue;
+    }
     // default to RIGID_STAGE_ID for "scene collision" if we don't know which
     // object was involved
     hit.objectId = RIGID_STAGE_ID;

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -493,8 +493,10 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
     ESP_ERROR() << "Cannot cast ray with zero length, aborting.";
     return results;
   }
-  btVector3 from(ray.origin - (ray.direction / rayLength) * bufferDistance);
+  btVector3 from(ray.origin - ((ray.direction / rayLength) * bufferDistance));
   btVector3 to(ray.origin + ray.direction * maxDistance);
+  double totalLength = (rayLength * maxDistance) + bufferDistance;
+  double scaledBuffer = bufferDistance / (totalLength);
 
   btCollisionWorld::AllHitsRayResultCallback allResults(from, to);
   bWorld_->rayTest(from, to, allResults);
@@ -506,8 +508,8 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
     hit.normal = Magnum::Vector3{allResults.m_hitNormalWorld[i]};
     hit.point = Magnum::Vector3{allResults.m_hitPointWorld[i]};
     hit.rayDistance =
-        (static_cast<double>(allResults.m_hitFractions[i]) * maxDistance) -
-        bufferDistance;
+        (static_cast<double>((allResults.m_hitFractions[i])) - scaledBuffer) *
+        totalLength / rayLength;
     if (hit.rayDistance < 0) {
       // We cast the the ray from bufferDistance behind the origin, so we'll
       // throw away hits in the intermediate space.

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -193,10 +193,14 @@ class BulletPhysicsManager : public PhysicsManager {
    * distances will be in units of ray length.
    * @param maxDistance The maximum distance along the ray direction to search.
    * In units of ray length.
+   * @param bufferDistance The casts the ray from this distance behind the
+   * origin in the inverted ray direction to avoid errors related to casting
+   * rays inside a collision shape's margin.
    * @return The raycast results sorted by distance.
    */
   RaycastResults castRay(const esp::geo::Ray& ray,
-                         double maxDistance = 100.0) override;
+                         double maxDistance = 100.0,
+                         double bufferDistance = 0.08) override;
 
   /**
    * @brief Query the number of contact points that were active during the

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -419,12 +419,16 @@ class Simulator {
    * distances will be in units of ray length.
    * @param maxDistance The maximum distance along the ray direction to search.
    * In units of ray length.
+   * @param bufferDistance The casts the ray from this distance behind the
+   * origin in the inverted ray direction to avoid errors related to casting
+   * rays inside a collision shape's margin.
    * @return Raycast results sorted by distance.
    */
   esp::physics::RaycastResults castRay(const esp::geo::Ray& ray,
-                                       double maxDistance = 100.0) {
+                                       double maxDistance = 100.0,
+                                       double bufferDistance = 0.08) {
     if (sceneHasPhysics()) {
-      return physicsManager_->castRay(ray, maxDistance);
+      return physicsManager_->castRay(ray, maxDistance, bufferDistance);
     }
     return esp::physics::RaycastResults();
   }


### PR DESCRIPTION
## Motivation and Context

This PR fixes a long-standing raycasting bug related to the behavior of Bullet physics raycasting within the collision margin of a convex shape.

**TL;DR: we add a hidden "buffer distance" to the raycast to avoid missing an object from within its margin.**

**Context:** 
- Bullet physics raycasts do not register hits from within convex shapes, neither entering, nor exiting.
- Each collision shape has a configurable margin distance which is used to pad the collision detection algorithm to better catch upcoming impacts between dynamic shapes and avoid discrete collision issues near boundaries.
- (a) Raycasts against convex shapes hit the shape, not the margin.
- (b) Raycast origins within the margin are not considered.
- Taken together, (a) and (b) result in a narrow region of space near the surface of an object where a raycast will not register the object it is about to hit, though expecting a positive hit distance from the API. This "null" zone causes a number of bugs as we attempt to snap objects onto each other or detect which objects are resting upon others.

**Solution:**
- The simple solution is to back-pad the raycast origins and then re-scale the resulting distances such that rays cast within the margin still hit the shape as expected while any hits between the buffer and origin are discarded.

## How Has This Been Tested

CI raycast tests still pass as before with expected global hit points and distances, despite the buffer.
Added new unit tests to specifically target this bug and demonstrate the solution.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
