### PR TITLE
[bugfix] fix the bug causing early exit after any one visual shape is added

### DIFF
--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -371,12 +371,17 @@ bool BulletPhysicsManager::attachLinkGeometry(
         // cache the visual component for later query
         linkObject->visualAttachments_.emplace_back(
             &visualGeomComponent, visual.m_geometry.m_meshFileName);
-        return true;
+      } else {
+        // we failed to add the geom node
+        return false;
       }
+    } else {
+      // we failed to add create a visual shape
+      return false;
     }
   }
-
-  return false;
+  // we successfully added all shapes
+  return true;
 }
 
 void BulletPhysicsManager::setGravity(const Magnum::Vector3& gravity) {


### PR DESCRIPTION
## Motivation and Context

Fix a bug which caused only one visual shape in each AO link element to be added, skipping content.

## How Has This Been Tested

Locally validated, should be unit tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
