### PR TITLE
--[Bugfix] - Fix attributes save

### DIFF
--- a/src/esp/core/managedContainers/ManagedFileBasedContainer.h
+++ b/src/esp/core/managedContainers/ManagedFileBasedContainer.h
@@ -655,7 +655,7 @@ bool ManagedFileBasedContainer<T, Access>::saveManagedObjectToFile(
   } else {
     // directory found, strip it out and leave remainder (including potential
     // subdirs within directory)
-    fileNameRaw = objectHandle.substr(pos + fileDirectory.length() + 1);
+    fileNameRaw = objectHandle.substr(pos + fileDirectory.length());
   }
   std::string fileNameBase =
       FileUtil::splitExtension(FileUtil::splitExtension(fileNameRaw).first())

--- a/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
+++ b/src/esp/metadata/attributes/AbstractObjectAttributes.cpp
@@ -28,7 +28,7 @@ AbstractObjectAttributes::AbstractObjectAttributes(
   initTranslated("shader_type",
                  getShaderTypeName(ObjectInstanceShaderType::Material));
   // TODO remove this once ShaderType support is complete
-  setForceFlatShading(false);
+  init("force_flat_shading", false);
 
   // Default rendering and collisions will be mesh for physics objects and
   // scenes. Primitive-based objects do not currently support mesh collisions,


### PR DESCRIPTION
This PR addresses when an attributes filename has to be constructed from its handle. One of the paths to do this looked for the attributes' original file directory in its handle, and then removed that directory +1 from the handle to account for the once-missing trailing slash.  

However,  PR  #2541 modified the fileDirectory that is stored in the attributes to include the trailing slash, which required the modifications in this PR.

This also fixes a minor attributes issue where a boolean default value is not set as an init value (i.e. so it won't be written out to json if it is not changed).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally c++ and python
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
