### PR TITLE
[CI] Remove `imageio-ffmpeg` from dependencies.

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -162,7 +162,7 @@ jobs:
         conda activate habitat
         cd habitat-sim
         pip install -r requirements.txt --progress-bar off
-        pip install imageio imageio-ffmpeg
+        pip install imageio
         git submodule update --init --recursive --jobs 8
         python -u setup.py install --build-type "Release" --lto --headless --audio
         python examples/tutorials/audio_agent.py
@@ -201,7 +201,7 @@ jobs:
         cd habitat-sim
         pip install -r requirements.txt --progress-bar off
         git submodule update --init --recursive --jobs 8
-        pip install imageio imageio-ffmpeg
+        pip install imageio
         conda install -y -c conda-forge doxygen=1.9.5
         conda install -y  jinja2 pygments docutils
         sudo apt install --yes --allow-change-held-packages \

--- a/conda-build/habitat-sim/meta.yaml
+++ b/conda-build/habitat-sim/meta.yaml
@@ -69,7 +69,6 @@ requirements:
     - scipy>=1.3.0
     - tqdm
     - imageio
-    - imageio-ffmpeg
     - matplotlib
     - libxcb                             # [linux]
     - xorg-libx11                        # [linux]

--- a/src_python/habitat_sim/utils/viz_utils.py
+++ b/src_python/habitat_sim/utils/viz_utils.py
@@ -33,29 +33,6 @@ def is_notebook() -> bool:
         return True
 
 
-def get_fast_video_writer(video_file: str, fps: int = 60):
-    if (
-        "google.colab" in sys.modules
-        and os.path.splitext(video_file)[-1] == ".mp4"
-        and os.environ.get("IMAGEIO_FFMPEG_EXE") == "/usr/bin/ffmpeg"
-    ):
-        # USE GPU Accelerated Hardware Encoding
-        writer = imageio.get_writer(
-            video_file,
-            fps=fps,
-            codec="h264_nvenc",
-            mode="I",
-            bitrate="1000k",
-            format="FFMPEG",  # type: ignore[arg-type]
-            ffmpeg_log_level="info",
-            output_params=["-minrate", "500k", "-maxrate", "5000k"],
-        )
-    else:
-        # Use software encoding
-        writer = imageio.get_writer(video_file, fps=fps)
-    return writer
-
-
 def save_video(video_file: str, frames, fps: int = 60):
     """Saves the video using imageio. Will try to use GPU hardware encoding on
     Google Colab for faster video encoding. Will also display a progressbar.
@@ -64,7 +41,7 @@ def save_video(video_file: str, frames, fps: int = 60):
     :param frames: the actual frame objects to save
     :param fps: the fps of the video (default 60)
     """
-    writer = get_fast_video_writer(video_file, fps=fps)
+    writer = imageio.get_writer(video_file, fps=fps)
     for ob in tqdm(frames, desc="Encoding video:%s" % video_file):
         writer.append_data(ob)
     writer.close()
@@ -233,7 +210,7 @@ def make_video(
     if not video_file.endswith(".mp4"):
         video_file = video_file + ".mp4"
     print("Encoding the video: %s " % video_file)
-    writer = get_fast_video_writer(video_file, fps=fps)
+    writer = imageio.get_writer(video_file, fps=fps)
     observation_to_image = partial(observation_to_image, depth_clip=depth_clip)
 
     for ob in observations:


### PR DESCRIPTION
## Motivation and Context

The `imageio-ffmpeg` dependency is not strictly required to run `habitat-sim`.
This package depends on `libva`, which depends on `libgl`, `libglx`, `libegl` and `libglvnd`.
Those 4 last packages may conflict with Linux packages, causing the OpenGL front-end libraries to fail to communicate to the OpenGL backend.
This error may occur:
```
GL::Context: cannot retrieve OpenGL version: GL::Renderer::Error::InvalidValue
```

## How Has This Been Tested

Tested locally on a new conda environment.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
