### PR TITLE
--[Bugfix] - Compare Configuration scalar doubles properly

### DIFF
--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -884,7 +884,7 @@ Mn::Debug& operator<<(Mn::Debug& debug, const Configuration& cfg) {
 
 bool operator==(const Configuration& a, const Configuration& b) {
   if ((a.getNumSubconfigs() != b.getNumSubconfigs()) ||
-      (a.getNumValues() != b.getNumValues())) {
+      (a.getNumVisibleValues() != b.getNumVisibleValues())) {
     return false;
   }
   for (const auto& entry : a.configMap_) {

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -207,18 +207,35 @@ bool operator==(const ConfigValue& a, const ConfigValue& b) {
   if (a._typeAndFlags != b._typeAndFlags) {
     return false;
   }
+  const auto dataType = a.getType();
   // Pointer-backed data types need to have _data dereffed
-  if (isConfigValTypePointerBased(a.getType())) {
-    return pointerBasedConfigTypeHandlerFor(a.getType())
-        .comparator(a._data, b._data);
+  if (isConfigValTypePointerBased(dataType)) {
+    return pointerBasedConfigTypeHandlerFor(dataType).comparator(a._data,
+                                                                 b._data);
   }
 
-  // Trivial type : a._data holds the actual value
-  // _data array will always hold only legal data, since a ConfigValue should
-  // never change type.
+  // By here we know the type is a trivial type and that the types for both
+  // values are equal
+  if (a.reqsFuzzyCompare()) {
+    // Type is specified to require fuzzy comparison
+    switch (dataType) {
+      case ConfigValType::Double: {
+        return Mn::Math::equal(a.get<double>(), b.get<double>());
+      }
+      default: {
+        CORRADE_ASSERT_UNREACHABLE(
+            "Unknown/unsupported Type in ConfigValue::getAsString", "");
+      }
+    }
+  }
+
+  // Trivial non-fuzzy-comparison-requiring type : a._data holds the actual
+  // value _data array will always hold only legal data, since a ConfigValue
+  // should never change type.
   return std::equal(std::begin(a._data), std::end(a._data),
                     std::begin(b._data));
-}
+
+}  // ConfigValue::operator==
 
 bool operator!=(const ConfigValue& a, const ConfigValue& b) {
   return !(a == b);
@@ -236,7 +253,7 @@ std::string ConfigValue::getAsString() const {
       return std::to_string(get<int>());
     }
     case ConfigValType::Double: {
-      return std::to_string(get<double>());
+      return Cr::Utility::formatString("{}", get<double>());
     }
     case ConfigValType::String: {
       return get<std::string>();
@@ -295,7 +312,8 @@ std::string ConfigValue::getAsString() const {
 
 io::JsonGenericValue ConfigValue::writeToJsonObject(
     io::JsonAllocator& allocator) const {
-  // unknown is checked before this function is called, so does not need support
+  // unknown is checked before this function is called, so does not need
+  // support
   switch (getType()) {
     case ConfigValType::Boolean: {
       return io::toJsonValue(get<bool>(), allocator);
@@ -487,8 +505,8 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
       } else {
         // The array does not match any currently supported magnum
         // objects, so place in indexed subconfig of values.
-        // decrement count by 1 - the recursive subgroup load will count all the
-        // values.
+        // decrement count by 1 - the recursive subgroup load will count all
+        // the values.
         --numConfigSettings;
         // create a new subgroup
         std::shared_ptr<core::config::Configuration> subGroupPtr =
@@ -496,8 +514,8 @@ int Configuration::loadOneConfigFromJson(int numConfigSettings,
         // load array into subconfig
         numConfigSettings += subGroupPtr->loadFromJsonArray(jsonObj);
       }
-      // value in array is a number of specified length, else it is a string, an
-      // object or a nested array
+      // value in array is a number of specified length, else it is a string,
+      // an object or a nested array
     } else {
       // decrement count by 1 - the recursive subgroup load will count all the
       // values.
@@ -584,8 +602,8 @@ void Configuration::writeValuesToJson(io::JsonGenericValue& jsonObj,
           << "`, so nothing will be written to JSON for this key.";
 
     } else if (valIter->second.shouldWriteToFile()) {
-      // Create Generic value for key, using allocator, to make sure its a copy
-      // and lives long enough
+      // Create Generic value for key, using allocator, to make sure its a
+      // copy and lives long enough
       writeValueToJsonInternal(valIter->second, valIter->first.c_str(), jsonObj,
                                allocator);
     } else {
@@ -602,8 +620,8 @@ void Configuration::writeSubconfigsToJson(io::JsonGenericValue& jsonObj,
        ++cfgIter) {
     // only save if subconfig tree has value entries
     if (cfgIter->second->getConfigTreeNumValues() > 0) {
-      // Create Generic value for key, using allocator, to make sure its a copy
-      // and lives long enough
+      // Create Generic value for key, using allocator, to make sure its a
+      // copy and lives long enough
       io::JsonGenericValue name{cfgIter->first.c_str(), allocator};
       io::JsonGenericValue subObj =
           cfgIter->second->writeToJsonObject(allocator);
@@ -663,9 +681,9 @@ void Configuration::setSubconfigValsOfTypeInVector(
 /**
  * @brief Retrieves a shared pointer to a copy of the subConfig @ref
  * esp::core::config::Configuration that has the passed @p name . This will
- * create a pointer to a new sub-configuration if none exists already with that
- * name, but will not add this configuration to this Configuration's internal
- * storage.
+ * create a pointer to a new sub-configuration if none exists already with
+ * that name, but will not add this configuration to this Configuration's
+ * internal storage.
  *
  * @param name The name of the configuration to retrieve.
  * @return A pointer to a copy of the configuration having the requested

--- a/src/esp/core/Configuration.cpp
+++ b/src/esp/core/Configuration.cpp
@@ -224,7 +224,7 @@ bool operator==(const ConfigValue& a, const ConfigValue& b) {
       }
       default: {
         CORRADE_ASSERT_UNREACHABLE(
-            "Unknown/unsupported Type in ConfigValue::getAsString", "");
+            "Unknown/unsupported Type in ConfigValue::operator==()", "");
       }
     }
   }

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -272,8 +272,7 @@ constexpr ConfigValType configValTypeFor<Mn::Rad>() {
 /**
  * @brief Stream operator to support display of @ref ConfigValType enum tags
  */
-MAGNUM_EXPORT Mn::Debug& operator<<(Mn::Debug& debug,
-                                    const ConfigValType& value);
+Mn::Debug& operator<<(Mn::Debug& debug, const ConfigValType& value);
 
 /**
  * @brief This class uses an anonymous tagged union to store values of different
@@ -657,7 +656,7 @@ class ConfigValue {
 /**
  * @brief provide debug stream support for @ref ConfigValue
  */
-MAGNUM_EXPORT Mn::Debug& operator<<(Mn::Debug& debug, const ConfigValue& value);
+Mn::Debug& operator<<(Mn::Debug& debug, const ConfigValue& value);
 
 /**
  * @brief This class holds Configuration data in a map of ConfigValues, and
@@ -1734,8 +1733,7 @@ class Configuration {
 /**
  * @brief provide debug stream support for a @ref Configuration
  */
-MAGNUM_EXPORT Mn::Debug& operator<<(Mn::Debug& debug,
-                                    const Configuration& value);
+Mn::Debug& operator<<(Mn::Debug& debug, const Configuration& value);
 
 template <>
 std::vector<float> Configuration::getSubconfigValsOfTypeInVector(

--- a/src/esp/core/Configuration.h
+++ b/src/esp/core/Configuration.h
@@ -1227,9 +1227,25 @@ class Configuration {
   }
 
   /**
-   * @brief returns number of values in this Configuration.
+   * @brief Returns number of values in this Configuration.
    */
   int getNumValues() const { return valueMap_.size(); }
+
+  /**
+   * @brief Returns number of non-hidden values in this Configuration. This is
+   * necessary for determining whether or not configurations are "effectively"
+   * equal, where they contain the same data but may vary in number
+   * internal-use-only fields.
+   */
+  int getNumVisibleValues() const {
+    int numVals = 0;
+    for (const auto& val : valueMap_) {
+      if (!val.second.isHiddenVal()) {
+        numVals += 1;
+      }
+    }
+    return numVals;
+  }
 
   /**
    * @brief Return total number of values held by this Configuration and all


### PR DESCRIPTION
## Motivation and Context
This PR adds, and tests, proper fuzzy comparison between scalar ConfigValues that require it (i.e. doubles) using the same Magnum mechanism that supported Magnum floating point vector-based types use.  This comparison uses a scaled epsilon value that acts as a threshold between two values being equal or not.  See [here for comparison details](https://github.com/mosra/magnum/blob/ccb96f73c7154326589594e6c4260be9e796ecfb/src/Magnum/Math/TypeTraits.h#L485).

Support for fuzzy comparison must be implemented (following the pattern here for doubles) for any numeric types added to the ConfigValue supported list only if they do not use a similar comparison mechanism already (i.e. this does not need to be included for any magnum floating-point types)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python. Tests have been added to validate the process for both below-threshold and above-threshold values.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
