### PR TITLE
[CI] Fix CUDA 13 build and mypy type annotations

### DIFF
--- a/src/esp/gfx_batch/cuda_helpers/HelperCuda.h
+++ b/src/esp/gfx_batch/cuda_helpers/HelperCuda.h
@@ -1056,7 +1056,12 @@ inline int gpuDeviceInit(int devID) {
   cudaDeviceProp deviceProp;
   checkCudaErrors(cudaGetDeviceProperties(&deviceProp, devID));
 
-  if (deviceProp.computeMode == cudaComputeModeProhibited) {
+  // NOTE: cudaDeviceProp::computeMode was removed in CUDA 13; query it via
+  // cudaDeviceGetAttribute, which is supported in CUDA 12 and 13.
+  int computeMode = -1;
+  checkCudaErrors(
+      cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, devID));
+  if (computeMode == cudaComputeModeProhibited) {
     fprintf(stderr,
             "Error: device is running in <Compute Mode Prohibited>, no threads "
             "can use ::cudaSetDevice().\n");
@@ -1098,9 +1103,15 @@ inline int gpuGetMaxGflopsDeviceId() {
   while (current_device < device_count) {
     cudaGetDeviceProperties(&deviceProp, current_device);
 
+    // NOTE: cudaDeviceProp::computeMode was removed in CUDA 13; query it via
+    // cudaDeviceGetAttribute, which is supported in CUDA 12 and 13.
+    int computeMode = -1;
+    checkCudaErrors(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode,
+                                           current_device));
+
     // If this GPU is not running on Compute Mode prohibited, then we can add it
     // to the list
-    if (deviceProp.computeMode != cudaComputeModeProhibited) {
+    if (computeMode != cudaComputeModeProhibited) {
       if (deviceProp.major > 0 && deviceProp.major < 9999) {
         best_SM_arch = MAX(best_SM_arch, deviceProp.major);
       }
@@ -1124,9 +1135,19 @@ inline int gpuGetMaxGflopsDeviceId() {
   while (current_device < device_count) {
     cudaGetDeviceProperties(&deviceProp, current_device);
 
+    // NOTE: cudaDeviceProp::computeMode and cudaDeviceProp::clockRate were
+    // removed in CUDA 13; query them via cudaDeviceGetAttribute, which is
+    // supported in CUDA 12 and 13.
+    int computeMode = -1;
+    checkCudaErrors(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode,
+                                           current_device));
+    int clockRate = 0;
+    checkCudaErrors(cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate,
+                                           current_device));
+
     // If this GPU is not running on Compute Mode prohibited, then we can add it
     // to the list
-    if (deviceProp.computeMode != cudaComputeModeProhibited) {
+    if (computeMode != cudaComputeModeProhibited) {
       if (deviceProp.major == 9999 && deviceProp.minor == 9999) {
         sm_per_multiproc = 1;
       } else {
@@ -1136,7 +1157,7 @@ inline int gpuGetMaxGflopsDeviceId() {
 
       unsigned long long compute_perf =
           (unsigned long long)deviceProp.multiProcessorCount *
-          sm_per_multiproc * deviceProp.clockRate;
+          sm_per_multiproc * clockRate;
 
       if (compute_perf > max_compute_perf) {
         // If we find GPU with SM major > 2, search only these

--- a/src_python/habitat_sim/utils/datasets_download.py
+++ b/src_python/habitat_sim/utils/datasets_download.py
@@ -18,12 +18,12 @@ import tarfile
 import traceback
 import zipfile
 from shutil import which
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from git import Repo
 
-data_sources = {}
-data_groups = {}
+data_sources: Dict[str, Dict[str, Any]] = {}
+data_groups: Dict[str, List[str]] = {}
 
 
 def hm3d_train_configs_post(extract_dir: str) -> List[str]:
@@ -253,9 +253,11 @@ def initialize_test_data_sources(data_path):
                     ext="",
                     split=split,
                     data_format=data_format,
-                    version_string="-v0.2"
-                    if (version == "0.2" and data_format != "configs")
-                    else "",
+                    version_string=(
+                        "-v0.2"
+                        if (version == "0.2" and data_format != "configs")
+                        else ""
+                    ),
                 ),
                 "download_pre_args": "--location",
                 "package_name": "hm3d-{split}-{data_format}.tar{ext}".format(
@@ -270,9 +272,11 @@ def initialize_test_data_sources(data_path):
                 "downloaded_file_list": f"hm3d-{{version}}/{split}-{data_format}-files.json.gz",
                 "requires_auth": True,
                 "use_curl": True,
-                "post_extract_fn": hm3d_train_configs_post
-                if split == "train" and data_format == "configs"
-                else None,
+                "post_extract_fn": (
+                    hm3d_train_configs_post
+                    if split == "train" and data_format == "configs"
+                    else None
+                ),
             }
             for split, data_format, version in itertools.product(
                 ["minival", "train", "val"],
@@ -330,9 +334,9 @@ def initialize_test_data_sources(data_path):
                 "downloaded_file_list": f"hm3d-{{version}}/{split}-semantic-{data_format}-files.json.gz",
                 "requires_auth": True,
                 "use_curl": True,
-                "post_extract_fn": hm3d_semantic_configs_post
-                if data_format == "configs"
-                else None,
+                "post_extract_fn": (
+                    hm3d_semantic_configs_post if data_format == "configs" else None
+                ),
             }
             for split, data_format, version in itertools.product(
                 ["minival", "train", "val"], ["annots", "configs"], ["0.1", "0.2"]


### PR DESCRIPTION
## Summary

Fixes two CI failures on `main`:

### 1. Source build (Linux GPU CI) — CUDA 13 incompatibility

The Linux GPU CI workflow auto-detects the CUDA version from `nvidia-smi` and installs the matching `cuda-toolkit` (see `.github/actions/install_ubuntu_gpu_deps/action.yml`). The runner host now reports CUDA 13, and CUDA 13 finally removed the long-deprecated `computeMode` and `clockRate` fields from `cudaDeviceProp`. This caused `HelperCuda.h` to fail to compile with:

```
error: 'struct cudaDeviceProp' has no member named 'computeMode'
error: 'struct cudaDeviceProp' has no member named 'clockRate'
```

**Fix:** Replaced the three accesses to `deviceProp.computeMode` and the one access to `deviceProp.clockRate` in `src/esp/gfx_batch/cuda_helpers/HelperCuda.h` with `cudaDeviceGetAttribute` calls (`cudaDevAttrComputeMode` / `cudaDevAttrClockRate`). These attribute queries are supported on **both CUDA 12 and CUDA 13**, so the conda build (CUDA 12.1) and the source build (CUDA 13) both work.

### 2. mypy

`src_python/habitat_sim/utils/datasets_download.py` was missing type annotations on the module-level `data_sources` and `data_groups` dicts:

```
src_python/habitat_sim/utils/datasets_download.py:25: error: Need type annotation for "data_sources"
src_python/habitat_sim/utils/datasets_download.py:26: error: Need type annotation for "data_groups"
```

**Fix:** Added explicit `Dict[str, Dict[str, Any]]` and `Dict[str, List[str]]` annotations.

## Out of scope

The conda upload steps (Linux & macOS) are also failing with `Invalid Username password combination` for the `aihabitat` Anaconda Cloud account. That is a credential/secret rotation issue, not a code issue, and is not addressed here.

## Test plan

Rely on CI: the Linux GPU source build (Conda + source) and the mypy job should now pass.