### PR TITLE
--[Bugfix] - Address ObjectInstanceAttributes save issues

### DIFF
--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -751,6 +751,8 @@ class Configuration {
     return {};
   }
 
+  // ****************** Value Status ******************
+
   /**
    * @brief Return the @ref ConfigValType enum representing the type of the
    * value referenced by the passed @p key or @ref ConfigValType::Unknown
@@ -763,6 +765,46 @@ class Configuration {
     }
     ESP_ERROR() << "Key :" << key << "not present in Configuration.";
     return ConfigValType::Unknown;
+  }
+
+  /**
+   * @brief Returns whether or not the @ref ConfigValue specified
+   * by @p key is a default/initialization value or was intentionally set.
+   */
+  bool isDefaultVal(const std::string& key) const {
+    ValueMapType::const_iterator mapIter = valueMap_.find(key);
+    if (mapIter != valueMap_.end()) {
+      return mapIter->second.isDefaultVal();
+    }
+    ESP_ERROR() << "Key :" << key << "not present in Configuration.";
+    return false;
+  }
+
+  /**
+   * @brief Returns whether or not the @ref ConfigValue specified
+   * by @p key is a hidden value intended to be be only used internally.
+   */
+  bool isHiddenVal(const std::string& key) const {
+    ValueMapType::const_iterator mapIter = valueMap_.find(key);
+    if (mapIter != valueMap_.end()) {
+      return mapIter->second.isHiddenVal();
+    }
+    ESP_ERROR() << "Key :" << key << "not present in Configuration.";
+    return false;
+  }
+
+  /**
+   * @brief Returns whether or not the @ref ConfigValue specified
+   * by @p key is a translated value, meaning a string that corresponds to, and
+   * is translated into, an enum value for consumption.
+   */
+  bool isTranslated(const std::string& key) const {
+    ValueMapType::const_iterator mapIter = valueMap_.find(key);
+    if (mapIter != valueMap_.end()) {
+      return mapIter->second.isTranslated();
+    }
+    ESP_ERROR() << "Key :" << key << "not present in Configuration.";
+    return false;
   }
 
   // ****************** String Conversion ******************

--- a/src/esp/metadata/attributes/AbstractAttributes.h
+++ b/src/esp/metadata/attributes/AbstractAttributes.h
@@ -122,13 +122,33 @@ class AbstractAttributes
   }
 
   /**
+   * @brief Gets a const smart pointer reference to a view of the user-specified
+   * configuration data from config file. Habitat does not parse or process this
+   * data, but it will be available to the user via python bindings for each
+   * object.
+   */
+  std::shared_ptr<const Configuration> getUserConfigurationView() const {
+    return getSubconfigView("user_defined");
+  }
+
+  /**
    * @brief Gets a smart pointer reference to the actual user-specified
    * configuration data from config file. Habitat does not parse or process this
    * data, but it will be available to the user via python bindings for each
-   * object.  This method is for editing the configuration.
+   * object. This method is for editing the configuration.
    */
   std::shared_ptr<Configuration> editUserConfiguration() {
     return editSubconfig<Configuration>("user_defined");
+  }
+
+  /**
+   * @brief Move an existing user_defined subconfiguration into this
+   * configuration, overwriting the existing copy if it exists. Habitat does not
+   * parse or process this data, but it will be available to the user via python
+   * bindings for each object. This method is for editing the configuration.
+   */
+  void setUserConfiguration(std::shared_ptr<Configuration>& userAttr) {
+    setSubconfigPtr("user_defined", userAttr);
   }
 
   /**

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.h
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.h
@@ -77,11 +77,18 @@ class AbstractObjectAttributes : public AbstractAttributes {
   double getUnitsToMeters() const { return get<double>("units_to_meters"); }
 
   /**
-   * @brief If not visible can add dynamic non-rendered object into a scene. If
-   * is not visible then should not add object to drawables.
+   * @brief Set whether visible or not. If not visible can add dynamic
+   * non-rendered object into a scene. If is not visible then should not add
+   * object to drawables.
    */
   void setIsVisible(bool isVisible) { set("is_visible", isVisible); }
+  /**
+   * @brief Get whether visible or not. If not visible can add dynamic
+   * non-rendered object into a scene. If is not visible then should not add
+   * object to drawables.
+   */
   bool getIsVisible() const { return get<bool>("is_visible"); }
+
   void setFrictionCoefficient(double frictionCoefficient) {
     set("friction_coefficient", frictionCoefficient);
   }

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.cpp
@@ -16,6 +16,7 @@ ArticulatedObjectAttributes::ArticulatedObjectAttributes(
 
   init("render_asset", "");
   init("semantic_id", 0);
+  init("is_visible", true);
   // Initialize the default base type to be free joint
   initTranslated("base_type",
                  getAOBaseTypeName(ArticulatedObjectBaseType::Free));

--- a/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
+++ b/src/esp/metadata/attributes/ArticulatedObjectAttributes.h
@@ -100,6 +100,19 @@ class ArticulatedObjectAttributes : public AbstractAttributes {
   double getMassScale() const { return get<double>("mass_scale"); }
 
   /**
+   * @brief Set whether visible or not. If not visible can add dynamic
+   * non-rendered object into a scene. If is not visible then should not add
+   * object to drawables.
+   */
+  void setIsVisible(bool isVisible) { set("is_visible", isVisible); }
+  /**
+   * @brief Get whether visible or not. If not visible can add dynamic
+   * non-rendered object into a scene. If is not visible then should not add
+   * object to drawables.
+   */
+  bool getIsVisible() const { return get<bool>("is_visible"); }
+
+  /**
    * @brief Set the type of base/root joint to use to add this Articulated
    * Object to the world. Cannot be "UNSPECIFIED"
    */

--- a/src/esp/metadata/attributes/AttributesEnumMaps.cpp
+++ b/src/esp/metadata/attributes/AttributesEnumMaps.cpp
@@ -206,6 +206,7 @@ std::string getShaderTypeName(ObjectInstanceShaderType shaderTypeVal) {
 
 const std::map<std::string, SceneInstanceTranslationOrigin>
     InstanceTranslationOriginMap = {
+        {"default", SceneInstanceTranslationOrigin::Unknown},
         {"asset_local", SceneInstanceTranslationOrigin::AssetLocal},
         {"com", SceneInstanceTranslationOrigin::COM},
 };

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -59,15 +59,21 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   setHandle(handle);
   // set appropriate fields from abstract object attributes
   // Not initialize, since these are not default values
-  set("shader_type", getShaderTypeName(baseObjAttribs->getShaderType()));
-  // set to match attributes setting
-  set("is_instance_visible", (baseObjAttribs->getIsVisible() ? 1 : 0));
+
+  // Need to verify that the baseObjAttribs values are not defaults before we
+  // set these values.
+
+  if (!baseObjAttribs->isDefaultVal("shader_type")) {
+    setShaderType(getShaderTypeName(baseObjAttribs->getShaderType()));
+  }
+  if (!baseObjAttribs->isDefaultVal("is_visible")) {
+    setIsInstanceVisible(baseObjAttribs->getIsVisible());
+  }
 
   // set nonuniform scale to match attributes scale
-  setNonUniformScale(baseObjAttribs->getScale());
-  // Prepopulate user config to match baseObjAttribs' user config.
-  editUserConfiguration()->overwriteWithConfig(
-      baseObjAttribs->getUserConfiguration());
+  if (!baseObjAttribs->isDefaultVal("scale")) {
+    setNonUniformScale(baseObjAttribs->getScale());
+  }
 }
 
 std::string SceneObjectInstanceAttributes::getObjectInfoHeaderInternal() const {
@@ -124,15 +130,10 @@ void SceneObjectInstanceAttributes::writeValuesToJson(
     io::JsonAllocator& allocator) const {
   // map "handle" to "template_name" key in json
   writeValueToJson("handle", "template_name", jsonObj, allocator);
-  if (getTranslation() != Mn::Vector3()) {
-    writeValueToJson("translation", jsonObj, allocator);
-  }
-  if (getTranslationOrigin() != SceneInstanceTranslationOrigin::Unknown) {
-    writeValueToJson("translation_origin", jsonObj, allocator);
-  }
-  if (getRotation() != Mn::Quaternion(Mn::Math::IdentityInit)) {
-    writeValueToJson("rotation", jsonObj, allocator);
-  }
+  writeValueToJson("translation", jsonObj, allocator);
+  writeValueToJson("translation_origin", jsonObj, allocator);
+  writeValueToJson("rotation", jsonObj, allocator);
+
   // map "is_instance_visible" to boolean only if not -1, otherwise don't save
   int visSet = getIsInstanceVisible();
   if (visSet != ID_UNDEFINED) {
@@ -140,25 +141,12 @@ void SceneObjectInstanceAttributes::writeValuesToJson(
     auto jsonVal = io::toJsonValue(static_cast<bool>(visSet), allocator);
     jsonObj.AddMember("is_instance_visible", jsonVal, allocator);
   }
-  if (getMotionType() != esp::physics::MotionType::UNDEFINED) {
-    writeValueToJson("motion_type", jsonObj, allocator);
-  }
-  if (getShaderType() != ObjectInstanceShaderType::Unspecified) {
-    writeValueToJson("shader_type", jsonObj, allocator);
-  }
-  if (getUniformScale() != 1.0f) {
-    writeValueToJson("uniform_scale", jsonObj, allocator);
-  }
-  if (getNonUniformScale() != Mn::Vector3(1.0, 1.0, 1.0)) {
-    writeValueToJson("non_uniform_scale", jsonObj, allocator);
-  }
-  if (!getApplyScaleToMass()) {
-    writeValueToJson("apply_scale_to_mass", jsonObj, allocator);
-  }
-  if (getMassScale() != 1.0) {
-    writeValueToJson("mass_scale", jsonObj, allocator);
-  }
-
+  writeValueToJson("motion_type", jsonObj, allocator);
+  writeValueToJson("shader_type", jsonObj, allocator);
+  writeValueToJson("uniform_scale", jsonObj, allocator);
+  writeValueToJson("non_uniform_scale", jsonObj, allocator);
+  writeValueToJson("apply_scale_to_mass", jsonObj, allocator);
+  writeValueToJson("mass_scale", jsonObj, allocator);
   // take care of child class values, if any exist
   writeValuesToJsonInternal(jsonObj, allocator);
 
@@ -202,27 +190,40 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(
   // a scene instance.
   // Handle is set via init in base class, which would not be written out to
   // file if we did not explicitly set it.
+  // NOTE : this will not call a virtual override
+  // (SceneAOInstanceAttributes::setHandle) of AbstractAttributes::setHandle due
+  // to virtual dispatch not being available in constructor
   setHandle(handle);
 
   // Should not initialize these values but set them, since these are not
   // default values, but from an existing AO attributes.
-  // Set shader type to use aObjAttribs value
-  setShaderType(getShaderTypeName(aObjAttribs->getShaderType()));
-  // Set the instance base type to use aObjAttribs value
-  setBaseType(getAOBaseTypeName(aObjAttribs->getBaseType()));
-  // Set the instance source for the inertia calculation to use aObjAttribs
-  // value
-  setInertiaSource(getAOInertiaSourceName(aObjAttribs->getInertiaSource()));
-  // Set the instance link order to use aObjAttribs value
-  setLinkOrder(getAOLinkOrderName(aObjAttribs->getLinkOrder()));
-  // Set render mode to use aObjAttribs value
-  setRenderMode(getAORenderModeName(aObjAttribs->getRenderMode()));
 
-  // Prepopulate user config to match attribs' user config.
-  editUserConfiguration()->overwriteWithConfig(
-      aObjAttribs->getUserConfiguration());
-  editSubconfig<Configuration>("initial_joint_pose");
-  editSubconfig<Configuration>("initial_joint_velocities");
+  // Need to verify that the aObjAttribs values are not defaults before we
+  // set these values.
+  // Set shader type to use aObjAttribs value
+  if (!aObjAttribs->isDefaultVal("shader_type")) {
+    setShaderType(getShaderTypeName(aObjAttribs->getShaderType()));
+  }
+  if (!aObjAttribs->isDefaultVal("is_visible")) {
+    setIsInstanceVisible(aObjAttribs->getIsVisible());
+  }
+  if (!aObjAttribs->isDefaultVal("base_type")) {
+    // Set the instance base type to use aObjAttribs value
+    setBaseType(getAOBaseTypeName(aObjAttribs->getBaseType()));
+  }
+  if (!aObjAttribs->isDefaultVal("inertia_source")) {
+    // Set the instance source for the inertia calculation to use aObjAttribs
+    // value
+    setInertiaSource(getAOInertiaSourceName(aObjAttribs->getInertiaSource()));
+  }
+  if (!aObjAttribs->isDefaultVal("link_order")) {
+    // Set the instance link order to use aObjAttribs value
+    setLinkOrder(getAOLinkOrderName(aObjAttribs->getLinkOrder()));
+  }
+  if (!aObjAttribs->isDefaultVal("render_mode")) {
+    // Set render mode to use aObjAttribs value
+    setRenderMode(getAORenderModeName(aObjAttribs->getRenderMode()));
+  }
 }
 
 std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoHeaderInternal()
@@ -270,19 +271,10 @@ std::string SceneAOInstanceAttributes::getSceneObjInstanceInfoInternal() const {
 void SceneAOInstanceAttributes::writeValuesToJsonInternal(
     io::JsonGenericValue& jsonObj,
     io::JsonAllocator& allocator) const {
-  if (getBaseType() != ArticulatedObjectBaseType::Unspecified) {
-    writeValueToJson("base_type", jsonObj, allocator);
-  }
-  if (getInertiaSource() != ArticulatedObjectInertiaSource::Unspecified) {
-    writeValueToJson("inertia_source", jsonObj, allocator);
-  }
-  if (getLinkOrder() != ArticulatedObjectLinkOrder::Unspecified) {
-    writeValueToJson("link_order", jsonObj, allocator);
-  }
-  if (getRenderMode() != ArticulatedObjectRenderMode::Unspecified) {
-    writeValueToJson("render_mode", jsonObj, allocator);
-  }
-
+  writeValueToJson("base_type", jsonObj, allocator);
+  writeValueToJson("inertia_source", jsonObj, allocator);
+  writeValueToJson("link_order", jsonObj, allocator);
+  writeValueToJson("render_mode", jsonObj, allocator);
   writeValueToJson("auto_clamp_joint_limits", jsonObj, allocator);
 
 }  // SceneAOInstanceAttributes::writeValuesToJsonInternal

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.cpp
@@ -21,10 +21,12 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
     : AbstractAttributes(type, handle) {
   // default to unknown for object instances, to use attributes-specified
   // defaults
-  init("shader_type", getShaderTypeName(ObjectInstanceShaderType::Unspecified));
+  initTranslated("shader_type",
+                 getShaderTypeName(ObjectInstanceShaderType::Unspecified));
 
   // defaults to unknown/undefined
-  init("motion_type", getMotionTypeName(esp::physics::MotionType::UNDEFINED));
+  initTranslated("motion_type",
+                 getMotionTypeName(esp::physics::MotionType::UNDEFINED));
   // set to no rotation or translation
   init("rotation", Mn::Quaternion(Mn::Math::IdentityInit));
   init("translation", Mn::Vector3());
@@ -32,8 +34,9 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   // ID_UNDEFINED
   init("is_instance_visible", ID_UNDEFINED);
   // defaults to unknown so that obj instances use scene instance setting
-  init("translation_origin",
-       getTranslationOriginName(SceneInstanceTranslationOrigin::Unknown));
+  initTranslated(
+      "translation_origin",
+      getTranslationOriginName(SceneInstanceTranslationOrigin::Unknown));
   // set default multiplicative scaling values
   init("uniform_scale", 1.0);
   init("non_uniform_scale", Mn::Vector3{1.0, 1.0, 1.0});
@@ -50,6 +53,9 @@ SceneObjectInstanceAttributes::SceneObjectInstanceAttributes(
   // to a scene instance.
   // Handle is set via init in base class, which would not be written out to
   // file if we did not explicitly set it.
+  // NOTE : this will not call a virtual override
+  // (SceneAOInstanceAttributes::setHandle) of AbstractAttributes::setHandle due
+  // to virtual dispatch not being available in constructor
   setHandle(handle);
   // set appropriate fields from abstract object attributes
   // Not initialize, since these are not default values
@@ -168,19 +174,21 @@ SceneAOInstanceAttributes::SceneAOInstanceAttributes(const std::string& handle)
 
   // Set the instance base type to be unspecified - if not set in instance json,
   // use ao_config value
-  init("base_type", getAOBaseTypeName(ArticulatedObjectBaseType::Unspecified));
+  initTranslated("base_type",
+                 getAOBaseTypeName(ArticulatedObjectBaseType::Unspecified));
   // Set the instance source for the inertia calculation to be unspecified - if
   // not set in instance json, use ao_config value
-  init("inertia_source",
-       getAOInertiaSourceName(ArticulatedObjectInertiaSource::Unspecified));
+  initTranslated(
+      "inertia_source",
+      getAOInertiaSourceName(ArticulatedObjectInertiaSource::Unspecified));
   // Set the instance link order to use as unspecified - if not set in instance
   // json, use ao_config value
-  init("link_order",
-       getAOLinkOrderName(ArticulatedObjectLinkOrder::Unspecified));
+  initTranslated("link_order",
+                 getAOLinkOrderName(ArticulatedObjectLinkOrder::Unspecified));
   // Set render mode to be unspecified - if not set in instance json, use
   // ao_config value
-  init("render_mode",
-       getAORenderModeName(ArticulatedObjectRenderMode::Unspecified));
+  initTranslated("render_mode",
+                 getAORenderModeName(ArticulatedObjectRenderMode::Unspecified));
   editSubconfig<Configuration>("initial_joint_pose");
   editSubconfig<Configuration>("initial_joint_velocities");
 }

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -73,7 +73,7 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
                   << translation_origin
                   << "attempted to be set in SceneObjectInstanceAttributes :"
                   << getHandle() << ". Aborting.");
-    set("translation_origin", translation_origin);
+    setTranslated("translation_origin", translation_origin);
   }
 
   /**
@@ -145,7 +145,7 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
                   << "attempted to be set in SceneObjectInstanceAttributes :"
                   << getHandle() << ". Aborting.");
 
-    set("shader_type", shader_type);
+    setTranslated("shader_type", shader_type);
   }
 
   /**
@@ -324,7 +324,7 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
                   << baseType
                   << "attempted to be set in ArticulatedObjectAttributes:"
                   << getHandle() << ". Aborting.");
-    set("base_type", baseType);
+    setTranslated("base_type", baseType);
   }
 
   /**
@@ -356,7 +356,7 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
                   << inertiaSrc
                   << "attempted to be set in ArticulatedObjectAttributes:"
                   << getHandle() << ". Aborting.");
-    set("inertia_source", inertiaSrc);
+    setTranslated("inertia_source", inertiaSrc);
   }
 
   /**
@@ -388,7 +388,7 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
                   << linkOrder
                   << "attempted to be set in ArticulatedObjectAttributes:"
                   << getHandle() << ". Aborting.");
-    set("link_order", linkOrder);
+    setTranslated("link_order", linkOrder);
   }
 
   /**
@@ -419,7 +419,7 @@ class SceneAOInstanceAttributes : public SceneObjectInstanceAttributes {
                   << renderMode
                   << "attempted to be set in ArticulatedObjectAttributes:"
                   << getHandle() << ". Aborting.");
-    set("render_mode", renderMode);
+    setTranslated("render_mode", renderMode);
   }
 
   /**

--- a/src/esp/metadata/attributes/SceneInstanceAttributes.h
+++ b/src/esp/metadata/attributes/SceneInstanceAttributes.h
@@ -94,6 +94,13 @@ class SceneObjectInstanceAttributes : public AbstractAttributes {
   }
 
   /**
+   * @brief Get string representation of translation origin
+   */
+  std::string getTranslationOriginStr() const {
+    return get<std::string>("translation_origin");
+  }
+
+  /**
    * @brief Set the rotation of the object
    */
   void setRotation(const Mn::Quaternion& rotation) {

--- a/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
+++ b/src/esp/metadata/managers/SceneInstanceAttributesManager.cpp
@@ -375,9 +375,12 @@ void SceneInstanceAttributesManager::setAbstractObjectAttributesFromJson(
         instanceAttrs->setHandle(template_name);
       });
 
-  // Check for translation origin override for a particular instance.  Default
+  // Check for translation origin override for a particular instance. Default
   // to unknown, which will mean use scene instance-level default.
-  instanceAttrs->setTranslationOrigin(getTranslationOriginVal(jCell));
+  const std::string transOriginStr = getTranslationOriginVal(jCell);
+  if (transOriginStr != instanceAttrs->getTranslationOriginStr()) {
+    instanceAttrs->setTranslationOrigin(getTranslationOriginVal(jCell));
+  }
 
   // set specified shader type value.  May be Unspecified, which means the
   // default value specified in the stage or object attributes will be used.

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -975,7 +975,18 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
     return PhysicsObjectBase::getInitObjectInstanceAttrInternal<
         metadata::attributes::SceneAOInstanceAttributes>();
   }
-
+  /**
+   * @brief Returns a mutable copy of the @ref
+   * metadata::attributes::SceneAOInstanceAttributes used to place this
+   * Articulated Object initially in the scene.
+   * @return a read-only copy of the @ref metadata::attributes::SceneInstanceAttributes used to place
+   * this object in the scene.
+   */
+  std::shared_ptr<metadata::attributes::SceneAOInstanceAttributes>
+  getInitObjectInstanceAttrCopy() const {
+    return PhysicsObjectBase::getInitObjectInstanceAttrCopyInternal<
+        metadata::attributes::SceneAOInstanceAttributes>();
+  }
   /**
    * @brief Return a @ref
    * metadata::attributes::SceneAOInstanceAttributes reflecting the current

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -210,18 +210,14 @@ int PhysicsManager::cloneExistingObject(int objectID) {
     return ID_UNDEFINED;
   }
   auto objPtr = existingObjIter->second;
-  // Get object instance attributes copy
-  esp::metadata::attributes::SceneObjectInstanceAttributes::ptr objInstAttrs =
-      objPtr->getInitObjectInstanceAttrCopy();
-  // TODO initialize with current state of cloned object
+  // Get object instance attributes copy with current state of object instance
+  esp::metadata::attributes::SceneObjectInstanceAttributes::ptr
+      newObjInstAttrs = objPtr->getCurrentStateInstanceAttr();
 
   // Create object instance
   int newObjID =
-      addObjectInstance(objInstAttrs, &simulator_->getDrawableGroup(), nullptr,
-                        simulator_->getCurrentLightSetupKey());
-
-  // Update new object's values if necessary
-  // auto newObject = existingObjects_.find(newObjID);
+      addObjectInstance(newObjInstAttrs, &simulator_->getDrawableGroup(),
+                        nullptr, simulator_->getCurrentLightSetupKey());
 
   return newObjID;
 
@@ -587,18 +583,14 @@ int PhysicsManager::cloneExistingArticulatedObject(int aObjectID) {
     return ID_UNDEFINED;
   }
   auto aObjPtr = existingAOIter->second;
-  // Get object instance attributes copy
+  // Get articulated object instance attributes copy with current state of AO
   esp::metadata::attributes::SceneAOInstanceAttributes::ptr artObjInstAttrs =
-      aObjPtr->getInitObjectInstanceAttrCopy();
-  // TODO initialize with current state of cloned object
+      aObjPtr->getCurrentStateInstanceAttr();
 
   // Create object instance
   int newArtObjID = addArticulatedObjectInstance(
       artObjInstAttrs, &simulator_->getDrawableGroup(),
       simulator_->getCurrentLightSetupKey());
-
-  // Update new object's values if necessary
-  // auto newArtObj = existingArticulatedObjects_.find(newArtObjID);
 
   return newArtObjID;
 

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -211,8 +211,10 @@ int PhysicsManager::cloneExistingObject(int objectID) {
   }
   auto objPtr = existingObjIter->second;
   // Get object instance attributes copy
-  esp::metadata::attributes::SceneObjectInstanceAttributes::cptr objInstAttrs =
-      objPtr->getInitObjectInstanceAttr();
+  esp::metadata::attributes::SceneObjectInstanceAttributes::ptr objInstAttrs =
+      objPtr->getInitObjectInstanceAttrCopy();
+  // TODO initialize with current state of cloned object
+
   // Create object instance
   int newObjID = addObjectInstance(objInstAttrs, objPtr->isCOMCorrected(),
                                    &simulator_->getDrawableGroup(), nullptr,
@@ -581,8 +583,10 @@ int PhysicsManager::cloneExistingArticulatedObject(int aObjectID) {
   }
   auto aObjPtr = existingAOIter->second;
   // Get object instance attributes copy
-  esp::metadata::attributes::SceneAOInstanceAttributes::cptr artObjInstAttrs =
-      aObjPtr->getInitObjectInstanceAttr();
+  esp::metadata::attributes::SceneAOInstanceAttributes::ptr artObjInstAttrs =
+      aObjPtr->getInitObjectInstanceAttrCopy();
+  // TODO initialize with current state of cloned object
+
   // Create object instance
   int newArtObjID = addArticulatedObjectInstance(
       artObjInstAttrs, &simulator_->getDrawableGroup(),

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -325,7 +325,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
   int addObjectInstance(
       const esp::metadata::attributes::SceneObjectInstanceAttributes::cptr&
           objInstAttributes,
-      bool defaultCOMCorrection = false,
       DrawableGroup* drawables = nullptr,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY);
@@ -991,9 +990,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    * @param attachmentNode If supplied, attach the new physical object to an
    * existing SceneNode.
    * @param lightSetup The string name of the desired lighting setup to use.
-   * @param defaultCOMCorrection The default value of whether COM-based
-   * translation correction needs to occur. Only non-default from
-   * addObjectInstance method.
    * @param objInstAttributes The attributes that describe the desired state to
    * set this object on creation. If nullptr, create an empty default instance
    * and populate it properly based on the object config.
@@ -1005,7 +1001,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
       DrawableGroup* drawables = nullptr,
       scene::SceneNode* attachmentNode = nullptr,
       const std::string& lightSetup = DEFAULT_LIGHTING_KEY,
-      bool defaultCOMCorrection = false,
       esp::metadata::attributes::SceneObjectInstanceAttributes::cptr
           objInstAttributes = nullptr);
 

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -627,6 +627,11 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     if (!_initObjInstanceAttrs) {
       return nullptr;
     }
+    static_assert(
+        std::is_base_of<metadata::attributes::SceneObjectInstanceAttributes,
+                        T>::value,
+        "SceneObjectInstanceAttributes must be base class of desired instance "
+        "attributes class.");
     return T::create(*(static_cast<const T*>(_initObjInstanceAttrs.get())));
   }
 
@@ -643,6 +648,11 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     if (!_initObjInstanceAttrs) {
       return nullptr;
     }
+    static_assert(
+        std::is_base_of<metadata::attributes::SceneObjectInstanceAttributes,
+                        T>::value,
+        "SceneObjectInstanceAttributes must be base class of desired instance "
+        "attributes class.");
     return std::static_pointer_cast<const T>(_initObjInstanceAttrs);
   }
 

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -593,33 +593,57 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     return res;
   }  // getMarkerPointsGlobal
 
-  /** @brief Get the scale of the object set during initialization.
+  /**
+   * @brief Get the scale of the object set during initialization.
    * @return The scaling for the object relative to its initially loaded meshes.
    */
   virtual Magnum::Vector3 getScale() const { return _creationScale; }
 
-  /** @brief Return whether or not this object is articulated. Override in
-   * ArticulatedObject */
+  /**
+   * @brief Return whether or not this object is articulated. Override in
+   * ArticulatedObject
+   */
   bool isArticulated() const { return _isArticulated; }
 
   /** @brief Return the local axis-aligned bounding box of the this object.*/
   virtual const Mn::Range3D& getAabb() { return node().getCumulativeBB(); }
 
  protected:
+  /**
+   * @brief Used Internally on object creation. Set whether or not this object
+   * is articulated.
+   */
   void setIsArticulated(bool isArticulated) { _isArticulated = isArticulated; }
 
-  /** @brief Accessed internally. Get an appropriately cast copy of the @ref
+  /**
+   * @brief Accessed internally. Get an appropriately cast copy of the @ref
    * metadata::attributes::SceneObjectInstanceAttributes used to place the
    * object within the scene.
    * @return A copy of the initialization template used to create this object
    * instance or nullptr if no template exists.
    */
   template <class T>
-  std::shared_ptr<T> getInitObjectInstanceAttrInternal() const {
+  std::shared_ptr<T> getInitObjectInstanceAttrCopyInternal() const {
     if (!_initObjInstanceAttrs) {
       return nullptr;
     }
     return T::create(*(static_cast<const T*>(_initObjInstanceAttrs.get())));
+  }
+
+  /**
+   * @brief Accessed internally. Get the
+   * @ref metadata::attributes::SceneObjectInstanceAttributes used to
+   * create and place the object within the scene, appropriately cast for
+   * object type.
+   * @return A copy of the initialization template used to create this object
+   * instance or nullptr if no template exists.
+   */
+  template <class T>
+  std::shared_ptr<const T> getInitObjectInstanceAttrInternal() const {
+    if (!_initObjInstanceAttrs) {
+      return nullptr;
+    }
+    return std::static_pointer_cast<const T>(_initObjInstanceAttrs);
   }
 
   /**

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -689,7 +689,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     initAttrs->setRotation(getRotation());
     initAttrs->setMotionType(
         metadata::attributes::getMotionTypeName(objectMotionType_));
-
+    // TODO : Set instance user-defined to be delta from disk-version of
+    // creation config's
     return initAttrs;
   }
 

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -97,10 +97,10 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   template <class T>
   std::shared_ptr<T> getInitializationAttributes() const {
-    if (!initializationAttributes_) {
+    if (!objInitAttributes_) {
       return nullptr;
     }
-    return T::create(*(static_cast<const T*>(initializationAttributes_.get())));
+    return T::create(*(static_cast<const T*>(objInitAttributes_.get())));
   }
 
   /**
@@ -479,7 +479,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
 
   template <class U>
   void setSceneInstanceAttr(std::shared_ptr<U> instanceAttr) {
-    _initObjInstanceAttrs = std::move(instanceAttr);
+    _objInstanceInitAttributes = std::move(instanceAttr);
   }  // setSceneInstanceAttr
 
   /**
@@ -624,7 +624,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   template <class T>
   std::shared_ptr<T> getInitObjectInstanceAttrCopyInternal() const {
-    if (!_initObjInstanceAttrs) {
+    if (!_objInstanceInitAttributes) {
       return nullptr;
     }
     static_assert(
@@ -632,7 +632,8 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
                         T>::value,
         "SceneObjectInstanceAttributes must be base class of desired instance "
         "attributes class.");
-    return T::create(*(static_cast<const T*>(_initObjInstanceAttrs.get())));
+    return T::create(
+        *(static_cast<const T*>(_objInstanceInitAttributes.get())));
   }
 
   /**
@@ -645,7 +646,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   template <class T>
   std::shared_ptr<const T> getInitObjectInstanceAttrInternal() const {
-    if (!_initObjInstanceAttrs) {
+    if (!_objInstanceInitAttributes) {
       return nullptr;
     }
     static_assert(
@@ -653,7 +654,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
                         T>::value,
         "SceneObjectInstanceAttributes must be base class of desired instance "
         "attributes class.");
-    return std::static_pointer_cast<const T>(_initObjInstanceAttrs);
+    return std::static_pointer_cast<const T>(_objInstanceInitAttributes);
   }
 
   /**
@@ -673,7 +674,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    */
   template <class T>
   std::shared_ptr<T> getCurrentObjectInstanceAttrInternal() {
-    if (!_initObjInstanceAttrs) {
+    if (!_objInstanceInitAttributes) {
       return nullptr;
     }
     static_assert(
@@ -683,7 +684,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
         "class that inherits from SceneObjectInstanceAttributes");
 
     std::shared_ptr<T> initAttrs = std::const_pointer_cast<T>(
-        T::create(*(static_cast<const T*>(_initObjInstanceAttrs.get()))));
+        T::create(*(static_cast<const T*>(_objInstanceInitAttributes.get()))));
     // set values
     initAttrs->setTranslation(getUncorrectedTranslation());
     initAttrs->setRotation(getRotation());
@@ -746,8 +747,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
   /**
    * @brief Saved template attributes when the object was initialized.
    */
-  metadata::attributes::AbstractAttributes::cptr initializationAttributes_ =
-      nullptr;
+  metadata::attributes::AbstractAttributes::cptr objInitAttributes_ = nullptr;
 
   /**
    * @brief Set the object's creation scale
@@ -762,7 +762,7 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
    * creation.
    */
   std::shared_ptr<const metadata::attributes::SceneObjectInstanceAttributes>
-      _initObjInstanceAttrs = nullptr;
+      _objInstanceInitAttributes = nullptr;
 
   /**
    * @brief The scale applied to this object on creation

--- a/src/esp/physics/PhysicsObjectBase.h
+++ b/src/esp/physics/PhysicsObjectBase.h
@@ -686,8 +686,14 @@ class PhysicsObjectBase : public Magnum::SceneGraph::AbstractFeature3D {
     std::shared_ptr<T> initObjInstAttrsCopy = std::const_pointer_cast<T>(
         T::create(*(static_cast<const T*>(_objInstanceInitAttributes.get()))));
     // set values
-    initObjInstAttrsCopy->setTranslation(getUncorrectedTranslation());
-    initObjInstAttrsCopy->setRotation(getRotation());
+    const auto translation = getUncorrectedTranslation();
+    if (initObjInstAttrsCopy->getTranslation() != translation) {
+      initObjInstAttrsCopy->setTranslation(translation);
+    }
+    const auto rotation = getRotation();
+    if (initObjInstAttrsCopy->getRotation() != rotation) {
+      initObjInstAttrsCopy->setRotation(rotation);
+    }
     // only change if different
     if (initObjInstAttrsCopy->getMotionType() != objectMotionType_) {
       initObjInstAttrsCopy->setMotionType(

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -288,6 +288,18 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 
   /**
+   * @brief Returns a mutable copy of the @ref metadata::attributes::SceneObjectInstanceAttributes
+   * used to place this rigid object in the scene.
+   * @return a read-only copy of the @ref metadata::attributes::SceneInstanceAttributes used to place
+   * this object in the scene.
+   */
+  std::shared_ptr<metadata::attributes::SceneObjectInstanceAttributes>
+  getInitObjectInstanceAttrCopy() const {
+    return PhysicsObjectBase::getInitObjectInstanceAttrCopyInternal<
+        metadata::attributes::SceneObjectInstanceAttributes>();
+  }
+
+  /**
    * @brief Return a @ref
    * metadata::attributes::SceneObjectInstanceAttributes reflecting the current
    * state of this Rigid.

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -15,7 +15,7 @@ RigidObject::RigidObject(scene::SceneNode* rigidBodyNode,
 
 bool RigidObject::initialize(
     metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
-  if (initializationAttributes_ != nullptr) {
+  if (objInitAttributes_ != nullptr) {
     ESP_ERROR() << "Cannot initialize a RigidObject more than once";
     return false;
   }
@@ -26,7 +26,7 @@ bool RigidObject::initialize(
   // time
   setUserAttributes(initAttributes->getUserConfiguration());
   setMarkerSets(initAttributes->getMarkerSetsConfiguration());
-  initializationAttributes_ = std::move(initAttributes);
+  objInitAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }  // RigidObject::initialize
@@ -37,7 +37,7 @@ bool RigidObject::finalizeObject() {
   // cast initialization attributes
   metadata::attributes::ObjectAttributes::cptr ObjectAttributes =
       std::dynamic_pointer_cast<const metadata::attributes::ObjectAttributes>(
-          initializationAttributes_);
+          objInitAttributes_);
 
   if (!ObjectAttributes->getComputeCOMFromShape()) {
     // will be false if the COM is provided; shift by that COM

--- a/src/esp/physics/RigidObject.cpp
+++ b/src/esp/physics/RigidObject.cpp
@@ -91,7 +91,7 @@ void RigidObject::resetStateFromSceneInstanceAttr() {
 
   // set object's motion type if different than set value
   const physics::MotionType attrObjMotionType =
-      static_cast<physics::MotionType>(sceneInstanceAttr->getMotionType());
+      sceneInstanceAttr->getMotionType();
   if (attrObjMotionType != physics::MotionType::UNDEFINED) {
     this->setMotionType(attrObjMotionType);
   }

--- a/src/esp/physics/RigidStage.cpp
+++ b/src/esp/physics/RigidStage.cpp
@@ -13,7 +13,7 @@ RigidStage::RigidStage(scene::SceneNode* rigidBodyNode,
 
 bool RigidStage::initialize(
     metadata::attributes::AbstractObjectAttributes::ptr initAttributes) {
-  if (initializationAttributes_ != nullptr) {
+  if (objInitAttributes_ != nullptr) {
     ESP_ERROR() << "Cannot initialize a RigidStage more than once";
     return false;
   }
@@ -26,7 +26,7 @@ bool RigidStage::initialize(
   // time
   setUserAttributes(initAttributes->getUserConfiguration());
   setMarkerSets(initAttributes->getMarkerSetsConfiguration());
-  initializationAttributes_ = std::move(initAttributes);
+  objInitAttributes_ = std::move(initAttributes);
 
   return initialization_LibSpecific();
 }

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -172,7 +172,7 @@ void BulletArticulatedObject::initializeFromURDF(
   // set user config and initialization attributes
   setUserAttributes(initAttributes->getUserConfiguration());
   setMarkerSets(initAttributes->getMarkerSetsConfiguration());
-  initializationAttributes_ = initAttributes;
+  objInitAttributes_ = initAttributes;
 }
 
 void BulletArticulatedObject::constructStaticRigidBaseObject() {

--- a/src/esp/physics/bullet/BulletRigidObject.cpp
+++ b/src/esp/physics/bullet/BulletRigidObject.cpp
@@ -424,7 +424,7 @@ void BulletRigidObject::constructAndAddRigidBody(MotionType mt) {
 }
 
 std::string BulletRigidObject::getCollisionDebugName() {
-  return "RigidObject, " + initializationAttributes_->getHandle() + ", id " +
+  return "RigidObject, " + objInitAttributes_->getHandle() + ", id " +
          std::to_string(objectId_);
 }
 

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -616,12 +616,6 @@ bool Simulator::instanceObjectsForSceneAttributes(
   // node to attach object to
   scene::SceneNode* attachmentNode = nullptr;
 
-  // whether or not to correct for COM shift - only do for blender-sourced
-  // scene attributes
-  bool defaultCOMCorrection =
-      (curSceneInstanceAttributes_->getTranslationOrigin() ==
-       metadata::attributes::SceneInstanceTranslationOrigin::AssetLocal);
-
   // Iterate through instances, create object and implement initial
   // transformation.
   for (const auto& objInst : objectInstances) {
@@ -635,8 +629,8 @@ bool Simulator::instanceObjectsForSceneAttributes(
             config_.activeSceneName));
 
     // objID =
-    physicsManager_->addObjectInstance(objInst, defaultCOMCorrection,
-                                       &getDrawableGroup(), attachmentNode,
+    physicsManager_->addObjectInstance(objInst, &getDrawableGroup(),
+                                       attachmentNode,
                                        config_.sceneLightSetupKey);
   }  // for each object attributes
   return true;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -478,6 +478,21 @@ class Simulator {
   }
 
   /**
+   * @brief Return whether the @ref
+   * esp::metadata::attributes::SceneInstanceAttributes used to create the scene
+   * currently being simulated/displayed specifies a default COM handling for
+   * rigid objects
+   */
+
+  bool getCurSceneDefaultCOMHandling() const {
+    if (curSceneInstanceAttributes_ == nullptr) {
+      return false;
+    }
+    return (curSceneInstanceAttributes_->getTranslationOrigin() ==
+            metadata::attributes::SceneInstanceTranslationOrigin::AssetLocal);
+  }
+
+  /**
    * @brief Set the gravity in a physical scene.
    */
   void setGravity(const Magnum::Vector3& gravity) {


### PR DESCRIPTION
## Motivation and Context
This PR addresses the SceneInstance-specified DefaultCOMCorrection specification not being properly represented when an object is created in an existing, running scene. This causes these added objects to not be saved at the appropriate location should the modified scene be saved to JSON.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
