### PR TITLE
--[BE] - Save ref to object's ManagedObject wrapper for internal access.

### DIFF
--- a/src/esp/physics/ArticulatedLink.h
+++ b/src/esp/physics/ArticulatedLink.h
@@ -1,0 +1,211 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_PHYSICS_ARTICULATEDLINK_H_
+#define ESP_PHYSICS_ARTICULATEDLINK_H_
+
+/** @file
+ * @brief Class @ref esp::physics::ArticulatedLink
+ */
+
+#include "RigidBase.h"
+#include "esp/scene/SceneNode.h"
+
+namespace esp {
+namespace physics {
+
+////////////////////////////////////
+// Link
+////////////////////////////////////
+
+/**
+ * @brief A single rigid link in a kinematic chain. Abstract class. Feature
+ * attaches to a SceneNode.
+ */
+class ArticulatedLink : public RigidBase {
+ public:
+  ArticulatedLink(scene::SceneNode* bodyNode,
+                  int index,
+                  const assets::ResourceManager& resMgr)
+      : RigidBase(bodyNode,
+                  0,  // TODO: pass an actual object ID. This is currently
+                      // assigned AFTER creation.
+                  resMgr),
+        mbIndex_(index) {
+    setIsArticulated(true);
+  }
+
+  ~ArticulatedLink() override = default;
+
+  //! Get the link's index within its multibody
+  int getIndex() const { return mbIndex_; }
+
+  //! List of visual components attached to this link. Used for NavMesh
+  //! recomputation. Each entry is a child node of this link's node and a string
+  //! key to reference the asset in ResourceManager.
+  std::vector<std::pair<esp::scene::SceneNode*, std::string>>
+      visualAttachments_;
+
+  // RigidBase overrides
+
+  /**
+   * @brief Initializes the link.
+   * @param resMgr a reference to ResourceManager object
+   * @param handle The handle for the template structure defining relevant
+   * physical parameters for this object
+   * @return true if initialized successfully, false otherwise.
+   */
+  bool initialize(
+      CORRADE_UNUSED metadata::attributes::AbstractObjectAttributes::ptr
+          initAttributes) override {
+    return true;
+  }
+
+  void initializeArticulatedLink(const std::string& _linkName,
+                                 const Mn::Vector3& _scale) {
+    linkName = _linkName;
+    setScale(_scale);
+  }
+
+  /**
+   * @brief Finalize the creation of the link.
+   * @return whether successful finalization.
+   */
+  bool finalizeObject() override { return true; }
+
+  void setTransformation(
+      CORRADE_UNUSED const Magnum::Matrix4& transformation) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void setTranslation(CORRADE_UNUSED const Magnum::Vector3& vector) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void setRotation(
+      CORRADE_UNUSED const Magnum::Quaternion& quaternion) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void setRigidState(
+      CORRADE_UNUSED const core::RigidState& rigidState) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void resetTransformation() override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void translate(CORRADE_UNUSED const Magnum::Vector3& vector) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void translateLocal(CORRADE_UNUSED const Magnum::Vector3& vector) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotate(CORRADE_UNUSED const Magnum::Rad angleInRad,
+              CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateLocal(
+      CORRADE_UNUSED const Magnum::Rad angleInRad,
+      CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateX(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateY(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateZ(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateXLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateYLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  void rotateZLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  /**
+   * @brief Not used for articulated links.  Set or reset the object's state
+   * using the object's specified @p sceneInstanceAttributes_.
+   */
+  void resetStateFromSceneInstanceAttr() override {
+    ESP_DEBUG() << "ArticulatedLink can't do this.";
+  }
+
+  std::string linkName = "";
+  std::string linkJointName = "";
+
+  /**
+   * @brief Set the ManagedArticulatedObject encapsulating this link's owning
+   * Articulated Object
+   */
+  template <class T>
+  void setOwningManagedAO(const std::shared_ptr<T>& owningManagedAO) {
+    _owningManagedAO = owningManagedAO;
+  }
+
+ protected:
+  /**
+   * @brief Get the ManagedArticulatedObject encapsulating this link's owning
+   * Articulated Object
+   */
+  template <class T>
+  std::shared_ptr<T> getOwningManagedAOInternal() const {
+    if (!_owningManagedAO) {
+      return nullptr;
+    }
+    static_assert(
+        std::is_base_of<core::managedContainers::AbstractManagedObject,
+                        T>::value,
+        "ManagedArticulatedObject must be base class of desired "
+        "ArticulatedLink's Owning AO's Managed wrapper class.");
+    return std::static_pointer_cast<T>(_owningManagedAO);
+  }
+
+ private:
+  /**
+   * @brief Finalize the initialization of this link.
+   * @return true if initialized successfully, false otherwise.
+   */
+  bool initialization_LibSpecific() override { return true; }
+  /**
+   * @brief any physics-lib-specific finalization code that needs to be run
+   * after creation.
+   * @return whether successful finalization.
+   */
+  bool finalizeObject_LibSpecific() override { return true; }
+
+  // end RigidBase overrides
+
+  /**
+   * @brief The managed wrapper object for the AO that owns this link.
+   */
+  core::managedContainers::AbstractManagedObject::ptr _owningManagedAO =
+      nullptr;
+
+ protected:
+  int mbIndex_;
+
+ public:
+  ESP_SMART_POINTERS(ArticulatedLink)
+};
+
+}  // namespace physics
+}  // namespace esp
+#endif  // ESP_PHYSICS_ARTICULATEDLINK_H_

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -29,6 +29,7 @@ class ResourceManager;
 }
 
 namespace physics {
+class ManagedArticulatedObject;
 
 class URDFImporter;
 
@@ -1069,6 +1070,19 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
       recomputeAabb();
     }
     return aabb_;
+  }
+
+  /**
+   * @brief Get the ManagedArticulatedObject or BulletManagedArticulatedObject
+   * referencing this object.
+   */
+  template <class T>
+  std::shared_ptr<T> getManagedArticulatedObject() const {
+    static_assert(std::is_base_of<ManagedArticulatedObject, T>::value,
+                  "ManagedArticulatedObject must be base class of desired "
+                  "ArticulatedObject's Managed wrapper class.");
+
+    return PhysicsObjectBase::getManagedObjectPtrInternal<T>();
   }
 
  protected:

--- a/src/esp/physics/ArticulatedObject.h
+++ b/src/esp/physics/ArticulatedObject.h
@@ -11,7 +11,8 @@
  * JointMotorType, struct @ref JointMotorSettings
  */
 
-#include "RigidBase.h"
+#include "ArticulatedLink.h"
+#include "PhysicsObjectBase.h"
 #include "esp/core/Esp.h"
 #include "esp/geo/Geo.h"
 #include "esp/metadata/URDFParser.h"
@@ -129,164 +130,6 @@ struct JointMotor {
   int motorId;
 
   ESP_SMART_POINTERS(JointMotor)
-};
-
-////////////////////////////////////
-// Link
-////////////////////////////////////
-
-/**
- * @brief A single rigid link in a kinematic chain. Abstract class. Feature
- * attaches to a SceneNode.
- */
-class ArticulatedLink : public RigidBase {
- public:
-  ArticulatedLink(scene::SceneNode* bodyNode,
-                  int index,
-                  const assets::ResourceManager& resMgr)
-      : RigidBase(bodyNode,
-                  0,  // TODO: pass an actual object ID. This is currently
-                      // assigned AFTER creation.
-                  resMgr),
-        mbIndex_(index) {
-    setIsArticulated(true);
-  }
-
-  ~ArticulatedLink() override = default;
-
-  //! Get the link's index within its multibody
-  int getIndex() const { return mbIndex_; }
-
-  //! List of visual components attached to this link. Used for NavMesh
-  //! recomputation. Each entry is a child node of this link's node and a string
-  //! key to reference the asset in ResourceManager.
-  std::vector<std::pair<esp::scene::SceneNode*, std::string>>
-      visualAttachments_;
-
-  // RigidBase overrides
-
-  /**
-   * @brief Initializes the link.
-   * @param resMgr a reference to ResourceManager object
-   * @param handle The handle for the template structure defining relevant
-   * physical parameters for this object
-   * @return true if initialized successfully, false otherwise.
-   */
-  bool initialize(
-      CORRADE_UNUSED metadata::attributes::AbstractObjectAttributes::ptr
-          initAttributes) override {
-    return true;
-  }
-
-  void initializeArticulatedLink(const std::string& _linkName,
-                                 const Mn::Vector3& _scale) {
-    linkName = _linkName;
-    setScale(_scale);
-  }
-
-  /**
-   * @brief Finalize the creation of the link.
-   * @return whether successful finalization.
-   */
-  bool finalizeObject() override { return true; }
-
-  void setTransformation(
-      CORRADE_UNUSED const Magnum::Matrix4& transformation) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void setTranslation(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void setRotation(
-      CORRADE_UNUSED const Magnum::Quaternion& quaternion) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void setRigidState(
-      CORRADE_UNUSED const core::RigidState& rigidState) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void resetTransformation() override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void translate(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void translateLocal(CORRADE_UNUSED const Magnum::Vector3& vector) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotate(CORRADE_UNUSED const Magnum::Rad angleInRad,
-              CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateLocal(
-      CORRADE_UNUSED const Magnum::Rad angleInRad,
-      CORRADE_UNUSED const Magnum::Vector3& normalizedAxis) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateX(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateY(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateZ(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateXLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateYLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  void rotateZLocal(CORRADE_UNUSED const Magnum::Rad angleInRad) override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  /**
-   * @brief Not used for articulated links.  Set or reset the object's state
-   * using the object's specified @p sceneInstanceAttributes_.
-   */
-  void resetStateFromSceneInstanceAttr() override {
-    ESP_DEBUG() << "ArticulatedLink can't do this.";
-  }
-
-  std::string linkName = "";
-  std::string linkJointName = "";
-
- private:
-  /**
-   * @brief Finalize the initialization of this link.
-   * @return true if initialized successfully, false otherwise.
-   */
-  bool initialization_LibSpecific() override { return true; }
-  /**
-   * @brief any physics-lib-specific finalization code that needs to be run
-   * after creation.
-   * @return whether successful finalization.
-   */
-  bool finalizeObject_LibSpecific() override { return true; }
-
-  // end RigidBase overrides
-
- protected:
-  int mbIndex_;
-
- public:
-  ESP_SMART_POINTERS(ArticulatedLink)
 };
 
 ////////////////////////////////////
@@ -1070,6 +913,23 @@ class ArticulatedObject : public esp::physics::PhysicsObjectBase {
       recomputeAabb();
     }
     return aabb_;
+  }
+
+  /**
+   * @brief Map this AO's ManagedArticulatedObject to each link as their owning
+   * ManagedAO
+   */
+  template <class T>
+  void assignManagedAOtoLinks() {
+    static_assert(std::is_base_of<ManagedArticulatedObject, T>::value,
+                  "ManagedArticulatedObject must be base class of desired "
+                  "ArticulatedObject's Managed wrapper class.");
+    std::shared_ptr<T> managedAO =
+        PhysicsObjectBase::getManagedObjectPtrInternal<T>();
+    baseLink_->setOwningManagedAO(managedAO);
+    for (auto& link : links_) {
+      link.second->setOwningManagedAO(managedAO);
+    }
   }
 
   /**

--- a/src/esp/physics/CMakeLists.txt
+++ b/src/esp/physics/CMakeLists.txt
@@ -14,6 +14,7 @@ configure_file(
 
 add_library(
   physics STATIC
+  ArticulatedLink.h
   ArticulatedObject.h
   CollisionGroupHelper.cpp
   CollisionGroupHelper.h

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -319,17 +319,17 @@ int PhysicsManager::addObjectInternal(
   }
 
   // derive valid object ID and create new node if necessary
-  int nextObjectID_ = allocateObjectID();
+  int newObjectID = allocateObjectID();
   scene::SceneNode* objectNode = attachmentNode;
   if (attachmentNode == nullptr) {
     objectNode = &staticStageObject_->node().createChild();
   }
-
+  // Attempt to create a new object, initialize it and add to existingObjects_
   objectSuccess =
-      makeAndAddRigidObject(nextObjectID_, objectAttributes, objectNode);
+      makeAndAddRigidObject(newObjectID, objectAttributes, objectNode);
 
   if (!objectSuccess) {
-    deallocateObjectID(nextObjectID_);
+    deallocateObjectID(newObjectID);
     if (attachmentNode == nullptr) {
       delete objectNode;
     }
@@ -341,7 +341,7 @@ int PhysicsManager::addObjectInternal(
 
   // temp non-owning pointer to object
   esp::physics::RigidObject* const obj =
-      (existingObjects_.at(nextObjectID_).get());
+      (existingObjects_.at(newObjectID).get());
 
   obj->visualNodes_.push_back(obj->visualNode_);
 
@@ -358,7 +358,7 @@ int PhysicsManager::addObjectInternal(
   objectSuccess = obj->finalizeObject();
   if (!objectSuccess) {
     // if failed for some reason, remove and return
-    removeObject(nextObjectID_, true, true);
+    removeObject(newObjectID, true, true);
     ESP_ERROR() << "PhysicsManager::finalizeObject unsuccessful, so addObject `"
                 << objectAttributes->getHandle() << "` aborted.";
     return ID_UNDEFINED;
@@ -373,18 +373,21 @@ int PhysicsManager::addObjectInternal(
   ESP_DEBUG() << "Simplified template handle :" << simpleObjectHandle
               << " | newObjectHandle :" << newObjectHandle;
 
-  existingObjects_.at(nextObjectID_)->setObjectName(newObjectHandle);
+  obj->setObjectName(newObjectHandle);
 
   // 2.0 Get wrapper - name is irrelevant, do not register.
   ManagedRigidObject::ptr objWrapper = getRigidObjectWrapper();
 
   // 3.0 Put object in wrapper
-  objWrapper->setObjectRef(existingObjects_.at(nextObjectID_));
+  objWrapper->setObjectRef(existingObjects_.at(newObjectID));
 
   // 4.0 register wrapper in manager
-  rigidObjectManager_->registerObject(std::move(objWrapper), newObjectHandle);
+  rigidObjectManager_->registerObject(objWrapper, newObjectHandle);
 
-  return nextObjectID_;
+  // 4.5 register wrapper with object it contains
+  obj->setManagedObjectPtr(objWrapper);
+
+  return newObjectID;
 }  // PhysicsManager::addObject
 
 /////////////////////////////////

--- a/src/esp/physics/RigidObject.h
+++ b/src/esp/physics/RigidObject.h
@@ -29,6 +29,7 @@ namespace assets {
 class ResourceManager;
 }  // namespace assets
 namespace physics {
+class ManagedRigidObject;
 
 /**@brief Convenience struct for applying constant velocity control to a rigid
  * body. */
@@ -134,6 +135,19 @@ class RigidObject : public RigidBase {
     return PhysicsObjectBase::getInitializationAttributes<
         metadata::attributes::ObjectAttributes>();
   };
+
+  /**
+   * @brief Get the ManagedRigidObject or BulletManagedRigidObject referencing
+   * this object.
+   */
+  template <class T>
+  std::shared_ptr<T> getManagedRigidObject() const {
+    static_assert(std::is_base_of<ManagedRigidObject, T>::value,
+                  "ManagedRigidObject must be base class of desired "
+                  "RigidObject's Managed wrapper class.");
+
+    return PhysicsObjectBase::getManagedObjectPtrInternal<T>();
+  }
 
  private:
   /**

--- a/src/esp/physics/bullet/BulletArticulatedLink.h
+++ b/src/esp/physics/bullet/BulletArticulatedLink.h
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef ESP_PHYSICS_BULLET_BULLETARTICULATEDLINK_H_
+#define ESP_PHYSICS_BULLET_BULLETARTICULATEDLINK_H_
+
+#include "../ArticulatedLink.h"
+#include "BulletBase.h"
+#include "objectWrappers/ManagedBulletArticulatedObject.h"
+
+namespace esp {
+
+namespace physics {
+
+class ManagedBulletArticulatedObject;
+
+////////////////////////////////////
+// Link
+////////////////////////////////////
+
+class BulletArticulatedLink : public ArticulatedLink, public BulletBase {
+ public:
+  BulletArticulatedLink(scene::SceneNode* bodyNode,
+                        const assets::ResourceManager& resMgr,
+                        std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
+                        int index,
+                        std::shared_ptr<std::map<const btCollisionObject*, int>>
+                            collisionObjToObjIds)
+      : ArticulatedLink(bodyNode, index, resMgr),
+        BulletBase(std::move(bWorld), std::move(collisionObjToObjIds)) {}
+
+  Magnum::Range3D getCollisionShapeAabb() const override {
+    // TODO: collision object should be linked here
+    ESP_WARNING() << "Not implemented.";
+    return Magnum::Range3D();
+  }
+
+  //! link can't do this.
+  void setMotionType(CORRADE_UNUSED MotionType mt) override {
+    ESP_WARNING() << "Cannot set MotionType individually for links.";
+  }
+
+  std::shared_ptr<ManagedBulletArticulatedObject> getOwningManagedBulletAO()
+      const {
+    return ArticulatedLink::getOwningManagedAOInternal<
+        ManagedBulletArticulatedObject>();
+  }
+
+ protected:
+  int mbIndex_;
+
+ private:
+  ESP_SMART_POINTERS(BulletArticulatedLink)
+};
+}  // namespace physics
+}  // namespace esp
+
+#endif  // ESP_PHYSICS_BULLET_BULLETARTICULATEDLINK_H_

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -233,10 +233,6 @@ void BulletArticulatedObject::updateNodes(bool force) {
   }
 }
 
-////////////////////////////
-// BulletArticulatedLink
-////////////////////////////
-
 std::shared_ptr<metadata::attributes::SceneAOInstanceAttributes>
 BulletArticulatedObject::getCurrentStateInstanceAttr() {
   // get mutable copy of initialization SceneAOInstanceAttributes for this AO

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -5,6 +5,7 @@
 // Construction code adapted from Bullet3/examples/
 
 #include "BulletArticulatedObject.h"
+#include "BulletArticulatedLink.h"
 #include "BulletDynamics/Featherstone/btMultiBodyLinkCollider.h"
 #include "BulletPhysicsManager.h"
 #include "BulletURDFImporter.h"

--- a/src/esp/physics/bullet/BulletArticulatedObject.h
+++ b/src/esp/physics/bullet/BulletArticulatedObject.h
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "../ArticulatedObject.h"
-#include "BulletBase.h"
 #include "BulletDynamics/Featherstone/btMultiBodyJointMotor.h"
 #include "BulletDynamics/Featherstone/btMultiBodySphericalJointMotor.h"
 #include "BulletURDFImporter.h"
@@ -23,39 +22,6 @@ namespace physics {
 
 // forward declaration from BulletURDFImporter
 struct JointLimitConstraintInfo;
-
-////////////////////////////////////
-// Link
-////////////////////////////////////
-
-class BulletArticulatedLink : public ArticulatedLink, public BulletBase {
- public:
-  BulletArticulatedLink(scene::SceneNode* bodyNode,
-                        const assets::ResourceManager& resMgr,
-                        std::shared_ptr<btMultiBodyDynamicsWorld> bWorld,
-                        int index,
-                        std::shared_ptr<std::map<const btCollisionObject*, int>>
-                            collisionObjToObjIds)
-      : ArticulatedLink(bodyNode, index, resMgr),
-        BulletBase(std::move(bWorld), std::move(collisionObjToObjIds)) {}
-
-  Magnum::Range3D getCollisionShapeAabb() const override {
-    // TODO: collision object should be linked here
-    ESP_WARNING() << "Not implemented.";
-    return Magnum::Range3D();
-  }
-
-  //! link can't do this.
-  void setMotionType(CORRADE_UNUSED MotionType mt) override {
-    ESP_WARNING() << "Cannot set MotionType individually for links.";
-  }
-
- protected:
-  int mbIndex_;
-
- private:
-  ESP_SMART_POINTERS(BulletArticulatedLink)
-};
 
 ////////////////////////////////////
 // Articulated Object

--- a/src/esp/physics/bullet/CMakeLists.txt
+++ b/src/esp/physics/bullet/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(Bullet REQUIRED Dynamics)
 
 add_library(
   bulletphysics STATIC
+  BulletArticulatedLink.h
   BulletArticulatedObject.cpp
   BulletArticulatedObject.h
   BulletBase.cpp


### PR DESCRIPTION
This PR adds a pointer to each Rigid and Articulated Object to the Managed Object containing it. This is for python-driven internal access, so that, for instance, an articulated link can return a ManagedArticulatedObject reference to the AO it is a part of.

TODO : add tests for functionality

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
