### PR TITLE
--[Bugfix] - Storage of attribute source directory paths

### DIFF
--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -507,7 +507,7 @@ class ManagedFileBasedContainer : public ManagedContainer<T, Access> {
     std::string handleName = object->getHandle();
     auto loc = handleName.find_last_of('/');
     if (loc != std::string::npos) {
-      object->setFileDirectory(handleName.substr(0, loc));
+      object->setFileDirectory(handleName.substr(0, loc + 1));
     }
   }  // setFileDirectoryFromHandle
 


### PR DESCRIPTION
## Motivation and Context
This PR changes how attributes' directory paths are stored so that they end in an os separator ('/'). This corrects an issue where path merging was sometimes giving erroneous results in certain conditions, and also simplifies and unifies path building code called from the scene dastaset load.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python tests.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
