### PR TITLE
[CI] Migrate Codecov upload from legacy uploader to codecov-action@v5

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -151,6 +151,7 @@ jobs:
         files: ./habitat-sim/coverage.xml
         flags: Python
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
         fail_ci_if_error: false
     - name: Upload C++ coverage to Codecov
       uses: codecov/codecov-action@v5
@@ -158,6 +159,7 @@ jobs:
         files: ./habitat-sim/coverage.info
         flags: CPP
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
         fail_ci_if_error: false
     - name: install habitat-sim with audio and run audio_agent script
       run: |-


### PR DESCRIPTION
## Motivation and Context

The legacy standalone Codecov uploader (curl-based) was deprecated and no longer transmits coverage data without a repository upload token. This caused coverage uploads to silently stop ~10 months ago.

Changes:
- Replace legacy curl-based codecov uploader with codecov/codecov-action@v5
- Split the monolithic upload step into focused steps: generate C++ report, upload Python coverage, upload C++ coverage
- Add CODECOV_TOKEN secret for authenticated uploads (required since Feb 2024)
- Remove dead commented-out lcov filter commands
- Set fail_ci_if_error: false so Codecov outages don't break CI

## How Has This Been Tested

This CI should now run a code coverage upload

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
