### PR TITLE
--[BE] - Miscellaneous minor refactors and cleanup

### DIFF
--- a/.github/actions/install_ubuntu_deps/action.yml
+++ b/.github/actions/install_ubuntu_deps/action.yml
@@ -50,7 +50,7 @@ runs:
     run: |-
       echo "Install conda and dependencies"
       conda install -y pytorch==1.12.1 torchvision==0.13.1 -c pytorch -c nvidia
-      conda install -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis pytest-mock
+      conda install -y -c conda-forge ninja numpy=1.26.4 pytest pytest-cov ccache hypothesis pytest-mock
       pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython mock
     shell: bash -el {0}
   - name: Validate Pytorch Installation

--- a/examples/tutorials/async_rendering.py
+++ b/examples/tutorials/async_rendering.py
@@ -32,6 +32,11 @@ Known limitations/issues:
     back to the main thread by calling sim.get_sensor_observations_async_finish() by default.
 """
 
+
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 
 

--- a/examples/tutorials/stereo_agent.py
+++ b/examples/tutorials/stereo_agent.py
@@ -5,6 +5,10 @@
 
 import numpy as np
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 
 cv2 = None

--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -120,7 +120,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   }  // ManagedFileBasedContainer::createObjectFromJSONString
 
   /**
-   * @brief Method to load a Managed Object's data from a file.  If the file
+   * @brief Method to load a Managed Object's data from a file. If the file
    * type is not supported by specialization of this method, this method
    * executes and an error is thrown.
    * @tparam type of document to load.
@@ -131,15 +131,19 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
   template <typename U>
   ManagedFileIOPtr buildManagedObjectFromDoc(const std::string& filename,
                                              CORRADE_UNUSED const U& config) {
-    ESP_ERROR(Mn::Debug::Flag::NoSpace)
-        << "<" << this->objectType_
-        << "> : Failure loading attributes from document `" << filename
-        << "` of unknown type `" << typeid(U).name()
-        << "` so unable to build object.";
+    CORRADE_ASSERT(false,
+                   Cr::Utility::formatString(
+                       "<{}> : Failure loading attributes from document `{}` "
+                       "of unsupported file type `{}` so unable to build "
+                       "object. Make sure a specialization of "
+                       "ManagedFileBasedContainer::buildManagedObjectFromDoc() "
+                       "supporting this file type has been implemented.",
+                       this->objectType_, filename, typeid(U).name()),
+                   nullptr);
   }  // ManagedFileBasedContainer::buildManagedObjectFromDoc
 
   /**
-   * @brief Method to load a Managed Object's data from a file.  This is the
+   * @brief Method to load a Managed Object's data from a file. This is the
    * JSON specialization, using type inference.
    * @param filename name of file document to load from
    * @param config JSON document to read for data

--- a/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
+++ b/src/esp/physics/objectWrappers/ManagedArticulatedObject.h
@@ -346,8 +346,6 @@ class ManagedArticulatedObject
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getPhyObjInfoHeaderInternal() const override {

--- a/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
+++ b/src/esp/physics/objectWrappers/ManagedPhysicsObjectBase.h
@@ -387,8 +387,6 @@ class AbstractManagedPhysicsObject
   /**
    * @brief Retrieve a comma-separated string holding the header values for
    * the info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   virtual std::string getPhyObjInfoHeaderInternal() const = 0;

--- a/src/esp/physics/objectWrappers/ManagedRigidBase.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidBase.h
@@ -248,8 +248,6 @@ class AbstractManagedRigidBase
   /**
    * @brief Retrieve a comma-separated string holding the header values for the
    * info returned for this managed object, type-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
 
   std::string getPhyObjInfoHeaderInternal() const override {
@@ -263,8 +261,6 @@ class AbstractManagedRigidBase
   /**
    * @brief Retrieve a comma-separated string holding the header values for
    * the info returned for this managed object, rigid-base-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   virtual std::string getRigidBaseInfoHeaderInternal() const = 0;
   /**

--- a/src/esp/physics/objectWrappers/ManagedRigidObject.h
+++ b/src/esp/physics/objectWrappers/ManagedRigidObject.h
@@ -61,8 +61,6 @@ class ManagedRigidObject
   /**
    * @brief Retrieve a comma-separated string holding the header values for
    * the info returned for this managed object, rigid-base-specific.
-   * TODO : once Magnum supports retrieving key-values of configurations, use
-   * that to build this data.
    */
   std::string getRigidBaseInfoHeaderInternal() const override {
     return "Creation Attributes Name";

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 
 _test_scene = osp.abspath(

--- a/tests/test_compare_profiles.py
+++ b/tests/test_compare_profiles.py
@@ -8,6 +8,10 @@ import sqlite3
 from io import StringIO
 from unittest.mock import patch
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 from habitat_sim.utils import compare_profiles
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,10 @@ from os import path as osp
 
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim.bindings
 from utils import run_main_subproc
 

--- a/tests/test_greedy_follower.py
+++ b/tests/test_greedy_follower.py
@@ -7,6 +7,10 @@ from os import path as osp
 
 import numpy as np
 import pytest
+
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
 import tqdm
 
 import habitat_sim
@@ -78,6 +82,7 @@ def test_greedy_follower(test_navmesh, move_filter_fn, action_noise, pbar):
 
     scene_graph = habitat_sim.SceneGraph()
     agent = habitat_sim.Agent(scene_graph.get_root_node().create_child())
+    print(f"move_filter_fn : {move_filter_fn} action noise : {action_noise}")
     agent.controls.move_filter_fn = getattr(pathfinder, move_filter_fn)
 
     agent.agent_config.action_space["turn_left"].actuation.amount = TURN_DEGREE

--- a/tests/test_light_setup.py
+++ b/tests/test_light_setup.py
@@ -2,6 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 from habitat_sim.gfx import (
     DEFAULT_LIGHTING_KEY,

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -9,6 +9,10 @@ from typing import Any, Dict
 import numpy as np
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 import habitat_sim.utils.settings
 

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -9,6 +9,10 @@ from os import path as osp
 import numpy as np
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 from habitat_sim.sensors.noise_models import redwood_depth_noise_model
 from habitat_sim.sensors.noise_models.redwood_depth_noise_model import (

--- a/tests/test_physics_benchmarking.py
+++ b/tests/test_physics_benchmarking.py
@@ -6,6 +6,10 @@
 
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 import habitat_sim.utils.settings
 

--- a/tests/test_profiling_utils.py
+++ b/tests/test_profiling_utils.py
@@ -12,6 +12,10 @@ from unittest.mock import patch
 
 import pytest
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 from habitat_sim.utils import profiling_utils
 
 _ENV_VAR_NAME = "HABITAT_PROFILING"

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -2,6 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 import habitat_sim
 import habitat_sim.utils.settings
 

--- a/tests/test_snap_point.py
+++ b/tests/test_snap_point.py
@@ -6,6 +6,10 @@ import math
 
 import hypothesis
 import pytest
+
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
 from hypothesis import strategies as st
 
 import habitat_sim

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Need to import quaternion library here despite it not being used or else importing
+# habitat_sim below will cause an invalid free() when audio is enabled in sim compilation
+import quaternion  # noqa: F401
+
 from habitat_sim.utils.collect_env import main as collect_env
 
 


### PR DESCRIPTION
## Motivation and Context
This PR will contain various minor refactors and cleanup that I find as I complete other BE work that may be thematically orthogonal to the purpose of that work.

An important issue this PR addresses is that the python tests will currently abort if Habitat-sim is compiled with audio support. This is due to the import of habitat_sim in conftest.py causing an invalid free() unless the python quaternion library is imported first. This is discussed [in this issue](https://github.com/facebookresearch/habitat-sim/issues/1747).  Until a reason for this aberrant behavior can be determined, quaternion will be imported here so tests and examples don't fail.

NOTE : There is still an ongoing issue with running python tests with the audio subsystem enabled during compilation, where a greedy path without any action noise is perceived somehow as being a PyCapsule object; addressing that is beyond the scope of this PR.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
locally c++ and python tests
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
