### PR TITLE
add scale variable to the add_instance binding. 

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -181,6 +181,7 @@ void initRenderInstanceHelperBindings(py::module& m) {
            "use_xyzw_orientations=False, we assume wxyz.)")
       .def("add_instance", &RenderInstanceHelper::AddInstance,
            py::arg("asset_filepath"), py::arg("semantic_id"),
+           py::arg("scale") = Mn::Vector3(1.0, 1.0, 1.0),
            "R(Add an instance of a render asset to the scene. The asset can be "
            "for example a .glb or .obj 3D model file. The instance gets an "
            "identity pose; change it later using set_world_poses.)")

--- a/src/esp/sim/RenderInstanceHelper.cpp
+++ b/src/esp/sim/RenderInstanceHelper.cpp
@@ -19,7 +19,8 @@ RenderInstanceHelper::RenderInstanceHelper(Simulator& sim,
 }
 
 int RenderInstanceHelper::AddInstance(const std::string& assetFilepath,
-                                      int semanticId) {
+                                      int semanticId,
+                                      Magnum::Vector3 scale) {
   esp::assets::AssetInfo assetInfo;
   assetInfo.filepath = assetFilepath;
   assetInfo.forceFlatShading = false;
@@ -28,8 +29,6 @@ int RenderInstanceHelper::AddInstance(const std::string& assetFilepath,
   // flags |= RenderAssetInstanceCreationInfo::Flag::IsStatic;
   flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsRGBD;
   flags |= esp::assets::RenderAssetInstanceCreationInfo::Flag::IsSemantic;
-  const Corrade::Containers::Optional<Magnum::Vector3> scale =
-      Cr::Containers::NullOpt;
 
   assets::RenderAssetInstanceCreationInfo creation(assetFilepath, scale, flags,
                                                    DEFAULT_LIGHTING_KEY);

--- a/src/esp/sim/RenderInstanceHelper.cpp
+++ b/src/esp/sim/RenderInstanceHelper.cpp
@@ -20,7 +20,7 @@ RenderInstanceHelper::RenderInstanceHelper(Simulator& sim,
 
 int RenderInstanceHelper::AddInstance(const std::string& assetFilepath,
                                       int semanticId,
-                                      Magnum::Vector3 scale) {
+                                      const Magnum::Vector3& scale) {
   esp::assets::AssetInfo assetInfo;
   assetInfo.filepath = assetFilepath;
   assetInfo.forceFlatShading = false;

--- a/src/esp/sim/RenderInstanceHelper.h
+++ b/src/esp/sim/RenderInstanceHelper.h
@@ -53,7 +53,9 @@ class RenderInstanceHelper {
    */
   int AddInstance(const std::string& assetFilepath,
                   int semanticId,
-                  Magnum::Vector3 scale = Magnum::Vector3(1.0, 1.0, 1.0));
+                  const Magnum::Vector3& scale = Magnum::Vector3(1.0,
+                                                                 1.0,
+                                                                 1.0));
 
   /**
    * @brief Remove all instances from the scene.

--- a/src/esp/sim/RenderInstanceHelper.h
+++ b/src/esp/sim/RenderInstanceHelper.h
@@ -5,6 +5,7 @@
 #ifndef ESP_SIM_RENDERINSTANCEHELPER_H_
 #define ESP_SIM_RENDERINSTANCEHELPER_H_
 
+#include <Magnum/Math/Vector3.h>
 #include <string>
 #include <vector>
 
@@ -50,7 +51,9 @@ class RenderInstanceHelper {
    * @param assetFilepath can be for example a .glb or .obj 3D model file
    * @param semanticId used for semantic rendering
    */
-  int AddInstance(const std::string& assetFilepath, int semanticId);
+  int AddInstance(const std::string& assetFilepath,
+                  int semanticId,
+                  Magnum::Vector3 scale = Magnum::Vector3(1.0, 1.0, 1.0));
 
   /**
    * @brief Remove all instances from the scene.


### PR DESCRIPTION
## Motivation and Context

Adds a 3D scale vector to the add_instance python binding. Allows setting the render asset scale without instantiating a ManagedObject in Habitat (e.g. from the isaac integration).

## How Has This Been Tested

Tested in a local app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
