### PR TITLE
Remove matplotlib from conda requirements.

### DIFF
--- a/conda-build/habitat-sim/meta.yaml
+++ b/conda-build/habitat-sim/meta.yaml
@@ -70,7 +70,6 @@ requirements:
     - tqdm
     - imageio
     - imageio-ffmpeg
-    - matplotlib
     - libxcb                             # [linux]
     - xorg-libx11                        # [linux]
     - xorg-libxau                        # [linux]


### PR DESCRIPTION
## Motivation and Context

This changeset removes the `matplotlib` dependency from the conda build requirements.
This dependency includes many others that are likely to conflict with an environment.

## How Has This Been Tested

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
