### PR TITLE
addSensorToObject() expanded

### DIFF
--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1109,7 +1109,9 @@ esp::sensor::Sensor& Simulator::addSensorToObject(
         getRigidObjectManager()->getObjectCopyByID(objectId)->getSceneNode();
   } else if (getArticulatedObjectManager()->getObjectLibHasID(objectId)) {
     // This is a ManagedArticulatedObject
-    getArticulatedObjectManager()->getObjectCopyByID(objectId)->getSceneNode();
+    objectNode = getArticulatedObjectManager()
+                     ->getObjectCopyByID(objectId)
+                     ->getSceneNode();
   } else {
     // This could be a link, search for it
     for (auto ao :
@@ -1120,6 +1122,9 @@ esp::sensor::Sensor& Simulator::addSensorToObject(
         objectNode = ao.second->getLinkSceneNode(objectIdIx->second);
       }
     }
+    ESP_CHECK(objectNode != nullptr,
+              "Invalid object id provided for sensor attachemnt."
+                  << objectId << " No object found.");
   }
 
   esp::sensor::SensorFactory::createSensors(*objectNode, sensorSpecifications);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1097,10 +1097,33 @@ esp::sensor::Sensor& Simulator::addSensorToObject(
   getRenderGLContext();
 
   esp::sensor::SensorSetup sensorSpecifications = {sensorSpec};
-  esp::scene::SceneNode& objectNode =
-      *(getRigidObjectManager()->getObjectCopyByID(objectId)->getSceneNode());
-  esp::sensor::SensorFactory::createSensors(objectNode, sensorSpecifications);
-  return objectNode.getNodeSensorSuite().get(sensorSpec->uuid);
+
+  // Handle attachements to the SceneGraph
+  esp::scene::SceneNode* objectNode = nullptr;
+  if (objectId == RIGID_STAGE_ID) {
+    // This is the stage, attach to the root node
+    objectNode = &getActiveSceneGraph().getRootNode();
+  } else if (getRigidObjectManager()->getObjectLibHasID(objectId)) {
+    // This is a ManagedRigidObject
+    objectNode =
+        getRigidObjectManager()->getObjectCopyByID(objectId)->getSceneNode();
+  } else if (getArticulatedObjectManager()->getObjectLibHasID(objectId)) {
+    // This is a ManagedArticulatedObject
+    getArticulatedObjectManager()->getObjectCopyByID(objectId)->getSceneNode();
+  } else {
+    // This could be a link, search for it
+    for (auto ao :
+         getArticulatedObjectManager()->getObjectsByHandleSubstring()) {
+      auto linkObjectIds = ao.second->getLinkObjectIds();
+      auto objectIdIx = linkObjectIds.find(objectId);
+      if (objectIdIx != linkObjectIds.end()) {
+        objectNode = ao.second->getLinkSceneNode(objectIdIx->second);
+      }
+    }
+  }
+
+  esp::sensor::SensorFactory::createSensors(*objectNode, sensorSpecifications);
+  return objectNode->getNodeSensorSuite().get(sensorSpec->uuid);
 }
 
 void Simulator::setPathFinder(nav::PathFinder::ptr pathfinder) {

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -1114,7 +1114,7 @@ esp::sensor::Sensor& Simulator::addSensorToObject(
                      ->getSceneNode();
   } else {
     // This could be a link, search for it
-    for (auto ao :
+    for (auto& ao :
          getArticulatedObjectManager()->getObjectsByHandleSubstring()) {
       auto linkObjectIds = ao.second->getLinkObjectIds();
       auto objectIdIx = linkObjectIds.find(objectId);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -629,7 +629,8 @@ class Simulator {
   agent::Agent::ptr addAgent(const agent::AgentConfiguration& agentConfig);
 
   /**
-   * @brief Initialize sensor and attach to sceneNode of a particular object
+   * @brief Initialize a sensor from its spec and attach it to the SceneNode of
+   * a particular object or link.
    * @param objectId    Id of the object to which a sensor will be initialized
    * at its node
    * @param sensorSpec  SensorSpec of sensor to be initialized

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -834,6 +834,12 @@ void SimTest::addSensorToObject() {
                        observation.buffer->data}),
       Cr::Utility::Path::join(screenshotDir, "SimTestExpectedScene.png"),
       (Mn::DebugTools::CompareImageToFile{maxThreshold, 0.75f}));
+
+  // test attachement to AOs
+  auto articulatedObjMgr = simulator->getArticulatedObjectManager();
+  auto ao = articulatedObjMgr->addArticulatedObjectFromURDF(
+      "data/test_assets/urdf/prim_chain.urdf");
+  auto aoSensorSpec = esp::sensor::CameraSensorSpec::create();
 }
 
 void SimTest::createMagnumRenderingOff() {

--- a/src/tests/SimTest.cpp
+++ b/src/tests/SimTest.cpp
@@ -60,6 +60,8 @@ const std::string skokloster =
                             "habitat-test-scenes/skokloster-castle.glb");
 const std::string planeStage =
     Cr::Utility::Path::join(TEST_ASSETS, "scenes/plane.glb");
+const std::string primChain =
+    Cr::Utility::Path::join(TEST_ASSETS, "urdf/prim_chain.urdf");
 const std::string physicsConfigFile =
     Cr::Utility::Path::join(TEST_ASSETS, "testing.physics_config.json");
 const std::string screenshotDir =
@@ -837,9 +839,51 @@ void SimTest::addSensorToObject() {
 
   // test attachement to AOs
   auto articulatedObjMgr = simulator->getArticulatedObjectManager();
-  auto ao = articulatedObjMgr->addArticulatedObjectFromURDF(
-      "data/test_assets/urdf/prim_chain.urdf");
+  auto ao = articulatedObjMgr->addArticulatedObjectFromURDF(primChain);
+  CORRADE_VERIFY(ao->getSceneNode()->getSubtreeSensors().size() == 0);
   auto aoSensorSpec = esp::sensor::CameraSensorSpec::create();
+  aoSensorSpec->position = {0.0, 0.0, 0.0};
+  // attach to root of AO
+  aoSensorSpec->uuid = ao->getID();
+  simulator->addSensorToObject(ao->getID(), aoSensorSpec);
+  CORRADE_VERIFY(ao->getSceneNode()->getSubtreeSensors().size() == 1);
+  // attach to link of AO
+  int lastLinkIndex = ao->getNumLinks() - 1;
+  int linkObjectId = ao->getLinkIdsToObjectIds()[lastLinkIndex];
+  aoSensorSpec->uuid = linkObjectId;
+  simulator->addSensorToObject(linkObjectId, aoSensorSpec);
+  // Note the ArticulatedLinks are not in the subtree of the parent, so they
+  // will not be accessed via the subtree
+  CORRADE_VERIFY(ao->getSceneNode()->getSubtreeSensors().size() == 1);
+  CORRADE_VERIFY(
+      ao->getLinkSceneNode(lastLinkIndex)->getSubtreeSensors().size() == 1);
+  CORRADE_COMPARE(
+      ao->getLinkSceneNode(lastLinkIndex)
+          ->getSubtreeSensors()
+          .begin()
+          ->second.get()
+          .node()
+          .absoluteTransformation(),
+      ao->getLinkSceneNode(lastLinkIndex)->absoluteTransformation());
+
+  // verify adding to the global root node
+  aoSensorSpec->uuid = "global_sensor";
+  simulator->addSensorToObject(esp::RIGID_STAGE_ID, aoSensorSpec);
+  CORRADE_VERIFY(
+      simulator->getActiveSceneGraph().getRootNode().getNodeSensors().size() ==
+      1);
+  CORRADE_VERIFY(simulator->getActiveSceneGraph()
+                     .getRootNode()
+                     .getSubtreeSensors()
+                     .size() == 4);
+  CORRADE_COMPARE(simulator->getActiveSceneGraph()
+                      .getRootNode()
+                      .getNodeSensors()
+                      .at("global_sensor")
+                      .get()
+                      .node()
+                      .absoluteTransformation(),
+                  Mn::Matrix4{Mn::Math::IdentityInit});
 }
 
 void SimTest::createMagnumRenderingOff() {


### PR DESCRIPTION
## Motivation and Context

This PR expands the `addSensorToObject` function to cover all possible valid values for `objectId` and to throw an exception for invalid values.
- adds attachment to an ArticulatedObject's root or to any link
- adds attachment to the root SceneNode (global space) when `objectId == esp::RIGID_STAGE_ID`

## How Has This Been Tested

Added a C++ test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
