### PR TITLE
--[BE] - add drawCoordinateAxes and drawCone to debug line renderer

### DIFF
--- a/src/esp/bindings/GfxBindings.cpp
+++ b/src/esp/bindings/GfxBindings.cpp
@@ -255,6 +255,20 @@ void initGfxBindings(
           R"(Draw a circle in world-space or local-space (see pushTransform). The circle is an approximation; see numSegments.)",
           "translation"_a, "radius"_a, "color"_a, "num_segments"_a = 24,
           "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0})
+      .def("draw_cone", &DebugLineRender::drawCone,
+           R"(Draw a cone in world-space or local-space (see pushTransform).
+          The cone is a segmented circle (see drawCircle) with each segment endpoint
+          having a line drawn to the given apex.)",
+           "translation"_a, "apex"_a, "radius"_a, "color"_a,
+           "num_segments"_a = 12, "normal"_a = Magnum::Vector3{0.0, 1.0, 0.0})
+      .def(
+          "draw_axes", &DebugLineRender::drawCoordinateAxes,
+          R"(Draw a set of coordinate axes at the given XYZ translation and with
+          XYZ scaling in world-space or local-space (see pushTransform).
+          These axes are color-mapped such that XYZ->RGB and each positive axis
+          as a connical 'arrow head' of given radius.)",
+          "translation"_a, "scale"_a = Magnum::Vector3{1.0, 1.0, 1.0},
+          "radius"_a = 0.05)
       .def(
           "draw_transformed_line",
           py::overload_cast<const Magnum::Vector3&, const Magnum::Vector3&,

--- a/src/esp/gfx/DebugLineRender.h
+++ b/src/esp/gfx/DebugLineRender.h
@@ -133,6 +133,29 @@ class DebugLineRender {
                                                                   0.0));
 
   /**
+   * @brief Draw a cone in world-space or local-space (see pushTransform).
+   * The cone is a circle (see drawCircle) with each segment endpoint having a
+   * line drawn to the given apex.
+   */
+  void drawCone(const Magnum::Vector3& pos,
+                const Magnum::Vector3& apex,
+                float radius,
+                const Magnum::Color4& color,
+                int numSegments = 24,
+                const Magnum::Vector3& normal = Magnum::Vector3(0.0, 1.0, 0.0));
+
+  /**
+   * @brief Draw RGB->XYZ coordinate axes at given location with given
+   * scaling. A circle will be placed near the end of each positive axis.
+   * @param pos The location in world space to place the axes
+   * @param scale The length of each axis
+   * @param radius The radius of the positive-direction circle indicators
+   */
+  void drawCoordinateAxes(const Magnum::Vector3& pos,
+                          const Magnum::Vector3& scale = {1.0f, 1.0f, 1.0f},
+                          float radius = 0.05);
+
+  /**
    * @brief Draw a sequence of line segments with circles at the two endpoints.
    * In world-space or local-space (see pushTransform).
    */


### PR DESCRIPTION
## Motivation and Context
This PR adds some utility functions and python bindings to the DebugLineRenderer that will draw coordinate axes and draw a cone at a specific location.

draw_axes : 
Inserting the following python line in a draw statement  :
`debug_line_render.draw_axes(obj.translation)`

will yield the following axes centered at obj.translation (note the cones at the end of each axis indicated direction of increasing value):

![coordinateAxes](https://github.com/user-attachments/assets/c3a24716-a6fe-4e3b-ba47-b2cc1b060dc1)


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally with python utilities
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
