### PR TITLE
--[Bugfix] - Change assertion to just provide a user error if unused scale provided

### DIFF
--- a/src/esp/assets/ResourceManager.cpp
+++ b/src/esp/assets/ResourceManager.cpp
@@ -1419,10 +1419,12 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceVertSemantic(
     const RenderAssetInstanceCreationInfo& creation,
     scene::SceneNode* parent,
     DrawableGroup* drawables) {
-  CORRADE_INTERNAL_ASSERT(!creation.scale);  // IMesh doesn't support scale
-  CORRADE_INTERNAL_ASSERT(creation.lightSetupKey ==
-                          NO_LIGHT_KEY);  // IMesh doesn't support
-                                          // lighting
+  // IMesh doesn't support scale
+  if (creation.scale && creation.scale != Mn::Vector3(1.0f, 1.0f, 1.0f)) {
+    ESP_ERROR() << "The mesh used for Vertex-Semantics does not support "
+                   "non-unit scale. Specified scale multiplier of "
+                << creation.scale << " ignored.";
+  }
 
   const bool computeAbsoluteAABBs = creation.isStatic();
 
@@ -1437,7 +1439,7 @@ scene::SceneNode* ResourceManager::createRenderAssetInstanceVertSemantic(
   instanceRoot->MagnumObject::setTransformation(
       meshMetaData.root.transformFromLocalToParent);
   gfx::DrawableConfiguration drawableConfig{
-      creation.lightSetupKey,             // lightSetup Key
+      NO_LIGHT_KEY,                       // lightSetup Key
       PER_VERTEX_OBJECT_ID_MATERIAL_KEY,  // material key
       ObjectInstanceShaderType::Phong,    // shader type to use
       drawables,                          // drawable group


### PR DESCRIPTION
This PR changes an assertion that no scale is provided to the vertex-semantics mesh instantiation method to instead be a user error message, and removes an assertion that no lighting key be provided, but rather hardcodes the actual creation to be NO_LIGHT_KEY.  Recent changes to allow for support of stage scaling have caused datasets that instantiate vertex-semantics meshes (like Replica) to unnecessarily fire this assertion.  Besides, seems a bit extreme to assert on data being provided that is not even used. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally C++ and Python tests pass
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
