### PR TITLE
Add stage scaling from configured scale values.

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -496,6 +496,9 @@ bool ResourceManager::loadStage(
       renderInfo.filepath, Cr::Containers::NullOpt, flags, renderLightSetupKey);
   ESP_DEBUG() << "Start load render asset" << renderInfo.filepath << ".";
 
+  // Set the stage scale from the config
+  renderCreation.scale = stageAttributes->getScale();
+
   bool renderMeshSuccess = loadStageInternal(renderInfo,  // AssetInfo
                                              &renderCreation,
                                              &rootNode,    // parent scene node

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -78,7 +78,10 @@ void BulletRigidStage::constructAndAddCollisionObjects() {
     const assets::MeshMetaData& metaData =
         resMgr_.getMeshMetaData(collisionAssetHandle);
 
-    constructBulletSceneFromMeshes(Magnum::Matrix4{}, meshGroup, metaData.root);
+    // set the configured scaling as the initial transform for collision mesh
+    // construction
+    auto initial_transform = Magnum::Matrix4::scaling(initAttr->getScale());
+    constructBulletSceneFromMeshes(initial_transform, meshGroup, metaData.root);
 
     for (auto& object : bStaticCollisionObjects_) {
       object->setFriction(initAttr->getFrictionCoefficient());


### PR DESCRIPTION
## Motivation and Context

TL;DR: allows scaling set in the stage configs to propagate through to render and collision assets.

Context:
- We have allowed non-uniform (3D) scale vectors to be configured for object and stage configs ([doc page](https://aihabitat.org/docs/habitat-sim/attributesJSON.html#stageattributes)) for some time.
- However, the stage loading pathway has not used these values during construction of the render and collision objects.
- This PR simply queries existing configured scale when constructing the render instance and collision shapes for the stage asset.

NOTE: this is not tested for split semantic assets. It may require some additional implementation for split semantic scene graphs like HM3D, scannet, MP3D, etc... For context: this is because we load an additional asset into an additional SceneGraph for such assets. The scale should be pulled and set there as well.

## How Has This Been Tested

Locally in viewer. Should be CI tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
