### PR TITLE
[BE] - remove outdated functions from C++ simulator

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -298,14 +298,10 @@ void initSimBindings(py::module& m) {
           "cast_ray", &Simulator::castRay, "ray"_a, "max_distance"_a = 100.0,
           "buffer_distance"_a = 0.08,
           R"(Cast a ray into the collidable scene and return hit results. Physics must be enabled. max_distance in units of ray length.)")
-      .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
-           "object_id"_a,
-           R"(Enable or disable bounding box visualization for an object.)")
       .def(
           "recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
           "navmesh_settings"_a,
           R"(Recompute the NavMesh for a given PathFinder instance using configured NavMeshSettings.)")
-
       .def(
           "add_trajectory_object",
           [](Simulator& self, const std::string& name,

--- a/src/esp/physics/PhysicsManager.cpp
+++ b/src/esp/physics/PhysicsManager.cpp
@@ -940,26 +940,6 @@ int PhysicsManager::checkActiveObjects() {
   return numActive;
 }
 
-void PhysicsManager::setObjectBBDraw(int physObjectID,
-                                     DrawableGroup* drawables,
-                                     bool drawBB) {
-  auto objIter = getRigidObjIteratorOrAssert(physObjectID);
-  if (objIter->second->BBNode_ && !drawBB) {
-    // destroy the node
-    delete objIter->second->BBNode_;
-    objIter->second->BBNode_ = nullptr;
-  } else if (drawBB && objIter->second->visualNode_) {
-    // add a new BBNode
-    Magnum::Vector3 scale = objIter->second->getAabb().size() / 2.0;
-    objIter->second->BBNode_ = &objIter->second->visualNode_->createChild();
-    objIter->second->BBNode_->MagnumObject::setScaling(scale);
-    objIter->second->BBNode_->MagnumObject::setTranslation(
-        objIter->second->getAabb().center());
-    resourceManager_.addPrimitiveToDrawables(0, *objIter->second->BBNode_,
-                                             drawables);
-  }
-}
-
 metadata::attributes::PhysicsManagerAttributes::ptr
 PhysicsManager::getInitializationAttributes() const {
   return metadata::attributes::PhysicsManagerAttributes::create(

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -679,14 +679,6 @@ class PhysicsManager : public std::enable_shared_from_this<PhysicsManager> {
    */
   int checkActiveObjects();
 
-  /** @brief Set bounding box rendering for the object true or false.
-   * @param physObjectID The object ID and key identifying the object in @ref
-   * PhysicsManager::existingObjects_.
-   * @param drawables The drawables group with which to render the bounding box.
-   * @param drawBB Set rendering of the bounding box to true or false.
-   */
-  void setObjectBBDraw(int physObjectID, DrawableGroup* drawables, bool drawBB);
-
   /**
    * @brief Get the root node of an object's visual SceneNode subtree.
    *

--- a/src/esp/physics/RigidBase.h
+++ b/src/esp/physics/RigidBase.h
@@ -398,12 +398,6 @@ class RigidBase : public esp::physics::PhysicsObjectBase {
   }
 
   /**
-   * @brief The @ref SceneNode of a bounding box debug drawable. If nullptr, BB
-   * drawing is off. See @ref setObjectBBDraw().
-   */
-  scene::SceneNode* BBNode_ = nullptr;
-
-  /**
    * @brief All Drawable components are children of this node.
    *
    * Note that the transformation of this node is a composition of rotation and

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -990,14 +990,6 @@ bool Simulator::isNavMeshVisualizationActive() {
   return (navMeshVisNode_ != nullptr && navMeshVisPrimID_ != ID_UNDEFINED);
 }
 
-esp::physics::ManagedArticulatedObject::ptr
-Simulator::queryArticulatedObjWrapper(int objID) const {
-  if (!sceneHasPhysics()) {
-    return nullptr;
-  }
-  return getArticulatedObjectManager()->getObjectCopyByID(objID);
-}
-
 void Simulator::setMetadataMediator(
     metadata::MetadataMediator::ptr _metadataMediator) {
   metadataMediator_ = std::move(_metadataMediator);

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -96,8 +96,6 @@ class Simulator {
     return gfxReplayMgr_;
   }
 
-  void saveFrame(const std::string& filename);
-
   /**
    * @brief The ID of the CUDA device of the OpenGL context owned by the
    * simulator. This will only be nonzero if the simulator is built in
@@ -111,7 +109,6 @@ class Simulator {
   }
 
   // === Physics Simulator Functions ===
-  // TODO: support multi-scene physics (default sceneID=0 currently).
   /**
    * @brief Return manager for construction and access to articulated object
    * attributes for the current dataset.
@@ -296,26 +293,6 @@ class Simulator {
       return physicsManager_->getExistingObjectIDs();
     }
     return std::vector<int>();  // empty if no simulator exists
-  }
-
-  /**
-   * @brief Turn on/off rendering for the bounding box of the object's visual
-   * component.
-   *
-   * Assumes the new @ref esp::gfx::Drawable for the bounding box should be
-   * added to the active @ref esp::gfx::SceneGraph's default drawable group. See
-   * @ref esp::gfx::SceneGraph::getDrawableGroup().
-   *
-   * @param drawBB Whether or not the render the bounding box.
-   * @param objectId The object ID and key identifying the object in @ref
-   * esp::physics::PhysicsManager::existingObjects_.
-   */
-  void setObjectBBDraw(bool drawBB, int objectId) {
-    if (sceneHasPhysics()) {
-      getRenderGLContext();
-      auto& drawables = getDrawableGroup();
-      physicsManager_->setObjectBBDraw(objectId, &drawables, drawBB);
-    }
   }
 
   /**
@@ -925,18 +902,6 @@ class Simulator {
   buildCurrentStateSceneAttributes() const;
 
   bool sceneHasPhysics() const { return physicsManager_ != nullptr; }
-
-  /**
-   * @brief TEMPORARY until sim access to objects is completely removed.  This
-   * method will return an object's wrapper if the passed @p objID is valid.
-   * This wrapper will then be used by the calling
-   * function to access components of the object.
-   * @param objID The ID of the desired object
-   * @return A smart pointer to the wrapper referencing the desired object, or
-   * nullptr if DNE.
-   */
-  esp::physics::ManagedArticulatedObject::ptr queryArticulatedObjWrapper(
-      int objID) const;
 
   void reconfigureReplayManager(bool enableGfxReplaySave);
 

--- a/src/utils/viewer/viewer.cpp
+++ b/src/utils/viewer/viewer.cpp
@@ -2265,9 +2265,7 @@ void Viewer::keyPressEvent(KeyEvent& event) {
     case KeyEvent::Key::B: {
       // toggle bounding box on objects
       drawObjectBBs = !drawObjectBBs;
-      for (auto id : simulator_->getExistingObjectIDs()) {
-        simulator_->setObjectBBDraw(drawObjectBBs, id);
-      }
+      // TODO: do this with debug drawing instead
     } break;
     case KeyEvent::Key::C:
       showFPS_ = !showFPS_;


### PR DESCRIPTION
## Motivation and Context

Removes a few outdated things from C++ Simulator:
- `setObjectBBDraw` and python `set_object_bb_draw` - removed because debug line rendering is the preferred method for this kind of feature, not a Simulator API
- `saveFrame` - not implemented
- `queryArticulatedObjWrapper` - outdated, use the manager

## How Has This Been Tested

CI should pass (maybe not lab) see https://github.com/facebookresearch/habitat-lab/pull/2106

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
