### PR TITLE
[CI] restrict coverage to habitat local files

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -146,9 +146,9 @@ jobs:
         # https://github.com/psycofdj/coverxygen/issues/6
         sed -i -e 's/,-1$/,0/g' coverage.info
         # Strip vendored dependencies and test code from the C++ coverage report
-        lcov --remove coverage.info "*/deps/*" --output-file coverage.info > /dev/null
-        lcov --remove coverage.info "*/test/*" --output-file coverage.info > /dev/null
-        lcov --remove coverage.info "*/tests/*" --output-file coverage.info > /dev/null
+        lcov --remove coverage.info "*/deps/*" --output-file coverage.info --ignore-errors unused > /dev/null
+        lcov --remove coverage.info "*/test/*" --output-file coverage.info --ignore-errors unused > /dev/null
+        lcov --remove coverage.info "*/tests/*" --output-file coverage.info --ignore-errors unused > /dev/null
     - name: Upload Python coverage to Codecov
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
## Motivation and Context

Currently code coverage is very low because deps/ are included. We want to restrict coverage to local files.

## How Has This Been Tested

CI coverage metrics https://app.codecov.io/gh/facebookresearch/habitat-sim/tree/fix-codecov-upload

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
