### PR TITLE
Fix segfault in gfx-replay when there's an invalid path.

### DIFF
--- a/src/esp/gfx/replay/Player.cpp
+++ b/src/esp/gfx/replay/Player.cpp
@@ -248,8 +248,13 @@ void Player::applyKeyframe(const Keyframe& keyframe) {
 
   for (const auto& pair : keyframe.metadata) {
     const auto& instanceKey = pair.first;
-    implementation_->setNodeMetadata(createdInstances_[instanceKey],
-                                     pair.second);
+    const auto& it = createdInstances_.find(instanceKey);
+    if (it == createdInstances_.end()) {
+      // Missing instance for this key due to a failed instance creation
+      continue;
+    }
+    auto* node = it->second;
+    implementation_->setNodeMetadata(node, pair.second);
     creationRecords_[instanceKey].metadata = pair.second;
   }
 


### PR DESCRIPTION
## Motivation and Context

This fixes a segfault that can occur in gfx-replay when an asset has an invalid path.

## How Has This Been Tested

Tested locally on HITL.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
