### PR TITLE
--[BE] - Refactor Sensor Enum Names; Isolate Struct Templates

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1666,8 +1666,8 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceGeneralPrimitive(
 
   std::vector<StaticDrawableInfo> staticDrawableInfo;
 
-  auto nodeType = creation.isStatic() ? scene::SceneNodeType::EMPTY
-                                      : scene::SceneNodeType::OBJECT;
+  auto nodeType = creation.isStatic() ? scene::SceneNodeType::Empty
+                                      : scene::SceneNodeType::Object;
   bool computeAbsoluteAABBs = creation.isStatic();
 
   // If the object has a skin and a rig (articulated object), link them together
@@ -1712,7 +1712,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceGeneralPrimitive(
   }
 
   // set the node type for all cached visual nodes
-  if (nodeType != scene::SceneNodeType::EMPTY) {
+  if (nodeType != scene::SceneNodeType::Empty) {
     for (auto* node : visNodeCache) {
       node->setType(nodeType);
     }

--- a/src/esp/bindings/SceneBindings.cpp
+++ b/src/esp/bindings/SceneBindings.cpp
@@ -84,11 +84,11 @@ void initSceneBindings(
 
   // ==== enum SceneNodeType ====
   py::enum_<SceneNodeType>(m, "SceneNodeType")
-      .value("EMPTY", SceneNodeType::EMPTY)
-      .value("SENSOR", SceneNodeType::SENSOR)
-      .value("AGENT", SceneNodeType::AGENT)
-      .value("CAMERA", SceneNodeType::CAMERA)
-      .value("OBJECT", SceneNodeType::OBJECT);
+      .value("EMPTY", SceneNodeType::Empty)
+      .value("SENSOR", SceneNodeType::Sensor)
+      .value("AGENT", SceneNodeType::Agent)
+      .value("CAMERA", SceneNodeType::Camera)
+      .value("OBJECT", SceneNodeType::Object);
 
   pySceneNode
       .def(py::init_alias<std::reference_wrapper<SceneNode>>(),

--- a/src/esp/bindings/SensorBindings.cpp
+++ b/src/esp/bindings/SensorBindings.cpp
@@ -70,8 +70,8 @@ void initSensorBindings(py::module& m) {
   // NOTE : esp::sensor::SemanticSensorTarget is an alias for
   // esp::scene::SceneNodeSemanticDataIDX.
   py::enum_<SemanticSensorTarget>(m, "SemanticSensorTarget")
-      .value("SEMANTIC_ID", SemanticSensorTarget::SEMANTIC_ID)
-      .value("OBJECT_ID", SemanticSensorTarget::OBJECT_ID);
+      .value("SEMANTIC_ID", SemanticSensorTarget::SemanticID)
+      .value("OBJECT_ID", SemanticSensorTarget::ObjectID);
 
   py::enum_<FisheyeSensorModelType>(m, "FisheyeSensorModelType")
       .value("DOUBLE_SPHERE", FisheyeSensorModelType::DoubleSphere);

--- a/src/esp/core/Esp.h
+++ b/src/esp/core/Esp.h
@@ -22,6 +22,8 @@ namespace esp {
 
 // Faciliate enabling/disabling Function templates
 // Alias template enabling/disabling function templates based on some condition
+
+namespace {
 template <bool, typename T = void>
 struct EnableIfT {};
 
@@ -29,6 +31,8 @@ template <typename T>
 struct EnableIfT<true, T> {
   using Type = T;
 };
+
+}  // namespace
 
 // EnableIf expands to a type so this is implemented as an alias template
 // Cond is the condition for which the subsequent template should be executed,

--- a/src/esp/gfx/RenderCamera.cpp
+++ b/src/esp/gfx/RenderCamera.cpp
@@ -52,7 +52,7 @@ RenderCamera::RenderCamera(scene::SceneNode& node,
     : MagnumCamera{node}, semanticInfoIDX_(semanticDataIDX) {
   // Set to using the base semantic idx assigned to this camera
   semanticIDXToUse_ = semanticInfoIDX_;
-  node.setType(scene::SceneNodeType::CAMERA);
+  node.setType(scene::SceneNodeType::Camera);
   setAspectRatioPolicy(Mn::SceneGraph::AspectRatioPolicy::NotPreserved);
 }
 
@@ -146,7 +146,7 @@ size_t RenderCamera::removeNonObjects(DrawableTransforms& drawableTransforms) {
                           Mn::Matrix4>& a) {
         auto& node = static_cast<scene::SceneNode&>(a.first.get().object());
         // don't remove OBJECT types
-        return (node.getType() != scene::SceneNodeType::OBJECT);
+        return (node.getType() != scene::SceneNodeType::Object);
       });
   return (newEndIter - drawableTransforms.begin());
 }
@@ -156,7 +156,7 @@ uint32_t RenderCamera::draw(DrawableTransforms& drawableTransforms,
   previousNumVisibleDrawables_ = drawableTransforms.size();
 
   if (flags & Flag::UseDrawableIdAsObjectId) {
-    semanticIDXToUse_ = esp::scene::SceneNodeSemanticDataIDX::DRAWABLE_ID;
+    semanticIDXToUse_ = esp::scene::SceneNodeSemanticDataIDX::DrawableID;
   }
 
   MagnumCamera::draw(drawableTransforms);

--- a/src/esp/gfx/RenderCamera.h
+++ b/src/esp/gfx/RenderCamera.h
@@ -27,7 +27,7 @@ class RenderCamera : public MagnumCamera {
 
     /**
      * Cull Drawables not attached to @ref SceneNodes with @ref
-     * scene::SceneNodeType::OBJECT.
+     * scene::SceneNodeType::Object.
      */
     ObjectsOnly = 1 << 1,
     /**
@@ -271,13 +271,13 @@ class RenderCamera : public MagnumCamera {
   //! render for semantic sensors. This may be overridden by object picking
   //! code.
   esp::scene::SceneNodeSemanticDataIDX semanticInfoIDX_ =
-      esp::scene::SceneNodeSemanticDataIDX::SEMANTIC_ID;
+      esp::scene::SceneNodeSemanticDataIDX::SemanticID;
 
   //! the index to actually use to render semantic info. This will usually be
   //! the same as semanticInfoIDX above, but will hold a different value if
   //! being overridden by object picking.
   esp::scene::SceneNodeSemanticDataIDX semanticIDXToUse_ =
-      esp::scene::SceneNodeSemanticDataIDX::SEMANTIC_ID;
+      esp::scene::SceneNodeSemanticDataIDX::SemanticID;
 
   ESP_SMART_POINTERS(RenderCamera)
 };

--- a/src/esp/physics/bullet/BulletArticulatedObject.cpp
+++ b/src/esp/physics/bullet/BulletArticulatedObject.cpp
@@ -151,7 +151,7 @@ void BulletArticulatedObject::initializeFromURDF(
       linkObject->linkName = urdfLink->m_name;
       linkNamesToIDs_[linkObject->linkName] = bulletLinkIx;
 
-      linkObject->node().setType(esp::scene::SceneNodeType::OBJECT);
+      linkObject->node().setType(esp::scene::SceneNodeType::Object);
     }
 
     // Build damping motors

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -277,7 +277,7 @@ bool BulletPhysicsManager::attachLinkGeometry(
     scene::SceneNode& visualGeomComponent = linkObject->node().createChild();
     // cache the visual node
     linkObject->visualNodes_.push_back(&visualGeomComponent);
-    visualGeomComponent.setType(esp::scene::SceneNodeType::OBJECT);
+    visualGeomComponent.setType(esp::scene::SceneNodeType::Object);
     visualGeomComponent.setTransformation(
         link->m_inertia.m_linkLocalFrame.invertedRigid() *
         visual.m_linkLocalFrame);

--- a/src/esp/scene/SceneNode.cpp
+++ b/src/esp/scene/SceneNode.cpp
@@ -19,8 +19,9 @@ SceneNode::SceneNode()
     : Mn::SceneGraph::AbstractFeature3D{*this},
       nodeSensorSuite_(new esp::sensor::SensorSuite(*this)),
       subtreeSensorSuite_(new esp::sensor::SensorSuite(*this)),
-      semanticIDs_(static_cast<int>(SceneNodeSemanticDataIDX::NUM_SEMANTIC_IDS),
-                   0) {
+      semanticIDs_(
+          static_cast<int>(SceneNodeSemanticDataIDX::EndSemanticDataIDXs),
+          0) {
   setCachedTransformations(Mn::SceneGraph::CachedTransformation::Absolute);
   absoluteTransformation_ = absoluteTransformation();
   // Once created, nodeSensorSuite_ and subtreeSensorSuite_ are features owned

--- a/src/esp/scene/SceneNode.h
+++ b/src/esp/scene/SceneNode.h
@@ -33,11 +33,12 @@ class SceneGraph;
 
 // Future types may include e.g., "LIGHT"
 enum class SceneNodeType {
-  EMPTY = 0,
-  SENSOR = 1,
-  AGENT = 2,
-  CAMERA = 3,
-  OBJECT = 4,  // objects added via physics api
+  Empty = 0,
+  Sensor = 1,
+  Agent = 2,
+  Camera = 3,
+  Object = 4,  // objects added via physics api
+  EndSceneNodeType,
 };
 
 /**
@@ -52,24 +53,24 @@ enum class SceneNodeSemanticDataIDX {
    * attached Drawables with Semantic sensor when no perVertexObjectIds are
    * present.
    */
-  SEMANTIC_ID = 0,
+  SemanticID = 0,
 
   /**
    * @brief The object ID of the object represented by this scene node. This
    * value will be set to ID_UNDEFINED if the object is deleted without removing
    * the scene node/drawable.
    */
-  OBJECT_ID = 1,
+  ObjectID = 1,
 
   /**
    * @brief The drawable ID that draws this scene node.
    */
-  DRAWABLE_ID = 2,
+  DrawableID = 2,
   /**
    * @brief Insert the index of a new ID to represent in semantic observations
    * above this entry.
    */
-  NUM_SEMANTIC_IDS
+  EndSemanticDataIDXs
 };  // enum SceneNodeSemanticDataIDX
 
 // Enumeration of SceneNodeTags
@@ -155,35 +156,33 @@ class SceneNode : public MagnumObject,
 
   //! Returns node semanticId
   virtual int getSemanticId() const {
-    return semanticIDs_[static_cast<int>(
-        SceneNodeSemanticDataIDX::SEMANTIC_ID)];
+    return semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::SemanticID)];
   }
 
   //! Sets node semanticId
   virtual void setSemanticId(int semanticId) {
-    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::SEMANTIC_ID)] =
+    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::SemanticID)] =
         semanticId;
   }
 
   //! Gets node's owning objectID, for panoptic rendering.
   virtual int getBaseObjectId() const {
-    return semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::OBJECT_ID)];
+    return semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::ObjectID)];
   }
 
   //! Sets node's owning objectID, for panoptic rendering.
   void setBaseObjectId(int objectId) {
-    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::OBJECT_ID)] =
+    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::ObjectID)] =
         objectId;
   }
   //! Gets node's corresponding drawable's id, for panoptic rendering.
   virtual int getDrawableId() const {
-    return semanticIDs_[static_cast<int>(
-        SceneNodeSemanticDataIDX::DRAWABLE_ID)];
+    return semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::DrawableID)];
   }
 
   //! Sets node's corresponding drawable's id, for panoptic rendering.
   void setDrawableId(int drawableId) {
-    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::DRAWABLE_ID)] =
+    semanticIDs_[static_cast<int>(SceneNodeSemanticDataIDX::DrawableID)] =
         drawableId;
   }
 
@@ -310,7 +309,7 @@ class SceneNode : public MagnumObject,
   void clean(const Magnum::Matrix4& absoluteTransformation) override;
 
   // the type of the attached object (e.g., sensor, agent etc.)
-  SceneNodeType type_ = SceneNodeType::EMPTY;
+  SceneNodeType type_ = SceneNodeType::Empty;
   int id_ = ID_UNDEFINED;
 
   // SceneNodeTags of this node, used to flag attributes such as leaf node

--- a/src/esp/sensor/Sensor.cpp
+++ b/src/esp/sensor/Sensor.cpp
@@ -50,7 +50,7 @@ Sensor::Sensor(scene::SceneNode& node, SensorSpec::ptr spec)
   CORRADE_ASSERT(
       node.getSceneNodeTags() & scene::SceneNodeTag::Leaf,
       "Sensor::Sensor(): Cannot attach a sensor to a non-LEAF node.", );
-  node.setType(scene::SceneNodeType::SENSOR);
+  node.setType(scene::SceneNodeType::Sensor);
   CORRADE_ASSERT(spec_,
                  "Sensor::Sensor(): Cannot initialize sensor. The "
                  "specification is null.", );

--- a/src/esp/sensor/VisualSensor.h
+++ b/src/esp/sensor/VisualSensor.h
@@ -63,7 +63,7 @@ struct VisualSensorSpec : public SensorSpec {
    * @brief the type of semantic information being rendered by the semantic
    * sensor. Ignored by non-semantic sensors
    */
-  SemanticSensorTarget semanticTarget = SemanticSensorTarget::SEMANTIC_ID;
+  SemanticSensorTarget semanticTarget = SemanticSensorTarget::SemanticID;
 
   VisualSensorSpec();
   void sanityCheck() const override;

--- a/src/tests/CullingTest.cpp
+++ b/src/tests/CullingTest.cpp
@@ -155,7 +155,7 @@ void CullingTest::frustumCulling() {
   esp::scene::SceneNode agentNode = sceneGraph.getRootNode().createChild();
   esp::scene::SceneNode cameraNode = agentNode.createChild();
   esp::gfx::RenderCamera& renderCamera = *(new esp::gfx::RenderCamera(
-      cameraNode, esp::sensor::SemanticSensorTarget::SEMANTIC_ID));
+      cameraNode, esp::sensor::SemanticSensorTarget::SemanticID));
 
   // The camera to be set:
   // pos: {7.3589f, -6.9258f,4.9583f}


### PR DESCRIPTION
## Motivation and Context
This small PR does a bit of cleanup on 2 fronts : 
 - Make two sensor/scene node Enum classes' member enumeration's naming adhere to our standard practice (instead of all caps) - Note : this is in c++ only, their python bindings are unchanged.
 - Isolate 2 struct templates to be local to their containing file instead of in the global ESP namespace.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
