### PR TITLE
--Restrict CI Numpy version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
                 # For whatever reason we have to install pytorch first. If it isn't
                 # it installs the 1.4 cpuonly version. Which is no good.
                 conda install -y pytorch==1.12.1=py3.9_cuda11.3_cudnn8.3.2_0 torchvision==0.13.1=py39_cu113 cudatoolkit=11.3 -c pytorch -c nvidia
-                conda install -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis pytest-mock
+                conda install -y -c conda-forge ninja numpy==1.26.4 pytest pytest-cov ccache hypothesis pytest-mock
                 pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython mock
               fi
       - run: &validate_pytorch_installation
@@ -205,7 +205,7 @@ jobs:
                 hypothesis==6.29.3 \
                 isort==5.12.0 \
                 mypy \
-                numpy \
+                numpy==1.26.4 \
                 pytest \
                 sphinx \
                 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ matplotlib
 numba
 numpy==1.26.4
 numpy-quaternion
-pillow
+pillow==10.4.0
 scipy>=1.10.1
 tqdm


### PR DESCRIPTION
## Motivation and Context
Force every numpy version for CI to be the version we need to use due to Quaternion library (1.26.4). Also, restrict Pillow to 10.4.0, since the unrestricted version (11.0) introduced typing that conflicts with our current consumption of the library.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
CI is testing it.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
